### PR TITLE
SSSD testing with GH actions

### DIFF
--- a/.github/actions/conditional/action.yml
+++ b/.github/actions/conditional/action.yml
@@ -23,6 +23,9 @@ outputs:
   documentation:
     description: Should "documentation.yml" execute
     value: ${{ steps.changes.outputs.documentation }}
+  sssd:
+    description: Should "sssd.yml" execute
+    value: ${{ steps.changes.outputs.sssd }}
 
 runs:
   using: composite

--- a/.github/actions/conditional/conditions
+++ b/.github/actions/conditional/conditions
@@ -2,9 +2,9 @@
 #
 # To test a pattern run '.github/actions/conditional/conditional.sh <remote name> <branch>'
 
-.github/actions/                            ci operator js codeql-java codeql-themes guides documentation
+.github/actions/                            ci operator js codeql-java codeql-themes guides documentation sssd
 
-.github/workflows/ci.yml                    ci
+.github/workflows/ci.yml                    ci sssd
 .github/workflows/operator-ci.yml           operator
 .github/workflows/js-ci.yml                 js
 .github/workflows/codeql-analysis.yml       codeql-java codeql-themes
@@ -14,6 +14,7 @@
 */src/main/                                 ci operator
 */src/test/                                 ci operator
 pom.xml                                     ci operator
+federation/sssd/                            ci sssd
 
 docs/guides/                                guides
 docs/documentation/                         documentation

--- a/.github/scripts/run-ipa-tests.sh
+++ b/.github/scripts/run-ipa-tests.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -o pipefail
+
+echo "Modifying /etc/sssd/sssd.conf file"
+if ! grep -q ^ldap_user_extra_attrs /etc/sssd/sssd.conf; then
+  sed -i '/ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' /etc/sssd/sssd.conf
+fi
+if ! grep -q ^user_attributes /etc/sssd/sssd.conf; then
+  sed -i '/allowed_uids/a user_attributes = +mail, +telephoneNumber, +givenname, +sn' /etc/sssd/sssd.conf
+fi
+
+systemctl restart sssd
+sss_cache -E
+
+echo "Creating /etc/pam.d/keycloak file for PAM"
+cat >/etc/pam.d/keycloak <<EOF
+auth    required   pam_sss.so
+account required   pam_sss.so
+EOF
+
+if [[ "true" == "$1" ]]; then
+  echo "Adding users and groups for the test"
+
+  printf "%b" "password\n" | kinit admin
+  ipa group-add --desc='test group' testgroup
+  ipa user-add emily --first=Emily --last=Jones --email=emily@jones.com --random
+  ipa group-add-member testgroup --users=emily
+  ipa user-add bart --first=bart --last=bart --email= --random
+  ipa user-add david --first=david --last=david --random
+  kdestroy
+
+  ldapmodify -D "cn=Directory Manager" -w password <<EOF
+dn: uid=emily,cn=users,cn=accounts,dc=example,dc=test
+changetype: modify
+replace: userpassword
+userpassword: emily123
+
+dn: uid=bart,cn=users,cn=accounts,dc=example,dc=test
+changetype: modify
+replace: userpassword
+userpassword: bart123
+
+dn: uid=david,cn=users,cn=accounts,dc=example,dc=test
+changetype: modify
+replace: userpassword
+userpassword: david123
+
+EOF
+
+  printf "%b" "password\n" | kinit admin
+  ipa user-disable david
+  kdestroy
+fi
+
+echo "Installing jdk-17 in the container"
+dnf install -y java-17-openjdk-devel
+export JAVA_HOME=/etc/alternatives/java_sdk_17
+
+echo "Building quarkus keyclok server with SSSD integration"
+./mvnw install -nsu -B -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus
+
+echo "Executing SSSD tests"
+./mvnw -f testsuite/integration-arquillian/tests/other/sssd/pom.xml test -Psssd-testing -Pauth-server-quarkus

