### PR TITLE
Pass webauthn signature algorithm IDs as integers instead of strings

### DIFF
--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -36,7 +36,7 @@
                 let userid = "${userid}";
                 let username = "${username}";
 
-                let signatureAlgorithms = "${signatureAlgorithms}";
+                let signatureAlgorithms =[<#list signatureAlgorithms as sigAlg>${sigAlg},</#list>]
                 let pubKeyCredParams = getPubKeyCredParams(signatureAlgorithms);
 
                 let rpEntityName = "${rpEntityName}";
@@ -128,13 +128,12 @@
                     });
             }
 
-            function getPubKeyCredParams(signatureAlgorithms) {
+            function getPubKeyCredParams(signatureAlgorithmsList) {
                 let pubKeyCredParams = [];
-                if (signatureAlgorithms === "") {
+                if (signatureAlgorithmsList === []) {
                     pubKeyCredParams.push({type: "public-key", alg: -7});
                     return pubKeyCredParams;
                 }
-                let signatureAlgorithmsList = signatureAlgorithms.split(',');
 
                 for (let i = 0; i < signatureAlgorithmsList.length; i++) {
                     pubKeyCredParams.push({


### PR DESCRIPTION
The [specification](https://www.w3.org/TR/webauthn-2/#sctn-alg-identifier) defines `COSEAlgorithmIdentifier` to be an integer, not a string. By passing it as such, better compatibility with party-party authenticators can be had. With the fix applied, compared to the screenshot in the linked issue, you can see that the IDs are now integers:
<img width="304" alt="Screenshot 2023-06-06 at 5 16 16 PM" src="https://github.com/keycloak/keycloak/assets/68570223/e6144279-f1e4-4bd3-b42b-1cc19965b4d7">

I am unsure of where, or how, to add a regression test for this behavior. If this is something the maintainers see as necessary, I would greatly appreciate a few pointers.

Fixes https://github.com/keycloak/keycloak/issues/20831
