### PR TITLE
Avoid instantiating method not found exceptions when trying out properties

### DIFF
--- a/docs/documentation/release_notes/topics/22_0_0.adoc
+++ b/docs/documentation/release_notes/topics/22_0_0.adoc
@@ -77,3 +77,10 @@ If you are extending one of the following SPIs:
 
 See the link:{upgradingguide_link}[{upgradingguide_name}] for more details about how to
 update your custom providers.
+
+= SAML and OpenID Connect User Property mapper validation
+
+The SAML and OpenID Connect User Property now enforces the correct capitalization of the property names.
+Valid property names are: `firstName`, `lastName`, `emailVerified`, `groupsCount`, `createdTimestamp`, `federationLink`, `id`, `serviceAccountClientLink`, `enabled`, `email`, `username`.
+
+See the migration guide for more details.

--- a/docs/documentation/upgrading/topics/keycloak/changes-22_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-22_0_0.adoc
@@ -323,3 +323,18 @@ You need to add an empty `META-INF/beans.xml` to the JAR file where your custom 
 at runtime.
 
 You should also make sure your JAX-RS methods are declaring the expected media types for input and output by marking them with the `@Consumes` and `@Produces` annotations, respectively.
+
+= SAML and OpenID Connect User Property mapper validation
+
+Previous versions of the User Property mappers did not validate the name of the property when creating or updating it.
+They also supported case-insensitivity for the first letter as, for example, both `email` and `Email` accessed the email property.
+
+The User Property mappers now validate that the property named in the configuration is a valid user property of the `UserModel` interface.
+The validation is case-sensitive.
+Valid property names are: `firstName`, `lastName`, `emailVerified`, `groupsCount`, `createdTimestamp`, `federationLink`, `id`, `serviceAccountClientLink`, `enabled`, `email`, `username`.
+
+When executing the mapper, invalid property names map to the value `null` (as before) and log a warning in the log file (new in this version).
+Starting with this version, when modifying the mapper via the API or the UI with an invalid property name, Keycloak returns a validation error and the changes are not persisted.
+
+For the legacy configurations, Keycloak still supports property names starting with a capital letter, but will log a warning when such a mapping is executed.
+To avoid these logs and the runtime overhead, review and update existing configurations.

