### PR TITLE
Remove `ldapsOnly` option

### DIFF
--- a/docs/documentation/release_notes/topics/22_0_0.adoc
+++ b/docs/documentation/release_notes/topics/22_0_0.adoc
@@ -115,3 +115,12 @@ q=<name>:<value> <name>:<value> ...
 ```
 
 Where `<name>` and `<value>` represent the attribute name and value, respectively.
+
+= LDAPS-only Truststore option removed
+
+LDAP option to use truststore SPI `Only for ldaps` has been removed. This parameter is used to
+select truststore for TLS-secured LDAP connection: either internal Keycloak truststore is
+picked (`Always`), or the global JVM one (`Never`).
+
+Deployments where `Only for ldaps` was used will automatically behave as if `Always` option was
+selected for TLS-secured LDAP connections.

--- a/docs/documentation/server_admin/topics/admin-cli.adoc
+++ b/docs/documentation/server_admin/topics/admin-cli.adoc
@@ -1607,7 +1607,7 @@ $ kcadm.sh create components -r demorealm -s parentId=demorealmId -s id=demokerb
 +
 [options="nowrap"]
 ----
-$ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s 'config.priority=["1"]' -s 'config.fullSyncPeriod=["-1"]' -s 'config.changedSyncPeriod=["-1"]' -s 'config.cachePolicy=["DEFAULT"]' -s config.evictionDay=[] -s config.evictionHour=[] -s config.evictionMinute=[] -s config.maxLifespan=[] -s 'config.batchSizeForSync=["1000"]' -s 'config.editMode=["WRITABLE"]' -s 'config.syncRegistrations=["false"]' -s 'config.vendor=["other"]' -s 'config.usernameLDAPAttribute=["uid"]' -s 'config.rdnLDAPAttribute=["uid"]' -s 'config.uuidLDAPAttribute=["entryUUID"]' -s 'config.userObjectClasses=["inetOrgPerson, organizationalPerson"]' -s 'config.connectionUrl=["ldap://localhost:10389"]'  -s 'config.usersDn=["ou=People,dc=keycloak,dc=org"]' -s 'config.authType=["simple"]' -s 'config.bindDn=["uid=admin,ou=system"]' -s 'config.bindCredential=["secret"]' -s 'config.searchScope=["1"]' -s 'config.useTruststoreSpi=["ldapsOnly"]' -s 'config.connectionPooling=["true"]' -s 'config.pagination=["true"]' -s 'config.allowKerberosAuthentication=["true"]' -s 'config.serverPrincipal=["HTTP/localhost@KEYCLOAK.ORG"]' -s 'config.keyTab=["http.keytab"]' -s 'config.kerberosRealm=["KEYCLOAK.ORG"]' -s 'config.debug=["true"]' -s 'config.useKerberosForPasswordAuthentication=["true"]'
+$ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s 'config.priority=["1"]' -s 'config.fullSyncPeriod=["-1"]' -s 'config.changedSyncPeriod=["-1"]' -s 'config.cachePolicy=["DEFAULT"]' -s config.evictionDay=[] -s config.evictionHour=[] -s config.evictionMinute=[] -s config.maxLifespan=[] -s 'config.batchSizeForSync=["1000"]' -s 'config.editMode=["WRITABLE"]' -s 'config.syncRegistrations=["false"]' -s 'config.vendor=["other"]' -s 'config.usernameLDAPAttribute=["uid"]' -s 'config.rdnLDAPAttribute=["uid"]' -s 'config.uuidLDAPAttribute=["entryUUID"]' -s 'config.userObjectClasses=["inetOrgPerson, organizationalPerson"]' -s 'config.connectionUrl=["ldap://localhost:10389"]'  -s 'config.usersDn=["ou=People,dc=keycloak,dc=org"]' -s 'config.authType=["simple"]' -s 'config.bindDn=["uid=admin,ou=system"]' -s 'config.bindCredential=["secret"]' -s 'config.searchScope=["1"]' -s 'config.useTruststoreSpi=["always"]' -s 'config.connectionPooling=["true"]' -s 'config.pagination=["true"]' -s 'config.allowKerberosAuthentication=["true"]' -s 'config.serverPrincipal=["HTTP/localhost@KEYCLOAK.ORG"]' -s 'config.keyTab=["http.keytab"]' -s 'config.kerberosRealm=["KEYCLOAK.ORG"]' -s 'config.debug=["true"]' -s 'config.useKerberosForPasswordAuthentication=["true"]'
 ----
 
 [discrete]
@@ -1662,7 +1662,7 @@ For example:
 +
 [options="nowrap"]
 ----
-$ kcadm.sh create testLDAPConnection -s action=testConnection -s bindCredential=secret -s bindDn=uid=admin,ou=system -s connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=ldapsOnly
+$ kcadm.sh create testLDAPConnection -s action=testConnection -s bindCredential=secret -s bindDn=uid=admin,ou=system -s connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=always
 ----
 
 [discrete]
@@ -1676,7 +1676,7 @@ For example:
 +
 [options="nowrap"]
 ----
-$ kcadm.sh create testLDAPConnection -s action=testAuthentication -s bindCredential=secret -s bindDn=uid=admin,ou=system -s connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=ldapsOnly
+$ kcadm.sh create testLDAPConnection -s action=testAuthentication -s bindCredential=secret -s bindDn=uid=admin,ou=system -s connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=always
 ----
 
 

--- a/docs/documentation/server_admin/topics/user-federation/ldap.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/ldap.adoc
@@ -78,7 +78,7 @@ When you configure a secure connection URL to your LDAP store (for example,`ldap
 
 Configure the global truststore for {project_name} with the Truststore SPI. For more information about configuring the global truststore, see the https://www.keycloak.org/server/keycloak-truststore[Configuring a Truststore] {section}. If you do not configure the Truststore SPI, the truststore falls back to the default mechanism provided by Java, which can be the file supplied by the `javax.net.ssl.trustStore` system property or the cacerts file from the JDK if the system property is unset.
 
