### PR TITLE
TestLdapConnectionResource: give usefull feedback in UI on what faile…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/services/resources/admin/TestLdapConnectionResource.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/resources/admin/TestLdapConnectionResource.java
@@ -72,10 +72,13 @@ public class TestLdapConnectionResource {
 
         TestLdapConnectionRepresentation config = new TestLdapConnectionRepresentation(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, startTls, LDAPConstants.AUTH_TYPE_SIMPLE);
         config.setComponentId(componentId);
-        if (! LDAPServerCapabilitiesManager.testLDAP(config, session, realm)) {
-            throw ErrorResponse.error("LDAP test error", Response.Status.BAD_REQUEST);
+        try {
+            LDAPServerCapabilitiesManager.testLDAP(config, session, realm);
+            return Response.noContent().build();
+        } catch(Exception e) {
+            String errorMsg = LDAPServerCapabilitiesManager.getErrorCode(e);
+            throw ErrorResponse.error(errorMsg, Response.Status.BAD_REQUEST);
         }
-        return Response.noContent().build();
     }
 
     /**
@@ -86,10 +89,13 @@ public class TestLdapConnectionResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     public Response testLDAPConnection(TestLdapConnectionRepresentation config) {
-        if (! LDAPServerCapabilitiesManager.testLDAP(config, session, realm)) {
-            throw ErrorResponse.error("LDAP test error", Response.Status.BAD_REQUEST);
+        try {
+            LDAPServerCapabilitiesManager.testLDAP(config, session, realm);
+            return Response.noContent().build();
+        } catch(Exception e) {
+            String errorMsg = LDAPServerCapabilitiesManager.getErrorCode(e);
+            throw ErrorResponse.error(errorMsg, Response.Status.BAD_REQUEST);
         }
-        return Response.noContent().build();
     }
 
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -123,7 +123,9 @@ public final class LDAPContextManager implements AutoCloseable {
             }
         } catch (Exception e) {
             logger.error("Could not negotiate TLS", e);
-            throw new AuthenticationException("Could not negotiate TLS");
+            NamingException ne = new AuthenticationException("Could not negotiate TLS");
+            ne.setRootCause(e);
+            throw ne;
         }
 
         // throws AuthenticationException when authentication fails

--- a/js/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
@@ -93,8 +93,7 @@ const userImportingDisabledFailMessage =
   "User federation provider could not be saved: Can not disable Importing users when LDAP provider mode is UNSYNCED";
 
 const ldapTestSuccessMsg = "Successfully connected to LDAP";
-const ldapTestFailMsg =
-  "Error when trying to connect to LDAP. See server.log for details. LDAP test error";
+const ldapTestFailMsg = "Error when trying to connect to LDAP: 'SocketReset'";
 
 describe("User Federation LDAP tests", () => {
   beforeEach(() => {

--- a/js/apps/admin-ui/public/locales/en/user-federation.json
+++ b/js/apps/admin-ui/public/locales/en/user-federation.json
@@ -80,7 +80,7 @@
   "queryExtensions": "Query Supported Extensions",
   "testAuthentication": "Test authentication",
   "testSuccess": "Successfully connected to LDAP",
-  "testError": "Error when trying to connect to LDAP. See server.log for details. {{error}}",
+  "testError": "Error when trying to connect to LDAP: '{{error}}'",
   "learnMore": "Learn more",
   "managePriorities": "Manage priorities",
   "managePriorityOrder": "Manage priority order",


### PR DESCRIPTION
…d in LDAP connection/authentication/sync users

Currently, for all errors, a meaningless message "LDAP test error" or "unknown_error" is returned by the API.
To give some usefull feedback to the user, by creating an error message based on the exception being thrown

Closes: #15434

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
