### PR TITLE
Fixed error message for not matching password policy in admin API

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -52,6 +52,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.models.utils.RoleUtils;
+import org.keycloak.policy.PasswordPolicyNotMetException;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.provider.ProviderFactory;
@@ -210,6 +211,10 @@ public class UserResource {
         } catch (ReadOnlyException re) {
             session.getTransactionManager().setRollbackOnly();
             throw ErrorResponse.error("User is read only!", Status.BAD_REQUEST);
+        } catch (PasswordPolicyNotMetException e) {
+            session.getTransactionManager().setRollbackOnly();
+            logger.warn("Password policy not met", e);
+            throw ErrorResponse.error("Password policy not met", new Object[] { e.getMessage() }, Status.BAD_REQUEST);
         } catch (ModelException me) {
             logger.warn("Could not update user!", me);
             session.getTransactionManager().setRollbackOnly();

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -175,7 +175,8 @@ public class UsersResource {
             if (session.getTransactionManager().isActive()) {
                 session.getTransactionManager().setRollbackOnly();
             }
-            throw ErrorResponse.error("Password policy not met", Response.Status.BAD_REQUEST);
+            logger.warn("Password policy not met", e);
+            throw ErrorResponse.error("Password policy not met", new Object[] { e.getMessage() }, Response.Status.BAD_REQUEST);
         } catch (ModelException me){
             if (session.getTransactionManager().isActive()) {
                 session.getTransactionManager().setRollbackOnly();


### PR DESCRIPTION
We use the admin api to set the user details with our software and currently we can't determinate if the password does not match the password requirements.

Keycloak only returned "Could not update user", so we were not able to give the end-user the correct error message that his password does not match the policies.

We wrote this change so that we know what policy is not met and we are able to determine the correct error message for the end user.