### PR TITLE
Memory leak with PathCache.cache growing due the map was not synchron…

### DIFF
--- a/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/PathCache.java
+++ b/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/PathCache.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.adapters.authorization;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -53,12 +54,12 @@ public class PathCache {
      */
     PathCache(final int maxEntries, long maxAge,
             Map<String, PathConfig> paths) {
-        cache = new LinkedHashMap<String, CacheEntry>(16, DEFAULT_LOAD_FACTOR, true) {
+        cache = Collections.synchronizedMap(new LinkedHashMap<String, CacheEntry>(16, DEFAULT_LOAD_FACTOR, true) {
             @Override
             protected boolean removeEldestEntry(Map.Entry eldest) {
                 return cache.size()  > maxEntries;
             }
-        };
+        });
         this.maxAge = maxAge;
         this.enabled = ! (maxAge < -1 || (maxAge > -1 && maxAge <= 0));
         this.paths = paths;


### PR DESCRIPTION
…ized

closes #19096

@pedroigor Are you please able to review? This makes sure that the map is synchronized (we're doing similar for example in `ScriptCache` class, which correctly uses synchronized map).

I've did not added automated test, but executed manually the test class attached by the user on the GH issue. And indeed seeing that wrapping the map with `Collections.synchronizedMap` fixes the issue.
