### PR TITLE
implement oidc4ida

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -45,7 +45,7 @@ public class Profile {
 
         ACCOUNT_API("Account Management REST API", Type.DEFAULT),
         ACCOUNT2("Account Management Console version 2", Type.DEFAULT, Feature.ACCOUNT_API),
-        ACCOUNT3("Account Management Console version 3", Type.EXPERIMENTAL, Feature.ACCOUNT_API),
+        ACCOUNT3("Account Management Console version 3", Type.PREVIEW, Feature.ACCOUNT_API),
 
         ADMIN_FINE_GRAINED_AUTHZ("Fine-Grained Admin Permissions", Type.PREVIEW),
 
@@ -88,7 +88,9 @@ public class Profile {
 
         JS_ADAPTER("Host keycloak.js and keycloak-authz.js through the Keycloak sever", Type.DEFAULT),
 
-        FIPS("FIPS 140-2 mode", Type.DISABLED_BY_DEFAULT);
+        FIPS("FIPS 140-2 mode", Type.DISABLED_BY_DEFAULT),
+
+        IDA("OpenID Connect for Identity Assurance 1.0(OIDC4IDA)", Type.PREVIEW);
 
         private final Type type;
         private String label;

--- a/core/src/main/java/org/keycloak/representations/ClaimsRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/ClaimsRepresentation.java
@@ -123,6 +123,10 @@ public class ClaimsRepresentation {
 
         private List<CLAIM_TYPE> values;
 
+        private Map<String, Object> verification;
+
+        private Map<String, Object> claims;
+
         public Boolean getEssential() {
             return essential;
         }
@@ -149,6 +153,22 @@ public class ClaimsRepresentation {
 
         public void setValues(List<CLAIM_TYPE> values) {
             this.values = values;
+        }
+
+        public Map<String, Object> getVerification() {
+            return verification;
+        }
+
+        public void setVerification(Map<String, Object> verification) {
+            this.verification = verification;
+        }
+
+        public Map<String, Object> getClaims() {
+            return claims;
+        }
+
+        public void setClaims(Map<String, Object> claims) {
+            this.claims = claims;
         }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/IdaConstants.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/IdaConstants.java
@@ -1,0 +1,20 @@
+package org.keycloak.protocol.oidc.ida.mappers;
+
+public class IdaConstants {
+    public static final String IDA_PROVIDER_ID = "oidc-ida-mapper";
+
+    public static final String ERROR_MESSAGE_REQUEST_CLAIMS_ERROR = "The request claims are empty.";
+    public static final String ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR = "Could not connect the IDA External Store.";
+    public static final String ERROR_MESSAGE_REQUEST_CLAIMS_JSON_SYNTAX_ERROR_ERROR = "The request claims have syntax error in json.";
+
+    public static final String ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR = "The user claims of IDA external store have syntax error in json.";
+
+    public static final String ERROR_MESSAGE_IDA_EXTERNAL_STORE_NOT_SPECIFIED = "The IDA External Store has not been specified.";
+
+    public static final String USERINFO = "userinfo";
+    public static final String VERIFIED_CLAIMS = "verified_claims";
+
+    static final String IDA_DISPLAY_TYPE = "OpenID Connect for Identity Assurance 1.0(OIDC4IDA)";
+    static final String IDA_HELP_TEXT = "Adds Verified Claims to an OpenID Connect UserInfo response or an ID Token";
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/IdaProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/IdaProtocolMapper.java
@@ -1,0 +1,193 @@
+package org.keycloak.protocol.oidc.ida.mappers;
+
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.ProtocolMapperContainerModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.ida.mappers.connector.IdaConnector;
+import org.keycloak.protocol.oidc.ida.mappers.extractor.VerifiedClaimExtractor;
+import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+import org.keycloak.services.ErrorResponseException;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_REQUEST_CLAIMS_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_REQUEST_CLAIMS_JSON_SYNTAX_ERROR_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.IDA_DISPLAY_TYPE;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.IDA_HELP_TEXT;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.USERINFO;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.VERIFIED_CLAIMS;
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME;
+import static org.keycloak.protocol.oidc.utils.OIDCResponseType.ID_TOKEN;
+import static org.keycloak.util.TokenUtil.TOKEN_TYPE_BEARER;
+import static org.keycloak.util.TokenUtil.TOKEN_TYPE_ID;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.IDA_PROVIDER_ID;
+
+/**
+ * Support an extension of OpenID Connect for providing Replying Parties with Verified Claims about End-Users
+ * https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html
+ */
+public class IdaProtocolMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper,
+        UserInfoTokenMapper, EnvironmentDependentProviderFactory {
+    private static final Logger logger = Logger.getLogger(IdaProtocolMapper.class);
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    static {
+        OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, IdaProtocolMapper.class);
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        IdaConnector idaConnector = factory.create().getProvider(IdaConnector.class);
+        idaConnector.addIdaExternalStore(configProperties);
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return IDA_DISPLAY_TYPE;
+    }
+
+    @Override
+    public String getHelpText() {
+        return IDA_HELP_TEXT;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return IDA_PROVIDER_ID;
+    }
+
+    @Override
+    public void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel client,
+                               ProtocolMapperModel mapperModel) throws ProtocolMapperConfigException {
+        IdaConnector idaConnector = session.getProvider(IdaConnector.class);
+        idaConnector.validateIdaExternalStore(mapperModel.getConfig());
+    }
+
+    @Override
+    protected void setClaim(final IDToken token,
+                            final ProtocolMapperModel mappingModel,
+                            final UserSessionModel userSession,
+                            final KeycloakSession keycloakSession,
+                            final ClientSessionContext clientSessionCtx) {
+        // Obtaining request claims
+        AuthenticatedClientSessionModel acs = clientSessionCtx.getClientSession();
+        String requestString = acs.getNote(OIDCLoginProtocol.CLAIMS_PARAM);
+
+        List<Map<String, Object>> requestClaims = getRequestClaims(requestString, token.getType());
+
+        if (!requestClaims.isEmpty()) {
+            // Retrieving Verified Claims for a user from an external store
+            IdaConnector idaConnector = keycloakSession.getProvider(IdaConnector.class);
+            Map<String, Object> userAllClaims = idaConnector.getVerifiedClaims(mappingModel.getConfig(), userSession.getUser().getUsername());
+            // Filtering request claims from validated claims in an external store
+            List<Map<String, Object>> extractedClaims = new ArrayList<>();
+            for (Map<String, Object> requestClaim : requestClaims) {
+                Map<String, Object> extractedClaim = new VerifiedClaimExtractor(OffsetDateTime.now()).getFilteredClaims(requestClaim, userAllClaims);
+                extractedClaims.add(extractedClaim);
+            }
+            // Mapping filtering results to output
+            mappingModel.getConfig().put(TOKEN_CLAIM_NAME, VERIFIED_CLAIMS);
+
+            if (isArray(extractedClaims)) {
+                // verified Claims is array.
+                mappingModel.getConfig().put(ProtocolMapperUtils.MULTIVALUED, "true");
+                OIDCAttributeMapperHelper.mapClaim(token, mappingModel, extractedClaims);
+            } else {
+                // verified Claims is single value.
+                OIDCAttributeMapperHelper.mapClaim(token, mappingModel, extractedClaims.get(0));
+            }
+        }
+    }
+
+    private boolean isArray(List<Map<String, Object>> verifiedClaims) {
+        return !(verifiedClaims.size() == 1);
+    }
+
+    private List<Map<String, Object>> getRequestClaims(String requestString, String tokenType) {
+        Map<String, Object> requestMap = getRequestMap(requestString);
+        List<Map<String, Object>> requestClaims = new ArrayList<>();
+        String endpointKey = getEndPointKey(tokenType);
+        if(endpointKey != null) {
+            if (requestMap.get(endpointKey) instanceof Map) {
+                Map<String, Object> idTokenValue = (Map) requestMap.get(endpointKey);
+                if (idTokenValue.get(VERIFIED_CLAIMS) instanceof Map) {
+                    requestClaims.add((Map) idTokenValue.get(VERIFIED_CLAIMS));
+                } else if (idTokenValue.get(VERIFIED_CLAIMS) instanceof List) {
+                    requestClaims = (List) idTokenValue.get(VERIFIED_CLAIMS);
+                }
+            }
+        }
+        return requestClaims;
+    }
+
+    private Map<String, Object> getRequestMap(String requestString) {
+        if (requestString.isEmpty()) {
+            logger.errorf(ERROR_MESSAGE_REQUEST_CLAIMS_ERROR);
+            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, ERROR_MESSAGE_REQUEST_CLAIMS_ERROR,
+                    Response.Status.BAD_REQUEST);
+        }
+        try {
+            return JsonSerialization.readValue(requestString, Map.class);
+        } catch (IOException e) {
+            logger.errorf(ERROR_MESSAGE_REQUEST_CLAIMS_JSON_SYNTAX_ERROR_ERROR);
+            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, ERROR_MESSAGE_REQUEST_CLAIMS_JSON_SYNTAX_ERROR_ERROR,
+                    Response.Status.BAD_REQUEST);
+        }
+    }
+
+    private String getEndPointKey(String tokenType) {
+        if (tokenType == null) {
+            // transformUserInfoToken
+            return USERINFO;
+        }
+        switch (tokenType) {
+            // transformIDToken
+            case TOKEN_TYPE_ID:
+            // transformAccessToken
+            case TOKEN_TYPE_BEARER:
+                return ID_TOKEN;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public boolean isSupported() {
+        return Profile.isFeatureEnabled(Profile.Feature.IDA);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaConnector.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaConnector.java
@@ -1,0 +1,39 @@
+package org.keycloak.protocol.oidc.ida.mappers.connector;
+
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Connector that retrieve verified claims for a user from an external store
+ */
+public interface IdaConnector extends Provider {
+    String IDA_EXTERNAL_STORE_NAME = "ida.external.store";
+    String IDA_EXTERNAL_STORE_LABEL = "IDA External Store";
+    /**
+     * Add external store information to Protocolmapper
+     *
+     * @param configProperties
+     */
+    void addIdaExternalStore(List<ProviderConfigProperty> configProperties);
+
+    /**
+     * Validate the setting value of IDA External Store
+     *
+     * @param protocolMapperConfig
+     * @throws ProtocolMapperConfigException If the setting value is incorrect
+     */
+    void validateIdaExternalStore(Map<String, String> protocolMapperConfig) throws ProtocolMapperConfigException;
+
+    /**
+     * Get the verified claims of a specified user from an external store
+     *
+     * @param protocolMapperConfig Information set for Protocolmapper
+     * @param userId               Target User ID
+     * @return verified claims retrieved from an external store
+     */
+    Map<String, Object> getVerifiedClaims(Map<String, String> protocolMapperConfig, String userId);
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaConnectorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaConnectorFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.protocol.oidc.ida.mappers.connector;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface IdaConnectorFactory extends ProviderFactory<IdaConnector> {
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaConnectorSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaConnectorSpi.java
@@ -1,0 +1,27 @@
+package org.keycloak.protocol.oidc.ida.mappers.connector;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class IdaConnectorSpi implements Spi {
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "ida-connector";
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return IdaConnector.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return IdaConnectorFactory.class;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaHttpConnector.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaHttpConnector.java
@@ -1,0 +1,85 @@
+package org.keycloak.protocol.oidc.ida.mappers.connector;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import jakarta.ws.rs.core.Response;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.ErrorResponseException;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_IDA_EXTERNAL_STORE_NOT_SPECIFIED;
+import static org.keycloak.validate.validators.NotBlankValidator.MESSAGE_BLANK;
+import static org.keycloak.validate.validators.UriValidator.MESSAGE_INVALID_URI;
+
+/**
+ * Connector that uses HTTP to retrieve validated claims from an external store
+ */
+public class IdaHttpConnector implements IdaConnector {
+    private static final Logger logger = Logger.getLogger(IdaHttpConnector.class);
+    public static final String IDA_EXTERNAL_STORE_HELP_TEXT = "The URI of external store used by IDA";
+    public static final String ERROR_MESSAGE_INVALID_IDA_EXTERNAL_STORE = "Invalid URI of IDA external store.";
+
+    @Override
+    public void addIdaExternalStore(List<ProviderConfigProperty> configProperties) {
+        ProviderConfigProperty nameProperty = new ProviderConfigProperty();
+        nameProperty.setName(IDA_EXTERNAL_STORE_NAME);
+        nameProperty.setLabel(IDA_EXTERNAL_STORE_LABEL);
+        nameProperty.setType(ProviderConfigProperty.STRING_TYPE);
+        nameProperty.setHelpText(IDA_EXTERNAL_STORE_HELP_TEXT);
+        configProperties.add(nameProperty);
+    }
+
+    @Override
+    public void validateIdaExternalStore(Map<String, String> protocolMapperConfig) throws ProtocolMapperConfigException {
+        String externalStoreUrl = protocolMapperConfig.get(IDA_EXTERNAL_STORE_NAME);
+        if (externalStoreUrl == null || externalStoreUrl.isEmpty()) {
+            throw new ProtocolMapperConfigException(ERROR_MESSAGE_IDA_EXTERNAL_STORE_NOT_SPECIFIED, MESSAGE_BLANK);
+        }
+        try {
+            new URI(externalStoreUrl).toURL();
+        } catch (MalformedURLException | URISyntaxException e) {
+            throw new ProtocolMapperConfigException(ERROR_MESSAGE_INVALID_IDA_EXTERNAL_STORE, MESSAGE_INVALID_URI, e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getVerifiedClaims(Map<String, String> protocolMapperConfig, String userId) {
+        String externalStoreUrl = protocolMapperConfig.get(IDA_EXTERNAL_STORE_NAME);
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            SimpleHttp request = SimpleHttp.doGet(externalStoreUrl + "?userId=" + userId,
+                    client);
+            return request.asJson(Map.class);
+        } catch (IOException e) {
+            if (e instanceof UnknownHostException  || e instanceof HttpHostConnectException) {
+                logger.errorf(e, ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR + " IDA External Store='%s'", externalStoreUrl);
+                throw new ErrorResponseException(OAuthErrorException.SERVER_ERROR, ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR,
+                        Response.Status.INTERNAL_SERVER_ERROR);
+            } else if (e instanceof MismatchedInputException || e instanceof JsonParseException) {
+                logger.errorf(e, ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR);
+                throw new ErrorResponseException(OAuthErrorException.SERVER_ERROR, ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR,
+                        Response.Status.INTERNAL_SERVER_ERROR);
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void close() {}
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaHttpConnectorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/connector/IdaHttpConnectorFactory.java
@@ -1,0 +1,32 @@
+package org.keycloak.protocol.oidc.ida.mappers.connector;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class IdaHttpConnectorFactory implements IdaConnectorFactory {
+
+    private static final String PROVIDER_ID = "ida-http-connector";
+
+    @Override
+    public IdaConnector create(KeycloakSession session) {
+        return new IdaHttpConnector();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/extractor/ExtractorConstants.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/extractor/ExtractorConstants.java
@@ -1,0 +1,41 @@
+package org.keycloak.protocol.oidc.ida.mappers.extractor;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class ExtractorConstants {
+    static final int DATE_LENGTH = 10;
+
+    static final String KEY_FILTER_VALUE = "value";
+    static final String KEY_FILTER_VALUES = "values";
+    static final String KEY_FILTER_MAX_AGE = "max_age";
+
+    static final String KEY_ARRAY_MAX_AGE = "assurance_details";
+
+    static final String KEY_VERIFICATION = "verification";
+
+    static final String KEY_CLAIMS = "claims";
+
+    static final List<String> arrayKeys = new ArrayList<>();
+    static {
+        arrayKeys.add("check_details");
+        arrayKeys.add("attachments");
+        arrayKeys.add("assurance_details");
+        arrayKeys.add("evidence");
+        arrayKeys.add("evidence_ref");
+    }
+
+    static final List<DateTimeFormatter> DATETIME_FORMATTERS = Arrays.asList(
+            // Offset corresponds to ±hh,±hh:mm format
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+            // Offset corresponds to ±hh,±hhmm format
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX"),
+            // Offset corresponds to ±hh,±hhmm format
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmX")
+    );
+
+    static final String WARN_MESSAGE_CANNOT_PARSE_DATETIME = "Can't parse dateTime(%s).";
+    static final String WARN_MESSAGE_REQUESTED_CLAIM_IS_NOT_IN_VERIFIED_CLAIMS = "Ignore if the requested claim(%s) is not in Verified Claims";
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/extractor/VerifiedClaimExtractor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ida/mappers/extractor/VerifiedClaimExtractor.java
@@ -1,0 +1,230 @@
+package org.keycloak.protocol.oidc.ida.mappers.extractor;
+
+import org.jboss.logging.Logger;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.ZoneOffset.UTC;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.DATETIME_FORMATTERS;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.DATE_LENGTH;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.KEY_ARRAY_MAX_AGE;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.KEY_CLAIMS;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.KEY_FILTER_MAX_AGE;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.KEY_FILTER_VALUE;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.KEY_FILTER_VALUES;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.KEY_VERIFICATION;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.WARN_MESSAGE_CANNOT_PARSE_DATETIME;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.WARN_MESSAGE_REQUESTED_CLAIM_IS_NOT_IN_VERIFIED_CLAIMS;
+import static org.keycloak.protocol.oidc.ida.mappers.extractor.ExtractorConstants.arrayKeys;
+
+/**
+ * Class that implements the process of retrieving a request claim from a user's Verified Claims
+ */
+public class VerifiedClaimExtractor {
+    private static final Logger logger = Logger.getLogger(VerifiedClaimExtractor.class);
+    private final OffsetDateTime currentTime;
+    private boolean isVerificationFlag = false;
+
+    public VerifiedClaimExtractor(OffsetDateTime currentTime) {
+        this.currentTime = currentTime;
+    }
+
+    /**
+     * Retrieving a request claim from a user's Verified Claims
+     *
+     * @param requestClaims request Claims
+     * @param userAllVerifiedClaims user's Verified Claims
+     * @return request claim from a user's Verified Claims
+     */
+    public Map<String, Object> getFilteredClaims(Map<String, Object> requestClaims, Map<String, Object> userAllVerifiedClaims) {
+        Map<String, Object> filteredClaims = new HashMap<>();
+        boolean isAllOmit = extractClaims(requestClaims, userAllVerifiedClaims, filteredClaims);
+        if (filteredClaims.get(KEY_VERIFICATION) != null && requestClaims.get(KEY_CLAIMS) == null) {
+            // Keycloak proprietary specifications not written in the IDA specification
+            // Returns all claims of the user if claims element is not specified for requestClaims and
+            // one or more verification elements can be obtained
+            Object userAllClaims = userAllVerifiedClaims.get(KEY_CLAIMS);
+            if(userAllClaims != null) {
+                filteredClaims.put(KEY_CLAIMS, userAllClaims);
+            }
+        }
+        return (isAllOmit ? null : filteredClaims);
+    }
+
+    /**
+     * Parse the same JSON depth data in requestClaims and userAllClaims to set the results to responseClaims
+     * This method is called recursively for each JSON depth
+     *
+     * @param requestClaims
+     * @param userAllClaims
+     * @param filteredClaims
+     * @return if "value", "Values", "max_age" are under "verified_claims/verification" and do not match, return true, else return false
+     */
+    private boolean extractClaims(Map<String, Object> requestClaims, Map<String, Object> userAllClaims, Map<String, Object> filteredClaims) {
+        for (Map.Entry<String, Object> requestClaim : requestClaims.entrySet()) {
+            String requestKey = requestClaim.getKey();
+            Object requestValue = requestClaim.getValue();
+            Object userClaimValue = userAllClaims.get(requestKey);
+            if (userClaimValue == null) {
+                // Ignore if the requested claim is not in Verified Claims
+                logger.warnf(WARN_MESSAGE_REQUESTED_CLAIM_IS_NOT_IN_VERIFIED_CLAIMS, requestKey);
+                continue;
+            }
+
+            boolean isVerificationFlagBackup = isVerificationFlag;
+            if (requestKey.equals(KEY_VERIFICATION)) {
+                // Returns null if "value", "Values", "max_age" are under "verified_claims/verification" and do not match
+                // https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#section-6.5.2-1
+                isVerificationFlag = true;
+            }
+
+            if (requestValue == null || isEmptyMap(requestValue)) {
+                // Returns userClaimValue if requestValue is a null or empty map (if there is no filter condition)
+                // There is no description of the empty map({}) in the specification of the IDA.
+                // Therefore, in Keycloak, it is the specification that the empty map is treated the same as null.
+                if (userClaimValue != null) {
+                    filteredClaims.put(requestKey, userClaimValue);
+                }
+            } else if (requestValue instanceof Map) {
+                Map<String, Object> requestMap = (Map) requestValue;
+                Object value = requestMap.get(KEY_FILTER_VALUE);
+                List values = requestMap.get(KEY_FILTER_VALUES) instanceof List ? (List) requestMap.get(KEY_FILTER_VALUES) : null;
+                Long maxAge = requestMap.get(KEY_FILTER_MAX_AGE) instanceof Number ? Long.valueOf(((Number) requestMap.get(KEY_FILTER_MAX_AGE)).longValue()) : null;
+                if (value != null || values != null || maxAge != null) {
+                    // If a filtering attribute is provided
+                    // https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-defining-further-constraint
+                    if((value != null && value.equals(userClaimValue)) ||
+                            (values != null && values.stream().anyMatch(v -> userClaimValue.equals(v))) ||
+                            (maxAge != null && checkUserClaimValueWithMaxAge(maxAge, userClaimValue))){
+                        // If you meet one of the filtering condition
+                        filteredClaims.put(requestKey, userClaimValue);
+                    } else {
+                        // If none of the filtering conditions are met
+                        if(isVerificationFlag) {
+                            // Returns null if under verified_claims/verification
+                            return true;
+                        }
+                    }
+                } else {
+                    // If the requestValue is not a filter, make sure that userAllClaims is also a map and the recursive call
+                    if (userClaimValue instanceof Map) {
+                        Map<String, Object> subClaim = new HashMap<>();
+                        if (extractClaims(requestMap, (Map) userClaimValue, subClaim)) {
+                            return true;
+                        }
+                        filteredClaims.put(requestKey, subClaim);
+                    }
+                }
+            } else if (arrayKeys.contains(requestKey) && requestValue instanceof List) {
+                // If requestKey is the key of the array and the requestValue is a list,
+                // make sure that userClaimValue is also a list and all the combinations in the list are recursive calls
+                if (userClaimValue instanceof List) {
+                    if (extractAllList(requestKey, (List) requestValue, (List) userClaimValue, filteredClaims)) {
+                        return true;
+                    }
+                }
+            }
+            isVerificationFlag = isVerificationFlagBackup;
+        }
+        return false;
+    }
+
+    private boolean extractAllList(String requestKey, List requestList, List userClaimList, Map<String, Object> filteredClaims) {
+        if (requestKey.equals(KEY_ARRAY_MAX_AGE)) {
+            // For assurance_details, all the sub elements of the property are returned.
+            // https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#section-6.2-12
+            filteredClaims.put(requestKey, userClaimList);
+        } else {
+            List<Map<String, Object>> subClaimList = new ArrayList<>();
+            for (Object userClaim : userClaimList) {
+                if (!(userClaim instanceof Map)) {
+                    // The verified claim list element is always a Map, so if it is not a Map, ignore it.
+                    continue;
+                }
+                for (Object requestClaim : requestList) {
+                    if (!(requestClaim instanceof Map)) {
+                        // The request Claim list element is always a Map, so if it is not a Map, ignore it.
+                        continue;
+                    }
+                    Map<String, Object> filteredSubClaims = new HashMap<>();
+                    boolean isOmitList = extractClaims((Map<String, Object>) requestClaim, (Map<String, Object>) userClaim, filteredSubClaims);
+                    if (!isOmitList && filteredSubClaims != null && !filteredSubClaims.isEmpty()) {
+                        subClaimList.add(filteredSubClaims);
+                        break;
+                    }
+                }
+            }
+            if (subClaimList.isEmpty()){
+               return true;
+            } else  {
+                filteredClaims.put(requestKey, subClaimList);
+            }
+        }
+        return false;
+    }
+
+    private boolean checkUserClaimValueWithMaxAge(Long maxAge, Object userClaimValue) {
+        if (userClaimValue instanceof String) {
+            String userClaimString = (String) userClaimValue;
+            OffsetDateTime userClaimDateTime = parseDateTime(userClaimString);
+            if (userClaimDateTime == null) {
+                return false;
+            }
+            return currentTime.isBefore(userClaimDateTime.plusSeconds(maxAge));
+        }
+        return false;
+    }
+
+    /**
+     * Parse YYYY-MM-DD、YYYY-MM-DDThh:mm[:ss]TZD in iso8601 format
+     * https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#section-5.1-12
+     *
+     * @param dateTime
+     * @return OffsetDateTime. if can't parse dateTime, return null.
+     */
+    private OffsetDateTime parseDateTime(String dateTime) {
+        if (dateTime.length() < DATE_LENGTH) {
+            logger.warnf(WARN_MESSAGE_CANNOT_PARSE_DATETIME, dateTime);
+            return null;
+        }
+
+        if (dateTime.length() == DATE_LENGTH) {
+            try {
+                // Parsing YYYY-MM-DD format
+                return LocalDate.parse(dateTime).atTime(0, 0).atOffset(UTC);
+            } catch (DateTimeParseException e) {
+                logger.warnf(WARN_MESSAGE_CANNOT_PARSE_DATETIME, dateTime);
+                return null;
+            }
+        }
+
+        try {
+            // Parsing YYYY-MM-DDThh:mm[:ss] format
+            return LocalDateTime.parse(dateTime).atOffset(UTC);
+        } catch (DateTimeParseException e) {
+            // Offset may have been set, so check offset
+        }
+
+        for (DateTimeFormatter formatter : DATETIME_FORMATTERS) {
+            try {
+                // Parsing YYYY-MM-DDThh:mm[:ss]TZD format
+                return OffsetDateTime.parse(dateTime, formatter);
+            } catch (DateTimeParseException e) {
+                logger.warnf(WARN_MESSAGE_CANNOT_PARSE_DATETIME, dateTime);
+            }
+        }
+        return null;
+    }
+
+    private boolean isEmptyMap(Object requestValue) {
+        return requestValue instanceof Map && ((Map) requestValue).isEmpty();
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -45,3 +45,4 @@ org.keycloak.protocol.saml.mappers.SAMLAudienceResolveProtocolMapper
 org.keycloak.protocol.oidc.mappers.ClaimsParameterTokenMapper
 org.keycloak.protocol.saml.mappers.UserAttributeNameIdMapper
 org.keycloak.protocol.oidc.mappers.ClaimsParameterWithValueIdTokenMapper
+org.keycloak.protocol.oidc.ida.mappers.IdaProtocolMapper

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.ida.mappers.connector.IdaConnectorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.ida.mappers.connector.IdaConnectorFactory
@@ -1,0 +1,1 @@
+org.keycloak.protocol.oidc.ida.mappers.connector.IdaHttpConnectorFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -29,5 +29,6 @@ org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelSpi
 org.keycloak.protocol.oidc.grants.ciba.resolvers.CIBALoginUserResolverSpi
 org.keycloak.protocol.oidc.rar.AuthorizationRequestParserSpi
 org.keycloak.services.resources.admin.ext.AdminRealmResourceSpi
-org.keycloak.services.legacysessionsupport.LegacySessionSupportSpi
 org.keycloak.theme.freemarker.FreeMarkerSPI
+org.keycloak.protocol.oidc.ida.mappers.connector.IdaConnectorSpi
+

--- a/services/src/test/java/org/keycloak/protocol/oidc/ida/extractor/VerifiedClaimExtractorTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/ida/extractor/VerifiedClaimExtractorTest.java
@@ -1,0 +1,959 @@
+package org.keycloak.protocol.oidc.ida.extractor;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.protocol.oidc.ida.mappers.extractor.VerifiedClaimExtractor;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+public class VerifiedClaimExtractorTest {
+    static VerifiedClaimExtractor extractor;
+
+    private static final OffsetDateTime CURRENT_TIME =
+            OffsetDateTime.of(2022, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    static Map<String, Object> userClaim;
+
+    @Before
+    public void setUpBeforeClass() throws IOException {
+        extractor = new VerifiedClaimExtractor(CURRENT_TIME);
+        InputStream stream = getClass().getResourceAsStream("/org/keycloak/test/oidc/userClaims.json");
+        userClaim = (Map<String, Object>)JsonSerialization.readValue(stream, Map.class).get("verified_claims");
+    }
+
+    @Test
+    public void testBasicClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertBasicClaims(filteredClaims);
+    }
+
+    @Test
+    public void testEmptyMap() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":{}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertBasicClaims(filteredClaims);
+    }
+
+    @Test
+    public void testValueMatchUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":{" +
+                        "\"value\": \"uk_tfida\"}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertBasicClaims(filteredClaims);
+    }
+
+    @Test
+    public void testValueMatchUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":{" +
+                        "\"value\": \"Sarah\"}" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertBasicClaims(filteredClaims);
+    }
+
+    private void assertBasicClaims(Map<String, Object> filteredClaims) {
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName.equals("Sarah"));
+
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName == null);
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testValueNotMatchUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":{" +
+                        "\"value\": \"Unknown\"}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertTrue(filteredClaims == null);
+    }
+
+    @Test
+    public void testValueNotMatchUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":{" +
+                        "\"value\":\"Unknown\"" +
+                        "}," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName == null);
+
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName.equals("Meredyth"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testValuesMatchUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":{" +
+                        "\"values\":[\"Unknown0\",\"uk_tfida\"]" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertValuesMatch(filteredClaims);
+    }
+
+    @Test
+    public void testValuesMatchUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":{" +
+                        "\"values\":[\"Unknown0\",\"Sarah\"]" +
+                        "}," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertValuesMatch(filteredClaims);
+    }
+
+    private void assertValuesMatch(Map<String, Object> filteredClaims) {
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName.equals("Sarah"));
+
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName.equals("Meredyth"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testValuesNotMatchUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":{" +
+                        "\"values\":[\"Unknown0\",\"Unknown1\"]" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertTrue(filteredClaims == null);
+    }
+
+    @Test
+    public void testValuesNotMatchUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":{" +
+                        "\"values\":[\"Unknown0\",\"Unknown1\"]" +
+                        "}," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName == null);
+
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName.equals("Meredyth"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testMaxAgeSatisfiedUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"time\":{" +
+                        "\"max_age\": 2000000000" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName.equals("Sarah"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+
+        String time = (String) verification.get("time");
+        Assert.assertTrue(time.equals("2021-05-11T14:29Z"));
+    }
+
+    @Test
+    public void testMaxAgeSatisfiedUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"birthdate\":{" + // The actual value of birthdate is 1976-03-11".
+                        "\"max_age\": 2000000000" +
+                        "}," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String birthdate = (String) claims.get("birthdate");
+        Assert.assertTrue(birthdate.equals("1976-03-11"));
+
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName.equals("Meredyth"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testMaxAgeNotSatisfiedUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"time\":{" +
+                        "\"max_age\": 100" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertTrue(filteredClaims == null);
+    }
+
+    @Test
+    public void testMaxAgeNotSatisfiedUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"birthdate\":{" + // The actual value of birthdate is 1976-03-11".
+                        "\"max_age\": 100" +
+                        "}," +
+                        "\"family_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String birthdate = (String) claims.get("birthdate");
+        Assert.assertTrue(birthdate == null);
+
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName.equals("Meredyth"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testDateTime() throws IOException {
+        Map<String, Object> userClaim = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":\"my_framework\"" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"datetime_0\":\"2022-04-22\"," +
+
+                        "\"datetime_1\":\"2022-04-22T12:34:56+0900\"," +
+                        "\"datetime_2\":\"2022-04-22T12:34:56+09:00\"," +
+                        "\"datetime_3\":\"2022-04-22T12:34:56+09\"," +
+                        "\"datetime_4\":\"2022-04-22T12:34:56Z\"," +
+
+                        "\"datetime_5\":\"2022-04-22T12:34\"," +
+                        "\"datetime_6\":\"2022-04-22T12:34+0900\"," +
+                        "\"datetime_7\":\"2022-04-22T12:34+09:00\"," +
+                        "\"datetime_8\":\"2022-04-22T12:34+09\"," +
+                        "\"datetime_9\":\"2022-04-22T12:34Z\"" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"datetime_0\":{\"max_age\":2000000000}," +
+
+                        "\"datetime_1\":{\"max_age\":2000000000}," +
+                        "\"datetime_2\":{\"max_age\":2000000000}," +
+                        "\"datetime_3\":{\"max_age\":2000000000}," +
+                        "\"datetime_4\":{\"max_age\":2000000000}," +
+
+                        "\"datetime_5\":{\"max_age\":2000000000}," +
+                        "\"datetime_6\":{\"max_age\":2000000000}," +
+                        "\"datetime_7\":{\"max_age\":2000000000}," +
+                        "\"datetime_8\":{\"max_age\":2000000000}," +
+                        "\"datetime_9\":{\"max_age\":2000000000}" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String datetime_0 = (String) claims.get("datetime_0");
+        Assert.assertTrue(datetime_0.equals("2022-04-22"));
+
+        String datetime_1 = (String) claims.get("datetime_1");
+        Assert.assertTrue(datetime_1.equals("2022-04-22T12:34:56+0900"));
+
+        String datetime_2 = (String) claims.get("datetime_2");
+        Assert.assertTrue(datetime_2.equals("2022-04-22T12:34:56+09:00"));
+
+        String datetime_3 = (String) claims.get("datetime_3");
+        Assert.assertTrue(datetime_3.equals("2022-04-22T12:34:56+09"));
+
+        String datetime_4 = (String) claims.get("datetime_4");
+        Assert.assertTrue(datetime_4.equals("2022-04-22T12:34:56Z"));
+
+        String datetime_5 = (String) claims.get("datetime_5");
+        Assert.assertTrue(datetime_5.equals("2022-04-22T12:34"));
+
+        String datetime_6 = (String) claims.get("datetime_6");
+        Assert.assertTrue(datetime_6.equals("2022-04-22T12:34+0900"));
+
+        String datetime_7 = (String) claims.get("datetime_7");
+        Assert.assertTrue(datetime_7.equals("2022-04-22T12:34+09:00"));
+
+        String datetime_8 = (String) claims.get("datetime_8");
+        Assert.assertTrue(datetime_8.equals("2022-04-22T12:34+09"));
+
+        String datetime_9 = (String) claims.get("datetime_9");
+        Assert.assertTrue(datetime_9.equals("2022-04-22T12:34Z"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("my_framework"));
+    }
+
+    @Test
+    public void testBasicClaimsNested() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"address\":{" +
+                        "\"locality\":null" +
+                        "}" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertBasicNestedClaim(filteredClaims);
+    }
+
+    private void assertBasicNestedClaim(Map<String, Object> filteredClaims) {
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        Map<String, Object> address = (Map<String, Object>) claims.get("address");
+        Assert.assertNotNull(address);
+
+        String locality = (String) address.get("locality");
+        Assert.assertTrue(locality.equals("Edinburgh"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testValueNestedUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"assurance_process\":{" +
+                        "\"policy\":{" +
+                        "\"value\":\"gpg45\"" +
+                        "}" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertNotNull(givenName.equals("Sarah"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        Map<String, Object> assuranceProcess = (Map<String, Object>) verification.get("assurance_process");
+        Assert.assertNotNull(assuranceProcess);
+
+        String policy = (String) assuranceProcess.get("policy");
+        Assert.assertTrue(policy.equals("gpg45"));
+    }
+
+    @Test
+    public void testValueNotMatchNestedUnderVerification() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"assurance_process\":{" +
+                        "\"policy\":{" +
+                        "\"value\":\"Unknown0\"" +
+                        "}" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+        Assert.assertTrue(filteredClaims == null);
+    }
+
+    @Test
+    public void testValueMatchNestedUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"address\":{" +
+                        "\"locality\":{" +
+                        "\"value\":\"Edinburgh\"" +
+                        "}" +
+                        "}" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        assertBasicNestedClaim(filteredClaims);
+    }
+
+    @Test
+    public void testValueNotMatchNestedUnderClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"address\":{" +
+                        "\"locality\":{" +
+                        "\"value\":\"Unknown0\"" +
+                        "}" +
+                        "}" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        Map<String, Object> address = (Map<String, Object>) claims.get("address");
+        Assert.assertTrue(address.isEmpty());
+
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+    }
+
+    @Test
+    public void testAssuranceDetails() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"assurance_process\":{" +
+                        "\"assurance_details\":null" +
+                        "}" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName.equals("Sarah"));
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+
+        Map<String, Object> assuranceProcess = (Map<String, Object>) verification.get("assurance_process");
+        Assert.assertNotNull(assuranceProcess);
+
+        List assuranceDetails = (List) assuranceProcess.get("assurance_details");
+        Assert.assertTrue(assuranceDetails.size() == 3);
+    }
+
+    @Test
+    public void testArraySingleMatchSingle() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"evidence\":[" +
+                        "{" +
+                        "\"type\":{" +
+                        "\"value\":\"electronic_record\"" +
+                        "}," +
+                        "\"check_details\":[" +
+                        "{" +
+                        "\"check_method\":null," +
+                        "\"organization\":{" +
+                        "\"value\":\"TheCreditBureau\"" +
+                        "}," +
+                        "\"txn\":null" +
+                        "}" +
+                        "]" +
+                        "}" +
+                        "]" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        List evidenceList = (List) verification.get("evidence");
+        Assert.assertTrue(evidenceList.size() == 1);
+
+        Map<String, Object> evidenceValue = (Map<String, Object>)evidenceList.get(0);
+
+        String type = (String)evidenceValue.get("type");
+        Assert.assertTrue(type.equals("electronic_record"));
+
+        List checkDetails = (List) evidenceValue.get("check_details");
+        Assert.assertTrue(checkDetails.size() == 1);
+
+        Map<String, Object> checkDetail = (Map<String, Object>)checkDetails.get(0);
+
+        String checkMethod = (String)checkDetail.get("check_method");
+        Assert.assertTrue(checkMethod.equals("kbv"));
+
+        String organization = (String)checkDetail.get("organization");
+        Assert.assertTrue(organization.equals("TheCreditBureau"));
+
+        String txn = (String)checkDetail.get("txn");
+        Assert.assertTrue(txn.equals("kbv1-hf934hn09234ng03jj3"));
+    }
+
+    @Test
+    public void testArraySingleNotMatch() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"evidence\":[" +
+                        "{" +
+                        "\"type\":{" +
+                        "\"value\":\"unknown\"" +
+                        "}," +
+                        "\"check_details\":[" +
+                        "{" +
+                        "\"check_method\":null," +
+                        "\"organization\":{" +
+                        "\"value\":\"TheCreditBureau\"" +
+                        "}," +
+                        "\"txn\":null" +
+                        "}" +
+                        "]" +
+                        "}" +
+                        "]" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertTrue(filteredClaims == null);
+    }
+
+    @Test
+    public void testArraySingleMatchMulti() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"evidence\":[" +
+                        "{" +
+                        "\"type\":{" +
+                        "\"value\":\"electronic_record\"" +
+                        "}," +
+                        "\"check_details\":[" +
+                        "{" +
+                        "\"check_method\":null," +
+                        "\"organization\":null," +
+                        "\"txn\":null" +
+                        "}" +
+                        "]" +
+                        "}" +
+                        "]" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        List evidenceList = (List) verification.get("evidence");
+        Assert.assertTrue(evidenceList.size() == 5);
+
+        for(int i = 0; i < evidenceList.size() ; i++){
+            Map<String, Object> evidence = (Map<String, Object>)evidenceList.get(i);
+            String type = (String)evidence.get("type");
+            Assert.assertTrue(type.equals("electronic_record"));
+
+            List checkDetails = (List) evidence.get("check_details");
+            Assert.assertNotNull(checkDetails);
+        }
+    }
+
+    @Test
+    public void testArrayMultipleMatch() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null," +
+                        "\"evidence\":[" +
+                        "{" +
+                        "\"type\":{" +
+                        "\"value\":\"electronic_record\"" +
+                        "}," +
+                        "\"check_details\":[" +
+                        "{" +
+                        "\"check_method\":null," +
+                        "\"organization\":{" +
+                        "\"value\":\"TheCreditBureau\"" +
+                        "}," +
+                        "\"txn\":null" +
+                        "}" +
+                        "]" +
+                        "}," +
+                        "{" +
+                        "\"type\":{" +
+                        "\"value\":\"document\"" +
+                        "}" +
+                        "}" +
+                        "]" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Assert.assertNotNull(filteredClaims);
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        List evidenceList = (List) verification.get("evidence");
+        Assert.assertTrue(evidenceList.size() == 2);
+
+        for(int i = 0; i < evidenceList.size() ; i++){
+            Map<String, Object> evidence = (Map<String, Object>)evidenceList.get(i);
+            String type = (String)evidence.get("type");
+            Assert.assertTrue(type.equals("electronic_record") || type.equals("document"));
+        }
+    }
+
+    @Test
+    public void testRequestInvalidClaims() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_Framework\":null" +
+                        "}," +
+                        "\"claims\":{" +
+                        "\"given_name\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName.equals("Sarah"));
+    }
+
+    @Test
+    public void testOnlyVerifications() throws IOException {
+        Map<String, Object> request = JsonSerialization.readValue(
+                "{" +
+                        "\"verification\":{" +
+                        "\"trust_framework\":null" +
+                        "}" +
+                        "}"
+                , Map.class);
+
+        Map<String, Object> filteredClaims = extractor.getFilteredClaims(request, userClaim);
+
+        Map<String, Object> verification = (Map<String, Object>) filteredClaims.get("verification");
+        Assert.assertNotNull(verification);
+
+        String trustFramework = (String) verification.get("trust_framework");
+        Assert.assertTrue(trustFramework.equals("uk_tfida"));
+
+        Map<String, Object> claims = (Map<String, Object>) filteredClaims.get("claims");
+        Assert.assertNotNull(claims);
+
+        String givenName = (String) claims.get("given_name");
+        Assert.assertTrue(givenName.equals("Sarah"));
+        String familyName = (String) claims.get("family_name");
+        Assert.assertTrue(familyName.equals("Meredyth"));
+        String birthdate = (String) claims.get("birthdate");
+        Assert.assertTrue(birthdate.equals("1976-03-11"));
+        String country = ((Map<String, String>) claims.get("place_of_birth")).get("country");
+        Assert.assertTrue(country.equals("UK"));
+        Map<String, String> address = (Map<String, String>) claims.get("address");
+        String locality = (String) address.get("locality");
+        Assert.assertTrue(locality.equals("Edinburgh"));
+        String postalCode = (String) address.get("postal_code");
+        Assert.assertTrue(postalCode.equals("EH1 9GP"));
+        String addressCountry = (String) address.get("country");
+        Assert.assertTrue(addressCountry.equals("UK"));
+        String streetAddress = (String) address.get("street_address");
+        Assert.assertTrue(streetAddress.equals("122 Burns Crescent"));
+    }
+}

--- a/services/src/test/resources/org/keycloak/test/oidc/userClaims.json
+++ b/services/src/test/resources/org/keycloak/test/oidc/userClaims.json
@@ -1,0 +1,204 @@
+{
+  "verified_claims": {
+    "verification": {
+      "trust_framework": "uk_tfida",
+      "assurance_level": "medium",
+      "assurance_process": {
+        "policy": "gpg45",
+        "procedure": "m1b",
+        "assurance_details": [
+          {
+            "assurance_type": "evidence_validation",
+            "assurance_classification": "score_2",
+            "evidence_ref": [
+              {
+                "txn": "DL1-85762937582385820",
+                "evidence_metadata": {
+                  "evidence_classification": "score_3_strength"
+                }
+              }
+            ]
+          },
+          {
+            "assurance_type": "verification",
+            "assurance_classification": "score_2",
+            "evidence_ref": [
+              {
+                "txn": "kbv1-hf934hn09234ng03jj3",
+                "evidence_metadata": {
+                  "evidence_classification": "high_kbv"
+                }
+              },
+              {
+                "txn": "kbv2-nm0f23u9459fj38u5j6",
+                "evidence_metadata": {
+                  "evidence_classification": "medium_kbv"
+                }
+              },
+              {
+                "txn": "kbv3-jf9028h023hj0f9jh23",
+                "evidence_metadata": {
+                  "evidence_classification": "medium_kbv"
+                }
+              }
+            ]
+          },
+          {
+            "assurance_type": "counter_fraud",
+            "assurance_classification": "score_2",
+            "evidence_ref": [
+              {
+                "txn": "GRO-9824hngvp9278hf5tmp924y5h",
+                "evidence_metadata": {
+                  "evidence_classification": "mortality_check"
+                }
+              },
+              {
+                "txn": "fi-2nbf02hfn384ufn",
+                "evidence_metadata": {
+                  "evidence_classification": "id_fraud"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "time": "2021-05-11T14:29Z",
+      "verification_process": "7675D80F-57E0-AB14-9543-26B41FC22",
+      "evidence": [
+        {
+          "type": "document",
+          "check_details": [
+            {
+              "check_method": "data",
+              "organization": "DVLA",
+              "time": "2021-04-09T14:15Z",
+              "txn": "DL1-85762937582385820"
+            }
+          ],
+          "time": "2021-04-09T14:12Z",
+          "document_details": {
+            "type": "driving_permit",
+            "personal_number": "MORGA753116SM9IJ",
+            "document_number": "MORGA753116SM9IJ35",
+            "serial_number": "ZG21000001",
+            "date_of_issuance": "2021-01-01",
+            "date_of_expiry": "2030-12-31",
+            "issuer": {
+              "name": "DVLA",
+              "country": "UK",
+              "country_code": "GBR",
+              "jurisdiction": "GB-GBN"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "kbv",
+              "organization": "TheCreditBureau",
+              "txn": "kbv1-hf934hn09234ng03jj3"
+            }
+          ],
+          "time": "2021-04-09T14:12Z",
+          "record": {
+            "type": "mortgage_account",
+            "source": {
+              "name": "TheCreditBureau"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "kbv",
+              "organization": "OpenBankingTPP",
+              "txn": "kbv2-nm0f23u9459fj38u5j6"
+            }
+          ],
+          "time": "2021-04-09T14:12Z",
+          "record": {
+            "type": "bank_account",
+            "source": {
+              "name": "TheBank"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "kbv",
+              "organization": "GSMA",
+              "txn": "kbv3-jf9028h023hj0f9jh23"
+            }
+          ],
+          "time": "2021-04-09T15:42Z",
+          "record": {
+            "type": "mno",
+            "source": {
+              "name": "Vodafone"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "data",
+              "organization": "GRO",
+              "txn": "GRO-9824hngvp9278hf5tmp924y5h"
+            }
+          ],
+          "time": "2021-04-09T16:12Z",
+          "record": {
+            "type": "death_register",
+            "source": {
+              "name": "General Register Office",
+              "street_address": "PO BOX 2",
+              "locality": "Southport",
+              "postal_code": "PR8 2JD",
+              "country": "UK",
+              "country_code": "GBR",
+              "jurisdiction": "GB-EAW"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "data",
+              "organization": "NextLex",
+              "txn": "fi-2nbf02hfn384ufn"
+            }
+          ],
+          "time": "2021-04-09T16:51Z",
+          "record": {
+            "type": "fraud_register",
+            "source": {
+              "name": "National Fraud Database",
+              "jurisdiction": "UK"
+            }
+          }
+        }
+      ]
+    },
+    "claims": {
+      "given_name": "Sarah",
+      "family_name": "Meredyth",
+      "birthdate": "1976-03-11",
+      "place_of_birth": {
+        "country": "UK"
+      },
+      "address": {
+        "locality": "Edinburgh",
+        "postal_code": "EH1 9GP",
+        "country": "UK",
+        "street_address": "122 Burns Crescent"
+      }
+    }
+  }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
@@ -76,6 +76,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
@@ -767,5 +768,39 @@ public class TestingOIDCEndpointsApplicationResource {
             response.setIsBound(Boolean.TRUE);
         }
         return response;
+    }
+
+    @GET
+    @Path("/verified-claims")
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    public Response getVerifiedClaims(@QueryParam("userId") String userId) throws IOException {
+        Response.ResponseBuilder builder = Response.status(Status.OK);
+        Object userClaim;
+        switch (userId) {
+            case "test-user@localhost":
+                InputStream stream = getClass().getResourceAsStream("/org/keycloak/testsuite/oidc/userClaims.json");
+                userClaim = JsonSerialization.readValue(stream, Map.class).get("verified_claims");
+                break;
+            case "john-doh@localhost":
+                stream = getClass().getResourceAsStream("/org/keycloak/testsuite/oidc/userClaims2.json");
+                userClaim = JsonSerialization.readValue(stream, Map.class).get("verified_claims");
+                break;
+            case "keycloak-user@localhost":
+                userClaim = "";
+                break;
+            case "topgroupuser":
+                userClaim = "{\"verification\":{\"trust_framework\":\"uk_tfida\"}\"claims\":{\"given_name\":\"Sarah\"}}";
+                break;
+            case "level2groupuser":
+                userClaim = "{\"verified_claims\":{\"verification\":{\"trust_framework\":\"uk_tfida\"},\"claims\":{\"given_name\":\"Sarah\"}}}";
+                break;
+            case "rolerichuser":
+                userClaim = "{\"VERIFICATION\":{\"trust_framework\":\"uk_tfida\"},\"claim\":{\"given_name\":\"Sarah\"}}";
+                break;
+            default:
+                return Response.status(Status.BAD_REQUEST).build();
+        }
+        return builder.type(MediaType.APPLICATION_JSON).entity(userClaim).build();
     }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/org/keycloak/testsuite/oidc/userClaims.json
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/org/keycloak/testsuite/oidc/userClaims.json
@@ -1,0 +1,204 @@
+{
+  "verified_claims": {
+    "verification": {
+      "trust_framework": "uk_tfida",
+      "assurance_level": "medium",
+      "assurance_process": {
+        "policy": "gpg45",
+        "procedure": "m1b",
+        "assurance_details": [
+          {
+            "assurance_type": "evidence_validation",
+            "assurance_classification": "score_2",
+            "evidence_ref": [
+              {
+                "txn": "DL1-85762937582385820",
+                "evidence_metadata": {
+                  "evidence_classification": "score_3_strength"
+                }
+              }
+            ]
+          },
+          {
+            "assurance_type": "verification",
+            "assurance_classification": "score_2",
+            "evidence_ref": [
+              {
+                "txn": "kbv1-hf934hn09234ng03jj3",
+                "evidence_metadata": {
+                  "evidence_classification": "high_kbv"
+                }
+              },
+              {
+                "txn": "kbv2-nm0f23u9459fj38u5j6",
+                "evidence_metadata": {
+                  "evidence_classification": "medium_kbv"
+                }
+              },
+              {
+                "txn": "kbv3-jf9028h023hj0f9jh23",
+                "evidence_metadata": {
+                  "evidence_classification": "medium_kbv"
+                }
+              }
+            ]
+          },
+          {
+            "assurance_type": "counter_fraud",
+            "assurance_classification": "score_2",
+            "evidence_ref": [
+              {
+                "txn": "GRO-9824hngvp9278hf5tmp924y5h",
+                "evidence_metadata": {
+                  "evidence_classification": "mortality_check"
+                }
+              },
+              {
+                "txn": "fi-2nbf02hfn384ufn",
+                "evidence_metadata": {
+                  "evidence_classification": "id_fraud"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "time": "2021-05-11T14:29Z",
+      "verification_process": "7675D80F-57E0-AB14-9543-26B41FC22",
+      "evidence": [
+        {
+          "type": "document",
+          "check_details": [
+            {
+              "check_method": "data",
+              "organization": "DVLA",
+              "time": "2021-04-09T14:15Z",
+              "txn": "DL1-85762937582385820"
+            }
+          ],
+          "time": "2021-04-09T14:12Z",
+          "document_details": {
+            "type": "driving_permit",
+            "personal_number": "MORGA753116SM9IJ",
+            "document_number": "MORGA753116SM9IJ35",
+            "serial_number": "ZG21000001",
+            "date_of_issuance": "2021-01-01",
+            "date_of_expiry": "2030-12-31",
+            "issuer": {
+              "name": "DVLA",
+              "country": "UK",
+              "country_code": "GBR",
+              "jurisdiction": "GB-GBN"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "kbv",
+              "organization": "TheCreditBureau",
+              "txn": "kbv1-hf934hn09234ng03jj3"
+            }
+          ],
+          "time": "2021-04-09T14:12Z",
+          "record": {
+            "type": "mortgage_account",
+            "source": {
+              "name": "TheCreditBureau"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "kbv",
+              "organization": "OpenBankingTPP",
+              "txn": "kbv2-nm0f23u9459fj38u5j6"
+            }
+          ],
+          "time": "2021-04-09T14:12Z",
+          "record": {
+            "type": "bank_account",
+            "source": {
+              "name": "TheBank"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "kbv",
+              "organization": "GSMA",
+              "txn": "kbv3-jf9028h023hj0f9jh23"
+            }
+          ],
+          "time": "2021-04-09T15:42Z",
+          "record": {
+            "type": "mno",
+            "source": {
+              "name": "Vodafone"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "data",
+              "organization": "GRO",
+              "txn": "GRO-9824hngvp9278hf5tmp924y5h"
+            }
+          ],
+          "time": "2021-04-09T16:12Z",
+          "record": {
+            "type": "death_register",
+            "source": {
+              "name": "General Register Office",
+              "street_address": "PO BOX 2",
+              "locality": "Southport",
+              "postal_code": "PR8 2JD",
+              "country": "UK",
+              "country_code": "GBR",
+              "jurisdiction": "GB-EAW"
+            }
+          }
+        },
+        {
+          "type": "electronic_record",
+          "check_details": [
+            {
+              "check_method": "data",
+              "organization": "NextLex",
+              "txn": "fi-2nbf02hfn384ufn"
+            }
+          ],
+          "time": "2021-04-09T16:51Z",
+          "record": {
+            "type": "fraud_register",
+            "source": {
+              "name": "National Fraud Database",
+              "jurisdiction": "UK"
+            }
+          }
+        }
+      ]
+    },
+    "claims": {
+      "given_name": "Sarah",
+      "family_name": "Meredyth",
+      "birthdate": "1976-03-11",
+      "place_of_birth": {
+        "country": "UK"
+      },
+      "address": {
+        "locality": "Edinburgh",
+        "postal_code": "EH1 9GP",
+        "country": "UK",
+        "street_address": "122 Burns Crescent"
+      }
+    }
+  }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/org/keycloak/testsuite/oidc/userClaims2.json
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/org/keycloak/testsuite/oidc/userClaims2.json
@@ -1,0 +1,56 @@
+{
+    "sub": "BSmith",
+    "email": "bobsmith@example.com",
+    "verified_claims": {
+      "verification": {
+        "trust_framework": "authority_claims_example_framework",
+        "time":"2020-04-23T18:25Z",
+        "verification_process":"f24c6f-6d3f-4ec5-973e-b0d8506f3bc7"
+      },
+      "claims": {
+        "given_name": "Bob",
+        "family_name": "Smith",
+        "birthdate": "1981-01-26",
+        "authority": [ {
+            "applies_to": {
+                "organization_name": "Example Company Limited",
+                "trading_as": "XAmple",
+                "registered_address": "123 Acacia Avenue, Newtown, UK",
+                "registration_number": "12351235",
+                "registration_authority_code": "RA000585",
+                "legal_jurisdiction": "GB",
+                "entity_legal_form": "H0PO",
+                "organisation_status": "Active",
+                "incorporation_date": "2000-01-01",
+                "organization_identifiers": [{
+                    "identifier_type": "LEI",
+                    "identifier": "H7FNTJ4851HG0EXQ1Z70",
+                    "issuer": "RapidLEI"
+                    },
+                    {
+                    "identifier_type": "DUNS",
+                    "identifier": "123456789",
+                    "issuer": "Dun & Bradstreet"
+                    },
+                    {
+                    "identifier_type": "FRN",
+                    "identifier": "928911",
+                    "issuer": "FCA"
+                    }
+                ]   
+            },
+            "permission": [ {
+                "role": "Director",
+                "validity":[ {
+                    "start": "2018-03-02T10:00Z"
+                    }]
+            }],
+            "granted_by": {
+                "method": "appointment",
+                "granting_body": "Companies House",
+                "reason": "Official company officer"
+            }
+        }]
+      }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestApplicationResourceUrls.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestApplicationResourceUrls.java
@@ -65,4 +65,11 @@ public class TestApplicationResourceUrls {
 
         return builder.build().toString();
     }
+
+    public static String getVerifiedClaimsUri() {
+        UriBuilder builder = oidcClientEndpoints()
+                .path(TestOIDCEndpointsApplicationResource.class, "getVerifiedClaims");
+
+        return builder.build().toString();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
@@ -170,4 +170,10 @@ public interface TestOIDCEndpointsApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     IntentClientBindCheckExecutor.IntentBindCheckResponse checkIntentClientBound(IntentClientBindCheckExecutor.IntentBindCheckRequest request);
+
+    @GET
+    @Path("/verified-claims")
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    Response getVerifiedClaims(@QueryParam("userId") String userId);
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -312,6 +312,13 @@ public class OAuthClient {
         return new AuthorizationEndpointResponse(this);
     }
 
+    public AuthorizationEndpointResponse doSilentLogin() {
+        openLoginForm();
+        WaitUtils.waitForPageToLoad();
+
+        return new AuthorizationEndpointResponse(this);
+    }
+
     public AuthorizationEndpointResponse doLoginSocial(String brokerId, String username, String password) {
         openLoginForm();
         WaitUtils.waitForPageToLoad();
@@ -1723,6 +1730,19 @@ public class OAuthClient {
         } else {
             try {
                 this.claims = URLEncoder.encode(JsonSerialization.writeValueAsString(claims), "UTF-8");
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
+        return this;
+    }
+
+    public OAuthClient setStringClaims(String claims) {
+        if (claims == null) {
+            this.claims = null;
+        } else {
+            try {
+                this.claims = URLEncoder.encode(claims, "UTF-8");
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdaProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdaProtocolMapperTest.java
@@ -1,0 +1,995 @@
+package org.keycloak.testsuite.oidc;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.admin.client.resource.ProtocolMappersResource;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.ida.mappers.connector.IdaHttpConnector;
+import org.keycloak.representations.ClaimsRepresentation;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.UserInfo;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.client.resources.TestApplicationResourceUrls;
+import org.keycloak.testsuite.util.ClientManager;
+import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.ProtocolMapperUtil;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.common.Profile.Feature;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_REQUEST_CLAIMS_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.ERROR_MESSAGE_REQUEST_CLAIMS_JSON_SYNTAX_ERROR_ERROR;
+import static org.keycloak.protocol.oidc.ida.mappers.IdaConstants.IDA_PROVIDER_ID;
+import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+
+
+@EnableFeature(value = Feature.IDA, skipRestart = true)
+public class IdaProtocolMapperTest extends AbstractKeycloakTest {
+
+    @Before
+    public void clientConfiguration() {
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app").directAccessGrant(true);
+        oauth.clientId("test-app");
+    }
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realm = loadJson(getClass().getResourceAsStream("/testrealm.json"), RealmRepresentation.class);
+        testRealms.add(realm);
+    }
+
+    @Test
+    public void getIdTokenAccessTokenUserinfoTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void getIdTokenTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "false", "false");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), null);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void getAccessTokenTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("false", "true", "false");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+
+        checkResponse(idToken.getOtherClaims(), null);
+
+        String accessToken = response.getAccessToken();
+
+        //check accessTokenClaims
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void getUserInfoTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("false", "false", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        checkResponse(idToken.getOtherClaims(), null);
+
+        //check accessTokenClaims
+        String accessToken = response.getAccessToken();
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), null);
+
+        //check userinfoClaims
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void anotherUserNameTest() throws Exception {
+        ProtocolMappersResource protocolMappers =  setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "john-doh@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Bob");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Bob");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Bob");
+            setExpectedTrustFramework("authority_claims_example_framework");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void valueRequestMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{\"value\":\"Sarah\"}}",
+                "{\"trust_framework\":{\"value\":\"uk_tfida\"}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void valueRequestNotMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{}}", "{\"given_name\":{\"value\":\"Unknown\"}}",
+                "{\"trust_framework\":{\"value\":\"unknown\"}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void valuesRequestMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{\"values\":[\"Unknown\",\"Sarah\"]}}",
+                "{\"trust_framework\":{\"values\":[\"Unknown\",\"uk_tfida\"]}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void valuesRequestNotMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{}}", "{\"given_name\":{\"values\":[\"Unknown0\",\"Unknown1\"]}}",
+                "{\"trust_framework\":{\"values\":[\"Unknown0\",\"unknown1\"]}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void maxAgeRequestMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{},\"time\":{\"max_age\": 2000000000}}", "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{},\"birthdate\":{\"max_age\": 2000000000}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedTime("2021-05-11T14:29Z");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedTime("2021-05-11T14:29Z");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedBirthdate("1976-03-11");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void maxAgeRequestNotMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{},\"time\":{\"max_age\": 10}}", "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{},\"birthdate\":{\"max_age\": 10}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        checkResponse(idToken.getOtherClaims(), null);
+
+        String accessToken = response.getAccessToken();
+
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), null);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void nestRequestMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{}}", "{\"address\":{\"locality\":{}}}",
+                "{\"assurance_process\":{\"policy\":{\"value\":\"gpg45\"}}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedLocality("Edinburgh");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedLocality("Edinburgh");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedPolicy("gpg45");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void nestRequestNotMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{}}", "{\"address\":{\"locality\":{\"value\":\"unknown\"}}}",
+                "{\"assurance_process\":{\"policy\":{\"value\":\"unknown\"}}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedTrustFramework("uk_tfida");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void assuranceDetailsTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{},\"assurance_process\":{\"assurance_details\":{}}}", "{\"given_name\":{}}",
+                "{\"trust_framework\":{},\"assurance_process\":{\"assurance_details\":{}}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedAssuranceDetailsSize(3);
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedAssuranceDetailsSize(3);
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedAssuranceDetailsSize(3);
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void arrayMatchTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims("{\"trust_framework\":{},\"evidence\":[{\"type\":{\"value\":\"electronic_record\"},\"check_details\":[{\"check_method\":{},\"organization\":{\"value\":\"TheCreditBureau\"},\"txn\":{}}]}]}", "{\"given_name\":{}}",
+                "{\"trust_framework\":{},\"evidence\":[{\"type\":{\"value\":\"electronic_record\"},\"check_details\":[{\"check_method\":{},\"organization\":{\"value\":\"TheCreditBureau\"},\"txn\":{}}]}]}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        ExpectedClaims expectedIdTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedType("electronic_record");
+            setExpectedOrganization("TheCreditBureau");
+        }};
+        checkResponse(idToken.getOtherClaims(), expectedIdTokenClaims);
+
+        String accessToken = response.getAccessToken();
+        ExpectedClaims expectedAccessTokenClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedType("electronic_record");
+            setExpectedOrganization("TheCreditBureau");
+        }};
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), expectedAccessTokenClaims);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        ExpectedClaims expectedUserInfoClaims = new ExpectedClaims() {{
+            setExpectedGivenName("Sarah");
+            setExpectedTrustFramework("uk_tfida");
+            setExpectedType("electronic_record");
+            setExpectedOrganization("TheCreditBureau");
+        }};
+        checkResponse(userInfo.getOtherClaims(), expectedUserInfoClaims);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void verifiedClaimsArrayTest() throws Exception {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("{\"userinfo\":{\"verified_claims\":[{\"verification\":{\"trust_framework\":null}},{\"claims\":{\"family_name\":null}}]},\"id_token\":{\"verified_claims\":[{\"verification\":{\"assurance_level\":null}},{\"claims\":{\"given_name\":null}}]}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+        //check idTokenClaims
+        List<Map<String, Object>> verifiedClaims = (List<Map<String, Object>>) idToken.getOtherClaims().get("verified_claims");
+        Map<String, Object> verifiedClaim1 = verifiedClaims.get(0);
+        Assert.assertEquals("medium", ((Map<String, Object>)verifiedClaim1.get("verification")).get("assurance_level"));
+        Map<String, Object> verifiedClaim2 = verifiedClaims.get(1);
+        Assert.assertEquals("Sarah", ((Map<String, Object>)verifiedClaim2.get("claims")).get("given_name"));
+
+        UserInfo userInfo = oauth.doUserInfoRequest(response.getAccessToken());
+        //check userinfo
+        verifiedClaims = (List<Map<String, Object>>) userInfo.getOtherClaims().get("verified_claims");
+        verifiedClaim1 = verifiedClaims.get(0);
+        Assert.assertEquals("uk_tfida", ((Map<String, Object>)verifiedClaim1.get("verification")).get("trust_framework"));
+        verifiedClaim2 = verifiedClaims.get(1);
+        Assert.assertEquals("Meredyth", ((Map<String, Object>)verifiedClaim2.get("claims")).get("family_name"));
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void externalStoreConnectionErrorTest() throws Exception {
+        ProtocolMapperRepresentation idaProtocolMapper = ModelToRepresentation.toRepresentation(createClaimMapper("ida"));
+        Map<String, String> config = new HashMap<>();
+        config.put("id.token.claim", "true");
+        config.put("access.token.claim", "true");
+        config.put("userinfo.token.claim", "true");
+        config.put(IdaHttpConnector.IDA_EXTERNAL_STORE_NAME, "http://unknown");
+
+        idaProtocolMapper.setConfig(config);
+        ProtocolMappersResource protocolMappers = ApiUtil.findClientResourceByClientId(adminClient.realm("test"), "test-app").getProtocolMappers();
+        protocolMappers.createMapper(Arrays.asList(idaProtocolMapper));
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.SERVER_ERROR, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void externalStoreConnectionError2Test() throws Exception {
+        ProtocolMapperRepresentation idaProtocolMapper = ModelToRepresentation.toRepresentation(createClaimMapper("ida"));
+        Map<String, String> config = new HashMap<>();
+        config.put("id.token.claim", "true");
+        config.put("access.token.claim", "true");
+        config.put("userinfo.token.claim", "true");
+        config.put(IdaHttpConnector.IDA_EXTERNAL_STORE_NAME, "http://192.168.0.1");
+
+        idaProtocolMapper.setConfig(config);
+        ProtocolMappersResource protocolMappers = ApiUtil.findClientResourceByClientId(adminClient.realm("test"), "test-app").getProtocolMappers();
+        protocolMappers.createMapper(Arrays.asList(idaProtocolMapper));
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.SERVER_ERROR, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_CONNECT_IDA_EXTERNAL_STORE_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void requestClaimsEmptyTest() {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_REQUEST_CLAIMS_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void requestClaimsEmptyErrorTest() {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_REQUEST_CLAIMS_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void requestClaimsNotIncludeIdTokenErrorTest() {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("{\"verified_claims\":{\"claims\":{\"given_name\":null}}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        checkResponse(idToken.getOtherClaims(), null);
+
+        String accessToken = response.getAccessToken();
+
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), null);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void requestClaimsSyntaxErrorTest() {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("\"id_token\":{\"verified_claims\":{\"claims\":{\"given_name\":null}}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_REQUEST_CLAIMS_JSON_SYNTAX_ERROR_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void requestClaimsLetterErrorTest() {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("{\"USERINFO\":{\"verified_claims\":{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}},\"id_tokens\":{\"verified_claims\":{\"claims\":{\"given_name\":null}}}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        checkResponse(idToken.getOtherClaims(), null);
+
+        String accessToken = response.getAccessToken();
+
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), null);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void requestClaimsLetterError2Test() {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+        oauth.setStringClaims("{\"userinfo\":{\"VERIFIED_CLAIMS\":{\"verification\":{\"trust_framework\":null},\"claims\":{\"given_name\":null}}},\"id_token\":{\"verified_claim\":{\"claims\":{\"given_name\":null}}}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        //check idTokenClaims
+        checkResponse(idToken.getOtherClaims(), null);
+
+        String accessToken = response.getAccessToken();
+
+        //check accessTokenClaims
+        checkResponse(oauth.verifyToken(accessToken).getOtherClaims(), null);
+
+        UserInfo userInfo = oauth.doUserInfoRequest(accessToken);
+
+        //check userinfoClaims
+        checkResponse(userInfo.getOtherClaims(), null);
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void userClaimsEmptyErrorTest() throws IOException {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "keycloak-user@localhost", "password");
+
+        Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.SERVER_ERROR, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void userClaimsSyntaxErrorTest() throws IOException {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "topGroupUser", "password");
+
+        Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
+        Assert.assertEquals(OAuthErrorException.SERVER_ERROR, response.getError());
+        Assert.assertEquals(ERROR_MESSAGE_IDA_EXTERNAL_STORE_JSON_SYNTAX_ERROR_ERROR, response.getErrorDescription());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void userClaimsLetterErrorTest() throws IOException {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "level2GroupUser", "password");
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    @Test
+    public void userClaimsLetterError2Test() throws IOException {
+        ProtocolMappersResource protocolMappers = setIdaProtocolMapper("true", "true", "true");
+
+        setRequestClaims(null, "{\"given_name\":{}}",
+                "{\"trust_framework\":{}}", "{\"given_name\":{}}");
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "rolerichuser", "password");
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        deleteIdaProtocolMapper(protocolMappers);
+    }
+
+    private void checkResponse(Map<String, Object> otherClaims, ExpectedClaims expectedClaims) {
+        if (expectedClaims == null) {
+            Assert.assertTrue(otherClaims.isEmpty());
+            return;
+        }
+
+        Map<String, Object> verifiedClaims = (Map<String, Object>) otherClaims.get("verified_claims");
+        if (expectedClaims.expectedGivenName != null) {
+            Assert.assertEquals(expectedClaims.expectedGivenName,
+                    ((Map<String, Object>) verifiedClaims.get("claims")).get("given_name"));
+        }
+        if (expectedClaims.expectedTrustFramework != null) {
+            Assert.assertEquals(expectedClaims.expectedTrustFramework,
+                    ((Map<String, Object>) verifiedClaims.get("verification")).get("trust_framework"));
+        }
+        if (expectedClaims.expectedTime != null) {
+            Assert.assertEquals(expectedClaims.expectedTime,
+                    ((Map<String, Object>) verifiedClaims.get("verification")).get("time"));
+        }
+        if (expectedClaims.expectedBirthdate != null) {
+            Assert.assertEquals(expectedClaims.expectedBirthdate,
+                    ((Map<String, Object>) verifiedClaims.get("claims")).get("birthdate"));
+        }
+        if (expectedClaims.expectedPolicy != null) {
+            Assert.assertEquals(expectedClaims.expectedPolicy,
+                    ((Map<String, Object>) ((Map<String, Object>) verifiedClaims.get("verification")).get("assurance_process")).get("policy"));
+        }
+        if (expectedClaims.expectedLocality != null) {
+            Assert.assertEquals(expectedClaims.expectedLocality,
+                    ((Map<String, Object>) ((Map<String, Object>) verifiedClaims.get("claims")).get("address")).get("locality"));
+        }
+        if (expectedClaims.expectedAssuranceDetailsSize != null) {
+            Assert.assertEquals(expectedClaims.expectedAssuranceDetailsSize.intValue(),
+                    ((List) ((Map<String, Object>) ((Map<String, Object>) verifiedClaims.get("verification")).get("assurance_process")).get("assurance_details")).size());
+        }
+        if (expectedClaims.expectedType != null) {
+            Assert.assertEquals(expectedClaims.expectedType,
+                    ((Map<String, Object>) ((List) ((Map<String, Object>) verifiedClaims.get("verification")).get("evidence")).get(0)).get("type"));
+        }
+        if (expectedClaims.expectedOrganization != null) {
+            Assert.assertEquals(expectedClaims.expectedOrganization,
+                    ((Map<String, Object>) ((List) ((Map<String, Object>) ((List) ((Map<String, Object>) verifiedClaims.get("verification")).get("evidence")).get(0)).get("check_details")).get(0)).get("organization"));
+        }
+
+    }
+
+    private ProtocolMappersResource setIdaProtocolMapper(String isIdTokenTrue, String isAccessTokenTrue, String isUserinfoTrue) {
+        ProtocolMapperRepresentation idaProtocolMapper = ModelToRepresentation.toRepresentation(createClaimMapper("ida"));
+        Map<String, String> config = new HashMap<>();
+        config.put(IdaHttpConnector.IDA_EXTERNAL_STORE_NAME, TestApplicationResourceUrls.getVerifiedClaimsUri());
+        if (isIdTokenTrue != null) {
+            config.put("id.token.claim", isIdTokenTrue);
+        }
+        if (isAccessTokenTrue != null) {
+            config.put("access.token.claim", isAccessTokenTrue);
+        }
+        if (isUserinfoTrue != null) {
+            config.put("userinfo.token.claim", isUserinfoTrue);
+        }
+        idaProtocolMapper.setConfig(config);
+        ProtocolMappersResource protocolMappers = ApiUtil.findClientResourceByClientId(adminClient.realm("test"), "test-app").getProtocolMappers();
+        protocolMappers.createMapper(Arrays.asList(idaProtocolMapper));
+        return protocolMappers;
+    }
+
+    private void deleteIdaProtocolMapper(ProtocolMappersResource protocolMappers) {
+        ProtocolMapperRepresentation mapper = ProtocolMapperUtil.getMapperByNameAndProtocol(protocolMappers, OIDCLoginProtocol.LOGIN_PROTOCOL, "ida");
+        if (mapper != null) {
+            protocolMappers.delete(mapper.getId());
+        }
+    }
+
+    private static ProtocolMapperModel createClaimMapper(String name) {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+        mapper.setName(name);
+        mapper.setProtocolMapper(IDA_PROVIDER_ID);
+        mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        mapper.setConfig(Collections.emptyMap());
+        return mapper;
+    }
+
+    private void setRequestClaims(String idTokenVerification, String idTokenClaims, String userInfoVerification, String userInfoClaims) throws IOException {
+        ClaimsRepresentation claimsRepresentation = new ClaimsRepresentation();
+
+        // Set idtoken claims
+        Map<String, ClaimsRepresentation.ClaimValue> idTokenVerifiedClaims = new HashMap<>();
+        ClaimsRepresentation.ClaimValue idTokenClaimValue = new ClaimsRepresentation.ClaimValue();
+
+        if (idTokenVerification != null) {
+            idTokenClaimValue.setVerification(JsonSerialization.readValue(idTokenVerification, Map.class));
+        }
+        if (idTokenClaims != null) {
+            idTokenClaimValue.setClaims(JsonSerialization.readValue(idTokenClaims, Map.class));
+        }
+        idTokenVerifiedClaims.put("verified_claims", idTokenClaimValue);
+        claimsRepresentation.setIdTokenClaims(idTokenVerifiedClaims);
+
+        // Set userinfo claims
+        Map<String, ClaimsRepresentation.ClaimValue> userInfoVerifiedClaims = new HashMap<>();
+        ClaimsRepresentation.ClaimValue userInfoClaimValue = new ClaimsRepresentation.ClaimValue();
+        if (userInfoVerification != null) {
+            userInfoClaimValue.setVerification(JsonSerialization.readValue(userInfoVerification, Map.class));
+        }
+        if (userInfoClaims != null) {
+            userInfoClaimValue.setClaims(JsonSerialization.readValue(userInfoClaims, Map.class));
+        }
+        userInfoVerifiedClaims.put("verified_claims", userInfoClaimValue);
+        claimsRepresentation.setUserinfoClaims(userInfoVerifiedClaims);
+
+        oauth.claims(claimsRepresentation);
+    }
+
+    private OAuthClient.AccessTokenResponse browserLogin(String clientSecret, String username, String password) {
+        OAuthClient.AuthorizationEndpointResponse authsEndpointResponse = oauth.doLogin(username, password);
+        return oauth.doAccessTokenRequest(authsEndpointResponse.getCode(), clientSecret);
+    }
+
+    private static class ExpectedClaims {
+        private String expectedGivenName = null;
+        private String expectedTrustFramework = null;
+        private String expectedFamilyName = null;
+        private String expectedTime = null;
+        private String expectedLocality = null;
+        private Integer expectedAssuranceDetailsSize = null;
+        private String expectedType = null;
+        private String expectedOrganization = null;
+
+        private String expectedBirthdate = null;
+
+        private String expectedPolicy = null;
+
+        public void setExpectedGivenName(String expectedGivenName) {
+            this.expectedGivenName = expectedGivenName;
+        }
+
+        public void setExpectedTrustFramework(String expectedTrustFramework) {
+            this.expectedTrustFramework = expectedTrustFramework;
+        }
+
+        public void setExpectedTime(String expectedTime) {
+            this.expectedTime = expectedTime;
+        }
+
+        public void setExpectedLocality(String expectedLocality) {
+            this.expectedLocality = expectedLocality;
+        }
+
+        public void setExpectedAssuranceDetailsSize(Integer expectedAssuranceDetailsSize) {
+            this.expectedAssuranceDetailsSize = expectedAssuranceDetailsSize;
+        }
+
+        public void setExpectedType(String expectedType) {
+            this.expectedType = expectedType;
+        }
+
+        public void setExpectedOrganization(String expectedOrganization) {
+            this.expectedOrganization = expectedOrganization;
+        }
+
+        public void setExpectedBirthdate(String expectedBirthdate) {
+            this.expectedBirthdate = expectedBirthdate;
+        }
+
+        public void setExpectedPolicy(String expectedPolicy) {
+            this.expectedPolicy = expectedPolicy;
+        }
+    }
+}


### PR DESCRIPTION
To support OpenID Connect for Identity Assurance 1.0 (OIDC4IDA or IDA)*1 in Keycloak, implement the following specifications.
Assume that the user's verified claims have been stored in the external store.

1. Setting the URL of the external store
Set the external store URL in the protocolMapper settings screen.

2. In the execution of the token (userinfo) endpoint, obtain the verified claims of a user verified
 by the token endpoint from the external store specified in Step1.*2

3. Filtering verified claims obtained from an external store
Filtering the verified claims in the request claims specified in the auth endpoint's claims query

4. Set the filtered claim to id_token, access_token or UserInfo.

*1,Specifications for OpenID Connect for Identity Assurance 1.0
https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html

*2,About an IF with an external store
The default is HTTP, but it can be changed with SPI.
The response from the external store is the specification returned in JSON format as defined below.
https://bitbucket.org/openid/ekyc-ida/src/master/schema/verified_claims.json
