### PR TITLE
removes the filtering of erroneous enum values

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -248,27 +248,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>filterEnum</id>
-                        <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <replaceregexp file="${project.build.directory}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml"
-                                   match="[^\n]*- ENUM\$VALUES\s*\n"
-                                   flags="g"
-                                   replace=""/>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
With the update to fabric8 6.7.2, this filtering is no longer needed

Closes #20935

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
