### PR TITLE
adds the http service port if enabled

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -232,7 +232,7 @@ public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> {
         // probes
         var tlsConfigured = isTlsConfigured(keycloakCR);
         var protocol = !tlsConfigured ? "HTTP" : "HTTPS";
-        var kcPort = KeycloakServiceDependentResource.getServicePort(keycloakCR);
+        var kcPort = KeycloakServiceDependentResource.getServicePort(tlsConfigured, keycloakCR);
 
         // Relative path ends with '/'
         var kcRelativePath = Optional.ofNullable(readConfigurationValue(Constants.KEYCLOAK_HTTP_RELATIVE_PATH_KEY))

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -55,11 +55,12 @@ public class KeycloakIngress extends OperatorManagedResource {
     }
 
     private Ingress newIngress() {
-        var port = KeycloakServiceDependentResource.getServicePort(keycloak);
-        var annotations = new HashMap<String, String>();
-
         // set default annotations
-        if (isTlsConfigured(keycloak)) {
+        var annotations = new HashMap<String, String>();
+        boolean tlsConfigured = isTlsConfigured(keycloak);
+        var port = KeycloakServiceDependentResource.getServicePort(tlsConfigured, keycloak);
+
+        if (tlsConfigured) {
             annotations.put("nginx.ingress.kubernetes.io/backend-protocol", "HTTPS");
             annotations.put("route.openshift.io/termination", "passthrough");
         } else {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -278,6 +278,15 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
     }
 
     @Test
+    public void testHttpEnabledWithTls() {
+        var kc = getTestKeycloakDeployment(true);
+        kc.getSpec().getHttpSpec().setHttpEnabled(true);
+        deployKeycloak(k8sclient, kc, true);
+
+        assertKeycloakAccessibleViaService(kc, false, Constants.KEYCLOAK_HTTP_PORT);
+    }
+
+    @Test
     public void testHostnameStrict() {
         var kc = getTestKeycloakDeployment(true);
         deployKeycloak(k8sclient, kc, true);


### PR DESCRIPTION
@vmuzikar the only question here is that we have some logic that assume we're using the http port if tls is not specified - but that does not check if http is actually enabled.  Should we default to http enabled if tls is not configured or are we missing a validation?

Closes #22131

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
