### PR TITLE
processGrantRequest in TokenEndPoint uses new TokenManager instead of this.tokenMananager

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -180,7 +180,7 @@ public class TokenEndpoint {
                 @Override
                 public Response runInternal(KeycloakSession session) {
                     // create another instance of the endpoint to isolate each run.
-                    TokenEndpoint other = new TokenEndpoint(session, new TokenManager(),
+                    TokenEndpoint other = new TokenEndpoint(session, tokenManager,
                             new EventBuilder(session.getContext().getRealm(), session, clientConnection));
                     // process the request in the created instance.
                     return other.processGrantRequestInternal();


### PR DESCRIPTION
closes #20978

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
