### PR TITLE
Alternative languages should be able to fallback to the custom terms and conditions of the default language

### DIFF
--- a/themes/src/main/resources/theme/base/login/register-commons.ftl
+++ b/themes/src/main/resources/theme/base/login/register-commons.ftl
@@ -2,9 +2,17 @@
     <#if termsAcceptanceRequired??>
         <div class="form-group">
             <div class="${properties.kcInputWrapperClass!}">
-                ${msg("termsTitle")}
+                <#if msg("customTermsTitle") != "customTermsTitle">
+                    ${msg("customTermsTitle")}
+                <#else>
+                    ${msg("termsTitle")}
+                </#if>
                 <div id="kc-registration-terms-text">
-                    ${kcSanitize(msg("termsText"))?no_esc}
+                    <#if msg("customTermsText") != "customTermsText">
+                        ${kcSanitize(msg("customTermsText"))?no_esc}
+                    <#else>
+                        ${kcSanitize(msg("termsText"))?no_esc}
+                    </#if>
                 </div>
             </div>
         </div>

--- a/themes/src/main/resources/theme/base/login/terms.ftl
+++ b/themes/src/main/resources/theme/base/login/terms.ftl
@@ -1,10 +1,18 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayMessage=false; section>
     <#if section = "header">
-        ${msg("termsTitle")}
+        <#if msg("customTermsTitle") != "customTermsTitle">
+            ${msg("customTermsTitle")}
+        <#else>
+            ${msg("termsTitle")}
+        </#if>
     <#elseif section = "form">
     <div id="kc-terms-text">
-        ${kcSanitize(msg("termsText"))?no_esc}
+        <#if msg("customTermsText") != "customTermsText">
+            ${kcSanitize(msg("customTermsText"))?no_esc}
+        <#else>
+            ${kcSanitize(msg("termsText"))?no_esc}
+        </#if>
     </div>
     <form class="form-actions" action="${url.loginAction}" method="POST">
         <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="accept" id="kc-accept" type="submit" value="${msg("doAccept")}"/>


### PR DESCRIPTION
Fixes #21705

This change lets `terms.ftl` and `register-commons.ftl` support 2 new messages:
* `customTermsTitle` that will fallback to `termsTitle`
* `customTermsText` that will fallback to `termsText`

This is not a breaking change since `termsTitle` and `termsText` will keep being used in the absence of these new messages.

Theme implementors are expected to override `customTermsTitle` and `customTermsText` messages.