--- a/.github/scripts/run-ipa.sh
+++ b/.github/scripts/run-ipa.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o pipefail
+DOCKER=podman
+
+if [ -f "$HOME/ipa-data.tar" ]; then
+  echo "Using data from previous execution"
+  sudo tar xpf "$HOME/ipa-data.tar" -C "$HOME"
+else
+  mkdir "$HOME/ipa-data"
+fi
+
+echo "Starting ipa-server container"
+container=$($DOCKER run --detach --rm -h ipa.example.test --sysctl net.ipv6.conf.all.disable_ipv6=0 --workdir /github/workspace -v "$HOME/ipa-data":"/data":Z -v "$1":"/github/workspace" -v "$HOME/.m2":"/root/.m2" freeipa/freeipa-server:rocky-9 ipa-server-install --unattended --realm=EXAMPLE.TEST --ds-password=password --admin-password=password --idstart=60000)
+
+echo "Container $container started, waiting ipa-server configuration"
+sleep 30
+line=$($DOCKER logs $container | tail -1)
+regexp="FreeIPA server configured.|FreeIPA server started."
+while ! [[ "$line" =~ $regexp ]]; do
+  sleep 30
+  line=$($DOCKER logs $container | tail -1)
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+done
+
+new_install="false"
+if [[ $line == "FreeIPA server configured." ]]; then
+  new_install="true"
+fi
+echo "The server is ready, performing tests"
+$DOCKER exec $container .github/scripts/run-ipa-tests.sh $new_install
+result=$?
+
+$DOCKER stop $container
+
+if [ $result -eq 0 ]; then
+  echo "Doing a backup of the ipa-data directory for caching"
+  sudo tar cpf "$HOME/ipa-data.tar" -C "$HOME" ipa-data
+fi
+
+echo "Tests executed with result: $result"
+exit $result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ci: ${{ steps.conditional.outputs.ci }}
+      sssd: ${{ steps.conditional.outputs.sssd }}
     steps:
       - uses: actions/checkout@v3
 
@@ -458,6 +459,40 @@ jobs:
         with:
           job-name: WebAuthn IT
 
+  sssd-unit-tests:
+    name: SSSD
+    runs-on: ubuntu-latest
+    needs:
+      - conditional
+      - build
+    timeout-minutes: 30
+    steps:
+      - name: checkout
+        if: ${{ needs.conditional.outputs.sssd == 'true' }}
+        uses: actions/checkout@v3
+
+      - id: integration-test-setup
+        if: ${{ needs.conditional.outputs.sssd == 'true' }}
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+
+      - id: weekly-cache-key
+        if: ${{ needs.conditional.outputs.sssd == 'true' }}
+        name: Key for weekly rotation of cache
+        shell: bash
+        run: echo "key=ipa-data-`date -u "+%Y-%U"`" >> $GITHUB_OUTPUT
+
+      - id: cache-maven-repository
+        if: ${{ needs.conditional.outputs.sssd == 'true' }}
+        name: ipa-data cache
+        uses: actions/cache@v3
+        with:
+          path: ~/ipa-data.tar
+          key: ${{ steps.weekly-cache-key.outputs.key }}
+
+      - name: Run tests
+        if: ${{ needs.conditional.outputs.sssd == 'true' }}
+        run: .github/scripts/run-ipa.sh "${{ github.workspace }}"
 
   check-set-status:
     name: Set check conclusion
@@ -474,6 +509,7 @@ jobs:
       - fips-integration-tests
       - account-console-integration-tests
       - webauthn-integration-tests
+      - sssd-unit-tests
     runs-on: ubuntu-latest
     outputs:
       conclusion: ${{ steps.check.outputs.conclusion }}


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20265

SSSD testing via github actions. The testing is complicated, the summary the following:

1. There is an extra job in the main `ci.yml` for SSSD.
2. The job steps are only executed if `sssd` classes are modified. The `conditional` action has been changed to also manage `sssd` output. This condition is only for PRs. The test is always launched in local branches. The conditional if is added to the steps and not the job itself because the job is needed for the next check status job.
3. The job launches via script the [ipa-server docker container](https://hub.docker.com/r/freeipa/freeipa-server/) manually using `podman`. The container starts configuring the ipa server. This configuration is cached via github actions for next executions in the same branch during one week.
4. The script waits for the ipa-server to be ready and launches the tests via a podman run for the container (another script).
5. The exit code is retrieved and the container stopped/removed.

The full test is around 10m, 2m if cached. The image used is `rocky-9`. If we see it gives issues we can change to another one (fedora also tested and working).
