### PR TITLE
Remove duplicated properties from the main POM file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <cxf.undertow.version>3.3.10</cxf.undertow.version>
         <dom4j.version>2.1.3</dom4j.version>
         <h2.version>2.1.214</h2.version>
-        <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
         <hibernate-orm.version>6.2.1.Final</hibernate-orm.version>
         <hibernate.c3p0.version>${hibernate-orm.version}</hibernate.c3p0.version>
         <infinispan.version>14.0.8.Final</infinispan.version>


### PR DESCRIPTION
The property `jakarta.persistence.version` is duplicated in the main POM file.

Closes #20317

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
