### PR TITLE
Improve a11y by providing the current language in theme HTML

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -38,6 +38,9 @@ public class LoginPage extends LanguageComboboxAwarePage {
     @ArquillianResource
     protected OAuthClient oauth;
 
+    @FindBy(xpath = "//html")
+    protected WebElement htmlRoot;
+
     @FindBy(id = "username")
     protected WebElement usernameInput;
 
@@ -67,7 +70,6 @@ public class LoginPage extends LanguageComboboxAwarePage {
 
     @FindBy(className = "alert-success")
     private WebElement loginSuccessMessage;
-
 
     @FindBy(className = "alert-info")
     private WebElement loginInfoMessage;
@@ -109,12 +111,15 @@ public class LoginPage extends LanguageComboboxAwarePage {
         usernameInput.sendKeys(username);
         passwordInput.clear();
         clickLink(submitButton);
-
     }
+
     public void missingUsername() {
         clearUsernameInputAndWaitIfNecessary();
         clickLink(submitButton);
+    }
 
+    public String getHtmlLanguage() {
+        return htmlRoot.getAttribute("lang");
     }
 
     public String getUsername() {
@@ -168,6 +173,7 @@ public class LoginPage extends LanguageComboboxAwarePage {
     public String getSuccessMessage() {
         return loginSuccessMessage != null ? loginSuccessMessage.getText() : null;
     }
+
     public String getInfoMessage() {
         try {
             return getTextFromElement(loginInfoMessage);
@@ -175,7 +181,6 @@ public class LoginPage extends LanguageComboboxAwarePage {
             return null;
         }
     }
-
 
     public boolean isCurrent() {
         String realm = "test";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
@@ -121,6 +121,16 @@ public class LoginPageTest extends AbstractI18NTest {
     }
 
     @Test
+    public void htmlLangAttribute() {
+        loginPage.open();
+        assertEquals("en", loginPage.getHtmlLanguage());
+
+        oauth.uiLocales("de");
+        loginPage.open();
+        assertEquals("de", loginPage.getHtmlLanguage());
+    }
+
+    @Test
     public void acceptLanguageHeader() throws IOException {
         try(CloseableHttpClient httpClient = (CloseableHttpClient) new HttpClientBuilder().build()) {
             ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);

--- a/themes/src/main/resources/theme/base/account/template.ftl
+++ b/themes/src/main/resources/theme/base/account/template.ftl
@@ -1,6 +1,6 @@
 <#macro mainLayout active bodyClass>
 <!doctype html>
-<html>
+<html<#if realm.internationalizationEnabled> lang="${locale.currentLanguageTag}"</#if>>
 <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -1,6 +1,6 @@
 <#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false>
 <!DOCTYPE html>
-<html class="${properties.kcHtmlClass!}">
+<html class="${properties.kcHtmlClass!}"<#if realm.internationalizationEnabled> lang="${locale.currentLanguageTag}"</#if>>
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Providing a lang attribute with a valid language tag according to "RFC 5646: Tags for Identifying Languages (also known as BCP 47)" on the `<html>` element will help screen reading technology determine the proper language to announce. The identifying language tag should describe the language used by the majority of the content of the page. Without it, screen readers will typically default to the operating system's set language, which may cause mispronunciations.

### Source

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html#accessibility_concerns

Closes #19965
