### PR TITLE
Align naming of OTP policy window setting with actual semantics (#20469)

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/otp-policies.adoc
+++ b/docs/documentation/server_admin/topics/authentication/otp-policies.adoc
@@ -53,8 +53,8 @@ The default algorithm is SHA1. The other, more secure options are SHA256 and SHA
 
 The length of the OTP.  Short OTPs are user-friendly, easier to type, and easier to remember. Longer OTPs are more secure than shorter OTPs.
 
-===== Look ahead window
-The number of intervals the server attempts to match the hash. This option is present in {project_name} if the clock of the TOTP generator or authentication server become out-of-sync. The default value of 1 is adequate. This option is present in {project_name} to cover when the user's counter gets ahead of the server.
+===== Look around window
+The number of previous and following intervals the server attempts to match the hash. This option is present in {project_name} if the clock of the TOTP generator or authentication server become out-of-sync. The default value of 1 is adequate. This option is present in {project_name} to cover when the user's counter gets ahead of the server.
 
 ===== Initial counter
 

--- a/js/apps/admin-ui/public/locales/en/authentication-help.json
+++ b/js/apps/admin-ui/public/locales/en/authentication-help.json
@@ -12,6 +12,7 @@
   "webAuthnPolicyRpEntityName": "Human-readable server name as WebAuthn Relying Party",
   "otpHashAlgorithm": "What hashing algorithm should be used to generate the OTP.",
   "otpPolicyDigits": "How many digits should the OTP have?",
+  "lookAround": "How far around should the server look just in case the token generator and server are out of time sync or counter sync?",
   "lookAhead": "How far ahead should the server look just in case the token generator and server are out of time sync or counter sync?",
   "otpPolicyPeriod": "How many seconds should an OTP token be valid? Defaults to 30 seconds.",
   "otpPolicyCodeReusable": "Possibility to use the same OTP code again after successful authentication.",

--- a/js/apps/admin-ui/public/locales/en/authentication-help.json
+++ b/js/apps/admin-ui/public/locales/en/authentication-help.json
@@ -13,7 +13,6 @@
   "otpHashAlgorithm": "What hashing algorithm should be used to generate the OTP.",
   "otpPolicyDigits": "How many digits should the OTP have?",
   "lookAround": "How far around should the server look just in case the token generator and server are out of time sync or counter sync?",
-  "lookAhead": "How far ahead should the server look just in case the token generator and server are out of time sync or counter sync?",
   "otpPolicyPeriod": "How many seconds should an OTP token be valid? Defaults to 30 seconds.",
   "otpPolicyCodeReusable": "Possibility to use the same OTP code again after successful authentication.",
   "supportedApplications": "Applications that are known to work with the current OTP policy",

--- a/js/apps/admin-ui/public/locales/en/authentication.json
+++ b/js/apps/admin-ui/public/locales/en/authentication.json
@@ -21,6 +21,7 @@
   },
   "otpHashAlgorithm": "OTP hash algorithm",
   "otpPolicyDigits": "Number of digits",
+  "lookAround": "Look around window",
   "lookAhead": "Look ahead window",
   "otpPolicyPeriod": "OTP Token period",
   "otpPolicyPeriodErrorHint": "Value needs to be between 1 second and 2 minutes",

--- a/js/apps/admin-ui/public/locales/en/authentication.json
+++ b/js/apps/admin-ui/public/locales/en/authentication.json
@@ -22,7 +22,6 @@
   "otpHashAlgorithm": "OTP hash algorithm",
   "otpPolicyDigits": "Number of digits",
   "lookAround": "Look around window",
-  "lookAhead": "Look ahead window",
   "otpPolicyPeriod": "OTP Token period",
   "otpPolicyPeriodErrorHint": "Value needs to be between 1 second and 2 minutes",
   "otpPolicyCodeReusable": "Reusable token",

--- a/js/apps/admin-ui/public/locales/ja/authentication.json
+++ b/js/apps/admin-ui/public/locales/ja/authentication.json
@@ -15,7 +15,6 @@
   },
   "otpHashAlgorithm": "OTPハッシュ・アルゴリズム",
   "otpPolicyDigits": "桁数",
-  "lookAhead": "先読みウィンドウ",
   "otpPolicyPeriod": "OTPトークンの期間",
   "initialCounter": "初期カウンター",
   "webAuthnPolicySignatureAlgorithms": "署名アルゴリズム",

--- a/js/apps/admin-ui/public/locales/lt/authentication.json
+++ b/js/apps/admin-ui/public/locales/lt/authentication.json
@@ -12,7 +12,6 @@
   },
   "otpHashAlgorithm": "OTP maišos algoritmas",
   "otpPolicyDigits": "Skaitmenų skaičius",
-  "lookAhead": "Neatitikimo langas",
   "otpPolicyPeriod": "OTP rakto galiojimo intervalas",
   "initialCounter": "Pradinė skaitliuko reikšmė",
   "attestationPreference": {

--- a/js/apps/admin-ui/public/locales/no/authentication.json
+++ b/js/apps/admin-ui/public/locales/no/authentication.json
@@ -12,7 +12,6 @@
   },
   "otpHashAlgorithm": "OTP hash-algoritme",
   "otpPolicyDigits": "Antall siffer",
