### PR TITLE
Fix layout of tables in the new guides

### DIFF
--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -31,8 +31,10 @@ The cache configuration is a regular https://infinispan.org/docs/stable/titles/c
 The following table gives an overview of the specific caches Keycloak uses.
 You configure these caches in `conf/cache-ispn.xml`:
 
-|====
+[%autowidth]
+|===
 |Cache name|Cache Type|Description
+
 |realms|Local|Cache persisted realm data
 |users|Local|Cache persisted user data
 |authorization|Local|Cache persisted authorization data
@@ -45,7 +47,7 @@ You configure these caches in `conf/cache-ispn.xml`:
 |offlineClientSessions|Distributed|Caches client sessions, created upon successful authentication to a specific client and destroyed during logout, token revocation, or due to expiration
 |loginFailures|Distributed|keep track of failed logins, fraud detection
 |actionTokens|Distributed|Caches action Tokens
-|====
+|===
 
 === Cache types and defaults
 
@@ -157,16 +159,23 @@ To apply a specific cache stack, enter this command:
 The default stack is set to `UDP` when distributed caches are enabled.
 
 === Available transport stacks
+
 The following table shows transport stacks that are available without any further configuration than using the `--cache-stack` build option:
+
+[%autowidth]
 |===
 |Stack name|Transport protocol|Discovery
+
 |tcp|TCP|MPING (uses UDP multicast).
 |udp|UDP|UDP multicast
 |===
 
 The following table shows transport stacks that are available using the `--cache-stack` build option and a minimum configuration:
+
+[%autowidth]
 |===
 |Stack name|Transport protocol|Discovery
+
 |kubernetes|TCP|DNS_PING (requires `-Djgroups.dns.query=<headless-service-FQDN>` to be added to JAVA_OPTS or JAVA_OPTS_APPEND environment variable).
 |===
 
@@ -176,8 +185,10 @@ Note that _none_  of these stacks are Kubernetes / OpenShift stacks, so no need 
 In that case, use the `kubernetes` stack.
 Instead, when you have a distributed cache setup running on AWS EC2 instances, you would need to set the stack to `ec2`, because ec2 does not support a default discovery mechanism such as `UDP`.
 
+[%autowidth]
 |===
 |Stack name|Transport protocol|Discovery
+
 |ec2|TCP|NATIVE_S3_PING
 |google|TCP|GOOGLE_PING2
 |azure|TCP|AZURE_PING

--- a/docs/guides/server/configuration-metrics.adoc
+++ b/docs/guides/server/configuration-metrics.adoc
@@ -56,8 +56,9 @@ system_load_average_1m 4.005859375
 
 The table below summarizes the available metrics groups:
 
+[%autowidth]
 |===
-|*Metric* | *Description*
+|Metric | Description
 
 |System
 |A set of system-level metrics related to CPU and memory usage.

--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -9,7 +9,7 @@ summary="Understand how to configure and start Keycloak">
 This {section} explains the configuration methods for Keycloak and how to start and apply the preferred configuration. It includes configuration guidelines for optimizing Keycloak for faster startup and low memory footprint.
 
 == Configuring sources for Keycloak
-Keycloak loads the configuration from four sources, which are listed here in order of application. 
+Keycloak loads the configuration from four sources, which are listed here in order of application.
 
 . Command-line parameters
 . Environment variables
@@ -23,8 +23,9 @@ When an option is set in more than one source, the one that comes first in the l
 
 The following example shows how the `db-url` value is set in four configuration sources:
 
+[%autowidth]
 |===
-|*Source* | *Format*
+|Source | Format
 
 |Command line parameters
 |`--db-url=cliValue`
@@ -125,7 +126,7 @@ When the KeyStore is created, you can start the server using the following param
 <@kc.start parameters="--config-keystore=/path/to/keystore.p12 --config-keystore-password=storepass --config-keystore-type=PKCS12"/>
 
 === Format for raw Quarkus properties
