### PR TITLE
Fix grammar mistake in messages_en.properties

### DIFF
--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -505,7 +505,7 @@ access-denied-when-idp-auth=Access denied when authenticating with {0}
 frontchannel-logout.title=Logging out
 frontchannel-logout.message=You are logging out from following apps
 logoutConfirmTitle=Logging out
-logoutConfirmHeader=Do you want to logout?
+logoutConfirmHeader=Do you want to log out?
 doLogout=Logout
 
 readOnlyUsernameMessage=You can''t update your username as it is read-only.


### PR DESCRIPTION
This changes the text displayed on the logout page.

Here is a picture of the problem:  
![image](https://github.com/keycloak/keycloak/assets/6819464/456dac89-c282-4721-be60-1cbf15ae8e04)
