### PR TITLE
Align guava dependency with the Quarkus Platform BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
         <nashorn.version>15.4</nashorn.version>
         <ua-parser.version>1.5.4</ua-parser.version>
         <picketbox.version>5.0.3.Final</picketbox.version>
-        <google.guava.version>32.0.1-jre</google.guava.version>
         <xstream.version>1.4.20</xstream.version>
         <org.snakeyaml.snakeyaml-engine.version>2.6</org.snakeyaml.snakeyaml-engine.version>
 
@@ -573,12 +572,6 @@
                         <artifactId>jcommander</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${google.guava.version}</version>
             </dependency>
 
             <!-- Email Test Servers -->

--- a/services/src/main/java/org/keycloak/vault/FilesKeystoreVaultProvider.java
+++ b/services/src/main/java/org/keycloak/vault/FilesKeystoreVaultProvider.java
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer;
 
 import org.jboss.logging.Logger;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;

--- a/services/src/main/java/org/keycloak/vault/FilesPlainTextVaultProvider.java
+++ b/services/src/main/java/org/keycloak/vault/FilesPlainTextVaultProvider.java
@@ -2,7 +2,7 @@ package org.keycloak.vault;
 
 import org.jboss.logging.Logger;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;


### PR DESCRIPTION
Closes #21364

This is alignment with Quarkus BOMs. It is a small downgrade from 32.0.1 to 32.0.0 that Quarkus [uses](https://github.com/quarkusio/quarkus-platform/blob/3.2.0.Final/generated-platform-project/quarkus/bom/pom.xml#L568) but it should be ok from CVEs perspective.