### PR TITLE
Reference admin client from module instead of context

### DIFF
--- a/js/apps/admin-ui/src/App.tsx
+++ b/js/apps/admin-ui/src/App.tsx
@@ -13,7 +13,6 @@ import { KeycloakSpinner } from "./components/keycloak-spinner/KeycloakSpinner";
 import { RealmsProvider } from "./context/RealmsContext";
 import { RecentRealmsProvider } from "./context/RecentRealms";
 import { AccessContextProvider } from "./context/access/Access";
-import { AdminClientProvider } from "./context/auth/AdminClient";
 import { RealmContextProvider } from "./context/realm-context/RealmContext";
 import { ServerInfoProvider } from "./context/server-info/ServerInfoProvider";
 import { WhoAmIContextProvider } from "./context/whoami/WhoAmI";
@@ -23,23 +22,21 @@ import { AuthWall } from "./root/AuthWall";
 export const mainPageContentId = "kc-main-content-page-container";
 
 const AppContexts = ({ children }: PropsWithChildren) => (
-  <AdminClientProvider>
-    <WhoAmIContextProvider>
-      <RealmsProvider>
-        <RealmContextProvider>
-          <RecentRealmsProvider>
-            <AccessContextProvider>
-              <Help>
-                <AlertProvider>
-                  <SubGroups>{children}</SubGroups>
-                </AlertProvider>
-              </Help>
-            </AccessContextProvider>
-          </RecentRealmsProvider>
-        </RealmContextProvider>
-      </RealmsProvider>
-    </WhoAmIContextProvider>
-  </AdminClientProvider>
+  <WhoAmIContextProvider>
+    <RealmsProvider>
+      <RealmContextProvider>
+        <RecentRealmsProvider>
+          <AccessContextProvider>
+            <Help>
+              <AlertProvider>
+                <SubGroups>{children}</SubGroups>
+              </AlertProvider>
+            </Help>
+          </AccessContextProvider>
+        </RecentRealmsProvider>
+      </RealmContextProvider>
+    </RealmsProvider>
+  </WhoAmIContextProvider>
 );
 
 export const App = () => {

--- a/js/apps/admin-ui/src/authentication/AuthenticationSection.tsx
+++ b/js/apps/admin-ui/src/authentication/AuthenticationSection.tsx
@@ -1,3 +1,5 @@
+import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
+import RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import {
   AlertVariant,
   Button,
@@ -13,10 +15,10 @@ import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
-import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
-import RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import {
   RoutableTabs,
@@ -24,7 +26,7 @@ import {
 } from "../components/routable-tabs/RoutableTabs";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import helpUrls from "../help-urls";
 import { addTrailingSlash } from "../util";
@@ -32,16 +34,15 @@ import { getAuthorizationHeaders } from "../utils/getAuthorizationHeaders";
 import useLocaleSort, { mapByKey } from "../utils/useLocaleSort";
 import useToggle from "../utils/useToggle";
 import { BindFlowDialog } from "./BindFlowDialog";
-import { UsedBy } from "./components/UsedBy";
 import { DuplicateFlowModal } from "./DuplicateFlowModal";
-import { Policies } from "./policies/Policies";
 import { RequiredActions } from "./RequiredActions";
+import { UsedBy } from "./components/UsedBy";
+import { Policies } from "./policies/Policies";
 import { AuthenticationTab, toAuthentication } from "./routes/Authentication";
 import { toCreateFlow } from "./routes/CreateFlow";
 import { toFlow } from "./routes/Flow";
 
 import "./authentication-section.css";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 
 type UsedBy = "SPECIFIC_CLIENTS" | "SPECIFIC_PROVIDERS" | "DEFAULT";
 
@@ -83,7 +84,6 @@ const AliasRenderer = ({ id, alias, usedBy, builtIn }: AuthenticationType) => {
 
 export default function AuthenticationSection() {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const [key, setKey] = useState(0);
   const refresh = () => {

--- a/js/apps/admin-ui/src/authentication/BindFlowDialog.tsx
+++ b/js/apps/admin-ui/src/authentication/BindFlowDialog.tsx
@@ -13,8 +13,8 @@ import {
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import useToggle from "../utils/useToggle";
 import { REALM_FLOWS } from "./AuthenticationSection";
@@ -31,7 +31,6 @@ type BindFlowDialogProps = {
 export const BindFlowDialog = ({ flowAlias, onClose }: BindFlowDialogProps) => {
   const { t } = useTranslation("authentication");
   const { control, handleSubmit } = useForm<BindingForm>();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
   const [open, toggleOpen] = useToggle();

--- a/js/apps/admin-ui/src/authentication/DuplicateFlowModal.tsx
+++ b/js/apps/admin-ui/src/authentication/DuplicateFlowModal.tsx
@@ -12,8 +12,8 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { NameDescription } from "./form/NameDescription";
 import { toFlow } from "./routes/Flow";
@@ -34,7 +34,6 @@ export const DuplicateFlowModal = ({
   const { t } = useTranslation("authentication");
   const form = useForm<AuthenticationFlowRepresentation>({ mode: "onChange" });
   const { setValue, getValues, handleSubmit } = form;
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
   const { realm } = useRealm();

--- a/js/apps/admin-ui/src/authentication/EditFlowModal.tsx
+++ b/js/apps/admin-ui/src/authentication/EditFlowModal.tsx
@@ -9,10 +9,10 @@ import {
 } from "@patternfly/react-core";
 import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { useTranslation } from "react-i18next";
 
+import { useTranslation } from "react-i18next";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { NameDescription } from "./form/NameDescription";
 
 type EditFlowModalProps = {
@@ -22,7 +22,6 @@ type EditFlowModalProps = {
 
 export const EditFlowModal = ({ flow, toggleDialog }: EditFlowModalProps) => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const form = useForm<AuthenticationFlowRepresentation>({ mode: "onChange" });
   const { reset, handleSubmit } = form;

--- a/js/apps/admin-ui/src/authentication/FlowDetails.tsx
+++ b/js/apps/admin-ui/src/authentication/FlowDetails.tsx
@@ -1,52 +1,53 @@
-import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { Trans, useTranslation } from "react-i18next";
+import type AuthenticationExecutionInfoRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation";
+import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
 import {
-  DataList,
-  Label,
-  PageSection,
-  Toolbar,
-  ToolbarItem,
-  ToolbarContent,
-  ToggleGroup,
-  ToggleGroupItem,
   AlertVariant,
   Button,
   ButtonVariant,
+  DataList,
   DropdownItem,
+  Label,
+  PageSection,
+  ToggleGroup,
+  ToggleGroupItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
 } from "@patternfly/react-core";
 import {
   CheckCircleIcon,
-  TableIcon,
   DomainIcon,
+  TableIcon,
 } from "@patternfly/react-icons";
+import { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router-dom";
 
-import type AuthenticationExecutionInfoRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation";
-import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
-import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
-import type { FlowParams } from "./routes/Flow";
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
+import { useRealm } from "../context/realm-context/RealmContext";
+import useToggle from "../utils/useToggle";
+import { BindFlowDialog } from "./BindFlowDialog";
+import { DuplicateFlowModal } from "./DuplicateFlowModal";
+import { EditFlowModal } from "./EditFlowModal";
 import { EmptyExecutionState } from "./EmptyExecutionState";
+import { FlowDiagram } from "./components/FlowDiagram";
 import { FlowHeader } from "./components/FlowHeader";
 import { FlowRow } from "./components/FlowRow";
+import { AddStepModal } from "./components/modals/AddStepModal";
+import { AddSubFlowModal, Flow } from "./components/modals/AddSubFlowModal";
 import {
   ExecutionList,
   ExpandableExecution,
   IndexChange,
   LevelChange,
 } from "./execution-model";
-import { FlowDiagram } from "./components/FlowDiagram";
-import { useAlerts } from "../components/alert/Alerts";
-import { AddStepModal } from "./components/modals/AddStepModal";
-import { AddSubFlowModal, Flow } from "./components/modals/AddSubFlowModal";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { DuplicateFlowModal } from "./DuplicateFlowModal";
-import { useRealm } from "../context/realm-context/RealmContext";
-import useToggle from "../utils/useToggle";
 import { toAuthentication } from "./routes/Authentication";
-import { EditFlowModal } from "./EditFlowModal";
-import { BindFlowDialog } from "./BindFlowDialog";
+import type { FlowParams } from "./routes/Flow";
 
 export const providerConditionFilter = (
   value: AuthenticationProviderRepresentation
@@ -54,7 +55,6 @@ export const providerConditionFilter = (
 
 export default function FlowDetails() {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const { id, usedBy, builtIn } = useParams<FlowParams>();

--- a/js/apps/admin-ui/src/authentication/RequiredActions.tsx
+++ b/js/apps/admin-ui/src/authentication/RequiredActions.tsx
@@ -1,14 +1,15 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { AlertVariant, Switch } from "@patternfly/react-core";
-
 import type RequiredActionProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderRepresentation";
 import type RequiredActionProviderSimpleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderSimpleRepresentation";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { DraggableTable } from "./components/DraggableTable";
+import { AlertVariant, Switch } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { useFetch } from "../context/auth/AdminClient";
 import { toKey } from "../util";
+import { DraggableTable } from "./components/DraggableTable";
 
 type DataType = RequiredActionProviderRepresentation &
   RequiredActionProviderSimpleRepresentation;
@@ -22,7 +23,6 @@ type Row = {
 
 export const RequiredActions = () => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [actions, setActions] = useState<Row[]>();

--- a/js/apps/admin-ui/src/authentication/components/AddFlowDropdown.tsx
+++ b/js/apps/admin-ui/src/authentication/components/AddFlowDropdown.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
 import {
   Dropdown,
   DropdownItem,
@@ -7,11 +6,13 @@ import {
   Tooltip,
 } from "@patternfly/react-core";
 import { PlusIcon } from "@patternfly/react-icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
-import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 import type { ExpandableExecution } from "../execution-model";
 import { AddStepModal, FlowType } from "./modals/AddStepModal";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { AddSubFlowModal, Flow } from "./modals/AddSubFlowModal";
 
 type AddFlowDropdownProps = {
@@ -29,7 +30,6 @@ export const AddFlowDropdown = ({
   onAddFlow,
 }: AddFlowDropdownProps) => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
 
   const [open, setOpen] = useState(false);
   const [type, setType] = useState<FlowType>();

--- a/js/apps/admin-ui/src/authentication/components/ExecutionConfigModal.tsx
+++ b/js/apps/admin-ui/src/authentication/components/ExecutionConfigModal.tsx
@@ -16,12 +16,13 @@ import { CogIcon, TrashIcon } from "@patternfly/react-icons";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
 import type { ExpandableExecution } from "../execution-model";
 
@@ -38,7 +39,6 @@ export const ExecutionConfigModal = ({
   execution,
 }: ExecutionConfigModalProps) => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [show, setShow] = useState(false);

--- a/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
+++ b/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
@@ -13,7 +13,6 @@ import { useTranslation } from "react-i18next";
 
 import { fetchUsedBy } from "../../components/role-mapping/resource";
 import { KeycloakDataTable } from "../../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import useToggle from "../../utils/useToggle";
 import { AuthenticationType, REALM_FLOWS } from "../AuthenticationSection";
 
@@ -39,7 +38,6 @@ type UsedByModalProps = {
 
 const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
 
   const loader = async (
     first?: number,
@@ -47,7 +45,6 @@ const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
     search?: string
   ): Promise<{ name: string }[]> => {
     const result = await fetchUsedBy({
-      adminClient,
       id,
       type: isSpecificClient ? "clients" : "idp",
       first: first || 0,

--- a/js/apps/admin-ui/src/authentication/components/modals/AddStepModal.tsx
+++ b/js/apps/admin-ui/src/authentication/components/modals/AddStepModal.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
 import {
   Button,
   ButtonVariant,
@@ -9,10 +8,12 @@ import {
   PageSection,
   Radio,
 } from "@patternfly/react-core";
-import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../../../admin-client";
 import { PaginatingTableToolbar } from "../../../components/table-toolbar/PaginatingTableToolbar";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 import useLocaleSort, { mapByKey } from "../../../utils/useLocaleSort";
 import { providerConditionFilter } from "../../FlowDetails";
 
@@ -56,7 +57,6 @@ type AddStepModalProps = {
 
 export const AddStepModal = ({ name, type, onSelect }: AddStepModalProps) => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
 
   const [value, setValue] = useState<AuthenticationProviderRepresentation>();
   const [providers, setProviders] =

--- a/js/apps/admin-ui/src/authentication/components/modals/AddSubFlowModal.tsx
+++ b/js/apps/admin-ui/src/authentication/components/modals/AddSubFlowModal.tsx
@@ -14,10 +14,11 @@ import {
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../../admin-client";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 
 type AddSubFlowProps = {
   name: string;
@@ -51,7 +52,6 @@ export const AddSubFlowModal = ({
   const [openProvider, setOpenProvider] = useState(false);
   const [formProviders, setFormProviders] =
     useState<AuthenticationProviderRepresentation[]>();
-  const { adminClient } = useAdminClient();
 
   useFetch(
     () => adminClient.authenticationManagement.getFormProviders(),

--- a/js/apps/admin-ui/src/authentication/form/CreateFlow.tsx
+++ b/js/apps/admin-ui/src/authentication/form/CreateFlow.tsx
@@ -9,10 +9,10 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toAuthentication } from "../routes/Authentication";
 import { toFlow } from "../routes/Flow";
@@ -23,7 +23,6 @@ export default function CreateFlow() {
   const { t } = useTranslation("authentication");
   const navigate = useNavigate();
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const { addAlert } = useAlerts();
   const form = useForm<AuthenticationFlowRepresentation>();
   const { handleSubmit } = form;

--- a/js/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
@@ -15,12 +15,12 @@ import {
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
 
@@ -49,7 +49,6 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
     setValue,
     formState: { errors, isValid, isDirty },
   } = useForm<FormFields>({ mode: "onChange" });
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
   const [

--- a/js/apps/admin-ui/src/authentication/policies/OtpPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/OtpPolicy.tsx
@@ -19,12 +19,12 @@ import {
 import { useEffect, useMemo } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { TimeSelector } from "../../components/time-selector/TimeSelector";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import useLocaleSort from "../../utils/useLocaleSort";
 import useToggle from "../../utils/useToggle";
@@ -53,7 +53,6 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
     handleSubmit,
     formState: { isValid, isDirty, errors },
   } = useForm<FormFields>({ mode: "onChange", defaultValues: realm });
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
   const localeSort = useLocaleSort();

--- a/js/apps/admin-ui/src/authentication/policies/PasswordPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/PasswordPolicy.tsx
@@ -1,3 +1,5 @@
+import type PasswordPolicyTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/passwordPolicyTypeRepresentation";
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -21,15 +23,13 @@ import { useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
-import type PasswordPolicyTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/passwordPolicyTypeRepresentation";
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { PolicyRow } from "./PolicyRow";
-import { parsePolicy, serializePolicy, SubmittedValues } from "./util";
+import { SubmittedValues, parsePolicy, serializePolicy } from "./util";
 
 type PolicySelectProps = {
   onSelect: (row: PasswordPolicyTypeRepresentation) => void;
@@ -82,7 +82,6 @@ export const PasswordPolicy = ({
   const { t } = useTranslation("authentication");
   const { passwordPolicies } = useServerInfo();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
 

--- a/js/apps/admin-ui/src/authentication/policies/Policies.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/Policies.tsx
@@ -3,8 +3,9 @@ import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../../admin-client";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { CibaPolicy } from "./CibaPolicy";
 import { OtpPolicy } from "./OtpPolicy";
@@ -14,7 +15,6 @@ import { WebauthnPolicy } from "./WebauthnPolicy";
 export const Policies = () => {
   const { t } = useTranslation("authentication");
   const [subTab, setSubTab] = useState(1);
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const [realm, setRealm] = useState<RealmRepresentation>();
 

--- a/js/apps/admin-ui/src/authentication/policies/WebauthnPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/WebauthnPolicy.tsx
@@ -1,3 +1,4 @@
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -22,15 +23,14 @@ import {
   useFormContext,
 } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem, useHelp } from "ui-shared";
 
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { useHelp, HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { MultiLineInput } from "../../components/multi-line-input/MultiLineInput";
 import { TimeSelector } from "../../components/time-selector/TimeSelector";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
 
@@ -158,7 +158,6 @@ export const WebauthnPolicy = ({
   isPasswordLess = false,
 }: WebauthnPolicyProps) => {
   const { t } = useTranslation("authentication");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
   const { enabled } = useHelp();

--- a/js/apps/admin-ui/src/client-scopes/ChangeTypeDropdown.tsx
+++ b/js/apps/admin-ui/src/client-scopes/ChangeTypeDropdown.tsx
@@ -1,17 +1,16 @@
+import { AlertVariant, Select } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AlertVariant, Select } from "@patternfly/react-core";
 
+import type { Row } from "../clients/scopes/ClientScopes";
+import { useAlerts } from "../components/alert/Alerts";
 import {
+  ClientScope,
   allClientScopeTypes,
   changeClientScope,
   changeScope,
-  ClientScope,
   clientScopeTypesSelectOptions,
 } from "../components/client-scope/ClientScopeTypes";
-import type { Row } from "../clients/scopes/ClientScopes";
-import { useAdminClient } from "../context/auth/AdminClient";
-import { useAlerts } from "../components/alert/Alerts";
 
 type ChangeTypeDropdownProps = {
   clientId?: string;
@@ -27,7 +26,6 @@ export const ChangeTypeDropdown = ({
   const { t } = useTranslation("client-scopes");
   const [open, setOpen] = useState(false);
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   return (
@@ -45,13 +43,12 @@ export const ChangeTypeDropdown = ({
             selectedRows.map((row) => {
               return clientId
                 ? changeClientScope(
-                    adminClient,
                     clientId,
                     row,
                     row.type,
                     value as ClientScope
                   )
-                : changeScope(adminClient, row, value as ClientScope);
+                : changeScope(row, value as ClientScope);
             })
           );
           setOpen(false);

--- a/js/apps/admin-ui/src/client-scopes/ClientScopesSection.tsx
+++ b/js/apps/admin-ui/src/client-scopes/ClientScopesSection.tsx
@@ -1,6 +1,3 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import {
   AlertVariant,
   Button,
@@ -12,43 +9,45 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { cellWidth } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 
-import { useAdminClient } from "../context/auth/AdminClient";
-import { ViewHeader } from "../components/view-header/ViewHeader";
+import { adminClient } from "../admin-client";
+import type { Row } from "../clients/scopes/ClientScopes";
+import { getProtocolName } from "../clients/utils";
 import { useAlerts } from "../components/alert/Alerts";
+import {
+  AllClientScopeType,
+  AllClientScopes,
+  CellDropdown,
+  ClientScope,
+  ClientScopeDefaultOptionalType,
+  changeScope,
+  removeScope,
+} from "../components/client-scope/ClientScopeTypes";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useRealm } from "../context/realm-context/RealmContext";
+import helpUrls from "../help-urls";
 import { emptyFormatter } from "../util";
 import useLocaleSort, { mapByKey } from "../utils/useLocaleSort";
-import {
-  CellDropdown,
-  ClientScope,
-  AllClientScopes,
-  ClientScopeDefaultOptionalType,
-  changeScope,
-  removeScope,
-  AllClientScopeType,
-} from "../components/client-scope/ClientScopeTypes";
 import { ChangeTypeDropdown } from "./ChangeTypeDropdown";
-import { toNewClientScope } from "./routes/NewClientScope";
-
-import { toClientScope } from "./routes/ClientScope";
 import {
-  nameFilter,
-  protocolFilter,
   ProtocolType,
   SearchDropdown,
   SearchToolbar,
   SearchType,
+  nameFilter,
+  protocolFilter,
   typeFilter,
 } from "./details/SearchFilter";
-import type { Row } from "../clients/scopes/ClientScopes";
-import { getProtocolName } from "../clients/utils";
-import helpUrls from "../help-urls";
+import { toClientScope } from "./routes/ClientScope";
+import { toNewClientScope } from "./routes/NewClientScope";
 
 import "./client-scope.css";
 
@@ -58,8 +57,8 @@ type TypeSelectorProps = ClientScopeDefaultOptionalType & {
 
 const TypeSelector = (scope: TypeSelectorProps) => {
   const { t } = useTranslation("client-scopes");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
+
   return (
     <CellDropdown
       clientScope={scope}
@@ -67,7 +66,7 @@ const TypeSelector = (scope: TypeSelectorProps) => {
       all
       onSelect={async (value) => {
         try {
-          await changeScope(adminClient, scope, value as AllClientScopeType);
+          await changeScope(scope, value as AllClientScopeType);
           addAlert(t("clientScopeSuccess"), AlertVariant.success);
           scope.refresh();
         } catch (error) {
@@ -93,8 +92,6 @@ const ClientScopeDetailLink = ({
 export default function ClientScopesSection() {
   const { realm } = useRealm();
   const { t } = useTranslation("client-scopes");
-
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [kebabOpen, setKebabOpen] = useState(false);
@@ -165,7 +162,7 @@ export default function ClientScopesSection() {
       try {
         for (const scope of selectedScopes) {
           try {
-            await removeScope(adminClient, scope);
+            await removeScope(scope);
           } catch (error: any) {
             console.warn(
               "could not remove scope",

--- a/js/apps/admin-ui/src/client-scopes/CreateClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/CreateClientScope.tsx
@@ -2,13 +2,13 @@ import { AlertVariant, PageSection } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import {
-  changeScope,
   ClientScopeDefaultOptionalType,
+  changeScope,
 } from "../components/client-scope/ClientScopeTypes";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { convertFormValuesToObject } from "../util";
 import { ScopeForm } from "./details/ScopeForm";
@@ -18,7 +18,6 @@ export default function CreateClientScope() {
   const { t } = useTranslation("client-scopes");
   const navigate = useNavigate();
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const onSubmit = async (formData: ClientScopeDefaultOptionalType) => {
@@ -38,11 +37,7 @@ export default function CreateClientScope() {
         throw new Error(t("common:notFound"));
       }
 
-      await changeScope(
-        adminClient,
-        { ...clientScope, id: scope.id },
-        clientScope.type
-      );
+      await changeScope({ ...clientScope, id: scope.id }, clientScope.type);
 
       addAlert(t("createSuccess", AlertVariant.success));
 

--- a/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
@@ -14,16 +14,17 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { useAlerts } from "../components/alert/Alerts";
+import { useHelp } from "ui-shared";
 
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
 import {
   AllClientScopes,
-  changeScope,
   ClientScope,
   ClientScopeDefaultOptionalType,
+  changeScope,
 } from "../components/client-scope/ClientScopeTypes";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { useHelp } from "ui-shared";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import { RoleMapping, Row } from "../components/role-mapping/RoleMapping";
 import {
@@ -31,7 +32,7 @@ import {
   useRoutableTab,
 } from "../components/routable-tabs/RoutableTabs";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { convertFormValuesToObject } from "../util";
 import { useParams } from "../utils/useParams";
@@ -48,7 +49,6 @@ export default function EditClientScope() {
   const { t } = useTranslation("client-scopes");
   const navigate = useNavigate();
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const { id } = useParams<ClientScopeParams>();
   const { addAlert, addError } = useAlerts();
   const { enabled } = useHelp();
@@ -117,7 +117,7 @@ export default function EditClientScope() {
 
     try {
       await adminClient.clientScopes.update({ id }, clientScope);
-      await changeScope(adminClient, { ...clientScope, id }, clientScope.type);
+      await changeScope({ ...clientScope, id }, clientScope.type);
 
       addAlert(t("updateSuccess"), AlertVariant.success);
     } catch (error) {

--- a/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
@@ -14,16 +14,17 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useMatch, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { toClient } from "../../clients/routes/Client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
@@ -35,7 +36,6 @@ import "./mapping-details.css";
 
 export default function MappingDetails() {
   const { t } = useTranslation("client-scopes");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const { id, mapperId } = useParams<MapperParams>();

--- a/js/apps/admin-ui/src/clients/ClientDetails.tsx
+++ b/js/apps/admin-ui/src/clients/ClientDetails.tsx
@@ -17,6 +17,7 @@ import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import {
   ConfirmDialogModal,
@@ -36,7 +37,7 @@ import {
   ViewHeaderBadge,
 } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import {
   convertAttributeNameToForm,
@@ -188,7 +189,6 @@ export type FormFields = Omit<
 
 export default function ClientDetails() {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
   const { hasAccess } = useAccess();

--- a/js/apps/admin-ui/src/clients/ClientSessions.tsx
+++ b/js/apps/admin-ui/src/clients/ClientSessions.tsx
@@ -2,9 +2,8 @@ import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/
 import type UserSessionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation";
 import { PageSection } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-
+import { adminClient } from "../admin-client";
 import type { LoaderFunction } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
 import SessionsTable from "../sessions/SessionsTable";
 
 type ClientSessionsProps = {
@@ -12,7 +11,6 @@ type ClientSessionsProps = {
 };
 
 export const ClientSessions = ({ client }: ClientSessionsProps) => {
-  const { adminClient } = useAdminClient();
   const { t } = useTranslation("sessions");
 
   const loader: LoaderFunction<UserSessionRepresentation> = async (

--- a/js/apps/admin-ui/src/clients/ClientsSection.tsx
+++ b/js/apps/admin-ui/src/clients/ClientsSection.tsx
@@ -1,3 +1,5 @@
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
 import {
   AlertVariant,
   Badge,
@@ -8,37 +10,36 @@ import {
   TabTitleText,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { cellWidth, IRowData, TableText } from "@patternfly/react-table";
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
+import { IRowData, TableText, cellWidth } from "@patternfly/react-table";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { FormattedLink } from "../components/external-link/FormattedLink";
+import {
+  RoutableTabs,
+  useRoutableTab,
+} from "../components/routable-tabs/RoutableTabs";
 import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { useAccess } from "../context/access/Access";
 import { useRealm } from "../context/realm-context/RealmContext";
+import helpUrls from "../help-urls";
 import { emptyFormatter, exportClient } from "../util";
 import { convertClientToUrl } from "../utils/client-url";
 import { InitialAccessTokenList } from "./initial-access/InitialAccessTokenList";
+import { ClientRegistration } from "./registration/ClientRegistration";
 import { toAddClient } from "./routes/AddClient";
 import { toClient } from "./routes/Client";
-import { toImportClient } from "./routes/ImportClient";
-import { isRealmClient, getProtocolName } from "./utils";
-import helpUrls from "../help-urls";
-import { useAccess } from "../context/access/Access";
-import {
-  RoutableTabs,
-  useRoutableTab,
-} from "../components/routable-tabs/RoutableTabs";
 import { ClientsTab, toClients } from "./routes/Clients";
-import { ClientRegistration } from "./registration/ClientRegistration";
+import { toImportClient } from "./routes/ImportClient";
+import { getProtocolName, isRealmClient } from "./utils";
 
 const ClientDetailLink = (client: ClientRepresentation) => {
   const { t } = useTranslation("clients");
@@ -71,7 +72,6 @@ const ClientDescription = (client: ClientRepresentation) => (
 );
 
 const ClientHomeLink = (client: ClientRepresentation) => {
-  const { adminClient } = useAdminClient();
   const href = convertClientToUrl(client, adminClient.baseUrl);
 
   if (!href) {
@@ -117,8 +117,6 @@ const ToolbarItems = () => {
 export default function ClientsSection() {
   const { t } = useTranslation("clients");
   const { addAlert, addError } = useAlerts();
-
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const [key, setKey] = useState(0);

--- a/js/apps/admin-ui/src/clients/add/NewClientForm.tsx
+++ b/js/apps/admin-ui/src/clients/add/NewClientForm.tsx
@@ -11,10 +11,10 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertFormValuesToObject } from "../../util";
 import { FormFields } from "../ClientDetails";
@@ -27,7 +27,6 @@ import { LoginSettings } from "./LoginSettings";
 export default function NewClientForm() {
   const { t } = useTranslation("clients");
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const navigate = useNavigate();
 
   const [step, setStep] = useState(0);

--- a/js/apps/admin-ui/src/clients/advanced/AddHostDialog.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/AddHostDialog.tsx
@@ -9,9 +9,9 @@ import {
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../../context/auth/AdminClient";
 
 type FormFields = {
   node: string;
@@ -36,7 +36,6 @@ export const AddHostDialog = ({
     handleSubmit,
     formState: { isDirty, isValid },
   } = useForm<FormFields>();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   async function onSubmit({ node }: FormFields) {

--- a/js/apps/admin-ui/src/clients/advanced/AdvancedSettings.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/AdvancedSettings.tsx
@@ -11,13 +11,14 @@ import {
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import { FormAccess } from "../../components/form-access/FormAccess";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { FormAccess } from "../../components/form-access/FormAccess";
 import { KeyValueInput } from "../../components/key-value-form/KeyValueInput";
 import { MultiLineInput } from "../../components/multi-line-input/MultiLineInput";
 import { TimeSelector } from "../../components/time-selector/TimeSelector";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertAttributeNameToForm } from "../../util";
 import { FormFields } from "../ClientDetails";
@@ -41,7 +42,6 @@ export const AdvancedSettings = ({
 
   const [realm, setRealm] = useState<RealmRepresentation>();
   const { realm: realmName } = useRealm();
-  const { adminClient } = useAdminClient();
 
   useFetch(
     () => adminClient.realms.findOne({ realm: realmName }),

--- a/js/apps/admin-ui/src/clients/advanced/AuthenticationOverrides.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/AuthenticationOverrides.tsx
@@ -10,10 +10,11 @@ import { sortBy } from "lodash-es";
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import { FormAccess } from "../../components/form-access/FormAccess";
 import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+
+import { adminClient } from "../../admin-client";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import { useFetch } from "../../context/auth/AdminClient";
 
 type AuthenticationOverridesProps = {
   save: () => void;
@@ -28,7 +29,6 @@ export const AuthenticationOverrides = ({
   reset,
   hasConfigureAccess,
 }: AuthenticationOverridesProps) => {
-  const { adminClient } = useAdminClient();
   const { t } = useTranslation("clients");
   const [flows, setFlows] = useState<JSX.Element[]>([]);
   const [browserFlowOpen, setBrowserFlowOpen] = useState(false);

--- a/js/apps/admin-ui/src/clients/advanced/ClusteringPanel.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/ClusteringPanel.tsx
@@ -11,18 +11,18 @@ import {
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
 import {
   Action,
   KeycloakDataTable,
 } from "../../components/table-toolbar/KeycloakDataTable";
 import { TimeSelector } from "../../components/time-selector/TimeSelector";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import useFormatDate, { FORMAT_DATE_AND_TIME } from "../../utils/useFormatDate";
 import { AddHostDialog } from ".././advanced/AddHostDialog";
 import { AdvancedProps, parseResult } from "../AdvancedTab";
@@ -38,7 +38,6 @@ export const ClusteringPanel = ({
 }: AdvancedProps) => {
   const { t } = useTranslation("clients");
   const { control } = useFormContext();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const formatDate = useFormatDate();
 

--- a/js/apps/admin-ui/src/clients/advanced/RevocationPanel.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/RevocationPanel.tsx
@@ -10,12 +10,12 @@ import { useEffect, useRef } from "react";
 import { useFormContext } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import useFormatDate, { FORMAT_DATE_AND_TIME } from "../../utils/useFormatDate";
 import { AdvancedProps, parseResult } from "../AdvancedTab";
@@ -29,7 +29,6 @@ export const RevocationPanel = ({
   const pushRevocationButtonRef = useRef<HTMLElement>();
 
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert } = useAlerts();
   const formatDate = useFormatDate();

--- a/js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -1,3 +1,10 @@
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type EvaluationResultRepresentation from "@keycloak/keycloak-admin-client/lib/defs/evaluationResultRepresentation";
+import type PolicyEvaluationResponse from "@keycloak/keycloak-admin-client/lib/defs/policyEvaluationResponse";
+import type ResourceEvaluation from "@keycloak/keycloak-admin-client/lib/defs/resourceEvaluation";
+import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
+import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
 import {
   ActionGroup,
   Button,
@@ -12,34 +19,27 @@ import {
 import { useState } from "react";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import type EvaluationResultRepresentation from "@keycloak/keycloak-admin-client/lib/defs/evaluationResultRepresentation";
-import type PolicyEvaluationResponse from "@keycloak/keycloak-admin-client/lib/defs/policyEvaluationResponse";
-import type ResourceEvaluation from "@keycloak/keycloak-admin-client/lib/defs/resourceEvaluation";
-import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
-
+import { ForbiddenSection } from "../../ForbiddenSection";
+import { adminClient } from "../../admin-client";
+import { useAlerts } from "../../components/alert/Alerts";
 import { ClientSelect } from "../../components/client/ClientSelect";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import {
-  keyValueToArray,
   KeyValueType,
+  keyValueToArray,
 } from "../../components/key-value-form/key-value-convert";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { FormPanel } from "../../components/scroll-form/FormPanel";
 import { UserSelect } from "../../components/users/UserSelect";
 import { useAccess } from "../../context/access/Access";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { ForbiddenSection } from "../../ForbiddenSection";
 import { FormFields } from "../ClientDetails";
 import { defaultContextAttributes } from "../utils";
-import { Results } from "./evaluate/Results";
 import { KeyBasedAttributeInput } from "./KeyBasedAttributeInput";
-import { useAlerts } from "../../components/alert/Alerts";
+import { Results } from "./evaluate/Results";
 
 import "./auth-evaluate.css";
 
@@ -91,7 +91,6 @@ export const AuthorizationEvaluate = ({ client }: Props) => {
     formState: { isValid, errors },
   } = form;
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addError } = useAlerts();
   const realm = useRealm();
 

--- a/js/apps/admin-ui/src/clients/authorization/AuthorizationExport.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/AuthorizationExport.tsx
@@ -9,13 +9,14 @@ import {
 import { saveAs } from "file-saver";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextArea } from "../../components/keycloak-text-area/KeycloakTextArea";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { prettyPrintJSON } from "../../util";
 import { useParams } from "../../utils/useParams";
 import type { ClientParams } from "../routes/Client";
@@ -24,7 +25,6 @@ import "./authorization-details.css";
 
 export const AuthorizationExport = () => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { clientId } = useParams<ClientParams>();
   const { addAlert, addError } = useAlerts();
 

--- a/js/apps/admin-ui/src/clients/authorization/DeleteScopeDialog.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/DeleteScopeDialog.tsx
@@ -1,11 +1,11 @@
-import { useTranslation } from "react-i18next";
+import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
 import { Alert, AlertVariant } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
 
-import type { PermissionScopeRepresentation } from "./Scopes";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { ConfirmDialogModal } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
-import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
+import type { PermissionScopeRepresentation } from "./Scopes";
 
 type DeleteScopeDialogProps = {
   clientId: string;
@@ -26,7 +26,6 @@ export const DeleteScopeDialog = ({
   toggleDialog,
 }: DeleteScopeDialogProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   return (

--- a/js/apps/admin-ui/src/clients/authorization/DetailCell.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/DetailCell.tsx
@@ -1,13 +1,14 @@
-import { useState } from "react";
-import { DescriptionList } from "@patternfly/react-core";
-
 import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
+import { DescriptionList } from "@patternfly/react-core";
+import { useState } from "react";
+import { adminClient } from "../../admin-client";
+
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { DetailDescription, DetailDescriptionLink } from "./DetailDescription";
-import { toScopeDetails } from "../routes/Scope";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toPermissionDetails } from "../routes/PermissionDetails";
+import { toScopeDetails } from "../routes/Scope";
+import { DetailDescription, DetailDescriptionLink } from "./DetailDescription";
 
 import "./detail-cell.css";
 
@@ -20,7 +21,6 @@ type DetailCellProps = {
 };
 
 export const DetailCell = ({ id, clientId, uris }: DetailCellProps) => {
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const [scope, setScope] = useState<Scope>();
   const [permissions, setPermissions] =

--- a/js/apps/admin-ui/src/clients/authorization/PermissionDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/PermissionDetails.tsx
@@ -16,16 +16,17 @@ import { useState } from "react";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextArea } from "../../components/keycloak-text-area/KeycloakTextArea";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { toUpperCase } from "../../util";
 import { useParams } from "../../utils/useParams";
 import { toAuthorizationTab } from "../routes/AuthenticationTab";
@@ -60,7 +61,6 @@ export default function PermissionDetails() {
     NewPermissionParams & PermissionDetailsParams
   >();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const [permission, setPermission] = useState<PolicyRepresentation>();
   const [applyToResourceTypeFlag, setApplyToResourceTypeFlag] = useState(false);

--- a/js/apps/admin-ui/src/clients/authorization/Permissions.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Permissions.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type PolicyProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyProviderRepresentation";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import {
   Alert,
   AlertVariant,
@@ -22,24 +21,26 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
 
-import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
-import type PolicyProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyProviderRepresentation";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import useToggle from "../../utils/useToggle";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
+import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { SearchDropdown, SearchForm } from "./SearchDropdown";
-import { MoreLabel } from "./MoreLabel";
-import { DetailDescriptionLink } from "./DetailDescription";
-import { EmptyPermissionsState } from "./EmptyPermissionsState";
+import useToggle from "../../utils/useToggle";
 import { toNewPermission } from "../routes/NewPermission";
 import { toPermissionDetails } from "../routes/PermissionDetails";
-import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
 import { toPolicyDetails } from "../routes/PolicyDetails";
+import { DetailDescriptionLink } from "./DetailDescription";
+import { EmptyPermissionsState } from "./EmptyPermissionsState";
+import { MoreLabel } from "./MoreLabel";
+import { SearchDropdown, SearchForm } from "./SearchDropdown";
 
 import "./permissions.css";
 
@@ -68,7 +69,6 @@ const AssociatedPoliciesRenderer = ({
 export const AuthorizationPermissions = ({ clientId }: PermissionsProps) => {
   const { t } = useTranslation("clients");
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/clients/authorization/Policies.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Policies.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type PolicyProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyProviderRepresentation";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import {
   Alert,
   AlertVariant,
@@ -18,25 +17,27 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
 
-import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
-import type PolicyProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyProviderRepresentation";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { toPolicyDetails } from "../routes/PolicyDetails";
-import { MoreLabel } from "./MoreLabel";
-import { toUpperCase } from "../../util";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
+import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { toUpperCase } from "../../util";
 import useToggle from "../../utils/useToggle";
-import { NewPolicyDialog } from "./NewPolicyDialog";
 import { toCreatePolicy } from "../routes/NewPolicy";
 import { toPermissionDetails } from "../routes/PermissionDetails";
-import { SearchDropdown, SearchForm } from "./SearchDropdown";
+import { toPolicyDetails } from "../routes/PolicyDetails";
 import { DetailDescriptionLink } from "./DetailDescription";
+import { MoreLabel } from "./MoreLabel";
+import { NewPolicyDialog } from "./NewPolicyDialog";
+import { SearchDropdown, SearchForm } from "./SearchDropdown";
 
 type PoliciesProps = {
   clientId: string;
@@ -62,7 +63,6 @@ const DependentPoliciesRenderer = ({
 
 export const AuthorizationPolicies = ({ clientId }: PoliciesProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
   const navigate = useNavigate();

--- a/js/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
@@ -17,18 +17,19 @@ import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
-import type { KeyValueType } from "../../components/key-value-form/key-value-convert";
 import { KeyValueInput } from "../../components/key-value-form/KeyValueInput";
+import type { KeyValueType } from "../../components/key-value-form/key-value-convert";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { MultiLineInput } from "../../components/multi-line-input/MultiLineInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
 import { useParams } from "../../utils/useParams";
 import { toAuthorizationTab } from "../routes/AuthenticationTab";
@@ -52,7 +53,6 @@ export default function ResourceDetails() {
   const [permissions, setPermission] =
     useState<ResourceServerRepresentation[]>();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const form = useForm<SubmittedResource>({
     mode: "onChange",

--- a/js/apps/admin-ui/src/clients/authorization/Resources.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Resources.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
+import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import {
   Alert,
   AlertVariant,
@@ -17,21 +16,23 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
 
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
-import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import { DetailCell } from "./DetailCell";
-import { toCreateResource } from "../routes/NewResource";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { toResourceDetails } from "../routes/Resource";
-import { MoreLabel } from "./MoreLabel";
-import { toNewPermission } from "../routes/NewPermission";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
+import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { toNewPermission } from "../routes/NewPermission";
+import { toCreateResource } from "../routes/NewResource";
+import { toResourceDetails } from "../routes/Resource";
+import { DetailCell } from "./DetailCell";
+import { MoreLabel } from "./MoreLabel";
 import { SearchDropdown, SearchForm } from "./SearchDropdown";
 
 type ResourcesProps = {
@@ -51,7 +52,6 @@ const UriRenderer = ({ row }: { row: ResourceRepresentation }) => (
 export const AuthorizationResources = ({ clientId }: ResourcesProps) => {
   const { t } = useTranslation("clients");
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/clients/authorization/ResourcesPolicySelect.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ResourcesPolicySelect.tsx
@@ -1,15 +1,16 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Controller, useFormContext } from "react-hook-form";
-import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
-
-import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
 import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
+import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
 import type {
   Clients,
   PolicyQuery,
 } from "@keycloak/keycloak-admin-client/lib/resources/clients";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 
 type Type = "resources" | "policies";
 
@@ -57,7 +58,6 @@ export const ResourcesPolicySelect = ({
   isRequired = false,
 }: ResourcesPolicySelectProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
 
   const {
     control,

--- a/js/apps/admin-ui/src/clients/authorization/ScopeDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ScopeDetails.tsx
@@ -13,13 +13,14 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useParams } from "../../utils/useParams";
 import useToggle from "../../utils/useToggle";
 import { toAuthorizationTab } from "../routes/AuthenticationTab";
@@ -33,7 +34,6 @@ export default function ScopeDetails() {
   const { id, scopeId, realm } = useParams<ScopeDetailsParams>();
   const navigate = useNavigate();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [deleteDialog, toggleDeleteDialog] = useToggle();

--- a/js/apps/admin-ui/src/clients/authorization/ScopePicker.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ScopePicker.tsx
@@ -1,16 +1,17 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Controller, useFormContext } from "react-hook-form";
+import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
 import {
   FormGroup,
   Select,
   SelectOption,
   SelectVariant,
 } from "@patternfly/react-core";
-
-import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 
 type Scope = {
   id: string;
@@ -24,8 +25,6 @@ export const ScopePicker = ({ clientId }: { clientId: string }) => {
   const [open, setOpen] = useState(false);
   const [scopes, setScopes] = useState<ScopeRepresentation[]>();
   const [search, setSearch] = useState("");
-
-  const { adminClient } = useAdminClient();
 
   useFetch(
     () => {

--- a/js/apps/admin-ui/src/clients/authorization/ScopeSelect.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ScopeSelect.tsx
@@ -1,10 +1,11 @@
-import { useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Controller, useFormContext } from "react-hook-form";
-import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
-
 import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
+import { useRef, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 
 type ScopeSelectProps = {
   clientId: string;
@@ -18,7 +19,6 @@ export const ScopeSelect = ({
   preSelected,
 }: ScopeSelectProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
 
   const {
     control,

--- a/js/apps/admin-ui/src/clients/authorization/Scopes.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Scopes.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
+import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
 import {
   Button,
   DescriptionList,
@@ -16,23 +15,24 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
 
-import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
-import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
-
+import { adminClient } from "../../admin-client";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { toScopeDetails } from "../routes/Scope";
-import { toNewScope } from "../routes/NewScope";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
+import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
 import useToggle from "../../utils/useToggle";
+import { toNewPermission } from "../routes/NewPermission";
+import { toNewScope } from "../routes/NewScope";
+import { toPermissionDetails } from "../routes/PermissionDetails";
+import { toResourceDetails } from "../routes/Resource";
+import { toScopeDetails } from "../routes/Scope";
 import { DeleteScopeDialog } from "./DeleteScopeDialog";
 import { DetailDescriptionLink } from "./DetailDescription";
-import { toNewPermission } from "../routes/NewPermission";
-import { toResourceDetails } from "../routes/Resource";
-import { toPermissionDetails } from "../routes/PermissionDetails";
 
 type ScopesProps = {
   clientId: string;
@@ -51,7 +51,6 @@ type ExpandableRow = {
 export const AuthorizationScopes = ({ clientId }: ScopesProps) => {
   const { t } = useTranslation("clients");
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const [deleteDialog, toggleDeleteDialog] = useToggle();

--- a/js/apps/admin-ui/src/clients/authorization/Settings.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Settings.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Controller, FormProvider, useForm } from "react-hook-form";
+import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import {
   AlertVariant,
   Button,
@@ -10,17 +8,20 @@ import {
   Radio,
   Switch,
 } from "@patternfly/react-core";
-
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { FormAccess } from "../../components/form-access/FormAccess";
+import { useState } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { SaveReset } from "../advanced/SaveReset";
-import { ImportDialog } from "./ImportDialog";
-import useToggle from "../../utils/useToggle";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { useFetch } from "../../context/auth/AdminClient";
+import useToggle from "../../utils/useToggle";
+import { SaveReset } from "../advanced/SaveReset";
 import { DecisionStrategySelect } from "./DecisionStrategySelect";
+import { ImportDialog } from "./ImportDialog";
 
 const POLICY_ENFORCEMENT_MODES = [
   "ENFORCING",
@@ -41,7 +42,6 @@ export const AuthorizationSettings = ({ clientId }: { clientId: string }) => {
   const form = useForm<FormFields>({});
   const { control, reset, handleSubmit } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   useFetch(

--- a/js/apps/admin-ui/src/clients/authorization/policy/Client.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Client.tsx
@@ -1,17 +1,18 @@
-import { useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
 import {
-  SelectOption,
   FormGroup,
   Select,
+  SelectOption,
   SelectVariant,
 } from "@patternfly/react-core";
-
-import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../../admin-client";
+import { useFetch } from "../../../context/auth/AdminClient";
 
 export const Client = () => {
   const { t } = useTranslation("clients");
@@ -25,8 +26,6 @@ export const Client = () => {
   const [open, setOpen] = useState(false);
   const [clients, setClients] = useState<ClientRepresentation[]>([]);
   const [search, setSearch] = useState("");
-
-  const { adminClient } = useAdminClient();
 
   useFetch(
     async () => {

--- a/js/apps/admin-ui/src/clients/authorization/policy/ClientScope.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/ClientScope.tsx
@@ -1,7 +1,5 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useFormContext, Controller } from "react-hook-form";
-import { FormGroup, Button, Checkbox } from "@patternfly/react-core";
+import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
+import { Button, Checkbox, FormGroup } from "@patternfly/react-core";
 import { MinusCircleIcon } from "@patternfly/react-icons";
 import {
   TableComposable,
@@ -11,12 +9,15 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-
-import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { AddScopeDialog } from "../../scopes/AddScopeDialog";
+
+import { adminClient } from "../../../admin-client";
+import { useFetch } from "../../../context/auth/AdminClient";
 import useLocaleSort, { mapByKey } from "../../../utils/useLocaleSort";
+import { AddScopeDialog } from "../../scopes/AddScopeDialog";
 
 export type RequiredIdValue = {
   id: string;
@@ -40,7 +41,6 @@ export const ClientScope = () => {
     ClientScopeRepresentation[]
   >([]);
 
-  const { adminClient } = useAdminClient();
   const localeSort = useLocaleSort();
 
   useFetch(

--- a/js/apps/admin-ui/src/clients/authorization/policy/Group.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Group.tsx
@@ -1,22 +1,23 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useFormContext, Controller } from "react-hook-form";
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
+import { Button, Checkbox, FormGroup } from "@patternfly/react-core";
 import { MinusCircleIcon } from "@patternfly/react-icons";
-import { FormGroup, Button, Checkbox } from "@patternfly/react-core";
 import {
   TableComposable,
-  Thead,
-  Tr,
-  Th,
   Tbody,
   Td,
+  Th,
+  Thead,
+  Tr,
 } from "@patternfly/react-table";
-
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+
+import { adminClient } from "../../../admin-client";
 import { GroupPickerDialog } from "../../../components/group/GroupPickerDialog";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
+import { useFetch } from "../../../context/auth/AdminClient";
 
 type GroupForm = {
   groups?: GroupValue[];
@@ -43,8 +44,6 @@ export const Group = () => {
   const [selectedGroups, setSelectedGroups] = useState<GroupRepresentation[]>(
     []
   );
-
-  const { adminClient } = useAdminClient();
 
   useFetch(
     () => {

--- a/js/apps/admin-ui/src/clients/authorization/policy/PolicyDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/PolicyDetails.tsx
@@ -12,12 +12,13 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../../admin-client";
 import { useAlerts } from "../../../components/alert/Alerts";
 import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../../components/form-access/FormAccess";
 import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
 import { ViewHeader } from "../../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 import { useParams } from "../../../utils/useParams";
 import { toAuthorizationTab } from "../../routes/AuthenticationTab";
 import {
@@ -67,7 +68,6 @@ export default function PolicyDetails() {
   const form = useForm();
   const { reset, handleSubmit } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [policy, setPolicy] = useState<PolicyRepresentation>();

--- a/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
@@ -1,22 +1,23 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useFormContext, Controller } from "react-hook-form";
-import { FormGroup, Button, Checkbox } from "@patternfly/react-core";
+import { Button, Checkbox, FormGroup } from "@patternfly/react-core";
 import { MinusCircleIcon } from "@patternfly/react-icons";
 import {
   TableComposable,
-  Thead,
-  Tr,
-  Th,
   Tbody,
   Td,
+  Th,
+  Thead,
+  Tr,
 } from "@patternfly/react-table";
-
-import { Row, ServiceRole } from "../../../components/role-mapping/RoleMapping";
-import type { RequiredIdValue } from "./ClientScope";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+
+import { adminClient } from "../../../admin-client";
 import { AddRoleMappingModal } from "../../../components/role-mapping/AddRoleMappingModal";
+import { Row, ServiceRole } from "../../../components/role-mapping/RoleMapping";
+import { useFetch } from "../../../context/auth/AdminClient";
+import type { RequiredIdValue } from "./ClientScope";
 
 export const Role = () => {
   const { t } = useTranslation("clients");
@@ -32,8 +33,6 @@ export const Role = () => {
 
   const [open, setOpen] = useState(false);
   const [selectedRoles, setSelectedRoles] = useState<Row[]>([]);
-
-  const { adminClient } = useAdminClient();
 
   useFetch(
     async () => {

--- a/js/apps/admin-ui/src/clients/credentials/ClientSecret.tsx
+++ b/js/apps/admin-ui/src/clients/credentials/ClientSecret.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useFormContext } from "react-hook-form";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import {
   Alert,
   Button,
@@ -9,15 +7,17 @@ import {
   Split,
   SplitItem,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import { PasswordInput } from "../../components/password-input/PasswordInput";
-import { CopyToClipboardButton } from "../scopes/CopyToClipboardButton";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import useFormatDate from "../../utils/useFormatDate";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { PasswordInput } from "../../components/password-input/PasswordInput";
 import { useAccess } from "../../context/access/Access";
+import useFormatDate from "../../utils/useFormatDate";
+import { CopyToClipboardButton } from "../scopes/CopyToClipboardButton";
 
 export type ClientSecretProps = {
   client: ClientRepresentation;
@@ -86,7 +86,6 @@ const ExpireDateFormatter = ({ time }: { time: number }) => {
 
 export const ClientSecret = ({ client, secret, toggle }: ClientSecretProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [secretRotated, setSecretRotated] = useState<string | undefined>(

--- a/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
+++ b/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
@@ -21,18 +21,18 @@ import {
 import { useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
+import { HelpItem } from "ui-shared";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
+import { FormFields } from "../ClientDetails";
 import { ClientSecret } from "./ClientSecret";
 import { SignedJWT } from "./SignedJWT";
 import { X509 } from "./X509";
 
 import "./credentials.css";
-import { FormFields } from "../ClientDetails";
 
 type AccessToken = {
   registrationAccessToken: string;
@@ -46,7 +46,6 @@ export type CredentialsProps = {
 
 export const Credentials = ({ client, save, refresh }: CredentialsProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const clientId = client.id!;
 

--- a/js/apps/admin-ui/src/clients/import/ImportForm.tsx
+++ b/js/apps/admin-ui/src/clients/import/ImportForm.tsx
@@ -1,3 +1,4 @@
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import { Language } from "@patternfly/react-code-editor";
 import {
   ActionGroup,
@@ -11,14 +12,12 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { FileUploadForm } from "../../components/json-file-upload/FileUploadForm";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import {
   addTrailingSlash,
@@ -26,9 +25,9 @@ import {
   convertToFormValues,
 } from "../../util";
 import { getAuthorizationHeaders } from "../../utils/getAuthorizationHeaders";
-import { CapabilityConfig } from "../add/CapabilityConfig";
 import { ClientDescription } from "../ClientDescription";
 import { FormFields } from "../ClientDetails";
+import { CapabilityConfig } from "../add/CapabilityConfig";
 import { toClient } from "../routes/Client";
 import { toClients } from "../routes/Clients";
 
@@ -37,7 +36,6 @@ const isXml = (text: string) => text.match(/(<.[^(><.)]+>)/g);
 export default function ImportForm() {
   const { t } = useTranslation("clients");
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const form = useForm<FormFields>();
   const { register, handleSubmit, setValue } = form;

--- a/js/apps/admin-ui/src/clients/initial-access/CreateInitialAccessToken.tsx
+++ b/js/apps/admin-ui/src/clients/initial-access/CreateInitialAccessToken.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Controller, useForm } from "react-hook-form";
+import type ClientInitialAccessPresentation from "@keycloak/keycloak-admin-client/lib/defs/clientInitialAccessPresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -9,18 +7,20 @@ import {
   NumberInput,
   PageSection,
 } from "@patternfly/react-core";
-
-import type ClientInitialAccessPresentation from "@keycloak/keycloak-admin-client/lib/defs/clientInitialAccessPresentation";
-import { FormAccess } from "../../components/form-access/FormAccess";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { HelpItem } from "ui-shared";
-import { TimeSelector } from "../../components/time-selector/TimeSelector";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { useAdminClient } from "../../context/auth/AdminClient";
+import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import { AccessTokenDialog } from "./AccessTokenDialog";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import { TimeSelector } from "../../components/time-selector/TimeSelector";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useRealm } from "../../context/realm-context/RealmContext";
 import { toClients } from "../routes/Clients";
+import { AccessTokenDialog } from "./AccessTokenDialog";
 
 export default function CreateInitialAccessToken() {
   const { t } = useTranslation("clients");
@@ -30,7 +30,6 @@ export default function CreateInitialAccessToken() {
     formState: { isValid, errors },
   } = useForm({ mode: "onChange" });
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
 

--- a/js/apps/admin-ui/src/clients/initial-access/InitialAccessTokenList.tsx
+++ b/js/apps/admin-ui/src/clients/initial-access/InitialAccessTokenList.tsx
@@ -1,9 +1,11 @@
+import type ClientInitialAccessPresentation from "@keycloak/keycloak-admin-client/lib/defs/clientInitialAccessPresentation";
 import { AlertVariant, Button, ButtonVariant } from "@patternfly/react-core";
 import { wrappable } from "@patternfly/react-table";
-import type ClientInitialAccessPresentation from "@keycloak/keycloak-admin-client/lib/defs/clientInitialAccessPresentation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
@@ -11,15 +13,13 @@ import {
   Action,
   KeycloakDataTable,
 } from "../../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { toCreateInitialAccessToken } from "../routes/CreateInitialAccessToken";
 import useFormatDate, { FORMAT_DATE_AND_TIME } from "../../utils/useFormatDate";
+import { toCreateInitialAccessToken } from "../routes/CreateInitialAccessToken";
 
 export const InitialAccessTokenList = () => {
   const { t } = useTranslation("clients");
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
   const formatDate = useFormatDate();

--- a/js/apps/admin-ui/src/clients/keys/ExportSamlKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/ExportSamlKeyDialog.tsx
@@ -1,13 +1,13 @@
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
-import { Button, Modal, Form } from "@patternfly/react-core";
-import { saveAs } from "file-saver";
-
 import KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
-import { KeyForm, getFileExtension } from "./GenerateKeyDialog";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { useAdminClient } from "../../context/auth/AdminClient";
+import { Button, Form, Modal } from "@patternfly/react-core";
+import { saveAs } from "file-saver";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { KeyForm, getFileExtension } from "./GenerateKeyDialog";
 
 type ExportSamlKeyDialogProps = {
   clientId: string;
@@ -21,7 +21,6 @@ export const ExportSamlKeyDialog = ({
   const { t } = useTranslation("clients");
   const { realm } = useRealm();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const form = useForm<KeyStoreConfig>({

--- a/js/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -1,3 +1,5 @@
+import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
+import type KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
 import {
   ActionGroup,
   AlertVariant,
@@ -14,16 +16,15 @@ import {
 } from "@patternfly/react-core";
 import { saveAs } from "file-saver";
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
-
-import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
-import type KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { convertAttributeNameToForm } from "../../util";
 import useToggle from "../../utils/useToggle";
 import { FormFields } from "../ClientDetails";
@@ -47,7 +48,6 @@ export const Keys = ({ clientId, save, hasConfigureAccess }: KeysProps) => {
     getValues,
     formState: { isDirty },
   } = useFormContext<FormFields>();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [keyInfo, setKeyInfo] = useState<CertificateRepresentation>();

--- a/js/apps/admin-ui/src/clients/keys/SamlImportKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/SamlImportKeyDialog.tsx
@@ -1,13 +1,12 @@
-import { useTranslation } from "react-i18next";
-import { FormProvider, useFormContext } from "react-hook-form";
 import { AlertVariant } from "@patternfly/react-core";
+import { FormProvider, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
-import type { KeyTypes } from "./SamlKeys";
-import { KeyForm } from "./GenerateKeyDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useAlerts } from "../../components/alert/Alerts";
-import { SamlKeysDialogForm, submitForm } from "./SamlKeysDialog";
 import { ConfirmDialogModal } from "../../components/confirm-dialog/ConfirmDialog";
+import { KeyForm } from "./GenerateKeyDialog";
+import type { KeyTypes } from "./SamlKeys";
+import { SamlKeysDialogForm, submitForm } from "./SamlKeysDialog";
 
 type SamlImportKeyDialogProps = {
   id: string;
@@ -24,11 +23,10 @@ export const SamlImportKeyDialog = ({
   const form = useFormContext<SamlKeysDialogForm>();
   const { handleSubmit } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const submit = (form: SamlKeysDialogForm) => {
-    submitForm(form, id, attr, adminClient, (error) => {
+    submitForm(form, id, attr, (error) => {
       if (error) {
         addError("clients:importError", error);
       } else {

--- a/js/apps/admin-ui/src/clients/keys/SamlKeys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/SamlKeys.tsx
@@ -1,3 +1,4 @@
+import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -15,14 +16,14 @@ import { saveAs } from "file-saver";
 import { Fragment, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
-import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { FormPanel } from "../../components/scroll-form/FormPanel";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { convertAttributeNameToForm } from "../../util";
 import useToggle from "../../utils/useToggle";
 import { FormFields } from "../ClientDetails";
@@ -162,8 +163,6 @@ export const SamlKeys = ({ clientId, save }: SamlKeysProps) => {
   const [refresh, setRefresh] = useState(0);
 
   const { setValue } = useFormContext();
-
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   useFetch(

--- a/js/apps/admin-ui/src/clients/keys/SamlKeysDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/SamlKeysDialog.tsx
@@ -1,7 +1,5 @@
-import { useState } from "react";
-import { saveAs } from "file-saver";
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
+import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
+import type KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
 import {
   AlertVariant,
   Button,
@@ -19,16 +17,17 @@ import {
   TextContent,
   Title,
 } from "@patternfly/react-core";
-
-import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
-import type KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
-import type { KeyTypes } from "./SamlKeys";
+import { saveAs } from "file-saver";
+import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { useAdminClient } from "../../context/auth/AdminClient";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import { KeyForm } from "./GenerateKeyDialog";
 import { Certificate } from "./Certificate";
-import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
+import { KeyForm } from "./GenerateKeyDialog";
+import type { KeyTypes } from "./SamlKeys";
 
 type SamlKeysDialogProps = {
   id: string;
@@ -45,7 +44,6 @@ export const submitForm = async (
   form: SamlKeysDialogForm,
   id: string,
   attr: KeyTypes,
-  adminClient: KeycloakAdminClient,
   callback: (error?: unknown) => void
 ) => {
   try {
@@ -81,11 +79,10 @@ export const SamlKeysDialog = ({
     formState: { isValid },
   } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const submit = (form: SamlKeysDialogForm) => {
-    submitForm(form, id, attr, adminClient, (error) => {
+    submitForm(form, id, attr, (error) => {
       if (error) {
         addError("clients:importError", error);
       } else {

--- a/js/apps/admin-ui/src/clients/registration/ClientRegistrationList.tsx
+++ b/js/apps/admin-ui/src/clients/registration/ClientRegistrationList.tsx
@@ -4,16 +4,16 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import {
   Action,
   KeycloakDataTable,
 } from "../../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import useToggle from "../../utils/useToggle";
-
 import { toRegistrationProvider } from "../routes/AddRegistrationProvider";
 import { ClientRegistrationParams } from "../routes/ClientRegistration";
 import { AddProviderDialog } from "./AddProviderDialog";
@@ -48,7 +48,6 @@ export const ClientRegistrationList = ({
   const { subTab } = useParams<ClientRegistrationParams>();
   const navigate = useNavigate();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
   const [policies, setPolicies] = useState<ComponentRepresentation[]>([]);

--- a/js/apps/admin-ui/src/clients/registration/DetailProvider.tsx
+++ b/js/apps/admin-ui/src/clients/registration/DetailProvider.tsx
@@ -13,15 +13,17 @@ import { useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useParams } from "../../utils/useParams";
 import {
@@ -45,7 +47,6 @@ export default function DetailProvider() {
     formState: { errors },
   } = form;
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const [provider, setProvider] = useState<ComponentTypeRepresentation>();

--- a/js/apps/admin-ui/src/clients/roles/CreateClientRole.tsx
+++ b/js/apps/admin-ui/src/clients/roles/CreateClientRole.tsx
@@ -4,10 +4,10 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { AttributeForm } from "../../components/key-value-form/AttributeForm";
 import { RoleForm } from "../../components/role-form/RoleForm";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toClient } from "../routes/Client";
 import { toClientRole } from "../routes/ClientRole";
@@ -18,7 +18,6 @@ export default function CreateClientRole() {
   const form = useForm<AttributeForm>({ mode: "onChange" });
   const navigate = useNavigate();
   const { clientId } = useParams<NewRoleParams>();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
 

--- a/js/apps/admin-ui/src/clients/scopes/DecicatedScope.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/DecicatedScope.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import {
   AlertVariant,
   Divider,
@@ -7,14 +7,14 @@ import {
   PageSection,
   Switch,
 } from "@patternfly/react-core";
-
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import { FormAccess } from "../../components/form-access/FormAccess";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { useAdminClient } from "../../context/auth/AdminClient";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
+import { FormAccess } from "../../components/form-access/FormAccess";
 import { RoleMapping, Row } from "../../components/role-mapping/RoleMapping";
-import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import { useAccess } from "../../context/access/Access";
 
 type DedicatedScopeProps = {
@@ -25,7 +25,6 @@ export const DedicatedScope = ({
   client: initialClient,
 }: DedicatedScopeProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [client, setClient] = useState<ClientRepresentation>(initialClient);

--- a/js/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { MapperList } from "../../client-scopes/details/MapperList";
 import { useAlerts } from "../../components/alert/Alerts";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
@@ -19,7 +20,7 @@ import {
   useRoutableTab,
 } from "../../components/routable-tabs/RoutableTabs";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useParams } from "../../utils/useParams";
 import {
   DedicatedScopeDetailsParams,
@@ -33,8 +34,6 @@ export default function DedicatedScopes() {
   const { t } = useTranslation("clients");
   const navigate = useNavigate();
   const { realm, clientId } = useParams<DedicatedScopeDetailsParams>();
-
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [client, setClient] = useState<ClientRepresentation>();

--- a/js/apps/admin-ui/src/clients/scopes/EvaluateScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/EvaluateScopes.tsx
@@ -25,11 +25,12 @@ import { QuestionCircleIcon } from "@patternfly/react-icons";
 import { useEffect, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem, useHelp } from "ui-shared";
 
-import { useHelp, HelpItem } from "ui-shared";
+import { adminClient } from "../../admin-client";
 import { KeycloakDataTable } from "../../components/table-toolbar/KeycloakDataTable";
 import { UserSelect } from "../../components/users/UserSelect";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { prettyPrintJSON } from "../../util";
@@ -113,7 +114,6 @@ export const EvaluateScopes = ({ clientId, protocol }: EvaluateScopesProps) => {
   const prefix = "openid";
   const { t } = useTranslation("clients");
   const { enabled } = useHelp();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const mapperTypes = useServerInfo().protocolMapperTypes![protocol];
 

--- a/js/apps/admin-ui/src/clients/service-account/ServiceAccount.tsx
+++ b/js/apps/admin-ui/src/clients/service-account/ServiceAccount.tsx
@@ -1,19 +1,20 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
-import { Trans, useTranslation } from "react-i18next";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import { AlertVariant, PageSection } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
+import { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
-import { RoleMapping, Row } from "../../components/role-mapping/RoleMapping";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { toUser } from "../../user/routes/User";
-import { useRealm } from "../../context/realm-context/RealmContext";
+import { RoleMapping, Row } from "../../components/role-mapping/RoleMapping";
 import { useAccess } from "../../context/access/Access";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { toUser } from "../../user/routes/User";
 
 import "./service-account.css";
 
@@ -23,7 +24,6 @@ type ServiceAccountProps = {
 
 export const ServiceAccount = ({ client }: ServiceAccountProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/components/client-scope/ClientScopeTypes.tsx
+++ b/js/apps/admin-ui/src/components/client-scope/ClientScopeTypes.tsx
@@ -1,16 +1,15 @@
-import { useState } from "react";
-
-import type { TFunction } from "i18next";
-import { useTranslation } from "react-i18next";
+import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
 import {
   DropdownItem,
   Select,
   SelectOption,
   SelectProps,
 } from "@patternfly/react-core";
+import type { TFunction } from "i18next";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
-import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
-import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
+import { adminClient } from "../../admin-client";
 import { toUpperCase } from "../../util";
 
 export enum ClientScope {
@@ -96,25 +95,23 @@ export type ClientScopeDefaultOptionalType = ClientScopeRepresentation & {
 };
 
 export const changeScope = async (
-  adminClient: KeycloakAdminClient,
   clientScope: ClientScopeDefaultOptionalType,
   changeTo: AllClientScopeType
 ) => {
-  await removeScope(adminClient, clientScope);
-  await addScope(adminClient, clientScope, changeTo);
+  await removeScope(clientScope);
+  await addScope(clientScope, changeTo);
 };
 
-const castAdminClient = (adminClient: KeycloakAdminClient) =>
+const castAdminClient = () =>
   adminClient.clientScopes as unknown as {
     [index: string]: Function;
   };
 
 export const removeScope = async (
-  adminClient: KeycloakAdminClient,
   clientScope: ClientScopeDefaultOptionalType
 ) => {
   if (clientScope.type !== AllClientScopes.none)
-    await castAdminClient(adminClient)[
+    await castAdminClient()[
       `delDefault${
         clientScope.type === ClientScope.optional ? "Optional" : ""
       }ClientScope`
@@ -124,12 +121,11 @@ export const removeScope = async (
 };
 
 const addScope = async (
-  adminClient: KeycloakAdminClient,
   clientScope: ClientScopeDefaultOptionalType,
   type: AllClientScopeType
 ) => {
   if (type !== AllClientScopes.none)
-    await castAdminClient(adminClient)[
+    await castAdminClient()[
       `addDefault${type === ClientScope.optional ? "Optional" : ""}ClientScope`
     ]({
       id: clientScope.id!,
@@ -137,20 +133,18 @@ const addScope = async (
 };
 
 export const changeClientScope = async (
-  adminClient: KeycloakAdminClient,
   clientId: string,
   clientScope: ClientScopeRepresentation,
   type: AllClientScopeType,
   changeTo: ClientScopeType
 ) => {
   if (type !== "none") {
-    await removeClientScope(adminClient, clientId, clientScope, type);
+    await removeClientScope(clientId, clientScope, type);
   }
-  await addClientScope(adminClient, clientId, clientScope, changeTo);
+  await addClientScope(clientId, clientScope, changeTo);
 };
 
 export const removeClientScope = async (
-  adminClient: KeycloakAdminClient,
   clientId: string,
   clientScope: ClientScopeRepresentation,
   type: ClientScope
@@ -164,7 +158,6 @@ export const removeClientScope = async (
 };
 
 export const addClientScope = async (
-  adminClient: KeycloakAdminClient,
   clientId: string,
   clientScope: ClientScopeRepresentation,
   type: ClientScopeType

--- a/js/apps/admin-ui/src/components/client/ClientSelect.tsx
+++ b/js/apps/admin-ui/src/components/client/ClientSelect.tsx
@@ -1,3 +1,5 @@
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
 import {
   FormGroup,
   Select,
@@ -7,12 +9,11 @@ import {
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import type { ComponentProps } from "../dynamic/components";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
+import type { ComponentProps } from "../dynamic/components";
 
 type ClientSelectProps = ComponentProps & {
   namespace: string;
@@ -37,8 +38,6 @@ export const ClientSelect = ({
   const [open, setOpen] = useState(false);
   const [clients, setClients] = useState<ClientRepresentation[]>([]);
   const [search, setSearch] = useState("");
-
-  const { adminClient } = useAdminClient();
 
   useFetch(
     () => {

--- a/js/apps/admin-ui/src/components/download-dialog/DownloadDialog.tsx
+++ b/js/apps/admin-ui/src/components/download-dialog/DownloadDialog.tsx
@@ -11,13 +11,15 @@ import {
 import { saveAs } from "file-saver";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+
+import { HelpItem, useHelp } from "ui-shared";
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { addTrailingSlash, prettyPrintJSON } from "../../util";
 import { getAuthorizationHeaders } from "../../utils/getAuthorizationHeaders";
 import { ConfirmDialogModal } from "../confirm-dialog/ConfirmDialog";
-import { useHelp, HelpItem } from "ui-shared";
 import { KeycloakTextArea } from "../keycloak-text-area/KeycloakTextArea";
 
 type DownloadDialogProps = {
@@ -33,7 +35,6 @@ export const DownloadDialog = ({
   toggleDialog,
   protocol = "openid-connect",
 }: DownloadDialogProps) => {
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { t } = useTranslation("common");
   const { enabled } = useHelp();

--- a/js/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
+++ b/js/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -15,9 +14,11 @@ import {
   ModalVariant,
 } from "@patternfly/react-core";
 import { AngleRightIcon } from "@patternfly/react-icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 import { ListEmptyState } from "../list-empty-state/ListEmptyState";
 import { PaginatingTableToolbar } from "../table-toolbar/PaginatingTableToolbar";
 import { GroupPath } from "./GroupPath";
@@ -48,7 +49,6 @@ export const GroupPickerDialog = ({
   onConfirm,
 }: GroupPickerDialogProps) => {
   const { t } = useTranslation();
-  const { adminClient } = useAdminClient();
   const [selectedRows, setSelectedRows] = useState<SelectableGroup[]>([]);
 
   const [navigation, setNavigation] = useState<SelectableGroup[]>([]);

--- a/js/apps/admin-ui/src/components/permission-tab/PermissionTab.tsx
+++ b/js/apps/admin-ui/src/components/permission-tab/PermissionTab.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { Trans, useTranslation } from "react-i18next";
+import type { ManagementPermissionReference } from "@keycloak/keycloak-admin-client/lib/defs/managementPermissionReference";
 import {
   Card,
   CardBody,
@@ -19,13 +17,16 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
-import type { ManagementPermissionReference } from "@keycloak/keycloak-admin-client/lib/defs/managementPermissionReference";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useRealm } from "../../context/realm-context/RealmContext";
+import { adminClient } from "../../admin-client";
 import { toPermissionDetails } from "../../clients/routes/PermissionDetails";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { HelpItem } from "ui-shared";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
 import useLocaleSort from "../../utils/useLocaleSort";
 import { useConfirmDialog } from "../confirm-dialog/ConfirmDialog";
 
@@ -46,7 +47,6 @@ type PermissionsTabProps = {
 export const PermissionsTab = ({ id, type }: PermissionsTabProps) => {
   const { t } = useTranslation("common");
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const [realmId, setRealmId] = useState("");
   const [permission, setPermission] = useState<ManagementPermissionReference>();

--- a/js/apps/admin-ui/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/js/apps/admin-ui/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
 import {
   Button,
   Dropdown,
@@ -10,14 +8,15 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { FilterIcon } from "@patternfly/react-icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
-import { KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import useLocaleSort from "../../utils/useLocaleSort";
+import { ListEmptyState } from "../list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
 import { ResourcesKey, Row, ServiceRole } from "./RoleMapping";
 import { getAvailableRoles } from "./queries";
 import { getAvailableClientRoles } from "./resource";
-import { ListEmptyState } from "../list-empty-state/ListEmptyState";
 
 type AddRoleMappingModalProps = {
   id: string;
@@ -41,7 +40,6 @@ export const AddRoleMappingModal = ({
   onClose,
 }: AddRoleMappingModalProps) => {
   const { t } = useTranslation(type);
-  const { adminClient } = useAdminClient();
 
   const [searchToggle, setSearchToggle] = useState(false);
 
@@ -67,7 +65,7 @@ export const AddRoleMappingModal = ({
       params.search = search;
     }
 
-    const roles = await getAvailableRoles(adminClient, type, { ...params, id });
+    const roles = await getAvailableRoles(type, { ...params, id });
     const sorted = localeSort(roles, compareRow);
     return sorted.map((row) => {
       return {
@@ -83,7 +81,6 @@ export const AddRoleMappingModal = ({
     search?: string
   ): Promise<Row[]> => {
     const roles = await getAvailableClientRoles({
-      adminClient,
       id,
       type,
       first: first || 0,

--- a/js/apps/admin-ui/src/components/role-mapping/RoleMapping.tsx
+++ b/js/apps/admin-ui/src/components/role-mapping/RoleMapping.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import {
   AlertVariant,
   Badge,
@@ -9,17 +10,15 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { cellWidth } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
-import { AddRoleMappingModal } from "./AddRoleMappingModal";
-import { Action, KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
 import { emptyFormatter, upperCaseFormatter } from "../../util";
 import { useAlerts } from "../alert/Alerts";
 import { useConfirmDialog } from "../confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { ListEmptyState } from "../list-empty-state/ListEmptyState";
+import { Action, KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
+import { AddRoleMappingModal } from "./AddRoleMappingModal";
 import { deleteMapping, getEffectiveRoles, getMapping } from "./queries";
 import { getEffectiveClientRoles } from "./resource";
 
@@ -88,7 +87,6 @@ export const RoleMapping = ({
   save,
 }: RoleMappingProps) => {
   const { t } = useTranslation(type);
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [key, setKey] = useState(0);
@@ -107,11 +105,10 @@ export const RoleMapping = ({
     let effectiveRoles: Row[] = [];
     let effectiveClientRoles: Row[] = [];
     if (!hide) {
-      effectiveRoles = await getEffectiveRoles(adminClient, type, id);
+      effectiveRoles = await getEffectiveRoles(type, id);
 
       effectiveClientRoles = (
         await getEffectiveClientRoles({
-          adminClient,
           type,
           id,
         })
@@ -121,7 +118,7 @@ export const RoleMapping = ({
       }));
     }
 
-    const roles = await getMapping(adminClient, type, id);
+    const roles = await getMapping(type, id);
     const realmRolesMapping =
       roles.realmMappings?.map((role) => ({ role })) || [];
     const clientMapping = Object.values(roles.clientMappings || {})
@@ -149,7 +146,7 @@ export const RoleMapping = ({
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
       try {
-        await Promise.all(deleteMapping(adminClient, type, id, selected));
+        await Promise.all(deleteMapping(type, id, selected));
         addAlert(t("clients:clientScopeRemoveSuccess"), AlertVariant.success);
         refresh();
       } catch (error) {

--- a/js/apps/admin-ui/src/components/role-mapping/queries.ts
+++ b/js/apps/admin-ui/src/components/role-mapping/queries.ts
@@ -1,12 +1,13 @@
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
+import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
 import type MappingsRepresentation from "@keycloak/keycloak-admin-client/lib/defs/mappingsRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import type { ClientScopes } from "@keycloak/keycloak-admin-client/lib/resources/clientScopes";
+import type { Clients } from "@keycloak/keycloak-admin-client/lib/resources/clients";
 import type { Groups } from "@keycloak/keycloak-admin-client/lib/resources/groups";
 import type { Roles } from "@keycloak/keycloak-admin-client/lib/resources/roles";
 import type { Users } from "@keycloak/keycloak-admin-client/lib/resources/users";
-import type { Clients } from "@keycloak/keycloak-admin-client/lib/resources/clients";
-import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
 
+import { adminClient } from "../../admin-client";
 import { Row } from "./RoleMapping";
 
 export type ResourcesKey = keyof KeycloakAdminClient;
@@ -96,34 +97,23 @@ type queryType =
   | ListAvailableFunction
   | ListEffectiveFunction;
 
-const castAdminClient = (
-  adminClient: KeycloakAdminClient,
-  resource: ResourcesKey
-) =>
+const castAdminClient = (resource: ResourcesKey) =>
   adminClient[resource] as unknown as {
     [index in queryType]: (...params: any) => Promise<RoleRepresentation[]>;
   };
 
 const applyQuery = (
-  adminClient: KeycloakAdminClient,
   type: ResourcesKey,
   query: queryType,
   ...params: object[]
-): Promise<RoleRepresentation[]> =>
-  castAdminClient(adminClient, type)[query](...params);
+): Promise<RoleRepresentation[]> => castAdminClient(type)[query](...params);
 
-export const deleteMapping = (
-  adminClient: KeycloakAdminClient,
-  type: ResourcesKey,
-  id: string,
-  rows: Row[]
-) =>
+export const deleteMapping = (type: ResourcesKey, id: string, rows: Row[]) =>
   rows.map((row) => {
     const role = { id: row.role.id!, name: row.role.name! };
     const query = mapping[type]?.delete[row.client ? 0 : 1]!;
 
     return applyQuery(
-      adminClient,
       type,
       query,
       {
@@ -137,12 +127,11 @@ export const deleteMapping = (
   });
 
 export const getMapping = async (
-  adminClient: KeycloakAdminClient,
   type: ResourcesKey,
   id: string
 ): Promise<MappingsRepresentation> => {
   const query = mapping[type]!.listEffective[0];
-  const result = applyQuery(adminClient, type, query, { id });
+  const result = applyQuery(type, query, { id });
   if (type !== "roles") {
     return result as MappingsRepresentation;
   }
@@ -167,32 +156,30 @@ export const getMapping = async (
 };
 
 export const getEffectiveRoles = async (
-  adminClient: KeycloakAdminClient,
   type: ResourcesKey,
   id: string
 ): Promise<Row[]> => {
   const query = mapping[type]!.listEffective[1];
   if (type !== "roles") {
-    return (await applyQuery(adminClient, type, query, { id })).map((role) => ({
+    return (await applyQuery(type, query, { id })).map((role) => ({
       role,
     }));
   }
-  const roles = await applyQuery(adminClient, type, query, { id });
+  const roles = await applyQuery(type, query, { id });
   const parentRoles = await Promise.all(
     roles
       .filter((r) => r.composite)
-      .map((r) => applyQuery(adminClient, type, query, { id: r.id }))
+      .map((r) => applyQuery(type, query, { id: r.id }))
   );
   return [...roles, ...parentRoles.flat()].map((role) => ({ role }));
 };
 
 export const getAvailableRoles = async (
-  adminClient: KeycloakAdminClient,
   type: ResourcesKey,
   params: Record<string, string | number>
 ): Promise<Row[]> => {
   const query = mapping[type]!.listAvailable[1];
-  return (await applyQuery(adminClient, type, query, params)).map((role) => ({
+  return (await applyQuery(type, query, params)).map((role) => ({
     role,
   }));
 };

--- a/js/apps/admin-ui/src/components/role-mapping/resource.ts
+++ b/js/apps/admin-ui/src/components/role-mapping/resource.ts
@@ -1,12 +1,8 @@
-import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
-import { fetchAdminUI } from "../../context/auth/admin-ui-endpoint";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 
-type BaseQuery = {
-  adminClient: KeycloakAdminClient;
-};
+import { fetchAdminUI } from "../../context/auth/admin-ui-endpoint";
 
-type IDQuery = BaseQuery & {
+type IDQuery = {
   id: string;
   type: string;
 };
@@ -20,7 +16,6 @@ type PaginatingQuery = IDQuery & {
 type EffectiveClientRolesQuery = IDQuery;
 
 type Query = Partial<Omit<PaginatingQuery, "adminClient">> & {
-  adminClient: KeycloakAdminClient;
   endpoint: string;
 };
 
@@ -33,7 +28,6 @@ type ClientRole = {
 };
 
 const fetchEndpoint = async ({
-  adminClient,
   id,
   type,
   first,
@@ -41,7 +35,7 @@ const fetchEndpoint = async ({
   search,
   endpoint,
 }: Query): Promise<any> =>
-  fetchAdminUI(adminClient, `/ui-ext/${endpoint}/${type}/${id}`, {
+  fetchAdminUI(`/ui-ext/${endpoint}/${type}/${id}`, {
     first: (first || 0).toString(),
     max: (max || 10).toString(),
     search: search || "",
@@ -57,7 +51,7 @@ export const getEffectiveClientRoles = (
 ): Promise<ClientRole[]> =>
   fetchEndpoint({ ...query, endpoint: "effective-roles" });
 
-type UserQuery = BaseQuery & {
+type UserQuery = {
   lastName?: string;
   firstName?: string;
   email?: string;
@@ -75,15 +69,8 @@ export type BruteUser = UserRepresentation & {
   bruteForceStatus?: Record<string, object>;
 };
 
-export const findUsers = ({
-  adminClient,
-  ...query
-}: UserQuery): Promise<BruteUser[]> =>
-  fetchAdminUI(
-    adminClient,
-    "ui-ext/brute-force-user",
-    query as Record<string, string>
-  );
+export const findUsers = (query: UserQuery): Promise<BruteUser[]> =>
+  fetchAdminUI("ui-ext/brute-force-user", query as Record<string, string>);
 
 export const fetchUsedBy = (query: PaginatingQuery): Promise<string[]> =>
   fetchEndpoint({ ...query, endpoint: "authentication-management" });

--- a/js/apps/admin-ui/src/components/roles-list/RolesList.tsx
+++ b/js/apps/admin-ui/src/components/roles-list/RolesList.tsx
@@ -4,14 +4,15 @@ import { AlertVariant, Button, ButtonVariant } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, To, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toRealmSettings } from "../../realm-settings/routes/RealmSettings";
 import { emptyFormatter, upperCaseFormatter } from "../../util";
 import { useAlerts } from "../alert/Alerts";
 import { useConfirmDialog } from "../confirm-dialog/ConfirmDialog";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../keycloak-spinner/KeycloakSpinner";
 import { ListEmptyState } from "../list-empty-state/ListEmptyState";
 import { Action, KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
@@ -73,7 +74,6 @@ export const RolesList = ({
 }: RolesListProps) => {
   const { t } = useTranslation(messageBundle);
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
   const [realm, setRealm] = useState<RealmRepresentation>();

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -1,21 +1,21 @@
-import { useCallback, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Controller, useFormContext } from "react-hook-form";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
+import type { UserQuery } from "@keycloak/keycloak-admin-client/lib/resources/users";
 import {
-  SelectOption,
   FormGroup,
   Select,
+  SelectOption,
   SelectVariant,
 } from "@patternfly/react-core";
 import { debounce } from "lodash-es";
-
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-import type { UserQuery } from "@keycloak/keycloak-admin-client/lib/resources/users";
-import type { ComponentProps } from "../dynamic/components";
-
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useCallback, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 import useToggle from "../../utils/useToggle";
+import type { ComponentProps } from "../dynamic/components";
 
 type UserSelectProps = ComponentProps & {
   variant?: SelectVariant;
@@ -42,7 +42,6 @@ export const UserSelect = ({
   const [users, setUsers] = useState<(UserRepresentation | undefined)[]>([]);
   const [search, setSearch] = useState("");
 
-  const { adminClient } = useAdminClient();
   const debounceFn = useCallback(debounce(setSearch, 1000), []);
 
   useFetch(

--- a/js/apps/admin-ui/src/context/RealmsContext.tsx
+++ b/js/apps/admin-ui/src/context/RealmsContext.tsx
@@ -4,8 +4,9 @@ import { sortBy } from "lodash-es";
 import { PropsWithChildren, useCallback, useMemo, useState } from "react";
 import { createNamedContext, useRequiredContext } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { keycloak } from "../keycloak";
-import { useAdminClient, useFetch } from "./auth/AdminClient";
+import { useFetch } from "./auth/AdminClient";
 
 type RealmsContextProps = {
   /** A list of all the realms. */
@@ -20,7 +21,6 @@ export const RealmsContext = createNamedContext<RealmsContextProps | undefined>(
 );
 
 export const RealmsProvider = ({ children }: PropsWithChildren) => {
-  const { adminClient } = useAdminClient();
   const [realms, setRealms] = useState<RealmRepresentation[]>([]);
   const [refreshCount, setRefreshCount] = useState(0);
 

--- a/js/apps/admin-ui/src/context/auth/AdminClient.tsx
+++ b/js/apps/admin-ui/src/context/auth/AdminClient.tsx
@@ -1,26 +1,5 @@
-import KeycloakAdminClient from "@keycloak/keycloak-admin-client";
-import { DependencyList, PropsWithChildren, useEffect } from "react";
+import { DependencyList, useEffect } from "react";
 import { useErrorHandler } from "react-error-boundary";
-import { createNamedContext, useRequiredContext } from "ui-shared";
-
-import { adminClient } from "../../admin-client";
-
-export type AdminClientProps = {
-  adminClient: KeycloakAdminClient;
-};
-
-const AdminClientContext = createNamedContext<AdminClientProps | undefined>(
-  "AdminClientContext",
-  undefined
-);
-
-export const AdminClientProvider = ({ children }: PropsWithChildren) => (
-  <AdminClientContext.Provider value={{ adminClient }}>
-    {children}
-  </AdminClientContext.Provider>
-);
-
-export const useAdminClient = () => useRequiredContext(AdminClientContext);
 
 /**
  * Util function to only set the state when the component is still mounted.

--- a/js/apps/admin-ui/src/context/auth/admin-ui-endpoint.ts
+++ b/js/apps/admin-ui/src/context/auth/admin-ui-endpoint.ts
@@ -1,10 +1,8 @@
-import KeycloakAdminClient from "@keycloak/keycloak-admin-client";
-
+import { adminClient } from "../../admin-client";
 import { getAuthorizationHeaders } from "../../utils/getAuthorizationHeaders";
 import { joinPath } from "../../utils/joinPath";
 
 export async function fetchAdminUI<T>(
-  adminClient: KeycloakAdminClient,
   endpoint: string,
   query?: Record<string, string>
 ): Promise<T> {

--- a/js/apps/admin-ui/src/context/realm-context/RealmContext.tsx
+++ b/js/apps/admin-ui/src/context/realm-context/RealmContext.tsx
@@ -1,10 +1,10 @@
 import { PropsWithChildren, useEffect, useMemo } from "react";
 import { useMatch } from "react-router-dom";
+import { createNamedContext, useRequiredContext } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { DashboardRouteWithRealm } from "../../dashboard/routes/Dashboard";
 import environment from "../../environment";
-import { createNamedContext, useRequiredContext } from "ui-shared";
-import { useAdminClient } from "../auth/AdminClient";
 
 type RealmContextType = {
   realm: string;
@@ -16,7 +16,6 @@ export const RealmContext = createNamedContext<RealmContextType | undefined>(
 );
 
 export const RealmContextProvider = ({ children }: PropsWithChildren) => {
-  const { adminClient } = useAdminClient();
   const routeMatch = useMatch({
     path: DashboardRouteWithRealm.path,
     end: false,

--- a/js/apps/admin-ui/src/context/server-info/ServerInfoProvider.tsx
+++ b/js/apps/admin-ui/src/context/server-info/ServerInfoProvider.tsx
@@ -1,9 +1,10 @@
 import type { ServerInfoRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import { PropsWithChildren, useState } from "react";
-
-import { sortProviders } from "../../util";
 import { createNamedContext, useRequiredContext } from "ui-shared";
-import { useAdminClient, useFetch } from "../auth/AdminClient";
+
+import { adminClient } from "../../admin-client";
+import { sortProviders } from "../../util";
+import { useFetch } from "../auth/AdminClient";
 
 export const ServerInfoContext = createNamedContext<
   ServerInfoRepresentation | undefined
@@ -15,7 +16,6 @@ export const useLoginProviders = () =>
   sortProviders(useServerInfo().providers!["login-protocol"].providers);
 
 export const ServerInfoProvider = ({ children }: PropsWithChildren) => {
-  const { adminClient } = useAdminClient();
   const [serverInfo, setServerInfo] = useState<ServerInfoRepresentation>({});
 
   useFetch(adminClient.serverInfo.find, setServerInfo, []);

--- a/js/apps/admin-ui/src/context/whoami/WhoAmI.tsx
+++ b/js/apps/admin-ui/src/context/whoami/WhoAmI.tsx
@@ -1,11 +1,12 @@
 import type WhoAmIRepresentation from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 import { PropsWithChildren, useState } from "react";
+import { createNamedContext, useRequiredContext } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import environment from "../../environment";
 import i18n, { DEFAULT_LOCALE } from "../../i18n";
-import { createNamedContext, useRequiredContext } from "ui-shared";
-import { useAdminClient, useFetch } from "../auth/AdminClient";
+import { useFetch } from "../auth/AdminClient";
 
 export class WhoAmI {
   constructor(private me?: WhoAmIRepresentation) {
@@ -62,7 +63,6 @@ export const WhoAmIContext = createNamedContext<WhoAmIProps | undefined>(
 export const useWhoAmI = () => useRequiredContext(WhoAmIContext);
 
 export const WhoAmIContextProvider = ({ children }: PropsWithChildren) => {
-  const { adminClient } = useAdminClient();
   const [whoAmI, setWhoAmI] = useState<WhoAmI>(new WhoAmI());
   const [key, setKey] = useState(0);
 

--- a/js/apps/admin-ui/src/events/AdminEvents.tsx
+++ b/js/apps/admin-ui/src/events/AdminEvents.tsx
@@ -19,24 +19,24 @@ import {
   SelectVariant,
 } from "@patternfly/react-core";
 import {
-  cellWidth,
   Table,
   TableBody,
   TableHeader,
   TableVariant,
+  cellWidth,
 } from "@patternfly/react-table";
 import { pickBy } from "lodash-es";
 import { PropsWithChildren, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../admin-client";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { prettyPrintJSON } from "../util";
@@ -94,7 +94,6 @@ const DisplayDialog = ({
 
 export const AdminEvents = () => {
   const { t } = useTranslation("events");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const serverInfo = useServerInfo();
   const formatDate = useFormatDate();

--- a/js/apps/admin-ui/src/events/EventsSection.tsx
+++ b/js/apps/admin-ui/src/events/EventsSection.tsx
@@ -33,6 +33,7 @@ import { Controller, useForm } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import {
@@ -41,7 +42,7 @@ import {
 } from "../components/routable-tabs/RoutableTabs";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import helpUrls from "../help-urls";
 import { toRealmSettings } from "../realm-settings/routes/RealmSettings";
@@ -126,7 +127,6 @@ const UserDetailLink = (event: EventRepresentation) => {
 
 export default function EventsSection() {
   const { t } = useTranslation("events");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const formatDate = useFormatDate();
   const [key, setKey] = useState(0);

--- a/js/apps/admin-ui/src/groups/GroupAttributes.tsx
+++ b/js/apps/admin-ui/src/groups/GroupAttributes.tsx
@@ -1,30 +1,28 @@
-import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
 import {
   AlertVariant,
   PageSection,
   PageSectionVariants,
 } from "@patternfly/react-core";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import {
   AttributeForm,
   AttributesForm,
 } from "../components/key-value-form/AttributeForm";
 import {
-  keyValueToArray,
   arrayToKeyValue,
+  keyValueToArray,
 } from "../components/key-value-form/key-value-convert";
-import { useAdminClient } from "../context/auth/AdminClient";
-
-import { getLastId } from "./groupIdUtils";
 import { useSubGroups } from "./SubGroupsContext";
-import { useLocation } from "react-router-dom";
+import { getLastId } from "./groupIdUtils";
 
 export const GroupAttributes = () => {
   const { t } = useTranslation("groups");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const form = useForm<AttributeForm>({
     mode: "onChange",

--- a/js/apps/admin-ui/src/groups/GroupRoleMapping.tsx
+++ b/js/apps/admin-ui/src/groups/GroupRoleMapping.tsx
@@ -1,8 +1,8 @@
-import { useTranslation } from "react-i18next";
-import { AlertVariant } from "@patternfly/react-core";
-
 import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { AlertVariant } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { RoleMapping, Row } from "../components/role-mapping/RoleMapping";
 
@@ -13,7 +13,6 @@ type GroupRoleMappingProps = {
 
 export const GroupRoleMapping = ({ id, name }: GroupRoleMappingProps) => {
   const { t } = useTranslation("clients");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const assignRoles = async (rows: Row[]) => {

--- a/js/apps/admin-ui/src/groups/GroupTable.tsx
+++ b/js/apps/admin-ui/src/groups/GroupTable.tsx
@@ -1,23 +1,23 @@
-import { useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
-import { SearchInput, ToolbarItem } from "@patternfly/react-core";
-
 import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { SearchInput, ToolbarItem } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+
+import { adminClient } from "../admin-client";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { useAccess } from "../context/access/Access";
 import { fetchAdminUI } from "../context/auth/admin-ui-endpoint";
 import { useRealm } from "../context/realm-context/RealmContext";
-import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { GroupsModal } from "./GroupsModal";
-import { getLastId } from "./groupIdUtils";
-import { useSubGroups } from "./SubGroupsContext";
-import { toGroups } from "./routes/Groups";
-import { useAccess } from "../context/access/Access";
 import useToggle from "../utils/useToggle";
+import { GroupsModal } from "./GroupsModal";
+import { useSubGroups } from "./SubGroupsContext";
 import { DeleteGroup } from "./components/DeleteGroup";
 import { GroupToolbar } from "./components/GroupToolbar";
 import { MoveDialog } from "./components/MoveDialog";
+import { getLastId } from "./groupIdUtils";
+import { toGroups } from "./routes/Groups";
 
 type GroupTableProps = {
   refresh: () => void;
@@ -30,7 +30,6 @@ export const GroupTable = ({
 }: GroupTableProps) => {
   const { t } = useTranslation("groups");
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const [selectedRows, setSelectedRows] = useState<GroupRepresentation[]>([]);
 
@@ -70,14 +69,10 @@ export const GroupTable = ({
         ? group.subGroups
         : group.subGroups?.filter((g) => g.name?.includes(search));
     } else {
-      groupsData = await fetchAdminUI<GroupRepresentation[]>(
-        adminClient,
-        "ui-ext/groups",
-        {
-          ...params,
-          global: "false",
-        }
-      );
+      groupsData = await fetchAdminUI<GroupRepresentation[]>("ui-ext/groups", {
+        ...params,
+        global: "false",
+      });
     }
 
     if (!groupsData) {

--- a/js/apps/admin-ui/src/groups/GroupsModal.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsModal.tsx
@@ -1,3 +1,4 @@
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import {
   AlertVariant,
   Button,
@@ -8,11 +9,10 @@ import {
   ModalVariant,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 
@@ -30,7 +30,6 @@ export const GroupsModal = ({
   refresh,
 }: GroupsModalProps) => {
   const { t } = useTranslation("groups");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const {
     register,

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -16,11 +16,12 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { GroupBreadCrumbs } from "../components/bread-crumb/GroupBreadCrumbs";
 import { PermissionsTab } from "../components/permission-tab/PermissionTab";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import helpUrls from "../help-urls";
 import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
@@ -42,7 +43,6 @@ export default function GroupsSection() {
   const { t } = useTranslation("groups");
   const [activeTab, setActiveTab] = useState(0);
 
-  const { adminClient } = useAdminClient();
   const { subGroups, setSubGroups, currentGroup } = useSubGroups();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/groups/Members.tsx
+++ b/js/apps/admin-ui/src/groups/Members.tsx
@@ -1,7 +1,5 @@
-import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { useTranslation } from "react-i18next";
-import { uniqBy } from "lodash-es";
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   AlertVariant,
   Button,
@@ -11,25 +9,26 @@ import {
   KebabToggle,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { uniqBy } from "lodash-es";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useLocation } from "react-router-dom";
 
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
+import { GroupPath } from "../components/group/GroupPath";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
-import { useRealm } from "../context/realm-context/RealmContext";
-import { useAlerts } from "../components/alert/Alerts";
-import { emptyFormatter } from "../util";
-
-import { getLastId } from "./groupIdUtils";
-import { useSubGroups } from "./SubGroupsContext";
-import { MemberModal } from "./MembersModal";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { GroupPath } from "../components/group/GroupPath";
-import { toUser } from "../user/routes/User";
 import { useAccess } from "../context/access/Access";
+import { useRealm } from "../context/realm-context/RealmContext";
+import { toUser } from "../user/routes/User";
+import { emptyFormatter } from "../util";
+import { MemberModal } from "./MembersModal";
+import { useSubGroups } from "./SubGroupsContext";
+import { getLastId } from "./groupIdUtils";
 
 type MembersOf = UserRepresentation & {
   membership: GroupRepresentation[];
@@ -59,7 +58,6 @@ const UserDetailLink = (user: MembersOf) => {
 
 export const Members = () => {
   const { t } = useTranslation("groups");
-  const { adminClient } = useAdminClient();
 
   const { addAlert, addError } = useAlerts();
   const location = useLocation();

--- a/js/apps/admin-ui/src/groups/MembersModal.tsx
+++ b/js/apps/admin-ui/src/groups/MembersModal.tsx
@@ -1,19 +1,19 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   AlertVariant,
   Button,
   Modal,
   ModalVariant,
 } from "@patternfly/react-core";
-
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
-import { useAlerts } from "../components/alert/Alerts";
-import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { emptyFormatter } from "../util";
 import { differenceBy } from "lodash-es";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { emptyFormatter } from "../util";
 
 type MemberModalProps = {
   groupId: string;
@@ -22,7 +22,6 @@ type MemberModalProps = {
 
 export const MemberModal = ({ groupId, onClose }: MemberModalProps) => {
   const { t } = useTranslation("groups");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const [selectedRows, setSelectedRows] = useState<UserRepresentation[]>([]);
 

--- a/js/apps/admin-ui/src/groups/components/DeleteGroup.tsx
+++ b/js/apps/admin-ui/src/groups/components/DeleteGroup.tsx
@@ -1,10 +1,10 @@
-import { useTranslation } from "react-i18next";
-import { ButtonVariant } from "@patternfly/react-core";
-
 import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import { ConfirmDialogModal } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
+import { ButtonVariant } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
+import { ConfirmDialogModal } from "../../components/confirm-dialog/ConfirmDialog";
 
 type DeleteConfirmProps = {
   selectedRows: GroupRepresentation[];
@@ -20,7 +20,6 @@ export const DeleteGroup = ({
   refresh,
 }: DeleteConfirmProps) => {
   const { t } = useTranslation("groups");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const multiDelete = async () => {

--- a/js/apps/admin-ui/src/groups/components/GroupTree.tsx
+++ b/js/apps/admin-ui/src/groups/components/GroupTree.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import {
   AlertVariant,
   Checkbox,
@@ -14,22 +12,25 @@ import {
   TreeView,
   TreeViewDataItem,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { adminClient } from "../../admin-client";
+import { useAlerts } from "../../components/alert/Alerts";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import useToggle from "../../utils/useToggle";
-import { DeleteGroup } from "./DeleteGroup";
-import { GroupsModal } from "../GroupsModal";
-import { MoveDialog } from "./MoveDialog";
 import { PaginatingTableToolbar } from "../../components/table-toolbar/PaginatingTableToolbar";
-import { useSubGroups } from "../SubGroupsContext";
+import { useAccess } from "../../context/access/Access";
+import { useFetch } from "../../context/auth/AdminClient";
 import { fetchAdminUI } from "../../context/auth/admin-ui-endpoint";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { joinPath } from "../../utils/joinPath";
+import useToggle from "../../utils/useToggle";
+import { GroupsModal } from "../GroupsModal";
+import { useSubGroups } from "../SubGroupsContext";
 import { toGroups } from "../routes/Groups";
-import { useAlerts } from "../../components/alert/Alerts";
-import { useAccess } from "../../context/access/Access";
+import { DeleteGroup } from "./DeleteGroup";
+import { MoveDialog } from "./MoveDialog";
 
 import "./group-tree.css";
 
@@ -113,7 +114,6 @@ export const GroupTree = ({
   canViewDetails,
 }: GroupTreeProps) => {
   const { t } = useTranslation("groups");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const navigate = useNavigate();
   const { addAlert } = useAlerts();
@@ -163,7 +163,6 @@ export const GroupTree = ({
   useFetch(
     async () => {
       const groups = await fetchAdminUI<GroupRepresentation[]>(
-        adminClient,
         "ui-ext/groups",
         Object.assign(
           {

--- a/js/apps/admin-ui/src/groups/components/MoveDialog.tsx
+++ b/js/apps/admin-ui/src/groups/components/MoveDialog.tsx
@@ -1,10 +1,9 @@
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import { useTranslation } from "react-i18next";
 
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { GroupPickerDialog } from "../../components/group/GroupPickerDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
 
 type MoveDialogProps = {
   source: GroupRepresentation;
@@ -12,10 +11,7 @@ type MoveDialogProps = {
   refresh: () => void;
 };
 
-const moveToRoot = async (
-  adminClient: KeycloakAdminClient,
-  source: GroupRepresentation
-) => {
+const moveToRoot = async (source: GroupRepresentation) => {
   await adminClient.groups.del({ id: source.id! });
   const { id } = await adminClient.groups.create({
     ...source,
@@ -37,7 +33,6 @@ const moveToRoot = async (
 };
 
 const moveToGroup = async (
-  adminClient: KeycloakAdminClient,
   source: GroupRepresentation,
   dest: GroupRepresentation
 ) => {
@@ -52,15 +47,11 @@ const moveToGroup = async (
 
 export const MoveDialog = ({ source, onClose, refresh }: MoveDialogProps) => {
   const { t } = useTranslation("groups");
-
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const moveGroup = async (group?: GroupRepresentation[]) => {
     try {
-      await (group
-        ? moveToGroup(adminClient, source, group[0])
-        : moveToRoot(adminClient, source));
+      await (group ? moveToGroup(source, group[0]) : moveToRoot(source));
       refresh();
       addAlert(t("moveGroupSuccess"));
     } catch (error) {

--- a/js/apps/admin-ui/src/identity-providers/IdentityProvidersSection.tsx
+++ b/js/apps/admin-ui/src/identity-providers/IdentityProvidersSection.tsx
@@ -1,3 +1,4 @@
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import {
   AlertVariant,
   Badge,
@@ -22,9 +23,9 @@ import { groupBy, sortBy } from "lodash-es";
 import { Fragment, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
-
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import { IconMapper } from "ui-shared";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ClickableCard } from "../components/keycloak-card/ClickableCard";
@@ -33,7 +34,7 @@ import {
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import helpUrls from "../help-urls";
@@ -87,8 +88,6 @@ export default function IdentityProvidersSection() {
     useState<IdentityProviderRepresentation[]>();
   const [selectedProvider, setSelectedProvider] =
     useState<IdentityProviderRepresentation>();
-
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   useFetch(

--- a/js/apps/admin-ui/src/identity-providers/ManageOrderDialog.tsx
+++ b/js/apps/admin-ui/src/identity-providers/ManageOrderDialog.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { sortBy } from "lodash-es";
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import {
   Button,
   ButtonVariant,
@@ -13,11 +11,14 @@ import {
   DataListItemRow,
   Modal,
   ModalVariant,
-  TextContent,
   Text,
+  TextContent,
 } from "@patternfly/react-core";
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { sortBy } from "lodash-es";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 
 type ManageOrderDialogProps = {
@@ -30,7 +31,6 @@ export const ManageOrderDialog = ({
   onClose,
 }: ManageOrderDialogProps) => {
   const { t } = useTranslation("identity-providers");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [alias, setAlias] = useState("");

--- a/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
@@ -8,11 +8,10 @@ import {
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
-
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toUpperCase } from "../../util";
 import { useParams } from "../../utils/useParams";
@@ -31,7 +30,6 @@ export default function AddIdentityProvider() {
     formState: { isDirty },
   } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
   const { realm } = useRealm();

--- a/js/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
@@ -16,6 +16,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
@@ -24,7 +25,7 @@ import type { AttributeForm } from "../../components/key-value-form/AttributeFor
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
 import useLocaleSort, { mapByKey } from "../../utils/useLocaleSort";
@@ -57,7 +58,6 @@ export default function AddMapper() {
   const localeSort = useLocaleSort();
 
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
 
   const { id, providerId, alias } =
     useParams<IdentityProviderEditMapperParams>();

--- a/js/apps/admin-ui/src/identity-providers/add/AddOpenIdConnect.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddOpenIdConnect.tsx
@@ -9,10 +9,10 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toIdentityProvider } from "../routes/IdentityProvider";
 import { toIdentityProviders } from "../routes/IdentityProviders";
@@ -39,7 +39,6 @@ export default function AddOpenIdConnect() {
     formState: { isDirty },
   } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/identity-providers/add/AddSamlConnect.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddSamlConnect.tsx
@@ -1,3 +1,4 @@
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -8,11 +9,10 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toIdentityProvider } from "../routes/IdentityProvider";
 import { toIdentityProviders } from "../routes/IdentityProviders";
@@ -36,7 +36,6 @@ export default function AddSamlConnect() {
     formState: { isDirty },
   } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert } = useAlerts();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/identity-providers/add/AdvancedSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AdvancedSettings.tsx
@@ -1,3 +1,4 @@
+import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
 import {
   FormGroup,
   Select,
@@ -7,10 +8,10 @@ import {
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
 import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 import type { FieldProps } from "../component/FormGroupField";
 import { SwitchField } from "../component/SwitchField";
 import { TextField } from "../component/TextField";
@@ -23,7 +24,6 @@ const LoginFlow = ({
   const { t } = useTranslation("identity-providers");
   const { control } = useFormContext();
 
-  const { adminClient } = useAdminClient();
   const [flows, setFlows] = useState<AuthenticationFlowRepresentation[]>();
   const [open, setOpen] = useState(false);
 

--- a/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -18,6 +18,7 @@ import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
@@ -34,7 +35,7 @@ import {
   KeycloakDataTable,
 } from "../../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toUpperCase } from "../../util";
 import useIsFeatureEnabled, { Feature } from "../../utils/useIsFeatureEnabled";
@@ -76,7 +77,6 @@ type IdPWithMapperAttributes = IdentityProviderMapperRepresentation & {
 const Header = ({ onChange, value, save, toggleDeleteDialog }: HeaderProps) => {
   const { t } = useTranslation("identity-providers");
   const { alias: displayName } = useParams<{ alias: string }>();
-  const { adminClient } = useAdminClient();
   const [provider, setProvider] = useState<IdentityProviderRepresentation>();
 
   useFetch(
@@ -163,7 +163,6 @@ export default function DetailSettings() {
   const [selectedMapper, setSelectedMapper] =
     useState<IdPWithMapperAttributes>();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
   const { realm } = useRealm();

--- a/js/apps/admin-ui/src/identity-providers/add/OpenIdConnectSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/OpenIdConnectSettings.tsx
@@ -1,10 +1,10 @@
 import { FormGroup, Title } from "@patternfly/react-core";
 import { useFormContext } from "react-hook-form";
-
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
 import { JsonFileUpload } from "../../components/json-file-upload/JsonFileUpload";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { addTrailingSlash } from "../../util";
 import { getAuthorizationHeaders } from "../../utils/getAuthorizationHeaders";
@@ -15,7 +15,6 @@ export const OpenIdConnectSettings = () => {
   const { t } = useTranslation("identity-providers");
   const id = "oidc";
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const {
     setValue,

--- a/js/apps/admin-ui/src/identity-providers/add/SamlConnectSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/SamlConnectSettings.tsx
@@ -1,11 +1,10 @@
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import { FormGroup, Title } from "@patternfly/react-core";
 import { useFormContext } from "react-hook-form";
-
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { useAdminClient } from "../../context/auth/AdminClient";
 
+import { adminClient } from "../../admin-client";
 import { FileUploadForm } from "../../components/json-file-upload/FileUploadForm";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { useRealm } from "../../context/realm-context/RealmContext";
@@ -23,7 +22,6 @@ export const SamlConnectSettings = () => {
   const { t } = useTranslation("identity-providers");
   const id = "saml";
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const {
     setValue,

--- a/js/apps/admin-ui/src/identity-providers/component/DiscoveryEndpointField.tsx
+++ b/js/apps/admin-ui/src/identity-providers/component/DiscoveryEndpointField.tsx
@@ -2,10 +2,10 @@ import { FormGroup, Switch } from "@patternfly/react-core";
 import { ReactNode, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import environment from "../../environment";
 
 type DiscoveryEndpointFieldProps = {
@@ -20,9 +20,6 @@ export const DiscoveryEndpointField = ({
   children,
 }: DiscoveryEndpointFieldProps) => {
   const { t } = useTranslation("identity-providers");
-
-  const { adminClient } = useAdminClient();
-
   const {
     setValue,
     register,

--- a/js/apps/admin-ui/src/identity-providers/component/RedirectUrl.tsx
+++ b/js/apps/admin-ui/src/identity-providers/component/RedirectUrl.tsx
@@ -1,15 +1,14 @@
-import { useTranslation } from "react-i18next";
 import { ClipboardCopy, FormGroup } from "@patternfly/react-core";
-
+import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { addTrailingSlash } from "../../util";
 
 export const RedirectUrl = ({ id }: { id: string }) => {
   const { t } = useTranslation("identity-providers");
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const callbackUrl = `${addTrailingSlash(
     adminClient.baseUrl

--- a/js/apps/admin-ui/src/realm-roles/CreateRealmRole.tsx
+++ b/js/apps/admin-ui/src/realm-roles/CreateRealmRole.tsx
@@ -4,10 +4,10 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { AttributeForm } from "../components/key-value-form/AttributeForm";
 import { RoleForm } from "../components/role-form/RoleForm";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { toRealmRole } from "./routes/RealmRole";
 import { toRealmRoles } from "./routes/RealmRoles";
@@ -16,7 +16,6 @@ export default function CreateRealmRole() {
   const { t } = useTranslation("roles");
   const form = useForm<AttributeForm>({ mode: "onChange" });
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
 

--- a/js/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
+++ b/js/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
@@ -13,6 +13,7 @@ import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useLocation, useMatch, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { toClient } from "../clients/routes/Client";
 import {
   ClientRoleParams,
@@ -41,7 +42,7 @@ import {
   useRoutableTab,
 } from "../components/routable-tabs/RoutableTabs";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
 import { useParams } from "../utils/useParams";
@@ -57,8 +58,6 @@ export default function RealmRoleTabs() {
   });
   const { control, reset, setValue } = form;
   const navigate = useNavigate();
-
-  const { adminClient } = useAdminClient();
 
   const { id, clientId } = useParams<ClientRoleParams>();
   const { pathname } = useLocation();

--- a/js/apps/admin-ui/src/realm-roles/RealmRolesSection.tsx
+++ b/js/apps/admin-ui/src/realm-roles/RealmRolesSection.tsx
@@ -1,16 +1,15 @@
 import { PageSection } from "@patternfly/react-core";
 
+import { adminClient } from "../admin-client";
 import { RolesList } from "../components/roles-list/RolesList";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import helpUrls from "../help-urls";
 import { toAddRole } from "./routes/AddRole";
 import { toRealmRole } from "./routes/RealmRole";
 
 export default function RealmRolesSection() {
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { hasAccess } = useAccess();
   const isManager = hasAccess("manage-realm");

--- a/js/apps/admin-ui/src/realm-roles/UsersInRoleTab.tsx
+++ b/js/apps/admin-ui/src/realm-roles/UsersInRoleTab.tsx
@@ -2,12 +2,12 @@ import { Button, PageSection, Popover } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-
-import type { ClientRoleParams } from "../clients/routes/ClientRole";
 import { useHelp } from "ui-shared";
+
+import { adminClient } from "../admin-client";
+import type { ClientRoleParams } from "../clients/routes/ClientRole";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { emptyFormatter, upperCaseFormatter } from "../util";
 import { useParams } from "../utils/useParams";
@@ -18,8 +18,6 @@ export const UsersInRoleTab = () => {
 
   const { t } = useTranslation("roles");
   const { id, clientId } = useParams<ClientRoleParams>();
-
-  const { adminClient } = useAdminClient();
 
   const loader = async (first?: number, max?: number) => {
     const role = await adminClient.roles.findOneById({ id: id });

--- a/js/apps/admin-ui/src/realm-settings/AddClientProfileModal.tsx
+++ b/js/apps/admin-ui/src/realm-settings/AddClientProfileModal.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
-import { Button, Label, Modal, ModalVariant } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { useFetch, useAdminClient } from "../context/auth/AdminClient";
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
+import { Button, Label, Modal, ModalVariant } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { useFetch } from "../context/auth/AdminClient";
 
 type ClientProfile = ClientProfileRepresentation & {
   global: boolean;
@@ -32,7 +34,6 @@ export type AddClientProfileModalProps = {
 
 export const AddClientProfileModal = (props: AddClientProfileModalProps) => {
   const { t } = useTranslation("roles");
-  const { adminClient } = useAdminClient();
   const [selectedRows, setSelectedRows] = useState<RoleRepresentation[]>([]);
 
   const [tableProfiles, setTableProfiles] = useState<ClientProfile[]>();

--- a/js/apps/admin-ui/src/realm-settings/AddMessageBundleModal.tsx
+++ b/js/apps/admin-ui/src/realm-settings/AddMessageBundleModal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Button,
   ButtonVariant,
@@ -22,6 +21,8 @@ type AddMessageBundleModalProps = {
 };
 
 export type BundleForm = {
+  key: string;
+  value: string;
   messageBundle: KeyValueType;
 };
 

--- a/js/apps/admin-ui/src/realm-settings/ClientProfileForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/ClientProfileForm.tsx
@@ -26,16 +26,17 @@ import { Fragment, useMemo, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextArea } from "../components/keycloak-text-area/KeycloakTextArea";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { useParams } from "../utils/useParams";
 import { toAddExecutor } from "./routes/AddExecutor";
@@ -74,7 +75,6 @@ export default function ClientProfileForm() {
   });
 
   const { addAlert, addError } = useAlerts();
-  const { adminClient } = useAdminClient();
   const [profiles, setProfiles] = useState<ClientProfilesRepresentation>();
   const [isGlobalProfile, setIsGlobalProfile] = useState(false);
   const { realm, profileName } = useParams<ClientProfileParams>();

--- a/js/apps/admin-ui/src/realm-settings/DefaultGroupsTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/DefaultGroupsTab.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
-import { Trans, useTranslation } from "react-i18next";
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import {
   AlertVariant,
   Button,
@@ -14,22 +12,25 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
+import { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { useHelp } from "ui-shared";
 
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { GroupPickerDialog } from "../components/group/GroupPickerDialog";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import useToggle from "../utils/useToggle";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { useAlerts } from "../components/alert/Alerts";
-import { toUserFederation } from "../user-federation/routes/UserFederation";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
-import { GroupPickerDialog } from "../components/group/GroupPickerDialog";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
-import { useHelp } from "ui-shared";
+import { toUserFederation } from "../user-federation/routes/UserFederation";
+import useToggle from "../utils/useToggle";
 
 export const DefaultsGroupsTab = () => {
   const { t } = useTranslation("realm-settings");
@@ -43,7 +44,6 @@ export const DefaultsGroupsTab = () => {
   const [load, setLoad] = useState(0);
   const reload = () => setLoad(load + 1);
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const { enabled } = useHelp();

--- a/js/apps/admin-ui/src/realm-settings/EmailTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/EmailTab.tsx
@@ -15,14 +15,13 @@ import { useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-
+import { HelpItem } from "ui-shared";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import { PasswordInput } from "../components/password-input/PasswordInput";
 import { FormPanel } from "../components/scroll-form/FormPanel";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { toUser } from "../user/routes/User";
 import { emailRegexPattern } from "../util";
@@ -39,7 +38,6 @@ export const RealmSettingsEmailTab = ({
   realm: initialRealm,
 }: RealmSettingsEmailTabProps) => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
   const currentUser = useCurrentUser();

--- a/js/apps/admin-ui/src/realm-settings/ExecutorForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/ExecutorForm.tsx
@@ -15,13 +15,14 @@ import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { useParams } from "../utils/useParams";
 import { ClientProfileParams, toClientProfile } from "./routes/ClientProfile";
@@ -45,7 +46,6 @@ export default function ExecutorForm() {
   const { addAlert, addError } = useAlerts();
   const [selectExecutorTypeOpen, setSelectExecutorTypeOpen] = useState(false);
   const serverInfo = useServerInfo();
-  const { adminClient } = useAdminClient();
   const executorTypes =
     serverInfo.componentTypes?.[
       "org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider"

--- a/js/apps/admin-ui/src/realm-settings/GeneralTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/GeneralTab.tsx
@@ -15,13 +15,13 @@ import {
 import { useEffect, useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { FormattedLink } from "../components/external-link/FormattedLink";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeyValueInput } from "../components/key-value-form/KeyValueInput";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import {
   addTrailingSlash,
@@ -40,7 +40,6 @@ export const RealmSettingsGeneralTab = ({
   save,
 }: RealmSettingsGeneralTabProps) => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const form = useForm<RealmRepresentation>();
   const {

--- a/js/apps/admin-ui/src/realm-settings/LocalizationTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/LocalizationTab.tsx
@@ -16,8 +16,6 @@ import {
 } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
 import {
-  applyCellEdits,
-  cancelCellEdits,
   EditableTextCell,
   IEditableTextCell,
   IRow,
@@ -28,21 +26,24 @@ import {
   TableBody,
   TableHeader,
   TableVariant,
+  applyCellEdits,
+  cancelCellEdits,
   validateCellEdits,
 } from "@patternfly/react-table";
 import { cloneDeep, isEqual, uniqWith } from "lodash-es";
 import { useEffect, useMemo, useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import type { KeyValueType } from "../components/key-value-form/key-value-convert";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { FormPanel } from "../components/scroll-form/FormPanel";
 import { PaginatingTableToolbar } from "../components/table-toolbar/PaginatingTableToolbar";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { useWhoAmI } from "../context/whoami/WhoAmI";
@@ -64,6 +65,8 @@ export enum RowEditAction {
 }
 
 export type BundleForm = {
+  key: string;
+  value: string;
   messageBundle: KeyValueType;
 };
 
@@ -77,7 +80,6 @@ const localeToDisplayName = (locale: string) => {
 
 export const LocalizationTab = ({ save, realm }: LocalizationTabProps) => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const [addMessageBundleModalOpen, setAddMessageBundleModalOpen] =
     useState(false);
 

--- a/js/apps/admin-ui/src/realm-settings/LoginTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/LoginTab.tsx
@@ -1,11 +1,12 @@
-import { useTranslation } from "react-i18next";
-import { FormGroup, PageSection, Switch } from "@patternfly/react-core";
-import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
-import { FormPanel } from "../components/scroll-form/FormPanel";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { FormGroup, PageSection, Switch } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
+import { FormAccess } from "../components/form-access/FormAccess";
+import { FormPanel } from "../components/scroll-form/FormPanel";
 import { useRealm } from "../context/realm-context/RealmContext";
 
 type RealmSettingsLoginTabProps = {
@@ -22,7 +23,6 @@ export const RealmSettingsLoginTab = ({
   const { t } = useTranslation("realm-settings");
 
   const { addAlert, addError } = useAlerts();
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
 
   const updateSwitchValue = async (switches: SwitchType | SwitchType[]) => {

--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -13,19 +13,20 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { convertToFormValues } from "../util";
 import { useParams } from "../utils/useParams";
 import type { AttributeParams } from "./routes/Attribute";
 import { toUserProfile } from "./routes/UserProfile";
+import { UserProfileProvider } from "./user-profile/UserProfileContext";
 import { AttributeAnnotations } from "./user-profile/attribute/AttributeAnnotations";
 import { AttributeGeneralSettings } from "./user-profile/attribute/AttributeGeneralSettings";
 import { AttributePermission } from "./user-profile/attribute/AttributePermission";
 import { AttributeValidations } from "./user-profile/attribute/AttributeValidations";
-import { UserProfileProvider } from "./user-profile/UserProfileContext";
 
 import "./realm-settings-section.css";
 
@@ -120,7 +121,6 @@ const CreateAttributeFormContent = ({
 
 export default function NewAttributeSettings() {
   const { realm, attributeName } = useParams<AttributeParams>();
-  const { adminClient } = useAdminClient();
   const form = useForm<UserProfileAttributeType>();
   const { t } = useTranslation("realm-settings");
   const navigate = useNavigate();

--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicyCondition.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicyCondition.tsx
@@ -17,13 +17,14 @@ import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { FormPanel } from "../components/scroll-form/FormPanel";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { toEditClientPolicy } from "./routes/EditClientPolicy";
@@ -65,8 +66,6 @@ export default function NewClientPolicyCondition() {
     serverInfo.componentTypes?.[
       "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider"
     ];
-
-  const { adminClient } = useAdminClient();
 
   const setupForm = (condition: ClientPolicyConditionRepresentation) => {
     form.reset({ config: condition.configuration || {} });

--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicyForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicyForm.tsx
@@ -25,16 +25,17 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextArea } from "../components/keycloak-text-area/KeycloakTextArea";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { useParams } from "../utils/useParams";
@@ -69,7 +70,6 @@ export default function NewClientPolicyForm() {
   const { t } = useTranslation("realm-settings");
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
-  const { adminClient } = useAdminClient();
   const [policies, setPolicies] = useState<ClientPolicyRepresentation[]>();
   const [clientProfiles, setClientProfiles] = useState<
     ClientProfileRepresentation[]

--- a/js/apps/admin-ui/src/realm-settings/PartialExport.tsx
+++ b/js/apps/admin-ui/src/realm-settings/PartialExport.tsx
@@ -14,8 +14,9 @@ import {
 import { saveAs } from "file-saver";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { prettyPrintJSON } from "../util";
 
@@ -32,7 +33,6 @@ export const PartialExportDialog = ({
 }: PartialExportDialogProps) => {
   const { t } = useTranslation("realm-settings");
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [exportGroupsAndRoles, setExportGroupsAndRoles] = useState(false);

--- a/js/apps/admin-ui/src/realm-settings/PartialImport.tsx
+++ b/js/apps/admin-ui/src/realm-settings/PartialImport.tsx
@@ -1,11 +1,10 @@
-import {
-  useState,
-  useEffect,
-  FormEvent,
-  ChangeEvent,
-  MouseEvent as ReactMouseEvent,
-} from "react";
-import { useTranslation } from "react-i18next";
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import type {
+  PartialImportRealmRepresentation,
+  PartialImportResponse,
+  PartialImportResult,
+} from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import {
   Alert,
   Button,
@@ -28,21 +27,20 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
+import {
+  ChangeEvent,
+  FormEvent,
+  MouseEvent as ReactMouseEvent,
+  useEffect,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { JsonFileUpload } from "../components/json-file-upload/JsonFileUpload";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
-
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import type {
-  PartialImportRealmRepresentation,
-  PartialImportResponse,
-  PartialImportResult,
-} from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 
 export type PartialImportProps = {
   open: boolean;
@@ -72,7 +70,6 @@ const INITIAL_RESOURCES: Readonly<ResourceChecked> = {
 
 export const PartialImportDialog = (props: PartialImportProps) => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const [importedFile, setImportedFile] = useState<ImportedMultiRealm>();

--- a/js/apps/admin-ui/src/realm-settings/PoliciesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/PoliciesTab.tsx
@@ -18,6 +18,7 @@ import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
@@ -26,7 +27,7 @@ import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { prettyPrintJSON } from "../util";
 import { toAddClientPolicy } from "./routes/AddClientPolicy";
@@ -37,7 +38,6 @@ import "./realm-settings-section.css";
 
 export const PoliciesTab = () => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
   const navigate = useNavigate();

--- a/js/apps/admin-ui/src/realm-settings/ProfilesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/ProfilesTab.tsx
@@ -1,37 +1,39 @@
-import { useState } from "react";
-import { omit } from "lodash-es";
+import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
   ActionGroup,
   AlertVariant,
   Button,
   ButtonVariant,
-  FormGroup,
-  Label,
-  PageSection,
-  ToolbarItem,
   Divider,
   Flex,
   FlexItem,
+  FormGroup,
+  Label,
+  PageSection,
   Radio,
   Title,
+  ToolbarItem,
 } from "@patternfly/react-core";
-import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { omit } from "lodash-es";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { useTranslation } from "react-i18next";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
-import { useAlerts } from "../components/alert/Alerts";
 import { prettyPrintJSON } from "../util";
-import { Link } from "react-router-dom";
 import { toAddClientProfile } from "./routes/AddClientProfile";
-import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
 import { toClientProfile } from "./routes/ClientProfile";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 
 import "./realm-settings-section.css";
 
@@ -41,7 +43,6 @@ type ClientProfile = ClientProfileRepresentation & {
 
 export default function ProfilesTab() {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const [tableProfiles, setTableProfiles] = useState<ClientProfile[]>();

--- a/js/apps/admin-ui/src/realm-settings/RealmSettingsSection.tsx
+++ b/js/apps/admin-ui/src/realm-settings/RealmSettingsSection.tsx
@@ -1,14 +1,14 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import { useState } from "react";
 
+import { adminClient } from "../admin-client";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useParams } from "../utils/useParams";
 import { RealmSettingsTabs } from "./RealmSettingsTabs";
 import type { RealmSettingsParams } from "./routes/RealmSettings";
 
 export default function RealmSettingsSection() {
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useParams<RealmSettingsParams>();
   const [realm, setRealm] = useState<RealmRepresentation>();
   const [key, setKey] = useState(0);

--- a/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
+++ b/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
@@ -14,6 +14,7 @@ import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import type { KeyValueType } from "../components/key-value-form/key-value-convert";
@@ -23,7 +24,6 @@ import {
 } from "../components/routable-tabs/RoutableTabs";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useRealms } from "../context/RealmsContext";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { toDashboard } from "../dashboard/routes/Dashboard";
 import environment from "../environment";
@@ -65,7 +65,6 @@ const RealmSettingsHeader = ({
   refresh,
 }: RealmSettingsHeaderProps) => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { refresh: refreshRealms } = useRealms();
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
@@ -163,7 +162,6 @@ export const RealmSettingsTabs = ({
   refresh,
 }: RealmSettingsTabsProps) => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
   const { refresh: refreshRealms } = useRealms();

--- a/js/apps/admin-ui/src/realm-settings/UserRegistration.tsx
+++ b/js/apps/admin-ui/src/realm-settings/UserRegistration.tsx
@@ -1,14 +1,15 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { AlertVariant, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
-
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { useRealm } from "../context/realm-context/RealmContext";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { AlertVariant, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import { RoleMapping } from "../components/role-mapping/RoleMapping";
+import { useFetch } from "../context/auth/AdminClient";
+import { useRealm } from "../context/realm-context/RealmContext";
 import { DefaultsGroupsTab } from "./DefaultGroupsTab";
 
 export const UserRegistration = () => {
@@ -17,7 +18,6 @@ export const UserRegistration = () => {
   const [activeTab, setActiveTab] = useState(10);
   const [key, setKey] = useState(0);
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
 

--- a/js/apps/admin-ui/src/realm-settings/event-config/EventsTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/event-config/EventsTab.tsx
@@ -13,10 +13,11 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertToFormValues } from "../../util";
 import { AddEventTypesDialog } from "./AddEventTypesDialog";
@@ -47,7 +48,6 @@ export const EventsTab = ({ realm }: EventsTabProps) => {
   const [type, setType] = useState<EventsType>();
   const [addEventType, setAddEventType] = useState(false);
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
 

--- a/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
+import type { KeyMetadataRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/keyMetadataRepresentation";
 import {
   Button,
   ButtonVariant,
@@ -9,20 +8,22 @@ import {
   SelectOption,
   SelectVariant,
 } from "@patternfly/react-core";
-import { cellWidth } from "@patternfly/react-table";
 import { FilterIcon } from "@patternfly/react-icons";
+import { cellWidth } from "@patternfly/react-table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 
-import type { KeyMetadataRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/keyMetadataRepresentation";
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
+import { adminClient } from "../../admin-client";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../../components/table-toolbar/KeycloakDataTable";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { emptyFormatter } from "../../util";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { toKeysTab } from "../routes/KeysTab";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
+import { emptyFormatter } from "../../util";
 import useToggle from "../../utils/useToggle";
+import { toKeysTab } from "../routes/KeysTab";
 
 import "../realm-settings-section.css";
 
@@ -85,7 +86,6 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
   const [publicKey, setPublicKey] = useState("");
   const [certificate, setCertificate] = useState("");
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const [keyData, setKeyData] = useState<KeyData[]>();

--- a/js/apps/admin-ui/src/realm-settings/keys/KeysProvidersTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/KeysProvidersTab.tsx
@@ -17,10 +17,10 @@ import { KeyboardEvent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { DraggableTable } from "../../authentication/components/DraggableTable";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { KEY_PROVIDER_TYPE } from "../../util";
@@ -51,7 +51,6 @@ export const KeysProvidersTab = ({
 }: KeysProvidersTabProps) => {
   const { t } = useTranslation("realm-settings");
   const { addAlert, addError } = useAlerts();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const [searchVal, setSearchVal] = useState("");

--- a/js/apps/admin-ui/src/realm-settings/keys/KeysTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/KeysTab.tsx
@@ -1,17 +1,18 @@
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
+import { Tab, TabTitleText } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Tab, TabTitleText } from "@patternfly/react-core";
 
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { KEY_PROVIDER_TYPE } from "../../util";
+import { adminClient } from "../../admin-client";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import {
   RoutableTabs,
   useRoutableTab,
 } from "../../components/routable-tabs/RoutableTabs";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { KEY_PROVIDER_TYPE } from "../../util";
 import { KeySubTab, toKeysTab } from "../routes/KeysTab";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeysListTab } from "./KeysListTab";
 import { KeysProvidersTab } from "./KeysProvidersTab";
 
@@ -31,7 +32,6 @@ const sortByPriority = (components: ComponentRepresentation[]) => {
 export const KeysTab = () => {
   const { t } = useTranslation("realm-settings");
 
-  const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
 
   const [realmComponents, setRealmComponents] =

--- a/js/apps/admin-ui/src/realm-settings/keys/key-providers/KeyProviderForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/key-providers/KeyProviderForm.tsx
@@ -11,14 +11,15 @@ import {
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../../admin-client";
 import { useAlerts } from "../../../components/alert/Alerts";
 import { DynamicComponents } from "../../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 import { useServerInfo } from "../../../context/server-info/ServerInfoProvider";
 import { KEY_PROVIDER_TYPE } from "../../../util";
 import { useParams } from "../../../utils/useParams";
@@ -37,7 +38,6 @@ export const KeyProviderForm = ({
 }: KeyProviderFormProps) => {
   const { t } = useTranslation("realm-settings");
   const { id } = useParams<{ id: string }>();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const serverInfo = useServerInfo();

--- a/js/apps/admin-ui/src/realm-settings/user-profile/UserProfileContext.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/UserProfileContext.tsx
@@ -2,11 +2,12 @@ import type UserProfileConfig from "@keycloak/keycloak-admin-client/lib/defs/use
 import { AlertVariant } from "@patternfly/react-core";
 import { PropsWithChildren, useState } from "react";
 import { useTranslation } from "react-i18next";
-
-import { useAlerts } from "../../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useRealm } from "../../context/realm-context/RealmContext";
 import { createNamedContext, useRequiredContext } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { useAlerts } from "../../components/alert/Alerts";
+import { useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
 
 type UserProfileProps = {
   config: UserProfileConfig | null;
@@ -29,7 +30,6 @@ export const UserProfileContext = createNamedContext<
 >("UserProfileContext", undefined);
 
 export const UserProfileProvider = ({ children }: PropsWithChildren) => {
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const { t } = useTranslation();

--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
@@ -13,12 +13,13 @@ import { isEqual } from "lodash-es";
 import { useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import { FormAccess } from "../../../components/form-access/FormAccess";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../../admin-client";
+import { FormAccess } from "../../../components/form-access/FormAccess";
 import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 import { useParams } from "../../../utils/useParams";
 import { USERNAME_EMAIL } from "../../NewAttributeSettings";
 import type { AttributeParams } from "../../routes/Attribute";
@@ -33,7 +34,6 @@ const REQUIRED_FOR = [
 
 export const AttributeGeneralSettings = () => {
   const { t } = useTranslation("realm-settings");
-  const { adminClient } = useAdminClient();
   const form = useFormContext();
   const [clientScopes, setClientScopes] =
     useState<ClientScopeRepresentation[]>();

--- a/js/apps/admin-ui/src/realm/add/NewRealmForm.tsx
+++ b/js/apps/admin-ui/src/realm/add/NewRealmForm.tsx
@@ -11,12 +11,12 @@ import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { JsonFileUpload } from "../../components/json-file-upload/JsonFileUpload";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealms } from "../../context/RealmsContext";
 import { useWhoAmI } from "../../context/whoami/WhoAmI";
 import { toDashboard } from "../../dashboard/routes/Dashboard";
@@ -27,7 +27,6 @@ export default function NewRealmForm() {
   const navigate = useNavigate();
   const { refresh, whoAmI } = useWhoAmI();
   const { refresh: refreshRealms } = useRealms();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const [realm, setRealm] = useState<RealmRepresentation>();
 

--- a/js/apps/admin-ui/src/sessions/RevocationModal.tsx
+++ b/js/apps/admin-ui/src/sessions/RevocationModal.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import type GlobalRequestResult from "@keycloak/keycloak-admin-client/lib/defs/globalRequestResult";
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import {
   AlertVariant,
   Button,
@@ -10,16 +11,16 @@ import {
   TextContent,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
-import { emailRegexPattern } from "../util";
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { useRealm } from "../context/realm-context/RealmContext";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
-import type GlobalRequestResult from "@keycloak/keycloak-admin-client/lib/defs/globalRequestResult";
+import { useFetch } from "../context/auth/AdminClient";
+import { useRealm } from "../context/realm-context/RealmContext";
+import { emailRegexPattern } from "../util";
 
 type RevocationModalProps = {
   handleModalToggle: () => void;
@@ -34,7 +35,6 @@ export const RevocationModal = ({
   const { addAlert } = useAlerts();
 
   const { realm: realmName } = useRealm();
-  const { adminClient } = useAdminClient();
   const {
     register,
     handleSubmit,

--- a/js/apps/admin-ui/src/sessions/SessionsSection.tsx
+++ b/js/apps/admin-ui/src/sessions/SessionsSection.tsx
@@ -1,18 +1,18 @@
+import UserSessionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation";
 import {
   DropdownItem,
   PageSection,
   Select,
   SelectOption,
 } from "@patternfly/react-core";
+import { FilterIcon } from "@patternfly/react-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import UserSessionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation";
-import { FilterIcon } from "@patternfly/react-icons";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { fetchAdminUI } from "../context/auth/admin-ui-endpoint";
 import { useRealm } from "../context/realm-context/RealmContext";
 import helpUrls from "../help-urls";
@@ -26,7 +26,6 @@ type FilterType = "ALL" | "REGULAR" | "OFFLINE";
 export default function SessionsSection() {
   const { t } = useTranslation("sessions");
 
-  const { adminClient } = useAdminClient();
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
   const { addError } = useAlerts();
@@ -43,7 +42,6 @@ export default function SessionsSection() {
 
   const loader = async (first?: number, max?: number, search?: string) => {
     const data = await fetchAdminUI<UserSessionRepresentation[]>(
-      adminClient,
       "ui-ext/sessions",
       {
         first: `${first}`,

--- a/js/apps/admin-ui/src/sessions/SessionsTable.tsx
+++ b/js/apps/admin-ui/src/sessions/SessionsTable.tsx
@@ -11,6 +11,7 @@ import { ReactNode, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { toClient } from "../clients/routes/Client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
@@ -21,7 +22,6 @@ import {
   KeycloakDataTable,
   LoaderFunction,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useWhoAmI } from "../context/whoami/WhoAmI";
 import { keycloak } from "../keycloak";
@@ -79,7 +79,6 @@ export default function SessionsTable({
   const { realm } = useRealm();
   const { whoAmI } = useWhoAmI();
   const { t } = useTranslation("sessions");
-  const { adminClient } = useAdminClient();
   const { addError } = useAlerts();
   const formatDate = useFormatDate();
   const [key, setKey] = useState(0);

--- a/js/apps/admin-ui/src/user-federation/CreateUserFederationLdapSettings.tsx
+++ b/js/apps/admin-ui/src/user-federation/CreateUserFederationLdapSettings.tsx
@@ -3,22 +3,21 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
-import { toUserFederation } from "./routes/UserFederation";
-import { ExtendedHeader } from "./shared/ExtendedHeader";
 import {
   LdapComponentRepresentation,
-  serializeFormData,
   UserFederationLdapForm,
+  serializeFormData,
 } from "./UserFederationLdapForm";
+import { toUserFederation } from "./routes/UserFederation";
+import { ExtendedHeader } from "./shared/ExtendedHeader";
 
 export default function CreateUserFederationLdapSettings() {
   const { t } = useTranslation("user-federation");
   const form = useForm<LdapComponentRepresentation>({ mode: "onChange" });
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
 

--- a/js/apps/admin-ui/src/user-federation/ManagePriorityDialog.tsx
+++ b/js/apps/admin-ui/src/user-federation/ManagePriorityDialog.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { sortBy } from "lodash-es";
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import {
   Button,
   ButtonVariant,
@@ -13,11 +11,14 @@ import {
   DataListItemRow,
   Modal,
   ModalVariant,
-  TextContent,
   Text,
+  TextContent,
 } from "@patternfly/react-core";
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { sortBy } from "lodash-es";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 
 type ManagePriorityDialogProps = {
@@ -30,7 +31,6 @@ export const ManagePriorityDialog = ({
   onClose,
 }: ManagePriorityDialogProps) => {
   const { t } = useTranslation("user-federation");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [id, setId] = useState("");

--- a/js/apps/admin-ui/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/js/apps/admin-ui/src/user-federation/UserFederationKerberosSettings.tsx
@@ -10,8 +10,9 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useParams } from "../utils/useParams";
 import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
@@ -23,7 +24,6 @@ export default function UserFederationKerberosSettings() {
   const { t } = useTranslation("user-federation");
   const form = useForm<ComponentRepresentation>({ mode: "onChange" });
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const { id } = useParams<{ id?: string }>();

--- a/js/apps/admin-ui/src/user-federation/UserFederationLdapSettings.tsx
+++ b/js/apps/admin-ui/src/user-federation/UserFederationLdapSettings.tsx
@@ -10,32 +10,32 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import {
   RoutableTabs,
   useRoutableTab,
 } from "../components/routable-tabs/RoutableTabs";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
+import {
+  LdapComponentRepresentation,
+  UserFederationLdapForm,
+  serializeFormData,
+} from "./UserFederationLdapForm";
 import { LdapMapperList } from "./ldap/mappers/LdapMapperList";
 import {
-  toUserFederationLdap,
   UserFederationLdapParams,
   UserFederationLdapTab,
+  toUserFederationLdap,
 } from "./routes/UserFederationLdap";
 import { toUserFederationLdapMapper } from "./routes/UserFederationLdapMapper";
 import { ExtendedHeader } from "./shared/ExtendedHeader";
-import {
-  LdapComponentRepresentation,
-  serializeFormData,
-  UserFederationLdapForm,
-} from "./UserFederationLdapForm";
 
 export default function UserFederationLdapSettings() {
   const { t } = useTranslation("user-federation");
   const form = useForm<LdapComponentRepresentation>({ mode: "onChange" });
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { id } = useParams<UserFederationLdapParams>();
   const { addAlert, addError } = useAlerts();

--- a/js/apps/admin-ui/src/user-federation/UserFederationSection.tsx
+++ b/js/apps/admin-ui/src/user-federation/UserFederationSection.tsx
@@ -18,12 +18,13 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ClickableCard } from "../components/keycloak-card/ClickableCard";
 import { KeycloakCard } from "../components/keycloak-card/KeycloakCard";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import helpUrls from "../help-urls";
@@ -42,7 +43,6 @@ export default function UserFederationSection() {
   const { addAlert, addError } = useAlerts();
   const { t } = useTranslation("user-federation");
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
 

--- a/js/apps/admin-ui/src/user-federation/custom/CustomProviderSettings.tsx
+++ b/js/apps/admin-ui/src/user-federation/custom/CustomProviderSettings.tsx
@@ -10,13 +10,13 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
 import { useAlerts } from "../../components/alert/Alerts";
 import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
@@ -27,6 +27,7 @@ import { ExtendedHeader } from "../shared/ExtendedHeader";
 import { SettingsCache } from "../shared/SettingsCache";
 import { SyncSettings } from "./SyncSettings";
 
+import { adminClient } from "../../admin-client";
 import "./custom-provider-settings.css";
 
 export default function CustomProviderSettings() {
@@ -44,7 +45,6 @@ export default function CustomProviderSettings() {
     formState: { errors, isDirty },
   } = form;
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
   const [parentId, setParentId] = useState("");

--- a/js/apps/admin-ui/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/js/apps/admin-ui/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   FormGroup,
   Select,
@@ -10,12 +9,13 @@ import { isEqual } from "lodash-es";
 import { useState } from "react";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import { FormAccess } from "../../components/form-access/FormAccess";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { FormAccess } from "../../components/form-access/FormAccess";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 
 export type KerberosSettingsRequiredProps = {
@@ -32,7 +32,6 @@ export const KerberosSettingsRequired = ({
   const { t } = useTranslation("user-federation");
   const { t: helpText } = useTranslation("user-federation-help");
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   const [isEditModeDropdownOpen, setIsEditModeDropdownOpen] = useState(false);
@@ -71,7 +70,7 @@ export const KerberosSettingsRequired = ({
           fieldId="kc-ui-display-name"
           isRequired
           validated={form.formState.errors.name ? "error" : "default"}
-          helperTextInvalid={form.formState.errors.name?.message}
+          helperTextInvalid={(form.formState.errors.name as any)?.message}
         >
           {/* These hidden fields are required so data object written back matches data retrieved */}
           <KeycloakTextInput
@@ -119,12 +118,12 @@ export const KerberosSettingsRequired = ({
           fieldId="kc-kerberos-realm"
           isRequired
           validated={
-            form.formState.errors.config?.kerberosRealm?.[0]
+            (form.formState.errors.config as any)?.kerberosRealm?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.kerberosRealm?.[0].message
+            (form.formState.errors.config as any)?.kerberosRealm?.[0].message
           }
         >
           <KeycloakTextInput
@@ -132,7 +131,7 @@ export const KerberosSettingsRequired = ({
             id="kc-kerberos-realm"
             data-testid="kerberos-realm"
             validated={
-              form.formState.errors.config?.kerberosRealm?.[0]
+              (form.formState.errors.config as any)?.kerberosRealm?.[0]
                 ? "error"
                 : "default"
             }
@@ -156,12 +155,12 @@ export const KerberosSettingsRequired = ({
           fieldId="kc-server-principal"
           isRequired
           validated={
-            form.formState.errors.config?.serverPrincipal?.[0]
+            (form.formState.errors.config as any)?.serverPrincipal?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.serverPrincipal?.[0].message
+            (form.formState.errors.config as any)?.serverPrincipal?.[0].message
           }
         >
           <KeycloakTextInput
@@ -169,7 +168,7 @@ export const KerberosSettingsRequired = ({
             id="kc-server-principal"
             data-testid="kerberos-principal"
             validated={
-              form.formState.errors.config?.serverPrincipal?.[0]
+              (form.formState.errors.config as any)?.serverPrincipal?.[0]
                 ? "error"
                 : "default"
             }
@@ -193,16 +192,22 @@ export const KerberosSettingsRequired = ({
           fieldId="kc-key-tab"
           isRequired
           validated={
-            form.formState.errors.config?.keyTab?.[0] ? "error" : "default"
+            (form.formState.errors.config as any)?.keyTab?.[0]
+              ? "error"
+              : "default"
           }
-          helperTextInvalid={form.formState.errors.config?.keyTab?.[0].message}
+          helperTextInvalid={
+            (form.formState.errors.config as any)?.keyTab?.[0].message
+          }
         >
           <KeycloakTextInput
             isRequired
             id="kc-key-tab"
             data-testid="kerberos-keytab"
             validated={
-              form.formState.errors.config?.keyTab?.[0] ? "error" : "default"
+              (form.formState.errors.config as any)?.keyTab?.[0]
+                ? "error"
+                : "default"
             }
             {...form.register("config.keyTab.0", {
               required: {

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -1,12 +1,12 @@
 import { Button, FormGroup, Switch } from "@patternfly/react-core";
 import { Controller, UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { convertFormToSettings } from "./LdapSettingsConnection";
 
@@ -28,7 +28,6 @@ export const LdapSettingsAdvanced = ({
   const { t } = useTranslation("user-federation");
   const { t: helpText } = useTranslation("user-federation-help");
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
 

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type TestLdapConnectionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/testLdapConnection";
 import {
   AlertVariant,
@@ -14,14 +13,14 @@ import { get, isEqual } from "lodash-es";
 import { useState } from "react";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { PasswordInput } from "../../components/password-input/PasswordInput";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 
 export type LdapSettingsConnectionProps = {
@@ -62,7 +61,6 @@ export const LdapSettingsConnection = ({
 }: LdapSettingsConnectionProps) => {
   const { t } = useTranslation("user-federation");
   const { t: helpText } = useTranslation("user-federation-help");
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const edit = !!id;
@@ -116,12 +114,12 @@ export const LdapSettingsConnection = ({
           fieldId="kc-ui-connection-url"
           isRequired
           validated={
-            form.formState.errors.config?.connectionUrl?.[0]
+            (form.formState.errors.config as any)?.connectionUrl?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.connectionUrl?.[0].message
+            (form.formState.errors.config as any)?.connectionUrl?.[0].message
           }
         >
           <KeycloakTextInput
@@ -130,7 +128,7 @@ export const LdapSettingsConnection = ({
             id="kc-ui-connection-url"
             data-testid="ldap-connection-url"
             validated={
-              form.formState.errors.config?.connectionUrl?.[0]
+              (form.formState.errors.config as any)?.connectionUrl?.[0]
                 ? "error"
                 : "default"
             }
@@ -314,7 +312,7 @@ export const LdapSettingsConnection = ({
               fieldId="kc-ui-bind-dn"
               helperTextInvalid={t("validateBindDn")}
               validated={
-                form.formState.errors.config?.bindDn
+                (form.formState.errors.config as any)?.bindDn
                   ? ValidatedOptions.error
                   : ValidatedOptions.default
               }
@@ -325,7 +323,7 @@ export const LdapSettingsConnection = ({
                 id="kc-ui-bind-dn"
                 data-testid="ldap-bind-dn"
                 validated={
-                  form.formState.errors.config?.bindDn
+                  (form.formState.errors.config as any)?.bindDn
                     ? ValidatedOptions.error
                     : ValidatedOptions.default
                 }
@@ -343,7 +341,7 @@ export const LdapSettingsConnection = ({
               fieldId="kc-ui-bind-credentials"
               helperTextInvalid={t("validateBindCredentials")}
               validated={
-                form.formState.errors.config?.bindCredential
+                (form.formState.errors.config as any)?.bindCredential
                   ? ValidatedOptions.error
                   : ValidatedOptions.default
               }
@@ -355,7 +353,7 @@ export const LdapSettingsConnection = ({
                 id="kc-ui-bind-credentials"
                 data-testid="ldap-bind-credentials"
                 validated={
-                  form.formState.errors.config?.bindCredential
+                  (form.formState.errors.config as any)?.bindCredential
                     ? ValidatedOptions.error
                     : ValidatedOptions.default
                 }

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -8,12 +8,13 @@ import {
 import { useState } from "react";
 import { Controller, UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
-import { FormAccess } from "../../components/form-access/FormAccess";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../../admin-client";
+import { FormAccess } from "../../components/form-access/FormAccess";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 
 export type LdapSettingsGeneralProps = {
@@ -31,8 +32,6 @@ export const LdapSettingsGeneral = ({
 }: LdapSettingsGeneralProps) => {
   const { t } = useTranslation("user-federation");
   const { t: helpText } = useTranslation("user-federation-help");
-
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
 
   useFetch(

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { FormGroup, Switch } from "@patternfly/react-core";
 import { Controller, UseFormReturn, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -84,12 +83,13 @@ export const LdapSettingsKerberosIntegration = ({
               fieldId="kc-kerberos-realm"
               isRequired
               validated={
-                form.formState.errors.config?.kerberosRealm?.[0]
+                (form.formState.errors.config as any)?.kerberosRealm?.[0]
                   ? "error"
                   : "default"
               }
               helperTextInvalid={
-                form.formState.errors.config?.kerberosRealm?.[0].message
+                (form.formState.errors.config as any)?.kerberosRealm?.[0]
+                  .message
               }
             >
               <KeycloakTextInput
@@ -97,7 +97,7 @@ export const LdapSettingsKerberosIntegration = ({
                 id="kc-kerberos-realm"
                 data-testid="kerberos-realm"
                 validated={
-                  form.formState.errors.config?.kerberosRealm?.[0]
+                  (form.formState.errors.config as any)?.kerberosRealm?.[0]
                     ? "error"
                     : "default"
                 }
@@ -121,12 +121,13 @@ export const LdapSettingsKerberosIntegration = ({
               fieldId="kc-server-principal"
               isRequired
               validated={
-                form.formState.errors.config?.serverPrincipal?.[0]
+                (form.formState.errors.config as any)?.serverPrincipal?.[0]
                   ? "error"
                   : "default"
               }
               helperTextInvalid={
-                form.formState.errors.config?.serverPrincipal?.[0].message
+                (form.formState.errors.config as any)?.serverPrincipal?.[0]
+                  .message
               }
             >
               <KeycloakTextInput
@@ -134,7 +135,7 @@ export const LdapSettingsKerberosIntegration = ({
                 id="kc-server-principal"
                 data-testid="kerberos-principal"
                 validated={
-                  form.formState.errors.config?.serverPrincipal?.[0]
+                  (form.formState.errors.config as any)?.serverPrincipal?.[0]
                     ? "error"
                     : "default"
                 }
@@ -158,10 +159,12 @@ export const LdapSettingsKerberosIntegration = ({
               fieldId="kc-key-tab"
               isRequired
               validated={
-                form.formState.errors.config?.keyTab?.[0] ? "error" : "default"
+                (form.formState.errors.config as any)?.keyTab?.[0]
+                  ? "error"
+                  : "default"
               }
               helperTextInvalid={
-                form.formState.errors.config?.keyTab?.[0].message
+                (form.formState.errors.config as any)?.keyTab?.[0].message
               }
             >
               <KeycloakTextInput
@@ -169,7 +172,7 @@ export const LdapSettingsKerberosIntegration = ({
                 id="kc-key-tab"
                 data-testid="kerberos-keytab"
                 validated={
-                  form.formState.errors.config?.keyTab?.[0]
+                  (form.formState.errors.config as any)?.keyTab?.[0]
                     ? "error"
                     : "default"
                 }

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   FormGroup,
   Select,
@@ -55,10 +54,12 @@ export const LdapSettingsSearching = ({
           fieldId="kc-edit-mode"
           isRequired
           validated={
-            form.formState.errors.config?.editMode?.[0] ? "error" : "default"
+            (form.formState.errors.config as any)?.editMode?.[0]
+              ? "error"
+              : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.editMode?.[0].message
+            (form.formState.errors.config as any)?.editMode?.[0].message
           }
         >
           <Controller
@@ -83,7 +84,7 @@ export const LdapSettingsSearching = ({
                 selections={field.value}
                 variant={SelectVariant.single}
                 validated={
-                  form.formState.errors.config?.editMode?.[0]
+                  (form.formState.errors.config as any)?.editMode?.[0]
                     ? "error"
                     : "default"
                 }
@@ -107,9 +108,13 @@ export const LdapSettingsSearching = ({
           fieldId="kc-ui-users-dn"
           isRequired
           validated={
-            form.formState.errors.config?.usersDn?.[0] ? "error" : "default"
+            (form.formState.errors.config as any)?.usersDn?.[0]
+              ? "error"
+              : "default"
           }
-          helperTextInvalid={form.formState.errors.config?.usersDn?.[0].message}
+          helperTextInvalid={
+            (form.formState.errors.config as any)?.usersDn?.[0].message
+          }
         >
           <KeycloakTextInput
             isRequired
@@ -117,7 +122,9 @@ export const LdapSettingsSearching = ({
             id="kc-ui-users-dn"
             data-testid="ldap-users-dn"
             validated={
-              form.formState.errors.config?.usersDn?.[0] ? "error" : "default"
+              (form.formState.errors.config as any)?.usersDn?.[0]
+                ? "error"
+                : "default"
             }
             {...form.register("config.usersDn.0", {
               required: {
@@ -138,12 +145,13 @@ export const LdapSettingsSearching = ({
           fieldId="kc-username-ldap-attribute"
           isRequired
           validated={
-            form.formState.errors.config?.usernameLDAPAttribute?.[0]
+            (form.formState.errors.config as any)?.usernameLDAPAttribute?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.usernameLDAPAttribute?.[0].message
+            (form.formState.errors.config as any)?.usernameLDAPAttribute?.[0]
+              .message
           }
         >
           <KeycloakTextInput
@@ -152,7 +160,7 @@ export const LdapSettingsSearching = ({
             id="kc-username-ldap-attribute"
             data-testid="ldap-username-attribute"
             validated={
-              form.formState.errors.config?.usernameLDAPAttribute?.[0]
+              (form.formState.errors.config as any)?.usernameLDAPAttribute?.[0]
                 ? "error"
                 : "default"
             }
@@ -175,12 +183,12 @@ export const LdapSettingsSearching = ({
           fieldId="kc-rdn-ldap-attribute"
           isRequired
           validated={
-            form.formState.errors.config?.rdnLDAPAttribute?.[0]
+            (form.formState.errors.config as any)?.rdnLDAPAttribute?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.rdnLDAPAttribute?.[0].message
+            (form.formState.errors.config as any)?.rdnLDAPAttribute?.[0].message
           }
         >
           <KeycloakTextInput
@@ -189,7 +197,7 @@ export const LdapSettingsSearching = ({
             id="kc-rdn-ldap-attribute"
             data-testid="ldap-rdn-attribute"
             validated={
-              form.formState.errors.config?.rdnLDAPAttribute?.[0]
+              (form.formState.errors.config as any)?.rdnLDAPAttribute?.[0]
                 ? "error"
                 : "default"
             }
@@ -212,12 +220,13 @@ export const LdapSettingsSearching = ({
           fieldId="kc-uuid-ldap-attribute"
           isRequired
           validated={
-            form.formState.errors.config?.uuidLDAPAttribute?.[0]
+            (form.formState.errors.config as any)?.uuidLDAPAttribute?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.uuidLDAPAttribute?.[0].message
+            (form.formState.errors.config as any)?.uuidLDAPAttribute?.[0]
+              .message
           }
         >
           <KeycloakTextInput
@@ -226,7 +235,7 @@ export const LdapSettingsSearching = ({
             id="kc-uuid-ldap-attribute"
             data-testid="ldap-uuid-attribute"
             validated={
-              form.formState.errors.config?.uuidLDAPAttribute?.[0]
+              (form.formState.errors.config as any)?.uuidLDAPAttribute?.[0]
                 ? "error"
                 : "default"
             }
@@ -249,12 +258,13 @@ export const LdapSettingsSearching = ({
           fieldId="kc-user-object-classes"
           isRequired
           validated={
-            form.formState.errors.config?.userObjectClasses?.[0]
+            (form.formState.errors.config as any)?.userObjectClasses?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.userObjectClasses?.[0].message
+            (form.formState.errors.config as any)?.userObjectClasses?.[0]
+              .message
           }
         >
           <KeycloakTextInput
@@ -263,7 +273,7 @@ export const LdapSettingsSearching = ({
             id="kc-user-object-classes"
             data-testid="ldap-user-object-classes"
             validated={
-              form.formState.errors.config?.userObjectClasses?.[0]
+              (form.formState.errors.config as any)?.userObjectClasses?.[0]
                 ? "error"
                 : "default"
             }
@@ -285,19 +295,20 @@ export const LdapSettingsSearching = ({
           }
           fieldId="kc-user-ldap-filter"
           validated={
-            form.formState.errors.config?.customUserSearchFilter?.[0]
+            (form.formState.errors.config as any)?.customUserSearchFilter?.[0]
               ? "error"
               : "default"
           }
           helperTextInvalid={
-            form.formState.errors.config?.customUserSearchFilter?.[0].message
+            (form.formState.errors.config as any)?.customUserSearchFilter?.[0]
+              .message
           }
         >
           <KeycloakTextInput
             id="kc-user-ldap-filter"
             data-testid="user-ldap-filter"
             validated={
-              form.formState.errors.config?.customUserSearchFilter?.[0]
+              (form.formState.errors.config as any)?.customUserSearchFilter?.[0]
                 ? "error"
                 : "default"
             }

--- a/js/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -19,16 +19,17 @@ import { useState } from "react";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../../admin-client";
 import { useAlerts } from "../../../components/alert/Alerts";
 import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
 import { DynamicComponents } from "../../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../../components/form-access/FormAccess";
-import { HelpItem } from "ui-shared";
 import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 import { useRealm } from "../../../context/realm-context/RealmContext";
 import { convertFormValuesToObject, convertToFormValues } from "../../../util";
 import { useParams } from "../../../utils/useParams";
@@ -40,7 +41,6 @@ export default function LdapMapperDetails() {
   const [mapping, setMapping] = useState<ComponentRepresentation>();
   const [components, setComponents] = useState<ComponentTypeRepresentation[]>();
 
-  const { adminClient } = useAdminClient();
   const { id, mapperId } = useParams<UserFederationLdapMapperParams>();
   const navigate = useNavigate();
   const { realm } = useRealm();

--- a/js/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperList.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperList.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, To, useNavigate, useParams } from "react-router-dom";
 
+import { adminClient } from "../../../admin-client";
 import { useAlerts } from "../../../components/alert/Alerts";
 import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
 import { ListEmptyState } from "../../../components/list-empty-state/ListEmptyState";
@@ -16,7 +17,7 @@ import {
   Action,
   KeycloakDataTable,
 } from "../../../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useFetch } from "../../../context/auth/AdminClient";
 import useLocaleSort, { mapByKey } from "../../../utils/useLocaleSort";
 
 export type LdapMapperListProps = {
@@ -35,7 +36,6 @@ const MapperLink = ({ toDetail, ...mapper }: MapperLinkProps) => (
 export const LdapMapperList = ({ toCreate, toDetail }: LdapMapperListProps) => {
   const navigate = useNavigate();
   const { t } = useTranslation("user-federation");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);

--- a/js/apps/admin-ui/src/user-federation/shared/ExtendedHeader.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/ExtendedHeader.tsx
@@ -1,16 +1,16 @@
-import { useParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
 import {
   AlertVariant,
   DropdownItem,
   DropdownSeparator,
 } from "@patternfly/react-core";
+import { useFormContext, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { Header } from "./Header";
-import { useFormContext, useWatch } from "react-hook-form";
 
 type ExtendedHeaderProps = {
   provider: string;
@@ -27,7 +27,6 @@ export const ExtendedHeader = ({
 }: ExtendedHeaderProps) => {
   const { t } = useTranslation("user-federation");
   const { id } = useParams<{ id: string }>();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const { control } = useFormContext();

--- a/js/apps/admin-ui/src/user-federation/shared/Header.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/Header.tsx
@@ -8,10 +8,10 @@ import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { CustomUserFederationRouteParams } from "../routes/CustomUserFederation";
 import { toUserFederation } from "../routes/UserFederation";
@@ -33,7 +33,6 @@ export const Header = ({
   const { id } = useParams<Partial<CustomUserFederationRouteParams>>();
   const navigate = useNavigate();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
 

--- a/js/apps/admin-ui/src/user/CreateUser.tsx
+++ b/js/apps/admin-ui/src/user/CreateUser.tsx
@@ -6,17 +6,17 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { UserProfileProvider } from "../realm-settings/user-profile/UserProfileContext";
-import { toUser } from "./routes/User";
 import { UserForm } from "./UserForm";
 import {
   isUserProfileError,
   userProfileErrorToString,
 } from "./UserProfileFields";
+import { toUser } from "./routes/User";
 
 import "./user-section.css";
 
@@ -24,7 +24,6 @@ export default function CreateUser() {
   const { t } = useTranslation("users");
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const userForm = useForm<UserRepresentation>({ mode: "onChange" });
   const [addedGroups, setAddedGroups] = useState<GroupRepresentation[]>([]);

--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
@@ -21,7 +21,7 @@ import {
 } from "../components/routable-tabs/RoutableTabs";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { UserProfileProvider } from "../realm-settings/user-profile/UserProfileContext";
 import { useParams } from "../utils/useParams";
@@ -44,7 +44,6 @@ import { toUsers } from "./routes/Users";
 import "./user-section.css";
 
 export default function EditUser() {
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { id } = useParams<UserParams>();
   const { t } = useTranslation("users");
@@ -95,7 +94,6 @@ type EditUserFormProps = {
 const EditUserForm = ({ user, bruteForced, refresh }: EditUserFormProps) => {
   const { t } = useTranslation("users");
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
   const { hasAccess } = useAccess();

--- a/js/apps/admin-ui/src/user/FederatedUserLink.tsx
+++ b/js/apps/admin-ui/src/user/FederatedUserLink.tsx
@@ -1,11 +1,12 @@
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import { Button } from "@patternfly/react-core";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
+import { adminClient } from "../admin-client";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { toUserFederationLdap } from "../user-federation/routes/UserFederationLdap";
 
@@ -16,7 +17,6 @@ type FederatedUserLinkProps = {
 export const FederatedUserLink = ({ user }: FederatedUserLinkProps) => {
   const access = useAccess();
   const { realm } = useRealm();
-  const { adminClient } = useAdminClient();
 
   const [component, setComponent] = useState<ComponentRepresentation>();
 

--- a/js/apps/admin-ui/src/user/UserAttributes.tsx
+++ b/js/apps/admin-ui/src/user/UserAttributes.tsx
@@ -1,25 +1,24 @@
-import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   AlertVariant,
   PageSection,
   PageSectionVariants,
 } from "@patternfly/react-core";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import {
   AttributeForm,
   AttributesForm,
 } from "../components/key-value-form/AttributeForm";
 import {
+  KeyValueType,
   arrayToKeyValue,
   keyValueToArray,
-  KeyValueType,
 } from "../components/key-value-form/key-value-convert";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useUserProfile } from "../realm-settings/user-profile/UserProfileContext";
 
 type UserAttributesProps = {
@@ -28,7 +27,6 @@ type UserAttributesProps = {
 
 export const UserAttributes = ({ user: defaultUser }: UserAttributesProps) => {
   const { t } = useTranslation("users");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const [user, setUser] = useState<UserRepresentation>(defaultUser);
   const form = useForm<AttributeForm>({ mode: "onChange" });

--- a/js/apps/admin-ui/src/user/UserConsents.tsx
+++ b/js/apps/admin-ui/src/user/UserConsents.tsx
@@ -11,6 +11,7 @@ import { sortBy } from "lodash-es";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
@@ -18,7 +19,6 @@ import {
   Action,
   KeycloakDataTable,
 } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { emptyFormatter } from "../util";
 import useFormatDate from "../utils/useFormatDate";
 import { useParams } from "../utils/useParams";
@@ -31,7 +31,6 @@ export const UserConsents = () => {
   const formatDate = useFormatDate();
   const [key, setKey] = useState(0);
 
-  const { adminClient } = useAdminClient();
   const { id } = useParams<{ id: string }>();
   const alphabetize = (consentsList: UserConsentRepresentation[]) => {
     return sortBy(consentsList, (client) => client.clientId?.toUpperCase());

--- a/js/apps/admin-ui/src/user/UserCredentials.tsx
+++ b/js/apps/admin-ui/src/user/UserCredentials.tsx
@@ -1,18 +1,14 @@
-import {
-  DragEvent as ReactDragEvent,
-  Fragment,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import type CredentialRepresentation from "@keycloak/keycloak-admin-client/lib/defs/credentialRepresentation";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   AlertVariant,
-  PageSection,
-  PageSectionVariants,
   Button,
   ButtonVariant,
   Divider,
+  PageSection,
+  PageSectionVariants,
 } from "@patternfly/react-core";
+import styles from "@patternfly/react-styles/css/components/Table/table";
 import {
   TableComposable,
   Tbody,
@@ -21,22 +17,28 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
+import {
+  Fragment,
+  DragEvent as ReactDragEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
-import { useAlerts } from "../components/alert/Alerts";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import { HelpItem } from "ui-shared";
+
+import { adminClient } from "../admin-client";
+import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import type CredentialRepresentation from "@keycloak/keycloak-admin-client/lib/defs/credentialRepresentation";
-import { ResetPasswordDialog } from "./user-credentials/ResetPasswordDialog";
-import { ResetCredentialDialog } from "./user-credentials/ResetCredentialDialog";
-import { InlineLabelEdit } from "./user-credentials/InlineLabelEdit";
-import styles from "@patternfly/react-styles/css/components/Table/table";
-import { CredentialRow } from "./user-credentials/CredentialRow";
-import { toUpperCase } from "../util";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { useFetch } from "../context/auth/AdminClient";
+import { toUpperCase } from "../util";
 import { FederatedUserLink } from "./FederatedUserLink";
+import { CredentialRow } from "./user-credentials/CredentialRow";
+import { InlineLabelEdit } from "./user-credentials/InlineLabelEdit";
+import { ResetCredentialDialog } from "./user-credentials/ResetCredentialDialog";
+import { ResetPasswordDialog } from "./user-credentials/ResetPasswordDialog";
 
 import "./user-credentials.css";
 
@@ -57,7 +59,6 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
   const refresh = () => setKey(key + 1);
   const [isOpen, setIsOpen] = useState(false);
   const [openCredentialReset, setOpenCredentialReset] = useState(false);
-  const { adminClient } = useAdminClient();
   const [userCredentials, setUserCredentials] = useState<
     CredentialRepresentation[]
   >([]);

--- a/js/apps/admin-ui/src/user/UserForm.tsx
+++ b/js/apps/admin-ui/src/user/UserForm.tsx
@@ -15,14 +15,15 @@ import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { FormAccess } from "../components/form-access/FormAccess";
 import { GroupPickerDialog } from "../components/group/GroupPickerDialog";
-import { HelpItem } from "ui-shared";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { emailRegexPattern } from "../util";
 import useFormatDate from "../utils/useFormatDate";
@@ -92,7 +93,6 @@ export const UserForm = ({
   const isFeatureEnabled = useIsFeatureEnabled();
 
   const navigate = useNavigate();
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { hasAccess } = useAccess();
   const isManager = hasAccess("manage-users");

--- a/js/apps/admin-ui/src/user/UserGroups.tsx
+++ b/js/apps/admin-ui/src/user/UserGroups.tsx
@@ -1,3 +1,5 @@
+import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   AlertVariant,
   Button,
@@ -7,21 +9,20 @@ import {
 } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
 import { cellWidth } from "@patternfly/react-table";
-import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import { intersectionBy, sortBy } from "lodash-es";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useHelp } from "ui-shared";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { GroupPath } from "../components/group/GroupPath";
 import { GroupPickerDialog } from "../components/group/GroupPickerDialog";
-import { useHelp } from "ui-shared";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
-import { emptyFormatter } from "../util";
 import { useAccess } from "../context/access/Access";
+import { emptyFormatter } from "../util";
 
 type UserGroupsProps = {
   user: UserRepresentation;
@@ -49,7 +50,6 @@ export const UserGroups = ({ user }: UserGroupsProps) => {
   const { hasAccess } = useAccess();
   const isManager = hasAccess("manage-users");
 
-  const { adminClient } = useAdminClient();
   const alphabetize = (groupsList: GroupRepresentation[]) => {
     return sortBy(groupsList, (group) => group.path?.toUpperCase());
   };

--- a/js/apps/admin-ui/src/user/UserIdPModal.tsx
+++ b/js/apps/admin-ui/src/user/UserIdPModal.tsx
@@ -13,9 +13,9 @@ import { capitalize } from "lodash-es";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../context/auth/AdminClient";
 
 type UserIdpModalProps = {
   userId: string;
@@ -31,7 +31,6 @@ export const UserIdpModal = ({
   onRefresh,
 }: UserIdpModalProps) => {
   const { t } = useTranslation("users");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const {
     register,

--- a/js/apps/admin-ui/src/user/UserIdentityProviderLinks.tsx
+++ b/js/apps/admin-ui/src/user/UserIdentityProviderLinks.tsx
@@ -15,11 +15,11 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { FormPanel } from "../components/scroll-form/FormPanel";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { toIdentityProvider } from "../identity-providers/routes/IdentityProvider";
@@ -37,7 +37,6 @@ export const UserIdentityProviderLinks = ({
   const [federatedId, setFederatedId] = useState("");
   const [isLinkIdPModalOpen, setIsLinkIdPModalOpen] = useState(false);
 
-  const { adminClient } = useAdminClient();
   const { realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const { t } = useTranslation("users");

--- a/js/apps/admin-ui/src/user/UserRoleMapping.tsx
+++ b/js/apps/admin-ui/src/user/UserRoleMapping.tsx
@@ -1,8 +1,8 @@
-import { useTranslation } from "react-i18next";
-import { AlertVariant } from "@patternfly/react-core";
-
 import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { AlertVariant } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { RoleMapping, Row } from "../components/role-mapping/RoleMapping";
 
@@ -13,7 +13,6 @@ type UserRoleMappingProps = {
 
 export const UserRoleMapping = ({ id, name }: UserRoleMappingProps) => {
   const { t } = useTranslation("users");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const assignRoles = async (rows: Row[]) => {

--- a/js/apps/admin-ui/src/user/UserSessions.tsx
+++ b/js/apps/admin-ui/src/user/UserSessions.tsx
@@ -1,14 +1,13 @@
 import { PageSection } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 
-import { useAdminClient } from "../context/auth/AdminClient";
+import { adminClient } from "../admin-client";
 import { useRealm } from "../context/realm-context/RealmContext";
 import SessionsTable from "../sessions/SessionsTable";
 import { useParams } from "../utils/useParams";
 import type { UserParams } from "./routes/User";
 
 export const UserSessions = () => {
-  const { adminClient } = useAdminClient();
   const { id } = useParams<UserParams>();
   const { realm } = useRealm();
   const { t } = useTranslation("sessions");

--- a/js/apps/admin-ui/src/user/UsersSection.tsx
+++ b/js/apps/admin-ui/src/user/UsersSection.tsx
@@ -1,3 +1,6 @@
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   AlertVariant,
   Button,
@@ -30,9 +33,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
+import { adminClient } from "../admin-client";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
@@ -46,7 +47,7 @@ import {
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import helpUrls from "../help-urls";
 import { emptyFormatter } from "../util";
@@ -59,7 +60,6 @@ import "./user-section.css";
 
 export default function UsersSection() {
   const { t } = useTranslation("users");
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
   const navigate = useNavigate();
@@ -145,7 +145,6 @@ export default function UsersSection() {
 
     try {
       return await findUsers({
-        adminClient,
         briefRepresentation: true,
         ...params,
       });

--- a/js/apps/admin-ui/src/user/user-credentials/InlineLabelEdit.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/InlineLabelEdit.tsx
@@ -4,9 +4,9 @@ import { CheckIcon, PencilAltIcon, TimesIcon } from "@patternfly/react-icons";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useAdminClient } from "../../context/auth/AdminClient";
 
 type UserLabelForm = {
   userLabel: string;
@@ -28,7 +28,6 @@ export const InlineLabelEdit = ({
   const { t } = useTranslation("users");
   const { register, handleSubmit } = useForm<UserLabelForm>();
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const saveUserLabel = async (userLabel: UserLabelForm) => {

--- a/js/apps/admin-ui/src/user/user-credentials/RequiredActionMultiSelect.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/RequiredActionMultiSelect.tsx
@@ -8,9 +8,10 @@ import {
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import { HelpItem } from "ui-shared";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../context/auth/AdminClient";
 
 type RequiredActionMultiSelectProps = {
   name: string;
@@ -24,7 +25,6 @@ export const RequiredActionMultiSelect = ({
   help,
 }: RequiredActionMultiSelectProps) => {
   const { t } = useTranslation("users");
-  const { adminClient } = useAdminClient();
   const { control } = useFormContext();
   const [open, setOpen] = useState(false);
   const [requiredActions, setRequiredActions] = useState<

--- a/js/apps/admin-ui/src/user/user-credentials/ResetCredentialDialog.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/ResetCredentialDialog.tsx
@@ -1,14 +1,14 @@
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { ModalVariant, Form, AlertVariant } from "@patternfly/react-core";
-
 import type { RequiredActionAlias } from "@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderRepresentation";
-import { RequiredActionMultiSelect } from "./RequiredActionMultiSelect";
-import { ConfirmDialogModal } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../../context/auth/AdminClient";
-import { useAlerts } from "../../components/alert/Alerts";
-import { LifespanField } from "./LifespanField";
+import { AlertVariant, Form, ModalVariant } from "@patternfly/react-core";
 import { isEmpty } from "lodash-es";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+import { adminClient } from "../../admin-client";
+import { useAlerts } from "../../components/alert/Alerts";
+import { ConfirmDialogModal } from "../../components/confirm-dialog/ConfirmDialog";
+import { LifespanField } from "./LifespanField";
+import { RequiredActionMultiSelect } from "./RequiredActionMultiSelect";
 
 type ResetCredentialDialogProps = {
   userId: string;
@@ -41,7 +41,6 @@ export const ResetCredentialDialog = ({
   });
   const resetIsNotDisabled = !isEmpty(resetActionWatcher);
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const sendCredentialsResetEmail = async ({

--- a/js/apps/admin-ui/src/user/user-credentials/ResetPasswordDialog.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/ResetPasswordDialog.tsx
@@ -9,15 +9,15 @@ import {
 } from "@patternfly/react-core";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
 
+import { adminClient } from "../../admin-client";
 import { useAlerts } from "../../components/alert/Alerts";
 import {
   ConfirmDialogModal,
   useConfirmDialog,
 } from "../../components/confirm-dialog/ConfirmDialog";
-import { HelpItem } from "ui-shared";
 import { PasswordInput } from "../../components/password-input/PasswordInput";
-import { useAdminClient } from "../../context/auth/AdminClient";
 import useToggle from "../../utils/useToggle";
 
 type ResetPasswordDialogProps = {
@@ -60,7 +60,6 @@ export const ResetPasswordDialog = ({
   const [confirm, toggle] = useToggle(true);
   const password = watch("password", "");
 
-  const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
   const [toggleConfirmSaveModal, ConfirmSaveModal] = useConfirmDialog({

--- a/js/apps/admin-ui/src/utils/useCurrentUser.ts
+++ b/js/apps/admin-ui/src/utils/useCurrentUser.ts
@@ -1,11 +1,12 @@
 import UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import { useState } from "react";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+
+import { adminClient } from "../admin-client";
+import { useFetch } from "../context/auth/AdminClient";
 import { useWhoAmI } from "../context/whoami/WhoAmI";
 
 export function useCurrentUser() {
   const { whoAmI } = useWhoAmI();
-  const { adminClient } = useAdminClient();
   const [currentUser, setCurrentUser] = useState<UserRepresentation>();
 
   const userId = whoAmI.getUserId();


### PR DESCRIPTION
Removes the `AdminClientContext` in favor of directly importing the admin client from it's source module.