### PR TITLE
adds an instance label to support multiple instances

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-22_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-22_0_0.adoc
@@ -350,3 +350,7 @@ their corresponding replacements.
 * `KeycloakModelUtils#getClientScopeMappings` was removed.
 * Deprecated methods from `KeycloakSession` were removed.
 * `UserQueryProvider#getUsersStream` methods were removed.
+
+= Multiple Keycloak instances
+
+Multiple Keycloak CRs may be created in the same namespace and will be managed independently by the operator.  To allow for this StatefulSets created by older versions of the operator must be re-created.  This will happen automatically when the operator is upgraded and lead to small amount of downtime.

--- a/operator/src/main/java/org/keycloak/operator/Constants.java
+++ b/operator/src/main/java/org/keycloak/operator/Constants.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public final class Constants {
     public static final String CRDS_GROUP = "k8s.keycloak.org";
@@ -30,6 +29,7 @@ public final class Constants {
     public static final String SHORT_NAME = "kc";
     public static final String NAME = "keycloak";
     public static final String PLURAL_NAME = "keycloaks";
+    public static final String INSTANCE_LABEL = "app.kubernetes.io/instance";
     public static final String MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
     public static final String MANAGED_BY_VALUE = "keycloak-operator";
     public static final String COMPONENT_LABEL = "app.kubernetes.io/component";
@@ -40,9 +40,7 @@ public final class Constants {
             MANAGED_BY_LABEL, MANAGED_BY_VALUE
     )));
 
-    public static final String DEFAULT_LABELS_AS_STRING = DEFAULT_LABELS.entrySet().stream()
-            .map(e -> e.getKey() + "=" + e.getValue())
-            .collect(Collectors.joining(","));
+    public static final String DEFAULT_LABELS_AS_STRING = Utils.toSelectorString(DEFAULT_LABELS);
 
     public static final List<ValueOrSecret> DEFAULT_DIST_CONFIG_LIST = List.of(
             new ValueOrSecret("health-enabled", "true"),

--- a/operator/src/main/java/org/keycloak/operator/Utils.java
+++ b/operator/src/main/java/org/keycloak/operator/Utils.java
@@ -24,6 +24,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
@@ -43,6 +45,14 @@ public final class Utils {
 
     public static String asBase64(String toEncode) {
         return Base64.getEncoder().encodeToString(toEncode.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static String toSelectorString(Map<String, String> labels) {
+        if (labels == null || labels.isEmpty()) {
+            return null;
+        }
+        return labels.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(","));
     }
 
 }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryService.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryService.java
@@ -43,7 +43,7 @@ public class KeycloakDiscoveryService extends OperatorManagedResource implements
               .withProtocol("TCP")
               .withPort(Constants.KEYCLOAK_DISCOVERY_SERVICE_PORT)
               .endPort()
-              .withSelector(Constants.DEFAULT_LABELS)
+              .withSelector(getInstanceLabels())
               .withClusterIP("None")
               .build();
     }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakService.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakService.java
@@ -49,7 +49,7 @@ public class KeycloakService extends OperatorManagedResource implements StatusUp
               .withPort(getServicePort(keycloak))
               .withProtocol(Constants.KEYCLOAK_SERVICE_PROTOCOL)
               .endPort()
-              .withSelector(Constants.DEFAULT_LABELS)
+              .withSelector(getInstanceLabels())
               .build();
     }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
@@ -90,8 +90,8 @@ public class WatchedSecretsStore extends OperatorManagedResource {
     }
 
     @Override
