### PR TITLE
Downgrade Jansi library to prevent kcadm exception on Windows

### DIFF
--- a/integration/client-cli/admin-cli/pom.xml
+++ b/integration/client-cli/admin-cli/pom.xml
@@ -29,10 +29,20 @@
     <name>Keycloak Admin CLI</name>
     <description/>
 
+    <properties>
+        <jansi.version>1.18</jansi.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.aesh</groupId>
             <artifactId>aesh</artifactId>
+        </dependency>
+        <!-- Jansi library version needs to be overridden due to the backwards compatibility - see #21851 -->
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>${jansi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
Closes #21851

The Quarkus Platform BOM that we introduced in #21426 contains `jansi` version 2.4.0. `WindowsAnsiOutputStream`[ isn't though present in the later versions](https://github.com/fusesource/jansi/blob/5f5f95c78252ea661d8be55930e3a7c18da9bea8/changelog.md?plain=1#L208) of the library.  `org.jboss.aesh` seems to use the older `WindowsAnsiOutputStream`, which is replaced by `WindowsAnsiPrintStream` in the more recent versions. Therefore, the easiest way to overcome the exception is to override back to the compatible version 1.18.
