### PR TITLE
Warnings about TLS properties on startup

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -64,11 +64,11 @@ final class HttpPropertyMappers {
                         .paramLabel("protocols")
                         .build(),
                 fromOption(HttpOptions.HTTPS_CERTIFICATE_FILE)
-                        .to("quarkus.http.ssl.certificate.file")
+                        .to("quarkus.http.ssl.certificate.files")
                         .paramLabel("file")
                         .build(),
                 fromOption(HttpOptions.HTTPS_CERTIFICATE_KEY_FILE)
-                        .to("quarkus.http.ssl.certificate.key-file")
+                        .to("quarkus.http.ssl.certificate.key-files")
                         .paramLabel("file")
                         .build(),
                 fromOption(HttpOptions.HTTPS_KEY_STORE_FILE


### PR DESCRIPTION
Fixes #21801

There are no other deprecated properties. There are no tests for the TLS properties and for such a change, I think it's not necessary to create some. These warnings disappeared. 

New properties can be found here: https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus.http.ssl.certificate.key-files

@vmuzikar @ahus1 Could you please review it?