### PR TITLE
Update securing_applications guide for latest adapter changes (community)

### DIFF
--- a/docs/documentation/securing_apps/topics/oidc/java/java-adapters.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/java-adapters.adoc
@@ -1,5 +1,13 @@
 === Java adapters
 
+ifeval::[{project_community}==true]
+
+WARNING: {project_name} OpenID Connect java adapters are deprecated and may not work with the most recent versions of the particular servers or frameworks. We encourage
+you to migrate to different OIDC adapters usually provided by the particular server/framework or any other party. In case your application is on WildFly/EAP, the
+recommended alternative is Elytron OIDC client.
+
+endif::[]
+
 {project_name} comes with a range of different adapters for Java application. Selecting the correct adapter depends on the target platform.
 
 All Java adapters share a set of common configuration options described in the <<_java_adapter_config,Java Adapters Config>> chapter.

--- a/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -17,6 +17,11 @@ You can install this adapter from a ZIP file or from an RPM.
 endif::[]
 
 ifeval::[{project_community}==true]
+
+WARNING: We do not regularly test and maintain WildFly/EAP adapters. They may work only with WildFly version of 23 or earlier or with JBoss EAP 7. Also note
+that they may work only with JEE applications, but not with Jakarta applications. It is recommended to switch to Elytron OIDC Java adapter to
+secure your applications. It has very similar configuration to Keycloak Java adapters and migration your applications to it should be smooth.
+
 To be able to secure WAR apps deployed on JBoss EAP, WildFly or JBoss AS, you must install and configure the
 {project_name} adapter subsystem. You then have two options to secure your WARs.
 endif::[]
@@ -34,10 +39,6 @@ Both methods are described in this section.
 Adapters are available as a separate archive depending on what server version you are using.
 
 ifeval::[{project_community}==true]
-
-NOTE: We test and maintain adapters only with the most recent version of WildFly available upon the release. Once a new version of
-WildFly is released, the current adapters become deprecated and support for them will be removed after next WildFly release.
-The other alternative is to switch your applications from WildFly to the JBoss EAP, as the JBoss EAP adapter is supported for much longer period.
 
 .Procedure
 

--- a/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -20,7 +20,7 @@ ifeval::[{project_community}==true]
 
 WARNING: We do not regularly test and maintain WildFly/EAP adapters. They may work only with WildFly version of 23 or earlier or with JBoss EAP 7. Also note
 that they may work only with JEE applications, but not with Jakarta applications. It is recommended to switch to Elytron OIDC Java adapter to
-secure your applications. It has very similar configuration to Keycloak Java adapters and migration your applications to it should be smooth.
+secure your applications. It has very similar configuration to Keycloak Java adapters and migrating your applications to it should be smooth.
 
 To be able to secure WAR apps deployed on JBoss EAP, WildFly or JBoss AS, you must install and configure the
 {project_name} adapter subsystem. You then have two options to secure your WARs.

--- a/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -19,8 +19,8 @@ endif::[]
 ifeval::[{project_community}==true]
 
 WARNING: We do not regularly test and maintain WildFly/EAP adapters. They may work only with WildFly version 23 or earlier or with JBoss EAP 7. Also note
-that they may work only with JEE applications, but not with Jakarta applications. It is recommended to switch to Elytron OIDC Java adapter to
-secure your applications. It has very similar configuration to Keycloak Java adapters and migrating your applications to it should be smooth.
+that they may work only with JEE applications, but not with Jakarta applications. We recommend that you switch to Elytron OIDC Java adapter to
+secure your applications. This adapter has a similar configuration to Keycloak Java adapters and migrating your applications to it should be smooth.
 
 To be able to secure WAR apps deployed on JBoss EAP, WildFly or JBoss AS, you must install and configure the
 {project_name} adapter subsystem. You then have two options to secure your WARs.

--- a/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -18,7 +18,7 @@ endif::[]
 
 ifeval::[{project_community}==true]
 
-WARNING: We do not regularly test and maintain WildFly/EAP adapters. They may work only with WildFly version of 23 or earlier or with JBoss EAP 7. Also note
+WARNING: We do not regularly test and maintain WildFly/EAP adapters. They may work only with WildFly version 23 or earlier or with JBoss EAP 7. Also note
 that they may work only with JEE applications, but not with Jakarta applications. It is recommended to switch to Elytron OIDC Java adapter to
 secure your applications. It has very similar configuration to Keycloak Java adapters and migrating your applications to it should be smooth.
 

--- a/docs/documentation/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc
+++ b/docs/documentation/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc
@@ -13,10 +13,10 @@ Here's an example _web.xml_ file:
 [source,xml]
 ----
 
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-      version="3.0">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
 	<module-name>customer-portal</module-name>
 

