### PR TITLE
OTP support for binary secrets encoded in Base32

### DIFF
--- a/server-spi-private/src/test/java/org/keycloak/models/HmacTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/HmacTest.java
@@ -37,4 +37,23 @@ public class HmacTest {
         System.out.println(hmacOTP.validateHOTP("550233", decoded, 0));
         Assert.assertEquals(1, hmacOTP.validateHOTP("550233", decoded, 0));
     }
+    @Test
+    public void testHmacBase32() {
+        HmacOTP hmacOTP = new HmacOTP(6, HmacOTP.HMAC_SHA1, 10);
+        String decoded = "{B32}JNSVMMTEKZCUGSKJIVGHMNSQOZBDA5JT";
+        System.out.println(hmacOTP.generateHOTP(decoded, 0));
+        System.out.println(hmacOTP.validateHOTP("550233", decoded, 0));
+        Assert.assertEquals(1, hmacOTP.validateHOTP("550233", decoded, 0));
+    }
+    @Test
+    public void testHmacBase32Binary() {
+        // Secret from https://github.com/keycloak/keycloak/issues/11561
+        // Codes values validated aganist https://totp.app/
+        HmacOTP hmacOTP = new HmacOTP(6, HmacOTP.HMAC_SHA1, 30);
+        String decoded = "{B32}CDLYAYRJ73ORTU4PUWWATWSYQCP4H2QL";
+        String counter = "000000000359675C";
+        Assert.assertEquals("754397", hmacOTP.generateOTP(decoded, counter, 6, HmacOTP.HMAC_SHA1));
+        String counter2 = "0000000003596781";
+        Assert.assertEquals("386679", hmacOTP.generateOTP(decoded, counter2, 6, HmacOTP.HMAC_SHA1));
+    }    
 }

--- a/server-spi/src/main/java/org/keycloak/models/utils/HmacOTP.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/HmacOTP.java
@@ -112,7 +112,7 @@ public class HmacOTP {
 
         // Adding one byte to get the right conversion
         // byte[] k = hexStr2Bytes(key);
-        byte[] k = key.getBytes();
+        byte[] k = key.startsWith("{B32}") ? Base32.decode(key.substring(5)) : key.getBytes(); // if key has {B32} prefix is Base32 encoded
 
         hash = hmac_sha1(crypto, k, msg);
 


### PR DESCRIPTION

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

## Discussion
Started discussion as https://github.com/keycloak/keycloak/discussions/20781

## Issues

Closes https://github.com/keycloak/keycloak/issues/11561

Closes https://github.com/keycloak/keycloak/issues/9434

## One feature/change per PR
Only affects read of secrets stored with prefix {B32}

## One commit per PR
https://github.com/keycloak/keycloak/pull/20795
![image](https://github.com/keycloak/keycloak/assets/32266525/799b7bf6-b116-4eaa-a68b-f185c6d0754b)

## Commit

https://github.com/keycloak/keycloak/compare/main...rhyamada:keycloak:base32_otp_secret

`git commit -m "OTP support for binary secrets encoded in Base32" -m "Closes https://github.com/keycloak/keycloak/issues/11561" -m "Closes https://github.com/keycloak/keycloak/issues/9434"``

## No changes to code not directly related to your PR
I think so, there one line of change. 

```diff
-        byte[] k = key.getBytes();
+        byte[] k = key.startsWith("{B32}") ? Base32.decode(key.substring(5)) : key.getBytes(); // if key has {B32} prefix is Base32 encoded
```


## Includes functional/integration test
Has a functional test
```java
    @Test
    public void testHmacBase32() {
        HmacOTP hmacOTP = new HmacOTP(6, HmacOTP.HMAC_SHA1, 10);
        String decoded = "{B32}JNSVMMTEKZCUGSKJIVGHMNSQOZBDA5JT";
        System.out.println(hmacOTP.generateHOTP(decoded, 0));
        System.out.println(hmacOTP.validateHOTP("550233", decoded, 0));
        Assert.assertEquals(1, hmacOTP.validateHOTP("550233", decoded, 0));
    }
    @Test
    public void testHmacBase32Binary() {
        // Secret from https://github.com/keycloak/keycloak/issues/11561
        // Codes values validated aganist https://totp.app/
        HmacOTP hmacOTP = new HmacOTP(6, HmacOTP.HMAC_SHA1, 30);
        String decoded = "{B32}CDLYAYRJ73ORTU4PUWWATWSYQCP4H2QL";
        String counter = "000000000359675C";
        Assert.assertEquals("754397", hmacOTP.generateOTP(decoded, counter, 6, HmacOTP.HMAC_SHA1));
        String counter2 = "0000000003596781";
        Assert.assertEquals("386679", hmacOTP.generateOTP(decoded, counter2, 6, HmacOTP.HMAC_SHA1));
    } 
```


## Includes documentation
Where I put this???


## Passing all test
Running tests local
Have been passed with:

Test rewritten
```bash
HmacTest,java
```

Test not rewritten but could be affected
```bash
mvn -f testsuite/integration-arquillian/pom.xml clean install -Dtest=LoginTotpTest
```

Previous PR with a test flanky https://github.com/keycloak/keycloak/pull/20755