### PR TITLE
Align database versions in Quarkus integration tests with the root pom

### DIFF
--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -152,9 +152,11 @@
                             <systemPropertyVariables>
                                 <kc.test.storage.database>true</kc.test.storage.database>
                                 <!--DB Container -->
-                                <kc.db.postgresql.container.image>postgres:alpine</kc.db.postgresql.container.image>
-                                <kc.db.mariadb.container.image>mariadb:10.5.9</kc.db.mariadb.container.image>
+                                <kc.db.postgresql.container.image>postgres:${postgresql.version}</kc.db.postgresql.container.image>
+                                <kc.db.mariadb.container.image>mariadb:${mariadb.version}</kc.db.mariadb.container.image>
+                                <kc.db.mysql.container.image>mysql:${mysql.version}</kc.db.mysql.container.image>
                                 <kc.infinispan.container.image>quay.io/infinispan/server:${infinispan.version}</kc.infinispan.container.image>
+                                <kc.db.mssql.container.image>mcr.microsoft.com/mssql/server:${mssql.version}</kc.db.mssql.container.image>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/quarkus/tests/integration/src/test/resources/container-license-acceptance.txt
+++ b/quarkus/tests/integration/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-latest
+mcr.microsoft.com/mssql/server:2022-latest

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
@@ -103,28 +103,27 @@ public class DatabaseContainer {
     }
 
     private GenericContainer<?> createContainer() {
-        String POSTGRES_IMAGE = System.getProperty("kc.db.postgresql.container.image", "postgres:alpine");
-        String MARIADB_IMAGE = System.getProperty("kc.db.mariadb.container.image", "mariadb:10.5.9");
-        String MYSQL_IMAGE = System.getProperty("kc.db.mysql.container.image", "mysql:latest");
+        String POSTGRES_IMAGE = System.getProperty("kc.db.postgresql.container.image");
+        String MARIADB_IMAGE = System.getProperty("kc.db.mariadb.container.image");
+        String MYSQL_IMAGE = System.getProperty("kc.db.mysql.container.image");
         String INFINISPAN_IMAGE = System.getProperty("kc.infinispan.container.image");
-        String MSSQL_IMAGE = System.getProperty("kc.db.mssql.container.image", "mcr.microsoft.com/mssql/server:2019-latest");
-
-        DockerImageName POSTGRES = DockerImageName.parse(POSTGRES_IMAGE).asCompatibleSubstituteFor("postgres");
-        DockerImageName MARIADB = DockerImageName.parse(MARIADB_IMAGE).asCompatibleSubstituteFor("mariadb");
-        DockerImageName MYSQL = DockerImageName.parse(MYSQL_IMAGE).asCompatibleSubstituteFor("mysql");
-        DockerImageName MSSQL = DockerImageName.parse(MSSQL_IMAGE).asCompatibleSubstituteFor("sqlserver");
+        String MSSQL_IMAGE = System.getProperty("kc.db.mssql.container.image");
 
         switch (alias) {
             case "postgres":
-                return configureJdbcContainer(new PostgreSQLContainer(POSTGRES));
+                DockerImageName POSTGRES = DockerImageName.parse(POSTGRES_IMAGE).asCompatibleSubstituteFor("postgres");
+                return configureJdbcContainer(new PostgreSQLContainer<>(POSTGRES));
             case "mariadb":
-                return configureJdbcContainer(new MariaDBContainer(MARIADB));
+                DockerImageName MARIADB = DockerImageName.parse(MARIADB_IMAGE).asCompatibleSubstituteFor("mariadb");
+                return configureJdbcContainer(new MariaDBContainer<>(MARIADB));
             case "mysql":
-                return configureJdbcContainer(new MySQLContainer(MYSQL));
+                DockerImageName MYSQL = DockerImageName.parse(MYSQL_IMAGE).asCompatibleSubstituteFor("mysql");
+                return configureJdbcContainer(new MySQLContainer<>(MYSQL));
             case "mssql":
-                return configureJdbcContainer(new MSSQLServerContainer(MSSQL));
+                DockerImageName MSSQL = DockerImageName.parse(MSSQL_IMAGE).asCompatibleSubstituteFor("sqlserver");
+                return configureJdbcContainer(new MSSQLServerContainer<>(MSSQL));
             case "infinispan":
-                return configureInfinispanUser(new GenericContainer(INFINISPAN_IMAGE))
+                return configureInfinispanUser(new GenericContainer<>(INFINISPAN_IMAGE))
                         .withExposedPorts(11222);
             default:
                 throw new RuntimeException("Unsupported database: " + alias);


### PR DESCRIPTION
Now it is using the same version that is used in the integration test and which is stated in the docs as the tested version.

Closes: #15411

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
