### PR TITLE
Remove override of mime4j version in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -796,17 +796,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j</artifactId>
-                <version>${apache.mime4j.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-controller</artifactId>
                 <version>${wildfly.core.version}</version>


### PR DESCRIPTION
This uses 0.8.9 in the server dist:
```
$ cd keycloak
$ mvn dependency:tree -Dincludes=org.apache.james:*
...
[INFO] org.keycloak:keycloak-services:jar:999.0.0-SNAPSHOT
[INFO] \- org.jboss.resteasy:resteasy-multipart-provider:jar:4.7.9.Final:compile
[INFO]    +- org.apache.james:apache-mime4j-dom:jar:0.8.9:compile
[INFO]    |  \- org.apache.james:apache-mime4j-core:jar:0.8.9:compile
[INFO]    \- org.apache.james:apache-mime4j-storage:jar:0.8.9:compile
```

and uses `0.6` in the adapter-feature-pack:
```
$ cd keycloak/distribution
$ mvn dependency:tree -Dincludes=org.apache.james:*
...
[INFO] org.keycloak:keycloak-wildfly-adapter-dist:pom:999.0.0-SNAPSHOT
[INFO] \- org.keycloak:keycloak-adapter-feature-pack:zip:999.0.0-SNAPSHOT:compile
[INFO]    \- org.wildfly:wildfly-feature-pack:zip:23.0.2.Final:compile
[INFO]       \- org.wildfly:wildfly-ee-feature-pack-common:pom:23.0.2.Final:compile
[INFO]          \- org.apache.james:apache-mime4j:jar:0.6:compile
```