### PR TITLE
Adds a pod list rbac

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -32,6 +32,12 @@ rules:
       - patch
       - update
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
       - batch
     resources:
       - jobs


### PR DESCRIPTION
Unfortunately the minikube remote tests still pass even without this permission - I wasn't aware of this difference openshift handling.

I know fabric8 is still stuck at integration testing with openshift 3.11 - is there any desire around pushing to have something 4.x based runnable in a github action?

Closes #21814

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
