### PR TITLE
Fixes update email for impersonated users

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -71,10 +71,7 @@ import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.ForbiddenException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
-import org.keycloak.services.managers.AuthenticationManager;
-import org.keycloak.services.managers.BruteForceProtector;
-import org.keycloak.services.managers.UserConsentManager;
-import org.keycloak.services.managers.UserSessionManager;
+import org.keycloak.services.managers.*;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
@@ -146,7 +143,7 @@ public class UserResource {
     protected final KeycloakSession session;
 
     protected final HttpHeaders headers;
-    
+
     public UserResource(KeycloakSession session, UserModel user, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
         this.auth = auth;
@@ -156,7 +153,7 @@ public class UserResource {
         this.adminEvent = adminEvent.resource(ResourceType.USER);
         this.headers = session.getContext().getRequestHeaders();
     }
-    
+
     /**
      * Update the user
      *
@@ -372,6 +369,9 @@ public class UserResource {
         String impersonator = adminUser.getUsername();
         userSession.setNote(IMPERSONATOR_ID.toString(), impersonatorId);
         userSession.setNote(IMPERSONATOR_USERNAME.toString(), impersonator);
+
+        AuthenticationSessionManager authenticationSessionManager = new AuthenticationSessionManager(session);
+        authenticationSessionManager.setAuthSessionCookie(userSession.getId(), realm);
 
         AuthenticationManager.createLoginCookie(session, realm, userSession.getUser(), userSession, session.getContext().getUri(), clientConnection);
         URI redirect = Urls.accountBase(session.getContext().getUri().getBaseUri()).build(realm.getName());


### PR DESCRIPTION
After impersonating a user the auth_session_id is not updated correctly, and therefore still contains the impersonated users session id. This will create errors on the account page for the impersonated user.

In our case after changing the email of the impersonated user, the user was redirected to the 'already logged in page' and was unable to use the app again, due to inconsistent state. 
With this fix, the user is redirected to the 'verify email page'. 

Closes #21690