### PR TITLE
Removes the check for full readiness of 3 replicas

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -92,11 +92,6 @@ public class ClusteringTest extends BaseOperatorTest {
                 .ignoreExceptions()
                 .untilAsserted(() -> assertThat(kcPodsSelector.list().getItems().size()).isEqualTo(3));
 
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(60))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(crSelector.scale().getStatus().getReplicas()).isEqualTo(3));
-
         // when scale it down to 2
         crSelector.scale(2);
         assertThat(crSelector.scale().getSpec().getReplicas()).isEqualTo(2);


### PR DESCRIPTION
In the ci environment the amount of time between 3 pods being created and all being ready seems highly variable.  Also since we currently lack the status information to determine if a deployment is not progressing, it's best just to remove this check.  The later check asserting full readiness of 2 replicas will suffice to ensure that the scale subresource status is being updated.

Closes #20888

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
