### PR TITLE
Backport 20459 to 21.1

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
@@ -83,9 +83,6 @@ public abstract class AbstractUserProfileProvider<U extends UserProfileProvider>
             case ACCOUNT_OLD:
             case ACCOUNT:
             case UPDATE_PROFILE:
-                if (realm.isRegistrationEmailAsUsername()) {
-                    return false;
-                }
                 return realm.isEditUsernameAllowed();
             case UPDATE_EMAIL:
                 return realm.isRegistrationEmailAsUsername();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -386,6 +386,10 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
             user = updateAndGet(user);
             assertEquals("test-user@localhost", user.getUsername());
 
+            user.setEmail("new@localhost");
+            user = updateAndGet(user);
+            assertEquals("new@localhost", user.getUsername());
+
             realmRep.setRegistrationEmailAsUsername(false);
             adminClient.realm("test").update(realmRep);
 


### PR DESCRIPTION
Changing the email address has no impact at username regardless "Email as username" toggle

closes #20459

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
