### PR TITLE
changes the label prefix to operator.keycloak.org

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/Constants.java
+++ b/operator/src/main/java/org/keycloak/operator/Constants.java
@@ -33,7 +33,7 @@ public final class Constants {
     public static final String MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
     public static final String MANAGED_BY_VALUE = "keycloak-operator";
     public static final String COMPONENT_LABEL = "app.kubernetes.io/component";
-    public static final String KEYCLOAK_COMPONENT_LABEL = "keycloak.org/component";
+    public static final String KEYCLOAK_COMPONENT_LABEL = "operator.keycloak.org/component";
 
     public static final Map<String, String> DEFAULT_LABELS = Collections.unmodifiableMap(new TreeMap<>(Map.of(
             "app", NAME,


### PR DESCRIPTION
The worst case with this simplistic change is that currently watched secrets will be left with the old label still on them.  If we prefer to leave no trace, then removal can be added in this pr as well.

closes #21141

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
