### PR TITLE
Profile activation for WF app server doesn't properly work for Windows

### DIFF
--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -845,6 +845,23 @@
                 <module>wildfly</module>
             </modules>
         </profile>
+
+        <!-- Build app-server-wildfly on Windows by default -->
+        <!-- See https://github.com/keycloak/keycloak/issues/21284 -->
+        <profile>
+            <id>app-server-wildfly-windows</id>
+            <activation>
+                <property>
+                    <name>!skipAppServerWildfly</name>
+                </property>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <modules>
+                <module>wildfly</module>
+            </modules>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Fixes: #21284
Related-to: https://github.com/keycloak/keycloak/issues/21716

For Unix-like systems, the WildFly app server is built by default as the profile `app-server-wildfly` is activated by default. However, for Windows systems, the other profile(`windows-properties-cli`) is activated, and based on the Maven profile activation principles[1], profiles activated by the `activeByDefault` property are disabled. 

It means the WildFly app server is not implicitly built on Windows systems.
For Windows, we can specify another profile for building the module and avoid the logic behind the `activeByDefault`.

However, for our pipeline, when some other app server is used, the Wildfly would always be built as well (for Windows). We can prevent it by providing a property(`skipAppServerWildfly`) for disabling the profile for Windows. On a local Windows machine, even when the other app server is specified, the WF is built, but I don't see a big problem around that, as the approach with the WildFly app server as the default one, is only temporary. 

Keycloak pipeline MR: https://keycloak-gitlab.com/keycloak/keycloak-pipeline/-/merge_requests/276

[1] https://maven.apache.org/guides/introduction/introduction-to-profiles.html#implicit_profile_activation

@miquelsi Could you please check it?
cc: @ahus1 @Pepo48 