-    protected void setDefaultLabels(HasMetadata resource) {
-        super.setDefaultLabels(resource);
+    protected void setInstanceLabels(HasMetadata resource) {
+        super.setInstanceLabels(resource);
         resource.getMetadata().getLabels().put(Constants.COMPONENT_LABEL, COMPONENT);
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
@@ -166,6 +167,8 @@ public abstract class BaseOperatorTest {
   private static void createNamespace() {
     Log.info("Creating Namespace " + namespace);
     k8sclient.resource(new NamespaceBuilder().withNewMetadata().addToLabels("app","keycloak-test").withName(namespace).endMetadata().build()).create();
+    // ensure that the client defaults to the namespace - eventually most of the test code usage of inNamespace can be removed
+    k8sclient = k8sclient.adapt(NamespacedKubernetesClient.class).inNamespace(namespace);
   }
 
   private static void calculateNamespace() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -23,9 +23,12 @@ import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpecBuilder;
 import io.quarkus.logging.Log;
 import io.quarkus.test.junit.QuarkusTest;
+
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -204,7 +207,21 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
         try {
             var kc = getDefaultKeycloakDeployment();
             var deploymentName = kc.getMetadata().getName();
-            deployKeycloak(k8sclient, kc, true);
+
+            // create a dummy StatefulSet representing the pre-multiinstance state that we'll be forced to delete
+            StatefulSet statefulSet = new StatefulSetBuilder().withMetadata(kc.getMetadata()).editMetadata()
+                    .addToLabels(Constants.DEFAULT_LABELS).endMetadata().withNewSpec().withNewSelector()
+                    .withMatchLabels(Constants.DEFAULT_LABELS).endSelector().withServiceName("foo").withReplicas(0)
+                    .withNewTemplate().withNewMetadata().withLabels(Constants.DEFAULT_LABELS).endMetadata()
+                    .withNewSpec().addNewContainer().withName("pause").withImage("registry.k8s.io/pause:3.1")
+                    .endContainer().endSpec().endTemplate().endSpec().build();
+            k8sclient.resource(statefulSet).create();
+
+            // start will not be successful because the statefulSet is in the way
+            deployKeycloak(k8sclient, kc, false);
+            // once the statefulset is owned by the keycloak it will be picked up by the informer
+            k8sclient.resource(statefulSet).accept(s -> s.addOwnerReference(k8sclient.resource(kc).get()));
+            waitForKeycloakToBeReady(k8sclient, kc);
 
             Log.info("Trying to delete deployment");
             assertThat(k8sclient.apps().statefulSets().withName(deploymentName).delete()).isNotNull();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -101,11 +101,7 @@ public final class K8sUtils {
                 .timeout(5, TimeUnit.MINUTES)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
-                    var currentKc = client
-                            .resources(Keycloak.class)
-                            .inNamespace(kc.getMetadata().getNamespace())
-                            .withName(kc.getMetadata().getName())
-                            .get();
+                    var currentKc = client.resource(kc).get();
 
                     CRAssert.assertKeycloakStatusCondition(currentKc, KeycloakStatusCondition.READY, true);
                     CRAssert.assertKeycloakStatusCondition(currentKc, KeycloakStatusCondition.HAS_ERRORS, false);


### PR DESCRIPTION
Updates the dependent label and label selectors to include the kubernetes recommended instance label.  This renders moot the concern of #20854 in that any keycloak created with a name length over 63 characters will effectively be invalid as the label values for the instance name will then be invalid.  If supporting keycloak resource names greater than 63 characters is desirable or if we want the controller to validate the name length, I can address that with this pr.

The biggest issue that needs more discussion is https://github.com/keycloak/keycloak/compare/main...shawkins:iss10562?expand=1#diff-a4e5365416b1195232c06a11372ec4f5b48f0527e2a0de2ee356ec0b92697506R96 that is we aren't allowed to change the statefulet labelselectors because they are immutable.  This pr adds a simple check for this and deletes the existing statefulset, but it will cause a brief downtime for anyone who upgrades to this operator version.  Other options include:
- creating a temporary statefulset to take over while the existing one is deleted.  I don't see that pod adoption is happening with the existing statefulset definitions so that actually seems to be creating an entirely new set of pods, which will then be deleted one the new statefulset is ready.
- Only perform the deletion if there are multiple instances of keycloak - that would limit the downtime to only cases where someone is trying to have multiple instances.
- and/or other refinements are possible for the deletion operation, such as making it blocking, so that the recreation can happen immediately rather than waiting for the next event to trigger a reconciliation.  However it's generally not great to put possibly long blocking logic directly in the reconciliation logic - but I have noticed that the block owner deletion set on the depedent ownerReferences doesn't seem to actually be working.  That is even after the owning keycloak is gone the statefulset may temporarily remain.  

Also to the point of it of #10562 you could opt for a keycloak specific instance label instead (for a namespace keycloak.org is being used, operator.keycloak.org was suggested on the issue) - if this is done late, or anything that affects the statefulset selectors, we'll hit the same issue again.  So it's best to make sure we're good with what's being done here.

Closes #10562 #14220 - but does not address the concern of propogating other labels - for example general keycloak.metadata.labels or other cr locations. I think this is only happening now via the unsupported pod template.  Since this labels should not be part of the selectors, I agree with #10562 that is should be a separate enhancement.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
