### PR TITLE
Use same Java version when starting Keycloak for Cypress tests

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -226,6 +226,12 @@ jobs:
         with:
           name: keycloak
 
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
       - name: Start Keycloak Server
         run: |
           tar xfvz keycloak-999.0.0-SNAPSHOT.tar.gz


### PR DESCRIPTION
Currently the Cypress tests are failing due to the fact that a different Java version (GitHub default) is used than when Keycloak is built. This PR adds a step to set up the same Java version for the Cypress tests.