### PR TITLE
22352 kerberos fallback

### DIFF
--- a/common/src/main/java/org/keycloak/common/constants/KerberosConstants.java
+++ b/common/src/main/java/org/keycloak/common/constants/KerberosConstants.java
@@ -92,4 +92,9 @@ public class KerberosConstants {
      */
     public static final String GSS_DELEGATION_CREDENTIAL_DISPLAY_NAME = "gss delegation credential";
 
+    /**
+     * Attribute attached to the credential, which contains authenticated SPNEGO context. This is used in case that some LDAP/Kerberos provider was able to authenticate user via SPNEGO, but wasn't able
+     * to lookup it in his LDAP tree. In this case, LDAP lookup might be performed by other providers in the chain.
+     */
+    public static final String AUTHENTICATED_SPNEGO_CONTEXT = "authenticatedSpnegoContext";
 }

--- a/docs/documentation/release_notes/index.adoc
+++ b/docs/documentation/release_notes/index.adoc
@@ -16,6 +16,9 @@ include::topics/templates/release-header.adoc[]
 == {project_name_full} 23.0.0
 include::topics/23_0_0.adoc[leveloffset=2]
 
+== {project_name_full} 22.0.2
+include::topics/22_0_2.adoc[leveloffset=2]
+
 == {project_name_full} 22.0.0
 include::topics/22_0_0.adoc[leveloffset=2]
 

--- a/docs/documentation/release_notes/topics/22_0_2.adoc
+++ b/docs/documentation/release_notes/topics/22_0_2.adoc
@@ -1,4 +1,4 @@
 = Improvements in LDAP and Kerberos integration
 
-It is possible to have multiple LDAP providers in the realm, which support Kerberos integration with same Kerberos realm. When LDAP provider is not able to find user, which was authenticated through
-Kerberos/SPNEGO, there will be attempt to fallback to next LDAP provider.
+Keycloak now supports multiple LDAP providers in a realm, which support Kerberos integration with the same Kerberos realm. When an LDAP provider is not able to find the user which was authenticated through
+Kerberos/SPNEGO, Keycloak ties to fallback to the next LDAP provider.

--- a/docs/documentation/release_notes/topics/22_0_2.adoc
+++ b/docs/documentation/release_notes/topics/22_0_2.adoc
@@ -1,0 +1,4 @@
+= Improvements in LDAP and Kerberos integration
+
+It is possible to have multiple LDAP providers in the realm, which support Kerberos integration with same Kerberos realm. When LDAP provider is not able to find user, which was authenticated through
+Kerberos/SPNEGO, there will be attempt to fallback to next LDAP provider.

