### PR TITLE
Adding the ability to set ingressClassName

### DIFF
--- a/docs/guides/operator/basic-deployment.adoc
+++ b/docs/guides/operator/basic-deployment.adoc
@@ -176,7 +176,23 @@ CONDITION: RollingUpdate
 
 === Accessing the Keycloak deployment
 
-The Keycloak deployment is exposed through a basic Ingress and is accessible through the provided hostname.
+The Keycloak deployment is exposed through a basic Ingress and is accessible through the provided hostname.  On installations with multiple default IngressClass instances
+or when running on OpenShift 4.12+ you should provide an ingressClassName by setting `ingress` spec with `className` property to the desired class name:
+
+Edit YAML file `example-kc.yaml`:
+
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+    ...
+    ingress:
+      className: openshift-default
+----
+
 If the default ingress does not fit your use case, disable it by setting `ingress` spec with `enabled` property to `false` value:
 
 Edit YAML file `example-kc.yaml`:

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -72,11 +72,8 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
             annotations.put("route.openshift.io/termination", "edge");
         }
 
-        if (keycloak.getSpec().getIngressSpec() != null &&
-                keycloak.getSpec().getIngressSpec().getAnnotations() != null) {
-            annotations.putAll(keycloak.getSpec().getIngressSpec().getAnnotations());
-
-        }
+        var optionalSpec = Optional.ofNullable(keycloak.getSpec().getIngressSpec());
+        optionalSpec.map(IngressSpec::getAnnotations).ifPresent(annotations::putAll);
 
         Ingress ingress = new IngressBuilder()
                 .withNewMetadata()
@@ -85,6 +82,7 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
                     .addToAnnotations(annotations)
                 .endMetadata()
                 .withNewSpec()
+                    .withIngressClassName(optionalSpec.map(IngressSpec::getIngressClassName).orElse(null))
                     .withNewDefaultBackend()
                         .withNewService()
                             .withName(keycloak.getMetadata().getName() + Constants.KEYCLOAK_SERVICE_SUFFIX)

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/IngressSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/IngressSpec.java
@@ -27,18 +27,29 @@ import java.util.Map;
 public class IngressSpec {
 
     @JsonProperty("enabled")
-    private boolean enabled = true;
+    private boolean ingressEnabled = true;
+    
+    @JsonProperty("className")
+    private String ingressClassName;
 
     @JsonProperty("annotations")
     @JsonPropertyDescription("Additional annotations to be appended to the Ingress object")
     Map<String, String> annotations;
 
     public boolean isIngressEnabled() {
-        return enabled;
+        return ingressEnabled;
     }
 
     public void setIngressEnabled(boolean enabled) {
-        this.enabled = enabled;
+        this.ingressEnabled = enabled;
+    }
+    
+    public String getIngressClassName() {
+        return ingressClassName;
+    }
+    
+    public void setIngressClassName(String className) {
+        this.ingressClassName = className;
     }
 
     public Map<String, String> getAnnotations() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -55,6 +55,7 @@ public class CRSerializationTest {
         assertEquals("my-image", keycloak.getSpec().getImage());
         assertEquals("my-tls-secret", keycloak.getSpec().getHttpSpec().getTlsSecret());
         assertFalse(keycloak.getSpec().getIngressSpec().isIngressEnabled());
+        assertEquals("nginx", keycloak.getSpec().getIngressSpec().getIngressClassName());
         assertEquals(CUSTOM_INGRESS_ANNOTATION, keycloak.getSpec().getIngressSpec().getAnnotations());
 
         final TransactionsSpec transactionsSpec = keycloak.getSpec().getTransactionsSpec();

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -28,6 +28,7 @@ spec:
     poolMaxSize: 3
   ingress:
     enabled: false
+    className: nginx
     annotations:
       myAnnotation: myValue
       anotherAnnotation: anotherValue


### PR DESCRIPTION
Adds the ability to set the ingressClassName via spec.ingress.className.  This is needed when there are multiple default ingressclasses, or to prevent warning on openshift 4.12+.

The changes try to keep the same convention as the existing enabled/ingressEnabled field, but of course could be changed to use ingress.ingressClassName if that is more clear.

The only other approach here would be to automatically infer the default - in rough terms we'd have to look over the ingressclass instances and look for a single default, then use that.  However we'd likely have to start watching / be informed on ingressclass changes as the default or number of defaults could change - the latter would be problematic requiring at least a warning event (updating the Ingress to not have a default would cause creation attempts to fail).

cc @vmuzikar

Closes #20723