### PR TITLE
Update method for sending identity broker link confirmation

### DIFF
--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -19,14 +19,12 @@ package org.keycloak.email.freemarker;
 
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.email.EmailException;
@@ -136,21 +134,15 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
         BrokeredIdentityContext brokerContext = (BrokeredIdentityContext) this.attributes.get(IDENTITY_PROVIDER_BROKER_CONTEXT);
         String idpAlias = brokerContext.getIdpConfig().getAlias();
         String idpDisplayName = brokerContext.getIdpConfig().getDisplayName();
-        idpAlias = ObjectUtil.capitalize(idpAlias);
-        String displayName = idpAlias;
-        if (!ObjectUtil.isBlank(brokerContext.getIdpConfig().getDisplayName())) {
-            displayName = brokerContext.getIdpConfig().getDisplayName();
-        }
-
-        if (idpDisplayName != null && idpDisplayName.length() > 0) {
-            idpAlias = ObjectUtil.capitalize(idpDisplayName);
+        if (ObjectUtil.isBlank(idpDisplayName)) {
+            idpDisplayName = ObjectUtil.capitalize(idpAlias);
         }
 
         attributes.put("identityProviderContext", brokerContext);
         attributes.put("identityProviderAlias", idpAlias);
-        attributes.put("identityProviderDisplayName", displayName);
+        attributes.put("identityProviderDisplayName", idpDisplayName);
 
-        List<Object> subjectAttrs = Arrays.asList(displayName);
+        List<Object> subjectAttrs = Collections.singletonList(idpDisplayName);
         send("identityProviderLinkSubject", subjectAttrs, "identity-provider-link.ftl", attributes);
     }
 


### PR DESCRIPTION
This PR addresses an issue in the `sendConfirmIdentityBrokerLink` method where multiple reassignments led to a bug that caused the display name to be used as the alias, contrary to the intended behavior. This bug most likely went unnoticed as the alias is not being used in the template.

The fix ensures that the capitalized alias is used as the display name when the latter is missing, and improves the overall functionality and clarity of the method.