### PR TITLE
removes logging full resources to omit secret data

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/OperatorManagedResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/OperatorManagedResource.java
@@ -25,7 +25,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.quarkus.logging.Log;
 
 import org.keycloak.operator.Constants;
@@ -79,10 +78,11 @@ public abstract class OperatorManagedResource {
                         throw ex;
                     }
                 }
-                Log.debugf("Successfully created or updated resource: %s", resource);
+                Log.debugf("Successfully created or updated resource: %s %s/%s", resource.getKind(), resource.getMetadata().getNamespace(),
+                        resource.getMetadata().getName());
             } catch (Exception e) {
-                Log.error("Failed to create or update resource");
-                Log.error(Serialization.asYaml(resource));
+                Log.errorf("Failed to create or update resource %s %s/%s", resource.getKind(), resource.getMetadata().getNamespace(),
+                        resource.getMetadata().getName());
                 throw KubernetesClientException.launderThrowable(e);
             }
         });


### PR DESCRIPTION
Addresses the inclusion of full secrets into the logs for 22.0.  The 23 release and beyond will be handled by JOSDK changes.

Closes #22080

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
