### PR TITLE
Changed references to Jira issues to Github issues

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -11,7 +11,7 @@ Contributing to Keycloak Documentation
 
 See our [Contributor's Guide](internal_resources/contributing.adoc). The directory also includes a set of templates and other resources to help you get started.
 
-If you want to file a bug report or tell us about any other issue with this documentation, you are invited to please use our [issue tracker](https://issues.redhat.com/projects/KEYCLOAK/).
+If you want to file a bug report or tell us about any other issue with this documentation, you are invited to please use our [issue tracker](https://github.com/keycloak/keycloak/issues/).
 
 
 Building Keycloak Documentation

--- a/docs/documentation/topics/templates/header.adoc
+++ b/docs/documentation/topics/templates/header.adoc
@@ -1,3 +1,3 @@
 [sidebar,role="page-links"]
 link:https://github.com/keycloak/keycloak/tree/main/docs/documentation/{include_filename}[Edit this section, window="_blank"]
-link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12313920&components=12323375&issuetype=1&priority=3&description=File:%20{include_filename}[Report an issue, window="_blank"]
+link:https://github.com/keycloak/keycloak/issues/new?template=bug.yml&title=Docs:%20{include_filename}&description=%0A%0AFile:%20{include_filename}&version={project_version}&behaviorExpected=%3C!--%20describe%20what%20you%20want%20to%20see%20in%20the%20docs%20--%3E&behaviorActual=%3C!--%20describe%20what%20is%20currently%20wrong%20or%20missing%20in%20the%20docs%20--%3E&reproducer=%3C!--%20list%20steps%20in%20the%20application%20that%20show%20behavior%20that%20should%20be%20documented%20--%3E[Report an issue, window="_blank"]


### PR DESCRIPTION
Closes #19136

Changed the "Report an Issue" link to go to Github Issues instead of the Jira issue tracker.
