### PR TITLE
Avoid using deprecated junit APIs in tests

### DIFF
--- a/common/src/test/java/org/keycloak/common/util/StringSerializationTest.java
+++ b/common/src/test/java/org/keycloak/common/util/StringSerializationTest.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/crypto/default/src/test/java/org/keycloak/crypto/def/test/DefaultKeyStoreTypesTest.java
+++ b/crypto/default/src/test/java/org/keycloak/crypto/def/test/DefaultKeyStoreTypesTest.java
@@ -11,6 +11,8 @@ import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.KeystoreUtil;
 import org.keycloak.rule.CryptoInitRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -22,7 +24,7 @@ public class DefaultKeyStoreTypesTest {
     @Test
     public void testKeystoreFormats() {
         Set<KeystoreUtil.KeystoreFormat> supportedKeystoreFormats = CryptoIntegration.getProvider().getSupportedKeyStoreTypes().collect(Collectors.toSet());
-        Assert.assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
+        assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
                 KeystoreUtil.KeystoreFormat.JKS,
                 KeystoreUtil.KeystoreFormat.PKCS12,
                 KeystoreUtil.KeystoreFormat.BCFKS));

--- a/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronKeyStoreTypesTest.java
+++ b/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronKeyStoreTypesTest.java
@@ -30,6 +30,8 @@ import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.KeystoreUtil;
 import org.keycloak.rule.CryptoInitRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -42,7 +44,7 @@ public class ElytronKeyStoreTypesTest {
     @Test
     public void testKeystoreFormats() {
         Set<KeystoreUtil.KeystoreFormat> supportedKeystoreFormats = CryptoIntegration.getProvider().getSupportedKeyStoreTypes().collect(Collectors.toSet());
-        Assert.assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
+        assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
                 KeystoreUtil.KeystoreFormat.JKS,
                 KeystoreUtil.KeystoreFormat.PKCS12
         ));

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402KeystoreTypesTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402KeystoreTypesTest.java
@@ -15,6 +15,8 @@ import org.keycloak.common.util.Environment;
 import org.keycloak.common.util.KeystoreUtil;
 import org.keycloak.rule.CryptoInitRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -33,7 +35,7 @@ public class FIPS1402KeystoreTypesTest {
     public void testKeystoreFormatsInNonApprovedMode() {
         Assume.assumeFalse(CryptoServicesRegistrar.isInApprovedOnlyMode());
         Set<KeystoreUtil.KeystoreFormat> supportedKeystoreFormats = CryptoIntegration.getProvider().getSupportedKeyStoreTypes().collect(Collectors.toSet());
-        Assert.assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
+        assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
                 KeystoreUtil.KeystoreFormat.PKCS12,
                 KeystoreUtil.KeystoreFormat.BCFKS));
     }
@@ -43,7 +45,7 @@ public class FIPS1402KeystoreTypesTest {
     public void testKeystoreFormatsInApprovedMode() {
         Assume.assumeTrue(CryptoServicesRegistrar.isInApprovedOnlyMode());
         Set<KeystoreUtil.KeystoreFormat> supportedKeystoreFormats = CryptoIntegration.getProvider().getSupportedKeyStoreTypes().collect(Collectors.toSet());
-        Assert.assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
+        assertThat(supportedKeystoreFormats, Matchers.containsInAnyOrder(
                 KeystoreUtil.KeystoreFormat.BCFKS));
     }
 }

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402Pbkdf2PasswordPaddingTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402Pbkdf2PasswordPaddingTest.java
@@ -21,6 +21,7 @@ import org.keycloak.rule.CryptoInitRule;
 import org.keycloak.rule.RunInThreadRule;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -109,7 +110,7 @@ public class FIPS1402Pbkdf2PasswordPaddingTest {
         }
 
         logger.infof("Before password verification. BC FIPS approved mode: %b, password: %s", CryptoServicesRegistrar.isInApprovedOnlyMode(), password);
-        Assert.assertThat(true, is(pbkdf2HashProvider.verify(password, passwordCred)));
+        assertThat(true, is(pbkdf2HashProvider.verify(password, passwordCred)));
     }
 
 

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402SslTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402SslTest.java
@@ -28,6 +28,7 @@ import org.keycloak.common.util.Environment;
 import org.keycloak.rule.CryptoInitRule;
 
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -144,9 +145,9 @@ public class FIPS1402SslTest {
         logger.infof("Enabled ciphersuites: %s", enabledCipherSuites.size());
         logger.infof("Supported protocols: %s", supportedProtocols);
         logger.infof("Supported ciphers size: %d", supportedCiphers.size());
-        Assert.assertThat(enabledCipherSuites.size(), greaterThan(0));
-        Assert.assertThat(supportedProtocols.size(), greaterThan(0));
-        Assert.assertThat(supportedCiphers.size(), greaterThan(0));
+        assertThat(enabledCipherSuites.size(), greaterThan(0));
+        assertThat(supportedProtocols.size(), greaterThan(0));
+        assertThat(supportedCiphers.size(), greaterThan(0));
 
         SSLSessionContext sslServerCtx = context.getServerSessionContext();
         Assert.assertNotNull(sslServerCtx);

--- a/model/legacy-private/src/test/java/org/keycloak/models/datastore/LegacyMigrationManagerTest.java
+++ b/model/legacy-private/src/test/java/org/keycloak/models/datastore/LegacyMigrationManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.migration.ModelVersion;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.storage.datastore.LegacyMigrationManager.RHSSO_VERSION_7_0_KEYCLOAK_VERSION;
 import static org.keycloak.storage.datastore.LegacyMigrationManager.RHSSO_VERSION_7_1_KEYCLOAK_VERSION;
 import static org.keycloak.storage.datastore.LegacyMigrationManager.RHSSO_VERSION_7_2_KEYCLOAK_VERSION;
@@ -39,33 +40,33 @@ public class LegacyMigrationManagerTest {
 
     @Test
     public void testRHSSOVersionToKeycloakVersionConversion() {
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.0.0.GA"), is(equalTo(RHSSO_VERSION_7_0_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.0.1.GA"), is(equalTo(RHSSO_VERSION_7_0_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.0.2.GA"), is(equalTo(RHSSO_VERSION_7_0_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.0.0.GA"), is(equalTo(RHSSO_VERSION_7_0_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.0.1.GA"), is(equalTo(RHSSO_VERSION_7_0_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.0.2.GA"), is(equalTo(RHSSO_VERSION_7_0_KEYCLOAK_VERSION)));
         
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.1.0.GA"), is(equalTo(RHSSO_VERSION_7_1_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.1.1.GA"), is(equalTo(RHSSO_VERSION_7_1_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.1.2.GA"), is(equalTo(RHSSO_VERSION_7_1_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.1.0.GA"), is(equalTo(RHSSO_VERSION_7_1_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.1.1.GA"), is(equalTo(RHSSO_VERSION_7_1_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.1.2.GA"), is(equalTo(RHSSO_VERSION_7_1_KEYCLOAK_VERSION)));
 
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.2.0.GA"), is(equalTo(RHSSO_VERSION_7_2_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.2.1.GA"), is(equalTo(RHSSO_VERSION_7_2_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.2.2.GA"), is(equalTo(RHSSO_VERSION_7_2_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.2.0.GA"), is(equalTo(RHSSO_VERSION_7_2_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.2.1.GA"), is(equalTo(RHSSO_VERSION_7_2_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.2.2.GA"), is(equalTo(RHSSO_VERSION_7_2_KEYCLOAK_VERSION)));
 
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.3.0.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.3.1.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.3.2.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.3.10.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.3.0.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.3.1.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.3.2.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.3.10.GA"), is(equalTo(RHSSO_VERSION_7_3_KEYCLOAK_VERSION)));
 
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.4.0.GA"), is(equalTo(RHSSO_VERSION_7_4_KEYCLOAK_VERSION)));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.4.15.GA"), is(equalTo(RHSSO_VERSION_7_4_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.4.0.GA"), is(equalTo(RHSSO_VERSION_7_4_KEYCLOAK_VERSION)));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.4.15.GA"), is(equalTo(RHSSO_VERSION_7_4_KEYCLOAK_VERSION)));
 
         // check the conversion doesn't change version for keycloak
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7.0.0"), is(nullValue()));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("8.0.0"), is(nullValue()));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7.0.0"), is(nullValue()));
+        assertThat(convertRHSSOVersionToKeycloakVersion("8.0.0"), is(nullValue()));
 
         // check for CD releases
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("6"), is(equalTo(new ModelVersion("6.0.0"))));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("7"), is(equalTo(new ModelVersion("7.0.0"))));
-        Assert.assertThat(convertRHSSOVersionToKeycloakVersion("10"), is(equalTo(new ModelVersion("10.0.0"))));
+        assertThat(convertRHSSOVersionToKeycloakVersion("6"), is(equalTo(new ModelVersion("6.0.0"))));
+        assertThat(convertRHSSOVersionToKeycloakVersion("7"), is(equalTo(new ModelVersion("7.0.0"))));
+        assertThat(convertRHSSOVersionToKeycloakVersion("10"), is(equalTo(new ModelVersion("10.0.0"))));
     }
 }

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLAttributeQueryParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLAttributeQueryParserTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.Before;
 import org.w3c.dom.Element;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test class for SAML AttributeQuery parser.

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLAuthNRequestParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLAuthNRequestParserTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.Before;
 import org.w3c.dom.Element;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test class for SAML AuthNRequest parser.

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParserTest.java
@@ -105,7 +105,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 /**
  * Test class for SAML parser.

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloRequestParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloRequestParserTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.Before;
 import org.w3c.dom.Element;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test class for SAML SLO parser.

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/util/JAXPValidationUtilTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/util/JAXPValidationUtilTest.java
@@ -22,7 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.xml.sax.SAXException;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/services/src/test/java/org/keycloak/connections/httpclient/ProxyMappingsTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/ProxyMappingsTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for {@link ProxyMappings}.

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
@@ -20,7 +20,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.keycloak.utils.JsonUtils;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/services/src/test/java/org/keycloak/protocol/saml/SamlProtocolUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/saml/SamlProtocolUtilsTest.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SamlProtocolUtilsTest {
 

--- a/services/src/test/java/org/keycloak/test/broker/saml/SAMLDataMarshallerTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/saml/SAMLDataMarshallerTest.java
@@ -29,7 +29,7 @@ import org.keycloak.saml.processing.core.parsers.saml.SAMLParser;
 import java.io.InputStream;
 import org.hamcrest.CoreMatchers;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>

--- a/services/src/test/java/org/keycloak/utils/RegexUtilsTest.java
+++ b/services/src/test/java/org/keycloak/utils/RegexUtilsTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * <a href="mailto:external.benjamin.weimer@bosch-si.com">Benjamin Weimer</a>,

--- a/services/src/test/java/org/keycloak/vault/KeystoreVaultProviderTest.java
+++ b/services/src/test/java/org/keycloak/vault/KeystoreVaultProviderTest.java
@@ -9,7 +9,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.keycloak.vault.SecretContains.secretContains;
 

--- a/services/src/test/java/org/keycloak/vault/PlainTextVaultProviderTest.java
+++ b/services/src/test/java/org/keycloak/vault/PlainTextVaultProviderTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.vault.SecretContains.secretContains;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/CrossDCTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/CrossDCTestEnricher.java
@@ -51,7 +51,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakContainerFeaturesController.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakContainerFeaturesController.java
@@ -31,7 +31,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author mhajas

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/Creator.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/Creator.java
@@ -45,6 +45,8 @@ import jakarta.ws.rs.core.Response;
 import org.hamcrest.Matchers;
 import org.jboss.logging.Logger;
 import org.junit.Assert;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.ApiUtil.getCreatedId;
 
 /**
@@ -112,7 +114,7 @@ public class Creator<T> implements AutoCloseable {
 
     public static Creator<IdentityProviderResource> create(RealmResource realmResource, IdentityProviderRepresentation rep) {
         final IdentityProvidersResource res = realmResource.identityProviders();
-        Assert.assertThat("Identity provider alias must be specified", rep.getAlias(), Matchers.notNullValue());
+        assertThat("Identity provider alias must be specified", rep.getAlias(), Matchers.notNullValue());
         try (Response response = res.create(rep)) {
             String createdId = getCreatedId(response);
             final IdentityProviderResource r = res.get(rep.getAlias());

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/UserAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/UserAttributeUpdater.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.updaters.ServerResourceUpdater.updateViaAddRemove;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClient.java
@@ -96,7 +96,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.saml.common.constants.GeneralConstants.RELAY_STATE;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClientBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClientBuilder.java
@@ -46,6 +46,7 @@ import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.w3c.dom.Document;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.saml.SamlDocumentStepBuilder.saml2Object2String;
 
 /**
@@ -128,7 +129,7 @@ public class SamlClientBuilder {
 
     public SamlClientBuilder assertResponse(Matcher<? super CloseableHttpResponse> matcher) {
         steps.add((client, currentURI, currentResponse, context) -> {
-            Assert.assertThat(currentResponse, matcher);
+            assertThat(currentResponse, matcher);
             return null;
         });
         return this;
@@ -264,8 +265,8 @@ public class SamlClientBuilder {
         return
           doNotFollowRedirects()
           .addStep((client, currentURI, currentResponse, context) -> {
-            Assert.assertThat(currentResponse, Matchers.statusCodeIsHC(Status.FOUND));
-            Assert.assertThat("Location header not found", currentResponse.getFirstHeader("Location"), notNullValue());
+            assertThat(currentResponse, Matchers.statusCodeIsHC(Status.FOUND));
+            assertThat("Location header not found", currentResponse.getFirstHeader("Location"), notNullValue());
             return new HttpGet(currentResponse.getFirstHeader("Location").getValue());
           });
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlStreams.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlStreams.java
@@ -27,7 +27,7 @@ import org.keycloak.dom.saml.v2.protocol.ResponseType.RTChoiceType;
 import java.util.Objects;
 import java.util.stream.Stream;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/LoginBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/LoginBuilder.java
@@ -41,7 +41,7 @@ import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.Users.getPasswordOf;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/ModifySamlResponseStepBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/ModifySamlResponseStepBuilder.java
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/RequiredConsentBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/RequiredConsentBuilder.java
@@ -38,7 +38,7 @@ import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/SessionStateChecker.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/SessionStateChecker.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SessionStateChecker implements Runnable {
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/UpdateProfileBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/UpdateProfileBuilder.java
@@ -42,7 +42,7 @@ import org.jboss.logging.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
 /**
@@ -363,13 +364,13 @@ public class AssertEvents implements TestRule {
             if (expected.getError() != null && ! expected.getType().toString().endsWith("_ERROR")) {
                 expected.setType(expected.getType() + "_ERROR");
             }
-            Assert.assertThat("type", actual.getType(), is(expected.getType()));
-            Assert.assertThat("realm ID", actual.getRealmId(), is(realmId));
-            Assert.assertThat("client ID", actual.getClientId(), is(expected.getClientId()));
-            Assert.assertThat("error", actual.getError(), is(expected.getError()));
-            Assert.assertThat("ip address", actual.getIpAddress(), ipAddress);
-            Assert.assertThat("user ID", actual.getUserId(), is(userId));
-            Assert.assertThat("session ID", actual.getSessionId(), is(sessionId));
+            assertThat("type", actual.getType(), is(expected.getType()));
+            assertThat("realm ID", actual.getRealmId(), is(realmId));
+            assertThat("client ID", actual.getClientId(), is(expected.getClientId()));
+            assertThat("error", actual.getError(), is(expected.getError()));
+            assertThat("ip address", actual.getIpAddress(), ipAddress);
+            assertThat("user ID", actual.getUserId(), is(userId));
+            assertThat("session ID", actual.getSessionId(), is(sessionId));
 
             if (details == null || details.isEmpty()) {
 //                Assert.assertNull(actual.getDetails());
@@ -381,7 +382,7 @@ public class AssertEvents implements TestRule {
                         Assert.fail(d.getKey() + " missing");
                     }
 
-                    Assert.assertThat("Unexpected value for " + d.getKey(), actualValue, is(d.getValue()));
+                    assertThat("Unexpected value for " + d.getKey(), actualValue, is(d.getValue()));
                 }
                 /*
                 for (String k : actual.getDetails().keySet()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceCorsTest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceReadOnlyAttributesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceReadOnlyAttributesTest.java
@@ -35,6 +35,7 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -98,7 +99,7 @@ public class AccountRestServiceReadOnlyAttributesTest extends AbstractRestServic
     private void testAccountUpdateAttributeExpectFailure(String attrName, boolean deniedForAdminAsWell) throws IOException {
         // Attribute not yet supposed to be on the user
         UserRepresentation user = SimpleHttp.doGet(getAccountUrl(null), httpClient).auth(tokenUtil.getToken()).asJson(UserRepresentation.class);
-        Assert.assertThat(user.getAttributes().keySet(), not(contains(attrName)));
+        assertThat(user.getAttributes().keySet(), not(contains(attrName)));
 
         // Assert not possible to add the attribute to the user
         user.singleAttribute(attrName, "foo");
@@ -146,7 +147,7 @@ public class AccountRestServiceReadOnlyAttributesTest extends AbstractRestServic
     private void testAccountUpdateAttributeExpectSuccess(String attrName) throws IOException {
         // Attribute not yet supposed to be on the user
         UserRepresentation user = SimpleHttp.doGet(getAccountUrl(null), httpClient).auth(tokenUtil.getToken()).asJson(UserRepresentation.class);
-        Assert.assertThat(user.getAttributes().keySet(), not(contains(attrName)));
+        assertThat(user.getAttributes().keySet(), not(contains(attrName)));
 
         // Assert not possible to add the attribute to the user
         user.singleAttribute(attrName, "foo");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -869,7 +869,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(applications.isEmpty());
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        Assert.assertThat(apps.keySet(), containsInAnyOrder("in-use-client", "always-display-client", "direct-grant"));
+        assertThat(apps.keySet(), containsInAnyOrder("in-use-client", "always-display-client", "direct-grant"));
 
         assertClientRep(apps.get("in-use-client"), "In Use Client", null, false, true, false, null, inUseClientAppUri);
         assertClientRep(apps.get("always-display-client"), "Always Display Client", null, false, false, false, null, alwaysDisplayClientAppUri);
@@ -893,7 +893,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(applications.isEmpty());
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        Assert.assertThat(apps.keySet(), containsInAnyOrder("in-use-client"));
+        assertThat(apps.keySet(), containsInAnyOrder("in-use-client"));
 
         assertClientRep(apps.get("in-use-client"), "In Use Client", null, false, true, false, null, inUseClientAppUri);
     }
@@ -919,7 +919,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(applications.isEmpty());
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        Assert.assertThat(apps.keySet(), containsInAnyOrder("offline-client", "offline-client-without-base-url", "always-display-client", "direct-grant"));
+        assertThat(apps.keySet(), containsInAnyOrder("offline-client", "offline-client-without-base-url", "always-display-client", "direct-grant"));
 
         assertClientRep(apps.get("offline-client"), "Offline Client", null, false, true, true, null, offlineClientAppUri);
         assertClientRep(apps.get("offline-client-without-base-url"), "Offline Client Without Base URL", null, false, true, true, null, null);
@@ -969,7 +969,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
                 .asResponse();
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        Assert.assertThat(apps.keySet(), containsInAnyOrder(appId, "always-display-client", "direct-grant"));
+        assertThat(apps.keySet(), containsInAnyOrder(appId, "always-display-client", "direct-grant"));
 
         ClientRepresentation app = apps.get(appId);
         assertClientRep(app, null, "A third party application", true, false, false, null, "http://localhost:8180/auth/realms/master/app/auth");
@@ -1001,7 +1001,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(applications.isEmpty());
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        Assert.assertThat(apps.keySet(), containsInAnyOrder("root-url-client", "always-display-client", "direct-grant"));
+        assertThat(apps.keySet(), containsInAnyOrder("root-url-client", "always-display-client", "direct-grant"));
 
         assertClientRep(apps.get("root-url-client"), null, null, false, true, false, "http://localhost:8180/foo/bar", "/baz");
     }
@@ -1449,7 +1449,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(applications.isEmpty());
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        Assert.assertThat(apps.keySet(), containsInAnyOrder("offline-client", "always-display-client", "direct-grant"));
+        assertThat(apps.keySet(), containsInAnyOrder("offline-client", "always-display-client", "direct-grant"));
 
         assertClientRep(apps.get("offline-client"), "Offline Client", null, false, true, false, null, offlineClientAppUri);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/SessionRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/SessionRestServiceTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -857,7 +857,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         // email should be verified and required actions empty
         UserRepresentation user = testRealm().users().get(testUserId).toRepresentation();
         Assert.assertTrue(user.isEmailVerified());
-        Assert.assertThat(user.getRequiredActions(), Matchers.empty());
+        assertThat(user.getRequiredActions(), Matchers.empty());
     }
 
     @Test
@@ -896,7 +896,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         // email should be verified and required actions empty
         UserRepresentation user = testRealm().users().get(testUserId).toRepresentation();
         Assert.assertTrue(user.isEmailVerified());
-        Assert.assertThat(user.getRequiredActions(), Matchers.empty());
+        assertThat(user.getRequiredActions(), Matchers.empty());
     }
 
     @Test
@@ -940,7 +940,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         // email should be verified and required actions empty
         UserRepresentation user = testRealm().users().get(testUserId).toRepresentation();
         Assert.assertTrue(user.isEmailVerified());
-        Assert.assertThat(user.getRequiredActions(), Matchers.empty());
+        assertThat(user.getRequiredActions(), Matchers.empty());
 
         // after refresh in the first browser the app should be shown
         driver.navigate().refresh();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractSAMLAdapterClusteredTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractSAMLAdapterClusteredTest.java
@@ -18,7 +18,7 @@ package org.keycloak.testsuite.adapter;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.Users.setPasswordFor;
 import static org.keycloak.testsuite.auth.page.AuthRealm.DEMO;
 import static org.keycloak.testsuite.utils.io.IOUtil.loadRealm;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/fuse/FuseAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/fuse/FuseAdapterTest.java
@@ -17,7 +17,7 @@
 package org.keycloak.testsuite.adapter.example.fuse;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.auth.page.AuthRealm.DEMO;
 import static org.keycloak.testsuite.utils.fuse.FuseUtils.assertCommand;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
@@ -122,7 +122,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.auth.page.AuthRealm.DEMO;
 import static org.keycloak.testsuite.util.AdminClientUtil.NUMBER_OF_CONNECTIONS;
@@ -1197,19 +1197,19 @@ public class DemoServletsAdapterTest extends AbstractServletsAdapterTest {
         // Redirect client to login page if it's not an XHR
         response = target.request().header("X-Requested-With", "Dont-Know").header(HttpHeaders.ACCEPT, "*/*").get();
         Assert.assertEquals(302, response.getStatus());
