### PR TITLE
Only run the pre-commit hooks when Husky is installed

### DIFF
--- a/js/.husky/pre-commit
+++ b/js/.husky/pre-commit
@@ -1,4 +1,14 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+
+# Get the path the the Husky script.
+FILE="$(dirname "$0")/_/husky.sh"
+
+# Exit if Husky is not installed.
+if [ ! -f "$FILE" ]; then
+  exit 0;
+fi
+
+# Run the Husky script, and pre-commit hooks.
+. $FILE
 cd js
 npx lint-staged


### PR DESCRIPTION
Only runs the pre-commit hooks in [Husky](https://typicode.github.io/husky/) if it is installed. This prevents an error message from appearing if the pre-commit hook is registered, but Husky is no longer installed (for example, when pruning the directories).