### PR TITLE
Allow any JGroups stack with --cache-stack

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/legacy/infinispan/CacheManagerFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/legacy/infinispan/CacheManagerFactory.java
@@ -129,9 +129,8 @@ public class CacheManagerFactory {
     private void configureTransportStack(ConfigurationBuilderHolder builder) {
         String transportStack = Configuration.getRawValue("kc.cache-stack");
 
-        if (transportStack != null) {
-            builder.getGlobalConfigurationBuilder().transport().defaultTransport()
-                    .addProperty("configurationFile", "default-configs/default-jgroups-" + transportStack + ".xml");
+        if (transportStack != null && !transportStack.isBlank()) {
+            builder.getGlobalConfigurationBuilder().transport().defaultTransport().stack(transportStack);
         }
     }
 }


### PR DESCRIPTION
Closes #21064

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Backward compatibility is kept because of Infinispan's defaults stacks defined in https://github.com/infinispan/infinispan/blob/main/core/src/main/java/org/infinispan/remoting/transport/jgroups/BuiltinJGroupsChannelConfigurator.java

More info in #21064

