### PR TITLE
Downgrade jna to 4.5.1 to align with prod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <servlet.api.40.version>2.0.0.Final</servlet.api.40.version>
         <twitter4j.version>4.1.2</twitter4j.version>
-        <jna.version>5.8.0</jna.version>
+        <jna.version>4.5.1</jna.version>
 
         <!-- Databases -->
         <mysql.version>8.0</mysql.version>


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20387

Just downgrading the JNA dependency to 4.5.1. This way it is aligned with the prod team. If the library is upgraded to 5.8.0 as expected later we can upgrade again here.

Tested inside my VM with upstream and redhat version. It worked for me without any issue.
