### PR TITLE
Avoid using user property mapper when resolving root user attributes

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -134,25 +134,25 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
 
     void initBuiltIns() {
                 ProtocolMapperModel model;
-        model = UserPropertyMapper.createClaimMapper(USERNAME,
+        model = UserAttributeMapper.createClaimMapper(USERNAME,
                 "username",
-                "preferred_username", "String",
+                "preferred_username", String.class.getSimpleName(),
                 true, true);
         builtins.put(USERNAME, model);
 
-        model = UserPropertyMapper.createClaimMapper(EMAIL,
+        model = UserAttributeMapper.createClaimMapper(EMAIL,
                 "email",
                 "email", "String",
                 true, true);
         builtins.put(EMAIL, model);
 
-        model = UserPropertyMapper.createClaimMapper(GIVEN_NAME,
+        model = UserAttributeMapper.createClaimMapper(GIVEN_NAME,
                 "firstName",
                 "given_name", "String",
                 true, true);
         builtins.put(GIVEN_NAME, model);
 
-        model = UserPropertyMapper.createClaimMapper(FAMILY_NAME,
+        model = UserAttributeMapper.createClaimMapper(FAMILY_NAME,
                 "lastName",
                 "family_name", "String",
                 true, true);
@@ -205,7 +205,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         builtins.put(IMPERSONATOR_ID.getDisplayName(), UserSessionNoteMapper.createUserSessionNoteMapper(IMPERSONATOR_ID));
         builtins.put(IMPERSONATOR_USERNAME.getDisplayName(), UserSessionNoteMapper.createUserSessionNoteMapper(IMPERSONATOR_USERNAME));
 
-        model = UserPropertyMapper.createClaimMapper(UPN, "username",
+        model = UserAttributeMapper.createClaimMapper(UPN, "username",
                 "upn", "String",
                 true, true);
         builtins.put(UPN, model);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ClaimsParameterTokenMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ClaimsParameterTokenMapper.java
@@ -109,17 +109,17 @@ public class ClaimsParameterTokenMapper extends AbstractOIDCProtocolMapper imple
                         FullNameMapper fullNameMapper = new FullNameMapper();
                         fullNameMapper.setClaim(token, mappingModel, userSession);
                     } else if (i.equals(IDToken.GIVEN_NAME)) {
-                        UserPropertyMapper userPropertyMapper = new UserPropertyMapper();
-                        userPropertyMapper.setClaim(token, UserPropertyMapper.createClaimMapper("requested firstName", "firstName", IDToken.GIVEN_NAME, "String", false, true), userSession);
+                        UserAttributeMapper userPropertyMapper = new UserAttributeMapper();
+                        userPropertyMapper.setClaim(token, UserAttributeMapper.createClaimMapper("requested firstName", "firstName", IDToken.GIVEN_NAME, "String", false, true), userSession);
                     } else if (i.equals(IDToken.FAMILY_NAME)) {
-                        UserPropertyMapper userPropertyMapper = new UserPropertyMapper();
-                        userPropertyMapper.setClaim(token, UserPropertyMapper.createClaimMapper("requested lastName", "lastName", IDToken.FAMILY_NAME, "String", false, true), userSession);
+                        UserAttributeMapper userPropertyMapper = new UserAttributeMapper();
+                        userPropertyMapper.setClaim(token, UserAttributeMapper.createClaimMapper("requested lastName", "lastName", IDToken.FAMILY_NAME, "String", false, true), userSession);
                     } else if (i.equals(IDToken.PREFERRED_USERNAME)) {
-                        UserPropertyMapper userPropertyMapper = new UserPropertyMapper();
-                        userPropertyMapper.setClaim(token, UserPropertyMapper.createClaimMapper("requested username", "username", IDToken.PREFERRED_USERNAME, "String", false, true), userSession);
+                        UserAttributeMapper userPropertyMapper = new UserAttributeMapper();
+                        userPropertyMapper.setClaim(token, UserAttributeMapper.createClaimMapper("requested username", "username", IDToken.PREFERRED_USERNAME, "String", false, true), userSession);
                     } else if (i.equals(IDToken.EMAIL)) {
-                        UserPropertyMapper userPropertyMapper = new UserPropertyMapper();
-                        userPropertyMapper.setClaim(token, UserPropertyMapper.createClaimMapper("requested email", "email", IDToken.EMAIL, "String", false, true), userSession);
+                        UserAttributeMapper userPropertyMapper = new UserAttributeMapper();
+                        userPropertyMapper.setClaim(token, UserAttributeMapper.createClaimMapper("requested email", "email", IDToken.EMAIL, "String", false, true), userSession);
                     }
             });
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserAttributeMapper.java
@@ -131,5 +131,11 @@ public class UserAttributeMapper extends AbstractOIDCProtocolMapper implements O
         return mapper;
     }
 
-
+    public static ProtocolMapperModel createClaimMapper(String name,
+                                                        String userAttribute,
+                                                        String tokenClaimName, String claimType,
+                                                        boolean accessToken, boolean idToken) {
+        return createClaimMapper(name, userAttribute, tokenClaimName, claimType,
+                accessToken, idToken, false, false);
+    }
 }


### PR DESCRIPTION
Closes #20613

* Removes the `UserAttributeMapper` from the build-in mappers
* Adds the `UserPropertyMapper` as a replacement to the aforementioned mapper, only for root user attributes like username, first|last names, and email

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
