### PR TITLE
Always use latest version of Chrome and driver in integration tests

### DIFF
--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -21,6 +21,23 @@ runs:
         distribution: ${{ inputs.jdk-dist }}
         java-version: ${{ inputs.jdk-version }}
 
+    - id: determine-chromedriver
+      name: Determine latest ChromeDriver version
+      shell: bash
+      run: echo '::set-output name=version::$(curl --location --fail --retry 10 http://chromedriver.storage.googleapis.com/LATEST_RELEASE)'
+
+    - id: setup-chrome
+      name: Setup Chrome
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: ${{ steps.determine-chromedriver.outputs.version }}
+
+    - id: setup-chromedriver
+      name: Setup ChromeDriver
+      uses: nanasess/setup-chromedriver@v2
+      with:
+        chromedriver-version: ${{ steps.determine-chromedriver.outputs.version }}
+
     - id: maven-cache
       name: Maven cache
       uses: ./.github/actions/maven-cache

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/InternationalizationTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/InternationalizationTest.java
@@ -127,7 +127,6 @@ public class InternationalizationTest extends AbstractAccountTest {
     }
 
     @Test
-    @Ignore // TODO: Enable once chromedriver version 113.0.5672.92 is available in https://chromedriver.storage.googleapis.com/
     public void userAttributeTest() {
         testUser.setAttributes(singletonMap(UserModel.LOCALE, singletonList(CUSTOM_LOCALE)));
         testUserResource().update(testUser);

--- a/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnSigningInTest.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnSigningInTest.java
@@ -20,7 +20,6 @@ package org.keycloak.testsuite.webauthn.account;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
@@ -261,7 +260,6 @@ public class WebAuthnSigningInTest extends AbstractWebAuthnAccountTest {
     }
 
     @Test
-    @Ignore // TODO: Enable once chromedriver version 113.0.5672.92 is available in https://chromedriver.storage.googleapis.com/
     public void checkAuthenticatorTimeLocale() throws ParseException, IOException {
         addWebAuthnCredential("authenticator#1");
 


### PR DESCRIPTION
Changes the workflow to set up the integration tests so it always uses the latest version of Google Chrome and it's respective Web Driver.

Closes #20348