### PR TITLE
Fix deprecated API usage in quarkus module (#22163)

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -33,11 +33,11 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.deployment.builditem.StaticInitConfigSourceProviderBuildItem;
-import io.quarkus.hibernate.orm.deployment.AdditionalJpaModelBuildItem;
+import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
+import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentCustomizerBuildItem;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
@@ -71,7 +71,6 @@ import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionSpi;
 import org.keycloak.connections.jpa.updater.liquibase.LiquibaseJpaUpdaterProviderFactory;
 import org.keycloak.connections.jpa.updater.liquibase.conn.DefaultLiquibaseConnectionProvider;
-import org.keycloak.models.map.storage.jpa.EventListenerIntegrator;
 import org.keycloak.models.map.storage.jpa.JpaMapStorageProviderFactory;
 import org.keycloak.policy.BlacklistPasswordPolicyProviderFactory;
 import org.keycloak.protocol.ProtocolMapperSpi;
@@ -142,7 +141,6 @@ import static org.keycloak.quarkus.runtime.Environment.getProviderFiles;
 import static org.keycloak.quarkus.runtime.KeycloakRecorder.DEFAULT_HEALTH_ENDPOINT;
 import static org.keycloak.quarkus.runtime.KeycloakRecorder.DEFAULT_METRICS_ENDPOINT;
 import static org.keycloak.quarkus.runtime.Providers.getProviderManager;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getKcConfigValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getPropertyNames;
@@ -440,13 +438,13 @@ class KeycloakProcessor {
      * @param configSources
      */
     @BuildStep(onlyIfNot = IsIntegrationTest.class )
-    void configureConfigSources(BuildProducer<StaticInitConfigSourceProviderBuildItem> configSources) {
-        configSources.produce(new StaticInitConfigSourceProviderBuildItem(KeycloakConfigSourceProvider.class.getName()));
+    void configureConfigSources(BuildProducer<StaticInitConfigBuilderBuildItem> configSources) {
+        configSources.produce(new StaticInitConfigBuilderBuildItem(KeycloakConfigSourceProvider.class.getName()));
     }
 
     @BuildStep(onlyIf = IsIntegrationTest.class)
-    void prepareTestEnvironment(BuildProducer<StaticInitConfigSourceProviderBuildItem> configSources, DevServicesDatasourceResultBuildItem dbConfig) {
-        configSources.produce(new StaticInitConfigSourceProviderBuildItem("org.keycloak.quarkus.runtime.configuration.test.TestKeycloakConfigSourceProvider"));
+    void prepareTestEnvironment(BuildProducer< StaticInitConfigBuilderBuildItem> configSources, DevServicesDatasourceResultBuildItem dbConfig) {
+        configSources.produce(new StaticInitConfigBuilderBuildItem("org.keycloak.quarkus.runtime.configuration.test.TestKeycloakConfigSourceProvider"));
 
         // we do not enable dev services by default and the DevServicesDatasourceResultBuildItem might not be available when discovering build steps
         // Quarkus seems to allow that when the DevServicesDatasourceResultBuildItem is not the only parameter to the build step

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
@@ -73,7 +73,7 @@ class LiquibaseProcessor {
                         !Modifier.isPublic(found.flags())) {
                     continue;
                 }
-                AnnotationInstance annotationInstance = found.classAnnotation(liquibaseServiceName);
+                AnnotationInstance annotationInstance = found.declaredAnnotation(liquibaseServiceName);
                 if (annotationInstance == null || !annotationInstance.value("skip").asBoolean()) {
                     impls.add(found.name().toString());
                 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
@@ -21,11 +21,13 @@ package org.keycloak.quarkus.runtime.configuration;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.keycloak.quarkus.runtime.Environment;
 
-public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
+public class KeycloakConfigSourceProvider implements ConfigSourceProvider, ConfigBuilder {
 
     private static final List<ConfigSource> CONFIG_SOURCES = new ArrayList<>();
 
@@ -69,5 +71,10 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
             reload();
         }
         return CONFIG_SOURCES;
+    }
+
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        return builder.withSources(CONFIG_SOURCES);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/web/VertxClientCertificateLookup.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/web/VertxClientCertificateLookup.java
@@ -44,7 +44,7 @@ public class VertxClientCertificateLookup implements X509ClientCertificateLookup
 
         if (logger.isTraceEnabled() && certificates != null) {
             for (X509Certificate cert : certificates) {
-                logger.tracef("Certificate's SubjectDN => \"%s\"", cert.getSubjectDN().getName());
+                logger.tracef("Certificate's SubjectDN => \"%s\"", cert.getSubjectX500Principal().getName());
             }
         }
 

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
@@ -53,7 +53,7 @@ public class DatabaseContainer {
         if (alias.equals("infinispan")) {
             dist.setProperty("storage-hotrod-username", getUsername());
             dist.setProperty("storage-hotrod-password", getPassword());
-            dist.setProperty("storage-hotrod-host", container.getContainerIpAddress());
+            dist.setProperty("storage-hotrod-host", container.getHost());
             dist.setProperty("storage-hotrod-port", String.valueOf(container.getMappedPort(11222)));
         } else {
             dist.setProperty("db-username", getUsername());

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
@@ -1,8 +1,10 @@
 package org.keycloak.it.utils;
 
+import com.github.dockerjava.api.DockerClient;
 import org.jboss.logging.Logger;
 import org.keycloak.common.Version;
 import org.keycloak.it.junit5.extension.CLIResult;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.ToStringConsumer;
@@ -11,7 +13,6 @@ import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.LazyFuture;
-import org.testcontainers.utility.ResourceReaper;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -172,9 +173,9 @@ public final class DockerKeycloakDistribution implements KeycloakDistribution {
                     @Override
                     public void run() {
                         try {
-                            ResourceReaper
-                                    .instance()
-                                    .stopAndRemoveContainer(finalContainerId);
+                            DockerClient dockerClient = DockerClientFactory.lazyClient();
+                            dockerClient.killContainerCmd(containerId).exec();
+                            dockerClient.removeContainerCmd(containerId).withRemoveVolumes(true).withForce(true).exec();
                         } catch (Exception cause) {
                             throw new RuntimeException("Failed to stop and remove container", cause);
                         }


### PR DESCRIPTION
- `KeycloakConfigSourceProvider`  now implements `ConfigBuilder` in order to be usable as `StaticInitConfigBuilderBuildItem`
- `KeycloakProcessor` : 
   prefer `StaticInitConfigBuilderBuildItem` instead of `StaticInitConfigSourceProviderBuildItem`
   prefer `...deployment.spi.AdditionalJpaModelBuildItem` over `...deployment.AdditionalJpaModelBuildItem`
- `LiquibaseProcessor` -> use recommended method `declaredAnnotation(..)`
- `VertxClientCertificateLookup` use recommended `getSubjectX500Principal()` over `getSubjectDN()`
- `DatabaseContainer` -> prefer `container.getHost()` over `container.getContainerIpAddress()`
- `DockerKeycloakDistribution` -> replace `ResourceReaper` with direct `DockerClient` usage

Fixes #22163

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
