### PR TITLE
allow specifying format of "permission" parameter in the UMA grant token endpoint (#15947)

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethodAuthenticator.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethodAuthenticator.java
@@ -134,6 +134,14 @@ public class HttpMethodAuthenticator<R> {
             if (metadata.getResponseMode() != null) {
                 method.param("response_mode", metadata.getResponseMode());
             }
+
+            if (metadata.getPermissionResourceFormat() != null) {
+                method.param("permission_resource_format", metadata.getPermissionResourceFormat().toString());
+            }
+
+            if (metadata.getPermissionResourceMatchingUri() != null) {
+                method.param("permission_resource_matching_uri", metadata.getPermissionResourceMatchingUri().toString());
+            }
         }
 
         return method;

--- a/core/src/main/java/org/keycloak/representations/idm/authorization/AuthorizationRequest.java
+++ b/core/src/main/java/org/keycloak/representations/idm/authorization/AuthorizationRequest.java
@@ -187,6 +187,8 @@ public class AuthorizationRequest {
         private Boolean includeResourceName;
         private Integer limit;
         private String responseMode;
+        private String permissionResourceFormat;
+        private Boolean permissionResourceMatchingUri;
 
         public Boolean getIncludeResourceName() {
             if (includeResourceName == null) {
@@ -213,6 +215,22 @@ public class AuthorizationRequest {
 
         public String getResponseMode() {
             return responseMode;
+        }
+
+        public String getPermissionResourceFormat() {
+            return permissionResourceFormat;
+        }
+
+        public void setPermissionResourceFormat(String permissionResourceFormat) {
+            this.permissionResourceFormat = permissionResourceFormat;
+        }
+
+        public Boolean getPermissionResourceMatchingUri() {
+            return permissionResourceMatchingUri;
+        }
+
+        public void setPermissionResourceMatchingUri(Boolean permissionResourceMatchingUri) {
+            this.permissionResourceMatchingUri = permissionResourceMatchingUri;
         }
     }
 }

--- a/docs/documentation/authorization_services/topics/service-authorization-obtaining-permission.adoc
+++ b/docs/documentation/authorization_services/topics/service-authorization-obtaining-permission.adoc
@@ -38,6 +38,14 @@ This parameter is *optional*. A string representing a set of one or more resourc
 in order to request permission for multiple resource and scopes. This parameter is an extension to `urn:ietf:params:oauth:grant-type:uma-ticket` grant type in order to allow clients to send authorization requests without a
 permission ticket. The format of the string must be: `RESOURCE_ID#SCOPE_ID`. For instance: `Resource A#Scope A`, `Resource A#Scope A, Scope B, Scope C`, `Resource A`, `#Scope A`.
 +
+* **permission_resource_format**
++
+This parameter is *optional*. A string representing a format indicating the resource in the `permission` parameter. Possible values are `id` and `uri`. `id` indicates the format is `RESOURCE_ID`. `uri` indicates the format is `URI`. If not specified, the default is `id`.
++
+* **permission_resource_matching_uri**
++
+This parameter is *optional*. A boolean value that indicates whether to use path matching when representing resources in URI format in the `permission` parameter. If not specified, the default is false.
++
 * **audience**
 +
 This parameter is *optional*. The client identifier of the resource server to which the client is seeking access. This parameter is mandatory

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -19,6 +19,8 @@ package org.keycloak.authorization.authorization;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -59,12 +61,14 @@ import org.keycloak.authorization.util.Tokens;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.PathMatcher;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -801,6 +805,130 @@ public class AuthorizationTokenService {
 
         ClientConnection getClientConnection() {
             return clientConnection;
+        }
+
+        public void addPermissions(List<String> permissionList, String permissionResourceFormat, boolean matchingUri) {
+            if (permissionResourceFormat == null) {
+                permissionResourceFormat = "id";
+            }
+
+            switch (permissionResourceFormat) {
+                case "id":
+                    addPermissionsById(permissionList);
+                    break;
+                case "uri":
+                    addPermissionsByUri(permissionList, matchingUri);
+                    break;
+            }
+
+        }
+
+        private void addPermissionsById(List<String> permissionList) {
+            for (String permission : permissionList) {
+                String[] parts = permission.split("#");
+                String rsid = parts[0];
+
+                if (parts.length == 1) {
+                    addPermission(rsid);
+                } else {
+                    String[] scopes = parts[1].split(",");
+                    addPermission(rsid, scopes);
+                }
+            }
+        }
+
+        private void addPermissionsByUri(List<String> permissionList, boolean matchingUri) {
+            StoreFactory storeFactory = authorization.getStoreFactory();
+
+            for (String permission : permissionList) {
+                String[] parts = permission.split("#");
+                String uri = parts[0];
+
+                if (parts.length == 1) {
+                    // only resource uri is specified
+                    if (uri.isEmpty()) {
+                        CorsErrorResponseException invalidResourceException = new CorsErrorResponseException(getCors(),
+                            OAuthErrorException.INVALID_REQUEST, "You must provide the uri", Status.BAD_REQUEST);
+                        fireErrorEvent(getEvent(), Errors.INVALID_REQUEST, invalidResourceException);
+                        throw invalidResourceException;
+                    }
+
+                    List<Resource> resources = getResourceListByUri(uri, storeFactory, matchingUri);
+
+                    if (resources == null || resources.isEmpty()) {
+                        CorsErrorResponseException invalidResourceException = new CorsErrorResponseException(getCors(),
+                            "invalid_resource", "Resource with uri [" + uri + "] does not exist.", Status.BAD_REQUEST);
+                        fireErrorEvent(getEvent(), Errors.INVALID_REQUEST, invalidResourceException);
+                        throw invalidResourceException;
+                    }
+
+                    resources.stream().forEach(resource -> addPermission(resource.getId()));
+                } else {
+                    // resource uri and scopes are specified, or only scopes are specified
+                    String[] scopes = parts[1].split(",");
+                    
+                    if (uri.isEmpty()) {
+                        // only scopes are specified
+                        addPermission("", scopes);
+                        return;
+                    }
+
+                    List<Resource> resources = getResourceListByUri(uri, storeFactory, matchingUri);
+
+                    if (resources == null || resources.isEmpty()) {
+                        CorsErrorResponseException invalidResourceException = new CorsErrorResponseException(getCors(),
+                            "invalid_resource", "Resource with uri [" + uri + "] does not exist.", Status.BAD_REQUEST);
+                        fireErrorEvent(getEvent(), Errors.INVALID_REQUEST, invalidResourceException);
+                        throw invalidResourceException;
+                    }
+
+                    resources.stream().forEach(resource -> addPermission(resource.getId(), scopes));
+                }
+            }
+        }
+
+        private List<Resource> getResourceListByUri(String uri, StoreFactory storeFactory, boolean matchingUri) {
+            Map<Resource.FilterOption, String[]> search = new EnumMap<>(Resource.FilterOption.class);
+            search.put(Resource.FilterOption.URI, new String[] { uri });
+            ResourceServer resourceServer = storeFactory.getResourceServerStore()
+                .findByClient(getRealm().getClientByClientId(getAudience()));
+            List<Resource> resources = storeFactory.getResourceStore().find(getRealm(), resourceServer, search, -1,
+                Constants.DEFAULT_MAX_RESULTS);
+
+            if (!matchingUri || !resources.isEmpty()) {
+                return resources;
+            }
+
+            search = new EnumMap<>(Resource.FilterOption.class);
+            search.put(Resource.FilterOption.URI_NOT_NULL, new String[] { "true" });
+            search.put(Resource.FilterOption.OWNER, new String[] { resourceServer.getClientId() });
+
+            List<Resource> serverResources = storeFactory.getResourceStore().find(getRealm(), resourceServer, search, -1, -1);
+
+            PathMatcher<Map.Entry<String, Resource>> pathMatcher = new PathMatcher<Map.Entry<String, Resource>>() {
+                @Override
+                protected String getPath(Map.Entry<String, Resource> entry) {
+                    return entry.getKey();
+                }
+
+                @Override
+                protected Collection<Map.Entry<String, Resource>> getPaths() {
+                    Map<String, Resource> result = new HashMap<>();
+                    serverResources.forEach(resource -> resource.getUris().forEach(uri -> {
+                        result.put(uri, resource);
+                    }));
+
+                    return result.entrySet();
+                }
+            };
+
+            Map.Entry<String, Resource> matches = pathMatcher.matches(uri);
+
+            if (matches != null) {
+                return Collections.singletonList(matches.getValue());
+            }
+
+            return null;
         }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -960,17 +960,9 @@ public class TokenEndpoint {
 
         if (permissions != null) {
             event.detail(Details.PERMISSION, String.join("|", permissions));
-            for (String permission : permissions) {
-                String[] parts = permission.split("#");
-                String resource = parts[0];
-
-                if (parts.length == 1) {
-                    authorizationRequest.addPermission(resource);
-                } else {
-                    String[] scopes = parts[1].split(",");
-                    authorizationRequest.addPermission(parts[0], scopes);
-                }
-            }
+            String permissionResourceFormat = formParams.getFirst("permission_resource_format");
+            boolean permissionResourceMatchingUri = Boolean.parseBoolean(formParams.getFirst("permission_resource_matching_uri"));
+            authorizationRequest.addPermissions(permissions, permissionResourceFormat, permissionResourceMatchingUri);
         }
 
         Metadata metadata = new Metadata();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
@@ -30,6 +30,7 @@ import static org.keycloak.testsuite.util.OAuthClient.AUTH_SERVER_ROOT;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +96,7 @@ public class UmaGrantTypeTest extends AbstractResourceServerTest {
         authorization.policies().js().create(policy).close();
 
         ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
-        resourceA = addResource("Resource A", "ScopeA", "ScopeB", "ScopeC");
+        resourceA = addResource("Resource A", null, Collections.singleton("/resource"), false, "ScopeA", "ScopeB", "ScopeC");
 
         permission.setName(resourceA.getName() + " Permission");
         permission.addResource(resourceA.getName());
@@ -369,6 +370,60 @@ public class UmaGrantTypeTest extends AbstractResourceServerTest {
         assertNotNull(permissions);
         assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
         assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainDecisionUsingAccessToken() throws Exception {
+        AccessTokenResponse accessTokenResponse = getAuthzClient().obtainAccessToken("marta", "password");
+
+        // use "rsid" as "uri"
+        // uri and scopes exist
+        AuthorizationResponse response = authorizeDecision(accessTokenResponse.getToken(), null,
+            new PermissionRequest("/resource", "ScopeA", "ScopeB"));
+        assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        // uri and scopes are empty
+        try {
+            response = authorizeDecision(accessTokenResponse.getToken(), null, new PermissionRequest(null));
+            fail();
+        } catch (Exception ignore) {
+        }
+
+        // uri is empty but scopes exist
+        response = authorizeDecision(accessTokenResponse.getToken(), null, new PermissionRequest(null, "ScopeA", "ScopeB"));
+        assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        // test wild card
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        ResourceRepresentation resourceB = addResource("Resource B", null, Collections.singleton("/rs/*"), false, "ScopeD",
+            "ScopeE");
+
+        permission.setName(resourceB.getName() + " Permission");
+        permission.addResource(resourceB.getName());
+        permission.addPolicy("Default Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        // matchingUri is null, then result error
+        try {
+            response = authorizeDecision(accessTokenResponse.getToken(), null,
+                new PermissionRequest("/rs/data", "ScopeD", "ScopeE"));
+            fail();
+        } catch (Exception ignore) {
+        }
+
+        // matchingUri is true, then result true
+        response = authorizeDecision(accessTokenResponse.getToken(), true,
+            new PermissionRequest("/rs/data", "ScopeD", "ScopeE"));
+        assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        // matchingUri is false, then result error
+        try {
+            response = authorizeDecision(accessTokenResponse.getToken(), false,
+                new PermissionRequest("/rs/data", "ScopeD", "ScopeE"));
+            fail();
+        } catch (Exception ignore) {
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/15947

To get only the "result" by specifying the response_mode=decision at the token endpoint, it was necessary to obtain the "rsid" of the resource in advance by for example calling the /authz/protection/resource_set endpoint.
Example: grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&audience=< client_id >&response_mode=decision&permission=< rsid >

With this enhancement, you can get the "result" only from the "URI" of the resource without obtaining the "rsid" in advance.
Example: grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&audience=< client_id >&response_mode=decision&permission=< uri >&**permission_resource_format=uri**

specification
- The "permission_resource_format" parameter added this time could specify either "uri" or "id".
- If "uri" is specified in the "permission_resource_format" parameter, the URI of the resource can be specified in the permission parameter.
- If "id" is specified in the "permission_resource_format" parameter or if the "permission_resource_format" parameter is not specified, the "rsid" of the resource can be specified in the permission parameter as before.