### PR TITLE
improve realm file to not switch randomly otpSupportedApplications by export

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -474,6 +474,7 @@ public class ModelToRepresentation {
                 .stream()
                 .filter(p -> p.supports(otpPolicy))
                 .map(OTPApplicationProvider::getName)
+                .sorted(String::compareTo)
                 .collect(Collectors.toList()));
 
         WebAuthnPolicy webAuthnPolicy = realm.getWebAuthnPolicy();


### PR DESCRIPTION
Hi community,

this PR is to solve a sorting problem i encounter, if i export the keyloak realm.

In my setup the keycloak (21.0.1) is running in an docker container. After editing the config i like to export the realm file. This is used to reload the configuration in development.
To export the realm i use `docker exec -it $CONTAINER_ID /opt/keycloak/bin/kc.sh export --dir /opt/keycloak/data/import/ --realm $REALM --users different_files`.

Each time i export the realm the field `otpSupportedApplications` is mixed up.
Eg.:
1. first:  `"otpSupportedApplications" : [ "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName", "totpAppFreeOTPName" ],`
2. second:  `"otpSupportedApplications" : [ "totpAppMicrosoftAuthenticatorName", "totpAppFreeOTPName", "totpAppGoogleName" ],`
3.  then fist one again and so on

This also happening without restarting the server.

For development the realm file is included in git. So each export i have to manual change it back.

I hopes this is the line of code fixes the problem in this big project.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
