### PR TITLE
Default X-XSS-Protection value

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/BrowserSecurityHeaders.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/BrowserSecurityHeaders.java
@@ -28,7 +28,7 @@ public enum BrowserSecurityHeaders {
     CONTENT_SECURITY_POLICY_REPORT_ONLY("contentSecurityPolicyReportOnly", "Content-Security-Policy-Report-Only", ""),
     X_CONTENT_TYPE_OPTIONS("xContentTypeOptions", "X-Content-Type-Options", "nosniff"),
     X_ROBOTS_TAG("xRobotsTag", "X-Robots-Tag", "none"),
-    X_XSS_PROTECTION("xXSSProtection", "X-XSS-Protection", "1; mode=block"),
+    X_XSS_PROTECTION("xXSSProtection", "X-XSS-Protection", "0"),
     STRICT_TRANSPORT_SECURITY("strictTransportSecurity", "Strict-Transport-Security", "max-age=31536000; includeSubDomains"),
     REFERRER_POLICY("referrerPolicy", "Referrer-Policy", "no-referrer");
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection the `X-XSS-Protection` feature is barely supported in any newer browser and can potentially even be a security risk.

IMO, looking at the supported browsers, it might even make sense to remove it completely.

This guy has an even stronger opinion on this: https://stackoverflow.com/a/57802070