### PR TITLE
Fixes Datasource 'default': JDBC resources leaked

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
@@ -51,6 +51,7 @@ public class StreamsUtil {
         if (iterator.hasNext()) {
             return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
         } else {
+            stream.close();
             throw ex;
         }
     }
@@ -58,7 +59,7 @@ public class StreamsUtil {
     /**
      * Returns the original stream that is limited with {@link Stream#skip(long) skip} and
      * {@link Stream#limit(long) limit} functions based on values of {@code first} and {@code max} parameters.
-     * 
+     *
      * @param originalStream Stream to be limited.
      * @param first Index of first item to be returned by the stream. Ignored if negative, zero {@code null}.
      * @param max Maximum number of items to be returned by the stream. Ignored if negative or {@code null}.


### PR DESCRIPTION
In case of an exception when loading the realms list, the underlying JDBC resource stream is not closed before throwing. Therefore an error occurs in the log and the resource is leaked: 
`
"Datasource '<default>': JDBC resources leaked: 1 ResultSet(s) and 1 Statement(s)",
`

Closes #21691