--- a/docs/documentation/securing_apps/topics/saml/java/jetty-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/saml/java/jetty-adapter.adoc
@@ -2,7 +2,7 @@
 
 ==== Jetty SAML adapters
 
-WARNING: {project_name} Jetty SAML adapter is deprecated. It is recommended to use other client adapter if possible.
+WARNING: The {project_name} Jetty SAML adapter is deprecated. We recommend that you use another client adapter if possible.
 
 To be able to secure WAR apps deployed on Jetty you must install the {project_name} Jetty 9.4 SAML adapter into your Jetty installation. You then provide some extra configuration in each WAR you deploy to Jetty.
 

--- a/docs/documentation/securing_apps/topics/saml/java/jetty-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/saml/java/jetty-adapter.adoc
@@ -2,6 +2,8 @@
 
 ==== Jetty SAML adapters
 
+WARNING: {project_name} Jetty SAML adapter is deprecated. It is recommended to use other client adapter if possible.
+
 To be able to secure WAR apps deployed on Jetty you must install the {project_name} Jetty 9.4 SAML adapter into your Jetty installation. You then provide some extra configuration in each WAR you deploy to Jetty.
 
 Use the following installation and configuration procedures.

--- a/docs/documentation/securing_apps/topics/saml/java/tomcat-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/saml/java/tomcat-adapter.adoc
@@ -2,7 +2,7 @@
 
 ==== Tomcat SAML adapters
 
-WARNING: {project_name} Tomcat SAML adapter is deprecated. It is recommended to use other client adapter if possible.
+WARNING: The {project_name} Tomcat SAML adapter is deprecated. We recommend that you use another client adapter if possible.
 
 To be able to secure WAR apps deployed on Tomcat 8 or 9 you must install the Keycloak Tomcat SAML adapter into your Tomcat installation.
 You then have to provide some extra configuration in each WAR you deploy to Tomcat.

--- a/docs/documentation/securing_apps/topics/saml/java/tomcat-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/saml/java/tomcat-adapter.adoc
@@ -2,6 +2,8 @@
 
 ==== Tomcat SAML adapters
 
+WARNING: {project_name} Tomcat SAML adapter is deprecated. It is recommended to use other client adapter if possible.
+
 To be able to secure WAR apps deployed on Tomcat 8 or 9 you must install the Keycloak Tomcat SAML adapter into your Tomcat installation.
 You then have to provide some extra configuration in each WAR you deploy to Tomcat.
 

--- a/docs/documentation/securing_apps/topics/saml/mod-auth-mellon.adoc
+++ b/docs/documentation/securing_apps/topics/saml/mod-auth-mellon.adoc
@@ -2,6 +2,9 @@
 
 === mod_auth_mellon Apache HTTPD Module
 
+WARNING: {project_name} does not provide any official support to mod_auth_mellon. The instructions below are best-effort and may not be up-to-date.
+It is recommended to stick to official mod_auth_mellon documentation for more details.
+
 The https://github.com/latchset/mod_auth_mellon[mod_auth_mellon] module is an Apache HTTPD plugin for SAML. If your language/environment supports using Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your web application with SAML. For more details on this module see the _mod_auth_mellon_ GitHub repo.
 
 To configure mod_auth_mellon you need:

--- a/docs/documentation/securing_apps/topics/saml/mod-auth-mellon.adoc
+++ b/docs/documentation/securing_apps/topics/saml/mod-auth-mellon.adoc
@@ -3,7 +3,7 @@
 === mod_auth_mellon Apache HTTPD Module
 
 WARNING: {project_name} does not provide any official support to mod_auth_mellon. The instructions below are best-effort and may not be up-to-date.
-It is recommended to stick to official mod_auth_mellon documentation for more details.
+We recommend that you stick to official mod_auth_mellon documentation for more details.
 
 The https://github.com/latchset/mod_auth_mellon[mod_auth_mellon] module is an Apache HTTPD plugin for SAML. If your language/environment supports using Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your web application with SAML. For more details on this module see the _mod_auth_mellon_ GitHub repo.
 


### PR DESCRIPTION
closes #20994

- Added note that our OIDC java adapters are deprecated and applicable only to JEE
- Removed note from our OIDC JBoss adapter docs that "We test and support latest Wildfly version" as this is not accurate anymore. Instead added that people are encouraged to use elytron-oidc-client
- Some updates to SAML docs for Jakarta
- Some deprecation of SAML adapters (Jetty, Tomcat) and note that we don't support mod_auth_mellon.
