### PR TITLE
Improve Infinispan initialization

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/CacheBuildSteps.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/CacheBuildSteps.java
@@ -43,8 +43,8 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 
 public class CacheBuildSteps {
 
-    @Consume(KeycloakSessionFactoryPreInitBuildItem.class)
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Consume(ConfigBuildItem.class)
+    @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     void configureInfinispan(KeycloakRecorder recorder, BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItems, ShutdownContextBuildItem shutdownContext) {
         String configFile = getConfigValue("kc.spi-connections-infinispan-quarkus-config-file").getValue();


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/24860

**Start the default ISPN cache earlier in the startup flow** 
We don't really need to rely on Keycloak session factory initialization, as only the new thread with the default ISPN cache is started. It doesn't work with any providers implementation, only the Microprofile config is required, and we don't need any "runtime" config properties. As we don't use native builds, we can simply move the execution of the recorded bytecode for cacheManager to the STATIC_INIT and change the order of these executions. 

Old cache startup:
![old-ispn](https://github.com/keycloak/keycloak/assets/38039883/4c398970-38c9-4db9-b2fe-323882ac74e7)


New cache startup:
![new_ispn](https://github.com/keycloak/keycloak/assets/38039883/9f59e13d-9b02-4a1b-a4d4-0d4fab3f6b0a)

We can save around **~800ms for the startup.**

I've tried to do some experiments with the cache:
1) **One instance with the `join_timeout=10`**. The instance becomes the coordinator of the cluster almost immediately and doesn't affect any other startup items executions - works properly
2) **Cluster of 5 Keycloak instances.** The other instances are properly connected, and there's no issue.

@pedroigor @vmuzikar Could you please check it? Thanks!



