### PR TITLE
Changes to the time offset should be visible in all threads instantly

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Time.java
+++ b/common/src/main/java/org/keycloak/common/util/Time.java
@@ -24,7 +24,7 @@ import java.util.Date;
  */
 public class Time {
 
-    private static int offset;
+    private static volatile int offset;
 
     /**
      * Returns current time in seconds adjusted by adding {@link #offset) seconds.


### PR DESCRIPTION
This needs to be volatile as it is changed during tests at runtime and there is no other locking in place.

Closes #22243

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
