### PR TITLE
EventBuilder fixes to copy the store and session context

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.events;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.keycloak.events.Event;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * <p>Just an extension of TestEventsListenerProvider that includes the realm and
+ * client passed in the session context as details in the event.</p>
+ *
+ * @author rmartinc
+ */
+public class TestEventsListenerContextDetailsProvider extends TestEventsListenerProvider {
+
+    private final KeycloakSession session;
+
+    public TestEventsListenerContextDetailsProvider(KeycloakSession session) {
+        super(session);
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        event = event.clone();
+        Map<String, String> details = event.getDetails();
+        if (details == null) {
+            details = new HashMap<>();
+            event.setDetails(details);
+        }
+        if (session.getContext().getRealm() != null) {
+            details.put(TestEventsListenerContextDetailsProviderFactory.CONTEXT_REALM_DETAIL, session.getContext().getRealm().getName());
+        }
+        if (session.getContext().getClient() != null) {
+            details.put(TestEventsListenerContextDetailsProviderFactory.CONTEXT_CLIENT_DETAIL, session.getContext().getClient().getClientId());
+        }
+        super.onEvent(event);
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProviderFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.events;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * <p>Same events provider factory than <em>TestEventsListenerProviderFactory</em> but
+ * the implementation saves realm name and clientId  from the session context as details in
+ * the event. This way we can ensure that session context is correctly
+ * propagated to the event listener.</p>
+ *
+ * @author rmartinc
+ */
+public class TestEventsListenerContextDetailsProviderFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "event-queue-context-details";
+    public static final String CONTEXT_REALM_DETAIL = "context.realmName";
+    public static final String CONTEXT_CLIENT_DETAIL = "context.clientId";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new TestEventsListenerContextDetailsProvider(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -32,4 +32,5 @@
 # limitations under the License.
 #
 
+org.keycloak.testsuite.events.TestEventsListenerContextDetailsProviderFactory
 org.keycloak.testsuite.events.TestEventsListenerProviderFactory


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20757
Closes https://github.com/keycloak/keycloak/issues/20105

The `store` property was not cloned and it made the cloned builder not save the event to the store provider. This was triggered by this [commit](https://github.com/keycloak/keycloak/pull/19488/commits/097638a37a29272488e2b80f5bca750dc50b37ff#diff-6c641fd553097eb7d3a340bc4d676ff2c435bac772f3d57e343665c4bf867b6eL86-L87).
