### PR TITLE
Increase timeout for Legacy Store IT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
     name: Legacy Store IT
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         db: [postgres, mysql, oracle, mssql, mariadb]


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Legacy Store IT in Oracle 19c take longer than other DBs to run, so we have to increase the timeout.