### PR TITLE
Prevent exception in the log

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,18 +48,12 @@ jobs:
         name: Maven cache
         uses: ./.github/actions/maven-cache
 
-      - id: build-documentation
-        name: Build Keycloak
+      - id: build-test-documentation
+        name: Build and verify Keycloak documentation
         shell: bash
         run: |
           MVN_HTTP_CONFIG="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
-          ./mvnw install -DskipTests -am -pl docs/documentation/tests,docs/documentation/dist -nsu -B -e $MVN_HTTP_CONFIG -Pdocumentation
-
-      - id: test-documentation
-        name: Verify Keycloak documentation
-        shell: bash
-        run: |
-          ./mvnw test -Dtest=!ExternalLinksTest -am -pl docs/documentation/tests,docs/documentation/dist -nsu -B -e -Pdocumentation 
+          ./mvnw install -Dtest=!ExternalLinksTest -am -pl docs/documentation/tests,docs/documentation/dist -nsu -B -e $MVN_HTTP_CONFIG -Pdocumentation
 
       - id: upload-keycloak-documentation
         name: Upload Keycloak documentation
@@ -85,18 +79,12 @@ jobs:
         name: Maven cache
         uses: ./.github/actions/maven-cache
 
-      - id: build-documentation
-        name: Build Keycloak
+      - id: build-test-documentation
+        name: Build and verify Keycloak documentation
         shell: bash
         run: |
           MVN_HTTP_CONFIG="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
-          ./mvnw install -DskipTests -am -pl docs/documentation/tests -nsu -B -e -Pdocumentation $MVN_HTTP_CONFIG 
-
-      - id: test-documentation
-        name: Verify Keycloak documentation
-        shell: bash
-        run: |
-          ./mvnw test -Dtest=ExternalLinksTest -am -pl docs/documentation/tests,docs/documentation/dist -nsu -B -e -Pdocumentation
+          ./mvnw install -Dtest=ExternalLinksTest -am -pl docs/documentation/tests -nsu -B -e -Pdocumentation $MVN_HTTP_CONFIG 
 
   check:
     name: Status Check - Keycloak Documentation

--- a/docs/documentation/tests/pom.xml
+++ b/docs/documentation/tests/pom.xml
@@ -4,6 +4,11 @@
 
     <properties>
         <version.log4j>2.17.1</version.log4j>
+        <!-- this property prevents the warning "WARN FilenoUtil: Native subprocess control requires open access" when using JRuby for the unit tests on JDK17 -->
+        <surefire.system.args>
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+        </surefire.system.args>
     </properties>
 
     <build>
@@ -134,7 +139,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>2.1.0</version>
+            <version>2.5.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/ExternalLinksTest.java
+++ b/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/ExternalLinksTest.java
@@ -1,6 +1,8 @@
 package org.keycloak.documentation.test;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.keycloak.documentation.test.utils.LinkUtils;
@@ -10,11 +12,24 @@ import java.util.List;
 
 public class ExternalLinksTest {
 
+    static LinkUtils linkUtils = LinkUtils.getInstance();
+
+    @BeforeAll
+    public static void setup() {
+        linkUtils = LinkUtils.getInstance();
+    }
+
+    @AfterAll
+    public static void close() {
+        // this will save a cache with all verified links that will expire after one day.
+        linkUtils.close();
+    }
+
     @ParameterizedTest
     @MethodSource("org.keycloak.documentation.test.Guides#guides()")
     public void checkExternalLinks(String guideName) throws IOException {
         Guide guide = new Guide(guideName);
-        List<LinkUtils.InvalidLink> invalidLinks = LinkUtils.getInstance().findInvalidLinks(guide);
+        List<LinkUtils.InvalidLink> invalidLinks = linkUtils.findInvalidLinks(guide);
         if (!invalidLinks.isEmpty()) {
             StringBuilder sb = new StringBuilder();
             sb.append("Broken links (" + invalidLinks.size() + "):");

--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -41,3 +41,4 @@ https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#ro
 https://github.com/keycloak/keycloak/blob/main/docs/tests.md#kerberos-server
 https://github.com/apache/felix-dev/tree/master/http#using-the-osgi-http-whiteboard
 https://github.com/keycloak/keycloak/blob/025778fe9c745316f80b53fe3052aeb314e868ef/js/apps/admin-ui/public/locales/en/dashboard.json#L3
+https://github.com/keycloak/keycloak/issues/new?*


### PR DESCRIPTION
Also speed up the external link check by avoiding checking each bug submission link in the rendered docs which only differs by its parameter.

The external link check no completes in 2 minutes instead of 9 minutes on GitHub actions.

Closes #22200

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
