### PR TITLE
Compare SSSD email ignoring the case

### DIFF
--- a/.github/scripts/run-ipa-tests.sh
+++ b/.github/scripts/run-ipa-tests.sh
@@ -24,7 +24,7 @@ if [[ "true" == "$1" ]]; then
 
   printf "%b" "password\n" | kinit admin
   ipa group-add --desc='test group' testgroup
-  ipa user-add emily --first=Emily --last=Jones --email=emily@jones.com --random
+  ipa user-add emily --first=Emily --last=Jones --email=Emily@jones.com --random
   ipa group-add-member testgroup --users=emily
   ipa user-add bart --first=bart --last=bart --email= --random
   ipa user-add david --first=david --last=david --random

--- a/federation/sssd/src/main/java/org/keycloak/federation/sssd/api/Sssd.java
+++ b/federation/sssd/src/main/java/org/keycloak/federation/sssd/api/Sssd.java
@@ -113,12 +113,9 @@ public class Sssd {
                 return false;
             }
             if (email != null) {
-                return email.equals(userModel.getEmail());
+                return email.equalsIgnoreCase(userModel.getEmail());
             }
-            if (email != userModel.getEmail()) {
-                return false;
-            }
-            return true;
+            return userModel.getEmail() == null;
         }
 
         @Override


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/21394

Just comparing the email ignoring the case. One ipa user is changed to have an email with a capital letter. Maybe we have to rethink how we are doing this later but for the moment I'm just fixing the issue directly.