### PR TITLE
Using "Account is disabled" message (and also added new test case)

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsServiceChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsServiceChecks.java
@@ -153,7 +153,7 @@ public class LoginActionsServiceChecks {
         }
 
         if (! user.isEnabled()) {
-            throw new ExplainedVerificationException(Errors.USER_DISABLED, Messages.INVALID_USER);
+            throw new ExplainedVerificationException(Errors.USER_DISABLED, Messages.ACCOUNT_DISABLED);
         }
 
         if (userSetter != null) {


### PR DESCRIPTION
Closes #21473 

Using more specific message in case the user is disabled.
Added new test case (also tried to anticipate other test failures by running some of them locally).
