### PR TITLE
 Fixing Numbering Order for CONTRIBUTING.md and Comparison Method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ Here's a quick checklist for a good PR, more details below:
 3. One feature/change per PR
 4. One commit per PR
 5. PR rebased on main (`git rebase`, not `git pull`) 
-5. [Good descriptive commit message, with link to issue](#commit-messages-and-issue-linking)
-6. No changes to code not directly related to your PR
-7. Includes functional/integration test
-8. Includes documentation
+6. [Good descriptive commit message, with link to issue](#commit-messages-and-issue-linking)
+7. No changes to code not directly related to your PR
+8. Includes functional/integration test
+9. Includes documentation
 
 Once you have submitted your PR please monitor it for comments/feedback. We reserve the right to close inactive PRs if
 you do not respond within 2 weeks (bear in mind you can always open a new PR if it is closed due to inactivity).

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
@@ -68,7 +68,7 @@ public abstract class AbstractKeycloakAuthenticatorValve extends FormAuthenticat
             cache = false;
         } else if (Lifecycle.AFTER_START_EVENT.equals(event.getType())) {
         	keycloakInit();
-        } else if (event.getType() == Lifecycle.BEFORE_STOP_EVENT) {
+        } else if (event.getType().equals(Lifecycle.BEFORE_STOP_EVENT)) {
             beforeStop();
         }
     }

--- a/core/src/main/java/org/keycloak/representations/docker/DockerError.java
+++ b/core/src/main/java/org/keycloak/representations/docker/DockerError.java
@@ -60,7 +60,7 @@ public class DockerError {
 
         final DockerError that = (DockerError) o;
 
-        if (errorCode != that.errorCode) return false;
+        if (!errorCode.equals(that.errorCode)) return false;
         if (message != null ? !message.equals(that.message) : that.message != null) return false;
         return dockerErrorDetails != null ? dockerErrorDetails.equals(that.dockerErrorDetails) : that.dockerErrorDetails == null;
     }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserRequiredActionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserRequiredActionEntity.java
@@ -120,7 +120,7 @@ public class FederatedUserRequiredActionEntity {
 
             Key key = (Key) o;
 
-            if (action != key.action) return false;
+            if (!action.equals(key.action)) return false;
             if (userId != null ? !userId.equals(key.userId != null ? key.userId : null) : key.userId != null) return false;
 
             return true;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -517,7 +517,7 @@ public class CertificateValidator {
 
         logger.debugf("Certificate policies found: %s", String.join(",", policyList));
 
-        if (policyCheckMode == CERTIFICATE_POLICY_MODE_ANY)
+        if (policyCheckMode.equals(CERTIFICATE_POLICY_MODE_ANY))
         {
             boolean hasMatch = expectedPolicies.stream().anyMatch(p -> policyList.contains(p.toLowerCase()));
             if (!hasMatch) {


### PR DESCRIPTION
This PR addresses two key issues:

1.  It corrects the numbering order in the `CONTRIBUTING.md`  file, ensuring consistency and accuracy. 
2. It enhances the comparison logic by replacing the usage of the "==" operator with the appropriate "equals" method. 

These improvements significantly enhance the overall reliability and maintainability of the codebase.