### PR TITLE
finishes the conversion away from createOrReplace

### DIFF
--- a/docs/documentation/release_notes/topics/22_0_0.adoc
+++ b/docs/documentation/release_notes/topics/22_0_0.adoc
@@ -90,6 +90,10 @@ In relation to the KeyStore Vault news, we also integrated Quarkus's recently re
 
 The are additional fields available in the keycloak.status to facilitate keycloak being a scalable resource. There are also additional fields that make the status easier to interpret such as observedGeneration and condition observedGeneration and lastTransitionTime fields. However the condition status field was also changed from a boolean to a string for conformance with standard Kubernetes conditions. Please make sure any of your usage of this field is updated to expect the values "True", "False", or "Unknown", rather than true or false.
 
+= Co-management of Operator Resources
+
+In scenarios where advanced management is needed you may now directly update most fields on operator managed resources that have not been set by the operator directly. This can be used as an alternative to the unsupported stanza of the Keycloak spec. Like the unsupported stanza these direct modifications are not considered supported. If your modifications prevent the operator from being able to manage the resource, there Keycloak CR will show this error condition and the operator will log it.
+
 = Account Console v3 promoted to preview
 
 In version 21.1.0 of Keycloak the new Account Console (version 3) was introduced as an experimental feature. Starting this version it has been promoted to a preview feature.

