### PR TITLE
Fix User Event Types not visible when 'Save events disabled`

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/event-config/EventsTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/event-config/EventsTab.tsx
@@ -195,22 +195,20 @@ export const EventsTab = ({ realm }: EventsTabProps) => {
               />
             </FormAccess>
           </PageSection>
-          {events?.eventsEnabled && (
-            <PageSection>
-              <EventsTypeTable
-                key={tableKey}
-                addTypes={() => setAddEventType(true)}
-                eventTypes={events.enabledEventTypes || []}
-                onDelete={(value) => {
-                  const enabledEventTypes = events.enabledEventTypes?.filter(
-                    (e) => e !== value.id
-                  );
-                  addEvents(enabledEventTypes);
-                  setEvents({ ...events, enabledEventTypes });
-                }}
-              />
-            </PageSection>
-          )}
+          <PageSection>
+            <EventsTypeTable
+              key={tableKey}
+              addTypes={() => setAddEventType(true)}
+              eventTypes={events?.enabledEventTypes || []}
+              onDelete={(value) => {
+                const enabledEventTypes = events?.enabledEventTypes?.filter(
+                  (e) => e !== value.id
+                );
+                addEvents(enabledEventTypes);
+                setEvents({ ...events, enabledEventTypes });
+              }}
+            />
+          </PageSection>
         </Tab>
         <Tab
           eventKey="admin"


### PR DESCRIPTION
Fixes #20503

It doesn't hurt to let the user edit the event type list when not saving to database.  And the issue brings up a valid use case for it.