### PR TITLE
makes spec.replicas optional

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -39,7 +39,7 @@ public class KeycloakSpec {
 
     @SpecReplicas
     @JsonPropertyDescription("Number of Keycloak instances in HA mode. Default is 1.")
-    private int instances = 1;
+    private Integer instances;
 
     @JsonPropertyDescription("Custom Keycloak image to be used.")
     private String image;
@@ -137,11 +137,11 @@ public class KeycloakSpec {
         this.hostnameSpec = hostnameSpec;
     }
 
-    public int getInstances() {
+    public Integer getInstances() {
         return instances;
     }
 
-    public void setInstances(int instances) {
+    public void setInstances(Integer instances) {
         this.instances = instances;
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/CRDTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/CRDTest.java
@@ -33,6 +33,7 @@ import java.io.FileNotFoundException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportBuilder;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -80,6 +81,14 @@ public class CRDTest {
         kc.getMetadata().getAnnotations().put("x", "y");
         kc = client.resource(kc).serverSideApply();
         assertThat(kc.getMetadata().getAnnotations()).containsEntry("x", "y");
+    }
+
+    @Test
+    public void testKeycloakWithDefaultReplicas() {
+        var kc = K8sUtils.getDefaultKeycloakDeployment();
+        kc.getSpec().setInstances(null);
+
+        assertThat(client.resource(kc).create().getSpec().getInstances()).isNull();
     }
 
     private <T extends HasMetadata> void roundTrip(String resourceFile, Class<T> type) {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -108,8 +108,9 @@ public class ClusteringTest extends BaseOperatorTest {
 
     @Test
     public void testKeycloakScaleAsExpected() {
-        // given
+        // given a starting point of a default keycloak with null/default instances
         var kc = getTestKeycloakDeployment(false);
+        kc.getSpec().setInstances(null);
         var crSelector = k8sclient.resource(kc);
         K8sUtils.deployKeycloak(k8sclient, kc, true);
 


### PR DESCRIPTION
It is possible to combine the keycloak spec modification with a status update, but at least KeycloakIngress is also making a modification to the Keycloak, so it seems safer to have a seperate explicit handling of defaults - similar to https://github.com/kubernetes/kubernetes/blob/99190634ab252604a4496882912ac328542d649d/pkg/apis/apps/v1/defaults.go#L102

Closes #22151

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
