### PR TITLE
Not all getting started guides include creating the admin user.

### DIFF
--- a/docs/guides/getting-started/templates/realm-config.adoc
+++ b/docs/guides/getting-started/templates/realm-config.adoc
@@ -1,7 +1,7 @@
 == Log in to the Admin Console
 
 . Go to the {links-admin-console}.
-. Log in with the username and password you created earlier.
+. Log in with the admin user account.
 
 == Create a realm
 


### PR DESCRIPTION
For container cases the admin user has already been created.

The following illustrates where this text is inaccurate:
    https://www.keycloak.org/getting-started/getting-started-podman