-        Assert.assertThat(response.getHeaderString(HttpHeaders.LOCATION), containsString("response_type=code"));
+        assertThat(response.getHeaderString(HttpHeaders.LOCATION), containsString("response_type=code"));
         response.close();
 
         // Redirect client to login page if client explicitely understands HTML responses
         response = target.request().header(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9").get();
         Assert.assertEquals(302, response.getStatus());
-        Assert.assertThat(response.getHeaderString(HttpHeaders.LOCATION), containsString("response_type=code"));
+        assertThat(response.getHeaderString(HttpHeaders.LOCATION), containsString("response_type=code"));
         response.close();
 
         // Redirect client to login page if client understands all response types
         response = target.request().header(HttpHeaders.ACCEPT, "*/*").get();
         Assert.assertEquals(302, response.getStatus());
-        Assert.assertThat(response.getHeaderString(HttpHeaders.LOCATION), containsString("response_type=code"));
+        assertThat(response.getHeaderString(HttpHeaders.LOCATION), containsString("response_type=code"));
         response.close();
         client.close();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/KeycloakPrincipalSerializationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/KeycloakPrincipalSerializationTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 @AppServerContainer(ContainerConstants.APP_SERVER_UNDERTOW)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLClockSkewAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLClockSkewAdapterTest.java
@@ -39,6 +39,8 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import org.jboss.arquillian.graphene.page.Page;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.adapter.AbstractServletsAdapterTest.samlServletDeployment;
 import org.keycloak.testsuite.adapter.page.SalesPostClockSkewServlet;
 import static org.keycloak.testsuite.util.SamlClient.Binding.POST;
@@ -89,7 +91,7 @@ public class SAMLClockSkewAdapterTest extends AbstractSAMLServletAdapterTest {
                         return doc;
                     }).build().executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
 
-            Assert.assertThat(resultPage, matcher);
+            assertThat(resultPage, matcher);
         } finally {
             setAdapterAndServerTimeOffset(0, salesPostClockSkewServletPage.toString());
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLLoginResponseHandlingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLLoginResponseHandlingTest.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.ApiUtil.getCreatedId;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_PRIVATE_KEY;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_PUBLIC_KEY;
@@ -105,8 +105,8 @@ public class SAMLLoginResponseHandlingTest extends AbstractSAMLServletAdapterTes
                 .build()
                 .navigateTo(employee2ServletPage.getUriBuilder().clone().path("getAttributes").build())
                 .execute(response -> {
-                            Assert.assertThat(response, statusCodeIsHC(Response.Status.OK));
-                            Assert.assertThat(response, bodyHC(containsString("attribute-with-null-attribute-value: <br />")));
+                            assertThat(response, statusCodeIsHC(Response.Status.OK));
+                            assertThat(response, bodyHC(containsString("attribute-with-null-attribute-value: <br />")));
                         }
                 );
     }
@@ -122,7 +122,7 @@ public class SAMLLoginResponseHandlingTest extends AbstractSAMLServletAdapterTes
         new SamlClientBuilder()
                 .addStep((client, currentURI, currentResponse, context) ->
                         SamlClient.Binding.REDIRECT.createSamlUnsignedResponse(URI.create(employeeSigServletPage.toString() + "/saml"), null, document))
-                .execute(closeableHttpResponse -> Assert.assertThat(closeableHttpResponse, bodyHC(containsString("INVALID_SIGNATURE"))));
+                .execute(closeableHttpResponse -> assertThat(closeableHttpResponse, bodyHC(containsString("INVALID_SIGNATURE"))));
     }
 
     @Test
@@ -136,7 +136,7 @@ public class SAMLLoginResponseHandlingTest extends AbstractSAMLServletAdapterTes
         new SamlClientBuilder()
                 .addStep((client, currentURI, currentResponse, context) ->
                         SamlClient.Binding.REDIRECT.createSamlSignedResponse(URI.create(employeeSigServletPage.toString() + "/saml"), null, document, REALM_PRIVATE_KEY, REALM_PUBLIC_KEY))
-                .execute(closeableHttpResponse -> Assert.assertThat(closeableHttpResponse, bodyHC(containsString("ERROR_STATUS"))));
+                .execute(closeableHttpResponse -> assertThat(closeableHttpResponse, bodyHC(containsString("ERROR_STATUS"))));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLLogoutAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLLogoutAdapterTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.adapter.AbstractServletsAdapterTest.samlServletDeployment;
 import static org.keycloak.testsuite.adapter.servlet.SAMLServletAdapterTest.FORBIDDEN_TEXT;
 import static org.keycloak.testsuite.adapter.servlet.SAMLServletAdapterTest.WEBSPHERE_FORBIDDEN_TEXT;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
@@ -619,9 +619,9 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
           .navigateTo(employeeAcsServletPage.buildUri())
           .getSamlResponse(Binding.POST);
 
-        Assert.assertThat(samlResponse.getSamlObject(), instanceOf(AuthnRequestType.class));
-        Assert.assertThat(((AuthnRequestType) samlResponse.getSamlObject()).getAssertionConsumerServiceURL(), notNullValue());
-        Assert.assertThat(((AuthnRequestType) samlResponse.getSamlObject()).getAssertionConsumerServiceURL().getPath(), is("/employee-acs/a/different/endpoint/for/saml"));
+        assertThat(samlResponse.getSamlObject(), instanceOf(AuthnRequestType.class));
+        assertThat(((AuthnRequestType) samlResponse.getSamlObject()).getAssertionConsumerServiceURL(), notNullValue());
+        assertThat(((AuthnRequestType) samlResponse.getSamlObject()).getAssertionConsumerServiceURL().getPath(), is("/employee-acs/a/different/endpoint/for/saml"));
 
         assertSuccessfulLogin(employeeAcsServletPage, bburkeUser, testRealmSAMLPostLoginPage, "principal=bburke");
     }
@@ -897,8 +897,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
               .processSamlResponse(Binding.POST).build()
 
               .execute(r -> {
-                  Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-                  Assert.assertThat(r, bodyHC(containsString("urn:oasis:names:tc:SAML:2.0:status:RequestDenied")));  // TODO: revisit - should the HTTP status be 403 too?
+                  assertThat(r, statusCodeIsHC(Response.Status.OK));
+                  assertThat(r, bodyHC(containsString("urn:oasis:names:tc:SAML:2.0:status:RequestDenied")));  // TODO: revisit - should the HTTP status be 403 too?
               });
         } finally {
             salesPostEncServletPage.logout();
@@ -918,8 +918,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
               .processSamlResponse(Binding.POST).build()
 
               .execute(r -> {
-                  Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-                  Assert.assertThat(r, bodyHC(containsString("urn:oasis:names:tc:SAML:2.0:status:RequestDenied")));  // TODO: revisit - should the HTTP status be 403 too?
+                  assertThat(r, statusCodeIsHC(Response.Status.OK));
+                  assertThat(r, bodyHC(containsString("urn:oasis:names:tc:SAML:2.0:status:RequestDenied")));  // TODO: revisit - should the HTTP status be 403 too?
               });
         } finally {
             salesPostServletPage.logout();
@@ -976,8 +976,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
 
             UserRepresentation storedUser = u.resource().toRepresentation();
 
-            Assert.assertThat(storedUser, notNullValue());
-            Assert.assertThat("Database seems to be unable to store Unicode for username. Refer to KEYCLOAK-3439 and related issues.", storedUser.getUsername(), equalToIgnoringCase(username));
+            assertThat(storedUser, notNullValue());
+            assertThat("Database seems to be unable to store Unicode for username. Refer to KEYCLOAK-3439 and related issues.", storedUser.getUsername(), equalToIgnoringCase(username));
 
             assertSuccessfulLogin(salesPostSigServletPage, user, testRealmSAMLPostLoginPage, "principal=" + storedUser.getUsername());
 
@@ -1001,8 +1001,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
 
             UserRepresentation storedUser = u.resource().toRepresentation();
 
-            Assert.assertThat(storedUser, notNullValue());
-            Assert.assertThat("Database seems to be unable to store Unicode for username. Refer to KEYCLOAK-3439 and related issues.", storedUser.getUsername(), equalToIgnoringCase(username));
+            assertThat(storedUser, notNullValue());
+            assertThat("Database seems to be unable to store Unicode for username. Refer to KEYCLOAK-3439 and related issues.", storedUser.getUsername(), equalToIgnoringCase(username));
 
             assertSuccessfulLogin(employeeSigServletPage, user, testRealmSAMLRedirectLoginPage, "principal=" + storedUser.getUsername());
 
@@ -1027,14 +1027,14 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
           .login().user(user).build()
           .processSamlResponse(Binding.POST)
             .transformString(s -> {
-                Assert.assertThat(s, containsString(">bburke@redhat.com.additional.domain<"));
+                assertThat(s, containsString(">bburke@redhat.com.additional.domain<"));
                 s = s.replaceAll("bburke@redhat.com.additional.domain", "bburke@redhat.com<!-- comment -->.additional.domain");
                 return s;
             })
             .build()
           .executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
 
-        Assert.assertThat(resultPage, containsString("principal=bburke@redhat.com.additional.domain"));
+        assertThat(resultPage, containsString("principal=bburke@redhat.com.additional.domain"));
     }
 
     @Test
@@ -1048,14 +1048,14 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
           .login().user(user).build()
           .processSamlResponse(Binding.POST)
             .transformString(s -> {
-                Assert.assertThat(s, containsString(">bburke@redhat.com.additional.domain<"));
+                assertThat(s, containsString(">bburke@redhat.com.additional.domain<"));
                 s = s.replaceAll("bburke@redhat.com.additional.domain", "bburke@redhat.com");
                 return s;
             })
             .build()
           .executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
 
-        Assert.assertThat(resultPage, anyOf(
+        assertThat(resultPage, anyOf(
                 containsString("INVALID_SIGNATURE"),
                 containsString("Error 403: SRVE0295E: Error reported: 403") //WAS
         ));
@@ -1132,7 +1132,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
 
         assertCurrentUrlStartsWith(testRealmSAMLPostLoginPage);
         testRealmLoginPage.form().login("bburke@redhat.com", "password");
-        Assert.assertThat(URI.create(driver.getCurrentUrl()).getPath(), endsWith("secured/post"));
+        assertThat(URI.create(driver.getCurrentUrl()).getPath(), endsWith("secured/post"));
         waitUntilElement(By.xpath("//body")).text().contains("parameter=hello");
 
         // test that user principal and KeycloakSecurityContext available
@@ -1163,7 +1163,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
 
         samlidpInitiatedLoginPage.form().login(bburkeUser);
         assertCurrentUrlStartsWith(salesPost2ServletPage);
-        Assert.assertThat(URI.create(driver.getCurrentUrl()).getPath(), endsWith("foo"));
+        assertThat(URI.create(driver.getCurrentUrl()).getPath(), endsWith("foo"));
         waitUntilElement(By.xpath("//body")).text().contains("principal=bburke");
         salesPost2ServletPage.logout();
         checkLoggedOut(salesPost2ServletPage, testRealmSAMLPostLoginPage);
@@ -1204,8 +1204,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         assertCurrentUrlStartsWith(employeeServletPage);
         waitForPageToLoad();
         String pageSource = driver.getPageSource();
-        Assert.assertThat(pageSource, containsString("Relay state: " + SamlSPFacade.RELAY_STATE));
-        Assert.assertThat(pageSource, not(containsString("SAML response: null")));
+        assertThat(pageSource, containsString("Relay state: " + SamlSPFacade.RELAY_STATE));
+        assertThat(pageSource, not(containsString("SAML response: null")));
     }
 
     private static String[] parseCommaSeparatedAttributes(String body, String attribute) {
@@ -1458,8 +1458,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
           .navigateTo(employee2ServletPage.getUriBuilder().clone().path("getAttributes").build())
 
           .execute(r -> {
-              Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-              Assert.assertThat(r, bodyHC(containsString("boolean-attribute: true")));
+              assertThat(r, statusCodeIsHC(Response.Status.OK));
+              assertThat(r, bodyHC(containsString("boolean-attribute: true")));
           });
     }
 
@@ -1476,7 +1476,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
                 XPathExpression expr = xpath.compile("//*[local-name()='NameID']");
 
                 NodeList nodeList = (NodeList) expr.evaluate(responseDoc, XPathConstants.NODESET);
-                Assert.assertThat(nodeList.getLength(), is(1));
+                assertThat(nodeList.getLength(), is(1));
 
                 final Node nameIdNode = nodeList.item(0);
                 nameIdNode.getParentNode().removeChild(nameIdNode);
@@ -1488,8 +1488,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
           .navigateTo(employee2ServletPage.toString())
 
           .execute(r -> {
-              Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-              Assert.assertThat(r, bodyHC(containsString("principal=")));
+              assertThat(r, statusCodeIsHC(Response.Status.OK));
+              assertThat(r, bodyHC(containsString("principal=")));
           });
     }
 
@@ -1509,8 +1509,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
           .navigateTo(employee2ServletPage.toString())
 
           .execute(r -> {
-              Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-              Assert.assertThat(r, bodyHC(containsString("principal=")));
+              assertThat(r, statusCodeIsHC(Response.Status.OK));
+              assertThat(r, bodyHC(containsString("principal=")));
           });
     }
 
@@ -1536,13 +1536,13 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
             HttpUriRequest post = SamlClient.Binding.POST.createSamlUnsignedResponse(getAppServerSamlEndpoint(salesPostSigEmailServletPage), null, responseDoc);
             response = client.execute(post, context);
             System.out.println(EntityUtils.toString(response.getEntity()));
-            Assert.assertThat(response, statusCodeIsHC(Response.Status.FOUND));
+            assertThat(response, statusCodeIsHC(Response.Status.FOUND));
             response.close();
 
             HttpGet get = new HttpGet(salesPostSigEmailServletPage.toString());
             response = client.execute(get);
-            Assert.assertThat(response, statusCodeIsHC(Response.Status.OK));
-            Assert.assertThat(response, bodyHC(containsString("principal=bburke")));
+            assertThat(response, statusCodeIsHC(Response.Status.OK));
+            assertThat(response, bodyHC(containsString("principal=bburke")));
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         } finally {
@@ -1558,8 +1558,8 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
     public void testDifferentCookieName() {
         assertSuccessfulLogin(differentCookieNameServletPage, bburkeUser, testRealmSAMLPostLoginPage, "principal=bburke");
 
-        Assert.assertThat(driver.manage().getCookieNamed("DIFFERENT_SESSION_ID"), notNullValue());
-        Assert.assertThat(driver.manage().getCookieNamed("JSESSIONID"), nullValue());
+        assertThat(driver.manage().getCookieNamed("DIFFERENT_SESSION_ID"), notNullValue());
+        assertThat(driver.manage().getCookieNamed("JSESSIONID"), nullValue());
 
         salesPost2ServletPage.logout();
         checkLoggedOut(differentCookieNameServletPage, testRealmSAMLPostLoginPage);
@@ -1628,11 +1628,11 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         SOAPHeaderElement ecpRequestHeader = (SOAPHeaderElement)it.next();
         NodeList idpList = ecpRequestHeader.getElementsByTagNameNS("urn:oasis:names:tc:SAML:2.0:protocol", "IDPList");
 
-        Assert.assertThat("No IDPList returned from Service Provider", idpList.getLength(), is(1));
+        assertThat("No IDPList returned from Service Provider", idpList.getLength(), is(1));
 
         NodeList idpEntries = idpList.item(0).getChildNodes();
 
-        Assert.assertThat("No IDPEntry returned from Service Provider", idpEntries.getLength(), is(1));
+        assertThat("No IDPEntry returned from Service Provider", idpEntries.getLength(), is(1));
 
         String singleSignOnService = null;
 
@@ -1644,7 +1644,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
             singleSignOnService = location.getNodeValue();
         }
 
-        Assert.assertThat("Could not obtain SSO Service URL", singleSignOnService, notNullValue());
+        assertThat("Could not obtain SSO Service URL", singleSignOnService, notNullValue());
 
         Document authenticationRequest = authnRequestMessage.getSOAPBody().getFirstChild().getOwnerDocument();
         String username = "pedroigor";
@@ -1656,7 +1656,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
                 .header(HttpHeaders.AUTHORIZATION, authHeader)
                 .post(Entity.entity(DocumentUtil.asString(authenticationRequest), "text/xml"));
 
-        Assert.assertThat(authenticationResponse.getStatus(), is(OK.getStatusCode()));
+        assertThat(authenticationResponse.getStatus(), is(OK.getStatusCode()));
 
         SOAPMessage responseMessage  = MessageFactory.newInstance().createMessage(null, new ByteArrayInputStream(authenticationResponse.readEntity(byte[].class)));
 
@@ -1666,19 +1666,19 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
 
         NodeList ecpResponse = responseMessageHeaders.getElementsByTagNameNS(JBossSAMLURIConstants.ECP_PROFILE.get(), JBossSAMLConstants.RESPONSE__ECP.get());
 
-        Assert.assertThat("No ECP Response", ecpResponse.getLength(), is(1));
+        assertThat("No ECP Response", ecpResponse.getLength(), is(1));
 
         Node samlResponse = responseMessage.getSOAPBody().getFirstChild();
 
-        Assert.assertThat(samlResponse, notNullValue());
+        assertThat(samlResponse, notNullValue());
 
         ResponseType responseType = (ResponseType) SAMLParser.getInstance().parse(samlResponse);
         StatusCodeType statusCode = responseType.getStatus().getStatusCode();
 
-        Assert.assertThat(statusCode.getValue().toString(), is(JBossSAMLURIConstants.STATUS_SUCCESS.get()));
-        Assert.assertThat(responseType.getDestination(), is(ecpSPPage.toString()));
-        Assert.assertThat(responseType.getSignature(), notNullValue());
-        Assert.assertThat(responseType.getAssertions().size(), is(1));
+        assertThat(statusCode.getValue().toString(), is(JBossSAMLURIConstants.STATUS_SUCCESS.get()));
+        assertThat(responseType.getDestination(), is(ecpSPPage.toString()));
+        assertThat(responseType.getSignature(), notNullValue());
+        assertThat(responseType.getAssertions().size(), is(1));
 
         SOAPMessage samlResponseRequest = MessageFactory.newInstance().createMessage();
 
@@ -1700,7 +1700,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         }
 
         Response resourceResponse = resourceRequest.get();
-        Assert.assertThat(resourceResponse.readEntity(String.class), containsString("pedroigor"));
+        assertThat(resourceResponse.readEntity(String.class), containsString("pedroigor"));
     }
 
     @Test
@@ -1719,11 +1719,11 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         jakarta.xml.soap.Node ecpRequestHeader = it.next();
         NodeList idpList = ((SOAPHeaderElement)ecpRequestHeader).getElementsByTagNameNS("urn:oasis:names:tc:SAML:2.0:protocol", "IDPList");
 
-        Assert.assertThat("No IDPList returned from Service Provider", idpList.getLength(), is(1));
+        assertThat("No IDPList returned from Service Provider", idpList.getLength(), is(1));
 
         NodeList idpEntries = idpList.item(0).getChildNodes();
 
-        Assert.assertThat("No IDPEntry returned from Service Provider", idpEntries.getLength(), is(1));
+        assertThat("No IDPEntry returned from Service Provider", idpEntries.getLength(), is(1));
 
         String singleSignOnService = null;
 
@@ -1735,7 +1735,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
             singleSignOnService = location.getNodeValue();
         }
 
-        Assert.assertThat("Could not obtain SSO Service URL", singleSignOnService, notNullValue());
+        assertThat("Could not obtain SSO Service URL", singleSignOnService, notNullValue());
 
         Document authenticationRequest = authnRequestMessage.getSOAPBody().getFirstChild().getOwnerDocument();
         String username = "pedroigor";
@@ -1747,17 +1747,17 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
                 .header(HttpHeaders.AUTHORIZATION, authHeader)
                 .post(Entity.entity(DocumentUtil.asString(authenticationRequest), "application/soap+xml"));
 
-        Assert.assertThat(authenticationResponse.getStatus(), is(OK.getStatusCode()));
+        assertThat(authenticationResponse.getStatus(), is(OK.getStatusCode()));
 
         SOAPMessage responseMessage  = MessageFactory.newInstance().createMessage(null, new ByteArrayInputStream(authenticationResponse.readEntity(byte[].class)));
         Node samlResponse = responseMessage.getSOAPBody().getFirstChild();
 
-        Assert.assertThat(samlResponse, notNullValue());
+        assertThat(samlResponse, notNullValue());
 
         StatusResponseType responseType = (StatusResponseType) SAMLParser.getInstance().parse(samlResponse);
         StatusCodeType statusCode = responseType.getStatus().getStatusCode();
 
-        Assert.assertThat(statusCode.getStatusCode().getValue().toString(), is(not(JBossSAMLURIConstants.STATUS_SUCCESS.get())));
+        assertThat(statusCode.getStatusCode().getValue().toString(), is(not(JBossSAMLURIConstants.STATUS_SUCCESS.get())));
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletSessionTimeoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletSessionTimeoutTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_NAME;
 import static org.keycloak.testsuite.util.Matchers.bodyHC;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SamlSignatureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SamlSignatureTest.java
@@ -63,7 +63,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.ASSERTION_NSURI;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.PROTOCOL_NSURI;
 import static org.keycloak.testsuite.adapter.AbstractServletsAdapterTest.samlServletDeployment;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SecuredDeploymentsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SecuredDeploymentsAdapterTest.java
@@ -20,7 +20,7 @@ package org.keycloak.testsuite.adapter.servlet;
 
 import static org.hamcrest.Matchers.containsString;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.arquillian.AppServerTestEnricher.CURRENT_APP_SERVER;
 import static org.keycloak.testsuite.arquillian.AppServerTestEnricher.enableHTTPSForAppServer;
 import static org.keycloak.testsuite.util.ServerURLs.APP_SERVER_SSL_REQUIRED;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/cluster/OIDCAdapterClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/cluster/OIDCAdapterClusterTest.java
@@ -19,7 +19,7 @@ package org.keycloak.testsuite.adapter.servlet.cluster;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlEquals;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminHeadersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminHeadersTest.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AdminHeadersTest extends AbstractAdminTest {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -70,7 +70,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static org.keycloak.testsuite.admin.ImpersonationDisabledTest.IMPERSONATION_DISABLED;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
@@ -1010,7 +1010,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             List<UserRepresentation> result = client.realm("test").users().search(null, "test", null, null, -1, 20);
 
             Assert.assertEquals(20, result.size());
-            Assert.assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("b"))));
+            assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("b"))));
 
             result = client.realm("test").users().search(null, "test", null, null, 20, 40);
 
@@ -1023,12 +1023,12 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             List<UserRepresentation> result = client.realm("test").users().search(null, "test", null, null, -1, 20);
 
             Assert.assertEquals(20, result.size());
-            Assert.assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("a"))));
+            assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("a"))));
 
             client.realm("test").users().search(null, null, null, null, -1, -1);
 
             Assert.assertEquals(20, result.size());
-            Assert.assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("a"))));
+            assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("a"))));
         }
 
         try (Keycloak client = Keycloak.getInstance(getAuthServerContextRoot() + "/auth",
@@ -1037,12 +1037,12 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             List<UserRepresentation> result = client.realm("test").users().search(null, null, null, null, -1, 20);
 
             Assert.assertEquals(20, result.size());
-            Assert.assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("b"))));
+            assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("b"))));
 
             result = client.realm("test").users().search("test", -1, 20, false);
 
             Assert.assertEquals(20, result.size());
-            Assert.assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("b"))));
+            assertThat(result, Matchers.everyItem(Matchers.hasProperty("username", Matchers.startsWith("b"))));
 
             result = client.realm("test").users().search("a", -1, 20, false);
 
