### PR TITLE
Fix failing External Link Checks in docs

### DIFF
--- a/docs/documentation/securing_apps/topics/oidc/java/client-authentication.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/client-authentication.adoc
@@ -22,7 +22,7 @@ This is based on the https://datatracker.ietf.org/doc/html/rfc7523[RFC7523] spec
 
 * The client must have the private key and certificate. For  {project_name} this is available through the traditional `keystore` file, which is either available on the client application's classpath or somewhere on the file system.
 
-* Once the client application is started, it allows to download its public key in https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWKS] format using a URL such as \http://myhost.com/myapp/k_jwks, assuming that \http://myhost.com/myapp is the base URL of your client application. This URL can be used by {project_name} (see below).
+* Once the client application is started, it allows to download its public key in https://datatracker.ietf.org/doc/html/rfc7517[JWKS] format using a URL such as \http://myhost.com/myapp/k_jwks, assuming that \http://myhost.com/myapp is the base URL of your client application. This URL can be used by {project_name} (see below).
 
 * During authentication, the client generates a JWT token and signs it with its private key and sends it to {project_name} in
 the particular backchannel request (for example, code-to-token request) in the `client_assertion` parameter.

--- a/docs/documentation/securing_apps/topics/oidc/oidc-generic.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/oidc-generic.adoc
@@ -1,6 +1,6 @@
 === Other OpenID Connect libraries
 
-{project_name} can be secured by supplied adapters that are usually easier to use and provide better integration with {project_name}. However, if an adapter is not available for your programming language, framework, or platform you might opt to use a generic OpenID Connect Relying Party (RP) library instead. This chapter describes details specific to {project_name} and does not contain specific protocol details. For more information see the https://openid.net/connect/[OpenID Connect specifications] and https://datatracker.ietf.org/doc/html/rfc6749[OAuth2 specification].
+{project_name} can be secured by supplied adapters that are usually easier to use and provide better integration with {project_name}. However, if an adapter is not available for your programming language, framework, or platform you might opt to use a generic OpenID Connect Relying Party (RP) library instead. This chapter describes details specific to {project_name} and does not contain specific protocol details. For more information see the https://openid.net/developers/how-connect-works/[OpenID Connect specifications] and https://datatracker.ietf.org/doc/html/rfc6749[OAuth2 specification].
 
 ==== Endpoints
 

--- a/docs/documentation/securing_apps/topics/overview/supported-protocols.adoc
+++ b/docs/documentation/securing_apps/topics/overview/supported-protocols.adoc
@@ -6,7 +6,7 @@
 
 ==== OpenID Connect
 
-link:https://openid.net/connect/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
+link:https://openid.net/developers/how-connect-works/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
 While OAuth 2.0 is only a framework for building authorization protocols and is mainly incomplete, OIDC is a full-fledged authentication and authorization
 protocol.  OIDC also makes heavy use of the link:https://jwt.io[Json Web Token] (JWT) set of standards.  These standards define an
 identity token JSON format and ways to digitally sign and encrypt that data in a compact and web-friendly way.

--- a/docs/documentation/server_admin/topics/authentication/kerberos.adoc
+++ b/docs/documentation/server_admin/topics/authentication/kerberos.adoc
@@ -61,7 +61,7 @@ Ensure the keytab file `/tmp/http.keytab` is accessible on the host where {proje
 Install a Kerberos client on your machine.
 
 .Procedure
-. Install a Kerberos client. If your machine runs Fedora, Ubuntu, or RHEL, install the link:https://www.freeipa.org/page/Downloads[freeipa-client] package, containing a Kerberos client and other utilities.
+. Install a Kerberos client. If your machine runs Fedora, Ubuntu, or RHEL, install the link:https://freeipa.org/page/Downloads[freeipa-client] package, containing a Kerberos client and other utilities.
 . Configure the Kerberos client (on Linux, the configuration settings are in the link:https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html[/etc/krb5.conf] file ).
 +
 Add your Kerberos realm to the configuration and configure the HTTP domains your server runs on.

--- a/docs/documentation/server_admin/topics/clients/oidc/con-confidential-client-credentials.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-confidential-client-credentials.adoc
@@ -46,7 +46,7 @@ image:images/import-client-cert.png[Import Certificate]
 . Select the certificate file by clicking *Import File*.
 . Click *Import*.
 
-Importing a certificate is unnecessary if you click *Use JWKS URL*. In this case, you can provide the URL where the public key is published in https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK] format. With this option, if the key is ever changed, {project_name} reimports the key.
+Importing a certificate is unnecessary if you click *Use JWKS URL*. In this case, you can provide the URL where the public key is published in https://datatracker.ietf.org/doc/html/rfc7517[JWK] format. With this option, if the key is ever changed, {project_name} reimports the key.
 
 If you are using a client secured by {project_name} adapter, you can configure the JWKS URL in this format, assuming that https://myhost.com/myapp is the root URL of your client application:
 

