### PR TITLE
Handle error when Microsoft Graph API /me returns not successful

### DIFF
--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
@@ -69,9 +69,8 @@ public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider im
     protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
         try {
             JsonNode profile = SimpleHttp.doGet(PROFILE_URL, session).auth(accessToken).asJson();
-            String error = getJsonProperty(profile, "error");
-            if (error != null) {
-                throw new IdentityBrokerException("Error in Microsoft Graph API response: '" + error + "' payload: " + profile.toString());
+            if (profile.has("error") && !profile.get("error").isNull()) {
+                throw new IdentityBrokerException("Error in Microsoft Graph API response. Payload: " + profile.toString());
             }
             return extractIdentityFromProfile(null, profile);
         } catch (Exception e) {

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
@@ -69,6 +69,10 @@ public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider im
     protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
         try {
             JsonNode profile = SimpleHttp.doGet(PROFILE_URL, session).auth(accessToken).asJson();
+            String error = getJsonProperty(profile, "error");
+            if (error != null) {
+                throw new IdentityBrokerException("Error in Microsoft Graph API response: '" + error + "' payload: " + profile.toString());
+            }
             return extractIdentityFromProfile(null, profile);
         } catch (Exception e) {
             throw new IdentityBrokerException("Could not obtain user profile from Microsoft Graph", e);


### PR DESCRIPTION
Response from Microsoft Graph API /me can be error too. So if that happens, throw an exception instead of trying to extract the user id.

It happened to me that if the scopes did not contain `https://graph.microsoft.com/User.Read`, the login would fail. Error log was like:

```log
ERROR [org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider] (executor-thread-20) Failed to make identity provider oauth callback: org.keycloak.broker.provider.IdentityBrokerException: Could not obtain user profile from Microsoft Graph
	at org.keycloak.social.microsoft.MicrosoftIdentityProvider.doGetFederatedIdentity(MicrosoftIdentityProvider.java:74)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.getFederatedIdentity(AbstractOAuth2IdentityProvider.java:305)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider$Endpoint.authResponse(AbstractOAuth2IdentityProvider.java:505)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	...
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: No identifier provider for identity.
	at org.keycloak.broker.provider.BrokeredIdentityContext.<init>(BrokeredIdentityContext.java:55)
	at org.keycloak.social.microsoft.MicrosoftIdentityProvider.extractIdentityFromProfile(MicrosoftIdentityProvider.java:81)
	at org.keycloak.social.microsoft.MicrosoftIdentityProvider.doGetFederatedIdentity(MicrosoftIdentityProvider.java:72)
	... 50 more
```

There's no logging of the real response, so we had trouble finding the cause of the issue. With remote debugging we found it finally:

```json
 {
  "error": {
    "code": "UnknownError",
    "message": "",
    "innerError": {
      "date": "2023-07-14T09:50:41",
      "request-id": "aeaf24c5-2498-4c0c-8adb-d6e33406fce5",
      "client-request-id": "aeaf24c5-248adb-98-4c0c-d6e33406fce5"
    }
  }
}
```

Wasn't very helpful and finally we found the cause by just good guessing, trial and error style, the `https://graph.microsoft.com/User.Read` missing from the scopes which allows /me.
