### PR TITLE
Simplify TokenManager expiration calculations using SessionExpirationUtils

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -1580,20 +1580,22 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
                     .update()
                 );
 
-        oauth.doLogin("test-user@localhost", "password");
-        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        assertEquals(200, response.getStatusCode());
-        assertExpiration(response.getExpiresIn(), 65);
-
-        setTimeOffset(70);
-
+        getTestingClient().testing().setTestingInfinispanTimeService();
         try {
+            oauth.doLogin("test-user@localhost", "password");
+            String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+            OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
+            assertEquals(200, response.getStatusCode());
+            assertExpiration(response.getExpiresIn(), 65);
+
+            setTimeOffset(70);
+
             oauth.openLoginForm();
             code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
             OAuthClient.AccessTokenResponse response2 = oauth.doAccessTokenRequest(code, "password");
             assertExpiration(response2.getExpiresIn(), 65);
         } finally {
+            getTestingClient().testing().revertTestingInfinispanTimeService();
             resetTimeOffset();
         }
     }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20794

Reusing the new class `SessionExpirationUtils` to calculate the refresh token expiration time. Only one test failed because previously the lifespan was calculated using timestamp ([here](https://github.com/keycloak/keycloak/blob/21.1.1/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java#L977)). Now the session should expire and that needs the infinispan in place.

I have maintained the calculation of the access token lifespan when the related option is missing ([here](https://github.com/keycloak/keycloak/blob/21.1.1/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java#L935-L936)). The session calculation is using the max of both values (rememberme and max lifespan) but I think both values can be independent.