### PR TITLE
Make awaitInitialTransfer for ISPN configurable

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -253,6 +253,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
 
             int l1Lifespan = config.getInt("l1Lifespan", 600000);
             boolean l1Enabled = l1Lifespan > 0;
+            Boolean awaitInitialTransfer = config.getBoolean("awaitInitialTransfer", true);
             sessionConfigBuilder.clustering()
                     .hash()
                         .numOwners(owners)
@@ -260,7 +261,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                     .l1()
                         .enabled(l1Enabled)
                         .lifespan(l1Lifespan)
-                    .stateTransfer().timeout(30, TimeUnit.SECONDS)
+                    .stateTransfer().awaitInitialTransfer(awaitInitialTransfer).timeout(30, TimeUnit.SECONDS)
                     .build();
         }
 

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Infinispan.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Infinispan.java
@@ -95,13 +95,17 @@ public class Infinispan extends KeycloakModelParameters {
 
     @Override
     public void updateConfig(Config cf) {
-        cf.spi("connectionsInfinispan")
-            .provider("default")
-              .config("embedded", "true")
-              .config("clustered", "true")
-              .config("useKeycloakTimeService", "true")
-              .config("nodeName", "node-" + NODE_COUNTER.incrementAndGet())
-          .spi(UserLoginFailureSpi.NAME)
+        Config.ProviderConfig provider = cf.spi("connectionsInfinispan").provider("default");
+        provider = provider.config("embedded", "true")
+                .config("clustered", "true")
+                .config("useKeycloakTimeService", "true")
+                .config("nodeName", "node-" + NODE_COUNTER.incrementAndGet());
+
+        String preloading = System.getProperty("keycloak.userSessions.infinispan.preloadOfflineSessionsFromDatabase");
+        if (preloading != null && "true".equals(preloading)) {
+            provider.config("awaitInitialTransfer", "false");
+        }
+        cf.spi(UserLoginFailureSpi.NAME)
             .provider(InfinispanUserLoginFailureProviderFactory.PROVIDER_ID)
               .config("stalledTimeoutInSeconds", "10")
           .spi(UserSessionSpi.NAME)


### PR DESCRIPTION
Closes #16671

I run `OfflineSessionPersistenceTest` class around 600 times without a failure. The root cause why the initial state transfer occasionally never finishes is being investigated by Infinispan team, tracked by https://issues.redhat.com/browse/ISPN-14982 
