### PR TITLE
Add support for single-tenant mode to Microsoft Identity Provider

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
@@ -13,6 +13,7 @@ import ProviderBaseGeneralSettingsPage from "../support/pages/admin-ui/manage/id
 import ProviderBaseAdvancedSettingsPage from "../support/pages/admin-ui/manage/identity_providers/ProviderBaseAdvancedSettingsPage";
 import ProviderGithubGeneralSettings from "../support/pages/admin-ui/manage/identity_providers/social/ProviderGithubGeneralSettings";
 import ProviderGoogleGeneralSettings from "../support/pages/admin-ui/manage/identity_providers/social/ProviderGoogleGeneralSettings";
+import ProviderMicrosoftGeneralSettings from "../support/pages/admin-ui/manage/identity_providers/social/ProviderMicrosoftGeneralSettings";
 import ProviderOpenshiftGeneralSettings from "../support/pages/admin-ui/manage/identity_providers/social/ProviderOpenshiftGeneralSettings";
 import ProviderPaypalGeneralSettings from "../support/pages/admin-ui/manage/identity_providers/social/ProviderPaypalGeneralSettings";
 import ProviderStackoverflowGeneralSettings from "../support/pages/admin-ui/manage/identity_providers/social/ProviderStackoverflowGeneralSettings";
