### PR TITLE
SSSD documentation updated for quarkus distribution

### DIFF
--- a/docs/documentation/server_admin/topics/user-federation/sssd.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/sssd.adoc
@@ -62,7 +62,7 @@ If you do not make this change, you must set up a DNS server.
 +
 [source,bash,subs=+attributes]
 ----
-$ ipa user-add <username> --first=<first name> --last=<surname> --email=<email address> --phone=<telephoneNumber> --street=<street> \      --city=<city> --state=<state> --postalcode=<postal code> --password
+$ ipa user-add <username> --first=<first name> --last=<surname> --email=<email address> --phone=<telephoneNumber> --street=<street> --city=<city> --state=<state> --postalcode=<postal code> --password
 ----
 
 . Force set the user's password using kinit.
@@ -99,7 +99,7 @@ $ sudo yum install sssd-dbus
 $ bin/federation-sssd-setup.sh
 ----
 +
-This script makes the following changes to `/etc/sssd/sssd.conf`:
+The script can also be used as a guide to configure SSSD and PAM for {project_name}. It makes the following changes to `/etc/sssd/sssd.conf`:
 +
 [source,bash,subs=+attributes]
 ----
@@ -114,83 +114,58 @@ This script makes the following changes to `/etc/sssd/sssd.conf`:
   allowed_uids = root, yourOSUsername
   user_attributes = +mail, +telephoneNumber, +givenname, +sn
 ----
++
+The `ifp` service is added to SSSD and configured to allow the OS user to interrogate the IPA server through this interface.
++
+The script also creates a new PAM service `/etc/pam.d/keycloak` to authenticate users via SSSD:
++
+[source,bash,subs=+attributes]
+----
+auth    required   pam_sss.so
+account required   pam_sss.so
+----
 
 . Run `dbus-send` to ensure the setup is successful.
 +
 [source,bash,subs=+attributes]
 ----
-sudo dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserGroups string:john
+dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:<username> array:string:mail,givenname,sn,telephoneNumber
+
+dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserGroups string:<username>
 ----
 +
-If the setup is successful, you see the user's group. If this command returns a timeout or an error, the federation provider running on {project_name} cannot retrieve any data. This error usually happens because the server is not enrolled in the FreeIPA IdM server, or does not have permission to access the SSSD service.
+If the setup is successful, each command displays the user's attributes and groups respectively. If there is a timeout or an error, the federation provider running on {project_name} cannot retrieve any data. This error usually happens because the server is not enrolled in the FreeIPA IdM server, or does not have permission to access the SSSD service.
 +
 If you do not have permission to access the SSSD service, ensure that the user running the {project_name} server is in the `/etc/sssd/sssd.conf` file in the following section:
 +
 [source,bash,subs=+attributes]
 ----
 [ifp]
-allowed_uids = root, your_username
+allowed_uids = root, yourOSUsername
+----
++
+And the `ipaapi` system user is created inside the host. This user is necessary for the `ifp` service. Check the user is created in the system.
++
+[source,bash,subs=+attributes]
+----
+grep ipaapi /etc/passwd
+ipaapi:x:992:988:IPA Framework User:/:/sbin/nologin
 ----
 
 ==== Enabling the SSSD federation provider
 
-{project_name} uses DBus-Java to communicate at a low level with D-Bus. D-Bus depends on the http://www.matthew.ath.cx/projects/java/[Unix Sockets Library].
+{project_name} uses https://github.com/hypfvieh/dbus-java[DBus-Java] project to communicate at a low level with D-Bus and https://github.com/java-native-access/jna[JNA] to authenticate via Operating System Pluggable Authentication Modules (PAM).
 
-ifeval::[{project_community}==true]
+Although now {project_name} contains all the needed libraries to run the `SSSD` provider, JDK version 17 is needed. Therefore the `SSSD` provider will only be displayed when the host configuration is correct and JDK 17 is used to run {project_name}.
 
