### PR TITLE
"configured-user-storage-credential-types" endpoint now checks 'view'…

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -677,9 +677,8 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<String> getConfiguredUserStorageCredentialTypes() {
-        // This has "requireManage" due the compatibility with "credentials()" endpoint. Strictly said, it is reading endpoint, not writing,
-        // so may be revisited if to rather use "requireView" here in the future.
-        auth.users().requireManage(user);
+        // changed to "requireView" as per issue #20783
+        auth.users().requireView(user);
         return user.credentialManager().getConfiguredUserStorageCredentialTypesStream();
     }
 


### PR DESCRIPTION
… permission; it was 'manage" before

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
