### PR TITLE
Remove Brotli dependencies from the distribution and operator

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -97,6 +97,10 @@
             		<groupId>io.vertx</groupId>
             		<artifactId>vertx-uri-template</artifactId>
             	</exclusion>
+                <exclusion>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -28,6 +28,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
* excluded the dependencies from the keycloak-quarkus-server and operator poms

Closes #22482
