### PR TITLE
Fixes a NullPointerException after import validation

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -375,7 +375,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (user != null) {
             user = importValidation(realm, user);
             // Case when email was changed directly in the userStorage and doesn't correspond anymore to the email from local DB
-            if (email.equalsIgnoreCase(user.getEmail())) {
+            if (user != null && email.equalsIgnoreCase(user.getEmail())) {
                 return user;
             }
         }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
@@ -139,15 +139,15 @@ public class UserSyncTest extends KeycloakModelTest {
     @Test
     public void testRemovedLDAPUserShouldNotFailGetUserByEmail() {
         withRealm(realmId, (session, realm) -> {
+            UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));
+            // disable cache
+            providerModel.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
+            realm.updateComponent(providerModel);
+
             ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(realm);
             LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
             LDAPTestUtils.addLDAPUser(ldapFedProvider, realm, "user", "UserFN", "UserLN", "user@email.org", "userStreet", "1450");
             return null;
-        });
-
-        withRealm(realmId, (session, realm) -> {
-            UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));
-            return UserStorageSyncManager.syncAllUsers(session.getKeycloakSessionFactory(), realm.getId(), providerModel);
         });
 
         assertThat(withRealm(realmId, (session, realm) -> session.users().getUserByEmail(realm, "user@email.org")), is(notNullValue()));
@@ -157,11 +157,6 @@ public class UserSyncTest extends KeycloakModelTest {
             LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
             LDAPTestUtils.removeLDAPUserByUsername(ldapFedProvider, realm, ldapFedProvider.getLdapIdentityStore().getConfig(), "user");
             return null;
-        });
-
-        withRealm(realmId, (session, realm) -> {
-            UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));
-            return UserStorageSyncManager.syncAllUsers(session.getKeycloakSessionFactory(), realm.getId(), providerModel);
         });
 
         assertThat(withRealm(realmId, (session, realm) -> session.users().getUserByEmail(realm, "user@email.org")), is(nullValue()));


### PR DESCRIPTION
If the import validation (when getting a user by email) returns null, indicating that the user entity should be removed from local storage, an email equality check results in a NullPointerException.

This commit fixes this issue by explicitly checking for null.

Closes #20150
