### PR TITLE
Add logout other sessions checkbox to TOTP, webauthn and recovery authn codes setup pages

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/updateemail/UpdateEmailActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/updateemail/UpdateEmailActionToken.java
@@ -28,12 +28,19 @@ public class UpdateEmailActionToken extends DefaultActionToken {
 	private String oldEmail;
 	@JsonProperty("newEmail")
 	private String newEmail;
+    @JsonProperty("logoutSessions")
+    private Boolean logoutSessions;
 
-	public UpdateEmailActionToken(String userId, int absoluteExpirationInSecs, String oldEmail, String newEmail, String clientId){
+    public UpdateEmailActionToken(String userId, int absoluteExpirationInSecs, String oldEmail, String newEmail, String clientId) {
+          this(userId, absoluteExpirationInSecs, oldEmail, newEmail, clientId, null);
+    }
+
+	public UpdateEmailActionToken(String userId, int absoluteExpirationInSecs, String oldEmail, String newEmail, String clientId, Boolean logoutSessions){
 		super(userId, TOKEN_TYPE, absoluteExpirationInSecs, null);
 		this.oldEmail = oldEmail;
 		this.newEmail = newEmail;
 		this.issuedFor = clientId;
+        this.logoutSessions = Boolean.TRUE.equals(logoutSessions)? true : null;
 	}
 
 	private UpdateEmailActionToken(){
@@ -55,4 +62,12 @@ public class UpdateEmailActionToken extends DefaultActionToken {
 	public void setNewEmail(String newEmail) {
 		this.newEmail = newEmail;
 	}
+
+    public Boolean getLogoutSessions() {
+        return this.logoutSessions;
+    }
+
+    public void setLogoutSessions(Boolean logoutSessions) {
+        this.logoutSessions = Boolean.TRUE.equals(logoutSessions)? true : null;
+    }
 }

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/updateemail/UpdateEmailActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/updateemail/UpdateEmailActionTokenHandler.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import jakarta.ws.rs.core.Response;
 import org.keycloak.TokenVerifier;
+import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.actiontoken.AbstractActionTokenHandler;
 import org.keycloak.authentication.actiontoken.ActionTokenContext;
 import org.keycloak.authentication.actiontoken.TokenUtils;
@@ -73,6 +74,10 @@ public class UpdateEmailActionTokenHandler extends AbstractActionTokenHandler<Up
         }
 
         UpdateEmail.updateEmailNow(tokenContext.getEvent(), user, emailUpdateValidationResult);
+
+        if (Boolean.TRUE.equals(token.getLogoutSessions())) {
+            AuthenticatorUtil.logoutOtherSessions(tokenContext);
+        }
 
         tokenContext.getEvent().success();
 

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/RecoveryAuthnCodesAction.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/RecoveryAuthnCodesAction.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionFactory;
@@ -91,6 +92,10 @@ public class RecoveryAuthnCodesAction implements RequiredActionProvider, Require
         generatedUserLabel = httpReqParamsMap.getFirst(FIELD_USER_LABEL_HIDDEN);
 
         RecoveryAuthnCodesCredentialModel credentialModel = createFromValues(generatedCodes, generatedAtTime, generatedUserLabel);
+
+        if ("on".equals(httpReqParamsMap.getFirst("logout-sessions"))) {
+            AuthenticatorUtil.logoutOtherSessions(reqActionContext);
+        }
 
         recoveryCodeCredentialProvider.createCredential(reqActionContext.getRealm(), reqActionContext.getUser(),
                 credentialModel);

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateEmail.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionFactory;
@@ -97,16 +98,20 @@ public class UpdateEmail implements RequiredActionProvider, RequiredActionFactor
             return;
         }
 
+        final boolean logoutSessions = "on".equals(formData.getFirst("logout-sessions"));
         if (!realm.isVerifyEmail() || Validation.isBlank(newEmail)
                 || Objects.equals(user.getEmail(), newEmail) && user.isEmailVerified()) {
+            if (logoutSessions) {
+                AuthenticatorUtil.logoutOtherSessions(context);
+            }
             updateEmailWithoutConfirmation(context, emailUpdateValidationResult);
             return;
         }
 
-        sendEmailUpdateConfirmation(context);
+        sendEmailUpdateConfirmation(context, logoutSessions);
     }
 
