### PR TITLE
theme.properties customizations for account v3

### DIFF
--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -72,6 +74,14 @@
                             <value>href="${resourceUrl}/</value>
                         </replacement>
                         <replacement>
+                            <token><![CDATA[<link rel="icon" type="image/svg+xml" href="${resourceUrl}/favicon.svg" />]]></token>
+                            <value xml:space="preserve"><![CDATA[<link rel="icon" type="${properties.favIconType!"image/svg+xml"}" href="${resourceUrl}${properties.favIcon!"/favicon.svg"}" />]]></value>
+                        </replacement>
+                        <replacement>
+                            <token><![CDATA[<title>Keycloak account console</title>]]></token>
+                            <value xml:space="preserve"><![CDATA[<title>${properties.title!"Keycloak account console"}</title>]]></value>
+                        </replacement>
+                        <replacement>
                             <token><![CDATA[</body>]]></token>
                             <value xml:space="preserve">
 <![CDATA[
@@ -80,7 +90,9 @@
       "authUrl": "${authUrl}",
       "isRunningAsTheme": true,
       "realm": "${realm.name}",
-      "resourceUrl": "${resourceUrl}"
+      "resourceUrl": "${resourceUrl}",
+      "logo": "${properties.logo!""}",
+      "logoUrl": "${properties.logoUrl!""}"
     }
   </script>
 </body>
@@ -97,7 +109,7 @@
       </#list>
     </#if>
   </head>
-]]>	
+]]>
 </value>
                         </replacement>
                     </replacements>

--- a/js/apps/account-ui/src/environment.ts
+++ b/js/apps/account-ui/src/environment.ts
@@ -7,6 +7,10 @@ export type Environment = {
   realm: string;
   /** The URL to resources such as the files in the `public` directory. */
   resourceUrl: string;
+  /** Indicates the src for the Brand image */
+  logo: string;
+  /** Indicates the url to be followed when Brand image is clicked */
+  logoUrl: string;
 };
 
 // The default environment, used during development.
@@ -15,6 +19,8 @@ const defaultEnvironment: Environment = {
   isRunningAsTheme: false,
   realm: "master",
   resourceUrl: "http://localhost:8080",
+  logo: "/logo.svg",
+  logoUrl: "",
 };
 
 // Merge the default and injected environment variables together.

--- a/js/apps/account-ui/src/environment.ts
+++ b/js/apps/account-ui/src/environment.ts
@@ -20,7 +20,7 @@ const defaultEnvironment: Environment = {
   realm: "master",
   resourceUrl: "http://localhost:8080",
   logo: "/logo.svg",
-  logoUrl: "",
+  logoUrl: "/",
 };
 
 // Merge the default and injected environment variables together.

--- a/js/apps/account-ui/src/root/Root.tsx
+++ b/js/apps/account-ui/src/root/Root.tsx
@@ -50,6 +50,10 @@ export const Root = () => {
     [t]
   );
 
+  const brandImage = environment.logo ? environment.logo : "logo.svg";
+  const brandOnClickHandler = () =>
+    window.location.replace(environment.logoUrl);
+
   return (
     <Page
       header={
@@ -62,6 +66,7 @@ export const Root = () => {
               src: joinPath(environment.resourceUrl, "logo.svg"),
               alt: t("logo"),
               className: style.brand,
+              onClick: environment.logoUrl ? brandOnClickHandler : undefined,
             }}
             toolbarItems={[<ReferrerLink key="link" />]}
             keycloak={keycloak}

--- a/js/apps/account-ui/src/root/Root.tsx
+++ b/js/apps/account-ui/src/root/Root.tsx
@@ -35,13 +35,15 @@ const ReferrerLink = () => {
   ) : null;
 };
 
