### PR TITLE
Fix broken Adapters Feature Pack build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <aesh.version>2.4</aesh.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <apache.httpcomponents.httpcore.version>4.4.14</apache.httpcomponents.httpcore.version>
-        <apache.mime4j.version>0.8.9</apache.mime4j.version>
+        <apache.mime4j.version>0.6</apache.mime4j.version>
         <jboss.dmr.version>1.5.1.Final</jboss.dmr.version>
         <bouncycastle.version>1.70</bouncycastle.version>
 


### PR DESCRIPTION
Partially reverts ea99049c

The [failure](https://github.com/keycloak/keycloak/actions/runs/5120877265/jobs/9207919888) was visible in the JS CI. Seems like `org.apache.james:apache-mime4j` introduced some breaking changes as `jar` artifact is [no longer available](https://mvnrepository.com/artifact/org.apache.james/apache-mime4j/0.8.9) but is required by `org.wildfly:wildfly-feature-pack`.