### PR TITLE
Ensure client secret is encoded properly in `Authorization` header

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -79,7 +79,7 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
   if (credentials.clientSecret) {
     headers.set(
       "Authorization",
-      atob(credentials.clientId + ":" + credentials.clientSecret)
+      `Basic ${btoa(`${credentials.clientId}:${credentials.clientSecret}`)}`
     );
   }
 


### PR DESCRIPTION
Backports #19879