### PR TITLE
[docs] Add Keycloak JIRA login redirect to allow list.

### DIFF
--- a/docs/documentation/tests/src/test/resources/ignored-link-redirects
+++ b/docs/documentation/tests/src/test/resources/ignored-link-redirects
@@ -14,3 +14,4 @@ https://access.redhat.com/login?redirectTo=https://access.redhat.com/terms-based
 https://sso.redhat.com/auth/*
 REGEX:https://access.redhat.com/documentation/.*/index
 https://nodejs.org/en
+REGEX:/login\.jsp.+KEYCLOAK-[0-9]+.*


### PR DESCRIPTION
Modify the ignored-link-redirects to include a regex that covers the Keycloak JIRA login redirect.

This will prevent the tests from failing due to seeing the login redirect.

Closes keycloak/keycloak#20259

