### PR TITLE
adds port names to the pod / service

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/Constants.java
+++ b/operator/src/main/java/org/keycloak/operator/Constants.java
@@ -52,6 +52,8 @@ public final class Constants {
 
     public static final Integer KEYCLOAK_HTTP_PORT = 8080;
     public static final Integer KEYCLOAK_HTTPS_PORT = 8443;
+    public static final String KEYCLOAK_HTTP_PORT_NAME = "http";
+    public static final String KEYCLOAK_HTTPS_PORT_NAME = "https";
     public static final String KEYCLOAK_SERVICE_PROTOCOL = "TCP";
     public static final String KEYCLOAK_SERVICE_SUFFIX = "-service";
     public static final Integer KEYCLOAK_DISCOVERY_SERVICE_PORT = 7800;

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HTTPGetActionBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -333,12 +332,14 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
                                 .withName("keycloak")
                                 .withArgs("start")
                                 .addNewPort()
-                                    .withContainerPort(8443)
-                                    .withProtocol("TCP")
+                                    .withName(Constants.KEYCLOAK_HTTPS_PORT_NAME)
+                                    .withContainerPort(Constants.KEYCLOAK_HTTPS_PORT)
+                                    .withProtocol(Constants.KEYCLOAK_SERVICE_PROTOCOL)
                                 .endPort()
                                 .addNewPort()
-                                    .withContainerPort(8080)
-                                    .withProtocol("TCP")
+                                    .withName(Constants.KEYCLOAK_HTTP_PORT_NAME)
+                                    .withContainerPort(Constants.KEYCLOAK_HTTP_PORT)
+                                    .withProtocol(Constants.KEYCLOAK_SERVICE_PROTOCOL)
                                 .endPort()
                                 .withNewReadinessProbe()
                                     .withInitialDelaySeconds(20)
@@ -396,14 +397,14 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
         container.getReadinessProbe().setHttpGet(
             new HTTPGetActionBuilder()
                 .withScheme(protocol)
-                .withPort(new IntOrString(kcPort))
+                .withNewPort(kcPort)
                 .withPath(kcRelativePath + "health/ready")
                 .build()
         );
         container.getLivenessProbe().setHttpGet(
             new HTTPGetActionBuilder()
                 .withScheme(protocol)
-                .withPort(new IntOrString(kcPort))
+                .withNewPort(kcPort)
                 .withPath(kcRelativePath + "health/live")
                 .build()
         );

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -17,13 +17,14 @@
 package org.keycloak.operator.controllers;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+
 import org.keycloak.operator.Constants;
-import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusAggregator;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 
 import java.util.HashMap;
 import java.util.Optional;
@@ -80,7 +81,7 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
                     .withIngressClassName(optionalSpec.map(IngressSpec::getIngressClassName).orElse(null))
                     .withNewDefaultBackend()
                         .withNewService()
-                            .withName(keycloak.getMetadata().getName() + Constants.KEYCLOAK_SERVICE_SUFFIX)
+                            .withName(KeycloakService.getServiceName(keycloak))
                             .withNewPort()
                                 .withNumber(port)
                                 .withName("") // for SSA to clear the name if already set
@@ -94,7 +95,7 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
                                 .withPathType("ImplementationSpecific")
                                 .withNewBackend()
                                     .withNewService()
-                                        .withName(keycloak.getMetadata().getName() + Constants.KEYCLOAK_SERVICE_SUFFIX)
+                                        .withName(KeycloakService.getServiceName(keycloak))
                                         .withNewPort()
                                             .withNumber(port)
                                             .withName("") // for SSA to clear the name if already set

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakService.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakService.java
@@ -44,9 +44,11 @@ public class KeycloakService extends OperatorManagedResource implements StatusUp
     }
 
     private ServiceSpec getServiceSpec() {
+        String name = isTlsConfigured(keycloak) ? Constants.KEYCLOAK_HTTPS_PORT_NAME : Constants.KEYCLOAK_HTTP_PORT_NAME;
         return new ServiceSpecBuilder()
               .addNewPort()
               .withPort(getServicePort(keycloak))
+              .withName(name)
               .withProtocol(Constants.KEYCLOAK_SERVICE_PROTOCOL)
               .endPort()
               .withSelector(getInstanceLabels())
@@ -87,7 +89,11 @@ public class KeycloakService extends OperatorManagedResource implements StatusUp
 
     @Override
     public String getName() {
-        return cr.getMetadata().getName() + Constants.KEYCLOAK_SERVICE_SUFFIX;
+        return getServiceName(cr);
+    }
+
+    public static String getServiceName(HasMetadata keycloak) {
+        return keycloak.getMetadata().getName() + Constants.KEYCLOAK_SERVICE_SUFFIX;
     }
 
     public static int getServicePort(Keycloak keycloak) {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
@@ -62,6 +62,7 @@ public class KeycloakServicesTest extends BaseOperatorTest {
 
         // a managed change
         currentService.getSpec().getPorts().get(0).setProtocol("UDP");
+        currentService.getSpec().getPorts().get(0).setName(null);
 
         currentService.getMetadata().getLabels().putAll(labels);
 


### PR DESCRIPTION
Names the pod ports http and https respectively.  There doesn't seem to be a need for a port name on the discovery service.  On the keycloak service the singluar port is just called keycloak - but it could instead propagate the http / https name.  

~~The worst part about this is migrating the ingress from using a port number to port name.  That cannot be processed via server side apply nor strategic merge.  Either we do a simple delete (what's in this pr), or need to bring back the logic to overlay the current state with the desired and then do a replace or json patch.

If we move forward with the delete, I'll add a migration note.~~ - updated the pr to just remove the usage of the named service port and stick with the port number.

Looking over the type model for IngresSpec, there's very little that the user could co-manage beyond what is already settable - it would just be IngressTLS and additional fields on the DefaultBackend, which I can't think of any reason they would need to set.  I'd be fine as well with letting the resources dictate whether they want to use SSA or a replacement startegy so that we could eliminate the exceptional handling for just the migration cases (which is no longer a direct concern of this pr).

Using the pod port names in either the probes or the service targetPorts was causing issues for me, so the logic was left dealing with port numbers.

Closes #12593

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