--- a/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapperConfigException.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapperConfigException.java
@@ -22,30 +22,17 @@ package org.keycloak.protocol;
  */
 public class ProtocolMapperConfigException extends Exception {
 
-    private String messageKey;
+    private final String messageKey;
     private Object[] parameters;
-
-    public ProtocolMapperConfigException(String message) {
-        super(message);
-    }
 
     public ProtocolMapperConfigException(String message, String messageKey) {
         super(message);
         this.messageKey = messageKey;
     }
 
-    public ProtocolMapperConfigException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public ProtocolMapperConfigException(String message, String messageKey, Throwable cause) {
         super(message, cause);
         this.messageKey = messageKey;
-    }
-
-    public ProtocolMapperConfigException(String message, Object ... parameters) {
-        super(message);
-        this.parameters = parameters;
     }
 
     public ProtocolMapperConfigException(String messageKey, String message, Object ... parameters) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserPropertyMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserPropertyMapper.java
@@ -17,9 +17,13 @@
 
 package org.keycloak.protocol.oidc.mappers;
 
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperContainerModel;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.IDToken;
@@ -74,6 +78,17 @@ public class UserPropertyMapper extends AbstractOIDCProtocolMapper implements OI
     @Override
     public String getHelpText() {
         return "Map a built in user property (email, firstName, lastName) to a token claim.";
+    }
+
+    @Override
+    public void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel client, ProtocolMapperModel mappingModel) throws ProtocolMapperConfigException {
+        String propertyName = mappingModel.getConfig().get(ProtocolMapperUtils.USER_ATTRIBUTE);
+
+        if (propertyName == null || propertyName.trim().isEmpty()) return;
+
+        ProtocolMapperUtils.validateUserModelProperty(propertyName);
+
+        super.validateConfig(session, realm, client, mappingModel);
     }
 
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession) {

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
@@ -80,7 +80,7 @@ public class UserAttributeStatementMapper extends AbstractSAMLProtocolMapper imp
 
     @Override
     public String getHelpText() {
-        return "Map a custom user attribute to a to a SAML attribute.";
+        return "Map a custom user attribute to a SAML attribute.";
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapper.java
@@ -20,9 +20,12 @@ package org.keycloak.protocol.saml.mappers;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperContainerModel;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 
@@ -73,6 +76,17 @@ public class UserPropertyAttributeStatementMapper extends AbstractSAMLProtocolMa
     @Override
     public String getHelpText() {
         return "Map a built in user property (email, firstName, lastName) to a SAML attribute type.";
+    }
+
+    @Override
+    public void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel client, ProtocolMapperModel mappingModel) throws ProtocolMapperConfigException {
+        String propertyName = mappingModel.getConfig().get(ProtocolMapperUtils.USER_ATTRIBUTE);
+
+        if (propertyName == null || propertyName.trim().isEmpty()) return;
+
+        ProtocolMapperUtils.validateUserModelProperty(propertyName);
+
+        super.validateConfig(session, realm, client, mappingModel);
     }
 
     @Override

--- a/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol;
+
+import org.junit.Test;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Alexander Schwartz
+ */
+public class ProtocolMapperUtilsTest {
+
+    private final UserModel model = new DummyUserModel() {
+        @Override
+        public String getEmail() {
+            return "me@example.com";
+        }
+    };
+
+    @Test
+    public void shouldReadExistingProperty() {
+        assertEquals("me@example.com", ProtocolMapperUtils.getUserModelValue(model, "email"));
+    }
+
+    @Test
+    public void shouldReadExistingDeprecatedProperty() {
+        assertEquals("me@example.com", ProtocolMapperUtils.getUserModelValue(model, "Email"));
+    }
+
+    @Test
+    public void shouldDefaultToNullForNonexistingProperty() {
+        assertNull(ProtocolMapperUtils.getUserModelValue(model, "nonexistent"));
+    }
+
+    private static class DummyUserModel implements UserModel {
+
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public String getUsername() {
+            return null;
+        }
+
+        @Override
+        public void setUsername(String username) {
+
+        }
+
+        @Override
+        public Long getCreatedTimestamp() {
+            return null;
+        }
+
+        @Override
+        public void setCreatedTimestamp(Long timestamp) {
+
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+
+        }
+
+        @Override
+        public void setSingleAttribute(String name, String value) {
+
+        }
+
+        @Override
+        public void setAttribute(String name, List<String> values) {
+
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+
+        }
+
+        @Override
+        public String getFirstAttribute(String name) {
+            return null;
+        }
+
+        @Override
+        public Stream<String> getAttributeStream(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, List<String>> getAttributes() {
+            return null;
+        }
+
+        @Override
+        public Stream<String> getRequiredActionsStream() {
+            return null;
+        }
+
+        @Override
+        public void addRequiredAction(String action) {
+
+        }
+
+        @Override
+        public void removeRequiredAction(String action) {
+
+        }
+
+        @Override
+        public String getFirstName() {
+            return null;
+        }
+
+        @Override
+        public void setFirstName(String firstName) {
+
+        }
+
+        @Override
+        public String getLastName() {
+            return null;
+        }
+
+        @Override
+        public void setLastName(String lastName) {
+
+        }
+
+        @Override
+        public String getEmail() {
+            return null;
+        }
+
+        @Override
+        public void setEmail(String email) {
+
+        }
+
+        @Override
+        public boolean isEmailVerified() {
+            return false;
+        }
+
+        @Override
+        public void setEmailVerified(boolean verified) {
+
+        }
+
+        @Override
+        public Stream<GroupModel> getGroupsStream() {
+            return null;
+        }
+
+        @Override
+        public void joinGroup(GroupModel group) {
+
+        }
+
+        @Override
+        public void leaveGroup(GroupModel group) {
+
+        }
+
+        @Override
+        public boolean isMemberOf(GroupModel group) {
+            return false;
+        }
+
+        @Override
+        public String getFederationLink() {
+            return null;
+        }
+
+        @Override
+        public void setFederationLink(String link) {
+
+        }
+
+        @Override
+        public String getServiceAccountClientLink() {
+            return null;
+        }
+
+        @Override
+        public void setServiceAccountClientLink(String clientInternalId) {
+
+        }
+
+        @Override
+        public SubjectCredentialManager credentialManager() {
+            return null;
+        }
+
+        @Override
+        public Stream<RoleModel> getRealmRoleMappingsStream() {
+            return null;
+        }
+
+        @Override
+        public Stream<RoleModel> getClientRoleMappingsStream(ClientModel app) {
+            return null;
+        }
+
+        @Override
+        public boolean hasRole(RoleModel role) {
+            return false;
+        }
+
+        @Override
+        public void grantRole(RoleModel role) {
+
+        }
+
+        @Override
+        public Stream<RoleModel> getRoleMappingsStream() {
+            return null;
+        }
+
+        @Override
+        public void deleteRoleMapping(RoleModel role) {
+
+        }
+    }
+
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/UserPropertyMapperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/UserPropertyMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.mappers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.protocol.ProtocolMapperUtils;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Alexander Schwartz
+ */
+public class UserPropertyMapperTest {
+
+    @Test
+    public void shouldAcceptValidPropertyNames() throws ProtocolMapperConfigException {
+        ProtocolMapperModel mapping = new ProtocolMapperModel();
+        mapping.setConfig(new HashMap<>());
+        mapping.getConfig().put(ProtocolMapperUtils.USER_ATTRIBUTE, "email");
+        new UserPropertyMapper().validateConfig(null, null, null, mapping);
+    }
+
+    @Test
+    public void shouldRejectInvalidPropertyNames() {
+        ProtocolMapperModel mapping = new ProtocolMapperModel();
+        mapping.setConfig(new HashMap<>());
+        mapping.getConfig().put(ProtocolMapperUtils.USER_ATTRIBUTE, "Email");
+        ProtocolMapperConfigException exception = Assert.assertThrows(ProtocolMapperConfigException.class, () -> new UserPropertyMapper().validateConfig(null, null, null, mapping));
+        assertThat(exception.getMessage(), startsWith("User property 'Email' does not exist"));
+    }
+
+}

--- a/services/src/test/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.saml.mappers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.protocol.ProtocolMapperUtils;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Alexander Schwartz
+ */
+public class UserPropertyAttributeStatementMapperTest {
+
+    @Test
+    public void shouldAcceptValidPropertyNames() throws ProtocolMapperConfigException {
+        ProtocolMapperModel mapping = new ProtocolMapperModel();
+        mapping.setConfig(new HashMap<>());
+        mapping.getConfig().put(ProtocolMapperUtils.USER_ATTRIBUTE, "email");
+        new UserPropertyAttributeStatementMapper().validateConfig(null, null, null, mapping);
+    }
+
+    @Test
+    public void shouldRejectInvalidPropertyNames() {
+        ProtocolMapperModel mapping = new ProtocolMapperModel();
+        mapping.setConfig(new HashMap<>());
+        mapping.getConfig().put(ProtocolMapperUtils.USER_ATTRIBUTE, "Email");
+        ProtocolMapperConfigException exception = Assert.assertThrows(ProtocolMapperConfigException.class, () -> new UserPropertyAttributeStatementMapper().validateConfig(null, null, null, mapping));
+        assertThat(exception.getMessage(), startsWith("User property 'Email' does not exist"));
+    }
+
+}

--- a/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
@@ -35,6 +35,7 @@ clientRootURLInvalid=Root URL is not a valid URL
 clientRedirectURIsInvalid=A redirect URI is not a valid URI
 backchannelLogoutUrlIsInvalid=Backchannel logout URL is not a valid URL
 
+userPropertyMapperWrongProperty=User property ''{0}'' does not exist, try one of these property names: {1}
 
 pairwiseMalformedClientRedirectURI=Client contained an invalid redirect URI.
 pairwiseClientRedirectURIsMissingHost=Client redirect URIs must contain a valid host component.


### PR DESCRIPTION
This is a performance optimization and also improves usability in the UI as it validates properties.

Closes #20303

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
