### PR TITLE
Handle ignored artifacts separately

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.quarkus.runtime.configuration;
+
+import org.keycloak.common.Profile;
+import org.keycloak.config.StorageOptions;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static org.keycloak.quarkus.runtime.Environment.getCurrentOrCreateFeatureProfile;
+
+/**
+ * Ignore particular artifacts based on build configuration
+ */
+public class IgnoredArtifacts {
+
+    public static Set<String> getDefaultIgnoredArtifacts() {
+        return new Builder()
+                .append(fips())
+                .append(storage())
+                .build();
+    }
+
+    // FIPS
+    public static final Set<String> FIPS_ENABLED = Set.of(
+            "org.bouncycastle:bcprov-jdk18on",
+            "org.bouncycastle:bcpkix-jdk18on",
+            "org.bouncycastle:bcutil-jdk18on",
+            "org.keycloak:keycloak-crypto-default"
+    );
+
+    public static final Set<String> FIPS_DISABLED = Set.of(
+            "org.keycloak:keycloak-crypto-fips1402",
+            "org.bouncycastle:bc-fips",
+            "org.bouncycastle:bctls-fips",
+            "org.bouncycastle:bcpkix-fips"
+    );
+
+    private static Set<String> fips() {
+        final Profile profile = getCurrentOrCreateFeatureProfile();
+        boolean isFipsEnabled = profile.getFeatures().get(Profile.Feature.FIPS);
+
+        return isFipsEnabled ? FIPS_ENABLED : FIPS_DISABLED;
+    }
+
+    // Map Store
+    public static final Set<String> MAP_STORE = Set.of(
+            "org.keycloak:keycloak-model-map-jpa",
+            "org.keycloak:keycloak-model-map-hot-rod",
+            "org.keycloak:keycloak-model-map",
+            "org.keycloak:keycloak-model-map-file"
+    );
+
+    private static Set<String> storage() {
+        Optional<String> storage = Configuration.getOptionalValue(
+                MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + StorageOptions.STORAGE.getKey());
+
+        return storage.isEmpty() ? MAP_STORE : emptySet();
+    }
+
+    /**
+     * Builder for artifacts aggregation
+     */
+    private static final class Builder {
+        private final Set<String> finalIgnoredArtifacts;
+
+        public Builder() {
+            this.finalIgnoredArtifacts = new HashSet<>();
+        }
+
+        public Builder append(Set<String> ignoredArtifacts) {
+            finalIgnoredArtifacts.addAll(ignoredArtifacts);
+            return this;
+        }
+
+        public Set<String> build() {
+            return finalIgnoredArtifacts;
+        }
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
@@ -1,22 +1,13 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
-import static org.keycloak.quarkus.runtime.Environment.getCurrentOrCreateFeatureProfile;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
-
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import org.keycloak.common.Profile;
-import org.keycloak.common.Profile.Feature;
 import org.keycloak.config.ClassLoaderOptions;
-import org.keycloak.config.StorageOptions;
 import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
 
 final class ClassLoaderPropertyMappers {
 
@@ -33,28 +24,7 @@ final class ClassLoaderPropertyMappers {
 
     private static Optional<String> resolveIgnoredArtifacts(Optional<String> value, ConfigSourceInterceptorContext context) {
         if (Environment.isRebuildCheck() || Environment.isRebuild()) {
-            Profile profile = getCurrentOrCreateFeatureProfile();
-            Set<String> ignoredArtifacts = new HashSet<>();
-
-            if (profile.getFeatures().get(Feature.FIPS)) {
-                ignoredArtifacts.addAll(List.of(
-                        "org.bouncycastle:bcprov-jdk18on", "org.bouncycastle:bcpkix-jdk18on", "org.bouncycastle:bcutil-jdk18on", "org.keycloak:keycloak-crypto-default"));
-            } else {
-                ignoredArtifacts.addAll(List.of(
-                        "org.keycloak:keycloak-crypto-fips1402", "org.bouncycastle:bc-fips", "org.bouncycastle:bctls-fips", "org.bouncycastle:bcpkix-fips"));
-            }
-
-            Optional<String> storage = Configuration.getOptionalValue(
-                    MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + StorageOptions.STORAGE.getKey());
-
-            if (storage.isEmpty()) {
-                ignoredArtifacts.add("org.keycloak:keycloak-model-map-jpa");
-                ignoredArtifacts.add("org.keycloak:keycloak-model-map-hot-rod");
-                ignoredArtifacts.add("org.keycloak:keycloak-model-map");
-                ignoredArtifacts.add("org.keycloak:keycloak-model-map-file");
-            }
-
-            return Optional.of(String.join(",", ignoredArtifacts));
+            return Optional.of(String.join(",", IgnoredArtifacts.getDefaultIgnoredArtifacts()));
         }
 
         return value;

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.configuration.test;
+
+import org.junit.Test;
+import org.keycloak.common.Profile;
+import org.keycloak.common.profile.PropertiesProfileConfigResolver;
+import org.keycloak.config.StorageOptions;
+import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
+import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+
+import java.util.Properties;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class IgnoredArtifactsTest {
+
+    @Test
+    public void fipsDisabled() {
+        var profile = Profile.defaults();
+        assertThat(profile.isFeatureEnabled(Profile.Feature.FIPS), is(false));
+
+        var ignoredArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
+        assertThat(ignoredArtifacts.containsAll(IgnoredArtifacts.FIPS_DISABLED), is(true));
+    }
+
+    @Test
+    public void fipsEnabled() {
+        Properties properties = new Properties();
+        properties.setProperty("keycloak.profile.feature.fips", "enabled");
+        var profile = Profile.configure(new PropertiesProfileConfigResolver(properties));
+
+        assertThat(profile.isFeatureEnabled(Profile.Feature.FIPS), is(true));
+
+        var ignoredArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
+        assertThat(ignoredArtifacts.containsAll(IgnoredArtifacts.FIPS_ENABLED), is(true));
+    }
+
+    @Test
+    public void ignoredMapStorage() {
+        var ignoredArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
+        assertThat(ignoredArtifacts.containsAll(IgnoredArtifacts.MAP_STORE), is(true));
+
+        Consumer<String> assertStorage = (storage) -> {
+            System.setProperty(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + StorageOptions.STORAGE.getKey(), storage);
+
+            try {
+                final var artifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
+                assertThat(artifacts.containsAll(IgnoredArtifacts.MAP_STORE), is(false));
+            } finally {
+                System.setProperty(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + StorageOptions.STORAGE.getKey(), "");
+            }
+        };
+
+        assertStorage.accept("jpa");
+        assertStorage.accept("hotrod");
+        assertStorage.accept("file");
+        assertStorage.accept("chm");
+    }
+}


### PR DESCRIPTION
Closes #22430
Follow-up of #20976

These changes separate the handling of the ignored artifacts from the property mapper for better manageability of ignored artifacts. As we can consider, we're gonna also exclude artifacts for various JDBC vendors and health/metrics based on the configuration. The property mapper handling would be pretty messy.