### PR TITLE
Handle GitHub logout properly

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/GitHubLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/GitHubLoginPage.java
@@ -50,6 +50,8 @@ public class GitHubLoginPage extends AbstractSocialLoginPage {
     public void logout() {
         log.info("performing logout from GitHub");
         URLUtils.navigateToUri("https://github.com/logout");
-        UIUtils.clickLink(logoutButton);
+        if (URLUtils.currentUrlEquals("https://github.com/logout")) {
+            UIUtils.clickLink(logoutButton);
+        }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -372,6 +372,7 @@ public class SocialLoginTest extends AbstractKeycloakTest {
     public void githubLogin() throws InterruptedException {
         setTestProvider(GITHUB);
         performLogin();
+        assertUpdateProfile(true, true, false);
         appPage.assertCurrent();
         testTokenExchange();
     }
@@ -380,6 +381,7 @@ public class SocialLoginTest extends AbstractKeycloakTest {
     public void githubPrivateEmailLogin() throws InterruptedException {
         setTestProvider(GITHUB_PRIVATE_EMAIL);
         performLogin();
+        assertUpdateProfile(true, true, false);
         appPage.assertCurrent();
     }
 


### PR DESCRIPTION
- Resolves #22461 

This solution ensures that the logout process is on the correct URL while trying to click on the "Sign out" button.

Additionaly, the GitHub test cases lacked the profile info update method so this PR incorporates it to both test cases.