### PR TITLE
Fix test for brute force detection of recovery codes

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -28,7 +28,6 @@ import org.keycloak.testsuite.pages.SetupRecoveryAuthnCodesPage;
 import org.keycloak.testsuite.util.FlowUtil;
 import org.openqa.selenium.WebDriver;
 import org.junit.Assert;
-import  org.keycloak.testsuite.util.WaitUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -206,16 +205,15 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
                 long randomNumber = (long)Math.random()*1000000000000L;
                 enterRecoveryAuthnCodePage.enterRecoveryAuthnCode(String.valueOf(randomNumber));
                 enterRecoveryAuthnCodePage.clickSignInButton();
-                WaitUtils.waitForPageToLoad();
                 enterRecoveryAuthnCodePage.assertCurrent();
                 String feedbackText = enterRecoveryAuthnCodePage.getFeedbackText();
-                Assert.assertEquals(feedbackText, "Invalid recovery authentication code");
+                Assert.assertEquals("Invalid recovery authentication code", feedbackText);
             }
             // Now enter the right code which should not work
             enterRecoveryAuthnCodePage.enterRecoveryAuthnCode(generatedRecoveryAuthnCodes.get(enterRecoveryAuthnCodePage.getRecoveryAuthnCodeToEnterNumber()));
             enterRecoveryAuthnCodePage.clickSignInButton();
             // Message changes after exhausting number of brute force attempts
-            Assert.assertEquals(enterRecoveryAuthnCodePage.getFeedbackText(), "Invalid username or password.");
+            Assert.assertEquals("Invalid username or password.", enterRecoveryAuthnCodePage.getFeedbackText());
             enterRecoveryAuthnCodePage.assertAccountLinkAvailability(false);
         } finally {
             RealmRepresentation rep = testRealm().toRepresentation();


### PR DESCRIPTION
Fixes the test for brute force detection of recovery codes by removing the `waitForPageToLoad()` call. In Chrome calling the `waitForPageToLoad()` method causes ~2 second wait every time it's called, preventing the brute force detection from kicking in, whereas the default HtmlUnit driver does [not wait at all](https://github.com/keycloak/keycloak/blob/d80094793bae8efbe556e93d235cae72b28c0c70/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java#L130-L132).

Closes #13543