-The `Use Truststore SPI` configuration property, in the LDAP federation provider configuration, controls the truststore SPI. By default, {project_name} sets the property to `Only for ldaps`, which is adequate for most deployments.  {project_name} uses the Truststore SPI if the connection URL to LDAP starts with `ldaps` only.
+The `Use Truststore SPI` configuration property, in the LDAP federation provider configuration, controls the truststore SPI. By default, {project_name} sets the property to `Always`, which is adequate for most deployments.  {project_name} uses the Truststore SPI if the connection URL to LDAP starts with `ldaps` only.
 
 ==== Synchronizing LDAP users to {project_name}
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -25,7 +25,6 @@ import javax.naming.directory.SearchControls;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -66,7 +65,12 @@ public class LDAPConfig {
     }
 
     public String getUseTruststoreSpi() {
-        return config.getFirst(LDAPConstants.USE_TRUSTSTORE_SPI);
+        String value = config.getFirst(LDAPConstants.USE_TRUSTSTORE_SPI);
+        if (LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY.equals(value)) {
+            value = LDAPConstants.USE_TRUSTSTORE_ALWAYS;
+            config.putSingle(LDAPConstants.USE_TRUSTSTORE_SPI, value);
+        }
+        return value;
     }
 
     public String getUsersDn() {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -164,7 +164,7 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                 .add()
                 .property().name(LDAPConstants.USE_TRUSTSTORE_SPI)
                 .type(ProviderConfigProperty.STRING_TYPE)
-                .defaultValue("ldapsOnly")
+                .defaultValue("always")
                 .add()
                 .property().name(LDAPConstants.CONNECTION_POOLING)
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -80,8 +80,7 @@ public final class LDAPContextManager implements AutoCloseable {
         ldapContext = new InitialLdapContext(connProp, null);
         if (ldapConfig.isStartTls()) {
             SSLSocketFactory sslSocketFactory = null;
-            String useTruststoreSpi = ldapConfig.getUseTruststoreSpi();
-            if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
+            if (LDAPUtil.shouldUseTruststoreSpi(ldapConfig)) {
                 TruststoreProvider provider = session.getProvider(TruststoreProvider.class);
                 sslSocketFactory = provider.getSSLSocketFactory();
             }
@@ -191,9 +190,8 @@ public final class LDAPContextManager implements AutoCloseable {
 
         // when using Start TLS, use default socket factory for LDAP client but pass the TrustStore SSL socket factory later
         // when calling StartTlsResponse.negotiate(trustStoreSSLSocketFactory)
-        if (!ldapConfig.isStartTls()) {
-            String useTruststoreSpi = ldapConfig.getUseTruststoreSpi();
-            LDAPConstants.setTruststoreSpiIfNeeded(useTruststoreSpi, url, env);
+        if (LDAPUtil.shouldUseTruststoreSpi(ldapConfig)) {
+            env.put("java.naming.ldap.factory.socket", "org.keycloak.truststore.SSLSocketFactory");
         }
 
         String connectionPooling = ldapConfig.getConnectionPooling();

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -510,8 +510,7 @@ public class LDAPOperationManager {
             authCtx = new InitialLdapContext(env, null);
             if (config.isStartTls()) {
                 SSLSocketFactory sslSocketFactory = null;
-                String useTruststoreSpi = config.getUseTruststoreSpi();
-                if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
+                if (LDAPUtil.shouldUseTruststoreSpi(config)) {
                     TruststoreProvider provider = session.getProvider(TruststoreProvider.class);
                     sslSocketFactory = provider.getSSLSocketFactory();
                 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
@@ -17,7 +17,9 @@
 
 package org.keycloak.storage.ldap.idm.store.ldap;
 
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
+import org.keycloak.storage.ldap.LDAPConfig;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -260,5 +262,19 @@ public class LDAPUtil {
         }
     }
 
+    public static boolean shouldUseTruststoreSpi(LDAPConfig ldapConfig) {
+        boolean useSSL = ldapConfig.getConnectionUrl().toLowerCase().contains("ldaps://");
+        boolean defaultUseTruststore = useSSL || ldapConfig.isStartTls();
 
+        String useTruststoreSpi = ldapConfig.getUseTruststoreSpi();
+        if (useTruststoreSpi == null) {
+            return defaultUseTruststore;
+        }
+
+        if (LDAPConstants.USE_TRUSTSTORE_NEVER.equals(useTruststoreSpi)) {
+            return false;
+        }
+
+        return defaultUseTruststore;
+    }
 }

--- a/js/apps/admin-ui/cypress/e2e/user_fed_ldap_hardcoded_mapper_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/user_fed_ldap_hardcoded_mapper_test.spec.ts
@@ -29,7 +29,7 @@ const ldapVendor = "Active Directory";
 // connection and authentication settings
 const connectionUrlValid = "ldap://localhost:3004";
 const bindTypeSimple = "simple";
-const truststoreSpiOnlyLdaps = "Only for ldaps";
+const truststoreSpiAlways = "Always";
 const connectionTimeoutTwoSecs = "2000";
 const bindDnCnDc = "cn=user,dc=test";
 const bindCredsValid = "user";
@@ -93,7 +93,7 @@ describe("User Fed LDAP mapper tests", () => {
     providersPage.fillLdapConnectionData(
       connectionUrlValid,
       bindTypeSimple,
-      truststoreSpiOnlyLdaps,
+      truststoreSpiAlways,
       connectionTimeoutTwoSecs,
       bindDnCnDc,
       bindCredsValid

--- a/js/apps/admin-ui/cypress/e2e/user_fed_ldap_mapper_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/user_fed_ldap_mapper_test.spec.ts
@@ -23,7 +23,7 @@ const ldapVendor = "Active Directory";
 // connection and authentication settings
 const connectionUrlValid = "ldap://localhost:3004";
 const bindTypeSimple = "simple";
-const truststoreSpiOnlyLdaps = "Only for ldaps";
+const truststoreSpiAlways = "Always";
 const connectionTimeoutTwoSecs = "2000";
 const bindDnCnDc = "cn=user,dc=test";
 const bindCredsValid = "user";
@@ -96,7 +96,7 @@ describe("User Fed LDAP mapper tests", () => {
     providersPage.fillLdapConnectionData(
       connectionUrlValid,
       bindTypeSimple,
-      truststoreSpiOnlyLdaps,
+      truststoreSpiAlways,
       connectionTimeoutTwoSecs,
       bindDnCnDc,
       bindCredsValid

--- a/js/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
@@ -23,7 +23,7 @@ const updatedLdapName = `${firstLdapName}-updated`;
 // connection and authentication settings
 const connectionUrlValid = "ldap://localhost:3004";
 const bindTypeSimple = "simple";
-const truststoreSpiOnlyLdaps = "Only for ldaps";
+const truststoreSpiAlways = "Always";
 const connectionTimeoutTwoSecs = "2000";
 const bindDnCnDc = "cn=user,dc=test";
 const bindCredsValid = "user";
@@ -269,7 +269,7 @@ describe("User Federation LDAP tests", () => {
     providersPage.fillLdapConnectionData(
       connectionUrlValid,
       bindTypeSimple,
-      truststoreSpiOnlyLdaps,
+      truststoreSpiAlways,
       connectionTimeoutTwoSecs,
       bindDnCnDc,
       bindCredsValid

--- a/js/apps/admin-ui/public/locales/en/user-federation-help.json
+++ b/js/apps/admin-ui/public/locales/en/user-federation-help.json
@@ -7,7 +7,7 @@
   "ldapConnectionAndAuthorizationSettingsDescription": "This section contains options related to the configuration of the connection to the LDAP server. It also contains options related to authentication of the LDAP connection to the LDAP server.",
   "consoleDisplayConnectionUrlHelp": "Connection URL to your LDAP server",
   "enableStartTlsHelp": "Encrypts the connection to LDAP using STARTTLS, which will disable connection pooling",
-  "useTruststoreSpiHelp": "Specifies whether LDAP connection will use the Truststore SPI with the truststore configured in standalone.xml/domain.sml. 'Always' means that it will always use it. 'Never' means that it will not use it. 'Only for ldaps' means that it will use it if your connection URL use ldaps. Note that even if standalone.xml/domain.xml is not configured, the default java cacerts or certificate specified by 'javax.net.ssl.trustStore' property will be used.",
+  "useTruststoreSpiHelp": "Specifies whether LDAP connection will use the Truststore SPI with the truststore configured in command-line options. 'Always' means that it will always use it. 'Never' means that it will not use it. Note that even if Keycloak truststore is not configured, the default java cacerts or certificate specified by 'javax.net.ssl.trustStore' property will be used.",
   "connectionPoolingHelp": "Determines if Keycloak should use connection pooling for accessing LDAP server.",
   "connectionTimeoutHelp": "LDAP connection timeout in milliseconds",
   "bindTypeHelp": "Type of the authentication method used during LDAP bind operation. It is used in most of the requests sent to the LDAP server. Currently only 'none' (anonymous LDAP authentication) or 'simple' (bind credential + bind password authentication) mechanisms are available.",

--- a/js/apps/admin-ui/public/locales/en/user-federation.json
+++ b/js/apps/admin-ui/public/locales/en/user-federation.json
@@ -71,7 +71,6 @@
   "updateFirstLogin": "Update first login",
   "always": "Always",
   "never": "Never",
-  "onlyLdaps": "Only for ldaps",
   "oneLevel": "One Level",
   "subtree": "Subtree",
   "saveSuccess": "User federation provider successfully saved",

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -183,7 +183,7 @@ export const LdapSettingsConnection = ({
           <Controller
             name="config.useTruststoreSpi[0]"
             control={form.control}
-            defaultValue="ldapsOnly"
+            defaultValue="always"
             render={({ field }) => (
               <Select
                 toggleId="kc-use-truststore-spi"
@@ -198,7 +198,6 @@ export const LdapSettingsConnection = ({
                 selections={field.value}
               >
                 <SelectOption value="always">{t("always")}</SelectOption>
-                <SelectOption value="ldapsOnly">{t("onlyLdaps")}</SelectOption>
                 <SelectOption value="never">{t("never")}</SelectOption>
               </Select>
             )}

--- a/js/libs/keycloak-admin-client/test/realms.spec.ts
+++ b/js/libs/keycloak-admin-client/test/realms.spec.ts
@@ -413,7 +413,7 @@ describe("Realms", () => {
             connectionTimeout: "",
             connectionUrl: "1",
             startTls: "",
-            useTruststoreSpi: "ldapsOnly",
+            useTruststoreSpi: "always",
           }
         );
         fail("exception should have been thrown");
@@ -455,7 +455,7 @@ describe("Realms", () => {
             connectionTimeout: "",
             connectionUrl: "1",
             startTls: "",
-            useTruststoreSpi: "ldapsOnly",
+            useTruststoreSpi: "always",
           }
         );
         fail("exception should have been thrown");

--- a/model/map-ldap/pom.xml
+++ b/model/map-ldap/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>keycloak-model-map</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapContextManager.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapContextManager.java
@@ -96,8 +96,7 @@ public final class LdapMapContextManager implements AutoCloseable {
         ldapContext = new InitialLdapContext(connProp, null);
         if (ldapMapConfig.isStartTls()) {
             SSLSocketFactory sslSocketFactory = null;
-            String useTruststoreSpi = ldapMapConfig.getUseTruststoreSpi();
-            if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
+            if (LdapMapUtil.shouldUseTruststoreSpi(ldapMapConfig)) {
                 TruststoreProvider provider = session.getProvider(TruststoreProvider.class);
                 sslSocketFactory = provider.getSSLSocketFactory();
             }
@@ -204,9 +203,8 @@ public final class LdapMapContextManager implements AutoCloseable {
 
         // when using Start TLS, use default socket factory for LDAP client but pass the TrustStore SSL socket factory later
         // when calling StartTlsResponse.negotiate(trustStoreSSLSocketFactory)
-        if (!ldapMapConfig.isStartTls()) {
-            String useTruststoreSpi = ldapMapConfig.getUseTruststoreSpi();
-            LDAPConstants.setTruststoreSpiIfNeeded(useTruststoreSpi, url, env);
+        if (LdapMapUtil.shouldUseTruststoreSpi(ldapMapConfig)) {
+            env.put("java.naming.ldap.factory.socket", "org.keycloak.truststore.SSLSocketFactory");
         }
 
         String connectionPooling = ldapMapConfig.getConnectionPooling();

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapUtil.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapUtil.java
@@ -18,7 +18,9 @@
 package org.keycloak.models.map.storage.ldap.store;
 
 import org.jboss.logging.Logger;
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.map.storage.ldap.config.LdapMapConfig;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -253,4 +255,19 @@ public class LdapMapUtil {
         }
     }
 
+    public static boolean shouldUseTruststoreSpi(LdapMapConfig ldapConfig) {
+        boolean useSSL = ldapConfig.getConnectionUrl().toLowerCase().contains("ldaps://");
+        boolean defaultUseTruststore = useSSL || ldapConfig.isStartTls();
+
+        String useTruststoreSpi = ldapConfig.getUseTruststoreSpi();
+        if (useTruststoreSpi == null) {
+            return defaultUseTruststore;
+        }
+
+        if (LDAPConstants.USE_TRUSTSTORE_NEVER.equals(useTruststoreSpi)) {
+            return false;
+        }
+
+        return defaultUseTruststore;
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -59,6 +59,11 @@ public class LDAPConstants {
     public static final String USE_TRUSTSTORE_SPI = "useTruststoreSpi";
     public static final String USE_TRUSTSTORE_ALWAYS = "always";
     public static final String USE_TRUSTSTORE_NEVER = "never";
+
+    /**
+     * @deprecated Use {@link #USE_TRUSTSTORE_ALWAYS} instead.
+     */
+    @Deprecated
     public static final String USE_TRUSTSTORE_LDAPS_ONLY = "ldapsOnly";
 
     public static final String SEARCH_SCOPE = "searchScope";
@@ -156,25 +161,6 @@ public class LDAPConstants {
 
         return ENTRY_UUID;
     }
-
-
-
-    public static void setTruststoreSpiIfNeeded(String useTruststoreSpi, String url, Map<String, Object> env) {
-        boolean shouldSetTruststore;
-        if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
-            shouldSetTruststore = true;
-        } else if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_NEVER)) {
-            shouldSetTruststore = false;
-        } else {
-            shouldSetTruststore = toLdapUrls(url).stream()
-                            .anyMatch(urlPart -> urlPart.toLowerCase().startsWith("ldaps"));
-        }
-
-        if (shouldSetTruststore) {
-            env.put("java.naming.ldap.factory.socket", "org.keycloak.truststore.SSLSocketFactory");
-        }
-    }
-
 
     /**
      * @see com.sun.jndi.ldap.LdapURL#fromList(String) (Not using it directly to avoid usage of internal Java classes)

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -249,7 +249,7 @@ public class LDAPRule extends ExternalResource {
                 // Default to startTLS disabled
                 config.put(LDAPConstants.START_TLS, "false");
                 // By default use truststore from TruststoreSPI only for LDAP over SSL connections
-                config.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY);
+                config.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_ALWAYS);
         }
         switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED)) {
             case "true":


### PR DESCRIPTION
In `LDAPConstants.java`, the function to set the Truststore SPI system property was removed, as this is now handled by the `shouldUseTruststoreSpi` method in `LdapUtil`.

Closes: #9313
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
