### PR TITLE
Use new Root API to render Admin UI

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/realm_settings_general_tab_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/realm_settings_general_tab_test.spec.ts
@@ -52,6 +52,10 @@ describe("Realm settings general tab tests", () => {
     realmSettingsPage.disableRealm();
     masthead.checkNotificationMessage("Realm successfully updated", true);
 
+    // Sometimes it takes the Keycloak server a while to disable the realm, even though the notification message has been displayed.
+    // To prevent flaky tests, we wait a second before continuing.
+    cy.wait(1000);
+
     // Re-enable realm
     realmSettingsPage.toggleSwitch(`${realmName}-switch`);
     masthead.checkNotificationMessage("Realm successfully updated");

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/users/CredentialsPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/users/CredentialsPage.ts
@@ -63,7 +63,7 @@ export default class CredentialsPage {
   }
 
   clickConfirmationBtn() {
-    cy.findByTestId(this.confirmationButton).dblclick();
+    cy.findByTestId(this.confirmationButton).click();
 
     return this;
   }

--- a/js/apps/admin-ui/src/main.tsx
+++ b/js/apps/admin-ui/src/main.tsx
@@ -2,8 +2,7 @@ import "@patternfly/react-core/dist/styles/base.css";
 import "@patternfly/patternfly/patternfly-addons.css";
 
 import { StrictMode } from "react";
-// eslint-disable-next-line react/no-deprecated
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
 import { i18n } from "./i18n/i18n";
@@ -18,10 +17,10 @@ await i18n.init();
 
 const router = createHashRouter([RootRoute]);
 const container = document.getElementById("app");
+const root = createRoot(container!);
 
-render(
+root.render(
   <StrictMode>
     <RouterProvider router={router} />
   </StrictMode>,
-  container,
 );


### PR DESCRIPTION
This PR changes the default renderer for the Admin UI to the new [Root API](https://react.dev/reference/react-dom/client/createRoot). This is the last upgrade needed to get React 18 fully working, as per the [upgrade guide](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis):

> React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.