### PR TITLE
Use OIDCAttributeMapperHelper.mapClaim in the GroupMembershipMapper

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
@@ -21,6 +21,7 @@ import org.keycloak.models.GroupModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.IDToken;
@@ -98,9 +99,9 @@ public class GroupMembershipMapper extends AbstractOIDCProtocolMapper implements
                 ModelToRepresentation::buildGroupPath : GroupModel::getName;
         List<String> membership = userSession.getUser().getGroupsStream().map(toGroupRepresentation).collect(Collectors.toList());
 
-        String protocolClaim = mappingModel.getConfig().get(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME);
-
-        token.getOtherClaims().put(protocolClaim, membership);
+        // force multivalued as the attribute is not defined for this mapper
+        mappingModel.getConfig().put(ProtocolMapperUtils.MULTIVALUED, "true");
+        OIDCAttributeMapperHelper.mapClaim(token, mappingModel, membership);
     }
 
     public static ProtocolMapperModel create(String name,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.testsuite.admin.group;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -56,7 +58,7 @@ public class GroupMappersTest extends AbstractGroupTest {
         mapper.setProtocolMapper(GroupMembershipMapper.PROVIDER_ID);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         Map<String, String> config = new HashMap<>();
-        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "groups");
+        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "groups.groups");
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
         mapper.setConfig(config);
@@ -109,10 +111,9 @@ public class GroupMappersTest extends AbstractGroupTest {
 
             AccessToken token = login(user.getUsername(), "test-app", "password", user.getId());
             Assert.assertTrue(token.getRealmAccess().getRoles().contains("user"));
-            List<String> groups = (List<String>) token.getOtherClaims().get("groups");
-            Assert.assertNotNull(groups);
-            Assert.assertTrue(groups.size() == 1);
-            Assert.assertEquals("topGroup", groups.get(0));
+            Assert.assertNotNull(token.getOtherClaims().get("groups"));
+            Map<String, Collection<String>> groups = (Map<String, Collection<String>>) token.getOtherClaims().get("groups");
+            MatcherAssert.assertThat(groups.get("groups"), Matchers.contains("topGroup"));
             Assert.assertEquals("true", token.getOtherClaims().get("topAttribute"));
         }
         {
@@ -122,10 +123,9 @@ public class GroupMappersTest extends AbstractGroupTest {
             Assert.assertTrue(token.getRealmAccess().getRoles().contains("user"));
             Assert.assertTrue(token.getRealmAccess().getRoles().contains("admin"));
             Assert.assertTrue(token.getResourceAccess("test-app").getRoles().contains("customer-user"));
-            List<String> groups = (List<String>) token.getOtherClaims().get("groups");
-            Assert.assertNotNull(groups);
-            Assert.assertTrue(groups.size() == 1);
-            Assert.assertEquals("level2group", groups.get(0));
+            Assert.assertNotNull(token.getOtherClaims().get("groups"));
+            Map<String, Collection<String>> groups = (Map<String, Collection<String>>) token.getOtherClaims().get("groups");
+            MatcherAssert.assertThat(groups.get("groups"), Matchers.contains("level2group"));
             Assert.assertEquals("true", token.getOtherClaims().get("topAttribute"));
             Assert.assertEquals("true", token.getOtherClaims().get("level2Attribute"));
         }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/19767

Minor change to manage `OIDCAttributeMapperHelper.mapClaim` in the `GroupMembershipMapper`. Previously it was not used and that was the cause for the issue. The `multivalued` prop is always added to the config as it was not managed before (I preferred this and not change java code in the helper class). Test modified to use a nested claim instead a normal one.