-You can find an RPM for this library in https://github.com/keycloak/libunix-dbus-java/releases[the keycloak repository]. Before installing this RPM, check the RPM signature using this command:
-
-[source,bash,subs=+attributes]
-----
-  $ rpm -K libunix-dbus-java-0.8.0-1.fc24.x86_64.rpm
-  libunix-dbus-java-0.8.0-1.fc24.x86_64.rpm:
-    Header V4 RSA/SHA256 Signature, key ID 84dc9914: OK
-    Header SHA1 digest: OK (d17bb7ebaa7a5304c1856ee4357c8ba4ec9c0b89)
-    V4 RSA/SHA256 Signature, key ID 84dc9914: OK
-    MD5 digest: OK (770c2e68d052cb4a4473e1e9fd8818cf)
-----
-
-Install the RPM using this command:
-
-[source,bash,subs=+attributes]
-----
-$ sudo yum install libunix-dbus-java-0.8.0-1.fc24.x86_64.rpm
-----
-
-endif::[]
-
-ifeval::[{project_product}==true]
-
-Before enabling the SSSD Federation provider, install the RPM for this library:
-
-[source,bash,subs=+attributes]
-----
-$ sudo yum install rh-sso7-libunix-dbus-java
-----
-
-endif::[]
-
-{project_name} uses JNA to authenticate with PAM. Ensure you have the JAN package installed.
-
-[source,bash,subs=+attributes]
-----
-$ sudo yum install jna
-
-----
-
-Use the `sssctl user-checks` command to validate your setup:
-[source]
-----
-  $ sudo sssctl user-checks admin -s keycloak
-----
-
-=== Configuring a federated SSSD store
+==== Configuring a federated SSSD store
 
 After the installation, configure a federated SSSD store.
 
 .Procedure
 . Click *User Federation* in the menu.
-. From the *Add Provider* list select _sssd_. {project_name} brings you to the sssd configuration page.
+. If everything is setup successfully the *Add Sssd providers* button will be displayed in the page. Click on it.
+. Assign a name to the new provider.
 . Click *Save*.
 
-You can now authenticate against {project_name} using FreeIPA/IdM credentials.
+You can now authenticate against {project_name} using a FreeIPA/IdM user and credentials.

--- a/quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
+++ b/quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Setup for SSSD
+SSSD_FILE="/etc/sssd/sssd.conf"
+
+if [ -f "$SSSD_FILE" ];
+then
+
+  if ! grep -q ^ldap_user_extra_attrs $SSSD_FILE; then
+    sed -i '/ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' $SSSD_FILE
+  fi
+
+  if ! grep -q ^services.*ifp.* /etc/sssd/sssd.conf; then
+    sed -i '/^services/ s/$/, ifp/' $SSSD_FILE
+  fi
+
+  if ! grep -q ^allowed_uids $SSSD_FILE; then
+    sed -i '/\[ifp\]/a allowed_uids = root' $SSSD_FILE
+  fi
+
+  if ! grep -q ^user_attributes $SSSD_FILE; then
+    sed -i '/allowed_uids/a user_attributes = +mail, +telephoneNumber, +givenname, +sn' $SSSD_FILE
+  fi
+
+  systemctl restart sssd
+
+else
+  echo "Please make sure you have $SSSD_FILE into your system! Aborting."
+  exit 1
+fi
+
+# Setup for PAM
+PAM_FILE="/etc/pam.d/keycloak"
+
+if [ ! -f "$PAM_FILE" ];
+then
+cat <<EOF > $PAM_FILE
+  auth    required   pam_sss.so
+  account required   pam_sss.so
+EOF
+else
+  echo "$PAM_FILE already exists. Skipping it..."
+  exit 0
+fi


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20263

Documentation  changes for the SSSD provider.

- The integration does not need anymore a system .so library.  It needs JDK 17 or above to work. I'm adding that note only to the upstream keycloak as downstream will only be supported with JDK-17.
- Re-adding the script that was present in wildfly dist as it's still functional.

