### PR TITLE
FAPI 2.0 security profile - Reject Implicit Grant executor does not return an appropriate error

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/RejectImplicitGrantExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/RejectImplicitGrantExecutor.java
@@ -108,7 +108,7 @@ public class RejectImplicitGrantExecutor implements ClientPolicyExecutorProvider
         // Before client policies operation, Authorization Endpoint logic has already checked whether implicit/hybrid flow is activated for a client.
         // This method rejects implicit grant regardless of client setting for allowing implicit grant.
         if (parsedResponseType.isImplicitOrHybridFlow()) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_GRANT, "Implicit/Hybrid flow is prohibited.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Implicit/Hybrid flow is prohibited.");
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -1196,16 +1196,16 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
             oauth.clientId(clientId);
 
             // implicit grant
-            testProhibitedImplicitOrHybridFlow(false, OIDCResponseType.TOKEN, null, OAuthErrorException.INVALID_GRANT, expectedErrorDescription);
+            testProhibitedImplicitOrHybridFlow(false, OIDCResponseType.TOKEN, null, OAuthErrorException.INVALID_REQUEST, expectedErrorDescription);
 
             // hybrid grant
-            testProhibitedImplicitOrHybridFlow(true, OIDCResponseType.TOKEN + " " + OIDCResponseType.ID_TOKEN, "exsefweag", OAuthErrorException.INVALID_GRANT, expectedErrorDescription);
+            testProhibitedImplicitOrHybridFlow(true, OIDCResponseType.TOKEN + " " + OIDCResponseType.ID_TOKEN, "exsefweag", OAuthErrorException.INVALID_REQUEST, expectedErrorDescription);
 
             // hybrid grant
-            testProhibitedImplicitOrHybridFlow(true, OIDCResponseType.TOKEN + " " + OIDCResponseType.CODE, "exsefweag", OAuthErrorException.INVALID_GRANT, expectedErrorDescription);
+            testProhibitedImplicitOrHybridFlow(true, OIDCResponseType.TOKEN + " " + OIDCResponseType.CODE, "exsefweag", OAuthErrorException.INVALID_REQUEST, expectedErrorDescription);
 
             // hybrid grant
-            testProhibitedImplicitOrHybridFlow(true, OIDCResponseType.TOKEN + " " + OIDCResponseType.CODE + " " + OIDCResponseType.ID_TOKEN, "exsefweag", OAuthErrorException.INVALID_GRANT, expectedErrorDescription);
+            testProhibitedImplicitOrHybridFlow(true, OIDCResponseType.TOKEN + " " + OIDCResponseType.CODE + " " + OIDCResponseType.ID_TOKEN, "exsefweag", OAuthErrorException.INVALID_REQUEST, expectedErrorDescription);
 
         } finally {
             // revert test client instance settings the same as OAuthClient.init


### PR DESCRIPTION
Closes #20622