-    private void sendEmailUpdateConfirmation(RequiredActionContext context) {
+    private void sendEmailUpdateConfirmation(RequiredActionContext context, boolean logoutSessions) {
         UserModel user = context.getUser();
         String oldEmail = user.getEmail();
         String newEmail = context.getHttpRequest().getDecodedFormParameters().getFirst(UserModel.EMAIL);
@@ -119,7 +124,7 @@ public class UpdateEmail implements RequiredActionProvider, RequiredActionFactor
         AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
 
         UpdateEmailActionToken actionToken = new UpdateEmailActionToken(user.getId(), Time.currentTime() + validityInSecs,
-                oldEmail, newEmail, authenticationSession.getClient().getClientId());
+                oldEmail, newEmail, authenticationSession.getClient().getClientId(), logoutSessions);
 
         String link = Urls
                 .actionTokenBuilder(uriInfo.getBaseUri(), actionToken.serialize(session, realm, uriInfo),

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
@@ -29,15 +29,12 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ModelException;
-import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -95,9 +92,7 @@ public class UpdatePassword implements RequiredActionProvider, RequiredActionFac
     public void processAction(RequiredActionContext context) {
         EventBuilder event = context.getEvent();
         AuthenticationSessionModel authSession = context.getAuthenticationSession();
-        RealmModel realm = context.getRealm();
         UserModel user = context.getUser();
-        KeycloakSession session = context.getSession();
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
         event.event(EventType.UPDATE_PASSWORD);
         String passwordNew = formData.getFirst("password-new");
@@ -125,13 +120,8 @@ public class UpdatePassword implements RequiredActionProvider, RequiredActionFac
             return;
         }
 
-        if ("on".equals(formData.getFirst("logout-sessions")))
-        {
-            session.sessions().getUserSessionsStream(realm, user)
-                    .filter(s -> !Objects.equals(s.getId(), authSession.getParentSession().getId()))
-                    .collect(Collectors.toList()) // collect to avoid concurrent modification as backchannelLogout removes the user sessions.
-                    .forEach(s -> AuthenticationManager.backchannelLogout(session, realm, s, session.getContext().getUri(),
-                            context.getConnection(), context.getHttpRequest().getHttpHeaders(), true));
+        if ("on".equals(formData.getFirst("logout-sessions"))) {
+            AuthenticatorUtil.logoutOtherSessions(context);
         }
 
         try {

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
@@ -41,9 +41,7 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
@@ -18,6 +18,7 @@
 package org.keycloak.authentication.requiredactions;
 
 import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
@@ -103,6 +104,10 @@ public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory
                     .createResponse(UserModel.RequiredAction.CONFIGURE_TOTP);
             context.challenge(challenge);
             return;
+        }
+
+        if ("on".equals(formData.getFirst("logout-sessions"))) {
+            AuthenticatorUtil.logoutOtherSessions(context);
         }
 
         if (!CredentialHelper.createOTPCredential(context.getSession(), context.getRealm(), context.getUser(), challengeResponse, credentialModel)) {

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -35,6 +35,7 @@ import com.webauthn4j.data.AuthenticatorTransport;
 import org.jboss.logging.Logger;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.WebAuthnConstants;
+import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
@@ -52,6 +53,8 @@ import org.keycloak.events.Errors;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.WebAuthnPolicy;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
+import org.keycloak.utils.StringUtil;
 
 import com.webauthn4j.converter.util.ObjectConverter;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
@@ -73,8 +76,6 @@ import com.webauthn4j.validator.attestation.statement.tpm.TPMAttestationStatemen
 import com.webauthn4j.validator.attestation.statement.u2f.FIDOU2FAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessValidator;
-import org.keycloak.models.credential.WebAuthnCredentialModel;
-import org.keycloak.utils.StringUtil;
 
 import static org.keycloak.WebAuthnConstants.REG_ERR_DETAIL_LABEL;
 import static org.keycloak.WebAuthnConstants.REG_ERR_LABEL;
@@ -224,6 +225,10 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         }
 
         RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, isUserVerificationRequired);
+
+        if ("on".equals(params.getFirst("logout-sessions"))) {
+            AuthenticatorUtil.logoutOtherSessions(context);
+        }
 
         WebAuthnRegistrationManager webAuthnRegistrationManager = createWebAuthnRegistrationManager();
         try {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/UpdateEmailPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/UpdateEmailPage.java
@@ -20,11 +20,12 @@ import static org.keycloak.testsuite.util.UIUtils.clickLink;
 import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 
 import org.keycloak.models.UserModel;
+import org.keycloak.testsuite.pages.LogoutSessionsPage;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
-public class UpdateEmailPage extends RequiredActions {
+public class UpdateEmailPage extends LogoutSessionsPage {
 
     @FindBy(id = "email")
     private WebElement emailInput;
@@ -38,22 +39,20 @@ public class UpdateEmailPage extends RequiredActions {
     @FindBy(css = "input[type='submit']")
     private WebElement submitActionButton;
 
-    @Override
-    public String getActionId() {
-        return UserModel.RequiredAction.UPDATE_EMAIL.name();
-    }
+    @FindBy(css = "input[type='submit']")
+    private WebElement submitButton;
 
     @Override
     public boolean isCurrent() {
         return driver.getCurrentUrl().contains("login-actions/required-action")
-                && driver.getCurrentUrl().contains("execution=" + getActionId());
+                && driver.getCurrentUrl().contains("execution=" + UserModel.RequiredAction.UPDATE_EMAIL.name());
     }
 
     public void changeEmail(String email){
         emailInput.clear();
         emailInput.sendKeys(email);
 
-        submit();
+        clickLink(submitButton);
     }
 
     public String getEmail() {
@@ -84,4 +83,8 @@ public class UpdateEmailPage extends RequiredActions {
         clickLink(submitActionButton);
     }
 
+    @Override
+    public void open() throws Exception {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginConfigTotpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginConfigTotpPage.java
@@ -25,7 +25,7 @@ import org.openqa.selenium.support.FindBy;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class LoginConfigTotpPage extends AbstractPage {
+public class LoginConfigTotpPage extends LogoutSessionsPage {
 
     @FindBy(id = "totpSecret")
     private WebElement totpSecret;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordUpdatePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordUpdatePage.java
@@ -19,14 +19,12 @@ package org.keycloak.testsuite.pages;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.util.UIUtils.isElementVisible;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class LoginPasswordUpdatePage extends LanguageComboboxAwarePage {
+public class LoginPasswordUpdatePage extends LogoutSessionsPage {
 
     @FindBy(id = "password-new")
     private WebElement newPasswordInput;
@@ -42,9 +40,6 @@ public class LoginPasswordUpdatePage extends LanguageComboboxAwarePage {
 
     @FindBy(className = "kc-feedback-text")
     private WebElement feedbackMessage;
-
-    @FindBy(id = "logout-sessions")
-    private WebElement logoutSessionsCheckbox;
     
     @FindBy(name = "cancel-aia")
     private WebElement cancelAIAButton;
@@ -74,24 +69,6 @@ public class LoginPasswordUpdatePage extends LanguageComboboxAwarePage {
 
     public String getFeedbackMessage() {
         return feedbackMessage.getText();
-    }
-
-    public boolean isLogoutSessionDisplayed() {
-        return isElementVisible(logoutSessionsCheckbox);
-    }
-
-    public boolean isLogoutSessionsChecked() {
-        return logoutSessionsCheckbox.isSelected();
-    }
-
-    public void checkLogoutSessions() {
-        assertFalse("Logout sessions is checked", isLogoutSessionsChecked());
-        logoutSessionsCheckbox.click();
-    }
-
-    public void uncheckLogoutSessions() {
-        assertTrue("Logout sessions is not checked", isLogoutSessionsChecked());
-        logoutSessionsCheckbox.click();
     }
 
     public boolean isCancelDisplayed() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LogoutSessionsPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LogoutSessionsPage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.pages;
+
+import org.junit.Assert;
+import org.keycloak.testsuite.util.UIUtils;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * <p>A page that contains the logout other sessions checkbox.</p>
+ *
+ * @author rmartinc
+ */
+public abstract class LogoutSessionsPage extends LanguageComboboxAwarePage {
+
+    @FindBy(id = "logout-sessions")
+    private WebElement logoutSessionsCheckbox;
+
+    @Override
+    public void assertCurrent() {
+        super.assertCurrent();
+        Assert.assertTrue("The page doesn't display the logout other sessions checkbox", this.isLogoutSessionDisplayed());
+    }
+
+    public boolean isLogoutSessionDisplayed() {
+        return UIUtils.isElementVisible(logoutSessionsCheckbox);
+    }
+
+    public boolean isLogoutSessionsChecked() {
+        return logoutSessionsCheckbox.isSelected();
+    }
+
+    public void checkLogoutSessions() {
+        Assert.assertFalse("Logout sessions is checked", isLogoutSessionsChecked());
+        logoutSessionsCheckbox.click();
+    }
+
+    public void uncheckLogoutSessions() {
+        Assert.assertTrue("Logout sessions is not checked", isLogoutSessionsChecked());
+        logoutSessionsCheckbox.click();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SetupRecoveryAuthnCodesPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SetupRecoveryAuthnCodesPage.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
-public class SetupRecoveryAuthnCodesPage extends LanguageComboboxAwarePage {
+public class SetupRecoveryAuthnCodesPage extends LogoutSessionsPage {
 
     @FindBy(id = "kc-recovery-codes-list")
     private WebElement recoveryAuthnCodesList;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
@@ -18,12 +18,15 @@ package org.keycloak.testsuite.actions;
 
 import static org.junit.Assert.assertFalse;
 
+import java.util.Arrays;
+import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.Profile;
 import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -35,7 +38,9 @@ import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.auth.page.login.UpdateEmailPage;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.util.SecondBrowser;
 import org.keycloak.testsuite.util.UserBuilder;
+import org.openqa.selenium.WebDriver;
 
 @EnableFeature(Profile.Feature.UPDATE_EMAIL)
 public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTestRealmKeycloakTest {
@@ -51,6 +56,10 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 
 	@Page
 	protected AppPage appPage;
+
+        @Drone
+        @SecondBrowser
+        protected WebDriver driver2;
 
 	@Before
 	public void beforeTest() {
@@ -80,6 +89,13 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 		realmRepresentation.setRegistrationEmailAsUsername(enabled);
 		realmResource.update(realmRepresentation);
 	}
+
+        protected void configureRequiredActionsToUser(String username, String... actions) {
+                UserResource userResource = ApiUtil.findUserByUsernameId(testRealm(), username);
+                UserRepresentation userRepresentation = userResource.toRepresentation();
+                userRepresentation.setRequiredActions(Arrays.asList(actions));
+                userResource.update(userRepresentation);
+        }
 
 	protected void prepareUser(UserRepresentation user) {
 
@@ -168,7 +184,7 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 
 		setRegistrationEmailAsUsername(testRealm(), true);
 		try {
-			changeEmailUsingRequiredAction("new@localhost");
+			changeEmailUsingRequiredAction("new@localhost", true);
 
 			UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, "new@localhost");
 			Assert.assertNotNull(user);
@@ -177,5 +193,5 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 		}
 	}
 
-	protected abstract void changeEmailUsingRequiredAction(String newEmail) throws Exception;
+	protected abstract void changeEmailUsingRequiredAction(String newEmail, boolean logoutOtherSessions) throws Exception;
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTest.java
@@ -19,35 +19,66 @@ package org.keycloak.testsuite.actions;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testsuite.pages.AppPage;
+import org.keycloak.testsuite.util.OAuthClient;
 
 public class RequiredActionUpdateEmailTest extends AbstractRequiredActionUpdateEmailTest {
 
     @Override
-    protected void changeEmailUsingRequiredAction(String newEmail) {
+    protected void changeEmailUsingRequiredAction(String newEmail, boolean logoutOtherSessions) {
         loginPage.open();
 
         loginPage.login("test-user@localhost", "password");
-
         updateEmailPage.assertCurrent();
+        if (!logoutOtherSessions) {
+            updateEmailPage.uncheckLogoutSessions();
+        }
+        Assert.assertEquals(logoutOtherSessions, updateEmailPage.isLogoutSessionsChecked());
 
         updateEmailPage.changeEmail(newEmail);
     }
 
-    @Test
-    public void updateEmail() {
-        changeEmailUsingRequiredAction("new@localhost");
+    private void updateEmail(boolean logoutOtherSessions) {
+        // login using another session
+        configureRequiredActionsToUser("test-user@localhost");
+        UserResource testUser = testRealm().users().get(findUser("test-user@localhost").getId());
+        OAuthClient oauth2 = new OAuthClient();
+        oauth2.init(driver2);
+        oauth2.doLogin("test-user@localhost", "password");
+        EventRepresentation event1 = events.expectLogin().assertEvent();
+        assertEquals(1, testUser.getUserSessions().size());
+
+        // add the action and change it
+        configureRequiredActionsToUser("test-user@localhost", UserModel.RequiredAction.UPDATE_EMAIL.name());
+        changeEmailUsingRequiredAction("new@localhost", logoutOtherSessions);
 
         events.expectRequiredAction(EventType.UPDATE_EMAIL).detail(Details.PREVIOUS_EMAIL, "test-user@localhost")
                 .detail(Details.UPDATED_EMAIL, "new@localhost").assertEvent();
         assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
-        events.expectLogin().assertEvent();
+        EventRepresentation event2 = events.expectLogin().assertEvent();
+        List<UserSessionRepresentation> sessions = testUser.getUserSessions();
+        if (logoutOtherSessions) {
+            assertEquals(1, sessions.size());
+            assertEquals(event2.getSessionId(), sessions.iterator().next().getId());
+        } else {
+            assertEquals(2, sessions.size());
+            MatcherAssert.assertThat(sessions.stream().map(UserSessionRepresentation::getId).collect(Collectors.toList()),
+                    Matchers.containsInAnyOrder(event1.getSessionId(), event2.getSessionId()));
+        }
 
         // assert user is really updated in persistent store
         UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost");
@@ -55,5 +86,15 @@ public class RequiredActionUpdateEmailTest extends AbstractRequiredActionUpdateE
         assertEquals("Tom", user.getFirstName());
         assertEquals("Brady", user.getLastName());
         assertFalse(user.getRequiredActions().contains(UserModel.RequiredAction.UPDATE_EMAIL.name()));
+    }
+
+    @Test
+    public void updateEmailLogoutSessionsChecked() {
+        updateEmail(true);
+    }
+
+    @Test
+    public void updateEmailLogoutSessionsNotChecked() {
+        updateEmail(false);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
@@ -168,7 +168,7 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         getCleanup().addUserId(userId);
 
         // Setup OTP for the user
-        String totpSecret = setupOTPForUserWithRequiredAction(userId);
+        String totpSecret = setupOTPForUserWithRequiredAction(userId, true);
 
         // Assert user has OTP in the userStorage
         assertUserDontHaveDBCredentials();
@@ -209,7 +209,7 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         getCleanup().addUserId(userId);
 
         // Setup OTP
-        String totpSecret = setupOTPForUserWithRequiredAction(userId);
+        String totpSecret = setupOTPForUserWithRequiredAction(userId, true);
 
         assertUserDontHaveDBCredentials();
         assertUserHasOTPCredentialInUserStorage(true);
@@ -245,7 +245,7 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         String accountToken = tokenUtil.getToken();
 
         // Setup OTP
-        String totpSecret = setupOTPForUserWithRequiredAction(userId);
+        String totpSecret = setupOTPForUserWithRequiredAction(userId, false);
 
         assertUserDontHaveDBCredentials();
         assertUserHasOTPCredentialInUserStorage(true);
@@ -281,7 +281,7 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         getCleanup().addUserId(userId);
 
         // Setup OTP for the user
-        setupOTPForUserWithRequiredAction(userId);
+        setupOTPForUserWithRequiredAction(userId, true);
 
         // Assert user has OTP in the userStorage
         assertUserDontHaveDBCredentials();
@@ -315,7 +315,7 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
     }
 
     // return created totpSecret
-    private String setupOTPForUserWithRequiredAction(String userId) throws URISyntaxException, IOException {
+    private String setupOTPForUserWithRequiredAction(String userId, boolean logoutOtherSessions) throws URISyntaxException, IOException {
         // Add required action to the user to reset OTP
         UserResource user = testRealm().users().get(userId);
         UserRepresentation userRep = user.toRepresentation();
@@ -328,6 +328,9 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         testAppHelper.startLogin("otp1", "pass");
 
         configureTotpRequiredActionPage.assertCurrent();
+        if (!logoutOtherSessions) {
+            configureTotpRequiredActionPage.uncheckLogoutSessions();
+        }
         String totpSecret = configureTotpRequiredActionPage.getTotpSecret();
         configureTotpRequiredActionPage.configure(totp.generateTOTP(totpSecret));
         appPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -1,25 +1,39 @@
 package org.keycloak.testsuite.forms;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.AuthenticationFlow;
 import org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticatorFactory;
 import org.keycloak.authentication.authenticators.browser.PasswordFormFactory;
 import org.keycloak.authentication.authenticators.browser.UsernameFormFactory;
 import org.keycloak.credential.CredentialModel;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
 import org.keycloak.models.utils.RecoveryAuthnCodesUtils;
+import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
+import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.EnterRecoveryAuthnCodePage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.LoginUsernameOnlyPage;
@@ -27,16 +41,19 @@ import org.keycloak.testsuite.pages.PasswordPage;
 import org.keycloak.testsuite.pages.SelectAuthenticatorPage;
 import org.keycloak.testsuite.pages.SetupRecoveryAuthnCodesPage;
 import org.keycloak.testsuite.util.FlowUtil;
+import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.SecondBrowser;
 import org.openqa.selenium.WebDriver;
-import org.junit.Assert;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
 
 /**
@@ -44,15 +61,13 @@ import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
  *
  * @author <a href="mailto:vnukala@redhat.com">Venkata Nukala</a>
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @EnableFeature(value = RECOVERY_CODES, skipRestart = true)
 public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeycloakTest {
 
     private static final String BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES = "Browser with Recovery Authentication Codes";
 
     private static final int BRUTE_FORCE_FAIL_ATTEMPTS = 3;
-
-    @Drone
-    protected WebDriver driver;
 
     @Page
     protected LoginPage loginPage;
@@ -71,6 +86,16 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
 
     @Page
     protected PasswordPage passwordPage;
+
+    @Page
+    protected AppPage appPage;
+
+    @Drone
+    @SecondBrowser
+    private WebDriver driver2;
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
@@ -97,12 +122,63 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
         );
 
         ApiUtil.removeUserByUsername(testRealm(), "test-user@localhost");
-        String userId = createUser("test", "test-user@localhost", "password", UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
+        createUser("test", "test-user@localhost", "password", UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
+    }
+
+    private void testSetupRecoveryAuthnCodesLogoutOtherSessions(boolean logoutOtherSessions) {
+        // login with the user using the second driver
+        UserResource testUser = testRealm().users().get(findUser("test-user@localhost").getId());
+        OAuthClient oauth2 = new OAuthClient();
+        oauth2.init(driver2);
+        oauth2.doLogin("test-user@localhost", "password");
+        EventRepresentation event1 = events.expectLogin().assertEvent();
+        assertEquals(1, testUser.getUserSessions().size());
+
+        // add action to recovery codes for the test user
+        UserRepresentation userRepresentation = testUser.toRepresentation();
+        userRepresentation.setRequiredActions(Arrays.asList(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name()));
+        testUser.update(userRepresentation);
+
+        // login and configure codes
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+        setupRecoveryAuthnCodesPage.assertCurrent();
+        if (!logoutOtherSessions) {
+            setupRecoveryAuthnCodesPage.uncheckLogoutSessions();
+        }
+        Assert.assertEquals(logoutOtherSessions, setupRecoveryAuthnCodesPage.isLogoutSessionsChecked());
+        setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();
+        assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        EventRepresentation event2 = events.expectRequiredAction(EventType.CUSTOM_REQUIRED_ACTION)
+                .user(event1.getUserId()).detail(Details.USERNAME, "test-user@localhost").assertEvent();
+        event2 = events.expectLogin().user(event2.getUserId()).session(event2.getDetails().get(Details.CODE_ID))
+                .detail(Details.USERNAME, "test-user@localhost").assertEvent();
+
+        // assert old session is gone or is maintained
+        List<UserSessionRepresentation> sessions = testUser.getUserSessions();
+        if (logoutOtherSessions) {
+            assertEquals(1, sessions.size());
+            assertEquals(event2.getSessionId(), sessions.iterator().next().getId());
+        } else {
+            assertEquals(2, sessions.size());
+            MatcherAssert.assertThat(sessions.stream().map(UserSessionRepresentation::getId).collect(Collectors.toList()),
+                    Matchers.containsInAnyOrder(event1.getSessionId(), event2.getSessionId()));
+        }
+    }
+
+    @Test
+    public void test01SetupRecoveryAuthnCodesLogoutOtherSessionsChecked() throws Exception {
+        testSetupRecoveryAuthnCodesLogoutOtherSessions(true);
+    }
+
+    @Test
+    public void test02SetupRecoveryAuthnCodesLogoutOtherSessionsNotChecked() {
+        testSetupRecoveryAuthnCodesLogoutOtherSessions(false);
     }
 
     // In a sub-flow with alternative credential executors, test whether Recovery Authentication Codes are working
     @Test
-    public void testAuthenticateRecoveryAuthnCodes() {
+    public void test03AuthenticateRecoveryAuthnCodes() {
         try {
             configureBrowserFlowWithRecoveryAuthnCodes(testingClient);
             testRealm().flows().removeRequiredAction(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
@@ -146,7 +222,7 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
     @Test
     @IgnoreBrowserDriver(FirefoxDriver.class)
     @IgnoreBrowserDriver(ChromeDriver.class)
-    public void testSetupRecoveryAuthnCodes() {
+    public void test04SetupRecoveryAuthnCodes() {
         try {
             configureBrowserFlowWithRecoveryAuthnCodes(testingClient);
             RequiredActionProviderSimpleRepresentation simpleRepresentation = new RequiredActionProviderSimpleRepresentation();
@@ -174,11 +250,10 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
         }
     }
 
-
     @Test
     @IgnoreBrowserDriver(FirefoxDriver.class) // TODO: https://github.com/keycloak/keycloak/issues/13543
     @IgnoreBrowserDriver(ChromeDriver.class)
-    public void testBruteforceProtectionRecoveryAuthnCodes() {
+    public void test05BruteforceProtectionRecoveryAuthnCodes() {
         try {
             configureBrowserFlowWithRecoveryAuthnCodes(testingClient);
             RealmRepresentation rep = testRealm().toRepresentation();

--- a/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnRegisterPage.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnRegisterPage.java
@@ -18,7 +18,7 @@
 package org.keycloak.testsuite.webauthn.pages;
 
 import org.hamcrest.CoreMatchers;
-import org.keycloak.testsuite.pages.AbstractPage;
+import org.keycloak.testsuite.pages.LogoutSessionsPage;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.NoSuchElementException;
@@ -39,7 +39,7 @@ import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
  * Page will be displayed after successful JS call of "navigator.credentials.create", which will register WebAuthn credential
  * with the browser
  */
-public class WebAuthnRegisterPage extends AbstractPage {
+public class WebAuthnRegisterPage extends LogoutSessionsPage {
 
     public static final long ALERT_CHECK_TIMEOUT = 3; //seconds
     public static final long ALERT_DEFAULT_TIMEOUT = 60; //seconds

--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -1,4 +1,5 @@
 <#import "template.ftl" as layout>
+<#import "password-commons.ftl" as passwordCommons>
 <@layout.registrationLayout displayRequiredFields=false displayMessage=!messagesPerField.existsError('totp','userLabel'); section>
 
     <#if section = "header">
@@ -86,6 +87,10 @@
                         </span>
                     </#if>
                 </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <@passwordCommons.logoutOtherSessions/>
             </div>
 
             <#if isAppInitiatedAction??>

--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
@@ -1,4 +1,5 @@
 <#import "template.ftl" as layout>
+<#import "password-commons.ftl" as passwordCommons>
 <@layout.registrationLayout; section>
 
 <#if section = "header">
@@ -38,17 +39,18 @@
     </div>
 
     <!-- confirmation checkbox -->
-    <div class="${properties.kcCheckClass} ${properties.kcRecoveryCodesConfirmation}">
+    <div class="${properties.kcFormOptionsClass!}">
         <input class="${properties.kcCheckInputClass}" type="checkbox" id="kcRecoveryCodesConfirmationCheck" name="kcRecoveryCodesConfirmationCheck" 
         onchange="document.getElementById('saveRecoveryAuthnCodesBtn').disabled = !this.checked;"
         />
-        <label class="${properties.kcCheckLabelClass}" for="kcRecoveryCodesConfirmationCheck">${msg("recovery-codes-confirmation-message")}</label>
+        <label for="kcRecoveryCodesConfirmationCheck">${msg("recovery-codes-confirmation-message")}</label>
     </div>
 
-    <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-recovery-codes-settings-form" method="post">
+    <form action="${url.loginAction}" class="${properties.kcFormGroupClass!}" id="kc-recovery-codes-settings-form" method="post">
         <input type="hidden" name="generatedRecoveryAuthnCodes" value="${recoveryAuthnCodesConfigBean.generatedRecoveryAuthnCodesAsString}" />
         <input type="hidden" name="generatedAt" value="${recoveryAuthnCodesConfigBean.generatedAt?c}" />
         <input type="hidden" id="userLabel" name="userLabel" value="${msg("recovery-codes-label-default")}" />
+        <@passwordCommons.logoutOtherSessions/>
 
         <#if isAppInitiatedAction??>
             <input type="submit"

--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -1,4 +1,5 @@
 <#import "template.ftl" as layout>
+<#import "password-commons.ftl" as passwordCommons>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm'); section>
     <#if section = "header">
         ${msg("updatePasswordTitle")}
@@ -47,13 +48,7 @@
             </div>
 
             <div class="${properties.kcFormGroupClass!}">
-                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-                    <div class="${properties.kcFormOptionsWrapperClass!}">
-                        <div class="checkbox">
-                            <label><input type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked> ${msg("logoutOtherSessions")}</label>
-                        </div>
-                    </div>
-                </div>
+                <@passwordCommons.logoutOtherSessions/>
 
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                     <#if isAppInitiatedAction??>

--- a/themes/src/main/resources/theme/base/login/password-commons.ftl
+++ b/themes/src/main/resources/theme/base/login/password-commons.ftl
@@ -1,0 +1,12 @@
+<#macro logoutOtherSessions>
+    <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+        <div class="${properties.kcFormOptionsWrapperClass!}">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked>
+                    ${msg("logoutOtherSessions")}
+                </label>
+            </div>
+        </div>
+    </div>
+</#macro>

--- a/themes/src/main/resources/theme/base/login/update-email.ftl
+++ b/themes/src/main/resources/theme/base/login/update-email.ftl
@@ -1,4 +1,5 @@
 <#import "template.ftl" as layout>
+<#import "password-commons.ftl" as passwordCommons>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('email'); section>
     <#if section = "header">
         ${msg("updateEmailTitle")}
@@ -27,6 +28,8 @@
                     <div class="${properties.kcFormOptionsWrapperClass!}">
                     </div>
                 </div>
+
+                <@passwordCommons.logoutOtherSessions/>
 
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                     <#if isAppInitiatedAction??>

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -1,4 +1,6 @@
     <#import "template.ftl" as layout>
+    <#import "password-commons.ftl" as passwordCommons>
+
     <@layout.registrationLayout; section>
     <#if section = "title">
         title
@@ -15,6 +17,7 @@
                 <input type="hidden" id="authenticatorLabel" name="authenticatorLabel"/>
                 <input type="hidden" id="transports" name="transports"/>
                 <input type="hidden" id="error" name="error"/>
+                <@passwordCommons.logoutOtherSessions/>
             </div>
         </form>
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/10232

Main points:

* There is a macro that to include the logout other sessions checkbox to the needed ftl pages.
* The `login-recovery-authn-code-config.ftl` has been modified a bit to make both check-boxes (the previous confirmation box and the new logout other sessions input) look the same.
* Now all the actions calls a static method `logoutOtherSessions` if the form parameter `logout-sessions` is passed to `on`.
* Tests added for each action: totp, webauthn and recovery codes.
* The previous test `BackwardsCompatibilityUserStorageTest` needs changes because it registers totp with a session created before. So the test failed as the previous sessions was removed now.

@mposolda I have not modified the update email action as it was mentioned this way in the issue. But we can do the same for that action. The new account console also uses an AIA to update the user email, so I think it would be exactly the same.