### PR TITLE
Exposing the authz client

### DIFF
--- a/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/PolicyEnforcer.java
+++ b/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/PolicyEnforcer.java
@@ -131,6 +131,10 @@ public class PolicyEnforcer {
         return httpClient;
     }
 
+    public AuthzClient getAuthzClient() {
+        return authzClient;
+    }
+
     public Map<String, PathConfig> getPaths() {
         return Collections.unmodifiableMap(paths);
     }


### PR DESCRIPTION
* Helps to integrate with `quarkus-keycloak-authorization`. See https://github.com/pedroigor/quarkus/tree/tmp-kc-22