### PR TITLE
Better overview of tests execution for Quarkus IT

### DIFF
--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -36,6 +36,7 @@
         <kc.quarkus.tests.dist>raw</kc.quarkus.tests.dist>
         <approvaltests.version>14.0.0</approvaltests.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
+        <maven-surefire-junit5-tree-reporter.version>1.2.1</maven-surefire-junit5-tree-reporter.version>
     </properties>
 
     <dependencies>
@@ -93,8 +94,26 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>${maven-surefire-junit5-tree-reporter.version}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <argLine>-Djdk.net.hosts.file=${project.build.testOutputDirectory}/hosts_file -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.security=ALL-UNNAMED</argLine>
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                        <theme>ASCII</theme>
+                        <printStacktraceOnError>true</printStacktraceOnError>
+                        <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                        <printStderrOnError>true</printStderrOnError>
+                        <printStderrOnFailure>true</printStderrOnFailure>
+                    </statelessTestsetInfoReporter>
                     <systemPropertyVariables>
                         <kc.quarkus.tests.dist>${kc.quarkus.tests.dist}</kc.quarkus.tests.dist>
                     </systemPropertyVariables>


### PR DESCRIPTION
I found some of my old commits and maybe it'd be cool to improve our test execution summary for Quarkus.

It'll provide us a better overview of the status of particular test cases, their execution time and hide all unnecessary logs when the test pass. 

As it's only related to the testsuite, I don't see any security implication to include the dependency.

@vmuzikar WDYT?

![Screenshot from 2023-07-26 13-57-59](https://github.com/keycloak/keycloak/assets/38039883/3ea16196-036f-4488-9e37-0e080d440167)

When some failure occurs, the stacktrace and stderr are printed to the console:
![Screenshot from 2023-07-26 13-47-34](https://github.com/keycloak/keycloak/assets/38039883/96276c79-ce11-463c-af3e-0617bc1f2d83)

Old tests execution:
![Screenshot from 2023-07-26 13-52-26](https://github.com/keycloak/keycloak/assets/38039883/2e74a4e7-3c2a-44ba-b0a3-4de6060c73b0)


