### PR TITLE
Do not return an error when moving a group to the current parent

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -157,7 +157,9 @@ public class GroupsResource {
                 if (child == null) {
                     throw new NotFoundException("Could not find child by id");
                 }
-                realm.moveGroup(child, null);
+                if (child.getParentId() != null) {
+                    realm.moveGroup(child, null);
+                }
                 adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri());
             } else {
                 child = realm.createGroup(groupName);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -183,16 +183,27 @@ public class GroupTest extends AbstractGroupTest {
         assertSameNameNotAllowed(response,"Top level group named 'top' already exists.");
         response.close();
 
+        // allow moving the group to top level (nothing is done)
+        response = realm.groups().add(topGroup);
+        assertEquals(Response.Status.NO_CONTENT, response.getStatusInfo());
+        response.close();
+
         GroupRepresentation level2Group = new GroupRepresentation();
         level2Group.setName("level2");
         response = realm.groups().group(topGroup.getId()).subGroup(level2Group);
         assertEquals(201, response.getStatus()); // created status
+        level2Group.setId(ApiUtil.getCreatedId(response));
         response.close();
 
         GroupRepresentation anotherlevel2Group = new GroupRepresentation();
         anotherlevel2Group.setName("level2");
         response = realm.groups().group(topGroup.getId()).subGroup(anotherlevel2Group);
         assertSameNameNotAllowed(response,"Sibling group named 'level2' already exists.");
+        response.close();
+
+        // allow moving the group to the same parent (nothing is done)
+        response = realm.groups().group(topGroup.getId()).subGroup(level2Group);
+        assertEquals(Response.Status.NO_CONTENT, response.getStatusInfo());
         response.close();
     }
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/21242

Previously when an admin moved a group to the same current parent, the endpoint performs nothing but didn't return an error. After #16888 an error is returned. This PR just goes back to to previous behavior and allow it. Besides I'm using the same idea in both groups (top level groups and groups in another group), so the `GroupResource` removes the iteration (performance reasons) and checks if `ModelDuplicateException` is thrown, as [addTopLevelGroup is doing now](https://github.com/keycloak/keycloak/blob/21.1.2/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java#L172). Besides the new storages do not allow calling the method `moveGroup` with the same parent, so the method is only called when it makes sense and a real change is being performed.
