### PR TITLE
Fixes wrong 'azp' on exchanged refresh_token

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -403,7 +403,7 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         if (requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE)
             && OIDCAdvancedConfigWrapper.fromClientModel(client).isUseRefreshToken()) {
             responseBuilder.generateRefreshToken();
-            responseBuilder.getRefreshToken().issuedFor(client.getClientId());
+            responseBuilder.getRefreshToken().issuedFor(targetClient.getClientId());
         }
 
         String scopeParam = clientSessionCtx.getClientSession().getNote(OAuth2Constants.SCOPE);


### PR DESCRIPTION
This commit fixes a bug where the exchanged refresh_token has the wrong 'azp'. Previously the refresh_token received after a successfull token-exchange from clientA to clientB would result in a refresh_token that had 'azp' set to clientA, meaning that the exchanged refresh_token could only be used to refresh tokens for clientA. But the intent of the exchange is to be able to get tokens for clientB and refresh tokens for clientB. This commits set the 'azp' to clientB and the refresh_token can then be used to refresh tokens for clientB.

Closes #15330