### PR TITLE
trigger REMOVE_TOTP event on user credential removal

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -87,6 +87,7 @@ public interface Details {
     String CREDENTIAL_TYPE = "credential_type";
     String SELECTED_CREDENTIAL_ID = "selected_credential_id";
     String AUTHENTICATION_ERROR_DETAIL = "authentication_error_detail";
+    String CREDENTIAL_USER_LABEL = "credential_user_label";
 
     String NOT_BEFORE = "not_before";
     String NUM_FAILURES = "num_failures";

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -214,7 +214,7 @@ public class AccountRestService {
     @Path("/credentials")
     public AccountCredentialResource credentials() {
         checkAccountApiEnabled();
-        return new AccountCredentialResource(session, user, auth);
+        return new AccountCredentialResource(session, user, auth, event);
     }
 
     @Path("/resources")


### PR DESCRIPTION
Add trigger for REMOVE_TOTP event when user deletes credential via user account REST API (and therefore via account-console)

Closes #15403


Maybe a more general EventType like `REMOVE_CREDENTIAL ` might be needed?