### PR TITLE
Add Quarkus Unit tests to GHA CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,27 @@ jobs:
         with:
           job-name: Base IT
 
+  quarkus-unit-tests:
+    name: Quarkus UT
+    needs: build
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # We want to download Keycloak artifacts
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+
+      - name: Run unit tests
+        run: |
+          ./mvnw test -f quarkus/pom.xml -pl '!tests,!tests/junit5,!tests/integration,!dist'
+
+      - name: Upload JVM Heapdumps
+        if: always()
+        uses: ./.github/actions/upload-heapdumps
+
   quarkus-integration-tests:
     name: Quarkus IT
     needs: build
@@ -590,6 +611,7 @@ jobs:
     needs:
       - unit-tests
       - base-integration-tests
+      - quarkus-unit-tests
       - quarkus-integration-tests
       - jdk-integration-tests
       - new-store-integration-tests


### PR DESCRIPTION
When I was testing a particular issue on the Win machine, some test cases from the Quarkus module failed and the possible cause was provided yesterday. However, I need to verify it more. Moreover, I've also noticed we don't have covered Quarkus unit tests at all. 

As these are not time-consuming jobs, I'd propose to test it by default in our CI with Ubuntu and Windows. 

@jonkoops @stianst @vmuzikar Any input on this?