--- a/operator/src/main/java/org/keycloak/operator/Utils.java
+++ b/operator/src/main/java/org/keycloak/operator/Utils.java
@@ -19,9 +19,11 @@ package org.keycloak.operator;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
@@ -37,6 +39,10 @@ public final class Utils {
      */
     public static String iso8601Now() {
         return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+    }
+
+    public static String asBase64(String toEncode) {
+        return Base64.getEncoder().encodeToString(toEncode.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecret.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecret.java
@@ -5,6 +5,8 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
+
+import org.keycloak.operator.Utils;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
 import java.util.Optional;
@@ -35,8 +37,8 @@ public class KeycloakAdminSecret extends OperatorManagedResource {
                 .withNamespace(getNamespace())
                 .endMetadata()
                 .withType("kubernetes.io/basic-auth")
-                .addToStringData("username", "admin")
-                .addToStringData("password", UUID.randomUUID().toString().replace("-", ""))
+                .addToData("username", Utils.asBase64("admin"))
+                .addToData("password", Utils.asBase64(UUID.randomUUID().toString().replace("-", "")))
                 .build();
     }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -64,6 +64,7 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
                 .withLabelSelector(Constants.DEFAULT_LABELS_AS_STRING)
                 .withNamespaces(namespace)
                 .withSecondaryToPrimaryMapper(Mappers.fromOwnerReference())
+                .withOnUpdateFilter(new MetadataAwareOnUpdateFilter<>())
                 .build();
 
         InformerConfiguration<Service> servicesIC = InformerConfiguration
@@ -71,6 +72,7 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
                 .withLabelSelector(Constants.DEFAULT_LABELS_AS_STRING)
                 .withNamespaces(namespace)
                 .withSecondaryToPrimaryMapper(Mappers.fromOwnerReference())
+                .withOnUpdateFilter(new MetadataAwareOnUpdateFilter<>())
                 .build();
 
         InformerConfiguration<Ingress> ingressesIC = InformerConfiguration
@@ -78,6 +80,7 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
                 .withLabelSelector(Constants.DEFAULT_LABELS_AS_STRING)
                 .withNamespaces(namespace)
                 .withSecondaryToPrimaryMapper(Mappers.fromOwnerReference())
+                .withOnUpdateFilter(new MetadataAwareOnUpdateFilter<>())
                 .build();
 
         EventSource statefulSetEvent = new InformerEventSource<>(statefulSetIC, context);

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -29,6 +29,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.logging.Log;
+
 import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.operator.Config;
 import org.keycloak.operator.Constants;
@@ -86,32 +87,15 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
 
     @Override
     public Optional<HasMetadata> getReconciledResource() {
-        StatefulSet baseDeployment = new StatefulSetBuilder(this.baseDeployment).build(); // clone not to change the base template
-        StatefulSet reconciledDeployment;
         if (existingDeployment == null) {
             Log.info("No existing Deployment found, using the default");
-            reconciledDeployment = baseDeployment;
         }
         else {
-            Log.info("Existing Deployment found, updating specs");
-            reconciledDeployment = new StatefulSetBuilder(existingDeployment).build();
+            Log.info("Existing Deployment found, handling migration");
 
-            // don't overwrite metadata, just specs
-            reconciledDeployment.setSpec(baseDeployment.getSpec());
-
-            // don't fully overwrite annotations in pod templates to support rolling restarts (K8s sets some extra annotation to track restart)
-            // instead, merge it
-            if (existingDeployment.getSpec() != null && existingDeployment.getSpec().getTemplate() != null) {
-                mergeMaps(
-                        Optional.ofNullable(existingDeployment.getSpec().getTemplate().getMetadata()).map(m -> m.getAnnotations()).orElse(null),
-                        Optional.ofNullable(reconciledDeployment.getSpec().getTemplate().getMetadata()).map(m -> m.getAnnotations()).orElse(null),
-                        annotations -> reconciledDeployment.getSpec().getTemplate().getMetadata().setAnnotations(annotations));
-            }
-
-            migrateDeployment(existingDeployment, reconciledDeployment);
+            migrateDeployment(existingDeployment, baseDeployment);
         }
-
-        return Optional.of(reconciledDeployment);
+        return Optional.of(baseDeployment);
     }
 
     private StatefulSet fetchExistingDeployment() {
@@ -442,7 +426,8 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
 
         // merge with the CR; the values in CR take precedence
         if (keycloakCR.getSpec().getAdditionalOptions() != null) {
-            serverConfigsList.removeAll(keycloakCR.getSpec().getAdditionalOptions());
+            Set<String> inCr = keycloakCR.getSpec().getAdditionalOptions().stream().map(v -> v.getName()).collect(Collectors.toSet());
+            serverConfigsList.removeIf(v -> inCr.contains(v.getName()));
             serverConfigsList.addAll(keycloakCR.getSpec().getAdditionalOptions());
         }
 
@@ -495,7 +480,8 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
 
         return envVars;
     }
-    
+
+    @Override
     public void updateStatus(KeycloakStatusAggregator status) {
         status.apply(b -> b.withSelector(Constants.DEFAULT_LABELS_AS_STRING));
         validatePodTemplate(status);
@@ -512,7 +498,7 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
                 status.addNotReadyMessage("Waiting for more replicas");
             }
         }
-        
+
         if (migrationInProgress) {
             status.addNotReadyMessage("Performing Keycloak upgrade, scaling down the deployment");
         } else if (existingDeployment.getStatus() != null

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryService.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryService.java
@@ -40,6 +40,7 @@ public class KeycloakDiscoveryService extends OperatorManagedResource implements
     private ServiceSpec getServiceSpec() {
       return new ServiceSpecBuilder()
               .addNewPort()
+              .withProtocol("TCP")
               .withPort(Constants.KEYCLOAK_DISCOVERY_SERVICE_PORT)
               .endPort()
               .withSelector(Constants.DEFAULT_LABELS)
@@ -49,14 +50,7 @@ public class KeycloakDiscoveryService extends OperatorManagedResource implements
 
     @Override
     protected Optional<HasMetadata> getReconciledResource() {
-        var service = fetchExistingService();
-        if (service == null) {
-            service = newService();
-        } else {
-            service.setSpec(getServiceSpec());
-        }
-
-        return Optional.of(service);
+        return Optional.of(newService());
     }
 
     private Service newService() {
@@ -78,6 +72,7 @@ public class KeycloakDiscoveryService extends OperatorManagedResource implements
                 .get();
     }
 
+    @Override
     public void updateStatus(KeycloakStatusAggregator status) {
         if (existingService == null) {
             status.addNotReadyMessage("No existing Discovery Service found, waiting for creating a new one");

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -252,8 +252,10 @@ public class KeycloakDistConfigurator {
                 envVarBuilder.withValue(String.valueOf(value));
             }
 
-
-            envVars.add(envVarBuilder.build());
+            var toAdd = envVarBuilder.build();
+            if (!envVars.stream().anyMatch(envVar -> envVar.getName().equals(toAdd.getName()))) {
+                envVars.add(toAdd);
+            }
 
             return this;
         }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportController.java
@@ -60,13 +60,14 @@ public class KeycloakRealmImportController implements Reconciler<KeycloakRealmIm
                 .withLabelSelector(Constants.DEFAULT_LABELS_AS_STRING)
                 .withNamespaces(context.getControllerConfiguration().getConfigurationService().getClientConfiguration().getNamespace())
                 .withSecondaryToPrimaryMapper(Mappers.fromOwnerReference())
+                .withOnUpdateFilter(new MetadataAwareOnUpdateFilter<>())
                 .build();
 
         return EventSourceInitializer.nameEventSources(new InformerEventSource<>(jobIC, context));
     }
 
     @Override
-    public UpdateControl<KeycloakRealmImport> reconcile(KeycloakRealmImport realm, Context context) {
+    public UpdateControl<KeycloakRealmImport> reconcile(KeycloakRealmImport realm, Context<KeycloakRealmImport> context) {
         String realmName = realm.getMetadata().getName();
         String realmNamespace = realm.getMetadata().getNamespace();
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakService.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakService.java
@@ -55,14 +55,7 @@ public class KeycloakService extends OperatorManagedResource implements StatusUp
 
     @Override
     protected Optional<HasMetadata> getReconciledResource() {
-        var service = fetchExistingService();
-        if (service == null) {
-            service = newService();
-        } else {
-            service.setSpec(getServiceSpec());
-        }
-
-        return Optional.of(service);
+        return Optional.of(newService());
     }
 
     private Service newService() {
@@ -84,6 +77,7 @@ public class KeycloakService extends OperatorManagedResource implements StatusUp
                 .get();
     }
 
+    @Override
     public void updateStatus(KeycloakStatusAggregator status) {
         if (existingService == null) {
             status.addNotReadyMessage("No existing Keycloak Service found, waiting for creating a new one");
@@ -91,12 +85,13 @@ public class KeycloakService extends OperatorManagedResource implements StatusUp
         }
     }
 
+    @Override
     public String getName() {
         return cr.getMetadata().getName() + Constants.KEYCLOAK_SERVICE_SUFFIX;
     }
 
     public static int getServicePort(Keycloak keycloak) {
-        // we assume HTTP when TLS is not configureed
+        // we assume HTTP when TLS is not configured
         if (!isTlsConfigured(keycloak)) {
             return getValueFromSubSpec(keycloak.getSpec().getHttpSpec(), HttpSpec::getHttpPort).orElse(Constants.KEYCLOAK_HTTP_PORT);
         } else {

--- a/operator/src/main/java/org/keycloak/operator/controllers/MetadataAwareOnUpdateFilter.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/MetadataAwareOnUpdateFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.controllers;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.javaoperatorsdk.operator.processing.event.source.filter.OnUpdateFilter;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * addresses the additional events noted on https://github.com/fabric8io/kubernetes-client/issues/5215
+ * <p>
+ * - usage of secret stringData has been removed,
+ * - but ingress usage of empty strings is still problematic
+ * it seems best to leave this in place for all resources to make sure we don't get in a reconciliation loop.
+ * <p>
+ * This should be removable after switching to dependent resources
+ *
+ */
+public class MetadataAwareOnUpdateFilter<T extends HasMetadata> implements OnUpdateFilter<T> {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public boolean accept(HasMetadata newResource, HasMetadata oldResource) {
+        ObjectMeta newMetadata = newResource.getMetadata();
+        ObjectMeta oldMetadata = oldResource.getMetadata();
+        // quick check if anything meaningful has changed
+        if (!Objects.equals(newMetadata.getAnnotations(), oldMetadata.getAnnotations())
+                || !Objects.equals(newMetadata.getLabels(), oldMetadata.getLabels())
+                || !Objects.equals(newMetadata.getGeneration(), oldMetadata.getGeneration())) {
+            return true;
+        }
+        // check everything else besides the metadata
+        // since the hierarchy of model the does not implement hasCode/equals, we'll convert to a generic form
+        // that should be less expensive than full serialization
+        var newMap = (ObjectNode)mapper.valueToTree(newResource);
+        newMap.remove("metadata");
+        var oldMap = (ObjectNode)mapper.valueToTree(oldResource);
+        oldMap.remove("metadata");
+        return !oldMap.equals(newMap);
+    }
+
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -127,8 +128,7 @@ public abstract class BaseOperatorTest {
 
   private static void createRBACresourcesAndOperatorDeployment() throws FileNotFoundException {
     Log.info("Creating RBAC and Deployment into Namespace " + namespace);
-    k8sclient.load(new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + deploymentTarget + ".yml"))
-            .inNamespace(namespace).forceConflicts().serverSideApply();
+    K8sUtils.set(k8sclient, new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + deploymentTarget + ".yml"));
   }
 
   private static void cleanRBACresourcesAndOperatorDeployment() throws FileNotFoundException {
@@ -140,10 +140,8 @@ public abstract class BaseOperatorTest {
   private static void createCRDs() {
     Log.info("Creating CRDs");
     try {
-      var deploymentCRD = k8sclient.load(new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + "keycloaks.k8s.keycloak.org-v1.yml"));
-      deploymentCRD.forceConflicts().serverSideApply();
-      var realmImportCRD = k8sclient.load(new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + "keycloakrealmimports.k8s.keycloak.org-v1.yml"));
-      realmImportCRD.forceConflicts().serverSideApply();
+      K8sUtils.set(k8sclient, new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + "keycloaks.k8s.keycloak.org-v1.yml"));
+      K8sUtils.set(k8sclient, new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + "keycloakrealmimports.k8s.keycloak.org-v1.yml"));
     } catch (Exception e) {
       Log.warn("Failed to create Keycloak CRD, retrying", e);
       createCRDs();
@@ -177,7 +175,7 @@ public abstract class BaseOperatorTest {
   protected static void deployDB() {
     // DB
     Log.info("Creating new PostgreSQL deployment");
-    k8sclient.load(BaseOperatorTest.class.getResourceAsStream("/example-postgres.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
+    K8sUtils.set(k8sclient, BaseOperatorTest.class.getResourceAsStream("/example-postgres.yaml"));
 
     // Check DB has deployed and ready
     Log.info("Checking Postgres is running");
@@ -188,7 +186,7 @@ public abstract class BaseOperatorTest {
   }
 
   protected static void deployDBSecret() {
-    k8sclient.resource(getResourceFromFile("example-db-secret.yaml", Secret.class)).inNamespace(namespace).forceConflicts().serverSideApply();
+    K8sUtils.set(k8sclient, getResourceFromFile("example-db-secret.yaml", Secret.class));
   }
 
   protected static void deleteDB() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -149,9 +149,8 @@ public class ClusteringTest extends BaseOperatorTest {
         	keycloak.getMetadata().setResourceVersion(null);
         	keycloak.getSpec().setInstances(targetInstances);
         });
-        var realm = k8sclient.load(getClass().getResourceAsStream("/token-test-realm.yaml")).inNamespace(namespace);
+        K8sUtils.set(k8sclient, getClass().getResourceAsStream("/token-test-realm.yaml"));
         var realmImportSelector = k8sclient.resources(KeycloakRealmImport.class).inNamespace(namespace).withName("example-token-test-kc");
-        realm.forceConflicts().serverSideApply();
 
         Log.info("Waiting for a stable Keycloak Cluster");
         Awaitility.await()

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -203,6 +203,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 		});
 
         Awaitility.await()
+                .timeout(1, MINUTES)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
                     var i = ingressSelector.get();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
@@ -26,6 +26,7 @@ import org.keycloak.operator.controllers.KeycloakDiscoveryService;
 import org.keycloak.operator.controllers.KeycloakService;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,9 +43,10 @@ public class KeycloakServicesTest extends BaseOperatorTest {
         Log.info("Trying to delete the service");
         assertThat(serviceSelector.delete()).isNotNull();
         Awaitility.await()
+                .timeout(Duration.ofMinutes(1))
                 .untilAsserted(() -> assertThat(serviceSelector.get()).isNotNull());
 
-        K8sUtils.waitForKeycloakToBeReady(k8sclient, kc); // wait for reconciler to calm down to avoid race condititon
+        K8sUtils.waitForKeycloakToBeReady(k8sclient, kc); // wait for reconciler to calm down to avoid race condition
 
         Log.info("Trying to modify the service");
 
@@ -53,22 +55,29 @@ public class KeycloakServicesTest extends BaseOperatorTest {
         // ignoring current IP/s
         currentService.getSpec().setClusterIP(null);
         currentService.getSpec().setClusterIPs(null);
+
+        // an unmanaged change
+        currentService.getSpec().setSessionAffinity("ClientIP");
         var origSpecs = new ServiceSpecBuilder(currentService.getSpec()).build(); // deep copy
 
+        // a managed change
+        currentService.getSpec().getPorts().get(0).setProtocol("UDP");
+
         currentService.getMetadata().getLabels().putAll(labels);
-        currentService.getSpec().setSessionAffinity("ClientIP");
-        
+
         currentService.getMetadata().setResourceVersion(null);
-        k8sclient.resource(currentService).forceConflicts().serverSideApply();
+        k8sclient.resource(currentService).update();
 
         Awaitility.await()
+                .timeout(Duration.ofMinutes(1))
                 .untilAsserted(() -> {
                     var s = serviceSelector.get();
                     assertThat(s.getMetadata().getLabels().entrySet().containsAll(labels.entrySet())).isTrue(); // additional labels should not be overwritten
-                    // ignoring assigned IP/s
+                    // ignoring assigned IP/s and generated config
                     s.getSpec().setClusterIP(null);
                     s.getSpec().setClusterIPs(null);
-                    assertThat(s.getSpec()).isEqualTo(origSpecs); // specs should be reconciled back to original values
+                    s.getSpec().setSessionAffinityConfig(null);
+                    assertThat(s.getSpec()).isEqualTo(origSpecs); // managed spec fields should be reconciled back to original values
                 });
     }
 
@@ -82,6 +91,7 @@ public class KeycloakServicesTest extends BaseOperatorTest {
         Log.info("Trying to delete the discovery service");
         assertThat(discoveryServiceSelector.delete()).isNotNull();
         Awaitility.await()
+                .timeout(Duration.ofMinutes(1))
                 .untilAsserted(() -> assertThat(discoveryServiceSelector.get()).isNotNull());
 
         K8sUtils.waitForKeycloakToBeReady(k8sclient, kc); // wait for reconciler to calm down to avoid race condititon
@@ -93,20 +103,27 @@ public class KeycloakServicesTest extends BaseOperatorTest {
         // ignoring current IP/s
         currentDiscoveryService.getSpec().setClusterIP(null);
         currentDiscoveryService.getSpec().setClusterIPs(null);
-        var origDiscoverySpecs = new ServiceSpecBuilder(currentDiscoveryService.getSpec()).build(); // deep copy
 
         currentDiscoveryService.getMetadata().getLabels().putAll(labels);
+        // an unmanaged change
         currentDiscoveryService.getSpec().setSessionAffinity("ClientIP");
+        var origDiscoverySpecs = new ServiceSpecBuilder(currentDiscoveryService.getSpec()).build(); // deep copy
 
-        discoveryServiceSelector.edit(ignored -> currentDiscoveryService);
+        // a managed change
+        currentDiscoveryService.getSpec().getPorts().get(0).setProtocol("UDP");
+
+        currentDiscoveryService.getMetadata().setResourceVersion(null);
+        k8sclient.resource(currentDiscoveryService).update();
 
         Awaitility.await()
+                .timeout(Duration.ofMinutes(1))
                 .untilAsserted(() -> {
                     var ds = discoveryServiceSelector.get();
                     assertThat(ds.getMetadata().getLabels().entrySet().containsAll(labels.entrySet())).isTrue(); // additional labels should not be overwritten
-                    // ignoring assigned IP/s
+                    // ignoring assigned IP/s and generated config
                     ds.getSpec().setClusterIP(null);
                     ds.getSpec().setClusterIPs(null);
+                    ds.getSpec().setSessionAffinityConfig(null);
                     assertThat(ds.getSpec()).isEqualTo(origDiscoverySpecs); // specs should be reconciled back to original values
                 });
     }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
@@ -28,6 +28,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.keycloak.operator.testsuite.utils.CRAssert;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
 import java.util.Collections;
@@ -53,12 +54,8 @@ public class PodTemplateTest extends BaseOperatorTest {
 
     @Test
     public void testPodTemplateIsMerged() {
-        // Arrange
-        var keycloakWithPodTemplate = k8sclient
-                .load(getClass().getResourceAsStream("/correct-podtemplate-keycloak.yml"));
-
         // Act
-        keycloakWithPodTemplate.forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, getClass().getResourceAsStream("/correct-podtemplate-keycloak.yml"));
 
         // Assert
         Awaitility
@@ -99,7 +96,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, plainKc);
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -123,7 +120,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, plainKc);
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -149,7 +146,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, plainKc);
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -175,7 +172,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, plainKc);
 
         // Assert
         Log.info("Getting status of Keycloak");
@@ -193,7 +190,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         String secretDescriptorFilename = "test-docker-registry-secret.yaml";
 
         Secret imagePullSecret = getResourceFromFile(secretDescriptorFilename, Secret.class);
-        k8sclient.resource(imagePullSecret).inNamespace(namespace).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, imagePullSecret);
         LocalObjectReference localObjRefAsSecretTmp = new LocalObjectReferenceBuilder().withName(imagePullSecret.getMetadata().getName()).build();
 
         assertThat(localObjRefAsSecretTmp.getName()).isNotNull();
@@ -209,7 +206,7 @@ public class PodTemplateTest extends BaseOperatorTest {
         plainKc.getSpec().getUnsupported().setPodTeplate(podTemplate);
 
         // Act
-        k8sclient.resource(plainKc).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, plainKc);
 
         // Assert
         Log.info("Getting status of Keycloak");

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.keycloak.operator.testsuite.utils.CRAssert;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 import org.keycloak.operator.controllers.KeycloakService;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.UnsupportedSpec;
@@ -90,7 +91,7 @@ public class RealmImportTest extends BaseOperatorTest {
         deployKeycloak(k8sclient, kc, false);
 
         // Act
-        k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, getClass().getResourceAsStream("/example-realm.yaml"));
 
         // Assert
         var crSelector = k8sclient
@@ -151,7 +152,7 @@ public class RealmImportTest extends BaseOperatorTest {
         deployKeycloak(k8sclient, keycloak, false);
 
         // Act
-        k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, getClass().getResourceAsStream("/example-realm.yaml"));
 
         // Assert
         var crSelector = k8sclient
@@ -178,7 +179,7 @@ public class RealmImportTest extends BaseOperatorTest {
         deployKeycloak(k8sclient, getDefaultKeycloakDeployment(), true); // make sure there are no errors due to missing KC Deployment
 
         // Act
-        k8sclient.load(getClass().getResourceAsStream("/incorrect-realm.yaml")).inNamespace(namespace).forceConflicts().serverSideApply();
+        K8sUtils.set(k8sclient, getClass().getResourceAsStream("/incorrect-realm.yaml"));
 
         // Assert
         Awaitility.await()

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -64,19 +64,19 @@ public class WatchedSecretsTest extends BaseOperatorTest {
             Log.info("Updating DB Secret, expecting restart");
             testDeploymentRestarted(Set.of(kc), Set.of(), () -> {
                 dbSecret.getData().put(UUID.randomUUID().toString(), "YmxhaGJsYWg=");
-                k8sclient.resource(dbSecret).forceConflicts().serverSideApply();
+                k8sclient.resource(dbSecret).update();
             });
 
             Log.info("Updating TLS Secret, expecting restart");
             testDeploymentRestarted(Set.of(kc), Set.of(), () -> {
                 tlsSecret.getData().put(UUID.randomUUID().toString(), "YmxhaGJsYWg=");
-                k8sclient.resource(tlsSecret).forceConflicts().serverSideApply();
+                k8sclient.resource(tlsSecret).update();
             });
 
             Log.info("Updating DB Secret metadata, NOT expecting restart");
             testDeploymentRestarted(Set.of(), Set.of(kc), () -> {
                 dbSecret.getMetadata().getLabels().put(UUID.randomUUID().toString(), "YmxhaGJsYWg");
-                k8sclient.resource(dbSecret).forceConflicts().serverSideApply();
+                k8sclient.resource(dbSecret).update();
             });
         } catch (Exception e) {
             savePodLogs();
@@ -98,7 +98,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
 
             dbSecret.getData().put("username",
                     Base64.getEncoder().encodeToString(username.getBytes()));
-            k8sclient.resource(dbSecret).forceConflicts().serverSideApply();
+            k8sclient.resource(dbSecret).update();
 
             Awaitility.await()
                     .ignoreExceptions()
@@ -146,7 +146,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
             testDeploymentRestarted(Set.of(), Set.of(kc), () -> {
                 var dbSecret = getDbSecret();
                 dbSecret.getMetadata().getLabels().put(UUID.randomUUID().toString(), "YmxhaGJsYWg");
-                k8sclient.resource(dbSecret).forceConflicts().serverSideApply();
+                k8sclient.resource(dbSecret).update();
             });
 
             Awaitility.await().untilAsserted(() -> {
@@ -180,7 +180,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
             Log.info("Updating DB Secret, expecting restart of both KCs");
             testDeploymentRestarted(Set.of(kc1, kc2), Set.of(), () -> {
                 dbSecret.getData().put(UUID.randomUUID().toString(), "YmxhaGJsYWg=");
-                k8sclient.resource(dbSecret).forceConflicts().serverSideApply();
+                k8sclient.resource(dbSecret).update();
             });
 
             Log.info("Updating KC1 to not to rely on DB Secret");
@@ -192,7 +192,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
             Log.info("Updating DB Secret, expecting restart of just KC2");
             testDeploymentRestarted(Set.of(kc2), Set.of(kc1), () -> {
                 dbSecret.getData().put(UUID.randomUUID().toString(), "YmxhaGJsYWg=");
-                k8sclient.resource(dbSecret).forceConflicts().serverSideApply();
+                k8sclient.resource(dbSecret).update();
             });
         }
         catch (Exception e) {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -166,6 +166,9 @@ public class KeycloakDistConfiguratorTest {
         assertWarningStatusFirstClassFields(distConfig, false, expectedFields);
         expectedValues.forEach((k, v) -> assertEnvVarNotPresent(container.getEnv(), getKeycloakOptionEnvVarName(k)));
 
+        // mimic what KeycloakDeployment does and set all additionalOptions as env first
+        expectedValues.forEach((k, v) -> container.getEnv().add(new EnvVar(getKeycloakOptionEnvVarName(k), v, null)));
+
         config.accept(distConfig);
 
         assertWarningStatusFirstClassFields(distConfig, true, expectedFields);
@@ -180,8 +183,7 @@ public class KeycloakDistConfiguratorTest {
         assertThat(envVars).isNotNull();
         assertEnvVarPresent(envVars, varName);
 
-        final String foundValue = envVars.stream().filter(f -> varName.equals(f.getName()))
-                .findFirst()
+        var matching = envVars.stream().filter(f -> varName.equals(f.getName()))
                 .map(envVar -> {
                     if (envVar.getValue() != null) {
                         return envVar.getValue();
@@ -192,8 +194,9 @@ public class KeycloakDistConfiguratorTest {
                     }
 
                     return null;
-                })
-                .orElse(null);
+                }).collect(Collectors.toList());
+        assertThat(matching.size()).isLessThan(2);
+        final String foundValue = matching.stream().findFirst().orElse(null);
 
         assertThat(foundValue).isNotNull();
         assertThat(foundValue).isEqualTo(expectedValue);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -270,7 +270,7 @@ public class PodTemplateTest {
     }
 
     @Test
-    public void testAnnotationsAreMerged() {
+    public void testAnnotationsAreNotMerged() {
         // Arrange
         var existingDeployment = new StatefulSetBuilder()
                 .withNewSpec()
@@ -292,7 +292,6 @@ public class PodTemplateTest {
         var podTemplate = getDeployment(additionalPodTemplate, existingDeployment).getSpec().getTemplate();
 
         // Assert
-        assertThat(podTemplate.getMetadata().getAnnotations()).containsEntry("one", "1");
         assertThat(podTemplate.getMetadata().getAnnotations()).containsEntry("two", "2");
     }
 


### PR DESCRIPTION
This is a broader change given the implications of serverSideApply vs createOrReplace - mostly the concern of only applying the just the managed state, which is not based upon an existing resource.

The changes include:
- the introduction of an onUpdate filter MetadataAwareOnUpdateFilter to remove vacuous updates https://github.com/kubernetes/kubernetes/issues/118519 was opened specifically for Secrets, but I saw the same behavior on Ingress.  For safety/consistency it was added to all informer event sources, but that may not be necessary.  It would be better to prevent such modifications in the first place, but it's straight-forward to catch it after the fact.  The eventual usage of dependent resources should fully address this possibility
- There was some tweaking of the env logic needed because it could add multiple entries with the same name (one in KeycloakDeployment, and again in KeycloakDistConfigurator) and that would fail validation via a PATCH.
- the removal of any paths that modifed an existing item and provided that via getReconciledResource - instead we just want to provide the golden managed state and let server side apply figure the rest out.
- The follow on to the above point is that we should be able to use the resources from the informer / operator caches, rather than looking them up on each reconciliation, as there's no chance they are being modified inappropriately.  This was not done as part of this pr to keep the changes a little more focused.
- The next follow on is that means some of what we're asserting as durability no longer applies (there should be test failures related to this).  If a field is not managed, such as Service spec.sessionAffinity, then something else modifying that field means it won't get reverted by the operator.  A possible pro of this is that it allows for a broader, but likely unsupported, method for users to customize any of the dependent resources, rather than needing something like the spec.unsupported - however this gets messy when we have to delete our resources (see #20906) - if we simply throw away the existing state, then users will be required to watch the resource and reapply any of their changes.  The main con of this is that there's a greater chance the user could do something that's unsupported...  @vmuzikar @abstractj 
- ~~I had some initial test failures related to the watched secrets logic, rather than working through that as is, I modified this to not use a separate store and explicit rolling update.  Instead we'll annotate the Keycloak statefulset in such a way as to trigger the rolling restart when needed and to provide a simple tracking of the secrets it references.  If this looks like too much for this pr, I can go back and try to separate that off as it's own change.  Something similar may also be possible for the realm import logic to avoid the need to explicitly call for a rolling restart.~~ #21161

Closes #20850

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
