### PR TITLE
Properly handle execeptions thrown by Promises in the `usePromise()` hook

### DIFF
--- a/js/apps/account-ui/src/utils/usePromise.ts
+++ b/js/apps/account-ui/src/utils/usePromise.ts
@@ -52,15 +52,23 @@ export function usePromise<T>(
     const { signal } = controller;
 
     async function handlePromise() {
-      const value = await factory(signal);
+      // Try to resolve the Promise, if it fails, check if it was aborted.
+      try {
+        callback(await factory(signal));
+      } catch (error) {
+        // Ignore errors caused by aborting the Promise.
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
 
-      if (!signal.aborted) {
-        callback(value);
+        // Rethrow other errors.
+        throw error;
       }
     }
 
     handlePromise();
 
+    // Abort the Promise when the component unmounts, or the dependencies change.
     return () => controller.abort();
   }, deps);
 }


### PR DESCRIPTION
Adds improved error handling for the `usePromise()` hook, this fixes an issue where the exceptions were not caught.