### PR TITLE
widens status to be any type.

### DIFF
--- a/docs/documentation/release_notes/topics/22_0_0.adoc
+++ b/docs/documentation/release_notes/topics/22_0_0.adoc
@@ -88,7 +88,9 @@ In relation to the KeyStore Vault news, we also integrated Quarkus's recently re
 
 = k8s.keycloak.org/v2alpha1 changes
 
-The are additional fields available in the keycloak.status to facilitate keycloak being a scalable resource. There are also additional fields that make the status easier to interpret such as observedGeneration and condition observedGeneration and lastTransitionTime fields. However the condition status field was also changed from a boolean to a string for conformance with standard Kubernetes conditions. Please make sure any of your usage of this field is updated to expect the values "True", "False", or "Unknown", rather than true or false.
+The are additional fields available in the keycloak.status to facilitate keycloak being a scalable resource. There are also additional fields that make the status easier to interpret such as observedGeneration and condition observedGeneration and lastTransitionTime fields. 
+
+The condition status field was changed from a boolean to a string for conformance with standard Kubernetes conditions. In the CRD it will temporarily be represented as accepting any content, but it will only ever be a string.  Please make sure any of your usage of this field is updated to expect the values "True", "False", or "Unknown", rather than true or false.
 
 = Co-management of Operator Resources
 

--- a/docs/documentation/upgrading/topics/keycloak/changes-22_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-22_0_0.adoc
@@ -354,3 +354,7 @@ their corresponding replacements.
 = Multiple Keycloak instances
 
 Multiple Keycloak CRs may be created in the same namespace and will be managed independently by the operator.  To allow for this StatefulSets created by older versions of the operator must be re-created.  This will happen automatically when the operator is upgraded and lead to small amount of downtime.
+
+= k8s.keycloak.org/v2alpha1 changes
+
+The condition status field was changed from a boolean to a string for conformance with standard Kubernetes conditions. In the CRD it will temporarily be represented as accepting any content, but it will only ever be a string.  Please make sure any of your usage of this field is updated to expect the values "True", "False", or "Unknown", rather than true or false.

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/StatusCondition.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/StatusCondition.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.operator.crds.v2alpha1;
 
+import io.fabric8.kubernetes.api.model.AnyType;
+
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -35,7 +37,7 @@ public class StatusCondition {
     }
 
     private String type;
-    private String status = Status.Unknown.name();
+    private AnyType status = new AnyType(Status.Unknown.name());
     private String message;
     private String lastTransitionTime;
     private Long observedGeneration;
@@ -50,11 +52,11 @@ public class StatusCondition {
 
     @JsonIgnore
     public Boolean getStatus() {
-        if (status == null) {
+        if (status == null || status.getValue() == null) {
             return null;
         }
         // account for the legacy boolean string as well
-        switch (status) {
+        switch ((String)status.getValue()) {
         case "false":
         case "False":
             return false;
@@ -68,22 +70,22 @@ public class StatusCondition {
 
     @JsonProperty("status")
     public String getStatusString() {
-        return status;
+        return (String)status.getValue();
     }
 
     @JsonProperty("status")
     public void setStatusString(String status) {
-        this.status = status;
+        this.status = new AnyType(status);
     }
 
     @JsonIgnore
     public void setStatus(Boolean status) {
         if (status == null) {
-            this.status = Status.Unknown.name();
+            this.status = new AnyType(Status.Unknown.name());
         } else if (status) {
-            this.status = Status.True.name();
+            this.status = new AnyType(Status.True.name());
         } else {
-            this.status = Status.False.name();
+            this.status = new AnyType(Status.False.name());
         }
     }
 


### PR DESCRIPTION
this is to avoid olm complaining about an incompatible schema during upgrade.  The jsonschema representation of AnyType isn't quite correct as it also includes a value property - this will be fixed in fabric8 6.8.  Regardless the important part is that it's simply marked as a field that preserves unknown.  Once the initial reconciliation is performed against a newer operator version, the stored version of the resources will be updated to strings.  A later version of the operator then will be free to change the representation to string and that will then pass the validation check performed by olm.

Relates to #13074

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
