### PR TITLE
Run Dependabot on the weekend for `js` directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: weekly
+      day: saturday
     labels:
       - area/dependencies
       - team/ui


### PR DESCRIPTION
Bit less noise during the work week.