### PR TITLE
Fix IDELauncher after removing Vert.x Dev UI dependency

### DIFF
--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -19,6 +19,14 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server</artifactId>
         </dependency>
+
+        <!-- Necessary for proper execution of IDELauncher -->
+        <!-- Can be removed as part of the https://github.com/keycloak/keycloak/issues/22455 enhancement -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
I was able to reproduce an issue with missing dependency during the IDELauncher start. 

I've added the dependency to the `server` module, so it's possible to start Keycloak through the IDELauncher again.
The transitive JARs of the artifact are not included in the distribution. 

@vmuzikar Could you please check it?

