### PR TITLE
allows normal reconciliation to continue even if secrets are not present

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/Constants.java
+++ b/operator/src/main/java/org/keycloak/operator/Constants.java
@@ -38,6 +38,7 @@ public final class Constants {
     public static final String KEYCLOAK_COMPONENT_LABEL = "operator.keycloak.org/component";
     public static final String KEYCLOAK_WATCHED_SECRET_HASH_ANNOTATION = "operator.keycloak.org/watched-secret-hash";
     public static final String KEYCLOAK_WATCHING_ANNOTATION = "operator.keycloak.org/watching-secrets";
+    public static final String KEYCLOAK_MISSING_SECRETS_ANNOTATION = "operator.keycloak.org/missing-secrets";
 
     public static final String DEFAULT_LABELS_AS_STRING = "app=keycloak,app.kubernetes.io/managed-by=keycloak-operator";
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -130,7 +130,9 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
             updateControl = UpdateControl.updateStatus(kc);
         }
 
-        if (!status.isReady()) {
+        if (!status.isReady() || context.getSecondaryResource(StatefulSet.class)
+                .map(s -> s.getMetadata().getAnnotations().get(Constants.KEYCLOAK_MISSING_SECRETS_ANNOTATION))
+                .filter(Boolean::valueOf).isPresent()) {
             updateControl.rescheduleAfter(10, TimeUnit.SECONDS);
         }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsController.java
@@ -104,6 +104,8 @@ public class WatchedSecretsController implements Reconciler<Secret>, EventSource
     @Override
     public void annotateDeployment(List<String> desiredWatchedSecretsNames, Keycloak keycloakCR, StatefulSet deployment) {
         List<Secret> currentSecrets = fetchSecrets(desiredWatchedSecretsNames, keycloakCR.getMetadata().getNamespace());
+        deployment.getMetadata().getAnnotations().put(Constants.KEYCLOAK_MISSING_SECRETS_ANNOTATION,
+                Boolean.valueOf(currentSecrets.size() < desiredWatchedSecretsNames.size()).toString());
         deployment.getMetadata().getAnnotations().put(Constants.KEYCLOAK_WATCHING_ANNOTATION, desiredWatchedSecretsNames.stream().collect(Collectors.joining(";")));
         deployment.getSpec().getTemplate().getMetadata().getAnnotations().put(Constants.KEYCLOAK_WATCHED_SECRET_HASH_ANNOTATION, getSecretHash(currentSecrets));
     }

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsController.java
@@ -44,6 +44,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -110,7 +111,8 @@ public class WatchedSecretsController implements Reconciler<Secret>, EventSource
     private List<Secret> fetchSecrets(List<String> secretsNames, String namespace) {
         return secretsNames.stream()
                 .map(n -> Optional.ofNullable(secrets).flatMap(cache -> cache.get(new ResourceID(n, namespace)))
-                        .orElseGet(() -> client.secrets().inNamespace(namespace).withName(n).require()))
+                        .orElseGet(() -> client.secrets().inNamespace(namespace).withName(n).get()))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -87,8 +87,6 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         var kc = getTestKeycloakDeployment(false);
         deployKeycloak(k8sclient, kc, true);
 
-        var prevRevision = getStatefulSet(kc).getStatus().getUpdateRevision();
-
         var dbSecret = getDbSecret();
 
         dbSecret.getData().put("username",


### PR DESCRIPTION
The new logic for watching secrets retained the behavior of the 21.x - that is if the secret is not found in the main reconcilation loop then an exception is thrown.  However that is effectively inhibiting our 10 second retry logic.  

One fix is to remove the exception from retrieving non-existant secrets, which is shown in this pr.

Other options include:
- A concern with this quick fix is that eventually there could be optional secrets, which would allow the deployment to complete successfully and that we would not use / watch until the label were manually added or the next keycloak reconciliation.  We could instead simply watch all secrets in the namespace instead of requiring the watched label.  This would need to be done in conjunction with this change as we need the statefulset to exist - or we'd have to re-work the secret logic to work directly off of keycloaks, rather than the statefulsets.
- If we're not concerned about a potential optional case and/or we want to more generally handle error situations then we can consider:
  - An enhancement to ErrorStatusUpdateControl could be to allow for configurable retry similar to the main loop.  cc @csviri  This could ideally be made more sophisticated eventually by using a back-off time influenced by the hasErrors condition lastTransitionTime. 
  - Configure the operator in general for unlimited retries and a 10 second interval 

If we decide that this pr is good enough, I'll add some tests.

Closes #22170

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
