### PR TITLE
Use pre-release version to opt-in to Test Replay

### DIFF
--- a/js/apps/admin-ui/cypress.config.mjs
+++ b/js/apps/admin-ui/cypress.config.mjs
@@ -2,21 +2,11 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   projectId: "j4yhox",
-  screenshotsFolder: "assets/screenshots",
-  videosFolder: "assets/videos",
   chromeWebSecurity: false,
   viewportWidth: 1360,
   viewportHeight: 768,
   defaultCommandTimeout: 30000,
-  videoCompression: false,
-  numTestsKeptInMemory: 30,
-  videoUploadOnPasses: false,
   experimentalMemoryManagement: true,
-
-  retries: {
-    runMode: 3,
-  },
-
   e2e: {
     baseUrl: "http://localhost:8080",
     slowTestThreshold: 30000,

--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -101,7 +101,7 @@
     "@types/react-dom": "^18.2.7",
     "@types/uuid": "^9.0.2",
     "@vitejs/plugin-react-swc": "^3.3.2",
-    "cypress": "^12.17.2",
+    "cypress": "https://cdn.cypress.io/beta/npm/13.0.0/linux-x64/release/13.0.0-5d1e07a7aa228745b5e742aa3e912fcbd4cb217f/cypress.tgz",
     "cypress-axe": "^1.4.0",
     "jsdom": "^22.1.0",
     "ldap-server-mock": "^6.0.1",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2(vite@4.4.7)
       cypress:
-        specifier: ^12.17.2
+        specifier: https://cdn.cypress.io/beta/npm/13.0.0/linux-x64/release/13.0.0-5d1e07a7aa228745b5e742aa3e912fcbd4cb217f/cypress.tgz
         version: 12.17.2
       cypress-axe:
         specifier: ^1.4.0


### PR DESCRIPTION
Moves Cypress to a pre-release of version 13, this allows us to make use of the new "Test Replay" functionality in the Cypress Cloud, hopefully improving debuggability of tests running on CI. 