-In most cases, the available configuration options should suffice to configure the server. 
+In most cases, the available configuration options should suffice to configure the server.
 However, for a specific behavior or capability that is missing in the Keycloak configuration, you can use properties from the underlying Quarkus framework.
 
 If possible, avoid using properties directly from Quarkus, because they are unsupported by Keycloak. If your need is essential, consider opening an https://github.com/keycloak/keycloak/issues/new?assignees=&labels=kind%2Fenhancement%2Cstatus%2Ftriage&template=enhancement.yml[enhancement request] first. This approach helps us improve the configuration of Keycloak to fit your needs.
@@ -138,7 +139,7 @@ If an enhancement request is not possible, you can configure the server using ra
 You can use only a https://github.com/keycloak/keycloak/blob/main/quarkus/runtime/pom.xml#L17[subset] of the Quarkus extensions that are defined in the https://quarkus.io/guides/all-config[Quarkus documentation]. Also, note these differences for Quarkus properties:
 
 * A lock icon for a Quarkus property in the https://quarkus.io/guides/all-config[Quarkus documentation] indicates a build time property. You run the `build` command to apply this property. For details about the build command, see the subsequent sections on optimizing Keycloak.
-* No lock icon for a property in the Quarkus guide indicates a runtime property for Quarkus and Keycloak. 
+* No lock icon for a property in the Quarkus guide indicates a runtime property for Quarkus and Keycloak.
 
 . Use the `[-cf|--config-file]` command line parameter to include that file.
 

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -14,6 +14,7 @@ This {section} explains how to configure the Keycloak server to store data in a 
 
 The server has built-in support for different databases. You can query the available databases by viewing the expected values for the `db` configuration option. The following table lists the supported databases and their tested versions.
 
+[%autowidth]
 |===
 |Database | Option value | Tested Version
 

--- a/docs/guides/server/health.adoc
+++ b/docs/guides/server/health.adoc
@@ -65,8 +65,9 @@ The Dockerfile image `+HEALTHCHECK+` instruction defines a command that will be 
 
 The table below shows the available checks.
 
+[%autowidth]
 |===
-|*Check* | *Description* | *Requires Metrics*
+|Check | Description | Requires Metrics
 
 |Database
 |Returns the status of the database connection pool.

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -21,8 +21,10 @@ Logging is done on a per-category basis in Keycloak. You can configure logging f
 
 The following table defines the available log levels.
 
-|====
+[%autowidth]
+|===
 |Level|Description
+
 |FATAL|Critical failures with complete inability to serve any kind of request.
 |ERROR|A significant error or problem leading to the inability to process requests.
 |WARN|A non-critical error or problem that might not require immediate correction.
@@ -31,7 +33,7 @@ The following table defines the available log levels.
 |TRACE|Most detailed debugging information. Very high frequency.
 |ALL|Special level for all log messages.
 |OFF|Special level to turn logging off entirely (not recommended).
-|====
+|===
 
 === Configuring the root log level
 When no log level configuration exists for a more specific category logger, the enclosing category is used instead. When there is no enclosing category, the root logger level is used.
@@ -81,8 +83,10 @@ The logging format template for these lines can be applied at the root level. Th
 
 The format string supports the symbols in the following table:
 
-|====
+[%autowidth]
+|===
 |Symbol|Summary|Description
+
 |%%|%|Renders a simple % character.
 |%c|Category|Renders the log category name.
 |++%d{xxx}++|Date|Renders a date with the given date format string.String syntax defined by `java.text.SimpleDateFormat`

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -107,6 +107,7 @@ to create URLs using the scheme, host name, and port, being exposed by your prox
 When using a reverse proxy, Keycloak only requires certain paths need to be exposed.
 The following table shows the recommended paths to expose.
 
+[%autowidth]
 |===
 |Keycloak Path|Reverse Proxy Path|Exposed|Reason
 
@@ -170,6 +171,7 @@ clients. You are able to configure how the server is going to retrieve client ce
 
 The server supports some of the most commons TLS termination proxies such as:
 
+[%autowidth]
 |===
 |Proxy|Provider
 
@@ -196,6 +198,7 @@ forwarded by the proxy with the client certificate information.
 
 The available options for configuring a provider are:
 
+[%autowidth]
 |===
 |Option|Description
 


### PR DESCRIPTION
The blank line after the first row makes the first line a table header. The auto-width resizes the tables depending on the content, so columns with less content will have a smaller width, leaving more room for the columns with more content.

Closes #22405

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
