### PR TITLE
Expose additional information (expiration, sha1 hash) about realm keys in admin UI

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Encode.java
+++ b/common/src/main/java/org/keycloak/common/util/Encode.java
@@ -591,4 +591,16 @@ public class Encode
       return decode(string);
    }
 
+   public static String hexString(byte[] bytes) {
+
+      // this is not the fastest way to do it, but does not require dependencies and works with Java 11
+      // once the codebase is on Java 17, we can use HexFormat.of().formatHex(bytes) instead.
+      // As an alternative bouncycastle Hex.toHexString(bytes); is also an option, but I don't know if BC is always available.
+      StringBuilder sb = new StringBuilder(bytes.length * 2);
+      for (byte b: bytes) {
+         sb.append(String.format("%02x", b));
+      }
+      return sb.toString();
+   }
+
 }

--- a/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureSignerContext.java
+++ b/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureSignerContext.java
@@ -54,4 +54,9 @@ public class AsymmetricSignatureSignerContext implements SignatureSignerContext 
         }
     }
 
+    @Override
+    public byte[] getSHA1Thumbprint() {
+        return key.getSHA1Thumbprint();
+    }
+
 }

--- a/core/src/main/java/org/keycloak/crypto/KeyWrapper.java
+++ b/core/src/main/java/org/keycloak/crypto/KeyWrapper.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.crypto;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
 import java.util.HashMap;
 import java.util.List;
 import javax.crypto.SecretKey;
@@ -194,5 +197,17 @@ public class KeyWrapper {
         }
         key.isDefaultClientCertificate = this.isDefaultClientCertificate;
         return key;
+    }
+
+    public byte[] getSHA1Thumbprint() {
+        if (certificate == null) {
+            return null;
+        }
+        try {
+            // using SHA1 for certificate thumbprint should be fine
+            return MessageDigest.getInstance("SHA1").digest(certificate.getEncoded());
+        } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+            throw new RuntimeException("Could not get SHA1 hash of key", e);
+        }
     }
 }

--- a/core/src/main/java/org/keycloak/crypto/MacSignatureSignerContext.java
+++ b/core/src/main/java/org/keycloak/crypto/MacSignatureSignerContext.java
@@ -53,4 +53,9 @@ public class MacSignatureSignerContext implements SignatureSignerContext {
         }
     }
 
+    @Override
+    public byte[] getSHA1Thumbprint() {
+        return key.getSHA1Thumbprint();
+    }
+
 }

--- a/core/src/main/java/org/keycloak/crypto/SignatureSignerContext.java
+++ b/core/src/main/java/org/keycloak/crypto/SignatureSignerContext.java
@@ -26,4 +26,5 @@ public interface SignatureSignerContext {
 
     byte[] sign(byte[] data) throws SignatureException;
 
+    byte[] getSHA1Thumbprint();
 }

--- a/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
@@ -38,6 +38,8 @@ public class JWSBuilder {
     String contentType;
     byte[] contentBytes;
 
+    String thumbprint;
+
     public JWSBuilder type(String type) {
         this.type = type;
         return this;
@@ -74,6 +76,7 @@ public class JWSBuilder {
 
         if (type != null) builder.append(",\"typ\" : \"").append(type).append("\"");
         if (kid != null) builder.append(",\"kid\" : \"").append(kid).append("\"");
+        if (thumbprint != null) builder.append(",\"x5t\" : \"").append(thumbprint).append("\"");
         if (contentType != null) builder.append(",\"cty\":\"").append(contentType).append("\"");
         builder.append("}");
         return Base64Url.encode(builder.toString().getBytes(StandardCharsets.UTF_8));
@@ -105,7 +108,8 @@ public class JWSBuilder {
 
         public String sign(SignatureSignerContext signer) {
             kid = signer.getKid();
-
+            byte[] thumb = signer.getSHA1Thumbprint();
+            thumbprint = thumb != null ? Base64Url.encode(thumb) : null;
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(signer.getAlgorithm(), data, buffer);

--- a/core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
@@ -62,6 +62,12 @@ public class KeysMetadataRepresentation {
         private String certificate;
         private KeyUse use;
 
+        private Long notAfter;
+
+        private Long notBefore;
+
+        private String thumbprint;
+
         public String getProviderId() {
             return providerId;
         }
@@ -132,6 +138,30 @@ public class KeysMetadataRepresentation {
 
         public void setUse(KeyUse use) {
             this.use = use;
+        }
+
+        public Long getNotAfter() {
+            return notAfter;
+        }
+
+        public void setNotAfter(Long notAfter) {
+            this.notAfter = notAfter;
+        }
+
+        public Long getNotBefore() {
+            return notBefore;
+        }
+
+        public void setNotBefore(Long notBefore) {
+            this.notBefore = notBefore;
+        }
+
+        public String getThumbprint() {
+            return thumbprint;
+        }
+
+        public void setThumbprint(String thumbprint) {
+            this.thumbprint = thumbprint;
         }
     }
 }

--- a/js/apps/admin-ui/public/locales/en/realm-settings.json
+++ b/js/apps/admin-ui/public/locales/en/realm-settings.json
@@ -122,6 +122,9 @@
   "providerDescription": "Provider description",
   "addProvider": "Add provider",
   "publicKeys": "Public keys",
+  "notBefore": "Not before",
+  "notAfter": "Not after",
+  "thumbprint": "Thumbprint",
   "keysFilter": {
     "ACTIVE": "Active keys",
     "PASSIVE": "Passive keys",

--- a/js/libs/keycloak-admin-client/src/defs/keyMetadataRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/keyMetadataRepresentation.ts
@@ -15,4 +15,7 @@ export interface KeyMetadataRepresentation {
   algorithm?: string;
   publicKey?: string;
   certificate?: string;
+  notBefore?: number;
+  notAfter?: number;
+  thumbprint?: string;
 }


### PR DESCRIPTION
- Show Not After information
- Show certificate sha1 thumbprint

Incorporates: #7890

Fixes #17743 and KEYCLOAK-17609

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