@@ -1142,10 +1142,10 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             List<ClientRepresentation> result = client.realm("test").clients().findAll(null, true, false, 0, 1);
 
             Assert.assertEquals(1, result.size());
-            Assert.assertThat(result, Matchers.hasItem(Matchers.hasProperty("clientId", Matchers.is("client-search-09"))));
+            assertThat(result, Matchers.hasItem(Matchers.hasProperty("clientId", Matchers.is("client-search-09"))));
 
             result = client.realm("test").clients().findAll(null, true, false, 1, 1);
-            Assert.assertThat(result, Matchers.hasItem(Matchers.hasProperty("clientId", Matchers.is("client-search-10"))));
+            assertThat(result, Matchers.hasItem(Matchers.hasProperty("clientId", Matchers.is("client-search-10"))));
 
             Assert.assertEquals(1, result.size());
 
@@ -1196,7 +1196,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             List<ClientRepresentation> result = client.realm("test").clients().findAll("client-search-", true, true, 0, 10);
             clients.addAll(result);
             Assert.assertEquals(10, result.size());
-            Assert.assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList("client-search-09",
+            assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList("client-search-09",
                     "client-search-10",
                     "client-search-11",
                     "client-search-12",
@@ -1210,7 +1210,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             result = client.realm("test").clients().findAll("client-search-", true, true, 10, 10);
             clients.addAll(result);
             Assert.assertEquals(10, result.size());
-            Assert.assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList("client-search-19",
+            assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList("client-search-19",
                     "client-search-20",
                     "client-search-21",
                     "client-search-22",
@@ -1224,7 +1224,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             result = client.realm("test").clients().findAll("client-search-", true, true, 20, 10);
             clients.addAll(result);
             Assert.assertEquals(1, result.size());
-            Assert.assertThat(result, Matchers.hasItems(
+            assertThat(result, Matchers.hasItems(
                     Matchers.hasProperty("clientId", Matchers.isOneOf("client-search-29"))));
         }
     }
@@ -1279,7 +1279,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             List<ClientRepresentation> result = client.realm("test").clients().findAll("client-search-", true, true, 0, 10);
             clients.addAll(result);
             Assert.assertEquals(10, result.size());
-            Assert.assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList(
+            assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList(
                     "client-search-15",
                     "client-search-16",
                     "client-search-17",
@@ -1294,7 +1294,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             result = client.realm("test").clients().findAll("client-search-", true, true, 10, 10);
             clients.addAll(result);
             Assert.assertEquals(5, result.size());
-            Assert.assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList(
+            assertThat(result.stream().map(rep -> rep.getClientId()).collect(Collectors.toList()), Matchers.is(Arrays.asList(
                     "client-search-25",
                     "client-search-26",
                     "client-search-27",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -98,7 +98,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.XMLDSIG_NSURI;
@@ -1108,32 +1108,32 @@ public class IdentityProviderTest extends AbstractAdminTest {
         Document document = DocumentUtil.getDocument(body);
 
         Element signatureElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), XMLDSIG_NSURI.get(), "Signature");
-        Assert.assertThat("Signature not null", signatureElement, notNullValue());
+        assertThat("Signature not null", signatureElement, notNullValue());
 
         Element keyInfoElement = DocumentUtil.getDirectChildElement(signatureElement, XMLDSIG_NSURI.get(), "KeyInfo");
-        Assert.assertThat("KeyInfo not null", keyInfoElement, notNullValue());
+        assertThat("KeyInfo not null", keyInfoElement, notNullValue());
 
         Element x509DataElement = DocumentUtil.getDirectChildElement(keyInfoElement, XMLDSIG_NSURI.get(), "X509Data");
-        Assert.assertThat("X509Data not null", x509DataElement, notNullValue());
+        assertThat("X509Data not null", x509DataElement, notNullValue());
 
         Element x509CertificateElement = DocumentUtil.getDirectChildElement(x509DataElement, XMLDSIG_NSURI.get(), "X509Certificate");
-        Assert.assertThat("X509Certificate not null", x509CertificateElement, notNullValue());
+        assertThat("X509Certificate not null", x509CertificateElement, notNullValue());
 
         Element keyNameElement = DocumentUtil.getDirectChildElement(keyInfoElement, XMLDSIG_NSURI.get(), "KeyName");
-        Assert.assertThat("KeyName not null", keyNameElement, notNullValue());
+        assertThat("KeyName not null", keyNameElement, notNullValue());
 
         String activeSigCert = KeyUtils.findActiveSigningKey(realm, Constants.DEFAULT_SIGNATURE_ALGORITHM).getCertificate();
-        Assert.assertThat("activeSigCert not null", activeSigCert, notNullValue());
+        assertThat("activeSigCert not null", activeSigCert, notNullValue());
 
         X509Certificate activeX509SigCert = XMLSignatureUtil.getX509CertificateFromKeyInfoString(activeSigCert);
-        Assert.assertThat("KeyName matches subject DN",
+        assertThat("KeyName matches subject DN",
                 keyNameElement.getTextContent().trim(), equalTo(activeX509SigCert.getSubjectDN().getName()));
 
-        Assert.assertThat("Signing cert matches active realm cert",
+        assertThat("Signing cert matches active realm cert",
                 x509CertificateElement.getTextContent().trim(), equalTo(Base64.getEncoder().encodeToString(activeX509SigCert.getEncoded())));
 
         PublicKey activePublicSigKey = activeX509SigCert.getPublicKey();
-        Assert.assertThat("Metadata signature is valid",
+        assertThat("Metadata signature is valid",
                 new SAML2Signature().validate(document, new HardcodedKeyLocator(activePublicSigKey)), is(true));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IllegalAdminUpgradeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IllegalAdminUpgradeTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 
 /**
@@ -166,7 +167,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
             
@@ -176,7 +177,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -186,7 +187,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -196,7 +197,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -206,7 +207,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -216,7 +217,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -226,7 +227,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -236,7 +237,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -246,7 +247,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -256,7 +257,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -266,7 +267,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -276,7 +277,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -317,7 +318,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -327,7 +328,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -337,7 +338,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -347,7 +348,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -357,7 +358,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -367,7 +368,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -377,7 +378,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -387,7 +388,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -397,7 +398,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -407,7 +408,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -417,7 +418,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -427,7 +428,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm(TEST).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
 
@@ -468,7 +469,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -477,7 +478,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -486,7 +487,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -495,7 +496,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -504,7 +505,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -513,7 +514,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -522,7 +523,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -531,7 +532,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -540,7 +541,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -549,7 +550,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -558,7 +559,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -567,7 +568,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -576,7 +577,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -585,7 +586,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -594,7 +595,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));                    
                 }
                 roles.clear();
@@ -603,7 +604,7 @@ public class IllegalAdminUpgradeTest extends AbstractKeycloakTest {
                     realmClient.realm("master").users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                     Assert.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
-                    Assert.assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()), 
+                    assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/InitialAccessTokenResourceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/InitialAccessTokenResourceTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -80,6 +80,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.keycloak.services.resources.admin.AdminAuth.Resource.AUTHORIZATION;
 import static org.keycloak.services.resources.admin.AdminAuth.Resource.CLIENT;
@@ -509,10 +510,10 @@ public class PermissionsTest extends AbstractKeycloakTest {
             }
         }, Resource.CLIENT, false, true);
         List<ClientRepresentation> l = clients.get(AdminRoles.QUERY_CLIENTS).realm(REALM_NAME).clients().findAll();
-        Assert.assertThat(l, Matchers.empty());
+        assertThat(l, Matchers.empty());
 
         l = clients.get(AdminRoles.VIEW_CLIENTS).realm(REALM_NAME).clients().findAll();
-        Assert.assertThat(l, Matchers.not(Matchers.empty()));
+        assertThat(l, Matchers.not(Matchers.empty()));
 
         ClientRepresentation client = l.get(0);
         invoke(new InvocationWithResponse() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
@@ -34,6 +34,8 @@ import org.keycloak.testsuite.util.LDAPRule;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -145,7 +147,7 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
             "false", null, "false", LDAPConstants.AUTH_TYPE_SIMPLE);
 
         List<LDAPCapabilityRepresentation> ldapCapabilities = realm.ldapServerCapabilities(config);
-        Assert.assertThat(ldapCapabilities, Matchers.hasItem(new LDAPCapabilityRepresentation(PasswordModifyRequest.PASSWORD_MODIFY_OID, LDAPCapabilityRepresentation.CapabilityType.EXTENSION)));
+        assertThat(ldapCapabilities, Matchers.hasItem(new LDAPCapabilityRepresentation(PasswordModifyRequest.PASSWORD_MODIFY_OID, LDAPCapabilityRepresentation.CapabilityType.EXTENSION)));
 
         // Query the rootDSE failure
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ExecutionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ExecutionTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -96,7 +97,7 @@ public class ExecutionTest extends AbstractAuthenticationTest {
 
         AuthenticatorConfigRepresentation updated = authMgmtResource.getAuthenticatorConfig(authConfigRep.getId());
 
-        Assert.assertThat(updated.getConfig().values(), hasItems("test-updated", "skip"));
+        assertThat(updated.getConfig().values(), hasItems("test-updated", "skip"));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -56,6 +56,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.Matchers.body;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIs;
@@ -249,9 +250,9 @@ public class FlowTest extends AbstractAuthenticationTest {
         // copy using existing alias as new name
         Response response = authMgmtResource.copy("browser", params);
         try {
-            Assert.assertThat("Copy flow using the new alias of existing flow should fail", response, statusCodeIs(Status.CONFLICT));
-            Assert.assertThat("Copy flow using the new alias of existing flow should fail", response, body(containsString("already exists")));
-            Assert.assertThat("Copy flow using the new alias of existing flow should fail", response, body(containsString("flow alias")));
+            assertThat("Copy flow using the new alias of existing flow should fail", response, statusCodeIs(Status.CONFLICT));
+            assertThat("Copy flow using the new alias of existing flow should fail", response, body(containsString("already exists")));
+            assertThat("Copy flow using the new alias of existing flow should fail", response, body(containsString("flow alias")));
         } finally {
             response.close();
         }
@@ -260,7 +261,7 @@ public class FlowTest extends AbstractAuthenticationTest {
         params.clear();
         response = authMgmtResource.copy("non-existent", params);
         try {
-            Assert.assertThat("Copy non-existing flow", response, statusCodeIs(Status.NOT_FOUND));
+            assertThat("Copy non-existing flow", response, statusCodeIs(Status.NOT_FOUND));
         } finally {
             response.close();
         }
@@ -270,7 +271,7 @@ public class FlowTest extends AbstractAuthenticationTest {
         response = authMgmtResource.copy("browser", params);
         assertAdminEvents.assertEvent(testRealmId, OperationType.CREATE, AdminEventPaths.authCopyFlowPath("browser"), params, ResourceType.AUTH_FLOW);
         try {
-            Assert.assertThat("Copy flow", response, statusCodeIs(Status.CREATED));
+            assertThat("Copy flow", response, statusCodeIs(Status.CREATED));
         } finally {
             response.close();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ProvidersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ProvidersTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -239,7 +240,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
     private void compareProviders(List<Map<String, Object>> expected, List<Map<String, Object>> actual) {
         Assert.assertEquals("Providers count", expected.size(), actual.size());
         // compare ignoring list and map impl types
-        Assert.assertThat(normalizeResults(actual), is(normalizeResults(expected)));
+        assertThat(normalizeResults(actual), is(normalizeResults(expected)));
     }
 
     private List<Map<String, Object>> normalizeResults(List<Map<String, Object>> list) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/InstallationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/InstallationTest.java
@@ -45,7 +45,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import jakarta.ws.rs.NotFoundException;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.keycloak.common.Profile.Feature.AUTHORIZATION;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
@@ -78,6 +78,7 @@ import org.keycloak.util.JsonSerialization;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
 /**
  * @author <a href="mailto:vramik@redhat.com">Vlastislav Ramik</a>
@@ -166,7 +167,7 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
         CookieStore cookieStore = new BasicCookieStore();
         context.setCookieStore(cookieStore);
         HttpUriRequest request = handleLogin(getPageContent(oauth.getLoginFormUrl(), httpClient, context), userName, password);
-        Assert.assertThat(parseAndCloseResponse(httpClient.execute(request, context)), containsString("<title>AUTH_RESPONSE</title>"));
+        assertThat(parseAndCloseResponse(httpClient.execute(request, context)), containsString("<title>AUTH_RESPONSE</title>"));
         return context;
     }
 
@@ -267,8 +268,8 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
             oauth1.idTokenHint(idTokenHint).openLogout();
 
             // Code should be successfully exchanged for the token at max once. In some cases (EG. Cross-DC) it may not be even successfully exchanged
-            Assert.assertThat(codeToTokenSuccessCount.get(), Matchers.lessThanOrEqualTo(0));
-            Assert.assertThat(codeToTokenErrorsCount.get(), Matchers.greaterThanOrEqualTo(DEFAULT_THREADS));
+            assertThat(codeToTokenSuccessCount.get(), Matchers.lessThanOrEqualTo(0));
+            assertThat(codeToTokenErrorsCount.get(), Matchers.greaterThanOrEqualTo(DEFAULT_THREADS));
 
             log.infof("Iteration %d passed successfully", i);
         }
@@ -408,9 +409,9 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
             final HttpClientContext context = HttpClientContext.create();
             context.setCookieStore(templateContext.getCookieStore());
             String pageContent = getPageContent(oauth1.getLoginFormUrl(), httpClient, context);
-            Assert.assertThat(pageContent, Matchers.containsString("<title>AUTH_RESPONSE</title>"));
-            Assert.assertThat(context.getRedirectLocations(), Matchers.notNullValue());
-            Assert.assertThat(context.getRedirectLocations(), Matchers.not(Matchers.empty()));
+            assertThat(pageContent, Matchers.containsString("<title>AUTH_RESPONSE</title>"));
+            assertThat(context.getRedirectLocations(), Matchers.notNullValue());
+            assertThat(context.getRedirectLocations(), Matchers.not(Matchers.empty()));
             String currentUrl = context.getRedirectLocations().get(0).toString();
 
             Map<String, String> query = getQueryFromUrl(currentUrl);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialexport/PartialExportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialexport/PartialExportTest.java
@@ -26,6 +26,8 @@ import org.hamcrest.Matchers;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.representations.idm.UserRepresentation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -128,13 +130,13 @@ public class PartialExportTest extends AbstractAdminTest {
         Assert.assertNull("Password should be null", serviceAccount.getCredentials());
         if (rolesExpected) {
             List<String> realmRoles = serviceAccount.getRealmRoles();
-            Assert.assertThat("Realm roles are OK", realmRoles, Matchers.containsInAnyOrder("uma_authorization", "user", "offline_access"));
+            assertThat("Realm roles are OK", realmRoles, Matchers.containsInAnyOrder("uma_authorization", "user", "offline_access"));
 
             Map<String, List<String>> clientRoles = serviceAccount.getClientRoles();
             Assert.assertNotNull("Client roles are exported", clientRoles);
-            Assert.assertThat("Client roles for test-app-service-account are OK", clientRoles.get("test-app-service-account"),
+            assertThat("Client roles for test-app-service-account are OK", clientRoles.get("test-app-service-account"),
                     Matchers.containsInAnyOrder("test-app-service-account", "test-app-service-account-parent"));
-            Assert.assertThat("Client roles for account are OK", clientRoles.get("account"),
+            assertThat("Client roles for account are OK", clientRoles.get("account"),
                     Matchers.containsInAnyOrder("manage-account", "view-profile"));
         } else {
             Assert.assertNull("Service account should be exported without realm roles", serviceAccount.getRealmRoles());
@@ -254,7 +256,7 @@ public class PartialExportTest extends AbstractAdminTest {
         Assert.assertTrue("Client role test-app-allowed-by-scope for test-app-scope", roles.containsKey("test-app-allowed-by-scope"));
 
         roles = collectRoles(clientRoles.get("test-app-service-account"));
-        Assert.assertThat("Client roles are OK for test-app-service-account", roles.keySet(),
+        assertThat("Client roles are OK for test-app-service-account", roles.keySet(),
                 Matchers.containsInAnyOrder("test-app-service-account", "test-app-service-account-parent", "test-app-service-account-child"));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialimport/PartialImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialimport/PartialImportTest.java
@@ -413,8 +413,8 @@ public class PartialImportTest extends AbstractAuthTest {
             String id = result.getId();
             UserResource userRsc = testRealmResource().users().get(id);
             UserRepresentation user = userRsc.toRepresentation();
-            Assert.assertThat(user.getUsername(), startsWith(USER_PREFIX));
-            Assert.assertThat(userIds, hasItem(id));
+            assertThat(user.getUsername(), startsWith(USER_PREFIX));
+            assertThat(userIds, hasItem(id));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ConflictingScopePermissionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ConflictingScopePermissionTest.java
@@ -19,7 +19,7 @@ package org.keycloak.testsuite.authz;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.AssertEvents.isUUID;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionClaimTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionClaimTest.java
@@ -18,7 +18,7 @@ package org.keycloak.testsuite.authz;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionManagementTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.OAuthClient.AUTH_SERVER_ROOT;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaPermissionTicketPushedClaimsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaPermissionTicketPushedClaimsTest.java
@@ -18,7 +18,7 @@ package org.keycloak.testsuite.authz;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Collection;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementWithAuthzClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementWithAuthzClientTest.java
@@ -19,7 +19,7 @@ package org.keycloak.testsuite.authz.admin;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.ApiUtil.removeUserByUsername;
 import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.configurePostBrokerLoginWithOTP;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -42,7 +42,7 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.support.PageFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.assertHardCodedSessionNote;
 import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.configureAutoLinkFlow;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractIdentityProviderMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractIdentityProviderMapperTest.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.ApiUtil.createUserAndResetPasswordWithAdminClient;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.KcSamlBrokerConfiguration.ATTRIBUTE_TO_MAP_FRIENDLY_NAME;
 
 import java.util.List;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUsernameTemplateMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUsernameTemplateMapperTest.java
@@ -1,7 +1,7 @@
 package org.keycloak.testsuite.broker;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.broker.KcOidcBrokerConfiguration.ATTRIBUTE_TO_MAP_NAME;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/HardcodedUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/HardcodedUserAttributeMapperTest.java
@@ -2,7 +2,7 @@ package org.keycloak.testsuite.broker;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.FORCE;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.IMPORT;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/JsonUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/JsonUserAttributeMapperTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.FORCE;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.IMPORT;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.LEGACY;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerParameterForwardTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerParameterForwardTest.java
@@ -2,6 +2,7 @@ package org.keycloak.testsuite.broker;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
@@ -53,16 +54,16 @@ public class KcOidcBrokerParameterForwardTest extends AbstractBrokerTest {
 
         waitForPage(driver, "sign in to", true);
 
-        Assert.assertThat("Driver should be on the provider realm page right now",
+        assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));
 
-        Assert.assertThat(FORWARDED_PARAMETER + "=" + FORWARDED_PARAMETER_VALUE + " should be part of the url",
+        assertThat(FORWARDED_PARAMETER + "=" + FORWARDED_PARAMETER_VALUE + " should be part of the url",
                 driver.getCurrentUrl(), containsString(FORWARDED_PARAMETER + "=" + FORWARDED_PARAMETER_VALUE));
 
-        Assert.assertThat("\"" + PARAMETER_NOT_SET + "\"" + " should NOT be part of the url",
+        assertThat("\"" + PARAMETER_NOT_SET + "\"" + " should NOT be part of the url",
                 driver.getCurrentUrl(), not(containsString(PARAMETER_NOT_SET)));
 
-        Assert.assertThat("\"" + PARAMETER_NOT_FORWARDED +"\"" + " should be NOT part of the url",
+        assertThat("\"" + PARAMETER_NOT_FORWARDED +"\"" + " should be NOT part of the url",
                 driver.getCurrentUrl(), not(containsString(PARAMETER_NOT_FORWARDED)));
 
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
@@ -70,7 +71,7 @@ public class KcOidcBrokerParameterForwardTest extends AbstractBrokerTest {
 
         updateAccountInformationPage.assertCurrent();
 
-        Assert.assertThat("We must be on correct realm right now",
+        assertThat("We must be on correct realm right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.consumerRealmName() + "/"));
 
         log.debug("Updating info on updateAccount page");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerStateParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerStateParameterTest.java
@@ -30,7 +30,7 @@ import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginExpiredPage;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesDisabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesDisabledTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static java.util.Locale.ENGLISH;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.OAuth2Constants.UI_LOCALES_PARAM;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
@@ -49,10 +50,10 @@ public class KcOidcBrokerUiLocalesDisabledTest extends AbstractBrokerTest {
 
         waitForPage(driver, "sign in to", true);
 
-        Assert.assertThat("Driver should be on the provider realm page right now",
+        assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));
 
-        Assert.assertThat(UI_LOCALES_PARAM + "=" + ENGLISH.toLanguageTag() + " should be part of the url",
+        assertThat(UI_LOCALES_PARAM + "=" + ENGLISH.toLanguageTag() + " should be part of the url",
                 driver.getCurrentUrl(), not(containsString(UI_LOCALES_PARAM + "=" + ENGLISH.toLanguageTag())));
 
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
@@ -60,7 +61,7 @@ public class KcOidcBrokerUiLocalesDisabledTest extends AbstractBrokerTest {
 
         updateAccountInformationPage.assertCurrent();
 
-        Assert.assertThat("We must be on correct realm right now",
+        assertThat("We must be on correct realm right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.consumerRealmName() + "/"));
 
         log.debug("Updating info on updateAccount page");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesEnabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesEnabledTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import static java.util.Locale.ENGLISH;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.OAuth2Constants.UI_LOCALES_PARAM;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
@@ -48,10 +49,10 @@ public class KcOidcBrokerUiLocalesEnabledTest extends AbstractBrokerTest {
 
         waitForPage(driver, "sign in to", true);
 
-        Assert.assertThat("Driver should be on the provider realm page right now",
+        assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));
 
-        Assert.assertThat(UI_LOCALES_PARAM + "=" + ENGLISH.toLanguageTag() + " should be part of the url",
+        assertThat(UI_LOCALES_PARAM + "=" + ENGLISH.toLanguageTag() + " should be part of the url",
                 driver.getCurrentUrl(), containsString(UI_LOCALES_PARAM + "=" + ENGLISH.toLanguageTag()));
 
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
@@ -59,7 +60,7 @@ public class KcOidcBrokerUiLocalesEnabledTest extends AbstractBrokerTest {
 
         updateAccountInformationPage.assertCurrent();
 
-        Assert.assertThat("We must be on correct realm right now",
+        assertThat("We must be on correct realm right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.consumerRealmName() + "/"));
 
         log.debug("Updating info on updateAccount page");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesWithIdpHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesWithIdpHintTest.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.OAuth2Constants.*;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.*;
 import static org.keycloak.testsuite.broker.BrokerTestTools.*;
@@ -45,21 +46,21 @@ public class KcOidcBrokerUiLocalesWithIdpHintTest extends AbstractBrokerTest {
 
         waitForPage(driver, "belépés ide", true); // sign in to
 
-        Assert.assertThat("Driver should be on the provider realm page right now",
+        assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));
 
-        Assert.assertThat(UI_LOCALES_PARAM + "=" + HUNGARIAN.toLanguageTag() + " should be part of the url",
+        assertThat(UI_LOCALES_PARAM + "=" + HUNGARIAN.toLanguageTag() + " should be part of the url",
             driver.getCurrentUrl(), containsString(UI_LOCALES_PARAM + "=" + HUNGARIAN.toLanguageTag()));
-        Assert.assertThat("The provider realm should be in Hungarian because the ui_locales is passed",
+        assertThat("The provider realm should be in Hungarian because the ui_locales is passed",
             driver.getPageSource(), containsString("Jelentkezzen be a fiókjába")); // Sign in to your account
 
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
         waitForPage(driver, "felhasználói fiók adatok módosítása", false); // update account information
 
-        Assert.assertThat("The consumer realm should be in Hungarian even after the redirect from the IDP.",
+        assertThat("The consumer realm should be in Hungarian even after the redirect from the IDP.",
                 driver.getPageSource(), containsString("Felhasználói fiók adatok módosítása"));// update account information
 
-        Assert.assertThat("We must be on correct realm right now",
+        assertThat("We must be on correct realm right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.consumerRealmName() + "/"));
 
         log.debug("Updating info on updateAccount page");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerAllowedClockSkewTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerAllowedClockSkewTest.java
@@ -20,7 +20,7 @@ import java.io.Closeable;
 import jakarta.ws.rs.core.Response;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
@@ -100,8 +100,8 @@ public class KcSamlBrokerAllowedClockSkewTest extends AbstractInitializedBaseBro
 
               .getSamlResponse(SamlClient.Binding.POST);       // Response from consumer IdP
 
-            Assert.assertThat(samlResponse, Matchers.notNullValue());
-            Assert.assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+            assertThat(samlResponse, Matchers.notNullValue());
+            assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerSessionNotOnOrAfterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerSessionNotOnOrAfterTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_SAML_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.USER_EMAIL;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerTest.java
@@ -48,7 +48,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.saml.RoleMapperTest.ROLE_ATTRIBUTE_NAME;
 import static org.keycloak.testsuite.util.Matchers.isSamlResponse;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
@@ -293,8 +293,8 @@ public final class KcSamlBrokerTest extends AbstractAdvancedBrokerTest {
 
           .getSamlResponse(Binding.POST);       // Response from consumer IdP
 
-        Assert.assertThat(samlResponse, Matchers.notNullValue());
-        Assert.assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        assertThat(samlResponse, Matchers.notNullValue());
+        assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
     }
 
     @Test
@@ -343,8 +343,8 @@ public final class KcSamlBrokerTest extends AbstractAdvancedBrokerTest {
 
                 .getSamlResponse(Binding.POST);       // Response from consumer IdP
 
-        Assert.assertThat(samlResponse, Matchers.notNullValue());
-        Assert.assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        assertThat(samlResponse, Matchers.notNullValue());
+        assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
 
         Stream<AssertionType> assertionTypeStream = assertionsUnencrypted(samlResponse.getSamlObject());
         Stream<AttributeType> attributeStatementTypeStream = attributesUnecrypted(attributeStatements(assertionTypeStream));
@@ -389,8 +389,8 @@ public final class KcSamlBrokerTest extends AbstractAdvancedBrokerTest {
 
           .getSamlResponse(Binding.POST);       // Response from consumer IdP
 
-        Assert.assertThat(samlResponse, Matchers.notNullValue());
-        Assert.assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        assertThat(samlResponse, Matchers.notNullValue());
+        assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
       }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
@@ -63,7 +63,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_PROV_NAME;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -148,7 +148,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
 
         waitForPage("sign in to", true);
 
-        Assert.assertThat("Driver should be on the provider realm page right now",
+        assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + REALM_PROV_NAME + "/"));
 
         log.debug("Logging in");
@@ -157,7 +157,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
         waitForPage("update account information", false);
 
         Assert.assertTrue(updateAccountInformationPage.isCurrent());
-        Assert.assertThat("We must be on consumer realm right now",
+        assertThat("We must be on consumer realm right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + REALM_CONS_NAME + "/"));
 
         log.debug("Updating info on updateAccount page");
@@ -173,7 +173,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
         boolean isUserFound = users.stream().anyMatch(user -> user.getUsername().equals(CONSUMER_CHOSEN_USERNAME) && user.getEmail().equals("test@localhost"));
         Assert.assertTrue("There must be user " + CONSUMER_CHOSEN_USERNAME + " in realm " + REALM_CONS_NAME, isUserFound);
 
-        Assert.assertThat(driver.findElement(By.tagName("a")).getAttribute("id"), containsString("account"));
+        assertThat(driver.findElement(By.tagName("a")).getAttribute("id"), containsString("account"));
     }
 
     private String getSamlIdpInitiatedUrl(String realmName, String samlIdpInitiatedSsoUrlName) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlRequestedAuthnContextBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlRequestedAuthnContextBrokerTest.java
@@ -17,7 +17,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.AC_PASSWORD_PROTECTED_TRANSPORT;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.ASSERTION_NSURI;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.PROTOCOL_NSURI;
@@ -55,7 +55,7 @@ public final class KcSamlRequestedAuthnContextBrokerTest extends AbstractBrokerT
 
                         // Find the RequestedAuthnContext element
                         Element requestedAuthnContextElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), PROTOCOL_NSURI.get(), "RequestedAuthnContext");
-                        Assert.assertThat("RequestedAuthnContext element found in request document, but was not necessary as ClassRef/DeclRefs were not specified", requestedAuthnContextElement, Matchers.nullValue());
+                        assertThat("RequestedAuthnContext element found in request document, but was not necessary as ClassRef/DeclRefs were not specified", requestedAuthnContextElement, Matchers.nullValue());
                     }
                     catch (Exception ex)
                     {
@@ -90,7 +90,7 @@ public final class KcSamlRequestedAuthnContextBrokerTest extends AbstractBrokerT
 
                         // Find the RequestedAuthnContext element
                         Element requestedAuthnContextElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), PROTOCOL_NSURI.get(), "RequestedAuthnContext");
-                        Assert.assertThat("RequestedAuthnContext element found in request document, but was not necessary as ClassRef/DeclRefs were not specified", requestedAuthnContextElement, Matchers.nullValue());
+                        assertThat("RequestedAuthnContext element found in request document, but was not necessary as ClassRef/DeclRefs were not specified", requestedAuthnContextElement, Matchers.nullValue());
                     }
                     catch (Exception ex)
                     {
@@ -126,17 +126,17 @@ public final class KcSamlRequestedAuthnContextBrokerTest extends AbstractBrokerT
 
                         // Find the RequestedAuthnContext element
                         Element requestedAuthnContextElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), PROTOCOL_NSURI.get(), "RequestedAuthnContext");
-                        Assert.assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement, Matchers.notNullValue());
+                        assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement, Matchers.notNullValue());
 
                         // Verify the ComparisonType attribute
-                        Assert.assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement.getAttribute("Comparison"), Matchers.is(AuthnContextComparisonType.EXACT.value()));
+                        assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement.getAttribute("Comparison"), Matchers.is(AuthnContextComparisonType.EXACT.value()));
 
                         // Find the RequestedAuthnContext/ClassRef element
                         Element requestedAuthnContextClassRefElement = DocumentUtil.getDirectChildElement(requestedAuthnContextElement, ASSERTION_NSURI.get(), "AuthnContextClassRef");
-                        Assert.assertThat("RequestedAuthnContext/AuthnContextClassRef element not found in request document", requestedAuthnContextClassRefElement, Matchers.notNullValue());
+                        assertThat("RequestedAuthnContext/AuthnContextClassRef element not found in request document", requestedAuthnContextClassRefElement, Matchers.notNullValue());
 
                         // Make sure the RequestedAuthnContext/ClassRef element has the requested value
-                        Assert.assertThat("RequestedAuthnContext/AuthnContextClassRef element does not have the expected value", requestedAuthnContextClassRefElement.getTextContent(), Matchers.is(AC_PASSWORD_PROTECTED_TRANSPORT.get()));
+                        assertThat("RequestedAuthnContext/AuthnContextClassRef element does not have the expected value", requestedAuthnContextClassRefElement.getTextContent(), Matchers.is(AC_PASSWORD_PROTECTED_TRANSPORT.get()));
                     }
                     catch (Exception ex)
                     {
@@ -172,17 +172,17 @@ public final class KcSamlRequestedAuthnContextBrokerTest extends AbstractBrokerT
 
                         // Find the RequestedAuthnContext element
                         Element requestedAuthnContextElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), PROTOCOL_NSURI.get(), "RequestedAuthnContext");
-                        Assert.assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement, Matchers.notNullValue());
+                        assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement, Matchers.notNullValue());
 
                         // Verify the ComparisonType attribute
-                        Assert.assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement.getAttribute("Comparison"), Matchers.is(AuthnContextComparisonType.MINIMUM.value()));
+                        assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement.getAttribute("Comparison"), Matchers.is(AuthnContextComparisonType.MINIMUM.value()));
 
                         // Find the RequestedAuthnContext/DeclRef element
                         Element requestedAuthnContextDeclRefElement = DocumentUtil.getDirectChildElement(requestedAuthnContextElement, ASSERTION_NSURI.get(), "AuthnContextDeclRef");
-                        Assert.assertThat("RequestedAuthnContext/AuthnContextDeclRef element not found in request document", requestedAuthnContextDeclRefElement, Matchers.notNullValue());
+                        assertThat("RequestedAuthnContext/AuthnContextDeclRef element not found in request document", requestedAuthnContextDeclRefElement, Matchers.notNullValue());
 
                         // Make sure the RequestedAuthnContext/DeclRef element has the requested value
-                        Assert.assertThat("RequestedAuthnContext/AuthnContextDeclRef element does not have the expected value", requestedAuthnContextDeclRefElement.getTextContent(), Matchers.is("secure/name/password/icmaolr/uri"));
+                        assertThat("RequestedAuthnContext/AuthnContextDeclRef element does not have the expected value", requestedAuthnContextDeclRefElement.getTextContent(), Matchers.is("secure/name/password/icmaolr/uri"));
                     }
                     catch (Exception ex)
                     {
@@ -217,17 +217,17 @@ public final class KcSamlRequestedAuthnContextBrokerTest extends AbstractBrokerT
 
                         // Find the RequestedAuthnContext element
                         Element requestedAuthnContextElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), PROTOCOL_NSURI.get(), "RequestedAuthnContext");
-                        Assert.assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement, Matchers.notNullValue());
+                        assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement, Matchers.notNullValue());
 
                         // Verify the ComparisonType attribute
-                        Assert.assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement.getAttribute("Comparison"), Matchers.is(AuthnContextComparisonType.EXACT.value()));
+                        assertThat("RequestedAuthnContext element not found in request document", requestedAuthnContextElement.getAttribute("Comparison"), Matchers.is(AuthnContextComparisonType.EXACT.value()));
 
                         // Find the RequestedAuthnContext/ClassRef element
                         Element requestedAuthnContextClassRefElement = DocumentUtil.getDirectChildElement(requestedAuthnContextElement, ASSERTION_NSURI.get(), "AuthnContextClassRef");
-                        Assert.assertThat("RequestedAuthnContext/AuthnContextClassRef element not found in request document", requestedAuthnContextClassRefElement, Matchers.notNullValue());
+                        assertThat("RequestedAuthnContext/AuthnContextClassRef element not found in request document", requestedAuthnContextClassRefElement, Matchers.notNullValue());
 
                         // Make sure the RequestedAuthnContext/ClassRef element has the requested value
-                        Assert.assertThat("RequestedAuthnContext/AuthnContextClassRef element does not have the expected value", requestedAuthnContextClassRefElement.getTextContent(), Matchers.is(AC_PASSWORD_PROTECTED_TRANSPORT.get()));
+                        assertThat("RequestedAuthnContext/AuthnContextClassRef element does not have the expected value", requestedAuthnContextClassRefElement.getTextContent(), Matchers.is(AC_PASSWORD_PROTECTED_TRANSPORT.get()));
                     }
                     catch (Exception ex)
                     {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlSignedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlSignedBrokerTest.java
@@ -53,7 +53,7 @@ import org.w3c.dom.NodeList;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 import static org.keycloak.testsuite.util.Matchers.bodyHC;
 import static org.keycloak.testsuite.util.Matchers.isSamlResponse;
@@ -68,13 +68,13 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
         KeysMetadataRepresentation providerKeysMetadata = adminClient.realm(bc.providerRealmName()).keys().getKeyMetadata();
 
         String providerSigCert = KeyUtils.findActiveSigningKey(adminClient.realm(bc.providerRealmName()), Algorithm.RS256).getCertificate();
-        Assert.assertThat(providerSigCert, Matchers.notNullValue());
+        assertThat(providerSigCert, Matchers.notNullValue());
 
         String consumerEncCert = KeyUtils.findActiveEncryptingKey(adminClient.realm(bc.consumerRealmName()), Algorithm.RSA_OAEP).getCertificate();
-        Assert.assertThat(consumerEncCert, Matchers.notNullValue());
+        assertThat(consumerEncCert, Matchers.notNullValue());
 
         String consumerSigCert = KeyUtils.findActiveSigningKey(adminClient.realm(bc.consumerRealmName()), Algorithm.RS256).getCertificate();
-        Assert.assertThat(consumerSigCert, Matchers.notNullValue());
+        assertThat(consumerSigCert, Matchers.notNullValue());
 
         try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(identityProviderResource)
             .setAttribute(SAMLIdentityProviderConfig.VALIDATE_SIGNATURE, Boolean.toString(signedAssertion || signedDocument))
@@ -232,8 +232,8 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
 
           .getSamlResponse(Binding.POST);       // Response from consumer IdP
 
-        Assert.assertThat(samlResponse, Matchers.notNullValue());
-        Assert.assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        assertThat(samlResponse, Matchers.notNullValue());
+        assertThat(samlResponse.getSamlObject(), isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
     }
 
     @Test
@@ -259,7 +259,7 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
             List<ClientRepresentation> clientRepresentationList = super.createProviderClients();
 
             String consumerCert = KeyUtils.findActiveSigningKey(adminClient.realm(consumerRealmName()), Algorithm.RS256).getCertificate();
-            Assert.assertThat(consumerCert, Matchers.notNullValue());
+            assertThat(consumerCert, Matchers.notNullValue());
 
             for (ClientRepresentation client : clientRepresentationList) {
                 client.setClientAuthenticatorType("client-secret");
@@ -286,7 +286,7 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
             IdentityProviderRepresentation result = super.setUpIdentityProvider(syncMode);
 
             String providerCert = KeyUtils.findActiveSigningKey(adminClient.realm(providerRealmName()), Algorithm.RS256).getCertificate();
-            Assert.assertThat(providerCert, Matchers.notNullValue());
+            assertThat(providerCert, Matchers.notNullValue());
 
             Map<String, String> config = result.getConfig();
 
@@ -440,10 +440,10 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
         // Verifies that an AuthnRequest contains the KeyInfo/X509Data element when
         // client AuthnRequest signature is requested
         String providerCert = KeyUtils.findActiveSigningKey(adminClient.realm(bc.providerRealmName()), Algorithm.RS256).getCertificate();
-        Assert.assertThat(providerCert, Matchers.notNullValue());
+        assertThat(providerCert, Matchers.notNullValue());
 
         String consumerCert = KeyUtils.findActiveSigningKey(adminClient.realm(bc.consumerRealmName()), Algorithm.RS256).getCertificate();
-        Assert.assertThat(consumerCert, Matchers.notNullValue());
+        assertThat(consumerCert, Matchers.notNullValue());
 
         try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(identityProviderResource)
             .setAttribute(SAMLIdentityProviderConfig.VALIDATE_SIGNATURE, Boolean.toString(true))
@@ -474,15 +474,15 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
                     {
                         // Find the Signature element
                         Element signatureElement = DocumentUtil.getDirectChildElement(document.getDocumentElement(), XMLSignature.XMLNS, "Signature");
-                        Assert.assertThat("Signature element not found in request document", signatureElement, Matchers.notNullValue());
+                        assertThat("Signature element not found in request document", signatureElement, Matchers.notNullValue());
 
                         // Find the KeyInfo element
                         Element keyInfoElement = DocumentUtil.getDirectChildElement(signatureElement, XMLSignature.XMLNS, "KeyInfo");
-                        Assert.assertThat("KeyInfo element not found in request Signature element", keyInfoElement, Matchers.notNullValue());
+                        assertThat("KeyInfo element not found in request Signature element", keyInfoElement, Matchers.notNullValue());
 
                         // Find the X509Data element
                         Element x509DataElement = DocumentUtil.getDirectChildElement(keyInfoElement, XMLSignature.XMLNS, "X509Data");
-                        Assert.assertThat("X509Data element not found in request Signature/KeyInfo element", x509DataElement, Matchers.notNullValue());
+                        assertThat("X509Data element not found in request Signature/KeyInfo element", x509DataElement, Matchers.notNullValue());
                     }
                     catch (Exception ex)
                     {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlXPathAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlXPathAttributeMapperTest.java
@@ -24,6 +24,7 @@ import org.w3c.dom.Document;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_SAML_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
@@ -118,10 +119,10 @@ public class KcSamlXPathAttributeMapperTest extends AbstractInitializedBaseBroke
         RealmResource realm = adminClient.realm(bc.consumerRealmName());
 
         UserRepresentation user = realm.users().search(bc.getUserLogin()).get(0);
-        Assert.assertThat(user.getFirstName(), equalTo("Theo"));
-        Assert.assertThat(user.getLastName(), equalTo("Tester"));
-        Assert.assertThat(user.getEmail(), equalTo("test@example.org"));
-        Assert.assertThat(user.getAttributes().get("xml-output"), equalTo(Collections.singletonList("Some random text")));
+        assertThat(user.getFirstName(), equalTo("Theo"));
+        assertThat(user.getLastName(), equalTo("Tester"));
+        assertThat(user.getEmail(), equalTo("test@example.org"));
+        assertThat(user.getAttributes().get("xml-output"), equalTo(Collections.singletonList("Some random text")));
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmSessionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmSessionTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import static org.hamcrest.Matchers.equalTo;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.cli.KcAdmExec.execute;
 
@@ -67,7 +68,7 @@ public class KcAdmSessionTest extends AbstractAdmCliTest {
 
             assertExitCodeAndStdErrSize(exe, 0, 0);
             List<ObjectNode> roles = loadJson(exe.stdout(), LIST_OF_JSON);
-            Assert.assertThat("expected three realm roles available", roles.size(), equalTo(3));
+            assertThat("expected three realm roles available", roles.size(), equalTo(3));
 
             // create realm role
             exe = execute("create roles --config '" + configFile.getName() + "' -s name=testrole -s 'description=Test role' -o");
@@ -82,7 +83,7 @@ public class KcAdmSessionTest extends AbstractAdmCliTest {
 
             assertExitCodeAndStdErrSize(exe, 0, 0);
             roles = loadJson(exe.stdout(), LIST_OF_JSON);
-            Assert.assertThat("expected four realm roles available", roles.size(), equalTo(4));
+            assertThat("expected four realm roles available", roles.size(), equalTo(4));
 
             // create client
             exe = execute("create clients --config '" + configFile.getName() + "' -s clientId=testclient -i");
@@ -102,7 +103,7 @@ public class KcAdmSessionTest extends AbstractAdmCliTest {
 
             assertExitCodeAndStdErrSize(exe, 0, 0);
             roles = loadJson(exe.stdout(), LIST_OF_JSON);
-            Assert.assertThat("expected one role", roles.size(), equalTo(1));
+            assertThat("expected one role", roles.size(), equalTo(1));
             Assert.assertEquals("clientrole", roles.get(0).get("name").asText());
 
             // add created role to user - we are realm admin so we can add role to ourself

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmUpdateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmUpdateTest.java
@@ -20,6 +20,7 @@ import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
 import org.keycloak.broker.saml.SAMLIdentityProviderFactory;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.cli.KcAdmExec.CMD;
 import static org.keycloak.testsuite.cli.KcAdmExec.execute;
 import org.keycloak.testsuite.updaters.IdentityProviderCreator;
@@ -61,7 +62,7 @@ public class KcAdmUpdateTest extends AbstractAdmCliTest {
                 assertExitCodeAndStdErrSize(exe, 0, 0);
             }
 
-            Assert.assertThat(realmResource.identityProviders().get("idpAlias").toRepresentation().getDisplayName(), is(equalTo("SAML_UPDATED")));
+            assertThat(realmResource.identityProviders().get("idpAlias").toRepresentation().getDisplayName(), is(equalTo("SAML_UPDATED")));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/registration/KcRegCreateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/registration/KcRegCreateTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
 import static org.keycloak.testsuite.cli.KcRegExec.execute;
 
@@ -297,7 +298,7 @@ public class KcRegCreateTest extends AbstractRegCliTest {
 
                 Assert.assertNotNull("clientId", oidcClient.getClientId());
                 Assert.assertEquals("redirect_uris", Arrays.asList("http://localhost:8980/myapp5/*"), oidcClient.getRedirectUris());
-                Assert.assertThat("grant_types", oidcClient.getGrantTypes(), Matchers.containsInAnyOrder("authorization_code", "client_credentials", "refresh_token", OAuth2Constants.UMA_GRANT_TYPE));
+                assertThat("grant_types", oidcClient.getGrantTypes(), Matchers.containsInAnyOrder("authorization_code", "client_credentials", "refresh_token", OAuth2Constants.UMA_GRANT_TYPE));
                 Assert.assertEquals("response_types", Arrays.asList("code", "none"), oidcClient.getResponseTypes());
                 Assert.assertEquals("client_name", "My Reg Authz", oidcClient.getClientName());
                 Assert.assertEquals("client_uri", "http://localhost:8980/myapp5", oidcClient.getClientUri());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -1397,7 +1397,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             //clientResource = ApiUtil.findClientByClientId(adminClient.realm(TEST_REALM_NAME), TEST_CLIENT_NAME);
             clientRep = clientResource.toRepresentation();
             Assert.assertNull(clientRep.getAttributes().get(CibaConfig.OIDC_CIBA_GRANT_ENABLED));
-            Assert.assertThat(clientRep.getAttributes().get(CibaConfig.CIBA_BACKCHANNEL_AUTH_REQUEST_SIGNING_ALG), is(Algorithm.RS256));
+            assertThat(clientRep.getAttributes().get(CibaConfig.CIBA_BACKCHANNEL_AUTH_REQUEST_SIGNING_ALG), is(Algorithm.RS256));
 
             // user Backchannel Authentication Request
             AuthenticationRequestAcknowledgement response = oauth.doBackchannelAuthenticationRequest(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD, username, "gilwekDe3", "acr2");
@@ -1416,8 +1416,8 @@ public class CIBATest extends AbstractClientPoliciesTest {
             clientRep.setAttributes(attributes);
             clientResource.update(clientRep);
             clientRep = clientResource.toRepresentation();
-            Assert.assertThat(clientRep.getAttributes().get(CibaConfig.OIDC_CIBA_GRANT_ENABLED), is(Boolean.TRUE.toString()));
-            Assert.assertThat(clientRep.getAttributes().get(CibaConfig.CIBA_BACKCHANNEL_AUTH_REQUEST_SIGNING_ALG), is(Algorithm.ES256));
+            assertThat(clientRep.getAttributes().get(CibaConfig.OIDC_CIBA_GRANT_ENABLED), is(Boolean.TRUE.toString()));
+            assertThat(clientRep.getAttributes().get(CibaConfig.CIBA_BACKCHANNEL_AUTH_REQUEST_SIGNING_ALG), is(Algorithm.ES256));
 
             // user Backchannel Authentication Request
             response = doBackchannelAuthenticationRequest(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD, username, "Fkb4T3s");
@@ -1439,8 +1439,8 @@ public class CIBATest extends AbstractClientPoliciesTest {
             clientRep.setAttributes(attributes);
             clientResource.update(clientRep);
             clientRep = clientResource.toRepresentation();
-            Assert.assertThat(clientRep.getAttributes().get(CibaConfig.OIDC_CIBA_GRANT_ENABLED), is(Boolean.FALSE.toString()));
-            Assert.assertThat(clientRep.getAttributes().get(CibaConfig.CIBA_BACKCHANNEL_AUTH_REQUEST_SIGNING_ALG), is("none"));
+            assertThat(clientRep.getAttributes().get(CibaConfig.OIDC_CIBA_GRANT_ENABLED), is(Boolean.FALSE.toString()));
+            assertThat(clientRep.getAttributes().get(CibaConfig.CIBA_BACKCHANNEL_AUTH_REQUEST_SIGNING_ALG), is("none"));
 
             // user Token Request
             OAuthClient.AccessTokenResponse tokenRes = oauth.doBackchannelAuthenticationTokenRequest(SECOND_TEST_CLIENT_NAME, SECOND_TEST_CLIENT_SECRET, response.getAuthReqId());
@@ -1467,7 +1467,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
 
         rep = getClientDynamically(clientId);
         Assert.assertTrue(rep.getGrantTypes().contains(OAuth2Constants.CIBA_GRANT_TYPE));
-        Assert.assertThat(rep.getBackchannelAuthenticationRequestSigningAlg(), is(Algorithm.PS256));
+        assertThat(rep.getBackchannelAuthenticationRequestSigningAlg(), is(Algorithm.PS256));
     }
 
     @Test
@@ -2458,9 +2458,9 @@ public class CIBATest extends AbstractClientPoliciesTest {
 
             // user Backchannel Authentication Request
             AuthenticationRequestAcknowledgement response = oauth.doBackchannelAuthenticationRequest(clientId, clientSecret, null, null, null);
-            Assert.assertThat(response.getStatusCode(), is(equalTo(statusCode)));
-            Assert.assertThat(response.getError(), is(error));
-            Assert.assertThat(response.getErrorDescription(), is(errorDescription));
+            assertThat(response.getStatusCode(), is(equalTo(statusCode)));
+            assertThat(response.getError(), is(error));
+            assertThat(response.getErrorDescription(), is(errorDescription));
         } finally {
             revertCIBASettings(clientResource, clientRep);
         }
@@ -2519,8 +2519,8 @@ public class CIBATest extends AbstractClientPoliciesTest {
             // user Authentication Channel Request
             TestAuthenticationChannelRequest testRequest = doAuthenticationChannelRequest(bindingMessage);
             AuthenticationChannelRequest authenticationChannelReq = testRequest.getRequest();
-            Assert.assertThat(authenticationChannelReq.getBindingMessage(), is(equalTo(bindingMessage)));
-            Assert.assertThat(authenticationChannelReq.getScope(), is(containsString(OAuth2Constants.SCOPE_OPENID)));
+            assertThat(authenticationChannelReq.getBindingMessage(), is(equalTo(bindingMessage)));
+            assertThat(authenticationChannelReq.getScope(), is(containsString(OAuth2Constants.SCOPE_OPENID)));
 
             // user Authentication Channel completed
             EventRepresentation loginEvent = doAuthenticationChannelCallback(testRequest);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRedirectTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRedirectTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIs;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
@@ -88,6 +88,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
@@ -767,8 +768,8 @@ public class FAPI1Test extends AbstractClientPoliciesTest {
 
     private void assertSuccessfulTokenResponse(OAuthClient.AccessTokenResponse tokenResponse) {
         assertEquals(200, tokenResponse.getStatusCode());
-        Assert.assertThat(tokenResponse.getIdToken(), Matchers.notNullValue());
-        Assert.assertThat(tokenResponse.getAccessToken(), Matchers.notNullValue());
+        assertThat(tokenResponse.getIdToken(), Matchers.notNullValue());
+        assertThat(tokenResponse.getAccessToken(), Matchers.notNullValue());
 
         // Scope parameter must be present per FAPI
         Assert.assertNotNull(tokenResponse.getScope());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/SAMLClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/SAMLClientRegistrationTest.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionClusterTest.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 
 /**
@@ -94,7 +95,7 @@ public class AuthenticationSessionClusterTest extends AbstractClusterTest {
             driver.navigate().to(testAppLoginNode1URL);
             String authSessionCookie = AuthenticationSessionFailoverClusterTest.getAuthSessionCookieValue(driver);
 
-            Assert.assertThat(authSessionCookie.length(), Matchers.greaterThan(36));
+            assertThat(authSessionCookie.length(), Matchers.greaterThan(36));
             String route = authSessionCookie.substring(37);
             visitedRoutes.add(route);
 
@@ -102,7 +103,7 @@ public class AuthenticationSessionClusterTest extends AbstractClusterTest {
             driver.manage().deleteAllCookies();
         }
 
-        Assert.assertThat(visitedRoutes, Matchers.containsInAnyOrder(Matchers.startsWith("node1"), Matchers.startsWith("node2")));
+        assertThat(visitedRoutes, Matchers.containsInAnyOrder(Matchers.startsWith("node1"), Matchers.startsWith("node2")));
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE;
 import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_SESSION_COOKIE;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookiesPathTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookiesPathTest.java
@@ -38,6 +38,7 @@ import java.util.LinkedList;
 import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_HOST;
 
 import org.junit.After;
@@ -96,7 +97,7 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         // check cookie's path, for some reason IE adds extra slash to the beginning of the path
         cookies.stream()
                 .filter(cookie -> KEYCLOAK_COOKIE_NAMES.contains(cookie.getName()))
-                .forEach(cookie -> Assert.assertThat(cookie.getPath(), Matchers.endsWith("/auth/realms/foo/")));
+                .forEach(cookie -> assertThat(cookie.getPath(), Matchers.endsWith("/auth/realms/foo/")));
 
         // now navigate to realm which name overlaps the first realm and delete cookies for that realm (foobar)
         navigateToLoginPage("foobar");
@@ -115,7 +116,7 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         // check cookie's path, for some reason IE adds extra slash to the beginning of the path
         cookies.stream()
                 .filter(cookie -> KEYCLOAK_COOKIE_NAMES.contains(cookie.getName()))
-                .forEach(cookie -> Assert.assertThat(cookie.getPath(), Matchers.endsWith("/auth/realms/foobar/")));
+                .forEach(cookie -> assertThat(cookie.getPath(), Matchers.endsWith("/auth/realms/foobar/")));
 
         // lets back to "/realms/foo/account" to test the cookies for "foo" realm are still there and haven't been (correctly) sent to "foobar"
         oauth.realm("foo");
@@ -125,7 +126,7 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         Assert.assertTrue("There should be cookies sent!", cookies.size() > 0);
         cookies.stream()
                 .filter(cookie -> KEYCLOAK_COOKIE_NAMES.contains(cookie.getName()))
-                .forEach(cookie -> Assert.assertThat(cookie.getPath(), Matchers.endsWith("/auth/realms/foo/")));
+                .forEach(cookie -> assertThat(cookie.getPath(), Matchers.endsWith("/auth/realms/foo/")));
     }
 
     @Test
@@ -144,23 +145,23 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         CookieStore cookieStore = getCorrectCookies(oauth.getLoginFormUrl());
         cookieStore.addCookie(wrongCookie);
 
-        Assert.assertThat(cookieStore.getCookies(), Matchers.hasSize(3));
+        assertThat(cookieStore.getCookies(), Matchers.hasSize(3));
 
         login(oauth.getLoginFormUrl(), cookieStore);
 
         // old cookie has been removed
         // now we have AUTH_SESSION_ID, KEYCLOAK_IDENTITY, KEYCLOAK_SESSION
-        Assert.assertThat(cookieStore.getCookies().stream().map(org.apache.http.cookie.Cookie::getName).collect(Collectors.toList()), 
+        assertThat(cookieStore.getCookies().stream().map(org.apache.http.cookie.Cookie::getName).collect(Collectors.toList()),
                 Matchers.hasItems("AUTH_SESSION_ID", "KEYCLOAK_IDENTITY", "KEYCLOAK_SESSION"));
 
         // does each cookie's path end with "/"
-        cookieStore.getCookies().stream().filter(c -> !"OAuth_Token_Request_State".equals(c.getName())).map(org.apache.http.cookie.Cookie::getPath).forEach(path ->Assert.assertThat(path, Matchers.endsWith("/")));
+        cookieStore.getCookies().stream().filter(c -> !"OAuth_Token_Request_State".equals(c.getName())).map(org.apache.http.cookie.Cookie::getPath).forEach(path -> assertThat(path, Matchers.endsWith("/")));
 
         // KEYCLOAK_SESSION should end by AUTH_SESSION_ID value
         String authSessionId = cookieStore.getCookies().stream().filter(c -> "AUTH_SESSION_ID".equals(c.getName())).findFirst().get().getValue();
         String KCSessionId = cookieStore.getCookies().stream().filter(c -> "KEYCLOAK_SESSION".equals(c.getName())).findFirst().get().getValue();
         String KCSessionSuffix = KCSessionId.split("/")[2];
-        Assert.assertThat(authSessionId, Matchers.containsString(KCSessionSuffix));
+        assertThat(authSessionId, Matchers.containsString(KCSessionSuffix));
     }
 
     @Test
@@ -176,7 +177,7 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         // add old cookie with wrong path
         driver.manage().addCookie(wrongCookie);
         Set<Cookie> cookies = driver.manage().getCookies();
-        Assert.assertThat(cookies, Matchers.hasSize(1));
+        assertThat(cookies, Matchers.hasSize(1));
 
         driver.navigate().refresh();
         loginPage.login("foo", "password");
@@ -185,16 +186,16 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         cookies = driver.manage().getCookies().stream()
                 .filter(cookie -> KEYCLOAK_COOKIE_NAMES.contains(cookie.getName()))
                 .collect(Collectors.toSet());
-        Assert.assertThat(cookies, Matchers.hasSize(3));
+        assertThat(cookies, Matchers.hasSize(3));
 
         // does each cookie's path end with "/"
-        cookies.stream().map(Cookie::getPath).forEach(path -> Assert.assertThat(path, Matchers.endsWith("/")));
+        cookies.stream().map(Cookie::getPath).forEach(path -> assertThat(path, Matchers.endsWith("/")));
 
         // KEYCLOAK_SESSION should end by AUTH_SESSION_ID value
         String authSessionId = cookies.stream().filter(c -> "AUTH_SESSION_ID".equals(c.getName())).findFirst().get().getValue();
         String KCSessionId = cookies.stream().filter(c -> "KEYCLOAK_SESSION".equals(c.getName())).findFirst().get().getValue();
         String KCSessionSuffix = KCSessionId.split("/")[2];
-        Assert.assertThat(authSessionId, Matchers.containsString(KCSessionSuffix));
+        assertThat(authSessionId, Matchers.containsString(KCSessionSuffix));
     }
 
     @Test
@@ -213,23 +214,23 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         CookieStore cookieStore = getCorrectCookies(oauth.getLoginFormUrl());
         cookieStore.addCookie(wrongCookie);
 
-        Assert.assertThat(cookieStore.getCookies(), Matchers.hasSize(3));
+        assertThat(cookieStore.getCookies(), Matchers.hasSize(3));
 
         login(oauth.getLoginFormUrl(), cookieStore);
 
         // old cookie has been removed
         // now we have AUTH_SESSION_ID, KEYCLOAK_IDENTITY, KEYCLOAK_SESSION, OAuth_Token_Request_State
-        Assert.assertThat(cookieStore.getCookies().stream().map(org.apache.http.cookie.Cookie::getName).collect(Collectors.toList()), 
+        assertThat(cookieStore.getCookies().stream().map(org.apache.http.cookie.Cookie::getName).collect(Collectors.toList()),
                 Matchers.hasItems("AUTH_SESSION_ID", "KEYCLOAK_IDENTITY", "KEYCLOAK_SESSION"));
 
         // does each cookie's path end with "/"
-        cookieStore.getCookies().stream().filter(c -> !"OAuth_Token_Request_State".equals(c.getName())).map(org.apache.http.cookie.Cookie::getPath).forEach(path ->Assert.assertThat(path, Matchers.endsWith("/")));
+        cookieStore.getCookies().stream().filter(c -> !"OAuth_Token_Request_State".equals(c.getName())).map(org.apache.http.cookie.Cookie::getPath).forEach(path -> assertThat(path, Matchers.endsWith("/")));
 
         // KEYCLOAK_SESSION should end by AUTH_SESSION_ID value
         String authSessionId = cookieStore.getCookies().stream().filter(c -> "AUTH_SESSION_ID".equals(c.getName())).findFirst().get().getValue();
         String KCSessionId = cookieStore.getCookies().stream().filter(c -> "KEYCLOAK_SESSION".equals(c.getName())).findFirst().get().getValue();
         String KCSessionSuffix = KCSessionId.split("/")[2];
-        Assert.assertThat(authSessionId, Matchers.containsString(KCSessionSuffix));
+        assertThat(authSessionId, Matchers.containsString(KCSessionSuffix));
     }
 
     /**
@@ -318,7 +319,7 @@ public class CookiesPathTest extends AbstractKeycloakTest {
         post.setEntity(new UrlEncodedFormEntity(params));
 
         try (CloseableHttpResponse response = sendRequest(post, cookieStore, httpContext)) {
-            Assert.assertThat("Expected successful login.", response.getStatusLine().getStatusCode(), is(equalTo(200)));
+            assertThat("Expected successful login.", response.getStatusLine().getStatusCode(), is(equalTo(200)));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/AbstractAdminCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/AbstractAdminCrossDCTest.java
@@ -31,7 +31,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.hamcrest.Matcher;
 import org.junit.Before;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.representations.idm.ClientRepresentation;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/ActionTokenCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/ActionTokenCrossDCTest.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 import org.hamcrest.Matchers;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.testsuite.arquillian.CrossDCTestEnricher;
 import org.keycloak.testsuite.arquillian.annotation.InitialDcState;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/BruteForceCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/BruteForceCrossDCTest.java
@@ -42,6 +42,8 @@ import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -219,8 +221,8 @@ public class BruteForceCrossDCTest extends AbstractAdminCrossDCTest {
             log.infof("After concurrent update entry1: dc0User1=%d, dc1user1=%d", dc0user1, dc1user1);
 
             // TODO: The number of failures should be ideally exactly 21 in both DCs. Once we improve cross-dc, then improve this test and rather check for "Assert.assertEquals(dc0user1, 21)" and "Assert.assertEquals(dc1user1, 21)"
-            Assert.assertThat(dc0user1, Matchers.greaterThan(11));
-            Assert.assertThat(dc1user1, Matchers.greaterThan(11));
+            assertThat(dc0user1, Matchers.greaterThan(11));
+            assertThat(dc1user1, Matchers.greaterThan(11));
         }, 50, 50);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/LastSessionRefreshCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/LastSessionRefreshCrossDCTest.java
@@ -37,6 +37,8 @@ import jakarta.ws.rs.NotFoundException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -385,24 +387,24 @@ public class LastSessionRefreshCrossDCTest extends AbstractAdminCrossDCTest {
 
             // Check lastSessionRefresh updated on DC1
             if (expectedUpdatedLsrDc1) {
-                Assert.assertThat(newLsrDc1, Matchers.greaterThan(lsrDc1.get()));
+                assertThat(newLsrDc1, Matchers.greaterThan(lsrDc1.get()));
             } else {
                 Assert.assertEquals(newLsrDc1, lsrDc1.get());
             }
 
             // Check lastSessionRefresh updated on DC2
             if (expectedUpdatedLsrDc2) {
-                Assert.assertThat(newLsrDc2, Matchers.greaterThan(lsrDc2.get()));
+                assertThat(newLsrDc2, Matchers.greaterThan(lsrDc2.get()));
             } else {
                 Assert.assertEquals(newLsrDc2, lsrDc2.get());
             }
 
             // Check store statistics updated on JDG side
             if (expectedUpdatedRemoteCache) {
-                Assert.assertThat(newSessionStoresDc1, Matchers.greaterThan(sessionStoresDc1.get()));
-                Assert.assertThat(newSessionStoresDc2, Matchers.greaterThan(sessionStoresDc2.get()));
-                Assert.assertThat(newClientSessionStoresDc1, Matchers.greaterThan(clientSessionStoresDc1.get()));
-                Assert.assertThat(newClientSessionStoresDc2, Matchers.greaterThan(clientSessionStoresDc2.get()));
+                assertThat(newSessionStoresDc1, Matchers.greaterThan(sessionStoresDc1.get()));
+                assertThat(newSessionStoresDc2, Matchers.greaterThan(sessionStoresDc2.get()));
+                assertThat(newClientSessionStoresDc1, Matchers.greaterThan(clientSessionStoresDc1.get()));
+                assertThat(newClientSessionStoresDc2, Matchers.greaterThan(clientSessionStoresDc2.get()));
             } else {
                 Assert.assertEquals(newSessionStoresDc1, sessionStoresDc1.get());
                 Assert.assertEquals(newSessionStoresDc2, sessionStoresDc2.get());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/LoginCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/LoginCrossDCTest.java
@@ -25,7 +25,7 @@ import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.util.Matchers;
 import org.keycloak.testsuite.util.OAuthClient;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/SessionExpirationCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/SessionExpirationCrossDCTest.java
@@ -51,6 +51,8 @@ import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Tests the bulk removal of user sessions and expiration scenarios (eg. removing realm, removing user etc)
  *
@@ -225,7 +227,7 @@ public class SessionExpirationCrossDCTest extends AbstractAdminCrossDCTest {
 
             // Workaround...
             if (checkSomeMessagesSentBetweenDCs) {
-                Assert.assertThat(messagesCount, Matchers.greaterThan(0l));
+                assertThat(messagesCount, Matchers.greaterThan(0l));
             }
 
         }, 50, 50);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/SessionsPreloadCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/SessionsPreloadCrossDCTest.java
@@ -34,6 +34,8 @@ import org.keycloak.testsuite.util.OAuthClient;
 import java.util.Set;
 import org.hamcrest.Matchers;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Tests userSessions and offline sessions preloading at startup
  *
@@ -77,7 +79,7 @@ public class SessionsPreloadCrossDCTest extends AbstractAdminCrossDCTest {
         Set<String> sessions01keys = getTestingClientForStartedNodeInDc(0).testing().cache(InfinispanConnectionProvider.USER_SESSION_CACHE_NAME).enumerateKeys();
         Set<String> sessions02keys = getTestingClientForStartedNodeInDc(1).testing().cache(InfinispanConnectionProvider.USER_SESSION_CACHE_NAME).enumerateKeys();
         log.infof("sessions01keys: %s, sessions02keys: %s", sessions01keys, sessions02keys);
-        Assert.assertThat(sessions01keys, Matchers.equalTo(sessions02keys));
+        assertThat(sessions01keys, Matchers.equalTo(sessions02keys));
 
         // On DC2 sessions were preloaded from remoteCache
         Assert.assertTrue(getTestingClientForStartedNodeInDc(1).testing().cache(InfinispanConnectionProvider.WORK_CACHE_NAME).contains("distributed::remoteCacheLoad::sessions"));
@@ -121,7 +123,7 @@ public class SessionsPreloadCrossDCTest extends AbstractAdminCrossDCTest {
         Set<String> offlineSessions11keys = getTestingClientForStartedNodeInDc(0).testing().cache(InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME).enumerateKeys();
         Set<String> offlineSessions12keys = getTestingClientForStartedNodeInDc(1).testing().cache(InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME).enumerateKeys();
         log.infof("offlineSessions11keys: %s, offlineSessions12keys: %s", offlineSessions11keys, offlineSessions12keys);
-        Assert.assertThat(offlineSessions11keys, Matchers.equalTo(offlineSessions12keys));
+        assertThat(offlineSessions11keys, Matchers.equalTo(offlineSessions12keys));
 
         // On DC1 sessions were preloaded from DB. On DC2 sessions were preloaded from remoteCache
         Assert.assertTrue(getTestingClientForStartedNodeInDc(0).testing().cache(InfinispanConnectionProvider.WORK_CACHE_NAME).contains("distributed::offlineUserSessions"));
@@ -170,7 +172,7 @@ public class SessionsPreloadCrossDCTest extends AbstractAdminCrossDCTest {
                 int loginFailures1 = (Integer) getAdminClientForStartedNodeInDc(0).realm("test").attackDetection().bruteForceUserStatus(userId).get("numFailures");
                 int loginFailures2 = (Integer) getAdminClientForStartedNodeInDc(1).realm("test").attackDetection().bruteForceUserStatus(userId).get("numFailures");
                 log.infof("keys1: %d, keys2: %d, loginFailures1: %d, loginFailures2: %d", keys1, keys2, loginFailures1, loginFailures2);
-                Assert.assertThat(keys1, Matchers.equalTo(keys2));
+                assertThat(keys1, Matchers.equalTo(keys2));
                 Assert.assertEquals(loginFailuresBefore + SESSIONS_COUNT, loginFailures1);
                 Assert.assertEquals(loginFailuresBefore + SESSIONS_COUNT, loginFailures2);
             }, 3, 400);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -59,7 +59,7 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import org.junit.BeforeClass;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
@@ -81,7 +81,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.keycloak.util.JsonSerialization;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *
@@ -593,11 +593,11 @@ public class ExportImportUtil {
         Assert.assertNotNull(authzResource);
 
         List<ResourceRepresentation> resources = authzResource.resources().resources();
-        Assert.assertThat(resources.stream().map(ResourceRepresentation::getName).collect(Collectors.toList()),
+        assertThat(resources.stream().map(ResourceRepresentation::getName).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("Default Resource", "test"));
 
         List<PolicyRepresentation> policies = authzResource.policies().policies();
-        Assert.assertThat(policies.stream().map(PolicyRepresentation::getName).collect(Collectors.toList()),
+        assertThat(policies.stream().map(PolicyRepresentation::getName).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("User Policy", "Default Permission", "test-permission"));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -122,7 +123,7 @@ public class LDAPAccountRestApiTest extends AbstractLDAPTest {
         List<String> origLdapEntryDn = new ArrayList<>(user.getAttributes().get(LDAPConstants.LDAP_ENTRY_DN));
         Assert.assertEquals(1, origLdapId.size());
         Assert.assertEquals(1, origLdapEntryDn.size());
-        Assert.assertThat(user.getAttributes().keySet(), not(contains(KerberosFederationProvider.KERBEROS_PRINCIPAL)));
+        assertThat(user.getAttributes().keySet(), not(contains(KerberosFederationProvider.KERBEROS_PRINCIPAL)));
 
         // Trying to add KERBEROS_PRINCIPAL should fail (Adding attribute, which was not yet present)
         user.setFirstName("JohnUpdated");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
@@ -43,6 +43,7 @@ import org.keycloak.testsuite.util.UserBuilder;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *
@@ -128,7 +129,7 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
         List<String> origLdapEntryDn = new ArrayList<>(user.getAttributes().get(LDAPConstants.LDAP_ENTRY_DN));
         Assert.assertEquals(1, origLdapId.size());
         Assert.assertEquals(1, origLdapEntryDn.size());
-        Assert.assertThat(user.getAttributes().keySet(), not(contains(KerberosFederationProvider.KERBEROS_PRINCIPAL)));
+        assertThat(user.getAttributes().keySet(), not(contains(KerberosFederationProvider.KERBEROS_PRINCIPAL)));
 
         // Trying to add KERBEROS_PRINCIPAL should fail (Adding attribute, which was not yet present)
         user.setFirstName("JohnUpdated");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPMSADMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPMSADMapperTest.java
@@ -44,6 +44,7 @@ import org.keycloak.testsuite.util.LDAPTestConfiguration;
 import org.keycloak.testsuite.util.LDAPTestUtils;
 
 import static org.junit.Assert.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -150,7 +151,7 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
         Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
         // Check in LDAP, that johnkeycloak does not have pwdLastSet set to 0
-        Assert.assertThat(getPwdLastSetOfJohn(), Matchers.greaterThan(0L));
+        assertThat(getPwdLastSetOfJohn(), Matchers.greaterThan(0L));
 
         // Check in admin REST API, that johnkeycloak does not have required action on him
         johnRep = john.toRepresentation();
@@ -186,7 +187,7 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
         });
 
         // Check in LDAP, that johnkeycloak does not have pwdLastSet set to 0
-        Assert.assertThat(getPwdLastSetOfJohn(), Matchers.greaterThan(0L));
+        assertThat(getPwdLastSetOfJohn(), Matchers.greaterThan(0L));
 
         // Check in admin REST API, that johnkeycloak does not have required action on him
         johnRep = john.toRepresentation();
@@ -231,7 +232,7 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
         Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
         // Check in LDAP, that johnkeycloak does not have pwdLastSet set to 0
-        Assert.assertThat(getPwdLastSetOfJohn(), Matchers.greaterThan(0L));
+        assertThat(getPwdLastSetOfJohn(), Matchers.greaterThan(0L));
 
         // Check in admin REST API, that johnkeycloak does not have required action on him
         johnRep = john.toRepresentation();
@@ -264,7 +265,7 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
 
         // Check in LDAP, that johnkeycloak has pwdLastSet set attribute set in MSAD to bigger value than 0. Previous update of requiredAction did not updated LDAP
         long pwdLastSetFromLDAP = getPwdLastSetOfJohn();
-        Assert.assertThat(pwdLastSetFromLDAP, Matchers.greaterThan(0L));
+        assertThat(pwdLastSetFromLDAP, Matchers.greaterThan(0L));
 
         // Login as johnkeycloak and update password after login
         loginPage.open();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPNoCacheTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPNoCacheTest.java
@@ -60,7 +60,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPNoMSADTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPNoMSADTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test for special scenarios, which don't work on MSAD (eg. renaming user RDN to "sn=john2" )
@@ -180,7 +181,7 @@ public class LDAPNoMSADTest extends AbstractLDAPTest {
         userRep = user.toRepresentation();
 
         // ApacheDS bug causes that attribute, which was added to DN, is lowercased. Works for other LDAPs (RHDS, OpenLDAP)
-        Assert.assertThat("Doe3Changed", equalToIgnoringCase(userRep.getLastName()));
+        assertThat("Doe3Changed", equalToIgnoringCase(userRep.getLastName()));
         assertFirstRDNEndsWith(userRep, "johnkeycloak3", "Doe3Changed");
 
         // Remove user

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSamlIdPInitiatedVaryingLetterCaseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSamlIdPInitiatedVaryingLetterCaseTest.java
@@ -67,7 +67,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_SAML_ALIAS;
 import static org.keycloak.testsuite.federation.ldap.AbstractLDAPTest.TEST_REALM_NAME;
 import static org.keycloak.testsuite.federation.ldap.AbstractLDAPTest.ldapModelId;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -62,6 +62,8 @@ import org.keycloak.testsuite.util.WaitUtils;
 
 import jakarta.ws.rs.BadRequestException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -489,7 +491,7 @@ public class LDAPSyncTest extends AbstractLDAPTest {
 
             // sync to Keycloak should pass without an error
             SynchronizationResult syncResult = new GroupLDAPStorageMapperFactory().create(session, mapperModel).syncDataFromFederationProviderToKeycloak(appRealm);
-            Assert.assertThat(syncResult.getFailed(), Matchers.is(0));
+            assertThat(syncResult.getFailed(), Matchers.is(0));
         });
 
         testingClient.server().run(session -> {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/AbstractUserStorageDirtyDeletionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/AbstractUserStorageDirtyDeletionTest.java
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 
 import org.junit.BeforeClass;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.storage.UserStorageProviderModel.IMPORT_ENABLED;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
@@ -76,7 +76,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.junit.BeforeClass;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
@@ -44,7 +44,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/RoleStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/RoleStorageTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -78,7 +78,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.models.UserModel.RequiredAction.UPDATE_PROFILE;
@@ -259,12 +259,12 @@ public class UserStorageTest extends AbstractAuthTest {
         Cookie legacySessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE + LEGACY_COOKIE);
 
         String cookieValue = sameSiteSessionCookie.getValue();
-        Assert.assertThat(cookieValue.contains("spécial"), is(false));
-        Assert.assertThat(cookieValue.contains("sp%C3%A9cial"), is(true));
+        assertThat(cookieValue.contains("spécial"), is(false));
+        assertThat(cookieValue.contains("sp%C3%A9cial"), is(true));
 
         String legacyCookieValue = legacySessionCookie.getValue();
-        Assert.assertThat(legacyCookieValue.contains("spécial"), is(false));
-        Assert.assertThat(legacyCookieValue.contains("sp%C3%A9cial"), is(true));
+        assertThat(legacyCookieValue.contains("spécial"), is(false));
+        assertThat(legacyCookieValue.contains("sp%C3%A9cial"), is(true));
 
         AccountHelper.logout(testRealmResource(), "spécial");
     }
@@ -513,9 +513,9 @@ public class UserStorageTest extends AbstractAuthTest {
 
     @Test
     public void testQueryExactMatch() {
-        Assert.assertThat(testRealmResource().users().search("a", true), hasSize(0));
-        Assert.assertThat(testRealmResource().users().search("apollo", true), hasSize(1));
-        Assert.assertThat(testRealmResource().users().search("tbrady", true), hasSize(1));
+        assertThat(testRealmResource().users().search("a", true), hasSize(0));
+        assertThat(testRealmResource().users().search("apollo", true), hasSize(1));
+        assertThat(testRealmResource().users().search("tbrady", true), hasSize(1));
     }
 
     private void setDailyEvictionTime(int hour, int minutes) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -58,7 +58,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/CustomFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/CustomFlowTest.java
@@ -63,7 +63,7 @@ import java.util.Map;
 
 import jakarta.ws.rs.core.Response.Status;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIs;
 
 /**
@@ -218,7 +218,7 @@ public class CustomFlowTest extends AbstractFlowTest {
         Response response = authMgmtResource.copy("browser", params);
         String flowId = null;
         try {
-            Assert.assertThat("Copy flow", response, statusCodeIs(Response.Status.CREATED));
+            assertThat("Copy flow", response, statusCodeIs(Response.Status.CREATED));
             AuthenticationFlowRepresentation newFlow = findFlowByAlias(flowAlias);
             flowId = newFlow.getId();
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -69,6 +69,7 @@ import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.util.JsonSerialization;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for Level Of Assurance conditions in authentication flow.
@@ -662,7 +663,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
             // Test client scope was not created in the new realm when feature is disabled
             boolean acrScopeExists = newRealm.clientScopes().findAll().stream()
                     .anyMatch(clientScope -> OIDCLoginProtocolFactory.ACR_SCOPE.equals(clientScope.getName()));
-            Assert.assertThat(false, is(acrScopeExists));
+            assertThat(false, is(acrScopeExists));
         } finally {
             newRealm.remove();
         }
@@ -713,7 +714,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
     }
 
     private void assertErrorPage(String expectedError) {
-        Assert.assertThat(true, is(errorPage.isCurrent()));
+        assertThat(true, is(errorPage.isCurrent()));
         Assert.assertEquals(expectedError, errorPage.getError());
         events.clear();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -83,6 +83,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.common.Profile.Feature.DYNAMIC_SCOPES;
 import static org.keycloak.testsuite.admin.ApiUtil.findClientByClientId;
@@ -162,7 +163,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
     public void testBrowserSecurityHeaders() {
         Client client = AdminClientUtil.createResteasyClient();
         Response response = client.target(oauth.getLoginFormUrl()).request().get();
-        Assert.assertThat(response.getStatus(), is(equalTo(200)));
+        assertThat(response.getStatus(), is(equalTo(200)));
         for (BrowserSecurityHeaders header : BrowserSecurityHeaders.values()) {
             String headerValue = response.getHeaderString(header.getHeaderName());
             String expectedValue = header.getDefaultValue();
@@ -170,7 +171,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
                 Assert.assertNull(headerValue);
             } else {
                 Assert.assertNotNull(headerValue);
-                Assert.assertThat(headerValue, is(equalTo(expectedValue)));
+                assertThat(headerValue, is(equalTo(expectedValue)));
             }
         }
         response.close();
@@ -192,7 +193,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
             Client client = AdminClientUtil.createResteasyClient();
             Response response = client.target(oauth.getLoginFormUrl()).request().get();
             String headerValue = response.getHeaderString(cspReportOnlyHeader);
-            Assert.assertThat(headerValue, is(equalTo(expectedCspReportOnlyValue)));
+            assertThat(headerValue, is(equalTo(expectedCspReportOnlyValue)));
             response.close();
             client.close();
         } finally {
@@ -210,8 +211,8 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         UriBuilder b = OIDCLoginProtocolService.authUrl(UriBuilder.fromUri(AUTH_SERVER_ROOT));
         Response response = client.target(b.build(oauth.getRealm())).request().post(oauth.getLoginEntityForPOST());
         
-        Assert.assertThat(response.getStatus(), is(equalTo(200)));
-        Assert.assertThat(response, Matchers.body(containsString("Sign in")));
+        assertThat(response.getStatus(), is(equalTo(200)));
+        assertThat(response, Matchers.body(containsString("Sign in")));
 
         response.close();
         client.close();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ReAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ReAuthenticationTest.java
@@ -53,6 +53,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITHUB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE;
@@ -282,7 +283,7 @@ public class ReAuthenticationTest extends AbstractTestRealmKeycloakTest {
         assertInfoMessageAboutReAuthenticate(true);
 
         // Check there is NO password field
-        Assert.assertThat(true, is(driver.findElements(By.id("password")).isEmpty()));
+        assertThat(true, is(driver.findElements(By.id("password")).isEmpty()));
 
         // Github present, Google hidden
         assertSocialButtonsPresent(true, false);
@@ -316,19 +317,19 @@ public class ReAuthenticationTest extends AbstractTestRealmKeycloakTest {
 
 
     private void assertUsernameFieldAndOtherFields(boolean expectPresent) {
-        Assert.assertThat(expectPresent, is(loginPage.isUsernameInputPresent()));
-        Assert.assertThat(expectPresent, is(loginPage.isRegisterLinkPresent()));
-        Assert.assertThat(expectPresent, is(loginPage.isRememberMeCheckboxPresent()));
+        assertThat(expectPresent, is(loginPage.isUsernameInputPresent()));
+        assertThat(expectPresent, is(loginPage.isRegisterLinkPresent()));
+        assertThat(expectPresent, is(loginPage.isRememberMeCheckboxPresent()));
     }
 
     private void assertSocialButtonsPresent(boolean expectGithubPresent, boolean expectGooglePresent) {
-        Assert.assertThat(expectGithubPresent, is(loginPage.isSocialButtonPresent("github")));
-        Assert.assertThat(expectGooglePresent, is(loginPage.isSocialButtonPresent("google")));
+        assertThat(expectGithubPresent, is(loginPage.isSocialButtonPresent("github")));
+        assertThat(expectGooglePresent, is(loginPage.isSocialButtonPresent("google")));
     }
 
     private void assertInfoMessageAboutReAuthenticate(boolean expectPresent) {
         Matcher<String> expectedInfo = expectPresent ? is("Please re-authenticate to continue") : Matchers.nullValue(String.class);
-        Assert.assertThat(loginPage.getInfoMessage(), expectedInfo);
+        assertThat(loginPage.getInfoMessage(), expectedInfo);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/AbstractJavascriptTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/AbstractJavascriptTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractJavascriptTest extends AbstractAuthTest {
         if (output instanceof WebElement) {
             waitUntilElement((WebElement) output).text().contains(value);
         } else {
-            Assert.assertThat((String) output, containsString(value));
+            assertThat((String) output, containsString(value));
         }
     }
 
@@ -203,7 +203,7 @@ public abstract class AbstractJavascriptTest extends AbstractAuthTest {
     }
 
     public ResponseValidator assertResponseStatus(long status) {
-        return output -> Assert.assertThat(output, hasEntry("status", status));
+        return output -> assertThat(output, hasEntry("status", status));
     }
 
     public JavascriptStateValidator assertOutputContains(String text) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -279,7 +279,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .login(this::assertOnLoginPage)
                 .loginForm(testUser, this::assertOnTestAppUrl)
                 .init(defaultArguments(), this::assertInitAuth)
-                .getProfile((driver1, output, events) -> Assert.assertThat((Map<String, String>) output, hasEntry("username", testUser.getUsername())));
+                .getProfile((driver1, output, events) -> assertThat((Map<String, String>) output, hasEntry("username", testUser.getUsername())));
     }
 
     @Test
@@ -424,7 +424,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
         if (!"phantomjs".equals(System.getProperty("js.browser"))) {
             // I have no idea why, but this request doesn't work with phantomjs, it works in chrome
             testExecutor.logInAndInit(defaultArguments(), unauthorizedUser, this::assertInitAuth)
-                    .sendXMLHttpRequest(request, output -> Assert.assertThat(output, hasEntry("status", 403L)))
+                    .sendXMLHttpRequest(request, output -> assertThat(output, hasEntry("status", 403L)))
                     .logout(this::assertOnTestAppUrl)
                     .refresh();
         }
@@ -534,7 +534,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 ClaimsRepresentation claimsRep = JsonSerialization.readValue(claimsParam, ClaimsRepresentation.class);
                 ClaimsRepresentation.ClaimValue<String> claimValue = claimsRep.getClaimValue(IDToken.ACR, ClaimsRepresentation.ClaimContext.ID_TOKEN, String.class);
                 Assert.assertNames(claimValue.getValues(), "foo", "bar");
-                Assert.assertThat(claimValue.isEssential(), is(false));
+                assertThat(claimValue.isEssential(), is(false));
             } catch (IOException ioe) {
                 throw new AssertionError(ioe);
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/AuthenticationSessionProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/AuthenticationSessionProviderTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.models.Constants;
 import org.keycloak.testsuite.util.InfinispanTestTimeServiceRule;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/ConcurrentTransactionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/ConcurrentTransactionsTest.java
@@ -38,6 +38,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.keycloak.models.Constants;
 import org.keycloak.models.RoleModel;
 
@@ -289,7 +291,7 @@ public class ConcurrentTransactionsTest extends AbstractTestRealmKeycloakTest {
         }
 
         Assert.assertTrue(currentSession.realms().removeRealm(realm.getId()));
-        Assert.assertThat(currentSession.realms().getRealm(realm.getId()), is(nullValue()));
+        assertThat(currentSession.realms().getRealm(realm.getId()), is(nullValue()));
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserModelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserModelTest.java
@@ -49,6 +49,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -99,22 +100,22 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             attributes.put(UserModel.LAST_NAME, "last-name");
             List<UserModel> search = currentSession.users().searchForUserStream(realm, attributes)
                     .collect(Collectors.toList());
-            Assert.assertThat(search, hasSize(1));
-            Assert.assertThat(search.get(0).getUsername(), equalTo("user"));
+            assertThat(search, hasSize(1));
+            assertThat(search.get(0).getUsername(), equalTo("user"));
 
             attributes.clear();
             attributes.put(UserModel.EMAIL, "email");
             search = currentSession.users().searchForUserStream(realm, attributes)
                     .collect(Collectors.toList());
-            Assert.assertThat(search, hasSize(1));
-            Assert.assertThat(search.get(0).getUsername(), equalTo("user"));
+            assertThat(search, hasSize(1));
+            assertThat(search.get(0).getUsername(), equalTo("user"));
 
             attributes.clear();
             attributes.put(UserModel.LAST_NAME, "last-name");
             attributes.put(UserModel.EMAIL, "email");
             search = currentSession.users().searchForUserStream(realm, attributes).collect(Collectors.toList());
-            Assert.assertThat(search, hasSize(1));
-            Assert.assertThat(search.get(0).getUsername(), equalTo("user"));
+            assertThat(search, hasSize(1));
+            assertThat(search.get(0).getUsername(), equalTo("user"));
         });
     }
 
@@ -128,35 +129,35 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
 
             ClientModel client = realm.addClient("user");
 
-            Assert.assertThat(client.getWebOrigins(), empty());
+            assertThat(client.getWebOrigins(), empty());
 
             client.addWebOrigin("origin-1");
-            Assert.assertThat(client.getWebOrigins(), hasSize(1));
+            assertThat(client.getWebOrigins(), hasSize(1));
 
             client.addWebOrigin("origin-2");
-            Assert.assertThat(client.getWebOrigins(), hasSize(2));
+            assertThat(client.getWebOrigins(), hasSize(2));
 
             client.removeWebOrigin("origin-2");
-            Assert.assertThat(client.getWebOrigins(), hasSize(1));
+            assertThat(client.getWebOrigins(), hasSize(1));
 
             client.removeWebOrigin("origin-1");
-            Assert.assertThat(client.getWebOrigins(), empty());
+            assertThat(client.getWebOrigins(), empty());
 
             client = realm.addClient("oauthclient2");
 
-            Assert.assertThat(client.getWebOrigins(), empty());
+            assertThat(client.getWebOrigins(), empty());
 
             client.addWebOrigin("origin-1");
-            Assert.assertThat(client.getWebOrigins(), hasSize(1));
+            assertThat(client.getWebOrigins(), hasSize(1));
 
             client.addWebOrigin("origin-2");
-            Assert.assertThat(client.getWebOrigins(), hasSize(2));
+            assertThat(client.getWebOrigins(), hasSize(2));
 
             client.removeWebOrigin("origin-2");
-            Assert.assertThat(client.getWebOrigins(), hasSize(1));
+            assertThat(client.getWebOrigins(), hasSize(1));
 
             client.removeWebOrigin("origin-1");
-            Assert.assertThat(client.getWebOrigins(), empty());
+            assertThat(client.getWebOrigins(), empty());
         });
     }
 
@@ -170,7 +171,7 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
 
             UserModel user = currentSession.users().addUser(realm, "user");
             List<String> requiredActions = user.getRequiredActionsStream().collect(Collectors.toList());
-            Assert.assertThat(requiredActions, empty());
+            assertThat(requiredActions, empty());
 
             user.addRequiredAction(RequiredAction.CONFIGURE_TOTP);
             String id = realm.getId();
@@ -179,22 +180,22 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             user = currentSession.users().getUserByUsername(realm, "user");
 
             requiredActions = user.getRequiredActionsStream().collect(Collectors.toList());
-            Assert.assertThat(requiredActions, hasSize(1));
-            Assert.assertThat(requiredActions, contains(RequiredAction.CONFIGURE_TOTP.name()));
+            assertThat(requiredActions, hasSize(1));
+            assertThat(requiredActions, contains(RequiredAction.CONFIGURE_TOTP.name()));
             
             user.addRequiredAction(RequiredAction.CONFIGURE_TOTP);
             user = currentSession.users().getUserByUsername(realm, "user");
 
             requiredActions = user.getRequiredActionsStream().collect(Collectors.toList());
-            Assert.assertThat(requiredActions, hasSize(1));
-            Assert.assertThat(requiredActions, contains(RequiredAction.CONFIGURE_TOTP.name()));
+            assertThat(requiredActions, hasSize(1));
+            assertThat(requiredActions, contains(RequiredAction.CONFIGURE_TOTP.name()));
 
             user.addRequiredAction(RequiredAction.VERIFY_EMAIL.name());
             user = currentSession.users().getUserByUsername(realm, "user");
 
             requiredActions = user.getRequiredActionsStream().collect(Collectors.toList());
-            Assert.assertThat(requiredActions, hasSize(2));
-            Assert.assertThat(requiredActions, containsInAnyOrder(
+            assertThat(requiredActions, hasSize(2));
+            assertThat(requiredActions, containsInAnyOrder(
                     RequiredAction.CONFIGURE_TOTP.name(), 
                     RequiredAction.VERIFY_EMAIL.name())
             );
@@ -203,14 +204,14 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             user = currentSession.users().getUserByUsername(realm, "user");
 
             requiredActions = user.getRequiredActionsStream().collect(Collectors.toList());
-            Assert.assertThat(requiredActions, hasSize(1));
-            Assert.assertThat(requiredActions, contains(RequiredAction.VERIFY_EMAIL.name()));
+            assertThat(requiredActions, hasSize(1));
+            assertThat(requiredActions, contains(RequiredAction.VERIFY_EMAIL.name()));
 
             user.removeRequiredAction(RequiredAction.VERIFY_EMAIL.name());
             user = currentSession.users().getUserByUsername(realm, "user");
 
             requiredActions = user.getRequiredActionsStream().collect(Collectors.toList());
-            Assert.assertThat(requiredActions, empty());
+            assertThat(requiredActions, empty());
         });
     }
 
@@ -242,23 +243,23 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             UserModel user = currentSession.users().getUserByUsername(realm, "user");
 
             List<String> attrVals = user.getAttributeStream("key1").collect(Collectors.toList());
-            Assert.assertThat(attrVals, hasSize(1));
-            Assert.assertThat(attrVals, contains("value1"));
-            Assert.assertThat(user.getFirstAttribute("key1"), equalTo("value1"));
+            assertThat(attrVals, hasSize(1));
+            assertThat(attrVals, contains("value1"));
+            assertThat(user.getFirstAttribute("key1"), equalTo("value1"));
 
             attrVals = user.getAttributeStream("key2").collect(Collectors.toList());
-            Assert.assertThat(attrVals, hasSize(2));
-            Assert.assertThat(attrVals, containsInAnyOrder("val21", "val22"));
+            assertThat(attrVals, hasSize(2));
+            assertThat(attrVals, containsInAnyOrder("val21", "val22"));
 
             attrVals = user.getAttributeStream("key3").collect(Collectors.toList());
-            Assert.assertThat(attrVals, empty());
-            Assert.assertThat(user.getFirstAttribute("key3"), nullValue());
+            assertThat(attrVals, empty());
+            assertThat(user.getFirstAttribute("key3"), nullValue());
 
             Map<String, List<String>> allAttrVals = user.getAttributes();
-            Assert.assertThat(allAttrVals.keySet(), hasSize(6));
-            Assert.assertThat(allAttrVals.keySet(), containsInAnyOrder(UserModel.USERNAME, UserModel.FIRST_NAME, UserModel.LAST_NAME, UserModel.EMAIL, "key1", "key2"));
-            Assert.assertThat(allAttrVals.get("key1"), equalTo(user.getAttributeStream("key1").collect(Collectors.toList())));
-            Assert.assertThat(allAttrVals.get("key2"), equalTo(user.getAttributeStream("key2").collect(Collectors.toList())));
+            assertThat(allAttrVals.keySet(), hasSize(6));
+            assertThat(allAttrVals.keySet(), containsInAnyOrder(UserModel.USERNAME, UserModel.FIRST_NAME, UserModel.LAST_NAME, UserModel.EMAIL, "key1", "key2"));
+            assertThat(allAttrVals.get("key1"), equalTo(user.getAttributeStream("key1").collect(Collectors.toList())));
+            assertThat(allAttrVals.get("key2"), equalTo(user.getAttributeStream("key2").collect(Collectors.toList())));
 
             // Test remove and rewrite attribute
             user.removeAttribute("key1");
@@ -270,12 +271,12 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             RealmModel realm = currentSession.realms().getRealmByName("original");
 
             UserModel user = currentSession.users().getUserByUsername(realm, "user");
-            Assert.assertThat(user.getFirstAttribute("key1"), nullValue());
+            assertThat(user.getFirstAttribute("key1"), nullValue());
 
             List<String> attrVals = user.getAttributeStream("key2").collect(Collectors.toList());
 
-            Assert.assertThat(attrVals, hasSize(1));
-            Assert.assertThat(attrVals.get(0), equalTo("val23"));
+            assertThat(attrVals, hasSize(1));
+            assertThat(attrVals.get(0), equalTo("val23"));
         });
     }
 
@@ -305,9 +306,9 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             Map<String, List<String>> allAttrVals = user.getAttributes();
 
             // Ensure same transaction is able to see updated value
-            Assert.assertThat(allAttrVals.keySet(), hasSize(5));
-            Assert.assertThat(allAttrVals.keySet(), containsInAnyOrder("key1", UserModel.FIRST_NAME, UserModel.LAST_NAME, UserModel.EMAIL, UserModel.USERNAME));
-            Assert.assertThat(allAttrVals.get("key1"), contains("val2"));
+            assertThat(allAttrVals.keySet(), hasSize(5));
+            assertThat(allAttrVals.keySet(), containsInAnyOrder("key1", UserModel.FIRST_NAME, UserModel.LAST_NAME, UserModel.EMAIL, UserModel.USERNAME));
+            assertThat(allAttrVals.get("key1"), contains("val2"));
         });
     }
 
@@ -339,7 +340,7 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             // Overwrite the first attribute
             user.setSingleAttribute("key1", "value3");
 
-            Assert.assertThat(user.getAttributes(), equalTo(expected));
+            assertThat(user.getAttributes(), equalTo(expected));
 
             expectedAtomic.set(expected);
         });
@@ -349,7 +350,7 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             RealmModel realm = currentSession.realms().getRealmByName("original");
 
             Map<String, List<String>> expected = expectedAtomic.get();
-            Assert.assertThat(currentSession.users().getUserByUsername(realm, "user").getAttributes(), equalTo(expected));
+            assertThat(currentSession.users().getUserByUsername(realm, "user").getAttributes(), equalTo(expected));
         });
     }
 
@@ -372,8 +373,8 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
 
             List<UserModel> users = currentSession.users().searchForUserStream(realm, Map.of(UserModel.SEARCH, "user"), 0, 7)
                     .collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(1));
-            Assert.assertThat(users, contains(user1));
+            assertThat(users, hasSize(1));
+            assertThat(users, contains(user1));
         });
     }
 
@@ -412,22 +413,22 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
 
             List<UserModel> users = currentSession.users().searchForUserByUserAttributeStream(realm, "key1", "value1")
                     .collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(2));
-            Assert.assertThat(users, containsInAnyOrder(user1, user2));
+            assertThat(users, hasSize(2));
+            assertThat(users, containsInAnyOrder(user1, user2));
 
             users = currentSession.users().searchForUserByUserAttributeStream(realm, "key2", "value21")
                     .collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(2));
-            Assert.assertThat(users, containsInAnyOrder(user1, user3));
+            assertThat(users, hasSize(2));
+            assertThat(users, containsInAnyOrder(user1, user3));
 
             users = currentSession.users().searchForUserByUserAttributeStream(realm, "key2", "value22")
                     .collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(1));
-            Assert.assertThat(users, contains(user2));
+            assertThat(users, hasSize(1));
+            assertThat(users, contains(user2));
 
             users = currentSession.users().searchForUserByUserAttributeStream(realm, "key3", "value3")
                     .collect(Collectors.toList());
-            Assert.assertThat(users, empty());
+            assertThat(users, empty());
         });
     }
 
@@ -450,11 +451,11 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             user2.setLastName("Doe");
 
             // Search
-            Assert.assertThat(currentSession.users().getServiceAccount(client), nullValue());
+            assertThat(currentSession.users().getServiceAccount(client), nullValue());
             List<UserModel> users = currentSession.users().searchForUserStream(realm, Map.of(UserModel.SEARCH, "John Doe", UserModel.INCLUDE_SERVICE_ACCOUNT, "true"))
                     .collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(2));
-            Assert.assertThat(users, containsInAnyOrder(user1, user2));
+            assertThat(users, hasSize(2));
+            assertThat(users, containsInAnyOrder(user1, user2));
 
             // Link service account
             user1.setServiceAccountClientLink(client.getId());
@@ -470,22 +471,22 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             // Search and assert service account user not found
             ClientModel client = realm.getClientByClientId("foo");
             UserModel searched = currentSession.users().getServiceAccount(client);
-            Assert.assertThat(searched, equalTo(user1));
+            assertThat(searched, equalTo(user1));
             List<UserModel> users = currentSession.users().searchForUserStream(realm, Map.of(UserModel.SEARCH, "John Doe", UserModel.INCLUDE_SERVICE_ACCOUNT, "false"))
                     .collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(1));
-            Assert.assertThat(users, contains(user2));
+            assertThat(users, hasSize(1));
+            assertThat(users, contains(user2));
 
             users = currentSession.users().searchForUserStream(realm, Collections.singletonMap(UserModel.INCLUDE_SERVICE_ACCOUNT, Boolean.FALSE.toString())).collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(1));
-            Assert.assertThat(users, contains(user2));
+            assertThat(users, hasSize(1));
+            assertThat(users, contains(user2));
 
             users = currentSession.users().searchForUserStream(realm, Collections.emptyMap()).collect(Collectors.toList());
-            Assert.assertThat(users, hasSize(2));
-            Assert.assertThat(users, containsInAnyOrder(user1, user2));
+            assertThat(users, hasSize(2));
+            assertThat(users, containsInAnyOrder(user1, user2));
 
-            Assert.assertThat(currentSession.users().getUsersCount(realm, true), equalTo(2));
-            Assert.assertThat(currentSession.users().getUsersCount(realm, false), equalTo(1));
+            assertThat(currentSession.users().getUsersCount(realm, true), equalTo(2));
+            assertThat(currentSession.users().getUsersCount(realm, false), equalTo(1));
 
             // Remove client
             RealmManager realmMgr = new RealmManager(currentSession);
@@ -498,7 +499,7 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             KeycloakSession currentSession = sesServiceLink3;
             RealmModel realm = currentSession.realms().getRealmByName("original");
             // Assert service account removed as well
-            Assert.assertThat(currentSession.users().getUserByUsername(realm, "user1"), nullValue());
+            assertThat(currentSession.users().getUserByUsername(realm, "user1"), nullValue());
         });
     }
 
@@ -564,7 +565,7 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
 
             UserModel user1 = currentSession.users().getUserByUsername(realm, "user1");
             int notBefore = currentSession.users().getNotBeforeOfUser(realm, user1);
-            Assert.assertThat(notBefore, equalTo(10));
+            assertThat(notBefore, equalTo(10));
 
             // Try to update
             currentSession.users().setNotBeforeForUser(realm, user1, 20);
@@ -576,16 +577,16 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
 
             UserModel user1 = currentSession.users().getUserByUsername(realm, "user1");
             int notBefore = currentSession.users().getNotBeforeOfUser(realm, user1);
-            Assert.assertThat(notBefore, equalTo(20));
+            assertThat(notBefore, equalTo(20));
         });
     }
 
     private static void assertUserModel(UserModel expected, UserModel actual) {
-        Assert.assertThat(actual.getUsername(), equalTo(expected.getUsername()));
-        Assert.assertThat(actual.getCreatedTimestamp(), equalTo(expected.getCreatedTimestamp()));
-        Assert.assertThat(actual.getFirstName(), equalTo(expected.getFirstName()));
-        Assert.assertThat(actual.getLastName(), equalTo(expected.getLastName()));
-        Assert.assertThat(actual.getRequiredActionsStream().collect(Collectors.toSet()),
+        assertThat(actual.getUsername(), equalTo(expected.getUsername()));
+        assertThat(actual.getCreatedTimestamp(), equalTo(expected.getCreatedTimestamp()));
+        assertThat(actual.getFirstName(), equalTo(expected.getFirstName()));
+        assertThat(actual.getLastName(), equalTo(expected.getLastName()));
+        assertThat(actual.getRequiredActionsStream().collect(Collectors.toSet()),
                 containsInAnyOrder(expected.getRequiredActionsStream().toArray()));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -191,8 +191,8 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
         assertEquals(200, response.getStatusCode());
 
-        Assert.assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
+        assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
 
         assertEquals("Bearer", response.getTokenType());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
@@ -2,7 +2,7 @@ package org.keycloak.testsuite.oauth;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
 import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthPostMethodTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthPostMethodTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test for "client_secret_post" client authentication (clientID + clientSecret sent in the POST body instead of in "Authorization: Basic" header)
@@ -78,8 +79,8 @@ public class ClientAuthPostMethodTest extends AbstractKeycloakTest {
 
         assertEquals(200, response.getStatusCode());
 
-        Assert.assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
+        assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
 
         AccessToken token = oauth.verifyToken(response.getAccessToken());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -68,6 +68,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_ID;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_USERNAME;
@@ -417,7 +418,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
             Assert.assertNull(exchangedToken.getRealmAccess());
 
             Object impersonatorRaw = exchangedToken.getOtherClaims().get("impersonator");
-            Assert.assertThat(impersonatorRaw, instanceOf(Map.class));
+            assertThat(impersonatorRaw, instanceOf(Map.class));
             Map impersonatorClaim = (Map) impersonatorRaw;
 
             Assert.assertEquals(token.getSubject(), impersonatorClaim.get("id"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LegacyLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LegacyLogoutTest.java
@@ -124,7 +124,7 @@ public class LegacyLogoutTest extends AbstractTestRealmKeycloakTest {
         driver.navigate().to(logoutUrl);
 
         events.expectLogout(sessionId).detail(Details.REDIRECT_URI, APP_REDIRECT_URI).assertEvent();
-        Assert.assertThat(false, is(isSessionActive(sessionId)));
+        assertThat(false, is(isSessionActive(sessionId)));
         assertCurrentUrlEquals(APP_REDIRECT_URI);
     }
 
@@ -139,13 +139,13 @@ public class LegacyLogoutTest extends AbstractTestRealmKeycloakTest {
 
         // Assert logout confirmation page. Session still exists. Assert default language on logout page (English)
         logoutConfirmPage.assertCurrent();
-        Assert.assertThat(true, is(isSessionActive(sessionId)));
+        assertThat(true, is(isSessionActive(sessionId)));
         events.assertEmpty();
         logoutConfirmPage.confirmLogout();
 
         // Redirected back to the application with expected state
         events.expectLogout(sessionId).removeDetail(Details.REDIRECT_URI).assertEvent();
-        Assert.assertThat(false, is(isSessionActive(sessionId)));
+        assertThat(false, is(isSessionActive(sessionId)));
         assertCurrentUrlEquals(APP_REDIRECT_URI);
     }
 
@@ -200,7 +200,7 @@ public class LegacyLogoutTest extends AbstractTestRealmKeycloakTest {
             Assert.assertEquals("Invalid redirect uri", errorPage.getError());
 
             // Session still active
-            Assert.assertThat(true, is(isSessionActive(tokenResponse.getSessionState())));
+            assertThat(true, is(isSessionActive(tokenResponse.getSessionState())));
         } finally {
             // Revert
             clientRes.update(clientRepOrig);
@@ -249,7 +249,7 @@ public class LegacyLogoutTest extends AbstractTestRealmKeycloakTest {
         driver.navigate().to(logoutUrl);
 
         events.expectLogout(sessionId).detail(Details.REDIRECT_URI, APP_REDIRECT_URI).assertEvent();
-        Assert.assertThat(false, is(isSessionActive(sessionId)));
+        assertThat(false, is(isSessionActive(sessionId)));
         assertCurrentUrlEquals(APP_REDIRECT_URI);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutCorsTest.java
@@ -35,7 +35,7 @@ import org.keycloak.testsuite.util.RealmBuilder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
@@ -416,8 +417,8 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
 
         assertEquals(200, response.getStatusCode());
-        Assert.assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
+        assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
         assertEquals("Bearer", response.getTokenType());
 
         String expectedKid = Stream.of(oauth.doCertsRequest("test").getKeys())
@@ -465,9 +466,9 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         RefreshToken refreshToken = oauth.parseRefreshToken(refreshTokenString);
 
         Assert.assertNotNull(refreshTokenString);
-        Assert.assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
+        assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
         int actual = refreshToken.getExpiration() - getCurrentTime();
-        Assert.assertThat(actual, allOf(greaterThanOrEqualTo(1799 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
+        assertThat(actual, allOf(greaterThanOrEqualTo(1799 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
         assertEquals(sessionId, refreshToken.getSessionState());
 
         setTimeOffset(2);
@@ -481,11 +482,11 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         assertEquals(sessionId, refreshedToken.getSessionState());
         assertEquals(sessionId, refreshedRefreshToken.getSessionState());
 
-        Assert.assertThat(refreshResponse.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(refreshedToken.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(250 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(300 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
+        assertThat(refreshResponse.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(refreshedToken.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(250 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(300 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
 
-        Assert.assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
-        Assert.assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
+        assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
+        assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
 
         Assert.assertNotEquals(token.getId(), refreshedToken.getId());
         Assert.assertNotEquals(refreshToken.getId(), refreshedRefreshToken.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
@@ -53,7 +53,7 @@ import java.net.URL;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.util.OAuthClient.APP_ROOT;
 
@@ -505,7 +505,7 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
                         .build().toString();
                 if (browserUrlAfterRedirectFromKeycloak.endsWith("/")) browserUrlAfterRedirectFromKeycloak = browserUrlAfterRedirectFromKeycloak.substring(0, browserUrlAfterRedirectFromKeycloak.length() - 1);
                 if (Constants.INSTALLED_APP_URN.equals(redirectUri)) {
-                    Assert.assertThat(browserUrlAfterRedirectFromKeycloak, Matchers.endsWith("oauth/oob"));
+                    assertThat(browserUrlAfterRedirectFromKeycloak, Matchers.endsWith("oauth/oob"));
                 } else {
                     Assert.assertEquals(redirectUri, browserUrlAfterRedirectFromKeycloak);
                 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
@@ -292,7 +292,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
             assertTrue(accessToken.getResourceAccess("app").getRoles().contains("hardcoded"));
 
             // Assert audiences added through AudienceResolve mapper
-            Assert.assertThat(accessToken.getAudience(), arrayContainingInAnyOrder( "app", "account"));
+            assertThat(accessToken.getAudience(), arrayContainingInAnyOrder( "app", "account"));
 
             // Assert allowed origins
             Assert.assertNames(accessToken.getAllowedOrigins(), "http://localhost:8180", "https://localhost:8543");
@@ -580,7 +580,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm", "test-app"));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm", "test-app"));
         String realmRoleMappings = (String) roleMappings.get("realm");
         String testAppMappings = (String) roleMappings.get("test-app");
         assertRolesString(realmRoleMappings,
@@ -716,9 +716,9 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm", "test-app"));
-        Assert.assertThat(roleMappings.get("realm"), CoreMatchers.instanceOf(List.class));
-        Assert.assertThat(roleMappings.get("test-app"), CoreMatchers.instanceOf(List.class));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm", "test-app"));
+        assertThat(roleMappings.get("realm"), CoreMatchers.instanceOf(List.class));
+        assertThat(roleMappings.get("test-app"), CoreMatchers.instanceOf(List.class));
 
         List<String> realmRoleMappings = (List<String>) roleMappings.get("realm");
         List<String> testAppMappings = (List<String>) roleMappings.get("test-app");
@@ -761,9 +761,9 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm", "test-app"));
-        Assert.assertThat(roleMappings.get("realm"), CoreMatchers.instanceOf(List.class));
-        Assert.assertThat(roleMappings.get("test-app"), CoreMatchers.instanceOf(List.class));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm", "test-app"));
+        assertThat(roleMappings.get("realm"), CoreMatchers.instanceOf(List.class));
+        assertThat(roleMappings.get("test-app"), CoreMatchers.instanceOf(List.class));
 
         List<String> realmRoleMappings = (List<String>) roleMappings.get("realm");
         List<String> testAppMappings = (List<String>) roleMappings.get("test-app");
@@ -807,7 +807,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled AND it is filled only once
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder(clientId));
+        assertThat(roleMappings.keySet(), containsInAnyOrder(clientId));
         String testAppScopeMappings = (String) roleMappings.get(clientId);
         assertRolesString(testAppScopeMappings,
                 "customer-user"      // from assignment to level2group or level2group2. It is filled just once
@@ -836,7 +836,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm", clientId));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm", clientId));
         String realmRoleMappings = (String) roleMappings.get("realm");
         String testAppMappings = (String) roleMappings.get(clientId);
         assertRolesString(realmRoleMappings,
@@ -881,7 +881,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm"));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm"));
         String realmRoleMappings = (String) roleMappings.get("realm");
         String testAppAuthzMappings = (String) roleMappings.get(clientId);
         assertRolesString(realmRoleMappings,
@@ -914,7 +914,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm", clientId));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm", clientId));
         String realmRoleMappings = (String) roleMappings.get("realm");
         String testAppScopeMappings = (String) roleMappings.get(clientId);
         assertRolesString(realmRoleMappings,
@@ -948,7 +948,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // Verify attribute is filled
         Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
-        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm", clientId));
+        assertThat(roleMappings.keySet(), containsInAnyOrder("realm", clientId));
         String realmRoleMappings = (String) roleMappings.get("realm");
         String testAppScopeMappings = (String) roleMappings.get(clientId);
         assertRolesString(realmRoleMappings,
@@ -1771,13 +1771,13 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
     private void assertRolesString(String actualRoleString, String...expectedRoles) {
 
-        Assert.assertThat(actualRoleString.matches("^\\[.*\\]$"), is(true));
+        assertThat(actualRoleString.matches("^\\[.*\\]$"), is(true));
         String[] roles = actualRoleString.substring(1, actualRoleString.length() - 1).split(",\\s*");
 
         if (expectedRoles == null || expectedRoles.length == 0) {
-            Assert.assertThat(roles, arrayContainingInAnyOrder(""));
+            assertThat(roles, arrayContainingInAnyOrder(""));
         } else {
-            Assert.assertThat(roles, arrayContainingInAnyOrder(expectedRoles));
+            assertThat(roles, arrayContainingInAnyOrder(expectedRoles));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -86,6 +86,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.Assert.assertExpiration;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
@@ -1112,8 +1113,8 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
             String offlineTokenString = tokenResponse.getRefreshToken();
             RefreshToken offlineToken = oauth.parseRefreshToken(offlineTokenString);
 
-            Assert.assertThat(tokenResponse.getExpiresIn(), allOf(greaterThanOrEqualTo(59), lessThanOrEqualTo(60)));
-            Assert.assertThat(tokenResponse.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(29), lessThanOrEqualTo(30)));
+            assertThat(tokenResponse.getExpiresIn(), allOf(greaterThanOrEqualTo(59), lessThanOrEqualTo(60)));
+            assertThat(tokenResponse.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(29), lessThanOrEqualTo(30)));
             assertEquals(TokenUtil.TOKEN_TYPE_OFFLINE, offlineToken.getType());
 
             String introspectionResponse = oauth.introspectAccessTokenWithClientCredential("test-app", "password",
@@ -1122,7 +1123,7 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
             JsonNode jsonNode = objectMapper.readTree(introspectionResponse);
             Assert.assertEquals(true, jsonNode.get("active").asBoolean());
             Assert.assertEquals("test-user@localhost", jsonNode.get("email").asText());
-            Assert.assertThat(jsonNode.get("exp").asInt() - getCurrentTime(),
+            assertThat(jsonNode.get("exp").asInt() - getCurrentTime(),
                 allOf(greaterThanOrEqualTo(59), lessThanOrEqualTo(60)));
 
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -238,9 +238,9 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
 
         assertEquals("Bearer", tokenResponse.getTokenType());
 
-        Assert.assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
+        assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
         int actual = refreshToken.getExpiration() - getCurrentTime();
-        Assert.assertThat(actual, allOf(greaterThanOrEqualTo(1799 - ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + ALLOWED_CLOCK_SKEW)));
+        assertThat(actual, allOf(greaterThanOrEqualTo(1799 - ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + ALLOWED_CLOCK_SKEW)));
 
         assertEquals(sessionId, refreshToken.getSessionState());
 
@@ -253,11 +253,11 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
         assertEquals(sessionId, refreshedToken.getSessionState());
         assertEquals(sessionId, refreshedRefreshToken.getSessionState());
 
-        Assert.assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(refreshedToken.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(250 - ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(300 + ALLOWED_CLOCK_SKEW)));
+        assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(refreshedToken.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(250 - ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(300 + ALLOWED_CLOCK_SKEW)));
 
-        Assert.assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(10)));
-        Assert.assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(10)));
+        assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(10)));
+        assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(10)));
 
         // "test-app" should not be an audience in the refresh token
         assertEquals("test-app", refreshedRefreshToken.getIssuedFor());
@@ -968,7 +968,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             next = testingClient.testing().getLastSessionRefresh("test", sessionId, false);
 
             // lastSEssionRefresh should be updated because access code lifespan is higher than sso idle timeout
-            Assert.assertThat(next, allOf(greaterThan(last), lessThan(last + 50)));
+            assertThat(next, allOf(greaterThan(last), lessThan(last + 50)));
 
             RealmManager.realm(realmResource).ssoSessionIdleTimeout(1);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
@@ -68,7 +68,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
@@ -20,7 +20,7 @@ package org.keycloak.testsuite.oauth;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
@@ -221,8 +221,8 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
     private void expectSuccessfulResponseFromTokenEndpoint(String sessionId, String codeId, AccessTokenResponse response) throws Exception {
         assertEquals(200, response.getStatusCode());
 
-        Assert.assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
+        assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
 
         assertEquals("Bearer", response.getTokenType());
 
@@ -335,9 +335,9 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
 
         Assert.assertNotNull(refreshTokenString);
         assertEquals("Bearer", tokenResponse.getTokenType());
-        Assert.assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
+        assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
         int actual = refreshToken.getExpiration() - getCurrentTime();
-        Assert.assertThat(actual, allOf(greaterThanOrEqualTo(1799 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
+        assertThat(actual, allOf(greaterThanOrEqualTo(1799 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
         assertEquals(sessionId, refreshToken.getSessionState());
 
         setTimeOffset(2);
@@ -372,9 +372,9 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
 
         Assert.assertNotNull(refreshTokenString);
         assertEquals("Bearer", tokenResponse.getTokenType());
-        Assert.assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
+        assertThat(token.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(200), lessThanOrEqualTo(350)));
         int actual = refreshToken.getExpiration() - getCurrentTime();
-        Assert.assertThat(actual, allOf(greaterThanOrEqualTo(1799 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
+        assertThat(actual, allOf(greaterThanOrEqualTo(1799 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(1800 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
         assertEquals(sessionId, refreshToken.getSessionState());
 
         setTimeOffset(2);
@@ -409,11 +409,11 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         assertEquals(sessionId, refreshedToken.getSessionState());
         assertEquals(sessionId, refreshedRefreshToken.getSessionState());
 
-        Assert.assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
-        Assert.assertThat(refreshedToken.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(250 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(300 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
+        assertThat(response.getExpiresIn(), allOf(greaterThanOrEqualTo(250), lessThanOrEqualTo(300)));
+        assertThat(refreshedToken.getExpiration() - getCurrentTime(), allOf(greaterThanOrEqualTo(250 - RefreshTokenTest.ALLOWED_CLOCK_SKEW), lessThanOrEqualTo(300 + RefreshTokenTest.ALLOWED_CLOCK_SKEW)));
 
-        Assert.assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
-        Assert.assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
+        assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
+        assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
 
         Assert.assertNotEquals(token.getId(), refreshedToken.getId());
         Assert.assertNotEquals(refreshToken.getId(), refreshedRefreshToken.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
@@ -103,6 +103,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP;
@@ -216,7 +217,7 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         // Assert I need to login again through the login form. But username field is not present
         oauth.openLoginForm();
         loginPage.assertCurrent();
-        Assert.assertThat(false, is(loginPage.isUsernameInputPresent()));
+        assertThat(false, is(loginPage.isUsernameInputPresent()));
         loginPage.login("password");
         loginEvent = events.expectLogin().assertEvent();
 
@@ -385,7 +386,7 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         // Assert need to re-authenticate with prompt=login
         driver.navigate().to(oauth.getLoginFormUrl() + "&prompt=login");
         loginPage.assertCurrent();
-        Assert.assertThat(false, is(loginPage.isUsernameInputPresent()));
+        assertThat(false, is(loginPage.isUsernameInputPresent()));
         loginPage.login("password");
         Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -104,7 +104,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.util.OAuthClient.AUTH_SERVER_ROOT;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AbstractSamlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AbstractSamlTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.isSamlResponse;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.bodyHC;
 import static org.keycloak.testsuite.util.Matchers.isSamlStatusResponse;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AudienceProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AudienceProtocolMappersTest.java
@@ -36,6 +36,8 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import org.keycloak.testsuite.admin.ApiUtil;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
@@ -77,9 +79,9 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
           .getSamlResponse(SamlClient.Binding.POST);
 
         Assert.assertNotNull(document.getSamlObject());
-        Assert.assertThat(document.getSamlObject(), Matchers.isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        assertThat(document.getSamlObject(), Matchers.isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
         Assert.assertNotNull(((ResponseType) document.getSamlObject()).getAssertions());
-        Assert.assertThat(((ResponseType) document.getSamlObject()).getAssertions().size(), greaterThan(0));
+        assertThat(((ResponseType) document.getSamlObject()).getAssertions().size(), greaterThan(0));
         Assert.assertNotNull(((ResponseType) document.getSamlObject()).getAssertions().get(0));
         Assert.assertNotNull(((ResponseType) document.getSamlObject()).getAssertions().get(0).getAssertion());
         AudienceRestrictionType audience = ((ResponseType) document.getSamlObject())
@@ -91,7 +93,7 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
         Assert.assertNotNull(audience);
         Assert.assertNotNull(audience.getAudience());
         List<String> values = audience.getAudience().stream().map(uri -> uri.toString()).collect(Collectors.toList());
-        Assert.assertThat(values, containsInAnyOrder(audiences));
+        assertThat(values, containsInAnyOrder(audiences));
     }
 
     @Test
@@ -167,7 +169,7 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
             String employeeId = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee/").get(0).getId();
             Assert.assertNotNull(employeeId);
             List<RoleRepresentation> availables = adminClient.realm(REALM_NAME).clients().get(employee2Id).getScopeMappings().clientLevel(employeeId).listAvailable();
-            Assert.assertThat(availables.size(), greaterThan(0));
+            assertThat(availables.size(), greaterThan(0));
             // assign scope to only employee2 (employee-role-mapping should not be there)
             try (RoleScopeUpdater ru = cau.clientRoleScope(employeeId)
                     .add(availables.get(0))
@@ -195,7 +197,7 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
             String employeeId = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee/").get(0).getId();
             Assert.assertNotNull(employeeId);
             List<RoleRepresentation> availables = adminClient.realm(REALM_NAME).clientScopes().get(clientScopeId).getScopeMappings().clientLevel(employeeId).listAvailable();
-            Assert.assertThat(availables.size(), greaterThan(0));
+            assertThat(availables.size(), greaterThan(0));
             adminClient.realm(REALM_NAME).clientScopes().get(clientScopeId).getScopeMappings().clientLevel(employeeId).add(availables);
 
             // remove full scope and add the client scope

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestNameIdFormatTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestNameIdFormatTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
 import static org.keycloak.testsuite.util.SamlClient.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
 import static org.keycloak.testsuite.util.SamlClient.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/IdpInitiatedLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/IdpInitiatedLoginTest.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.updaters.IdentityProviderCreator;
@@ -180,8 +180,8 @@ public class IdpInitiatedLoginTest extends AbstractSamlTest {
         new SamlClientBuilder()
                 .idpInitiatedLogin(getAuthServerSamlEndpoint(REALM_NAME), "sales-post").build()
                 .execute(r -> {
-                    Assert.assertThat(r, statusCodeIsHC(Response.Status.BAD_REQUEST));
-                    Assert.assertThat(r, bodyHC(containsString("Wrong client protocol.")));
+                    assertThat(r, statusCodeIsHC(Response.Status.BAD_REQUEST));
+                    assertThat(r, bodyHC(containsString("Wrong client protocol.")));
                 });
 
 
@@ -195,8 +195,8 @@ public class IdpInitiatedLoginTest extends AbstractSamlTest {
                 .idpInitiatedLogin(getAuthServerSamlEndpoint(REALM_NAME), "sales-post").build()
                 .login().user(bburkeUser).build()
                 .execute(r -> {
-                    Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-                    Assert.assertThat(r, bodyHC(allOf(
+                    assertThat(r, statusCodeIsHC(Response.Status.OK));
+                    assertThat(r, bodyHC(allOf(
                             containsString("Redirecting, please wait."),
                             containsString("<input type=\"hidden\" name=\"SAMLResponse\""), 
                             containsString("<h1 id=\"kc-page-title\">")
@@ -217,8 +217,8 @@ public class IdpInitiatedLoginTest extends AbstractSamlTest {
                 .idpInitiatedLogin(getAuthServerSamlEndpoint(REALM_NAME), "sales-post").build()
                 .login().idp("saml-idp").build()
                 .execute(r -> {
-                    Assert.assertThat(r, statusCodeIsHC(Response.Status.OK));
-                    Assert.assertThat(r, bodyHC(allOf(
+                    assertThat(r, statusCodeIsHC(Response.Status.OK));
+                    assertThat(r, bodyHC(allOf(
                             containsString("Redirecting, please wait."),
                             containsString("<input type=\"hidden\" name=\"SAMLRequest\""), 
                             containsString("<h1 id=\"kc-page-title\">")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/IncludeOneTimeUseConditionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/IncludeOneTimeUseConditionTest.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * KEYCLOAK-4360

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -69,7 +69,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.Matchers.*;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ProtocolMapperTest.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.saml.RoleMapperTest.createSamlProtocolMapper;
 import static org.keycloak.testsuite.util.SamlStreams.assertionsUnencrypted;
 import static org.keycloak.testsuite.util.SamlStreams.attributeStatements;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/RoleMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/RoleMapperTest.java
@@ -46,7 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlClientTest.java
@@ -24,6 +24,8 @@ import org.w3c.dom.Document;
 import java.io.IOException;
 import java.net.URI;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  *
  * @author mkanis
@@ -47,7 +49,7 @@ public class SamlClientTest extends AbstractSamlTest {
             CloseableHttpResponse response = sendPost(post, client);
             Assert.assertEquals(response.getStatusLine().getStatusCode(), 400);
             String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
-            Assert.assertThat(s, Matchers.containsString("Wrong client protocol."));
+            assertThat(s, Matchers.containsString("Wrong client protocol."));
 
             response.close();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlConsentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlConsentTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author mhajas

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlRedirectBindingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlRedirectBindingTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.dom.saml.v2.protocol.ResponseType;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlReverseProxyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlReverseProxyTest.java
@@ -39,7 +39,7 @@ import java.net.URI;
 import java.util.HashMap;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlXMLAttacksTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlXMLAttacksTest.java
@@ -28,7 +28,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.util.Matchers.bodyHC;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SessionNotOnOrAfterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SessionNotOnOrAfterTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import org.junit.Assert;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.dom.saml.v2.assertion.ConditionsType;
 import org.keycloak.dom.saml.v2.assertion.SubjectConfirmationDataType;
 import org.keycloak.dom.saml.v2.assertion.SubjectConfirmationType;
@@ -42,7 +42,7 @@ public class SessionNotOnOrAfterTest extends AbstractSamlTest {
 
         Assert.assertNotNull(resp);
         Assert.assertNotNull(resp.getAssertions());
-        Assert.assertThat(resp.getAssertions().size(), greaterThan(0));
+        assertThat(resp.getAssertions().size(), greaterThan(0));
         Assert.assertNotNull(resp.getAssertions().get(0));
         Assert.assertNotNull(resp.getAssertions().get(0).getAssertion());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedSAMLScriptMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedSAMLScriptMapperTest.java
@@ -38,7 +38,7 @@ import org.keycloak.testsuite.util.SamlClientBuilder;
 import org.keycloak.util.JsonSerialization;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.common.Profile.Feature.SCRIPTS;
 import static org.keycloak.testsuite.arquillian.DeploymentTargetModifier.AUTH_SERVER_CURRENT;
 import static org.keycloak.testsuite.saml.RoleMapperTest.createSamlProtocolMapper;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/FixedHostnameTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/FixedHostnameTest.java
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer.QUARKUS;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AssertAdminEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AssertAdminEvents.java
@@ -46,6 +46,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -188,7 +190,7 @@ public class AssertAdminEvents implements TestRule {
 
         public AdminEventRepresentation assertEvent(AdminEventRepresentation actual) {
             Assert.assertEquals(expected.getRealmId(), actual.getRealmId());
-            Assert.assertThat(actual.getResourcePath(), resourcePath);
+            assertThat(actual.getResourcePath(), resourcePath);
             Assert.assertEquals(expected.getResourceType(), actual.getResourceType());
             Assert.assertEquals(expected.getOperationType(), actual.getOperationType());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TextFileCheckerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TextFileCheckerTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  *
  * @author hmlnarik
@@ -87,7 +89,7 @@ public class TextFileCheckerTest {
     public void assertCheckedOutputIs(String... expectedOutput) throws IOException {
         List<String> target = new LinkedList<>();
         tfc.checkFiles(false, collector(target));
-        Assert.assertThat(target,
+        assertThat(target,
           expectedOutput == null || expectedOutput.length == 0
             ? Matchers.empty()
             : Matchers.contains(expectedOutput));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserCRLTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserCRLTest.java
@@ -34,6 +34,7 @@ import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.WebDriver;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN_EMAIL;
 
@@ -219,7 +220,7 @@ public class X509BrowserCRLTest extends AbstractX509AuthenticationTest {
         // Verify there is an error message
         Assert.assertNotNull(loginPage.getError());
 
-        Assert.assertThat(loginPage.getError(), containsString(expectedError));
+        assertThat(loginPage.getError(), containsString(expectedError));
 
         // Continue with form based login
         loginPage.login("test-user@localhost", "password");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USER_ATTRIBUTE;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SERIALNUMBER_ISSUERDN;
@@ -105,7 +106,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
 
         loginConfirmationPage.open();
 
-        Assert.assertThat(loginPage.getError(), containsString("Certificate validation's failed.\n" +
+        assertThat(loginPage.getError(), containsString("Certificate validation's failed.\n" +
                 "Certificate revoked or incorrect."));
     }
 
@@ -135,7 +136,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
             // Verify there is an error message
             Assert.assertNotNull(loginPage.getError());
 
-            Assert.assertThat(loginPage.getError(), containsString("Certificate validation's failed."));
+            assertThat(loginPage.getError(), containsString("Certificate validation's failed."));
         } finally {
             testingClient.testing().reenableTruststoreSpi();
         }
@@ -292,7 +293,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
 
         loginPage.open();
 
-        Assert.assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed."));
+        assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed."));
 
         loginPage.login("test-user@localhost", "password");
 
@@ -312,7 +313,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         loginConfirmationPage.open();
         loginPage.assertCurrent();
 
-        Assert.assertThat(loginPage.getInfoMessage(), containsString("X509 client authentication has not been configured yet"));
+        assertThat(loginPage.getInfoMessage(), containsString("X509 client authentication has not been configured yet"));
         // Continue with form based login
         loginPage.login("test-user@localhost", "password");
 
@@ -344,7 +345,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         // Verify there is an error message
         Assert.assertNotNull(loginPage.getError());
 
-        Assert.assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed."));
+        assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed."));
         events.expectLogin()
                 .user((String) null)
                 .session((String) null)
@@ -421,7 +422,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         // Verify there is an error message
         Assert.assertNotNull(loginPage.getError());
 
-        Assert.assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed."));
+        assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed."));
 
         AssertEvents.ExpectedEvent expectedEvent = events.expectLogin()
                 .user((String) null)
@@ -458,7 +459,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
 
             Assert.assertNotNull(loginPage.getError());
 
-            Assert.assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed.\nUser is disabled"));
+            assertThat(loginPage.getError(), containsString("X509 certificate authentication's failed.\nUser is disabled"));
 
             events.expectLogin()
                     .user(userId)
@@ -528,7 +529,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         loginConfirmationPage.open();
         loginPage.assertCurrent();
 
-        Assert.assertThat(loginPage.getInfoMessage(), containsString("X509 client authentication has not been configured yet"));
+        assertThat(loginPage.getInfoMessage(), containsString("X509 client authentication has not been configured yet"));
         loginPage.assertCurrent();
 
         // Now setup certificate and login with certificate in existing authenticationSession (Not 100% same scenario as KEYCLOAK-5466, but very similar)
@@ -546,20 +547,20 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         loginConfirmationPage.open();
 
         log.debug("check if on confirm page");
-        Assert.assertThat(loginConfirmationPage.getSubjectDistinguishedNameText(), startsWith("EMAILADDRESS=test-user@localhost"));
+        assertThat(loginConfirmationPage.getSubjectDistinguishedNameText(), startsWith("EMAILADDRESS=test-user@localhost"));
         log.debug("check if locale is EN");
-        Assert.assertThat(loginConfirmationPage.getLanguageDropdownText(), is(equalTo("English")));
+        assertThat(loginConfirmationPage.getLanguageDropdownText(), is(equalTo("English")));
 
         log.debug("change locale to DE");
         loginConfirmationPage.openLanguage("Deutsch");
         log.debug("check if locale is DE");
-        Assert.assertThat(loginConfirmationPage.getLanguageDropdownText(), is(equalTo("Deutsch")));
-        Assert.assertThat(DroneUtils.getCurrentDriver().getPageSource(), containsString("X509 Client Zertifikat:"));
+        assertThat(loginConfirmationPage.getLanguageDropdownText(), is(equalTo("Deutsch")));
+        assertThat(DroneUtils.getCurrentDriver().getPageSource(), containsString("X509 Client Zertifikat:"));
 
         log.debug("confirm cert");
         loginConfirmationPage.confirm();
 
         log.debug("check if logged in");
-        Assert.assertThat(appPage.getRequestType(), is(equalTo(AppPage.RequestType.AUTH_RESPONSE)));
+        assertThat(appPage.getRequestType(), is(equalTo(AppPage.RequestType.AUTH_RESPONSE)));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509DirectGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509DirectGrantTest.java
@@ -43,6 +43,7 @@ import jakarta.ws.rs.core.Response;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USER_ATTRIBUTE;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.ISSUERDN;
@@ -94,7 +95,7 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
 
         assertEquals(401, response.getStatusCode());
         assertEquals("invalid_request", response.getError());
-        Assert.assertThat(response.getErrorDescription(), containsString("X509 certificate authentication's failed."));
+        assertThat(response.getErrorDescription(), containsString("X509 certificate authentication's failed."));
     }
 
     @Test
@@ -144,7 +145,7 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
 
         assertEquals(401, response.getStatusCode());
         assertEquals("invalid_request", response.getError());
-        Assert.assertThat(response.getErrorDescription(), containsString("Key Usage bit 'dataEncipherment' is not set."));
+        assertThat(response.getErrorDescription(), containsString("Key Usage bit 'dataEncipherment' is not set."));
         events.clear();
     }
 
@@ -242,7 +243,7 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
 
         assertEquals(401, response.getStatusCode());
         assertEquals("invalid_request", response.getError());
-        Assert.assertThat(response.getErrorDescription(), containsString("Certificate has been revoked, certificate's subject:"));
+        assertThat(response.getErrorDescription(), containsString("Certificate has been revoked, certificate's subject:"));
 
     }
 
@@ -287,7 +288,7 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
 
         assertEquals(401, response.getStatusCode());
         assertEquals("invalid_request", response.getError());
-        Assert.assertThat(response.getErrorDescription(), containsString("has expired on:"));
+        assertThat(response.getErrorDescription(), containsString("has expired on:"));
     }
 
     private void loginForceTemporaryAccountLock() throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderFailOpenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderFailOpenTest.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.WebDriver;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN_EMAIL;
 
@@ -67,7 +68,7 @@ public class X509OCSPResponderFailOpenTest extends AbstractX509AuthenticationTes
         assertEquals("invalid_request", response.getError());
 
         // Make sure we got the right error
-        Assert.assertThat(response.getErrorDescription(), containsString("OCSP check failed"));
+        assertThat(response.getErrorDescription(), containsString("OCSP check failed"));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderSpecificCertTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderSpecificCertTest.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.core.Response;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN_EMAIL;
 
@@ -81,7 +82,7 @@ public class X509OCSPResponderSpecificCertTest extends AbstractX509Authenticatio
         assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatusCode());
         assertEquals("invalid_request", response.getError());
 
-        Assert.assertThat(response.getErrorDescription(), containsString("Responder's certificate is not authorized to sign OCSP responses"));
+        assertThat(response.getErrorDescription(), containsString("Responder's certificate is not authorized to sign OCSP responses"));
     }
 
     @Test
@@ -120,7 +121,7 @@ public class X509OCSPResponderSpecificCertTest extends AbstractX509Authenticatio
         assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatusCode());
         assertEquals("invalid_request", response.getError());
 
-        Assert.assertThat(response.getErrorDescription(), containsString("Certificate's been revoked."));
+        assertThat(response.getErrorDescription(), containsString("Certificate's been revoked."));
     }
 
     @Before

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderTest.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.core.Response;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN_EMAIL;
 
@@ -90,7 +91,7 @@ public class X509OCSPResponderTest extends AbstractX509AuthenticationTest {
         assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatusCode());
         assertEquals("invalid_request", response.getError());
 
-        Assert.assertThat(response.getErrorDescription(), containsString("Certificate's been revoked."));
+        assertThat(response.getErrorDescription(), containsString("Certificate's been revoked."));
     }
 
     @Test
@@ -120,7 +121,7 @@ public class X509OCSPResponderTest extends AbstractX509AuthenticationTest {
             assertEquals("invalid_request", response.getError());
 
             // the ocsp signer cert is issued by the same CA but no OCSP-Signing extension so error
-            Assert.assertThat(response.getErrorDescription(), containsString("Responder's certificate not valid for signing OCSP responses"));
+            assertThat(response.getErrorDescription(), containsString("Responder's certificate not valid for signing OCSP responses"));
         } finally {
             oauth.httpClient(previous);
         }

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/MyResourcesTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/MyResourcesTest.java
@@ -40,7 +40,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD;

--- a/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/AccountLinkSpringBootTest.java
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/AccountLinkSpringBootTest.java
@@ -48,7 +48,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.models.AccountRoles.MANAGE_ACCOUNT;
 import static org.keycloak.models.AccountRoles.MANAGE_ACCOUNT_LINKS;
 import static org.keycloak.testsuite.admin.ApiUtil.createUserAndResetPasswordWithAdminClient;

--- a/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/SessionSpringBootTest.java
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/SessionSpringBootTest.java
@@ -147,7 +147,7 @@ public class SessionSpringBootTest extends AbstractSpringBootTest {
         driver2.navigate().to(logoutUrl);
 
         waitForPageToLoad();
-        Assert.assertThat(true, is(secondBrowserLogoutConfirmPage.isCurrent(driver2)));
+        assertThat(true, is(secondBrowserLogoutConfirmPage.isCurrent(driver2)));
         secondBrowserLogoutConfirmPage.confirmLogout(driver2);
         waitForPageToLoad();
         secondBrowserInfoPage.assertCurrent();

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderOfflineModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderOfflineModelTest.java
@@ -59,6 +59,8 @@ import java.util.stream.IntStream;
 import org.keycloak.testsuite.model.KeycloakModelTest;
 import org.keycloak.testsuite.model.RequireProvider;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
@@ -390,7 +392,7 @@ public class UserSessionProviderOfflineModelTest extends KeycloakModelTest {
         List<String> offlineUserSessionIds =  withRealm(realmId, (session, realm) -> {
             UserModel user = session.users().getUserByUsername(realm, "user1");
             List<String> ids = session.sessions().getOfflineUserSessionsStream(realm, user).map(UserSessionModel::getId).collect(Collectors.toList());
-            Assert.assertThat(ids, Matchers.hasSize(2));
+            assertThat(ids, Matchers.hasSize(2));
             return ids;
         });
 


### PR DESCRIPTION
Fixes: #22111 
- Replaced usage of Assert.assertThat with static import
- Replaced static import org.junit.Assert.assertThat with org.hamcrest.MatcherAssert.assertThat

Warnings during build:
````
# before
$ cat ../202307310837-kc-build.txt | grep -i WARN | wc -l
2578

# after
$ cat ../202307311251-kc-build.txt | grep -i WARN | wc -l                
2325
````
