### PR TITLE
Add image references for offline installs

### DIFF
--- a/operator/scripts/create-olm-bundle.sh
+++ b/operator/scripts/create-olm-bundle.sh
@@ -71,6 +71,12 @@ yq ea -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env
 yq ea -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name": "POD_NAME", "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}}]' "$CSV_PATH"
 yq ea -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name": "OPERATOR_NAME", "value": "keycloak-operator"}]' "$CSV_PATH"
 
+# Add image references (both operator and operand) allowing offline (airgap installs) on OpenShift
+# See https://docs.openshift.com/container-platform/4.12/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks
+KEYCLOAK_IMAGE=`yq eval  '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env.[] | select(.name == "OPERATOR_KEYCLOAK_IMAGE") | .value' "$CSV_PATH"`
+yq ea -i ".spec.relatedImages += [{\"image\":\"$OPERATOR_DOCKER_IMAGE:$VERSION\", \"name\":\"OPERATOR_IMAGE\"}]" "$CSV_PATH"
+yq ea -i ".spec.relatedImages += [{\"image\":\"$KEYCLOAK_IMAGE\", \"name\":\"KEYCLOAK_IMAGE\"}]" "$CSV_PATH"
+
 { set +x; } 2>/dev/null
 echo ""
 echo "Created OLM bundle ok!"


### PR DESCRIPTION
Closes #15562
Closes #21827

Addresses https://github.com/keycloak/keycloak/issues/21827 and https://github.com/keycloak/keycloak/issues/15562 by adding the `relatedImages` list into Keycloak operator `ClusterServiceVersion`.

Tested by launching manually on top of nightly build:
```sh
$ pwd
/GitHub/keycloak/operator/scripts
$ ./create-olm-bundle.sh 22.0.1 22.0.0 quay.io/keycloak/keycloak-operator
```

which resulted with the following snippet added into `../olm/22.0.1/manifests/keycloak-operator.clusterserviceversion.yaml`:

```yaml
...
  relatedImages:
    - image: quay.io/keycloak/keycloak-operator:22.0.1
      name: OPERATOR_IMAGE
    - image: quay.io/keycloak/keycloak:nightly
      name: KEYCLOAK_IMAGE
```

-----

Given it's my very first contribution to this project, please be gentle :)
Yet, seriously, please clarify whether I actually modified the correct file (`create-olm-bundle.sh`) since I am not yet 100% sure this is the file which is used to generate the final operator CSV before operator bundle image is created. I do understand that quarkus bundle extension is used to create initial CSV template and then the shell script it used to add/remove things from the generated `*.clusterserviceversion.yaml` file. Please confirm or clarify what's the proper place to modify.

I am not sure got to have it properly tested in the automated way - seems that the build uses minikube for testing, with online installation of the operator / operand. In theory we could use some OpenShift (OCP) cluster where the images are mirrored into it, yet seems it would require building the whole testing framework with standing up OCP, etc - pls let me know.

If I failed to follow any of the rules in the Contributing guide, please let me know, it was not intentional.