### PR TITLE
removes the termination grace period override

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -265,7 +265,7 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
           return;
       }
       try {
-          if (!context.getTestStatus().isTestFailed() && !(context.getTestStatus().getTestErrorCause() instanceof TestAbortedException)) {
+          if (!context.getTestStatus().isTestFailed() || context.getTestStatus().getTestErrorCause() instanceof TestAbortedException) {
               return;
           }
           Log.warnf("Test failed with %s: %s", context.getTestStatus().getTestErrorCause().getMessage(), context.getTestStatus().getTestErrorCause().getClass().getName());

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.quarkus.logging.Log;
 import io.quarkus.test.junit.QuarkusTest;
+
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -105,7 +106,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
 
     @Test
     public void testSecretsCanBeUnWatched() {
-        var kc = getTestKeycloakDeployment(true);
+        var kc = getTestKeycloakDeployment(false);
         deployKeycloak(k8sclient, kc, true);
 
         Log.info("Updating KC to not to rely on DB Secret");
@@ -230,7 +231,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         kc.getSpec().getDatabaseSpec().setUsernameSecret(null);
         kc.getSpec().getDatabaseSpec().setPasswordSecret(null);
 
-        var username = new ValueOrSecret("db-username", "postgres");
+        var username = new ValueOrSecret("db-username", "kc-user");
         var password = new ValueOrSecret("db-password", "testpassword");
 
         kc.getSpec().getAdditionalOptions().remove(username);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -30,7 +30,6 @@ import io.quarkus.logging.Log;
 
 import org.awaitility.Awaitility;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
-import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 
 import java.io.ByteArrayOutputStream;
@@ -83,10 +82,6 @@ public final class K8sUtils {
         if (deployTlsSecret) {
             set(client, getDefaultTlsSecret());
         }
-
-        // speed the cleanup of pods
-        kc.setSpec(new KeycloakSpecBuilder(kc.getSpec()).editOrNewUnsupported().editOrNewPodTemplate().editOrNewSpec()
-                .withTerminationGracePeriodSeconds(0L).endSpec().endPodTemplate().endUnsupported().build());
 
         set(client, kc);
 


### PR DESCRIPTION
It does appear that non-graceful termination makes it more possible to put the database in a bad state.

This does leave in place the tweak to remove the probes for some of the tests, that seems to account for about 4 seconds per pod start of improvement, or somewhere around 1-2 minutes over the entire test suite run.  There are two options there:
1. just remove this optimization also
2. allow it to be enabled or disabled by a flag so that at least the CI remote test run would run with probes enabled.

Closes #22160

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
