### PR TITLE
Bugfix setOrCreateChild that is expecting returning id, but not receiving one

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/groups.ts
+++ b/js/libs/keycloak-admin-client/src/resources/groups.ts
@@ -77,7 +77,6 @@ export class Groups extends Resource<{ realm?: string }> {
     method: "POST",
     path: "/{id}/children",
     urlParamKeys: ["id"],
-    returnResourceIdInLocationHeader: { field: "id" },
   });
 
   /**


### PR DESCRIPTION
Trying to fix the following error when using setOrCreateChild "location header is not found in request"