### PR TITLE
changes to speed up test times

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -54,11 +54,11 @@ public class ClusteringTest extends BaseOperatorTest {
     @Test
     public void testMultipleDeployments() throws InterruptedException {
         // given
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
 
         // another instance running off the same database
         // - should eventually give this a separate schema
-        var kc1 = K8sUtils.getDefaultKeycloakDeployment();
+        var kc1 = getTestKeycloakDeployment(true);
         kc1.getMetadata().setName("another-example");
         kc1.getSpec().getHostnameSpec().setHostname("another-example.com");
         // this is using the wrong tls-secret, but simply removing http spec renders the pod unstartable
@@ -109,7 +109,7 @@ public class ClusteringTest extends BaseOperatorTest {
     @Test
     public void testKeycloakScaleAsExpected() {
         // given
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(false);
         var crSelector = k8sclient.resource(kc);
         K8sUtils.deployKeycloak(k8sclient, kc, true);
 
@@ -196,7 +196,7 @@ public class ClusteringTest extends BaseOperatorTest {
     public void testKeycloakCacheIsConnected() throws Exception {
         // given
         Log.info("Setup");
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(false);
         var crSelector = k8sclient.resource(kc);
         K8sUtils.deployKeycloak(k8sclient, kc, false);
         var targetInstances = 3;

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -63,7 +63,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testIngressOnHTTP() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(false);
         kc.getSpec().getHttpSpec().setTlsSecret(null);
         kc.getSpec().getHttpSpec().setHttpEnabled(true);
         var hostnameSpecBuilder = new HostnameSpecBuilder()
@@ -89,7 +89,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testIngressOnHTTPS() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(false);
         var hostnameSpecBuilder = new HostnameSpecBuilder()
                 .withStrict(false)
                 .withStrictBackchannel(false);
@@ -142,7 +142,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testIngressHostname() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
         var hostnameSpec = new HostnameSpecBuilder().withHostname("foo.bar").build();
         kc.getSpec().setHostnameSpec(hostnameSpec);
 
@@ -170,7 +170,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testMainIngressDurability() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
         kc.getSpec().setIngressSpec(new IngressSpec());
         kc.getSpec().getIngressSpec().setIngressEnabled(true);
         kc.getSpec().getIngressSpec().setAnnotations(Map.of("haproxy.router.openshift.io/disable_cookies", "true"));
@@ -226,8 +226,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testCustomIngressDeletion() {
-
-        Keycloak defaultKeycloakDeployment = K8sUtils.getDefaultKeycloakDeployment();
+        Keycloak defaultKeycloakDeployment = getTestKeycloakDeployment(true);
         String kcDeploymentName = defaultKeycloakDeployment.getMetadata().getName();
         Resource<Ingress> customIngressDeployedManuallySelector = null;
         Ingress customIngressCreatedManually;
@@ -271,10 +270,10 @@ public class KeycloakIngressTest extends BaseOperatorTest {
             }
         }
     }
-    
+
     @Test
     public void testCustomIngressClassName() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
         kc.getSpec().setIngressSpec(new IngressSpecBuilder().withIngressClassName("nginx").build());
         K8sUtils.deployKeycloak(k8sclient, kc, true);
 
@@ -307,7 +306,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testCustomIngressAnnotations() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
         kc.getSpec().setIngressSpec(new IngressSpec());
         kc.getSpec().getIngressSpec().setIngressEnabled(true);
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class KeycloakServicesTest extends BaseOperatorTest {
     @Test
     public void testMainServiceDurability() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
         K8sUtils.deployKeycloak(k8sclient, kc, true);
         var service = new KeycloakService(k8sclient, kc);
         var serviceSelector = k8sclient.services().inNamespace(namespace).withName(service.getName());
@@ -84,7 +84,7 @@ public class KeycloakServicesTest extends BaseOperatorTest {
 
     @Test
     public void testDiscoveryServiceDurability() {
-        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(true);
         K8sUtils.deployKeycloak(k8sclient, kc, true);
         var discoveryService = new KeycloakDiscoveryService(k8sclient, kc);
         var discoveryServiceSelector = k8sclient.services().inNamespace(namespace).withName(discoveryService.getName());

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.keycloak.operator.Constants.KEYCLOAK_HTTPS_PORT;
 import static org.keycloak.operator.controllers.KeycloakDistConfigurator.getKeycloakOptionEnvVarName;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
-import static org.keycloak.operator.testsuite.utils.K8sUtils.getDefaultKeycloakDeployment;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.inClusterCurl;
 import static org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition.DONE;
 import static org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition.HAS_ERRORS;
@@ -81,7 +80,8 @@ public class RealmImportTest extends BaseOperatorTest {
     @Test
     public void testWorkingRealmImport() {
         // Arrange
-        var kc = getDefaultKeycloakDeployment();
+        var kc = getTestKeycloakDeployment(false);
+        kc.getSpec().setImage(null); // checks the job args for the base, not custom image
         kc.getSpec().setImagePullSecrets(Arrays.asList(new LocalObjectReferenceBuilder().withName("my-empty-secret").build()));
         deployKeycloak(k8sclient, kc, false);
 
@@ -98,9 +98,10 @@ public class RealmImportTest extends BaseOperatorTest {
                 .pollDelay(1, SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), DONE, false);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), STARTED, true);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), HAS_ERRORS, false);
+                    KeycloakRealmImport cr = crSelector.get();
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, DONE, false);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, STARTED, true);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, HAS_ERRORS, false);
                 });
 
         Awaitility.await()
@@ -108,9 +109,10 @@ public class RealmImportTest extends BaseOperatorTest {
                 .pollDelay(1, SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), DONE, true);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), STARTED, false);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), HAS_ERRORS, false);
