### PR TITLE
File store freeze

### DIFF
--- a/model/build-processor/src/main/java/org/keycloak/models/map/processor/GenerateEntityImplementationsProcessor.java
+++ b/model/build-processor/src/main/java/org/keycloak/models/map/processor/GenerateEntityImplementationsProcessor.java
@@ -575,6 +575,10 @@ public class GenerateEntityImplementationsProcessor extends AbstractGenerateEnti
                 pw.println("        return entityFieldDelegate.isUpdated();");
                 pw.println("    }");
 
+                pw.println("    @Override public void markUpdatedFlag() {");
+                pw.println("        entityFieldDelegate.markUpdatedFlag();");
+                pw.println("    }");
+
                 pw.println("    @Override public void clearUpdatedFlag() {");
                 pw.println("        entityFieldDelegate.clearUpdatedFlag();");
                 pw.println("    }");

--- a/model/build-processor/src/main/java/org/keycloak/models/map/processor/GenerateEntityImplementationsProcessor.java
+++ b/model/build-processor/src/main/java/org/keycloak/models/map/processor/GenerateEntityImplementationsProcessor.java
@@ -579,6 +579,10 @@ public class GenerateEntityImplementationsProcessor extends AbstractGenerateEnti
                 pw.println("        entityFieldDelegate.clearUpdatedFlag();");
                 pw.println("    }");
 
