### PR TITLE
Avoid calls to Control Plane when the secondary resource is in cache

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -103,9 +103,7 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
         var kcAdminSecret = new KeycloakAdminSecret(client, kc);
         kcAdminSecret.createOrUpdateReconciled();
 
-        // TODO use caches in secondary resources; this is a workaround for https://github.com/java-operator-sdk/java-operator-sdk/issues/830
-        // KeycloakDeployment deployment = new KeycloakDeployment(client, config, kc, context.getSecondaryResource(Deployment.class).orElse(null));
-        var kcDeployment = new KeycloakDeployment(client, config, kc, null, kcAdminSecret.getName());
+        var kcDeployment = new KeycloakDeployment(client, config, kc, context.getSecondaryResource(StatefulSet.class).orElse(null), kcAdminSecret.getName());
         var watchedSecrets = new WatchedSecretsStore(kcDeployment.getConfigSecretsNames(), client, kc);
         kcDeployment.createOrUpdateReconciled();
         if (watchedSecrets.changesDetected()) {


### PR DESCRIPTION
Closes #21109

@keycloak/cloud-native Could you please check it? Thanks



During reconciliation, we've avoided calls connected to the log message 'Trying to fetch existing Deployment from the API'.
![image](https://github.com/keycloak/keycloak/assets/38039883/6b919666-29ac-4c85-80bb-c087abad6744)
