### PR TITLE
Run Dependabot daily to reduce weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,18 @@ updates:
     open-pull-requests-limit: 999
     rebase-strategy: disabled
     schedule:
-      interval: weekly
-      day: saturday
+      interval: daily
+      time: 00:00
+      timezone: Etc/GMT
     labels:
       - area/dependencies
       - area/ci
   - package-ecosystem: npm
     directory: /themes/src/main/resources/theme/keycloak/common/resources
     schedule:
-      interval: weekly
-      day: saturday
+      interval: daily
+      time: 00:00
+      timezone: Etc/GMT
     open-pull-requests-limit: 999
     rebase-strategy: disabled
     labels:
@@ -30,8 +32,9 @@ updates:
     rebase-strategy: disabled
     versioning-strategy: increase
     schedule:
-      interval: weekly
-      day: saturday
+      interval: daily
+      time: 00:00
+      timezone: Etc/GMT
     labels:
       - area/dependencies
       - team/ui


### PR DESCRIPTION
Run Dependabot daily at midnight (GMT - Greenwich Mean Time) to reduce the amount of PRs on a single day of the week. Often these PRs have merge conflicts, requiring a lot of rebases and CI time to get them all merged. Merging them in as part of the daily process should reduce this friction.