+                pw.println("    @Override public String toString() {");
+                pw.println("        return \"%\" + String.valueOf(entityFieldDelegate);");
+                pw.println("    }");
+
                 getAllAbstractMethods(e)
                   .forEach(ee -> {
                       String originalField = m2field.get(ee);
@@ -699,6 +703,10 @@ public class GenerateEntityImplementationsProcessor extends AbstractGenerateEnti
                 pw.println("    }");
                 pw.println("    public org.keycloak.models.map.common.delegate.DelegateProvider<" + className + "> getDelegateProvider() {");
                 pw.println("        return this.delegateProvider;");
+                pw.println("    }");
+
+                pw.println("    @Override public String toString() {");
+                pw.println("        return \"/\" + String.valueOf(this.delegateProvider);");
                 pw.println("    }");
 
                 getAllAbstractMethods(e)

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
@@ -265,8 +265,8 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
         for (int counter = 0; counter < 100; counter++) {
             LOG.tracef("Attempting to create file %s", sp, StackUtil.getShortStackTrace());
             try {
-                touch(sp);
                 final String res = String.join(ID_COMPONENT_SEPARATOR, escapedProposedId);
+                touch(res, sp);
                 LOG.tracef("determineKeyFromValue: got %s for created %s", res, value);
                 return res;
             } catch (FileAlreadyExistsException ex) {
@@ -408,7 +408,7 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
         }
     }
 
-    protected abstract void touch(Path sp) throws IOException;
+    protected abstract void touch(String proposedId, Path sp) throws IOException;
 
     protected abstract boolean removeIfExists(Path sp);
 

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
@@ -222,7 +222,7 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
 
         String[] escapedProposedId = escapeId(proposedId);
         final String res = String.join(ID_COMPONENT_SEPARATOR, escapedProposedId);
-        if (LOG.isDebugEnabled()) {
+        if (LOG.isTraceEnabled()) {
             LOG.tracef("determineKeyFromValue: got %s (%s) for %s", res, res == null ? null : String.join(" [/] ", proposedId), value);
         }
         return res;

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
@@ -137,7 +137,7 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
 
     // Percent sign + Unix (/) and https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file reserved characters
     private static final Pattern RESERVED_CHARACTERS = Pattern.compile("[%<:>\"/\\\\|?*=]");
-    private static final String ID_COMPONENT_SEPARATOR = ":";
+    public static final String ID_COMPONENT_SEPARATOR = ":";
     private static final String ESCAPING_CHARACTER = "=";
     private static final Pattern ID_COMPONENT_SEPARATOR_PATTERN = Pattern.compile(Pattern.quote(ID_COMPONENT_SEPARATOR) + "+");
 

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileCrudOperations.java
@@ -25,6 +25,7 @@ import org.keycloak.models.map.common.AbstractEntity;
 import org.keycloak.models.map.common.ExpirationUtils;
 import org.keycloak.models.map.common.HasRealmId;
 import org.keycloak.models.map.common.StringKeyConverter;
+import org.keycloak.models.map.common.StringKeyConverter.StringKey;
 import org.keycloak.models.map.common.UpdatableEntity;
 import org.keycloak.models.map.realm.MapRealmEntity;
 import org.keycloak.models.map.storage.ModelEntityUtil;
@@ -184,11 +185,11 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
             return null;
         }
 
-        String escapedId = determineKeyFromValue(parsedObject, false);
         final String fileNameStr = fileName.getFileName().toString();
         final String idFromFilename = fileNameStr.substring(0, fileNameStr.length() - FILE_SUFFIX.length());
+        String escapedId = determineKeyFromValue(parsedObject, idFromFilename);
         if (escapedId == null) {
-            LOG.debugf("Determined ID from filename: %s%s", idFromFilename);
+            LOG.tracef("Determined ID from filename: %s%s", idFromFilename);
             escapedId = idFromFilename;
         } else if (!escapedId.endsWith(idFromFilename)) {
             LOG.warnf("Id \"%s\" does not conform with filename \"%s\", expected: %s", escapedId, fileNameStr, escapeId(escapedId));
@@ -210,6 +211,23 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
         return value;
     }
 
+    public String determineKeyFromValue(V value, String lastIdComponentIfUnset) {
+        String[] proposedId = suggestedPath.apply(value);
+
+        if (proposedId == null || proposedId.length == 0) {
+            return lastIdComponentIfUnset;
+        } else if (proposedId[proposedId.length - 1] == null) {
+            proposedId[proposedId.length - 1] = lastIdComponentIfUnset;
+        }
+
+        String[] escapedProposedId = escapeId(proposedId);
+        final String res = String.join(ID_COMPONENT_SEPARATOR, escapedProposedId);
+        if (LOG.isDebugEnabled()) {
+            LOG.tracef("determineKeyFromValue: got %s (%s) for %s", res, res == null ? null : String.join(" [/] ", proposedId), value);
+        }
+        return res;
+    }
+
     /**
      * Returns escaped ID - relative file name in the file system with path separator {@link #ID_COMPONENT_SEPARATOR}.
      *
@@ -218,22 +236,16 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
      * @return
      */
     @Override
-    public String determineKeyFromValue(V value, boolean forCreate) {
+    public String determineKeyFromValue(V value) {
         final boolean randomId;
         String[] proposedId = suggestedPath.apply(value);
 
-        if (!forCreate) {
-            String[] escapedProposedId = escapeId(proposedId);
-            final String res = proposedId == null ? null : String.join(ID_COMPONENT_SEPARATOR, escapedProposedId);
-            if (LOG.isDebugEnabled()) {
-                LOG.debugf("determineKeyFromValue: got %s (%s) for %s", res, res == null ? null : String.join(" [/] ", proposedId), value);
-            }
-            return res;
-        }
-
         if (proposedId == null || proposedId.length == 0) {
             randomId = value.getId() == null;
-            proposedId = new String[]{value.getId() == null ? StringKeyConverter.StringKey.INSTANCE.yieldNewUniqueKey() : value.getId()};
+            proposedId = new String[] { value.getId() == null ? StringKey.INSTANCE.yieldNewUniqueKey() : value.getId() };
+        } else if (proposedId[proposedId.length - 1] == null) {
+            randomId = true;
+            proposedId[proposedId.length - 1] = StringKey.INSTANCE.yieldNewUniqueKey();
         } else {
             randomId = false;
         }
@@ -242,7 +254,7 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
         Path sp = getPathForEscapedId(escapedProposedId);   // sp will never be null
 
         final Path parentDir = sp.getParent();
-        if (!Files.isDirectory(parentDir)) {
+        if (! Files.isDirectory(parentDir)) {
             try {
                 Files.createDirectories(parentDir);
             } catch (IOException ex) {
@@ -255,13 +267,13 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
             try {
                 touch(sp);
                 final String res = String.join(ID_COMPONENT_SEPARATOR, escapedProposedId);
-                LOG.debugf("determineKeyFromValue: got %s for created %s", res, value);
+                LOG.tracef("determineKeyFromValue: got %s for created %s", res, value);
                 return res;
             } catch (FileAlreadyExistsException ex) {
-                if (!randomId) {
+                if (! randomId) {
                     throw new ModelDuplicateException("File " + sp + " already exists!");
                 }
-                final String lastComponent = StringKeyConverter.StringKey.INSTANCE.yieldNewUniqueKey();
+                final String lastComponent = StringKey.INSTANCE.yieldNewUniqueKey();
                 escapedProposedId[escapedProposedId.length - 1] = lastComponent;
                 sp = getPathForEscapedId(escapedProposedId);
             } catch (IOException ex) {
@@ -299,7 +311,7 @@ public abstract class FileCrudOperations<V extends AbstractEntity & UpdatableEnt
 
         // We cannot use Files.find since it throws an UncheckedIOException if it lists a file which is removed concurrently
         // before its BasicAttributes can be retrieved for its BiPredicate parameter
-        try (Stream<Path> dirStream = Files.walk(dataDirectory, entityClass == MapRealmEntity.class ? 1 : 2)) {
+        try (Stream<Path> dirStream = Files.walk(dataDirectory, entityClass == MapRealmEntity.class ? 1 : 3)) {
             // The paths list has to be materialized first, otherwise "dirStream" would be closed
             // before the resulting stream would be read and would return empty result
             paths = dirStream.collect(Collectors.toList());

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorage.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorage.java
@@ -50,7 +50,7 @@ import java.util.function.Function;
  * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
  */
 public class FileMapStorage<V extends AbstractEntity & UpdatableEntity, M>
-  extends ConcurrentHashMapStorage<String, V, M> {
+  extends ConcurrentHashMapStorage<String, V, M, FileCrudOperations<V, M>> {
 
     private static final Logger LOG = Logger.getLogger(FileMapStorage.class);
 
@@ -203,7 +203,7 @@ public class FileMapStorage<V extends AbstractEntity & UpdatableEntity, M>
 
     private static class Crud<V extends AbstractEntity & UpdatableEntity, M> extends FileCrudOperations<V, M> {
 
-        private FileMapStorage store;
+        private FileMapStorage<V, M> store;
 
         public Crud(Class<V> entityClass, Function<String, Path> dataDirectoryFunc, Function<V, String[]> suggestedPath, boolean isExpirableEntity) {
             super(entityClass, dataDirectoryFunc, suggestedPath, isExpirableEntity);
@@ -250,7 +250,7 @@ public class FileMapStorage<V extends AbstractEntity & UpdatableEntity, M>
         public <T, EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> void set(EF field, T value) {
             String id = entity.getId();
             super.set(field, value);
-            if (! Objects.equals(id, map.determineKeyFromValue(entity, false))) {
+            if (! Objects.equals(id, map.determineKeyFromValue(entity, "RAND"))) {
                 throw new ReadOnlyException("Cannot change " + field + " as that would change primary key");
             }
         }

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorage.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorage.java
@@ -44,6 +44,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.keycloak.models.map.storage.file.FileCrudOperations.ID_COMPONENT_SEPARATOR;
+
 /**
  * {@link MapStorage} implementation used with the file map storage.
  *
@@ -250,7 +252,46 @@ public class FileMapStorage<V extends AbstractEntity & UpdatableEntity, M>
         public <T, EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> void set(EF field, T value) {
             String id = entity.getId();
             super.set(field, value);
-            if (! Objects.equals(id, map.determineKeyFromValue(entity, "RAND"))) {
+            checkIdMatches(id, field);
+        }
+
+        @Override
+        public <T, EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> void collectionAdd(EF field, T value) {
+            String id = entity.getId();
+            super.collectionAdd(field, value);
+            checkIdMatches(id, field);
+        }
+
+        @Override
+        public <T, EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> Object collectionRemove(EF field, T value) {
+            String id = entity.getId();
+            final Object res = super.collectionRemove(field, value);
+            checkIdMatches(id, field);
+            return res;
+        }
+
+        @Override
+        public <K, T, EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> void mapPut(EF field, K key, T value) {
+            String id = entity.getId();
+            super.mapPut(field, key, value);
+            checkIdMatches(id, field);
+        }
+
+        @Override
+        public <K, EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> Object mapRemove(EF field, K key) {
+            String id = entity.getId();
+            final Object res = super.mapRemove(field, key);
+            checkIdMatches(id, field);
+            return res;
+        }
+
+        private <EF extends java.lang.Enum<? extends org.keycloak.models.map.common.EntityField<V>> & org.keycloak.models.map.common.EntityField<V>> void checkIdMatches(String id, EF field) throws ReadOnlyException {
+            final String idNow = map.determineKeyFromValue(entity, "");
+            if (! Objects.equals(id, idNow)) {
+                if (idNow.endsWith(ID_COMPONENT_SEPARATOR) && id.startsWith(idNow)) {
+                    return;
+                }
+
                 throw new ReadOnlyException("Cannot change " + field + " as that would change primary key");
             }
         }

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorageProvider.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorageProvider.java
@@ -55,7 +55,7 @@ public class FileMapStorageProvider implements MapStorageProvider {
         return (MapStorage<V, M>) SessionAttributesUtils.createMapStorageIfAbsent(session, getClass(), modelType, factoryId, () -> createFileMapStorage(modelType));
     }
 
-    private <V extends AbstractEntity & UpdatableEntity, M> ConcurrentHashMapStorage<?, V, M> createFileMapStorage(Class<M> modelType) {
+    private <V extends AbstractEntity & UpdatableEntity, M> ConcurrentHashMapStorage<?, V, M, FileCrudOperations<V, M>> createFileMapStorage(Class<M> modelType) {
         String areaName = getModelName(modelType, modelType.getSimpleName());
         final Class<V> et = ModelEntityUtil.getEntityType(modelType);
         Function<V, String[]> uniqueHumanReadableField = (Function<V, String[]>) UNIQUE_HUMAN_READABLE_NAME_FIELD.get(et);

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorageProviderFactory.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/FileMapStorageProviderFactory.java
@@ -78,8 +78,10 @@ public class FileMapStorageProviderFactory implements AmphibianProviderFactory<M
       // authz
       entry(MapResourceServerEntity.class,  ((Function<MapResourceServerEntity, String[]>) v -> new String[] { v.getClientId() })),
       entry(MapPolicyEntity.class,          ((Function<MapPolicyEntity, String[]>) v -> new String[] { v.getResourceServerId(), v.getName() })),
-      entry(MapPermissionTicketEntity.class,((Function<MapPermissionTicketEntity, String[]>) v -> new String[] { v.getResourceServerId(), v.getId()})),
-      entry(MapResourceEntity.class,        ((Function<MapResourceEntity, String[]>) v -> new String[] { v.getResourceServerId(), v.getName() })),
+      entry(MapPermissionTicketEntity.class,((Function<MapPermissionTicketEntity, String[]>) v -> new String[] { v.getResourceServerId(), null })),
+      entry(MapResourceEntity.class,        ((Function<MapResourceEntity, String[]>) v -> Objects.equals(v.getResourceServerId(), v.getOwner())
+                                                                                          ? new String[] { v.getResourceServerId(), v.getName() }
+                                                                                          : new String[] { v.getResourceServerId(), v.getName(), v.getOwner() })),
       entry(MapScopeEntity.class,           ((Function<MapScopeEntity, String[]>) v -> new String[] { v.getResourceServerId(), v.getName() }))
     );
 

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/common/BlockContext.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/common/BlockContext.java
@@ -135,7 +135,7 @@ public interface BlockContext<V> {
 
         @Override
         public void writeValue(Object value, WritingMechanism mech) {
-            if (UndefinedValuesUtils.isUndefined(value)) return;
+            if (value == null || (value.getClass() != String.class && UndefinedValuesUtils.isUndefined(value))) return;
             mech.writeObject(value);
         }
 

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/common/MapEntityContext.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/common/MapEntityContext.java
@@ -243,6 +243,11 @@ public class MapEntityContext<T> implements BlockContext<T> {
         });
     }
 
+    @Override
+    public String toString() {
+        return "MapEntityContext[" + objectClass.getCanonicalName() + ']';
+    }
+
     public static class MapEntitySequenceYamlContext<T> extends DefaultListContext<T> {
 
         public MapEntitySequenceYamlContext(Class<T> itemClass) {

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/yaml/YamlParser.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/yaml/YamlParser.java
@@ -46,6 +46,9 @@ import org.snakeyaml.engine.v2.resolver.ScalarResolver;
 import org.snakeyaml.engine.v2.scanner.StreamReader;
 import org.keycloak.models.map.storage.file.common.BlockContext;
 
+import java.util.Map;
+import org.snakeyaml.engine.v2.constructor.ConstructScalar;
+import org.snakeyaml.engine.v2.nodes.Node;
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
 
 /**
@@ -73,15 +76,24 @@ public class YamlParser<E> {
         public Object constructStandardJavaInstance(ScalarNode node) {
             return findConstructorFor(node)
                 .map(constructor -> constructor.construct(node))
-                .orElseThrow(() -> new ConstructorException(null, Optional.empty(), "could not determine a constructor for the tag " + node.getTag(), node.getStartMark()));
+                .orElseThrow(() -> new ConstructorException(null, Optional.empty(), "Could not determine a constructor for the tag " + node.getTag(), node.getStartMark()));
         }
 
         public static final MiniConstructor INSTANCE = new MiniConstructor();
     }
 
+    private static final class NullConstructor extends ConstructScalar {
+
+        @Override
+        public Object construct(Node node) {
+            return null;
+        }
+    }
+
     private static final LoadSettings SETTINGS = LoadSettings.builder()
       .setAllowRecursiveKeys(false)
       .setParseComments(false)
+      .setTagConstructors(Map.of(Tag.NULL, new NullConstructor()))
       .build();
 
     public static <E> E parse(Path path, BlockContext<E> initialContext) {

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/yaml/YamlParser.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/yaml/YamlParser.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.models.map.storage.file.yaml;
 
+import org.keycloak.models.map.common.CastUtils;
 import org.keycloak.models.map.storage.file.common.BlockContextStack;
 import org.keycloak.models.map.storage.file.common.BlockContext.DefaultListContext;
 import org.keycloak.models.map.storage.file.common.BlockContext.DefaultMapContext;
@@ -187,7 +188,11 @@ public class YamlParser<E> {
             Object key = parseNodeInFreshContext();
             LOG.tracef("Parsed mapping key: %s", key);
             if (! (key instanceof String)) {
-                throw new IllegalStateException("Invalid key in map: " + key);
+                try {
+                    key = CastUtils.cast(key, String.class);
+                } catch (IllegalStateException ex) {
+                    throw new IllegalStateException("Invalid key in map: " + key);
+                }
             }
             Object value = parseNodeInFreshContext((String) key);
             LOG.tracef("Parsed mapping value: %s", value);

--- a/model/map-file/src/main/java/org/keycloak/models/map/storage/file/yaml/YamlWritingMechanism.java
+++ b/model/map-file/src/main/java/org/keycloak/models/map/storage/file/yaml/YamlWritingMechanism.java
@@ -141,8 +141,15 @@ public class YamlWritingMechanism implements WritingMechanism, Closeable {
     }
 
     private ScalarStyle determineStyle(Object value) {
-        if (value instanceof String && ((String) value).lastIndexOf('\n') > 0) {
-            return ScalarStyle.FOLDED;
+        if (value instanceof String) {
+            String sValue = (String) value;
+            // TODO: Check numeric values and quote those as well
+            if ("null".equals(sValue)) {
+                return ScalarStyle.DOUBLE_QUOTED;
+            }
+            if (sValue.length() > 120 || sValue.lastIndexOf('\n') > 0) {
+                return ScalarStyle.FOLDED;
+            }
         }
         return ScalarStyle.PLAIN;
     }

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/HotRodMapStorageProvider.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/HotRodMapStorageProvider.java
@@ -88,7 +88,7 @@ public class HotRodMapStorageProvider implements MapStorageProvider {
         }
     }
 
-    private <K, E extends AbstractHotRodEntity, V extends HotRodEntityDelegate<E> & AbstractEntity, M> ConcurrentHashMapStorage<K, V, M> createHotRodMapStorage(KeycloakSession session, Class<M> modelType, MapStorageProviderFactory.Flag... flags) {
+    private <K, E extends AbstractHotRodEntity, V extends HotRodEntityDelegate<E> & AbstractEntity, M> ConcurrentHashMapStorage<K, V, M, ?> createHotRodMapStorage(KeycloakSession session, Class<M> modelType, MapStorageProviderFactory.Flag... flags) {
         HotRodConnectionProvider connectionProvider = session.getProvider(HotRodConnectionProvider.class);
         HotRodEntityDescriptor<E, V> entityDescriptor = (HotRodEntityDescriptor<E, V>) factory.getEntityDescriptor(modelType);
         Map<SearchableModelField<? super M>, MapModelCriteriaBuilder.UpdatePredicatesFunc<String, V, M>> fieldPredicates = MapFieldPredicates.getPredicates((Class<M>) entityDescriptor.getModelTypeClass());

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/transaction/AllAreasHotRodStoresWrapper.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/transaction/AllAreasHotRodStoresWrapper.java
@@ -30,10 +30,10 @@ import java.util.function.Supplier;
  */
 public class AllAreasHotRodStoresWrapper extends AbstractKeycloakTransaction {
 
-    private final Map<Class<?>, ConcurrentHashMapStorage<?, ?, ?>> MapKeycloakStoresMap = new ConcurrentHashMap<>();
+    private final Map<Class<?>, ConcurrentHashMapStorage<?, ?, ?, ?>> MapKeycloakStoresMap = new ConcurrentHashMap<>();
 
-    public ConcurrentHashMapStorage<?, ?, ?> getOrCreateStoreForModel(Class<?> modelType, Supplier<ConcurrentHashMapStorage<?, ?, ?>> supplier) {
-        ConcurrentHashMapStorage<?, ?, ?> store = MapKeycloakStoresMap.computeIfAbsent(modelType, t -> supplier.get());
+    public ConcurrentHashMapStorage<?, ?, ?, ?> getOrCreateStoreForModel(Class<?> modelType, Supplier<ConcurrentHashMapStorage<?, ?, ?, ?>> supplier) {
+        ConcurrentHashMapStorage<?, ?, ?, ?> store = MapKeycloakStoresMap.computeIfAbsent(modelType, t -> supplier.get());
         if (!store.isActive()) {
             store.begin();
         }

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodUserSessionMapStorage.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodUserSessionMapStorage.java
@@ -25,6 +25,7 @@ import org.keycloak.models.map.common.StringKeyConverter;
 import org.keycloak.models.map.common.delegate.SimpleDelegateProvider;
 import org.keycloak.models.map.storage.QueryParameters;
 import org.keycloak.models.map.storage.CrudOperations;
+import org.keycloak.models.map.storage.chm.ConcurrentHashMapCrudOperations;
 import org.keycloak.models.map.storage.chm.ConcurrentHashMapStorage;
 import org.keycloak.models.map.storage.chm.MapModelCriteriaBuilder;
 import org.keycloak.models.map.storage.criteria.DefaultModelCriteria;
@@ -43,15 +44,15 @@ import java.util.stream.Stream;
 
 import static org.keycloak.models.map.storage.ModelCriteriaBuilder.Operator.IN;
 
-public class HotRodUserSessionMapStorage<K> extends ConcurrentHashMapStorage<K, MapUserSessionEntity, UserSessionModel> {
+public class HotRodUserSessionMapStorage<K> extends ConcurrentHashMapStorage<K, MapUserSessionEntity, UserSessionModel, CrudOperations<MapUserSessionEntity, UserSessionModel>> {
 
-    private final ConcurrentHashMapStorage<String, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionStore;
+    private final ConcurrentHashMapStorage<String, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel, CrudOperations<MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel>> clientSessionStore;
 
     public HotRodUserSessionMapStorage(CrudOperations<MapUserSessionEntity, UserSessionModel> map,
                                        StringKeyConverter<K> keyConverter,
                                        DeepCloner cloner,
                                        Map<SearchableModelField<? super UserSessionModel>, MapModelCriteriaBuilder.UpdatePredicatesFunc<K, MapUserSessionEntity, UserSessionModel>> fieldPredicates,
-                                       ConcurrentHashMapStorage<String, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionStore
+                                       ConcurrentHashMapStorage<String, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel, CrudOperations<MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel>> clientSessionStore
     ) {
         super(map, keyConverter, cloner, fieldPredicates);
         this.clientSessionStore = clientSessionStore;

--- a/model/map/src/main/java/org/keycloak/models/map/common/UpdatableEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/UpdatableEntity.java
@@ -33,6 +33,11 @@ public interface UpdatableEntity {
         public void clearUpdatedFlag() {
             this.updated = false;
         }
+
+        @Override
+        public void markUpdatedFlag() {
+            this.updated = true;
+        }
     }
 
     /**
@@ -46,4 +51,10 @@ public interface UpdatableEntity {
      * {@link #isUpdated()} would return {@code false}.
      */
     default void clearUpdatedFlag() { }
+
+    /**
+     * An optional operation setting the updated flag. Right after using this method, the
+     * {@link #isUpdated()} would return {@code true}.
+     */
+    default void markUpdatedFlag() { }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/common/delegate/EntityFieldDelegate.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/delegate/EntityFieldDelegate.java
@@ -54,6 +54,16 @@ public interface EntityFieldDelegate<E> extends UpdatableEntity {
         }
 
         @Override
+        public void markUpdatedFlag() {
+            entity.markUpdatedFlag();
+        }
+
+        @Override
+        public void clearUpdatedFlag() {
+            entity.clearUpdatedFlag();
+        }
+
+        @Override
         public String toString() {
             return "&" + String.valueOf(entity);
         }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/CrudOperations.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/CrudOperations.java
@@ -134,7 +134,7 @@ public interface CrudOperations<V extends AbstractEntity & UpdatableEntity, M> {
      * @param value
      * @return
      */
-    default String determineKeyFromValue(V value, boolean forCreate) {
+    default String determineKeyFromValue(V value) {
         return value == null ? null : value.getId();
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorage.java
@@ -144,7 +144,7 @@ public class ConcurrentHashMapStorage<K, V extends AbstractEntity & UpdatableEnt
         }
     }
 
-    enum MapOperation {
+    protected enum MapOperation {
         CREATE, UPDATE, DELETE,
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProvider.java
@@ -58,7 +58,7 @@ public class ConcurrentHashMapStorageProvider implements MapStorageProvider {
         });
     }
 
-    private <V extends AbstractEntity & UpdatableEntity, M> ConcurrentHashMapStorage getMapStorage(Class<?> modelType, CrudOperations<V, M> crud) {
+    private <K, V extends AbstractEntity & UpdatableEntity, M> ConcurrentHashMapStorage getMapStorage(Class<?> modelType, ConcurrentHashMapCrudOperations<K, V, M> crud) {
         if (modelType == SingleUseObjectValueModel.class) {
             return new SingleUseObjectMapStorage(crud, factory.getKeyConverter(modelType), CLONER, MapFieldPredicates.getPredicates(modelType));
         }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/SingleUseObjectMapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/SingleUseObjectMapStorage.java
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class SingleUseObjectMapStorage<K> extends ConcurrentHashMapStorage<K, MapSingleUseObjectEntity, SingleUseObjectValueModel> {
+public class SingleUseObjectMapStorage<K> extends ConcurrentHashMapStorage<K, MapSingleUseObjectEntity, SingleUseObjectValueModel, CrudOperations<MapSingleUseObjectEntity, SingleUseObjectValueModel>> {
 
     public SingleUseObjectMapStorage(CrudOperations<MapSingleUseObjectEntity, SingleUseObjectValueModel> map,
                                      StringKeyConverter<K> keyConverter,

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserEntity.java
@@ -119,7 +119,7 @@ public interface MapUserEntity extends UpdatableEntity, AbstractEntity, EntityWi
             int indexToRemove = toMoveIndex < ourCredentialIndex ? ourCredentialIndex + 1 : ourCredentialIndex;
             credentialsList.remove(indexToRemove);
 
-            this.updated = true;
+            markUpdatedFlag();
             return true;
         }
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/ConcurrentHashMapStorageTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/ConcurrentHashMapStorageTest.java
@@ -86,9 +86,9 @@ public class ConcurrentHashMapStorageTest extends KeycloakModelTest {
         String component2Id = createMapStorageComponent("component2", "keyType", "string");
 
         String[] ids = withRealm(realmId, (session, realm) -> {
-            ConcurrentHashMapStorage<K, MapClientEntity, ClientModel> storageMain = (ConcurrentHashMapStorage<K, MapClientEntity, ClientModel>) (MapStorage) session.getProvider(MapStorageProvider.class, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID).getMapStorage(ClientModel.class);
-            ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel> storage1 = (ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component1Id).getMapStorage(ClientModel.class);
-            ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel> storage2 = (ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component2Id).getMapStorage(ClientModel.class);
+            ConcurrentHashMapStorage<K, MapClientEntity, ClientModel, ?> storageMain = (ConcurrentHashMapStorage<K, MapClientEntity, ClientModel, ?>) (MapStorage) session.getProvider(MapStorageProvider.class, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID).getMapStorage(ClientModel.class);
+            ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel, ?> storage1 = (ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel, ?>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component1Id).getMapStorage(ClientModel.class);
+            ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel, ?> storage2 = (ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel, ?>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component2Id).getMapStorage(ClientModel.class);
 
             // Assert that the map storage can be used both as a standalone store and a component
             assertThat(storageMain, notNullValue());
@@ -157,7 +157,7 @@ public class ConcurrentHashMapStorageTest extends KeycloakModelTest {
         assertClientsPersisted(component1Id, component2Id, idMain, id1, id2);
     }
 
-    private <K,K1> void assertClientDoesNotExist(ConcurrentHashMapStorage<K, MapClientEntity, ClientModel> storage, String id, final StringKeyConverter<K1> kc, final StringKeyConverter<K> kcStorage) {
+    private <K,K1> void assertClientDoesNotExist(ConcurrentHashMapStorage<K, MapClientEntity, ClientModel, ?> storage, String id, final StringKeyConverter<K1> kc, final StringKeyConverter<K> kcStorage) {
         // Assert that the other stores do not contain the to-be-created clients (if they use compatible key format)
         try {
             assertThat(storage.read(id), nullValue());
@@ -170,11 +170,11 @@ public class ConcurrentHashMapStorageTest extends KeycloakModelTest {
         // Check that in the next transaction, the objects are still there
         withRealm(realmId, (session, realm) -> {
             @SuppressWarnings("unchecked")
-            ConcurrentHashMapStorage<K, MapClientEntity, ClientModel> storageMain = (ConcurrentHashMapStorage<K, MapClientEntity, ClientModel>) (MapStorage) session.getProvider(MapStorageProvider.class, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID).getMapStorage(ClientModel.class);
+            ConcurrentHashMapStorage<K, MapClientEntity, ClientModel, ?> storageMain = (ConcurrentHashMapStorage<K, MapClientEntity, ClientModel, ?>) (MapStorage) session.getProvider(MapStorageProvider.class, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID).getMapStorage(ClientModel.class);
             @SuppressWarnings("unchecked")
-            ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel> storage1 = (ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component1Id).getMapStorage(ClientModel.class);
+            ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel, ?> storage1 = (ConcurrentHashMapStorage<K1, MapClientEntity, ClientModel, ?>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component1Id).getMapStorage(ClientModel.class);
             @SuppressWarnings("unchecked")
-            ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel> storage2 = (ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component2Id).getMapStorage(ClientModel.class);
+            ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel, ?> storage2 = (ConcurrentHashMapStorage<K2, MapClientEntity, ClientModel, ?>) (MapStorage) session.getComponentProvider(MapStorageProvider.class, component2Id).getMapStorage(ClientModel.class);
 
             final StringKeyConverter<K> kcMain = (StringKeyConverter<K>) StringKeyConverter.UUIDKey.INSTANCE;
             final StringKeyConverter<K1> kc1 = (StringKeyConverter<K1>) StringKeyConverter.ULongKey.INSTANCE;


### PR DESCRIPTION
This PR consists of several commits:
- [Fix ID determination](https://github.com/keycloak/keycloak/commit/0471b248ce085cc04c75679c3af9c23cb75314bb) adds a type variable for CRUD operations and consequently cleans up file structure @mhajas
- [Forbid changing ID (other setters)](https://github.com/keycloak/keycloak/commit/962d967463079acc4b322080914fff6bdae2cb41) fixes forgotten methods for writing potentially changing ID which were bypassed originally
- [Improve handling of null values](https://github.com/keycloak/keycloak/commit/a25b8d146858f8c236fe81497adf292e9411d255) correctly escapes `"null"` String in yaml files so that it is read as `"null"` and not `null`
- [Support convertible keys in maps](https://github.com/keycloak/keycloak/commit/bfbbaa478585b999efc20382db2777510d1a15a6) ensures that if map key is a non-string (e.g. `12` number), it is still read as `String` key
- [Fix writing empty values](https://github.com/keycloak/keycloak/commit/08d0b159eb28abab151e1d5dd94625871d84237c) ensures that empty value is written so that `""` is not read as `null`
- [Fix updated flag](https://github.com/keycloak/keycloak/commit/61d57eaf6ce1651f20ed097c8d74f18632f3c850) fixes delegates which could accidentally have swallowed `updated` flag instead of passing it on to delegated entity @mhajas
- [Proceed if an object has been deleted in the same tx](https://github.com/keycloak/keycloak/commit/d7f50b464a5ff1f004ed165712c58015f5ef1285) ensures that a removed-and-then-created file is not removed upon commit

Closes: #20288

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
