### PR TITLE
Prevent creation of authenticator execution configs with invalid IDs

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -870,6 +870,7 @@ public class AuthenticationManagementResource {
         auth.realm().requireManageRealm();
         
         ReservedCharValidator.validate(json.getAlias());
+    	json.setId(null);
 
         AuthenticationExecutionModel model = realm.getAuthenticationExecutionById(execution);
         if (model == null) {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

#19466 updated the representation-to-model implementation to accept IDs. However, the POST endpoint for creating configs should be aware of this to obey POST semantics. Additionally, it's currently possible to create config objects with any non-null ID, including empty strings.