### PR TITLE
simplifying status updates to a single method for each controller

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -38,7 +38,6 @@ import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatus;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusAggregator;
-import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -113,14 +112,11 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
         kcDeployment.updateStatus(statusAggregator);
 
         var kcService = new KeycloakService(client, kc);
-        kcService.updateStatus(statusAggregator);
         kcService.createOrUpdateReconciled();
         var kcDiscoveryService = new KeycloakDiscoveryService(client, kc);
-        kcDiscoveryService.updateStatus(statusAggregator);
         kcDiscoveryService.createOrUpdateReconciled();
 
         var kcIngress = new KeycloakIngress(client, kc);
-        kcIngress.updateStatus(statusAggregator);
         kcIngress.createOrUpdateReconciled();
 
         var status = statusAggregator.build();
@@ -136,8 +132,7 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
             updateControl = UpdateControl.updateStatus(kc);
         }
 
-        if (status.findCondition(KeycloakStatusCondition.READY)
-                .filter(c -> !Boolean.TRUE.equals(c.getStatus())).isPresent()) {
+        if (!status.isReady()) {
             updateControl.rescheduleAfter(10, TimeUnit.SECONDS);
         }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -60,7 +60,7 @@ import java.util.stream.Stream;
 
 import static org.keycloak.operator.crds.v2alpha1.CRDUtils.isTlsConfigured;
 
-public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> implements StatusUpdater<KeycloakStatusAggregator> {
+public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> {
 
     private final Config operatorConfig;
     private final KeycloakDistConfigurator distConfigurator;
@@ -364,7 +364,6 @@ public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> imp
         return envVars;
     }
 
-    @Override
     public void updateStatus(KeycloakStatusAggregator status) {
         status.apply(b -> b.withSelector(Utils.toSelectorString(getInstanceLabels())));
         validatePodTemplate(status);

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryService.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryService.java
@@ -22,19 +22,16 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
-import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusAggregator;
 
 import java.util.Optional;
 
-public class KeycloakDiscoveryService extends OperatorManagedResource implements StatusUpdater<KeycloakStatusAggregator> {
-
-    private Service existingService;
+public class KeycloakDiscoveryService extends OperatorManagedResource {
 
     public KeycloakDiscoveryService(KubernetesClient client, Keycloak keycloakCR) {
         super(client, keycloakCR);
-        this.existingService = fetchExistingService();
     }
 
     private ServiceSpec getServiceSpec() {
@@ -63,22 +60,6 @@ public class KeycloakDiscoveryService extends OperatorManagedResource implements
                 .withSpec(getServiceSpec())
                 .build();
         return service;
-    }
-
-    private Service fetchExistingService() {
-        return client
-                .services()
-                .inNamespace(getNamespace())
-                .withName(getName())
-                .get();
-    }
-
-    @Override
-    public void updateStatus(KeycloakStatusAggregator status) {
-        if (existingService == null) {
-            status.addNotReadyMessage("No existing Discovery Service found, waiting for creating a new one");
-            return;
-        }
     }
 
     @Override

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
-import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusAggregator;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 
 import java.util.HashMap;
@@ -31,7 +30,7 @@ import java.util.Optional;
 
 import static org.keycloak.operator.crds.v2alpha1.CRDUtils.isTlsConfigured;
 
-public class KeycloakIngress extends OperatorManagedResource implements StatusUpdater<KeycloakStatusAggregator> {
+public class KeycloakIngress extends OperatorManagedResource {
 
     private final Ingress existingIngress;
     private final Keycloak keycloak;
@@ -128,18 +127,6 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
                 .inNamespace(getNamespace())
                 .withName(getName())
                 .get();
-    }
-
-    @Override
-    public void updateStatus(KeycloakStatusAggregator status) {
-        IngressSpec ingressSpec = keycloak.getSpec().getIngressSpec();
-        if (ingressSpec == null) {
-            ingressSpec = new IngressSpec();
-            ingressSpec.setIngressEnabled(true);
-        }
-        if (ingressSpec.isIngressEnabled() && existingIngress == null) {
-            status.addNotReadyMessage("No existing Keycloak Ingress found, waiting for creating a new one");
-        }
     }
 
     @Override

--- a/operator/src/main/java/org/keycloak/operator/controllers/StatusUpdater.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/StatusUpdater.java
@@ -1,6 +1,0 @@
-package org.keycloak.operator.controllers;
-
-public interface StatusUpdater<T> {
-
-    void updateStatus(T status);
-}

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/CRDUtils.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/CRDUtils.java
@@ -21,22 +21,14 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 public final class CRDUtils {
     public static boolean isTlsConfigured(Keycloak keycloakCR) {
-        var tlsSecret = getValueFromSubSpec(keycloakCR.getSpec().getHttpSpec(), HttpSpec::getTlsSecret);
+        var tlsSecret = Optional.ofNullable(keycloakCR.getSpec().getHttpSpec()).map(HttpSpec::getTlsSecret);
         return tlsSecret.isPresent() && !tlsSecret.get().trim().isEmpty();
     }
 
-    public static <T, R> Optional<R> getValueFromSubSpec(T subSpec, Function<T, R> valueSupplier) {
-        if (subSpec != null) {
-            return Optional.ofNullable(valueSupplier.apply(subSpec));
-        } else {
-            return Optional.empty();
-        }
-    }
 }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakStatus.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakStatus.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.fabric8.kubernetes.model.annotation.LabelSelector;
 import io.fabric8.kubernetes.model.annotation.StatusReplicas;
 import io.javaoperatorsdk.operator.api.ObservedGenerationAware;
@@ -68,6 +70,11 @@ public class KeycloakStatus implements ObservedGenerationAware {
             return Optional.empty();
         }
         return conditions.stream().filter(c -> type.equals(c.getType())).findFirst();
+    }
+
+    @JsonIgnore
+    public boolean isReady() {
+        return findCondition(KeycloakStatusCondition.READY).map(KeycloakStatusCondition::getStatus).orElse(false);
     }
 
     @Override

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -41,7 +41,6 @@ import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
@@ -50,9 +49,10 @@ import org.keycloak.operator.controllers.KeycloakDeployment;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpecFluent.UnsupportedNested;
-import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatus;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.UnsupportedSpecFluent.PodTemplateNested;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
+import org.opentest4j.TestAbortedException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -261,15 +261,14 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
           return;
       }
       try {
-          if (!context.getTestStatus().isTestFailed()) {
+          if (!context.getTestStatus().isTestFailed() && !(context.getTestStatus().getTestErrorCause() instanceof TestAbortedException)) {
               return;
           }
+          Log.warnf("Test failed with %s: %s", context.getTestStatus().getTestErrorCause().getMessage(), context.getTestStatus().getTestErrorCause().getClass().getName());
           savePodLogs();
           // provide some helpful entries in the main log as well
           k8sclient.resources(Keycloak.class).list().getItems().stream()
-                  .filter(kc -> !Boolean.TRUE.equals(Optional.ofNullable(kc.getStatus())
-                          .flatMap(keycloak -> keycloak.findCondition(KeycloakStatusCondition.READY))
-                          .map(KeycloakStatusCondition::getStatus).orElse(null)))
+                  .filter(kc -> !Optional.ofNullable(kc.getStatus()).map(KeycloakStatus::isReady).orElse(false))
                   .forEach(kc -> {
                       Log.warnf("Keycloak failed to become ready \"%s\" %s", kc.getMetadata().getName(), Serialization.asYaml(kc.getStatus()));
                       var statefulSet = k8sclient.resources(StatefulSet.class).withName(KeycloakDeployment.getName(kc)).get();
@@ -280,7 +279,7 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
                                       try {
                                           String log = k8sclient.pods().resource(pod).getLog();
                                           if (log.length() > 5000) {
-                                              log = log.substring(log.length() - 5000, log.length());
+                                              log = log.substring(log.length() - 5000);
                                           }
                                           Log.warnf("Not ready pod log \"%s\": %s", pod.getMetadata().getName(), log);
                                       } catch (KubernetesClientException e) {


### PR DESCRIPTION
The operator sdk does not make it convienent to support a whiteboard approach to status aggregation.  Outside of our primary status update logic, the other methods were simply doing existence checks.  If the subsequent create running in the same reconciliation cycle suceeds, then there's no need to add the status stating that the resource doesn't exist.  If the subsequent create fails, then we'll have an error condition added to the status which should contain sufficent clues what and why it failed.

Closes #22182

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