+                    KeycloakRealmImport cr = crSelector.get();
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, DONE, true);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, STARTED, false);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, HAS_ERRORS, false);
                 });
         var job = k8sclient.batch().v1().jobs().inNamespace(namespace).withName("example-count0-kc").get();
         assertThat(job.getSpec().getTemplate().getMetadata().getLabels().get("app")).isEqualTo("keycloak-realm-import");
@@ -120,11 +122,10 @@ public class RealmImportTest extends BaseOperatorTest {
         assertThat(job.getSpec().getTemplate().getSpec().getImagePullSecrets().size()).isEqualTo(1);
         assertThat(job.getSpec().getTemplate().getSpec().getImagePullSecrets().get(0).getName()).isEqualTo("my-empty-secret");
 
-        var service = new KeycloakService(k8sclient, getDefaultKeycloakDeployment());
         String url =
-                "https://" + service.getName() + "." + namespace + ":" + KEYCLOAK_HTTPS_PORT + "/realms/count0";
+                "https://" + KeycloakService.getServiceName(kc) + "." + namespace + ":" + KEYCLOAK_HTTPS_PORT + "/realms/count0";
 
-        Awaitility.await().atMost(10, MINUTES).untilAsserted(() -> {
+        Awaitility.await().atMost(10, MINUTES).ignoreExceptions().untilAsserted(() -> {
             Log.info("Starting curl Pod to test if the realm is available");
             Log.info("Url: '" + url + "'");
             String curlOutput = inClusterCurl(k8sclient, namespace, url);
@@ -139,7 +140,7 @@ public class RealmImportTest extends BaseOperatorTest {
     @EnabledIfSystemProperty(named = OPERATOR_CUSTOM_IMAGE, matches = ".+")
     public void testWorkingRealmImportWithCustomImage() {
         // Arrange
-        var keycloak = getDefaultKeycloakDeployment();
+        var keycloak = getTestKeycloakDeployment(false);
         keycloak.getSpec().setImage(customImage);
         // Removing the Database so that a subsequent build will by default act on h2
         // TODO: uncomment the following line after resolution of: https://github.com/keycloak/keycloak/issues/11767
@@ -160,9 +161,10 @@ public class RealmImportTest extends BaseOperatorTest {
                 .pollDelay(5, SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), DONE, true);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), STARTED, false);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), HAS_ERRORS, false);
+                    KeycloakRealmImport cr = crSelector.get();
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, DONE, true);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, STARTED, false);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, HAS_ERRORS, false);
                 });
 
         assertThat(getJobArgs()).doesNotContain("build");
@@ -171,7 +173,7 @@ public class RealmImportTest extends BaseOperatorTest {
     @Test
     public void testNotWorkingRealmImport() {
         // Arrange
-        deployKeycloak(k8sclient, getDefaultKeycloakDeployment(), true); // make sure there are no errors due to missing KC Deployment
+        deployKeycloak(k8sclient, getTestKeycloakDeployment(false), true); // make sure there are no errors due to missing KC Deployment
 
         // Act
         K8sUtils.set(k8sclient, getClass().getResourceAsStream("/incorrect-realm.yaml"));
@@ -186,10 +188,10 @@ public class RealmImportTest extends BaseOperatorTest {
                             .resources(KeycloakRealmImport.class)
                             .inNamespace(namespace)
                             .withName("example-count0-kc");
-
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), DONE, false);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), STARTED, false);
-                    CRAssert.assertKeycloakRealmImportStatusCondition(crSelector.get(), HAS_ERRORS, true);
+                    KeycloakRealmImport cr = crSelector.get();
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, DONE, false);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, STARTED, false);
+                    CRAssert.assertKeycloakRealmImportStatusCondition(cr, HAS_ERRORS, true);
                 });
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -40,6 +40,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.UnsupportedSpec;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -93,7 +94,7 @@ public class PodTemplateTest {
 
         var deployment = new KeycloakDeployment(null, config, kc, existingDeployment, "dummy-admin");
 
-        return (StatefulSet) deployment.getReconciledResource().get();
+        return deployment.getReconciledResource().get();
     }
 
     private StatefulSet getDeployment(PodTemplateSpec podTemplate, StatefulSet existingDeployment) {
@@ -367,5 +368,17 @@ public class PodTemplateTest {
         var fourth = setUpRelativePath.apply("/some/");
         assertEquals("/some/health/ready", fourth.getReadinessProbe().getHttpGet().getPath());
         assertEquals("/some/health/live", fourth.getLivenessProbe().getHttpGet().getPath());
+    }
+
+    @Test
+    public void testDefaultArgs() {
+        // Arrange
+        PodTemplateSpec additionalPodTemplate = null;
+
+        // Act
+        var podTemplate = getDeployment(additionalPodTemplate).getSpec().getTemplate();
+
+        // Assert
+        assertThat(podTemplate.getSpec().getContainers().get(0).getArgs()).doesNotContain("--optimized");
     }
 }


### PR DESCRIPTION
There are several things going on here:

- removal of probe InitialDelaySeconds and changing the PeriodSeconds to 1.  I realize that this cuts the total time in half, but it still seems quite long.   This can be superceded by work on #21111

- broadly using the custom image if it's supplied (this can be documented or done with additional properties).  However the testHttpRelativePathWith tests don't pass with the custom-keycloak image, that seems to inhibit being able to set an alternative path.  The testWorkingRealmImport is dependent on a regular image in so much as it expects the job arguments to contain build.  If we like something like this approach we split of unit tests for specific non-custom conditions we want to test.

- change the curl logic to be installed once per namespace / test class

It does not go further and use pause pods, but from what I saw before around 1/3 of the integration tests don't need a running keycloak.

Closes #10731

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
