### PR TITLE
Ensure that the flow tested to be deleted is a built in flow

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -104,13 +104,14 @@ public class FlowTest extends AbstractAuthenticationTest {
 
         // test that built-in flow cannot be deleted
         List<AuthenticationFlowRepresentation> flows = authMgmtResource.getFlows();
-        for (AuthenticationFlowRepresentation flow : flows) {
-            try {
-                authMgmtResource.deleteFlow(flow.getId());
-                Assert.fail("deleteFlow should fail for built in flow");
-            } catch (BadRequestException e) {
-                break;
-            }
+        AuthenticationFlowRepresentation builtInFlow = flows.stream().filter(AuthenticationFlowRepresentation::isBuiltIn).findAny().orElse(null);
+        Assert.assertNotNull("No built in flow in the realm", builtInFlow);
+        try {
+            authMgmtResource.deleteFlow(builtInFlow.getId());
+            Assert.fail("deleteFlow should fail for built in flow");
+        } catch (BadRequestException e) {
+            OAuth2ErrorRepresentation error = e.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            Assert.assertEquals("Can't delete built in flow", error.getError());
         }
 
         // try create new flow using alias of already existing flow


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/20763

Just choosing a built-in flow to test it cannot be deleted. My feeling is that another test was added that creates a new flow and it is returned first sometimes, that makes `FlowTest#testAddRemoveFlow` flaky.

Tested with mariadb, previously in my laptop it failed more or less 1 in 10, now I could run 100 times with no issues. Let's see if it works in the CI.
