### PR TITLE
Removes the initial delay seconds and drops the period to 1 second

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -241,9 +241,8 @@ public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> imp
 
         if (!containerBuilder.hasReadinessProbe()) {
             containerBuilder.withNewReadinessProbe()
-                .withInitialDelaySeconds(20)
-                .withPeriodSeconds(2)
-                .withFailureThreshold(250)
+                .withPeriodSeconds(10)
+                .withFailureThreshold(3)
                 .withNewHttpGet()
                 .withScheme(protocol)
                 .withNewPort(kcPort)
@@ -253,15 +252,25 @@ public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> imp
         }
         if (!containerBuilder.hasLivenessProbe()) {
             containerBuilder.withNewLivenessProbe()
-                .withInitialDelaySeconds(20)
-                .withPeriodSeconds(2)
-                .withFailureThreshold(150)
+                .withPeriodSeconds(10)
+                .withFailureThreshold(3)
                 .withNewHttpGet()
                 .withScheme(protocol)
                 .withNewPort(kcPort)
                 .withPath(kcRelativePath + "health/live")
                 .endHttpGet()
                 .endLivenessProbe();
+        }
+        if (!containerBuilder.hasStartupProbe()) {
+            containerBuilder.withNewStartupProbe()
+                .withPeriodSeconds(1)
+                .withFailureThreshold(600)
+                .withNewHttpGet()
+                .withScheme(protocol)
+                .withNewPort(kcPort)
+                .withPath(kcRelativePath + "health/started")
+                .endHttpGet()
+                .endStartupProbe();
         }
 
         // add in ports - there's no merging being done here


### PR DESCRIPTION
Separated these changes from https://github.com/keycloak/keycloak/pull/21658#discussion_r1270554809

With the values and probe implementations we currently have it doesn't seem to make sense to have a initial delay.  Also setting the period delay to 1 second, while having the total failure time, makes the probe more responsive to passing.

However it seems like there may be some cases where it's taking pods to become ready - such as starting against a database in a different AZ.  

We're currently just relying on the default smallrye liveness and startup probes.  I am not familar enough with how things are functioning to understand if the default startup probe would catch this situation - it seems like it would be tied to the notion of quarkus startup.

What @mabartos was suggesting on #21111 would be to add:

```
        if (!containerBuilder.hasStartupProbe()) {
            containerBuilder.withNewStartupProbe()
                .withPeriodSeconds(1)
                .withFailureThreshold(?)
                .withNewHttpGet()
                .withScheme(protocol)
                .withNewPort(kcPort)
                .withPath(kcRelativePath + "health/started")
                .endHttpGet()
                .endStartupProbe();
        }
```

I'm tested that and it seems to have a neglible impact on performance, so if it is effective in detecting "long startup" conditions, then we should consider adding it and reducing the other failure thresholds.

cc @vmuzikar 

Closes #21111

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
