### PR TITLE
Print 'key' in ReadOnlyAttributeUnchangedValidator failure log message

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/validator/ReadOnlyAttributeUnchangedValidator.java
+++ b/services/src/main/java/org/keycloak/userprofile/validator/ReadOnlyAttributeUnchangedValidator.java
@@ -82,7 +82,7 @@ public class ReadOnlyAttributeUnchangedValidator implements SimpleValidator {
         }
 
         if (!isUnchanged(existingValue, value)) {
-            logger.warnf("Attempt to edit denied attribute '%s' of user '%s'", pattern, user == null ? "new user" : user.getFirstAttribute(UserModel.USERNAME));
+            logger.warnf("Attempt to edit denied for attribute '%s' with pattern '%s' of user '%s'", key, pattern, user == null ? "new user" : user.getFirstAttribute(UserModel.USERNAME));
             context.addError(new ValidationError(ID, key, UPDATE_READ_ONLY_ATTRIBUTES_REJECTED_MSG));
         }
 


### PR DESCRIPTION
This change is quite useful for debugging and helps identify which specific attribute makes the update fail. Currently, the full pattern is printed which consists of multiple attributes.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