-  "lookAhead": "Look Ahead Window",
   "otpPolicyPeriod": "Engangskode token",
   "initialCounter": "Initiell teller",
   "attestationPreference": {

--- a/js/apps/admin-ui/public/locales/pt-BR/authentication.json
+++ b/js/apps/admin-ui/public/locales/pt-BR/authentication.json
@@ -12,7 +12,6 @@
   },
   "otpHashAlgorithm": "Algoritmo de hash OTP",
   "otpPolicyDigits": "Quantidade de dígitos",
-  "lookAhead": "Look Ahead Window",
   "otpPolicyPeriod": "Período de token OTP ",
   "initialCounter": "Contador inicial",
   "attestationPreference": {

--- a/js/apps/admin-ui/public/locales/ru/authentication.json
+++ b/js/apps/admin-ui/public/locales/ru/authentication.json
@@ -12,7 +12,6 @@
   },
   "otpHashAlgorithm": "Алгоритм хеша OTP",
   "otpPolicyDigits": "Количество цифр",
-  "lookAhead": "Окно вперед",
   "otpPolicyPeriod": "Период токена OTP",
   "initialCounter": "Начальное значение счетчика",
   "attestationPreference": {

--- a/js/apps/admin-ui/public/locales/zh-CN/authentication-help.json
+++ b/js/apps/admin-ui/public/locales/zh-CN/authentication-help.json
@@ -12,7 +12,6 @@
   "webAuthnPolicyRpEntityName": "便于阅读的 WebAuthn依赖方的服务器名称",
   "otpHashAlgorithm": "应该使用什么哈希算法来生成 OTP。",
   "otpPolicyDigits": "OTP 应该有多少位数？",
-  "lookAhead": "如果令牌生成器和服务器不同步或计数器不同步，服务器应该向前查看多久？",
   "otpPolicyPeriod": "OTP 令牌应该多少秒有效？默认为 30 秒。",
   "otpPolicyCodeReusable": "验证成功后可以再次使用相同的 OTP 代码。",
   "supportedApplications": "已知适用于当前 OTP 策略的应用程序",

--- a/js/apps/admin-ui/public/locales/zh-CN/authentication.json
+++ b/js/apps/admin-ui/public/locales/zh-CN/authentication.json
@@ -21,7 +21,6 @@
   },
   "otpHashAlgorithm": "OTP哈希算法",
   "otpPolicyDigits": "位数",
-  "lookAhead": "前瞻窗口",
   "otpPolicyPeriod": "OTP 令牌周期",
   "otpPolicyPeriodErrorHint": "时间需要在 1 秒到 2 分钟之间",
   "otpPolicyCodeReusable": "可重复使用的令牌",

--- a/js/apps/admin-ui/src/authentication/policies/OtpPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/OtpPolicy.tsx
@@ -204,14 +204,14 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
           />
         </FormGroup>
         <FormGroup
-          label={t("lookAhead")}
+          label={t("lookAround")}
           labelIcon={
             <HelpItem
-              helpText={t("authentication-help:lookAhead")}
-              fieldLabelId="authentication:lookAhead"
+              helpText={t("authentication-help:lookAround")}
+              fieldLabelId="authentication:lookAround"
             />
           }
-          fieldId="lookAhead"
+          fieldId="lookAround"
         >
           <Controller
             name="otpPolicyLookAheadWindow"
@@ -225,7 +225,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
 
               return (
                 <NumberInput
-                  id="lookAhead"
+                  id="lookAround"
                   value={value}
                   min={MIN_VALUE}
                   onPlus={() => setValue(value + 1)}

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
@@ -81,7 +81,7 @@ public class TimeBasedOTP extends HmacOTP {
     public boolean validateTOTP(String token, byte[] secret) {
         long currentInterval = this.clock.getCurrentInterval();
 
-        for (int i = 0; i <= (lookAheadWindow * 2); i++) {
+        for (int i = 0; i <= (lookAroundWindow * 2); i++) {
             long delta = clockSkewIndexToDelta(i);
             long adjustedInterval = currentInterval + delta;
 

--- a/server-spi/src/main/java/org/keycloak/models/utils/HmacOTP.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/HmacOTP.java
@@ -36,12 +36,12 @@ public class HmacOTP {
     private static final int[] DIGITS_POWER = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000};
     protected final String algorithm;
     protected final int numberDigits;
-    protected final int lookAheadWindow;
+    protected final int lookAroundWindow;
 
     public HmacOTP(int numberDigits, String algorithm, int delayWindow) {
         this.numberDigits = numberDigits;
         this.algorithm = algorithm;
-        this.lookAheadWindow = delayWindow;
+        this.lookAroundWindow = delayWindow;
     }
 
     public static String generateSecret(int length) {
@@ -80,7 +80,7 @@ public class HmacOTP {
     public int validateHOTP(String token, byte[] key, int counter) {
 
         int newCounter = counter;
-        for (newCounter = counter; newCounter <= counter + lookAheadWindow; newCounter++) {
+        for (newCounter = counter; newCounter <= counter + lookAroundWindow; newCounter++) {
             String candidate = generateHOTP(key, newCounter);
             if (candidate.equals(token)) {
                 return newCounter + 1;


### PR DESCRIPTION
This PR uses the term "look-around" to describe the used OTP code lookup strategy.

Previously, the admin-ui incorrectly described the window setting as look-ahead although the implementation uses look-around semantics.

Note that this change affects only the admin-ui and the OTP implementation.

I  deliberately avoid changing RealmModel / Representation / persistence models to prevent the need for migration.

Fixes #20469

![image](https://github.com/keycloak/keycloak/assets/314690/753be00c-8679-4583-adc7-30e50c80231d)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