+const logoUrl = environment.logoUrl ? environment.logoUrl : "/";
+const internalLogoHref = useHref(logoUrl);
+
 export const Root = () => {
   const { t } = useTranslation();
   const brandImage = environment.logo ? environment.logo : "logo.svg";
-  const logoUrl = environment.logoUrl ? environment.logoUrl : "/";
 
   // User can indicate that he wants an internal URL by starting it with "/"
-  const indexHref = logoUrl.startsWith("/") ? useHref(logoUrl) : logoUrl;
+  const indexHref = logoUrl.startsWith("/") ? internalLogoHref : logoUrl;
 
   const translations = useMemo<Translations>(
     () => ({

--- a/js/apps/account-ui/src/root/Root.tsx
+++ b/js/apps/account-ui/src/root/Root.tsx
@@ -37,7 +37,7 @@ const ReferrerLink = () => {
 
 export const Root = () => {
   const { t } = useTranslation();
-  const brandImage = environment.logo ? environment.logo : "logo.svg";
+  const brandImage = environment.logo || "logo.svg";
   const logoUrl = environment.logoUrl ? environment.logoUrl : "/";
   const internalLogoHref = useHref(logoUrl);
 

--- a/js/apps/account-ui/src/root/Root.tsx
+++ b/js/apps/account-ui/src/root/Root.tsx
@@ -37,7 +37,11 @@ const ReferrerLink = () => {
 
 export const Root = () => {
   const { t } = useTranslation();
-  const indexHref = useHref("/");
+  const brandImage = environment.logo ? environment.logo : "logo.svg";
+  const logoUrl = environment.logoUrl ? environment.logoUrl : "/";
+
+  // User can indicate that he wants an internal URL by starting it with "/"
+  const indexHref = logoUrl.startsWith("/") ? useHref(logoUrl) : logoUrl;
 
   const translations = useMemo<Translations>(
     () => ({
@@ -50,10 +54,6 @@ export const Root = () => {
     [t]
   );
 
-  const brandImage = environment.logo ? environment.logo : "logo.svg";
-  const brandOnClickHandler = () =>
-    window.location.replace(environment.logoUrl);
-
   return (
     <Page
       header={
@@ -63,10 +63,9 @@ export const Root = () => {
             showNavToggle
             brand={{
               href: indexHref,
-              src: joinPath(environment.resourceUrl, "logo.svg"),
+              src: joinPath(environment.resourceUrl, brandImage),
               alt: t("logo"),
               className: style.brand,
-              onClick: environment.logoUrl ? brandOnClickHandler : undefined,
             }}
             toolbarItems={[<ReferrerLink key="link" />]}
             keycloak={keycloak}

--- a/js/apps/account-ui/src/root/Root.tsx
+++ b/js/apps/account-ui/src/root/Root.tsx
@@ -35,12 +35,11 @@ const ReferrerLink = () => {
   ) : null;
 };
 
-const logoUrl = environment.logoUrl ? environment.logoUrl : "/";
-const internalLogoHref = useHref(logoUrl);
-
 export const Root = () => {
   const { t } = useTranslation();
   const brandImage = environment.logo ? environment.logo : "logo.svg";
+  const logoUrl = environment.logoUrl ? environment.logoUrl : "/";
+  const internalLogoHref = useHref(logoUrl);
 
   // User can indicate that he wants an internal URL by starting it with "/"
   const indexHref = logoUrl.startsWith("/") ? internalLogoHref : logoUrl;


### PR DESCRIPTION
Fixes #20200

Sample `theme.properties`
```
# This theme will inherit everything from its parent unless
# it is overridden in the current theme.
parent=keycloak.v3

# This is the title of the Account UI.
# It can be any title.
title=My Account UI Title

# Look at the styles.css file to see examples of using PatternFly's CSS variables
# for modifying look and feel. Note that multiple stylesheets can be listed
# using a space as a delimiter.
styles=css/styles.css

# This is the logo in upper lefthand corner.
# It must be a relative path.
# Defaults to Keycloak logo.
logo=/public/retro-keycloak-logo.png

# This is the link followed when clicking on the logo.
# It can be any valid URL, including an external site.
# For an internal path, it should start with a slash as in "/personal-info"
# By default, this will go to the home page, which is "/".
logoUrl=http://www.keycloak.org

# This is the icon for the account console.
# It must be a relative path.
favIcon=/public/favicon.ico

# This is the mime type for the favIcon.
# Default value is 'image/svg+xml'
favIconType=image/x-icon
```
