### PR TITLE
Show warning message when overriding build options during starts

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -66,7 +66,6 @@ import org.keycloak.common.util.StreamUtil;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.SecurityOptions;
 import org.keycloak.config.StorageOptions;
-import org.keycloak.config.TransactionOptions;
 import org.keycloak.connections.jpa.DefaultJpaConnectionProviderFactory;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionSpi;
@@ -146,7 +145,6 @@ import static org.keycloak.quarkus.runtime.KeycloakRecorder.DEFAULT_HEALTH_ENDPO
 import static org.keycloak.quarkus.runtime.KeycloakRecorder.DEFAULT_METRICS_ENDPOINT;
 import static org.keycloak.quarkus.runtime.Providers.getProviderManager;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getKcConfigValue;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcBooleanValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getPropertyNames;
@@ -501,6 +499,11 @@ class KeycloakProcessor {
             properties.put(String.format("kc.provider.file.%s.last-modified", jar.getName()), String.valueOf(jar.lastModified()));
         }
 
+        if (!Environment.isRebuildCheck()) {
+            // not auto-build (e.g.: start without optimized option) but a regular build to create an optimized server image
+            Configuration.markAsOptimized(properties);
+        }
+
         String profile = Environment.getProfile();
 
         if (profile != null) {
@@ -536,6 +539,10 @@ class KeycloakProcessor {
         }
 
         if (value != null && value.getValue() != null) {
+            if (value.getConfigSourceName() == null) {
+                // only persist build options resolved from config sources and not default values
+                return;
+            }
             String rawValue = value.getRawValue();
 
             if (rawValue == null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -43,6 +45,14 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
     public static final String PERSISTED_PROPERTIES = "META-INF/keycloak-persisted.properties";
     private static final PersistedConfigSource INSTANCE = new PersistedConfigSource();
 
+    /**
+     * MicroProfile Config does not allow removing a config source when resolving properties. In order to be able
+     * to resolve the current (not the persisted value) value for a property, even if not explicitly set at runtime, we need
+     * to ignore this config source. Otherwise, default values are not resolved at runtime because the property will be
+     * resolved from this config source, if persisted.
+     */
+    private static final ThreadLocal<Boolean> ENABLED = new ThreadLocal<>();
+
     private PersistedConfigSource() {
         super(readProperties(), "", 200);
     }
@@ -58,13 +68,26 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
 
     @Override
     public String getValue(String propertyName) {
-        String value = super.getValue(propertyName);
+        if (isEnabled()) {
+            String value = super.getValue(propertyName);
 
-        if (value != null) {
-            return value;
+            if (value != null) {
+                return value;
+            }
+
+            return super.getValue(propertyName.replace(Configuration.OPTION_PART_SEPARATOR_CHAR, '.'));
         }
 
-        return super.getValue(propertyName.replace(Configuration.OPTION_PART_SEPARATOR_CHAR, '.'));
+        return null;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        if (isEnabled()) {
+            return super.getPropertyNames();
+        }
+
+        return Set.of();
     }
 
     private static Map<String, String> readProperties() {
@@ -121,5 +144,18 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
         }
 
         return null;
+    }
+
+    public void enable(boolean enabled) {
+        if (enabled) {
+            ENABLED.remove();
+        } else {
+            ENABLED.set(enabled);
+        }
+    }
+
+    private boolean isEnabled() {
+        Boolean result = ENABLED.get();
+        return result == null ? true : result;
     }
 }

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -1,13 +1,6 @@
 # Default and non-production grade database vendor
 db=dev-file
 
-# Insecure requests are disabled by default
-http-enabled=false
-
-# Metrics and healthcheck are disabled by default
-health-enabled=false
-metrics-enabled=false
-
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.http-enabled=true
 %dev.hostname-strict=false

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
@@ -35,13 +35,13 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
-@DistributionTest
+@DistributionTest(defaultOptions = {"--http-enabled=true", "--hostname-strict=false"})
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(OrderAnnotation.class)
 public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(1)
     void reAugOnFirstRun(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -50,7 +50,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(QuarkusPropertiesAutoBuildDistTest.UpdateConsoleLogLevelToWarn.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(2)
     void testQuarkusRuntimePropDoesNotTriggerReAug(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -60,7 +60,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(UpdateConsoleLogLevelToInfo.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(3)
     void testNoReAugAfterChangingRuntimeProperty(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -70,7 +70,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(AddAdditionalDatasource.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(4)
     void testReAugForAdditionalDatasource(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -79,7 +79,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(ChangeAdditionalDatasourceUsername.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(5)
     void testNoReAugForAdditionalDatasourceRuntimeProperty(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -88,7 +88,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(ChangeAdditionalDatasourceDbKind.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(6)
     void testNoReAugWhenBuildTimePropertiesAreTheSame(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -97,7 +97,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(AddAdditionalDatasource2.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start" })
     @Order(7)
     void testReAugWhenAnotherDatasourceAdded(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -105,14 +105,13 @@ public class QuarkusPropertiesAutoBuildDistTest {
     }
 
     @Test
-    @BeforeStartDistribution(EnableQuarkusMetrics.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @BeforeStartDistribution(SetDatabaseKind.class)
+    @Launch({ "start" })
     @Order(8)
     void testWrappedBuildPropertyTriggersBuildButGetsIgnoredWhenSetByQuarkus(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertBuild();
-        when().get("/metrics").then()
-                .statusCode(404);
+        cliResult.assertStarted();
     }
 
     public static class UpdateConsoleLogLevelToWarn implements Consumer<KeycloakDistribution> {
@@ -163,11 +162,11 @@ public class QuarkusPropertiesAutoBuildDistTest {
         }
     }
 
-    public static class EnableQuarkusMetrics implements Consumer<KeycloakDistribution> {
+    public static class SetDatabaseKind implements Consumer<KeycloakDistribution> {
         @Override
         public void accept(KeycloakDistribution distribution) {
             distribution.setManualStop(true);
-            distribution.setQuarkusProperty("quarkus.micrometer.enabled","true");
+            distribution.setQuarkusProperty("quarkus.datasource.db-kind", "postgres");
         }
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -104,16 +104,6 @@ public class QuarkusPropertiesDistTest {
 
     @Test
     @BeforeStartDistribution(UpdateHibernateMetricsFromQuarkusProps.class)
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
-    @Order(7)
-    void testBuildRunTimeMismatchOnQuarkusBuildPropWarning(LaunchResult result) {
-        CLIResult cliResult = (CLIResult) result;
-        cliResult.assertNoBuild();
-        cliResult.assertBuildRuntimeMismatchWarning(QUARKUS_BUILDTIME_HIBERNATE_METRICS_KEY);
-    }
-
-    @Test
-    @BeforeStartDistribution(UpdateHibernateMetricsFromQuarkusProps.class)
     @Launch({ "build", "--metrics-enabled=true" })
     @Order(8)
     void buildFirstWithUnknownQuarkusBuildProperty(LaunchResult result) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -14,18 +14,18 @@ public class ShowConfigCommandDistTest {
     void testShowConfigPicksUpRightConfigDependingOnCurrentMode(KeycloakDistribution distribution) {
         CLIResult initialResult = distribution.run("show-config");
         initialResult.assertMessage("Current Mode: production");
-        initialResult.assertMessage("kc.http-enabled =  false");
+        initialResult.assertMessage("kc.db =  dev-file");
 
         distribution.run("start-dev");
 
         CLIResult devModeResult = distribution.run("show-config");
         devModeResult.assertMessage("Current Mode: development");
-        devModeResult.assertMessage("kc.http-enabled =  true");
+        devModeResult.assertMessage("kc.db =  dev-file");
 
         distribution.run("build");
 
         CLIResult resetResult = distribution.run("show-config");
         resetResult.assertMessage("Current Mode: production");
-        resetResult.assertMessage("kc.http-enabled =  false");
+        resetResult.assertMessage("kc.db =  dev-file");
     }
 }


### PR DESCRIPTION
Closes #20582

Now, if you try to run a build:

```
kc.sh build --db=postgres
```

and then you `start` the server without the `optimized` flag (auto-build), you will see a message like this:

```
kc.sh start

The previous optimized build will be overridden with the following build options:
        - db=postgres > db=dev-file
To avoid that, run the 'build' command again and then start the optimized server instance using the '--optimized' flag.
```

Note that during the `start` no option was set and the value set to `db` will change to the default value `db=dev-file`.

The message makes clear what is happening and warning the user about the changes in the configuration with hints about how to properly run optimized server images.

This also makes it easier to show/explain the idea behind optimized images and how auto-build works. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
