### PR TITLE
Force user to authenticate before bootstrapping Admin Console

### DIFF
--- a/js/apps/admin-ui/src/keycloak.ts
+++ b/js/apps/admin-ui/src/keycloak.ts
@@ -9,3 +9,15 @@ export const keycloak = new Keycloak({
     ? "security-admin-console"
     : "security-admin-console-v2",
 });
+
+export async function initKeycloak() {
+  const authenticated = await keycloak.init({
+    onLoad: "check-sso",
+    pkceMethod: "S256",
+  });
+
+  // Force the user to login if not authenticated.
+  if (!authenticated) {
+    await keycloak.login();
+  }
+}

--- a/js/apps/admin-ui/src/main.tsx
+++ b/js/apps/admin-ui/src/main.tsx
@@ -6,13 +6,13 @@ import { render } from "react-dom";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
 import { initI18n } from "./i18n";
-import { keycloak } from "./keycloak";
+import { initKeycloak } from "./keycloak";
 import { RootRoute } from "./routes";
 
 import "./index.css";
 
 // Initialize required components before rendering app.
-await keycloak.init({ onLoad: "check-sso", pkceMethod: "S256" });
+await initKeycloak();
 await initI18n();
 
 const router = createHashRouter([RootRoute]);


### PR DESCRIPTION
Forces the user to be authenticated when initializing Keycloak JS during the bootstrapping process of the Admin Console. This could help towards fixing #20196