### PR TITLE
Remove Vert.x Dev UI dependency

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -29,6 +29,13 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <exclusions>
+                <!-- Can be removed as part of the https://github.com/keycloak/keycloak/issues/22455 enhancement -->
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The distribution does not contain the additional JARs anymore.

@vmuzikar Could you please check it?