### PR TITLE
Add correct Node.js version range for Admin Client

### DIFF
--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^18"
+    "node": ">=18"
   },
   "scripts": {
     "build": "wireit",


### PR DESCRIPTION
Made a mistake under #20515, this should be a greater or equal than of version 18 of Node.js.