### PR TITLE
Group "move to root" now maintains members

### DIFF
--- a/js/apps/admin-ui/src/groups/components/MoveDialog.tsx
+++ b/js/apps/admin-ui/src/groups/components/MoveDialog.tsx
@@ -14,7 +14,7 @@ type MoveDialogProps = {
 const moveToRoot = async (source: GroupRepresentation) => {
   try {
     await adminClient.groups.create(source);
-  } catch (error: any) {
+  } catch (error) {
     if (error.response) {
       throw error;
     }

--- a/js/apps/admin-ui/src/groups/components/MoveDialog.tsx
+++ b/js/apps/admin-ui/src/groups/components/MoveDialog.tsx
@@ -12,23 +12,12 @@ type MoveDialogProps = {
 };
 
 const moveToRoot = async (source: GroupRepresentation) => {
-  await adminClient.groups.del({ id: source.id! });
-  const { id } = await adminClient.groups.create({
-    ...source,
-    id: undefined,
-  });
-  if (source.subGroups) {
-    await Promise.all(
-      source.subGroups.map((s) =>
-        adminClient.groups.setOrCreateChild(
-          { id: id! },
-          {
-            ...s,
-            id: undefined,
-          }
-        )
-      )
-    );
+  try {
+    await adminClient.groups.create(source);
+  } catch (error: any) {
+    if (error.response) {
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
Replaced delete/recreate operations with single create operation using the existing Group resource. Since the resource already has an Id, this simply moves it to the root-level.

Closes #20615