@@ -50,6 +51,7 @@ describe("Identity provider test", () => {
     Facebook: new ProviderFacebookGeneralSettings(),
     Github: new ProviderGithubGeneralSettings(),
     Google: new ProviderGoogleGeneralSettings(),
+    Microsoft: new ProviderMicrosoftGeneralSettings(),
     "Openshift-v3": new ProviderOpenshiftGeneralSettings(),
     "Openshift-v4": new ProviderOpenshiftGeneralSettings(),
     Paypal: new ProviderPaypalGeneralSettings(),

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/social/ProviderMicrosoftGeneralSettings.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/social/ProviderMicrosoftGeneralSettings.ts
@@ -1,0 +1,29 @@
+import ProviderBaseGeneralSettingsPage from "../ProviderBaseGeneralSettingsPage";
+
+const TENANT_ID_VALUE = "12345678-9abc-def0-1234-56789abcdef0";
+
+export default class ProviderMicrosoftGeneralSettings extends ProviderBaseGeneralSettingsPage {
+  private tenantIdTestId = "tenantId";
+
+  public typeTenantIdInput(value: string) {
+    cy.findByTestId(this.tenantIdTestId).type(value).blur();
+    return this;
+  }
+
+  public assertTenantIdInputEqual(value: string) {
+    cy.findByTestId(this.tenantIdTestId).should("have.value", value);
+    return this;
+  }
+
+  public fillData(idpName: string) {
+    this.fillCommonFields(idpName);
+    this.typeTenantIdInput(TENANT_ID_VALUE);
+    return this;
+  }
+
+  public assertFilledDataEqual(idpName: string) {
+    this.assertCommonFilledDataEqual(idpName);
+    this.assertTenantIdInputEqual(TENANT_ID_VALUE);
+    return this;
+  }
+}

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProviderConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.social.microsoft;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.models.IdentityProviderModel;
+
+public class MicrosoftIdentityProviderConfig extends OIDCIdentityProviderConfig {
+
+    public MicrosoftIdentityProviderConfig(IdentityProviderModel model) {
+        super(model);
+    }
+
+    public MicrosoftIdentityProviderConfig() {
+
+    }
+
+    public String getTenantId() {
+        String tenantId = getConfig().get("tenantId");
+
+        return tenantId == null || tenantId.isEmpty() ? null : tenantId;
+    }
+
+    public void setTenantId(final String tenantId) {
+        getConfig().put("tenantId", tenantId);
+    }
+}

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProviderFactory.java
@@ -16,11 +16,14 @@
  */
 package org.keycloak.social.microsoft;
 
-import org.keycloak.broker.oidc.OAuth2IdentityProviderConfig;
 import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProviderFactory;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.List;
 
 /**
  * @author Vlastimil Elias (velias at redhat dot com)
@@ -36,16 +39,26 @@ public class MicrosoftIdentityProviderFactory extends AbstractIdentityProviderFa
 
     @Override
     public MicrosoftIdentityProvider create(KeycloakSession session, IdentityProviderModel model) {
-        return new MicrosoftIdentityProvider(session, new OAuth2IdentityProviderConfig(model));
+        return new MicrosoftIdentityProvider(session, new MicrosoftIdentityProviderConfig(model));
     }
 
     @Override
-    public OAuth2IdentityProviderConfig createConfig() {
-        return new OAuth2IdentityProviderConfig();
+    public MicrosoftIdentityProviderConfig createConfig() {
+        return new MicrosoftIdentityProviderConfig();
     }
 
     @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property().name("tenantId")
+                .label("Tenant ID")
+                .helpText("Uses single-tenant auth endpoints when specified, uses 'common' multi-tenant endpoints otherwise.")
+                .type(ProviderConfigProperty.STRING_TYPE).add()
+                .build();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -84,6 +84,7 @@ import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE_NON_
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.INSTAGRAM;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.LINKEDIN;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.MICROSOFT;
+import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.MICROSOFT_SINGLE_TENANT;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.OPENSHIFT;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.OPENSHIFT4;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.OPENSHIFT4_KUBE_ADMIN;
@@ -126,6 +127,7 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         TWITTER("twitter", TwitterConsentLoginPage.class),
         LINKEDIN("linkedin-openid-connect", LinkedInLoginPage.class),
         MICROSOFT("microsoft", MicrosoftLoginPage.class),
+        MICROSOFT_SINGLE_TENANT("microsoft", "microsoft-single-tenant", MicrosoftLoginPage.class),
         PAYPAL("paypal", PayPalLoginPage.class),
         STACKOVERFLOW("stackoverflow", StackOverflowLoginPage.class),
         OPENSHIFT("openshift-v3", OpenShiftLoginPage.class),
@@ -409,6 +411,15 @@ public class SocialLoginTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void microsoftSingleTenantLogin() {
+        setTestProvider(MICROSOFT_SINGLE_TENANT);
+        navigateToLoginPage();
+        assertTrue(driver.getCurrentUrl().contains("/" + getConfig(MICROSOFT_SINGLE_TENANT, "tenantId") + "/"));
+        doLogin();
+        appPage.assertCurrent();
+    }
+
+    @Test
     public void paypalLogin() {
         setTestProvider(PAYPAL);
         performLogin();
@@ -448,6 +459,13 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         }
         if (provider == OPENSHIFT || provider == OPENSHIFT4 || provider == OPENSHIFT4_KUBE_ADMIN) {
             idp.getConfig().put("baseUrl", getConfig(provider, "baseUrl"));
+        }
+        if (provider == MICROSOFT_SINGLE_TENANT) {
+            final String tenantId = getConfig(provider, "tenantId");
+            if (tenantId == null) {
+                throw new IllegalArgumentException("'tenantId' for Microsoft IdP must be specified");
+            }
+            idp.getConfig().put("tenantId", tenantId);
         }
         if (provider == PAYPAL) {
             idp.getConfig().put("sandbox", getConfig(provider, "sandbox"));


### PR DESCRIPTION
This is pretty much #11207, but updated to main. Description copied from #11207:



This change allows the usage of "single-tenant" App Registrations on Azure AD.

Microsoft distinguishes between single-tenant and multi-tenant app registrations.
Usually, enterprise companies would rather like to use so called "single-tenant" app registrations instead of multi-tenant app registrations [1], as they're limited to users in their tenant.
Since 2018, Microsoft disallowed the use of the global "/common/" endpoints for single-tenant applications [2]. The usual answer on the internet has been "use the generic oidc provider". While the generic OIDC provider works fine most of the cases, it doesn't work properly when using the "exchange-token" feature of keycloak.

The generic OIDC connector maps user identities to the OIDC subject field "sub" [3], which differs on the same account for every client on Microsoft [4] (OIDC spec refers to the 'pairwise' mode here [5]). However, the microsoft social connector stores the object id of the account in keycloak for federated users [6].

Therefore, while using the token-exchange feature from external to internal tokens, the different "sub" fields per client for the same account leads to mapping problems [7]. The token-exchange provider fails to find the respective user and tries to create a new user with the same mail address, which fails.

This patch allows to use the Microsoft social provider with single-tenant apps, which makes it easier for admins to configure microsoft federation, if the only need a single-tenant to federate, as they have to configure way less properties compared to the generic OIDC adapter  resolves the token-exchange feature for Microsoft federated users

[1] https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps
[2] https://keycloak.discourse.group/t/how-to-configure-microsoft-identity-provider-with-single-tenant/11741 https://lists.jboss.org/pipermail/keycloak-user/2019-February/017254.html
[3] https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java#L651
[4] https://stackoverflow.com/questions/52876679/the-sub-claim-value-is-different-between-access-and-id-tokens
[5] https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes
[6] https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java#L80
[7] https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java#L485

Fixes #20695
Closes #11207
