### PR TITLE
Null check for src attribute on script tags that are inserted in html

### DIFF
--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -39,7 +39,7 @@ function Keycloak (config) {
 
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
-        if ((scripts[i].src.indexOf('keycloak.js') !== -1 || scripts[i].src.indexOf('keycloak.min.js') !== -1) && scripts[i].src.indexOf('version=') !== -1) {
+        if (scripts[i].src !== null && (scripts[i].src.indexOf('keycloak.js') !== -1 || scripts[i].src.indexOf('keycloak.min.js') !== -1) && scripts[i].src.indexOf('version=') !== -1) {
             kc.iframeVersion = scripts[i].src.substring(scripts[i].src.indexOf('version=') + 8).split('&')[0];
         }
     }
@@ -898,7 +898,7 @@ function Keycloak (config) {
                 if (!config['url']) {
                     var scripts = document.getElementsByTagName('script');
                     for (var i = 0; i < scripts.length; i++) {
-                        if (scripts[i].src.match(/.*keycloak\.js/)) {
+                        if (scripts[i].src !== null && scripts[i].src.match(/.*keycloak\.js/)) {
                             config.url = scripts[i].src.substr(0, scripts[i].src.indexOf('/js/keycloak.js'));
                             break;
                         }

--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -39,7 +39,7 @@ function Keycloak (config) {
 
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
-        if (scripts[i].src !== null && (scripts[i].src.indexOf('keycloak.js') !== -1 || scripts[i].src.indexOf('keycloak.min.js') !== -1) && scripts[i].src.indexOf('version=') !== -1) {
+        if (scripts[i].src && (scripts[i].src.indexOf('keycloak.js') !== -1 || scripts[i].src.indexOf('keycloak.min.js') !== -1) && scripts[i].src.indexOf('version=') !== -1) {
             kc.iframeVersion = scripts[i].src.substring(scripts[i].src.indexOf('version=') + 8).split('&')[0];
         }
     }
@@ -898,7 +898,7 @@ function Keycloak (config) {
                 if (!config['url']) {
                     var scripts = document.getElementsByTagName('script');
                     for (var i = 0; i < scripts.length; i++) {
-                        if (scripts[i].src !== null && scripts[i].src.match(/.*keycloak\.js/)) {
+                        if (scripts[i].src && scripts[i].src.match(/.*keycloak\.js/)) {
                             config.url = scripts[i].src.substr(0, scripts[i].src.indexOf('/js/keycloak.js'));
                             break;
                         }


### PR DESCRIPTION
Reopening #20315 and attaching a video with the repro case. src attribute in script tags can be null.


https://github.com/keycloak/keycloak/assets/98841829/cb12159c-9f45-4aa7-bea8-a56eeffef3bf


Closes #20331 