### PR TITLE
Fix script tests on windows

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -85,8 +85,10 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
     @Override
     public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
         try {
+            log.infof("Deploying archive %s to quarkus container", archive.getName());
             deployArchiveToServer(archive);
             restartServer();
+            log.infof("Deployed archive %s and restarted quarkus container", archive.getName());
         } catch (Exception e) {
             throw new DeploymentException(e.getMessage(), e);
         }
@@ -96,6 +98,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
 
     @Override
     public void undeploy(Archive<?> archive) throws DeploymentException {
+        log.infof("Undeploying archive %s from quarkus container", archive.getName());
         File wrkDir = configuration.getProvidersPath().resolve("providers").toFile();
         try {
             if (isWindows()) {
@@ -104,6 +107,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
             }
             Files.deleteIfExists(wrkDir.toPath().resolve(archive.getName()));
             restartServer();
+            log.infof("Undeployed archive %s and restarted quarkus container", archive.getName());
         } catch (Exception e) {
             throw new DeploymentException(e.getMessage(), e);
         }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -27,6 +27,7 @@ import org.apache.commons.exec.StreamPumper;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.logging.Logger;
 import org.keycloak.testsuite.model.StoreProvider;
+import org.keycloak.testsuite.util.WaitUtils;
 
 /**
  * @author mhajas
@@ -193,6 +194,11 @@ public class KeycloakQuarkusServerDeployableContainer extends AbstractQuarkusDep
         if (!isWindows()) {
             return;
         }
+
+        // Wait some time before killing the windows processes. Otherwise there is a risk that some already commited H2 transactions
+        // won't be written to disk in time and hence those transactions may be lost, which could result in test failures in the next step after server restart.
+        // See http://repository.transtep.com/repository/thirdparty/H2/1.0.63/docs/html/advanced.html#durability_problems for the details
+        WaitUtils.pause(2000);
 
         CompletableFuture allProcesses = CompletableFuture.completedFuture(null);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedSAMLScriptMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedSAMLScriptMapperTest.java
@@ -6,19 +6,15 @@ import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.Response;
 
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.keycloak.common.Profile;
 import org.keycloak.dom.saml.v2.assertion.AssertionType;
 import org.keycloak.dom.saml.v2.assertion.AttributeType;
 import org.keycloak.protocol.saml.SamlProtocol;
@@ -29,8 +25,8 @@ import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.provider.ScriptProviderDescriptor;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeatures;
 import org.keycloak.testsuite.saml.AbstractSamlTest;
 import org.keycloak.testsuite.saml.RoleMapperTest;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
@@ -53,6 +49,7 @@ import static org.keycloak.testsuite.util.SamlStreams.attributesUnecrypted;
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
+@EnableFeature(value = SCRIPTS, skipRestart = true)
 public class DeployedSAMLScriptMapperTest extends AbstractSamlTest {
 
     private static final String SCRIPT_DEPLOYMENT_NAME = "scripts.jar";
@@ -60,7 +57,8 @@ public class DeployedSAMLScriptMapperTest extends AbstractSamlTest {
     private ClientAttributeUpdater cau;
     private ProtocolMappersUpdater pmu;
 
-    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = false, testable = false)
+    // Managed to make sure that archive is deployed once in @BeforeClass stage and undeployed once in @AfterClass stage
+    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = true, testable = false)
     @TargetsContainer(AUTH_SERVER_CURRENT)
     public static JavaArchive deploy() throws IOException {
         ScriptProviderDescriptor representation = new ScriptProviderDescriptor();
@@ -78,15 +76,6 @@ public class DeployedSAMLScriptMapperTest extends AbstractSamlTest {
         ContainerAssume.assumeNotAuthServerUndertow();
     }
 
-    @ArquillianResource
-    private Deployer deployer;
-
-    @Before
-    public void deployScripts() throws Exception {
-        deployer.deploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
-    }
-
     @Before
     public void cleanMappersAndScopes() {
         this.cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_EMPLOYEE_2)
@@ -101,13 +90,8 @@ public class DeployedSAMLScriptMapperTest extends AbstractSamlTest {
                 .addCleanup(this.pmu);
     }
 
-    @After
-    public void onAfter() throws Exception {
-        deployer.undeploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
-    }
-
     @Test
+    @DisableFeature(value = SCRIPTS, executeAsLast = false, skipRestart = true)
     public void testScriptMapperNotAvailableThroughAdminRest() {
         assertFalse(adminClient.serverInfo().getInfo().getProtocolMapperTypes().get(SamlProtocol.LOGIN_PROTOCOL).stream()
                 .anyMatch(
@@ -127,7 +111,6 @@ public class DeployedSAMLScriptMapperTest extends AbstractSamlTest {
 
 
     @Test
-    @EnableFeature(value = SCRIPTS, skipRestart = true, executeAsLast = false)
     public void testScriptMappingThroughServerDeploy() {
         // ScriptBasedMapper still not available even if SCRIPTS feature is enabled
         testScriptMapperNotAvailableThroughAdminRest();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptAuthenticatorTest.java
@@ -24,15 +24,12 @@ import java.io.IOException;
 
 import jakarta.ws.rs.core.Response;
 
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.graphene.page.Page;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -69,7 +66,8 @@ public class DeployedScriptAuthenticatorTest extends AbstractFlowTest {
     public static final String EXECUTION_ID = "scriptAuth";
     private static final String SCRIPT_DEPLOYMENT_NAME = "scripts.jar";
 
-    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = false, testable = false)
+    // Managed to make sure that archive is deployed once in @BeforeClass stage and undeployed once in @AfterClass stage
+    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = true, testable = false)
     @TargetsContainer(AUTH_SERVER_CURRENT)
     public static JavaArchive deploy() throws IOException {
         ScriptProviderDescriptor representation = new ScriptProviderDescriptor();
@@ -92,9 +90,6 @@ public class DeployedScriptAuthenticatorTest extends AbstractFlowTest {
 
     @Page
     protected LoginPage loginPage;
-
-    @ArquillianResource
-    private Deployer deployer;
 
     private AuthenticationFlowRepresentation flow;
 
@@ -122,8 +117,6 @@ public class DeployedScriptAuthenticatorTest extends AbstractFlowTest {
     }
 
     public void configureFlows() throws Exception {
-        deployer.deploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
         if (testContext.isInitialized()) {
             return;
         }
@@ -171,12 +164,6 @@ public class DeployedScriptAuthenticatorTest extends AbstractFlowTest {
         addExecutionResponse.close();
 
         testContext.setInitialized(true);
-    }
-
-    @After
-    public void onAfter() throws Exception {
-        deployer.undeploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptMapperTest.java
@@ -25,15 +25,11 @@ import static org.keycloak.testsuite.util.ProtocolMapperUtil.createScriptMapper;
 
 import java.io.IOException;
 
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.ClientResource;
@@ -44,6 +40,7 @@ import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.provider.ScriptProviderDescriptor;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.OAuthClient;
@@ -52,11 +49,13 @@ import org.keycloak.util.JsonSerialization;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
+@EnableFeature(value = SCRIPTS, skipRestart = true)
 public class DeployedScriptMapperTest extends AbstractTestRealmKeycloakTest {
 
     private static final String SCRIPT_DEPLOYMENT_NAME = "scripts.jar";
 
-    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = false, testable = false)
+    // Managed to make sure that archive is deployed once in @BeforeClass stage and undeployed once in @AfterClass stage
+    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = true, testable = false)
     @TargetsContainer(AUTH_SERVER_CURRENT)
     public static JavaArchive deploy() throws IOException {
         ScriptProviderDescriptor representation = new ScriptProviderDescriptor();
@@ -74,27 +73,13 @@ public class DeployedScriptMapperTest extends AbstractTestRealmKeycloakTest {
         ContainerAssume.assumeNotAuthServerUndertow();
     }
 
-    @ArquillianResource
-    private Deployer deployer;
-
-    @Before
-    public void configureFlows() throws Exception {
-        deployer.deploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
-    }
-
-    @After
-    public void onAfter() throws Exception {
-        deployer.undeploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
-    }
-
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
 
     }
 
     @Test
+    @DisableFeature(value = SCRIPTS, executeAsLast = false, skipRestart = true)
     public void testScriptMapperNotAvailable() {
         assertFalse(adminClient.serverInfo().getInfo().getProtocolMapperTypes().get(OIDCLoginProtocol.LOGIN_PROTOCOL).stream()
                 .anyMatch(
@@ -102,7 +87,6 @@ public class DeployedScriptMapperTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    @EnableFeature(value = SCRIPTS, skipRestart = true, executeAsLast = false)
     public void testTokenScriptMapping() {
         {
             ClientResource app = findClientResourceByClientId(adminClient.realm("test"), "test-app");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptPolicyTest.java
@@ -24,14 +24,11 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.List;
 
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,7 +47,6 @@ import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.provider.ScriptProviderDescriptor;
-import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.testsuite.authz.AbstractAuthzTest;
 import org.keycloak.testsuite.util.ClientBuilder;
@@ -68,7 +64,8 @@ public class DeployedScriptPolicyTest extends AbstractAuthzTest {
 
     private static final String SCRIPT_DEPLOYMENT_NAME = "scripts.jar";
 
-    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = false, testable = false)
+    // Managed to make sure that archive is deployed once in @BeforeClass stage and undeployed once in @AfterClass stage
+    @Deployment(name = SCRIPT_DEPLOYMENT_NAME, managed = true, testable = false)
     @TargetsContainer(AUTH_SERVER_CURRENT)
     public static JavaArchive deploy() throws IOException {
         ScriptProviderDescriptor representation = new ScriptProviderDescriptor();
@@ -88,9 +85,6 @@ public class DeployedScriptPolicyTest extends AbstractAuthzTest {
         ContainerAssume.assumeNotAuthServerUndertow();
     }
 
-    @ArquillianResource
-    private Deployer deployer;
-
     @Override
     public void addTestRealms(List<RealmRepresentation> testRealms) {
         testRealms.add(RealmBuilder.create().name("authz-test")
@@ -108,16 +102,8 @@ public class DeployedScriptPolicyTest extends AbstractAuthzTest {
 
     @Before
     public void onBefore() throws Exception {
-        deployer.deploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
         AuthorizationResource authorization = getAuthorizationResource();
         authorization.resources().create(new ResourceRepresentation("Default Resource"));
-    }
-
-    @After
-    public void onAfter() throws Exception {
-        deployer.undeploy(SCRIPT_DEPLOYMENT_NAME);
-        reconnectAdminClient();
     }
 
     @Test


### PR DESCRIPTION
Closes #21778 #21779 #21780

There are 2 problems with the script tests.

1. When the Quarkus server is restarted on Windows, it is a chance that some H2 DB transactions, which were commited shortly before the restart, are lost. So for instance when some test (like `DeployedScriptAuthenticatorTest`, but can be any other test) imports `test` realm, and then restarts server, it is a chance that after restart, the `test` realm is not available. Something about this is described in the H2 documentation http://repository.transtep.com/repository/thirdparty/H2/1.0.63/docs/html/advanced.html#durability_problems . I've added delay 2 seconds on windows before restart the server, which should ensure all the commited transactions should be synced to the disk

2. All the script tests are doing deploy/undeploy of script archives after every method, which makes them very uneffective and bad for performance as each deploy/undeploy causes server restart. I've changed this to deploy/undeploy once per class (before class and after class).
