### PR TITLE
Upgrade owasp sanitizer to newest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <resteasy-legacy.version>4.7.7.Final</resteasy-legacy.version>
         <resteasy.version>6.2.3.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
-        <owasp.html.sanitizer.version>20211018.2</owasp.html.sanitizer.version>
+        <owasp.html.sanitizer.version>20220608.1</owasp.html.sanitizer.version>
         <slf4j-api.version>2.0.6</slf4j-api.version>
         <slf4j.version>2.0.6</slf4j.version>
         <sun.istack.version>3.0.10</sun.istack.version>


### PR DESCRIPTION
closes #20388

This is the latest version from https://repo.maven.apache.org/maven2/com/googlecode/owasp-java-html-sanitizer/owasp-java-html-sanitizer/ 
