### PR TITLE
Raise required version of Node.js to 18

### DIFF
--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^18"
   },
   "scripts": {
     "build": "wireit",


### PR DESCRIPTION
Raises the required version of Node.js to 18, which is the minimum version [with support](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility) for the Fetch API.

Closes #20515