### PR TITLE
`keycloakCRName` and `realm` are no longer marked as required in KeycloakRealmImport CRD

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/realmimport/KeycloakRealmImportSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/realmimport/KeycloakRealmImportSpec.java
@@ -17,16 +17,15 @@
 package org.keycloak.operator.crds.v2alpha1.realmimport;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.fabric8.generator.annotation.Required;
 import org.keycloak.representations.idm.RealmRepresentation;
-
-import jakarta.validation.constraints.NotNull;
 
 public class KeycloakRealmImportSpec {
 
-    @NotNull
+    @Required
     @JsonPropertyDescription("The name of the Keycloak CR to reference, in the same namespace.")
     private String keycloakCRName;
-    @NotNull
+    @Required
     @JsonPropertyDescription("The RealmRepresentation to import into Keycloak.")
     private RealmRepresentation realm;
 


### PR DESCRIPTION
Closes #21607

(cherry picked from commit 6a3ea1a084bf7cf844c9330a42b425f2cb927760)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
