### PR TITLE
FAPI 2.0 security profile - make client policy conditions called by PRE_AUTHORIZATION_REQUEST

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
@@ -30,6 +30,7 @@ import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepres
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.context.PreAuthorizationRequestContext;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
@@ -68,6 +69,11 @@ public class ClientRolesCondition extends AbstractClientPolicyConditionProvider<
     @Override
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
         switch (context.getEvent()) {
+            case PRE_AUTHORIZATION_REQUEST:
+                PreAuthorizationRequestContext paContext = (PreAuthorizationRequestContext) context;
+                ClientModel client = session.getContext().getRealm().getClientByClientId(paContext.getClientId());
+                if (isRolesMatched(client)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
             case AUTHORIZATION_REQUEST:
             case TOKEN_REQUEST:
             case TOKEN_RESPONSE:

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExtendedEventTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExtendedEventTest.java
@@ -584,10 +584,18 @@ public class ClientPoliciesExtendedEventTest extends AbstractClientPoliciesTest 
         ).toString();
         updateProfiles(json);
 
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+        String cid = createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
+            clientRep.setSecret(clientSecret);
+        });
+        adminClient.realm(REALM_NAME).clients().get(cid).roles().create(RoleBuilder.create().name(SAMPLE_CLIENT_ROLE).build());
+
         // register policies
         json = (new ClientPoliciesBuilder()).addPolicy(
-                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
-                        .addCondition(AnyClientConditionFactory.PROVIDER_ID, createAnyClientConditionConfig())
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Dei Eischt Politik", Boolean.TRUE)
+                        .addCondition(ClientRolesConditionFactory.PROVIDER_ID,
+                                createClientRolesConditionConfig(Arrays.asList(SAMPLE_CLIENT_ROLE)))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -595,7 +603,7 @@ public class ClientPoliciesExtendedEventTest extends AbstractClientPoliciesTest 
 
         // Authorization Request
         oauth.realm(REALM_NAME);
-        oauth.clientId("foo");
+        oauth.clientId(clientId);
         oauth.openLoginForm();
         assertTrue(errorPage.isCurrent());
         assertEquals("Exception thrown intentionally", errorPage.getError());


### PR DESCRIPTION

closes #22043

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