--- a/docs/documentation/server_admin/topics/identity-broker/oidc.adoc
+++ b/docs/documentation/server_admin/topics/identity-broker/oidc.adoc
@@ -67,7 +67,7 @@ If the user is unauthenticated in the IDP, the client still receives a `login_re
 |This switch is applicable if `Validate Signatures` is *ON*. If *Use JWKS URL* is *ON*, {project_name} downloads the IDP's public keys from the JWKS URL. New keys download when the identity provider generates a new keypair. If *OFF*, {project_name} uses the public key (or certificate) from its database, so when the IDP keypair changes, import the new key to the {project_name} database as well.
 
 |JWKS URL
-|The URL pointing to the location of the IDP JWK keys. For more information, see the https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK specification]. If you use an external {project_name} as an IDP, you can use a URL such as http://broker-keycloak:8180{kc_realms_path}/test/protocol/openid-connect/certs if your brokered {project_name} is running on http://broker-keycloak:8180 and its realm is `test`.
+|The URL pointing to the location of the IDP JWK keys. For more information, see the https://datatracker.ietf.org/doc/html/rfc7517[JWK specification]. If you use an external {project_name} as an IDP, you can use a URL such as http://broker-keycloak:8180{kc_realms_path}/test/protocol/openid-connect/certs if your brokered {project_name} is running on http://broker-keycloak:8180 and its realm is `test`.
 
 |Validating Public Key
 |The public key in PEM format that {project_name} uses to verify external IDP signatures. This key applies if `Use JWKS URL` is *OFF*.

--- a/docs/documentation/server_admin/topics/overview/how.adoc
+++ b/docs/documentation/server_admin/topics/overview/how.adoc
@@ -2,7 +2,7 @@
 === Basic {project_name} operations
 
 {project_name} is a separate server that you manage on your network.  Applications are configured to point to and
-be secured by this server.  {project_name} uses open protocol standards like link:https://openid.net/connect/[OpenID Connect]
+be secured by this server.  {project_name} uses open protocol standards like link:https://openid.net/developers/how-connect-works/[OpenID Connect]
 or link:http://saml.xml.org/saml-specifications[SAML 2.0] to secure
 your applications.  Browser applications redirect a user's browser from the application to the {project_name} authentication
 server where they enter their credentials.  This redirection is important because users are completely isolated from applications and

--- a/docs/documentation/server_admin/topics/sso-protocols/con-oidc.adoc
+++ b/docs/documentation/server_admin/topics/sso-protocols/con-oidc.adoc
@@ -2,7 +2,7 @@
 
 === OpenID Connect
 [role="_abstract"]
-link:https://openid.net/connect/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
+link:https://openid.net/developers/how-connect-works/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
 
 OAuth 2.0 is a framework for building authorization protocols and is incomplete. OIDC, however, is a full authentication and authorization protocol that uses the link:https://jwt.io[Json Web Token] (JWT) standards.  The JWT standards define an identity token JSON format and methods to digitally sign and encrypt data in a compact and web-friendly way.
 

--- a/docs/documentation/server_admin/topics/sso-protocols/oidc.adoc
+++ b/docs/documentation/server_admin/topics/sso-protocols/oidc.adoc
@@ -2,7 +2,7 @@
 
 === OpenID Connect
 
-link:https://openid.net/connect/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
+link:https://openid.net/developers/how-connect-works/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
 While OAuth 2.0 is only a framework for building authorization protocols and is mainly incomplete, OIDC is a full-fledged authentication and authorization
 protocol.  OIDC also makes heavy use of the link:https://jwt.io[Json Web Token] (JWT) set of standards.  These standards define an
 identity token JSON format and ways to digitally sign and encrypt that data in a compact and web-friendly way.

--- a/docs/documentation/server_admin/topics/user-federation/sssd.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/sssd.adoc
@@ -18,7 +18,7 @@ image:images/keycloak-sssd-freeipa-integration-overview.png[]
 
 ==== FreeIPA/IdM server
 
-The https://hub.docker.com/r/freeipa/freeipa-server/[FreeIPA Docker image] is available in Docker Hub. To set up the FreeIPA server, see the https://www.freeipa.org/page/Quick_Start_Guide[FreeIPA documentation].
+The https://hub.docker.com/r/freeipa/freeipa-server/[FreeIPA Docker image] is available in Docker Hub. To set up the FreeIPA server, see the https://freeipa.org/page/Quick_Start_Guide[FreeIPA documentation].
 
 .Procedure
 . Run your FreeIPA server using this command:


### PR DESCRIPTION
Update URLs that are just redirects to another page. Point to RFC 7517 for JWK draft docs that were hosted on personal site

Closes keycloak/keycloak#21263
