### PR TITLE
Remove override of mime4j version in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
         <aesh.version>2.4</aesh.version>
         <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
         <apache.httpcomponents.httpcore.version>4.4.16</apache.httpcomponents.httpcore.version>
-        <apache.mime4j.version>0.6</apache.mime4j.version>
         <jboss.dmr.version>1.5.1.Final</jboss.dmr.version>
         <bouncycastle.version>1.73</bouncycastle.version>
         <bouncycastle-bcprov-jdk15on.version>1.70</bouncycastle-bcprov-jdk15on.version>
@@ -804,17 +803,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${apache.httpcomponents.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j</artifactId>
-                <version>${apache.mime4j.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>


### PR DESCRIPTION
This is a backport of #20687 and also removes the no-longer used property

Closes #20892
