### PR TITLE
Preserve user id on partial import

### DIFF
--- a/services/src/main/java/org/keycloak/partialimport/UsersPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/UsersPartialImport.java
@@ -110,7 +110,9 @@ public class UsersPartialImport extends AbstractPartialImport<UserRepresentation
 
     @Override
     public void create(RealmModel realm, KeycloakSession session, UserRepresentation user) {
-        user.setId(KeycloakModelUtils.generateId());
+        if (user.getId() == null) {
+            user.setId(KeycloakModelUtils.generateId());
+        }
         UserModel userModel = RepresentationToModel.createUser(session, realm, user);
         if (userModel == null) throw new RuntimeException("Unable to create user " + getName(user));
         createdIds.put(getName(user), userModel.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -556,8 +556,9 @@ public abstract class AbstractKeycloakTest {
         return ApiUtil.createUserWithAdminClient(adminClient.realm(realm), homer);
     }
 
-    public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, List<String> groups, boolean enabled) {
+    public static UserRepresentation createUserRepresentation(String id, String username, String email, String firstName, String lastName, List<String> groups, boolean enabled) {
         UserRepresentation user = new UserRepresentation();
+        user.setId(id);
         user.setUsername(username);
         user.setEmail(email);
         user.setFirstName(firstName);
@@ -565,6 +566,10 @@ public abstract class AbstractKeycloakTest {
         user.setGroups(groups);
         user.setEnabled(enabled);
         return user;
+    }
+
+    public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, List<String> groups, boolean enabled) {
+        return createUserRepresentation(null, username, email, firstName, lastName, groups, enabled);
     }
 
     public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, boolean enabled) {


### PR DESCRIPTION
Fixes #14134

Only generate new ID for imported user when none is provided. This allows for importing users with the same id without them being altered.