### PR TITLE
Add "created at" column to user credentials table in admin ui

### DIFF
--- a/js/apps/admin-ui/src/user/UserCredentials.tsx
+++ b/js/apps/admin-ui/src/user/UserCredentials.tsx
@@ -408,6 +408,7 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
                 <Th aria-hidden="true" />
                 <Th>{t("type")}</Th>
                 <Th>{t("userLabel")}</Th>
+                <Th>{t("createdAt")}</Th>
                 <Th>{t("data")}</Th>
                 <Th aria-hidden="true" />
                 <Th aria-hidden="true" />

--- a/js/apps/admin-ui/src/user/user-credentials/CredentialRow.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/CredentialRow.tsx
@@ -13,6 +13,7 @@ import type CredentialRepresentation from "@keycloak/keycloak-admin-client/lib/d
 import useToggle from "../../utils/useToggle";
 import useLocaleSort from "../../utils/useLocaleSort";
 import { CredentialDataDialog } from "./CredentialDataDialog";
+import useFormatDate from "../../utils/useFormatDate";
 
 type CredentialRowProps = {
   credential: CredentialRepresentation;
@@ -27,6 +28,7 @@ export const CredentialRow = ({
   toggleDelete,
   children,
 }: CredentialRowProps) => {
+  const formatDate = useFormatDate();
   const { t } = useTranslation("users");
   const [showData, toggleShow] = useToggle();
   const [kebabOpen, toggleKebab] = useToggle();
@@ -63,6 +65,7 @@ export const CredentialRow = ({
       )}
 
       <Td>{children}</Td>
+      <Td>{formatDate(new Date(credential.createdDate!))}</Td>
       <Td>
         <Button
           className="kc-showData-btn"


### PR DESCRIPTION
Adds the "Created at" column to the user credentials table in the admin ui

![image](https://github.com/keycloak/keycloak/assets/314690/cc91c6f1-1a4b-4f93-aa50-e6641e9ea14f)


Fixes #21746

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
