### PR TITLE
Ensure mounted state in `useSetTimeout()` remains consistent

### DIFF
--- a/js/apps/admin-ui/src/utils/useSetTimeout.ts
+++ b/js/apps/admin-ui/src/utils/useSetTimeout.ts
@@ -4,13 +4,14 @@ export default function useSetTimeout() {
   const didUnmountRef = useRef(false);
   const { current: scheduledTimers } = useRef(new Set<number>());
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    didUnmountRef.current = false;
+
+    return () => {
       didUnmountRef.current = true;
       clearAll();
-    },
-    [],
-  );
+    };
+  }, []);
 
   function clearAll() {
     scheduledTimers.forEach((timer) => clearTimeout(timer));


### PR DESCRIPTION
Ensures that the value of `didUnmountRef` remains consistent between renders of `useSetTimeout()`.

Since enabling the new Root API (#21102), React will [automatically umount components](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development) to find bugs. This causes the 'unmounted' state to become inconsistent, as we did not set the initial state of the mount.

This state is now set properly during mount, which resolves the issue.