### PR TITLE
Ignore UnknownHostException for Quarkus IT on local

### DIFF
--- a/quarkus/tests/integration/src/test/resources/application.properties
+++ b/quarkus/tests/integration/src/test/resources/application.properties
@@ -17,3 +17,6 @@
 quarkus.vault.devservices.enabled=false
 quarkus.datasource.devservices.enabled=false
 quarkus.devservices.enabled=true
+
+# Avoid throwing the UnknownHostException for external hosts file used for FIPS testing
+quarkus.log.category."org.eclipse.aether.internal.impl".level=error


### PR DESCRIPTION
We will avoid logging the information about the inability to resolve the host in hosts file, which was introduced for the FIPS testing. IMHO, we can log only errors from that, and the functionality for testing doesn't change.

@rmartinc @vmuzikar Could you please review it? 

We will avoid logging of this:
```
2023-07-27 16:01:26,366 WARN  [org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper] (main) Failed to get hostname, using 'localhost': java.net.UnknownHostException: mabartos: Unable to resolve host mabartos in hosts file /home/mabartos/Documents/RH/keycloak/quarkus/tests/integration/target/test-classes/hosts_file
        at java.base/java.net.InetAddress.getLocalHost(InetAddress.java:1671)
        at org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper.getHostname(DiscriminatingNameMapper.java:90)
        at org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper.<init>(DiscriminatingNameMapper.java:69)
        at org.eclipse.aether.internal.impl.synccontext.named.NameMappers.discriminatingNameMapper(NameMappers.java:68)
        at org.eclipse.aether.internal.impl.synccontext.named.providers.DiscriminatingNameMapperProvider.<init>(DiscriminatingNameMapperProvider.java:39)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
        at io.smallrye.beanbag.ConstructorSupplier.get(ConstructorSupplier.java:34)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getBean(Scope.java:237)
        at io.smallrye.beanbag.BeanResolver.get(BeanResolver.java:20)
        at io.smallrye.beanbag.BeanSupplier.lambda$transform$1(BeanSupplier.java:42)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getAllBeansWithNames(Scope.java:145)
        at io.smallrye.beanbag.AllBeansWithNamesResolver.get(AllBeansWithNamesResolver.java:18)
        at io.smallrye.beanbag.AllBeansWithNamesResolver.get(AllBeansWithNamesResolver.java:8)
        at io.smallrye.beanbag.ConstructorSupplier.get(ConstructorSupplier.java:27)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getBean(Scope.java:237)
        at io.smallrye.beanbag.BeanResolver.get(BeanResolver.java:20)
        at io.smallrye.beanbag.ConstructorSupplier.get(ConstructorSupplier.java:27)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getBean(Scope.java:237)
        at io.smallrye.beanbag.BeanResolver.get(BeanResolver.java:20)
        at io.smallrye.beanbag.ConstructorSupplier.get(ConstructorSupplier.java:27)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getBean(Scope.java:237)
        at io.smallrye.beanbag.BeanResolver.get(BeanResolver.java:20)
        at io.smallrye.beanbag.ConstructorSupplier.get(ConstructorSupplier.java:27)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getBean(Scope.java:237)
        at io.smallrye.beanbag.BeanResolver.get(BeanResolver.java:20)
        at io.smallrye.beanbag.ConstructorSupplier.get(ConstructorSupplier.java:27)
        at io.smallrye.beanbag.Bean$Pending.get(Bean.java:125)
        at io.smallrye.beanbag.Bean.get(Bean.java:47)
        at io.smallrye.beanbag.Scope.getBean(Scope.java:237)
        at io.smallrye.beanbag.Scope.requireBean(Scope.java:164)
        at io.smallrye.beanbag.BeanBag.requireBean(BeanBag.java:84)
        at io.smallrye.beanbag.maven.MavenFactory.getRepositorySystem(MavenFactory.java:163)
        at io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext.initRepoSystemAndManager(BootstrapMavenContext.java:868)
        at io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext.getRepositorySystem(BootstrapMavenContext.java:276)
        at io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver.<init>(MavenArtifactResolver.java:114)
        at io.quarkus.bootstrap.BootstrapAppModelFactory.getAppModelResolver(BootstrapAppModelFactory.java:163)
        at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModel(BootstrapAppModelFactory.java:282)
        at io.quarkus.bootstrap.app.QuarkusBootstrap.bootstrap(QuarkusBootstrap.java:133)
        at io.quarkus.test.junit.AbstractJvmQuarkusTestExtension.createAugmentor(AbstractJvmQuarkusTestExtension.java:185)
        at io.quarkus.test.junit.QuarkusMainTestExtension.ensurePrepared(QuarkusMainTestExtension.java:81)
        at io.quarkus.test.junit.QuarkusMainTestExtension.beforeEach(QuarkusMainTestExtension.java:58)
        at org.keycloak.it.junit5.extension.CLITestExtension.beforeEach(CLITestExtension.java:112)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeBeforeEachCallbacks$2(TestMethodTestDescriptor.java:166)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeBeforeMethodsOrCallbacksUntilExceptionOccurs$6(TestMethodTestDescriptor.java:202)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeBeforeMethodsOrCallbacksUntilExceptionOccurs(TestMethodTestDescriptor.java:202)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeBeforeEachCallbacks(TestMethodTestDescriptor.java:165)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:132)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
        at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
        at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:139)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)
Caused by: java.net.UnknownHostException: Unable to resolve host mabartos in hosts file /home/mabartos/Documents/RH/keycloak/quarkus/tests/integration/target/test-classes/hosts_file
        at java.base/java.net.InetAddress$HostsFileNameService.lookupAllHostAddr(InetAddress.java:1082)
        at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1543)
        at java.base/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:852)
        at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1533)
        at java.base/java.net.InetAddress.getLocalHost(InetAddress.java:1666)
        ... 112 more
```