### PR TITLE
Handle exceptions thrown when requesting `storage-access` permission

### DIFF
--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/3p-cookies-step1.html
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/3p-cookies-step1.html
@@ -29,9 +29,15 @@
         }
 
         // Otherwise, check whether unpartitioned cookie access has been granted to another same-site embed.
-        const permission = await navigator.permissions.query({
-          name: "storage-access",
-        });
+        let permission;
+
+        try {
+          permission = await navigator.permissions.query({
+            name: "storage-access",
+          });
+        } catch (error) {
+          return false;
+        }
 
         // If not, signal that there is no support.
         if (permission.state !== "granted") {


### PR DESCRIPTION
Adds an error handler when requesting the `storage-access` permission when checking 3rd-party cookie access. If an error is thrown, it falls back to the regular redirect flow to detect 3rd-party cookie support.

The Permission API will sometimes [throw exceptions](https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query#exceptions) when requesting access to storage, specifically in Safari this occurs more than in other browsers (likely it doesn't support the `storage-access` permission yet, see https://github.com/keycloak/keycloak/issues/21307#issuecomment-1613451532). This can result in the iframe timing out, failing the authentication check and leaving client applications in a unusable state.

Closes #21307