### PR TITLE
mostly updating the logic to newer fabric8 apis

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -119,7 +119,7 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
     }
 
     protected void deleteExistingIngress() {
-        client.network().v1().ingresses().inNamespace(getNamespace()).delete(existingIngress);
+        client.resource(existingIngress).delete();
     }
 
     private boolean isExistingIngressFromSameOwnerReference() {

--- a/operator/src/main/java/org/keycloak/operator/controllers/OperatorManagedResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/OperatorManagedResource.java
@@ -54,7 +54,11 @@ public abstract class OperatorManagedResource {
                 setOwnerReferences(resource);
 
                 Log.debugf("Creating or updating resource: %s", resource);
-                resource = client.resource(resource).inNamespace(getNamespace()).createOrReplace();
+                // Until https://github.com/fabric8io/kubernetes-client/issues/5215 is resolved
+                // or event filtering is added, serverSideApply should not be used here
+                // resource.getMetadata().setResourceVersion(null);
+            	// resource = client.resource(resource).inNamespace(getNamespace()).forceConflicts().serverSideApply();
+            	resource = client.resource(resource).inNamespace(getNamespace()).createOrReplace();
                 Log.debugf("Successfully created or updated resource: %s", resource);
             } catch (Exception e) {
                 Log.error("Failed to create or update resource");

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
@@ -166,13 +166,7 @@ public class WatchedSecretsStore extends OperatorManagedResource {
 
     private Set<Secret> fetchCurrentSecrets(Set<String> secretsNames) {
         return secretsNames.stream()
-                .map(n -> {
-                    Secret secret = client.secrets().inNamespace(getNamespace()).withName(n).get();
-                    if (secret == null) {
-                        throw new IllegalStateException("Secret " + n + " not found");
-                    }
-                    return secret;
-                })
+                .map(n -> client.secrets().inNamespace(getNamespace()).withName(n).require())
                 .collect(Collectors.toSet());
     }
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -16,10 +16,12 @@
  */
 package org.keycloak.operator.crds.v2alpha1.deployment;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
+
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.DatabaseSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
@@ -31,6 +33,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class KeycloakSpec {
 
     @JsonPropertyDescription("Number of Keycloak instances in HA mode. Default is 1.")

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/ValueOrSecret.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/ValueOrSecret.java
@@ -21,9 +21,12 @@ import io.fabric8.kubernetes.api.model.SecretKeySelector;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ValueOrSecret {
     private String name;
     private String value;

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/DatabaseSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/DatabaseSpec.java
@@ -17,11 +17,13 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.sundr.builder.annotations.Buildable;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class DatabaseSpec {
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/FeatureSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/FeatureSpec.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -25,6 +26,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.io.Serializable;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @JsonPropertyOrder({"enabled", "disabled"})
 public class FeatureSpec implements Serializable {

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/HostnameSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/HostnameSpec.java
@@ -17,11 +17,13 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class HostnameSpec implements Serializable {
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/HttpSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/HttpSpec.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.sundr.builder.annotations.Buildable;
 import org.keycloak.operator.Constants;
@@ -24,6 +25,7 @@ import org.keycloak.operator.Constants;
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class HttpSpec {
     @JsonPropertyDescription("A secret containing the TLS configuration for HTTPS. Reference: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets.")

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/IngressSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/IngressSpec.java
@@ -17,12 +17,14 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.sundr.builder.annotations.Buildable;
 
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class IngressSpec {
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TransactionsSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TransactionsSpec.java
@@ -17,11 +17,13 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.sundr.builder.annotations.Buildable;
 
 import java.io.Serializable;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class TransactionsSpec implements Serializable {
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/UnsupportedSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/UnsupportedSpec.java
@@ -17,11 +17,13 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder",
         lazyCollectionInitEnabled = false, refs = {
         @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -193,14 +193,14 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
         Log.info("Trying to modify the ingress");
 
-        var currentIngress = ingressSelector.get();
         var labels = Map.of("address", "EvergreenTerrace742");
-        currentIngress.getSpec().getDefaultBackend().getService().setPort(new ServiceBackendPortBuilder().withName("foo").build());
+		ingressSelector.accept(currentIngress -> {
+			currentIngress.getMetadata().setResourceVersion(null);
+			currentIngress.getSpec().getDefaultBackend().getService().setPort(new ServiceBackendPortBuilder().withName("foo").build());
 
-        currentIngress.getMetadata().getAnnotations().clear();
-        currentIngress.getMetadata().getLabels().putAll(labels);
-
-        ingressSelector.createOrReplace(currentIngress);
+	        currentIngress.getMetadata().getAnnotations().clear();
+	        currentIngress.getMetadata().getLabels().putAll(labels);
+		});
 
         Awaitility.await()
                 .ignoreExceptions()
@@ -396,7 +396,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
                 .endSpec()
                 .build();
 
-        customIngressCreated = k8sclient.network().v1().ingresses().inNamespace(targetNamespace).create(customIngressCreated);
+        customIngressCreated = k8sclient.resource(customIngressCreated).create();
 
         return customIngressCreated;
     }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
@@ -57,8 +57,9 @@ public class KeycloakServicesTest extends BaseOperatorTest {
 
         currentService.getMetadata().getLabels().putAll(labels);
         currentService.getSpec().setSessionAffinity("ClientIP");
-
-        serviceSelector.createOrReplace(currentService);
+        
+        currentService.getMetadata().setResourceVersion(null);
+        k8sclient.resource(currentService).forceConflicts().serverSideApply();
 
         Awaitility.await()
                 .untilAsserted(() -> {
@@ -97,7 +98,7 @@ public class KeycloakServicesTest extends BaseOperatorTest {
         currentDiscoveryService.getMetadata().getLabels().putAll(labels);
         currentDiscoveryService.getSpec().setSessionAffinity("ClientIP");
 
-        discoveryServiceSelector.createOrReplace(currentDiscoveryService);
+        discoveryServiceSelector.edit(ignored -> currentDiscoveryService);
 
         Awaitility.await()
                 .untilAsserted(() -> {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
@@ -58,7 +58,7 @@ public class PodTemplateTest extends BaseOperatorTest {
                 .load(getClass().getResourceAsStream("/correct-podtemplate-keycloak.yml"));
 
         // Act
-        keycloakWithPodTemplate.createOrReplace();
+        keycloakWithPodTemplate.forceConflicts().serverSideApply();
 
         // Assert
         Awaitility
@@ -99,7 +99,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).createOrReplace();
+        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -123,7 +123,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).createOrReplace();
+        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -149,7 +149,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).createOrReplace();
+        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -175,7 +175,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).createOrReplace();
+        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -193,7 +193,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         String secretDescriptorFilename = "test-docker-registry-secret.yaml";
 
         Secret imagePullSecret = getResourceFromFile(secretDescriptorFilename, Secret.class);
-        k8sclient.secrets().inNamespace(namespace).createOrReplace(imagePullSecret);
+        k8sclient.resource(imagePullSecret).inNamespace(namespace).forceConflicts().serverSideApply();
         LocalObjectReference localObjRefAsSecretTmp = new LocalObjectReferenceBuilder().withName(imagePullSecret.getMetadata().getName()).build();
 
         assertThat(localObjRefAsSecretTmp.getName()).isNotNull();
@@ -209,7 +209,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).createOrReplace();
+        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
 
         // Assert
         Log.info("Getting status of Keycloak");

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -90,7 +90,7 @@ public class RealmImportTest extends BaseOperatorTest {
         deployKeycloak(k8sclient, kc, false);
 
         // Act
-        k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).createOrReplace();
+        k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
 
         // Assert
         var crSelector = k8sclient
@@ -151,7 +151,7 @@ public class RealmImportTest extends BaseOperatorTest {
         deployKeycloak(k8sclient, keycloak, false);
 
         // Act
-        k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).createOrReplace();
+        k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
 
         // Assert
         var crSelector = k8sclient
@@ -178,7 +178,7 @@ public class RealmImportTest extends BaseOperatorTest {
         deployKeycloak(k8sclient, getDefaultKeycloakDeployment(), true); // make sure there are no errors due to missing KC Deployment
 
         // Act
-        k8sclient.load(getClass().getResourceAsStream("/incorrect-realm.yaml")).inNamespace(namespace).createOrReplace();
+        k8sclient.load(getClass().getResourceAsStream("/incorrect-realm.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
 
         // Assert
         Awaitility.await()

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.extended.run.RunConfigBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.quarkus.logging.Log;
@@ -59,10 +58,10 @@ public final class K8sUtils {
     }
 
     public static void deployKeycloak(KubernetesClient client, Keycloak kc, boolean waitUntilReady, boolean deployTlsSecret) {
-        client.resources(Keycloak.class).inNamespace(kc.getMetadata().getNamespace()).createOrReplace(kc);
+        client.resource(kc).forceConflicts().serverSideApply();
 
         if (deployTlsSecret) {
-            client.secrets().inNamespace(kc.getMetadata().getNamespace()).createOrReplace(getDefaultTlsSecret());
+            client.resource(getDefaultTlsSecret()).inNamespace(kc.getMetadata().getNamespace()).serverSideApply();
         }
 
         if (waitUntilReady) {
@@ -100,13 +99,12 @@ public final class K8sUtils {
         var podName = KubernetesResourceUtil.sanitizeName("curl-" + UUID.randomUUID());
         try {
             Pod curlPod = k8sclient.run().inNamespace(namespace)
-                    .withRunConfig(new RunConfigBuilder()
+                    .withNewRunConfig()
                             .withArgs(args)
                             .withName(podName)
                             .withImage("curlimages/curl:7.78.0")
                             .withRestartPolicy("Never")
-                            .build())
-                    .done();
+                            .done();
             Log.info("Waiting for curl Pod to finish running");
             Awaitility.await().atMost(3, TimeUnit.MINUTES)
                     .until(() -> {


### PR DESCRIPTION
The changes on the model to use JsonInclude relates to https://github.com/fabric8io/kubernetes-client/discussions/5214 - with fabric8 6.6 pojos will need that annotation to not include explicit nulls in the json/yaml serialization, which at least for me caused validation errors when performing patch operations.

As described in https://github.com/fabric8io/kubernetes-client/issues/5215 I'll also add to fabric8 an unlock function, which will make some of the logic read a little more cleanly once that is available - that is needed because createOrReplace was effectively unlocked (repeatedly trying with newer resourceVersions until succeeding), so the replacement calls need to be as well.

However these changes are also incomplete as the actual business logic call to createOrReplace in OperatorManagedResource was not changed https://github.com/keycloak/keycloak/compare/main...shawkins:iss20822?expand=1#diff-43891e330f46cb5ae01773f1441187a00a65e36e3eb1ca38b70b86c380b6c120R57 - using serverSideApply there is generating extra revisions, which we'll discuss how to handle on https://github.com/fabric8io/kubernetes-client/issues/5215  That may also be less of an issue after using dependent resources #13453 as the operator sdk should do more automatic filtering.

Closes #20822 