### PR TITLE
Test fixes for Operator on OpenShift

### DIFF
--- a/operator/src/main/resources/example-db-secret.yaml
+++ b/operator/src/main/resources/example-db-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: keycloak-db-secret
-data:
-  username: cG9zdGdyZXM= # postgres
-  password: dGVzdHBhc3N3b3Jk # testpassword
+stringData:
+  username: "kc-user"
+  password: "testpassword"
 type: Opaque

--- a/operator/src/main/resources/example-postgres.yaml
+++ b/operator/src/main/resources/example-postgres.yaml
@@ -16,16 +16,25 @@ spec:
     spec:
       containers:
         - name: postgresql-db
-          image: postgres:latest
+          # WARN: this image is not ARM64 native, consider using "postgres:latest" or "registry.redhat.io/rhel9/postgresql-15:latest" if you need that
+          # See also https://github.com/sclorg/postgresql-container/pull/527
+          # Using c8s instead of c9s as c9s requires additional arguments for emulation on ARM machines, while c8s works OOTB
+          image: quay.io/sclorg/postgresql-15-c8s:latest
           volumeMounts:
-            - mountPath: /data
+            - mountPath: /var/lib/pgsql/data
               name: cache-volume
           env:
-            - name: POSTGRES_PASSWORD
-              value: testpassword
-            - name: PGDATA
-              value: /data/pgdata
-            - name: POSTGRES_DB
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: keycloak-db-secret
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: keycloak-db-secret
+            - name: POSTGRESQL_DATABASE
               value: keycloak
       volumes:
         - name: cache-volume

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -164,10 +164,16 @@ public abstract class BaseOperatorTest {
   }
 
   private static void calculateNamespace() {
-    namespace = "keycloak-test-" + UUID.randomUUID();
+    namespace = getNewRandomNamespaceName();
+  }
+
+  public static String getNewRandomNamespaceName() {
+      return "keycloak-test-" + UUID.randomUUID();
   }
 
   protected static void deployDB() {
+    deployDBSecret();
+
     // DB
     Log.info("Creating new PostgreSQL deployment");
     K8sUtils.set(k8sclient, BaseOperatorTest.class.getResourceAsStream("/example-postgres.yaml"));
@@ -176,8 +182,6 @@ public abstract class BaseOperatorTest {
     Log.info("Checking Postgres is running");
     Awaitility.await()
             .untilAsserted(() -> assertThat(k8sclient.apps().statefulSets().inNamespace(namespace).withName("postgresql-db").get().getStatus().getReadyReplicas()).isEqualTo(1));
-
-    deployDBSecret();
   }
 
   protected static void deployDBSecret() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -32,6 +32,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpecBuilder;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.UnsupportedSpecBuilder;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 import org.keycloak.operator.controllers.KeycloakIngress;
 
@@ -76,6 +77,19 @@ public class KeycloakIngressTest extends BaseOperatorTest {
             // on OpenShift, when Keycloak is configured for HTTP only, we use edge TLS termination, i.e. Route still uses TLS
             baseUrl = "https://" + testHostname + ":443";
             hostnameSpecBuilder.withHostname(testHostname);
+            // see https://github.com/keycloak/keycloak/issues/14400#issuecomment-1659900081
+            kc.getSpec().setUnsupported(new UnsupportedSpecBuilder()
+                    .withNewPodTemplate()
+                        .withNewSpec()
+                            .addNewContainer()
+                                .addNewEnv()
+                                    .withName("KC_PROXY")
+                                    .withValue("edge")
+                                .endEnv()
+                            .endContainer()
+                        .endSpec()
+                    .endPodTemplate()
+                    .build());
         }
         else {
             baseUrl = "http://" + kubernetesIp + ":80";

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -278,7 +278,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         kc.getSpec().getDatabaseSpec().setUsernameSecret(null);
         kc.getSpec().getDatabaseSpec().setPasswordSecret(null);
 
-        var username = new ValueOrSecret("db-username", "postgres");
+        var username = new ValueOrSecret("db-username", "kc-user");
         var password = new ValueOrSecret("db-password", "testpassword");
 
         kc.getSpec().getAdditionalOptions().remove(username);


### PR DESCRIPTION
Backports #22120 and #22149. The backport is not 1:1, manual changes were necessary mainly to WatchedSecrets test.

Closes https://github.com/keycloak/keycloak/issues/22032
Closes https://github.com/keycloak/keycloak/issues/22140
Closes https://github.com/keycloak/keycloak/issues/22142