### PR TITLE
Fix for Email settings erased after any change on realm settings

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/EmailTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/EmailTab.tsx
@@ -11,7 +11,6 @@ import {
   PageSection,
   Switch,
 } from "@patternfly/react-core";
-import { useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
@@ -32,17 +31,18 @@ import "./realm-settings-section.css";
 
 type RealmSettingsEmailTabProps = {
   realm: RealmRepresentation;
+  save: (realm: RealmRepresentation) => void;
 };
 
 export const RealmSettingsEmailTab = ({
-  realm: initialRealm,
+  realm,
+  save,
 }: RealmSettingsEmailTabProps) => {
   const { t } = useTranslation("realm-settings");
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
   const currentUser = useCurrentUser();
 
-  const [realm, setRealm] = useState(initialRealm);
   const {
     register,
     control,
@@ -63,21 +63,6 @@ export const RealmSettingsEmailTab = ({
     name: "smtpServer.auth",
     defaultValue: "",
   });
-
-  const save = async (form: RealmRepresentation) => {
-    try {
-      const savedRealm = { ...realm, ...form };
-
-      // For default value, back end is expecting null instead of empty string
-      if (savedRealm.smtpServer?.port === "") savedRealm.smtpServer.port = null;
-
-      await adminClient.realms.update({ realm: realmName }, savedRealm);
-      setRealm(savedRealm);
-      addAlert(t("saveSuccess"), AlertVariant.success);
-    } catch (error) {
-      addError("realm-settings:saveError", error);
-    }
-  };
 
   const testConnection = async () => {
     const toNumber = (value: string) => Number(value);

--- a/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
+++ b/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
@@ -199,14 +199,15 @@ export const RealmSettingsTabs = ({
     }
 
     try {
-      await adminClient.realms.update(
-        { realm: realmName },
-        {
-          ...realm,
-          ...r,
-          id: r.realm,
-        }
-      );
+      const savedRealm = {
+        ...realm,
+        ...r,
+        id: r.realm,
+      };
+
+      // For default value, back end is expecting null instead of empty string
+      if (savedRealm.smtpServer?.port === "") savedRealm.smtpServer.port = null;
+      await adminClient.realms.update({ realm: realmName }, savedRealm);
       addAlert(t("saveSuccess"), AlertVariant.success);
     } catch (error) {
       addError("realm-settings:saveError", error);
@@ -293,7 +294,7 @@ export const RealmSettingsTabs = ({
             data-testid="rs-email-tab"
             {...emailTab}
           >
-            <RealmSettingsEmailTab realm={realm} />
+            <RealmSettingsEmailTab realm={realm} save={save} />
           </Tab>
           <Tab
             title={<TabTitleText>{t("themes")}</TabTitleText>}

--- a/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
+++ b/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
@@ -199,14 +199,16 @@ export const RealmSettingsTabs = ({
     }
 
     try {
-      const savedRealm = {
+      const savedRealm: RealmRepresentation = {
         ...realm,
         ...r,
         id: r.realm,
       };
 
-      // For default value, back end is expecting null instead of empty string
-      if (savedRealm.smtpServer?.port === "") savedRealm.smtpServer.port = null;
+      // For the default value, null is expected instead of an empty string.
+      if (savedRealm.smtpServer?.port === "") {
+        savedRealm.smtpServer = { ...savedRealm.smtpServer, port: null };
+      }
       await adminClient.realms.update({ realm: realmName }, savedRealm);
       addAlert(t("saveSuccess"), AlertVariant.success);
     } catch (error) {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Modified the save function in RealmSettingsTabs.tsx to save the email settings and removed the custom save function from EmailTab.tsx.

Closes #19746