--- a/server-spi/src/main/java/org/keycloak/models/CredentialValidationOutput.java
+++ b/server-spi/src/main/java/org/keycloak/models/CredentialValidationOutput.java
@@ -38,7 +38,11 @@ public class CredentialValidationOutput {
     }
 
     public static CredentialValidationOutput failed() {
-        return new CredentialValidationOutput(null, CredentialValidationOutput.Status.FAILED, new HashMap<String, String>());
+        return new CredentialValidationOutput(null, CredentialValidationOutput.Status.FAILED, new HashMap<>());
+    }
+
+    public static CredentialValidationOutput fallback() {
+        return new CredentialValidationOutput(null, CredentialValidationOutput.Status.FALLBACK, new HashMap<>());
     }
 
     public UserModel getAuthenticatedUser() {
@@ -63,6 +67,26 @@ public class CredentialValidationOutput {
     }
 
     public enum Status {
-        AUTHENTICATED, FAILED, CONTINUE
+
+        /**
+         * User was successfully authenticated. The {@link #getAuthenticatedUser()} must return authenticated user when this is used
+         */
+        AUTHENTICATED,
+
+        /**
+         * Federation provider failed to authenticate user. This is typically used when user storage provider recognizes the user, but credentials
+         * are incorrect, so federation provider can mark whole authentication as not successful without eventual fallback to other user storage provider
+         */
+        FAILED,
+
+        /**
+         * Federation provider was not able to recognize the user. Fallback to other user storage provider in the chain might be possible
+         */
+        FALLBACK,
+
+        /**
+         * Federation provider did not fully authenticate user. It may be needed to ask user for further challenge
+         */
+        CONTINUE,
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/CredentialValidationOutput.java
+++ b/server-spi/src/main/java/org/keycloak/models/CredentialValidationOutput.java
@@ -80,12 +80,13 @@ public class CredentialValidationOutput {
         FAILED,
 
         /**
-         * Federation provider was not able to recognize the user. Fallback to other user storage provider in the chain might be possible
+         * Federation provider was not able to recognize the user. It is possible that credential was valid, but fereration provider was not able to lookup the user in it's storage.
+         * Fallback to other user storage provider in the chain might be possible
          */
         FALLBACK,
 
         /**
-         * Federation provider did not fully authenticate user. It may be needed to ask user for further challenge
+         * Federation provider did not fully authenticate user. It may be needed to ask user for further challenge to then re-try authentication with same federation provider
          */
         CONTINUE,
     }

--- a/server-spi/src/main/java/org/keycloak/models/UserCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserCredentialModel.java
@@ -193,7 +193,7 @@ public class UserCredentialModel implements CredentialInput {
         this.algorithm = algorithm;
     }
 
-    public void setNote(String key, String value) {
+    public void setNote(String key, Object value) {
         this.notes.put(key, value);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
@@ -279,7 +279,7 @@ public abstract class AbstractKerberosTest extends AbstractAuthTest {
     }
 
 
-    protected void assertUser(String expectedUsername, String expectedEmail, String expectedFirstname,
+    protected UserRepresentation assertUser(String expectedUsername, String expectedEmail, String expectedFirstname,
                               String expectedLastname, boolean updateProfileActionExpected) {
         try {
             UserRepresentation user = ApiUtil.findUserByUsername(testRealmResource(), expectedUsername);
@@ -294,8 +294,15 @@ public abstract class AbstractKerberosTest extends AbstractAuthTest {
             } else {
                 Assert.assertTrue(user.getRequiredActions().isEmpty());
             }
+            return user;
         } finally {
         }
+    }
+
+    protected void assertUserStorageProvider(UserRepresentation user, String providerName) {
+        if (user.getFederationLink() == null) Assert.fail("Federation link on user " + user.getUsername() + " was null");
+        ComponentRepresentation rep = testRealmResource().components().component(user.getFederationLink()).toRepresentation();
+        Assert.assertEquals(providerName, rep.getName());
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosLdapMultipleLDAPProvidersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosLdapMultipleLDAPProvidersTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.testsuite.federation.kerberos;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.keycloak.common.constants.KerberosConstants;
+import org.keycloak.component.PrioritizedComponentModel;
+import org.keycloak.federation.kerberos.CommonKerberosConfig;
+import org.keycloak.models.LDAPConstants;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
+import org.keycloak.storage.ldap.kerberos.LDAPProviderKerberosConfig;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.util.KerberosRule;
+import org.keycloak.testsuite.util.OAuthClient;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class KerberosLdapMultipleLDAPProvidersTest extends AbstractKerberosTest {
+
+    private static final String PROVIDER_CONFIG_LOCATION = "classpath:kerberos/kerberos-ldap-crt-connection.properties";
+
+    @ClassRule
+    public static KerberosRule kerberosRule = new KerberosRule(PROVIDER_CONFIG_LOCATION, KerberosEmbeddedServer.DEFAULT_KERBEROS_REALM);
+
+    @ClassRule
+    public static KerberosRule kerberosRule2 = new KerberosRule(PROVIDER_CONFIG_LOCATION, KerberosEmbeddedServer.DEFAULT_KERBEROS_REALM_2);
+
+
+    @Override
+    protected KerberosRule getKerberosRule() {
+        return kerberosRule;
+    }
+
+
+    @Override
+    protected CommonKerberosConfig getKerberosConfig() {
+        return new LDAPProviderKerberosConfig(getUserStorageConfiguration());
+    }
+
+    @Override
+    protected ComponentRepresentation getUserStorageConfiguration() {
+        ComponentRepresentation rep = getUserStorageConfiguration("kerberos-ldap", LDAPStorageProviderFactory.PROVIDER_NAME);
+        // This provider works. It would be executed as 2nd provider (individual tests are supposed to add other provider, which should have lower priority to be invoked first)
+        rep.getConfig().putSingle(PrioritizedComponentModel.PRIORITY, "10");
+        return rep;
+    }
+
+    @Test
+    public void test01spnegoWith1stProviderBrokenKerberosConfiguration() throws Exception {
+        // Add LDAP, which is invoked first. The Kerberos configuration is broken, so SPNEGO workflow is failing entirely
+        ComponentRepresentation rep = getUserStorageConfiguration();
+        rep.setName("kerberos-ldap-foo");
+        rep.getConfig().putSingle(PrioritizedComponentModel.PRIORITY, "1");
+        rep.getConfig().putSingle(KerberosConstants.KERBEROS_REALM, "FOO.ORG");
+        rep.getConfig().putSingle(KerberosConstants.SERVER_PRINCIPAL, "HTTP/localhost@FOO.ORG");
+        Response resp = testRealmResource().components().add(rep);
+        getCleanup().addComponentId(ApiUtil.getCreatedId(resp));
+        resp.close();
+
+        OAuthClient.AccessTokenResponse tokenResponse = assertSuccessfulSpnegoLogin("hnelson2@KC2.COM", "hnelson2", "secret");
+        AccessToken token = oauth.verifyToken(tokenResponse.getAccessToken());
+        Assert.assertEquals(token.getEmail(), "hnelson2@kc2.com");
+        UserRepresentation user = assertUser("hnelson2", "hnelson2@kc2.com", "Horatio", "Nelson", false);
+        assertUserStorageProvider(user, "kerberos-ldap");
+    }
+
+    @Test
+    public void test02spnegoWith1stProviderBrokenLookupOfKerberosUser() throws Exception {
+        // Add LDAP, which is invoked first. The Kerberos configuration is OK, so SPNEGO workflow should be fine.
+        // However lookup LDAP based on Kerberos principal is broken, so fallback to next provider would be needed
+        ComponentRepresentation rep = getUserStorageConfiguration();
+        rep.setName("kerberos-ldap-broken-lookup");
+        rep.getConfig().putSingle(PrioritizedComponentModel.PRIORITY, "1");
+        rep.getConfig().putSingle(LDAPConstants.CUSTOM_USER_SEARCH_FILTER, "(mail=nonexistent@email.org)");
+        Response resp = testRealmResource().components().add(rep);
+        getCleanup().addComponentId(ApiUtil.getCreatedId(resp));
+        resp.close();
+
+        OAuthClient.AccessTokenResponse tokenResponse = assertSuccessfulSpnegoLogin("hnelson2@KC2.COM", "hnelson2", "secret");
+        AccessToken token = oauth.verifyToken(tokenResponse.getAccessToken());
+        Assert.assertEquals(token.getEmail(), "hnelson2@kc2.com");
+        UserRepresentation user = assertUser("hnelson2", "hnelson2@kc2.com", "Horatio", "Nelson", false);
+        assertUserStorageProvider(user, "kerberos-ldap");
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneMultipleProvidersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneMultipleProvidersTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.testsuite.federation.kerberos;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.keycloak.common.constants.KerberosConstants;
+import org.keycloak.component.PrioritizedComponentModel;
+import org.keycloak.federation.kerberos.CommonKerberosConfig;
+import org.keycloak.federation.kerberos.KerberosConfig;
+import org.keycloak.federation.kerberos.KerberosFederationProviderFactory;
+import org.keycloak.models.LDAPConstants;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.util.KerberosRule;
+import org.keycloak.testsuite.util.OAuthClient;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class KerberosStandaloneMultipleProvidersTest extends AbstractKerberosTest {
+
+    private static final String PROVIDER_CONFIG_LOCATION = "classpath:kerberos/kerberos-standalone-connection.properties";
+
+
+    @ClassRule
+    public static KerberosRule kerberosRule = new KerberosRule(PROVIDER_CONFIG_LOCATION, KerberosEmbeddedServer.DEFAULT_KERBEROS_REALM);
+
+
+    @ClassRule
+    public static KerberosRule kerberosRule2 = new KerberosRule(PROVIDER_CONFIG_LOCATION, KerberosEmbeddedServer.DEFAULT_KERBEROS_REALM_2);
+
+
+    @Override
+    protected KerberosRule getKerberosRule() {
+        return kerberosRule;
+    }
+
+    @Override
+    protected CommonKerberosConfig getKerberosConfig() {
+        return new KerberosConfig(getUserStorageConfiguration());
+    }
+
+    @Override
+    protected ComponentRepresentation getUserStorageConfiguration() {
+        ComponentRepresentation rep = getUserStorageConfiguration("kerberos-standalone", KerberosFederationProviderFactory.PROVIDER_NAME);
+        // This provider works. It would be executed as 2nd provider (individual tests are supposed to add other provider, which should have lower priority to be invoked first)
+        rep.getConfig().putSingle(PrioritizedComponentModel.PRIORITY, "10");
+        return rep;
+    }
+
+    @Test
+    public void test01spnegoWith1stProviderBrokenKerberosConfiguration() throws Exception {
+        // Add LDAP, which is invoked first. The Kerberos configuration is broken, so SPNEGO workflow is failing entirely
+        ComponentRepresentation rep = getUserStorageConfiguration();
+        rep.setName("kerberos-foo");
+        rep.getConfig().putSingle(PrioritizedComponentModel.PRIORITY, "1");
+        rep.getConfig().putSingle(KerberosConstants.KERBEROS_REALM, "FOO.ORG");
+        rep.getConfig().putSingle(KerberosConstants.SERVER_PRINCIPAL, "HTTP/localhost@FOO.ORG");
+        Response resp = testRealmResource().components().add(rep);
+        getCleanup().addComponentId(ApiUtil.getCreatedId(resp));
+        resp.close();
+
+        OAuthClient.AccessTokenResponse tokenResponse = assertSuccessfulSpnegoLogin("hnelson2@KC2.COM", "hnelson2", "secret");
+        AccessToken token = oauth.verifyToken(tokenResponse.getAccessToken());
+        Assert.assertEquals(token.getEmail(), "hnelson2@keycloak.org");
+        UserRepresentation user = assertUser("hnelson2", "hnelson2@keycloak.org", null, null, false);
+        assertUserStorageProvider(user, "kerberos-standalone");
+    }
+
+    @Test
+    public void test02spnegoWith1stProviderBrokenLookupOfKerberosUser() throws Exception {
+        // Add LDAP, which is invoked first. The Kerberos configuration is OK, so SPNEGO workflow should be fine.
+        // However lookup LDAP based on Kerberos principal is broken, so fallback to next provider would be needed
+        ComponentRepresentation rep = getUserStorageConfiguration();
+        rep.setName("kerberos-ldap-broken-lookup");
+        rep.setProviderId(LDAPStorageProviderFactory.PROVIDER_NAME);
+        rep.getConfig().putSingle(PrioritizedComponentModel.PRIORITY, "1");
+        rep.getConfig().putSingle(LDAPConstants.CUSTOM_USER_SEARCH_FILTER, "(mail=nonexistent@email.org)");
+        Response resp = testRealmResource().components().add(rep);
+        getCleanup().addComponentId(ApiUtil.getCreatedId(resp));
+        resp.close();
+
+        OAuthClient.AccessTokenResponse tokenResponse = assertSuccessfulSpnegoLogin("hnelson2@KC2.COM", "hnelson2", "secret");
+        AccessToken token = oauth.verifyToken(tokenResponse.getAccessToken());
+        Assert.assertEquals(token.getEmail(), "hnelson2@keycloak.org");
+        UserRepresentation user = assertUser("hnelson2", "hnelson2@keycloak.org", null, null, false);
+        assertUserStorageProvider(user, "kerberos-standalone");
+    }
+}


### PR DESCRIPTION
Closes #22352 #9422 #14665 .

Summary of changes:
- It adds new state `FALLBACK` to `CredentialValidationOutput.Status`. This means that federation provider was not able to finish authentication, and wants to fallback to other providers.
The status `FAILED` means that user storage provider wants to finish authentication with failure without fallback to other providers (current behaviour from Keycloak main). Status `CONTINUE` means that federation provider does not want to finish, but doesn't want fallback as another challenge response might need to be sent to the user (current behaviour from Keycloak main). Added also javadoc to what those status should mean.
@ahus1 This should raise your concern from the https://github.com/keycloak/keycloak/pull/22353#issuecomment-1674989476 as it should be possible to acknowledge fallback as well as fail authentication right away.

- There are 2 scenarios when there are multiple LDAP providers and fallback to next federation provider might be needed. Added automated tests to both of them in this PR:

1) Scenario when `ldap-provider-1` (which is 1st in the chain) is not able to do SPNEGO authentication at all. For instance because token contains completely different kerberos realm. In this case SPNEGO authentication did not success, so fallback to another provider might be needed

2) Scenario when `ldap-provider-1` (which is 1st in the chain) is able to do SPNEGO authentication, but that provider is not able to lookup the user. This is common scenario with various "forest trust" scenarios. For this case, I've introduced note `KerberosConstants.AUTHENTICATED_SPNEGO_CONTEXT` when the authenticated Spnego from 1st provider can be saved and then next provider in the chain (like `ldap-provider-2`) can lookup user.

It can be better if same provider always does both SPNEGO authentication and lookup the user, but repeating SPNEGO authentication with same token is not possible as this would replay error (Something like `Caused by: KrbException: Request is a replay (34)`) and authentication would not be possible to happen.

At the same time, I don't see much issues with provider1 doing SPNEGO authentication and provider2 doing eventual lookup the user. Assumption is that administrator has control over the user-storage providers configured in the realm and hence automatically doing fallback does not seem to me as an issue. We can eventually add an option to LDAP/Kerberos providers like `Supports fallback for Kerberos authentication`, which will allow both save spnego context for next providers as well as consume spnego context from previous providers. But so far, I did not messed with another option due I don't see issues with doing fallback automatically and the amount of options on LDAP-provider is already quite big.

I've updated only `UserStorageManager` in this PR, but did not updated `MapUserProvider`. I am not sure if it is needed to deal with the map storage and also wanted to first ask for the feedback in this PR. I can possibly update `MapUserProvider` as well if you think it is necessary and we're ok with those changes.

@ahus1 To your question from  about detecting realm from spnego token - This is not easily possible. Spnego token is Base64 encoded token in ASN1 format with complicated structure. It might be possible to parse it with some 3rd party library or with BouncyCastle. Some hints are here https://stackoverflow.com/questions/4508555/decrypt-kerberos-ticket-using-spnego . I've tried to parse it with BouncyCastle (just for fun) in this branch https://github.com/mposolda/keycloak/blob/22352-spnego-parsing/crypto/default/src/test/java/org/keycloak/crypto/def/test/SPNEGOParseExample.java, but figured it is not trivial... At the same time, even if we figure parsing, announce which kerberos realms the LDAP provider supports won't be very useful as it is possible that realm `MYREALM.ORG` is supported by 2 LDAP providers `ldap-provider-1` and `ldap-provider-2` and hence fallback might be still needed as user authenticated by `ldap-provider-1` might be available in the LDAP subtree of `ldap-provider-2`. Also requirement to announce realms might not be very useful in the scenarios with MSAD forest trust with many realms when realms are added to the forest ad-hoc and hence the change in the configuration of LDAP providers would be needed always when adding new realm. However it can help with the scenario 1 I've described above as the provider1 would not try to authenticate SPNEGO token, which is clearly for different realm.
