### PR TITLE
Avoid using JBoss dependency which contains some old Log4j classes

### DIFF
--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -656,12 +656,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- logging wrapper for log4j-->
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
-
         <!-- twitter api -->
         <dependency>
             <groupId>org.twitter4j</groupId>


### PR DESCRIPTION
This assumes all dependencies already use different logging frameworks

Closes #15844

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
