### PR TITLE
Stops the recreation of managed Keycloak Statefulset Pods when Keycloak Operator restarts occasionally.

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/Constants.java
+++ b/operator/src/main/java/org/keycloak/operator/Constants.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.operator;
 
+import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
+
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -39,12 +42,13 @@ public final class Constants {
             .map(e -> e.getKey() + "=" + e.getValue())
             .collect(Collectors.joining(","));
 
-    public static final Map<String, String> DEFAULT_DIST_CONFIG = Map.of(
-        "health-enabled","true",
-        "cache", "ispn",
-        "cache-stack", "kubernetes",
-        "proxy", "passthrough"
+    public static final List<ValueOrSecret> DEFAULT_DIST_CONFIG_LIST = List.of(
+            new ValueOrSecret("health-enabled", "true"),
+            new ValueOrSecret("cache", "ispn"),
+            new ValueOrSecret("cache-stack", "kubernetes"),
+            new ValueOrSecret("proxy", "passthrough")
     );
+
 
     public static final Integer KEYCLOAK_HTTP_PORT = 8080;
     public static final Integer KEYCLOAK_HTTPS_PORT = 8443;

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -429,19 +429,17 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
 
     private List<EnvVar> getEnvVars() {
         // default config values
-        List<ValueOrSecret> serverConfig = Constants.DEFAULT_DIST_CONFIG.entrySet().stream()
-                .map(e -> new ValueOrSecret(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
+        List<ValueOrSecret> serverConfigsList = new ArrayList<>(Constants.DEFAULT_DIST_CONFIG_LIST);
 
         // merge with the CR; the values in CR take precedence
         if (keycloakCR.getSpec().getAdditionalOptions() != null) {
-            serverConfig.removeAll(keycloakCR.getSpec().getAdditionalOptions());
-            serverConfig.addAll(keycloakCR.getSpec().getAdditionalOptions());
+            serverConfigsList.removeAll(keycloakCR.getSpec().getAdditionalOptions());
+            serverConfigsList.addAll(keycloakCR.getSpec().getAdditionalOptions());
         }
 
         // set env vars
         serverConfigSecretsNames = new HashSet<>();
-        List<EnvVar> envVars = serverConfig.stream()
+        List<EnvVar> envVars = serverConfigsList.stream()
                 .map(v -> {
                     var envBuilder = new EnvVarBuilder().withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(v.getName()));
                     var secret = v.getSecret();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -145,11 +145,19 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
             deployKeycloak(k8sclient, defaultKCDeploy, false);
 
             assertThat(
-                    Constants.DEFAULT_DIST_CONFIG.get(valueSecretHealthProp.getName())
+                    Constants.DEFAULT_DIST_CONFIG_LIST.stream()
+                                                      .filter(oneValueOrSecret -> oneValueOrSecret.getName().equalsIgnoreCase(valueSecretHealthProp.getName()))
+                                                      .findFirst()
+                                                      .get()
+                                                      .getValue()
             ).isEqualTo("true"); // just a sanity check default values did not change
 
             assertThat(
-                    Constants.DEFAULT_DIST_CONFIG.get(valueSecretProxyProp.getName())
+                    Constants.DEFAULT_DIST_CONFIG_LIST.stream()
+                                                      .filter(oneValueOrSecret -> oneValueOrSecret.getName().equalsIgnoreCase(valueSecretProxyProp.getName()))
+                                                      .findFirst()
+                                                      .get()
+                                                      .getValue()
             ).isEqualTo("passthrough"); // just a sanity check default values did not change
 
             Awaitility.await()


### PR DESCRIPTION
When the Operator container is restarted occasionally the Pod Template of the Keycloak StatefulSets managed by the Operator changes which leads to a recreation of the Keycloak containers managed by the Operator. This behavior happens because the Map used for the [default configurations] does not guarantee the order when converted later to a list.

This was fixed by sorting the Map of "default configurations" before converting to a List.


Closes #19725