### PR TITLE
Profile activation for WF app server doesn't properly work for Windows

### DIFF
--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -845,6 +845,23 @@
                 <module>wildfly</module>
             </modules>
         </profile>
+
+        <!-- Build app-server-wildfly on Windows by default -->
+        <!-- See https://github.com/keycloak/keycloak/issues/21284 -->
+        <profile>
+            <id>app-server-wildfly-windows</id>
+            <activation>
+                <property>
+                    <name>!skipAppServerWildfly</name>
+                </property>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <modules>
+                <module>wildfly</module>
+            </modules>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Backport of https://github.com/keycloak/keycloak/pull/21948

@Pepo48 @vmuzikar Could you please check it? Thanks