### PR TITLE
Fixes the links to the REST api documentation

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -14,7 +14,7 @@ SHORT_VERSION=`echo $NEW_VERSION | awk -F '.' '{ print $1"."$2 }'`
 sed -i 's/:project_version: .*/:project_version: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 sed -i 's/:project_versionMvn: .*/:project_versionMvn: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 sed -i 's/:project_versionNpm: .*/:project_versionNpm: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
-sed -i 's/:project_versionDoc: .*/:project_versionDoc: '$SHORT_VERSION'/' topics/templates/document-attributes.adoc
+sed -i 's/:project_versionDoc: .*/:project_versionDoc: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 cd -
 
 # Keycloak JS


### PR DESCRIPTION
Closes #20700

The page https://www.keycloak.org/docs/21.1.1/api_documentation/#admin-rest-api-documentation contains a link to the JavaDoc documentation and a link to the Admin REST api documentation. Both links cause a "Page not found" error. The reason is that the links do not contain the patch version
