### PR TITLE
Upgrade JNA library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <servlet.api.40.version>2.0.0.Final</servlet.api.40.version>
         <twitter4j.version>4.1.2</twitter4j.version>
-        <jna.version>4.1.0</jna.version>
+        <jna.version>5.8.0</jna.version>
 
         <!-- Databases -->
         <mysql.version>8.0.23</mysql.version>


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20305

Upgrading JNA dependency for SSSD integration to 5.8.0.