### PR TITLE
Remove Oracle Database JDBC driver from the Keycloak distribution

### DIFF
--- a/docs/documentation/release_notes/topics/23_0_0.adoc
+++ b/docs/documentation/release_notes/topics/23_0_0.adoc
@@ -14,4 +14,8 @@ the latest FAPI 2 draft specifications when communicating with your clients. Tha
 Keycloak has preview for support for OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP). Thanks to
 https://github.com/tnorimat[Takashi Norimatsu] and https://github.com/dteleguin[Dmitry Telegin] for their contributions.
 
+= Oracle Database driver not part of the distribution
 
+The Oracle Database JDBC driver is no longer part of the Keycloak distribution.
+Administrators will need to install a version of the Oracle Driver matching their environment
+as described in the configuring the database {section}.

--- a/docs/documentation/upgrading/topics/keycloak/changes-23_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-23_0_0.adoc
@@ -30,3 +30,8 @@ Previous versions of Keycloak supported specifying the encoding in the first lin
 Message properties files for themes are now read in UTF-8 encoding, with an automatic fallback to ISO-8859-1 encoding.
 If you are using a different encoding, convert the files to UTF-8.
 
+= Oracle Database driver not part of the distribution
+
+The Oracle Database JDBC driver is no longer part of the Keycloak distribution.
+Administrators will need to install a version of the Oracle Driver matching their environment
+as described in the configuring the database {section}.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -28,7 +28,7 @@ The server has built-in support for different databases. You can query the avail
 By default, the server uses the `dev-file` database. This is the default database that the server will use to persist data and
 only exists for development use-cases. The `dev-file` database is not suitable for production use-cases, and must be replaced before deploying to production.
 
-== Installing a database driver
+== Installing a database driver (Oracle)
 
 Database drivers are shipped as part of Keycloak except for the Oracle Database driver which needs to be installed separately.
 

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -28,6 +28,46 @@ The server has built-in support for different databases. You can query the avail
 By default, the server uses the `dev-file` database. This is the default database that the server will use to persist data and
 only exists for development use-cases. The `dev-file` database is not suitable for production use-cases, and must be replaced before deploying to production.
 
+== Installing a database driver
+
+Database drivers are shipped as part of Keycloak except for the Oracle Database driver which needs to be installed separately.
+
+Install the Oracle Database driver if you want to connect to an Oracle Database, or skip this section if you want to connect to a different database.
+
+To install the Oracle Database driver for Keycloak:
+
+. Download the `ojdbc11` and `orai18n` JAR files from one of the following sources:
+
+.. *Zipped JDBC driver and Companion Jars* version ${properties["oracle-jdbc.version"]} from the https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html[Oracle driver download page].
+
+.. Maven Central via `link:++https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/${properties["oracle-jdbc.version"]}/ojdbc11-${properties["oracle-jdbc.version"]}.jar++[ojdbc11]` and `link:++https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar++[orai18n]`.
+
+.. Installation media recommended by the database vendor for the specific database in use.
+
+. When running the unzipped distribution: Place the `ojdbc11` and `orai18n` JAR files in Keycloak's `providers` folder
+
+. When running containers: Build a custom Keycloak image and add the JARs in the `providers` folder. When building a custom image for the Keycloak Operator, those images need to be optimized images with all build-time options of Keycloak set.
++
+A minimal Dockerfile to build an image which can be used with the Keycloak Operator and includes Oracle Database JDBC drivers downloaded from Maven Central looks like the following:
++
+[source,dockerfile]
+----
+FROM quay.io/keycloak/keycloak:latest
+ADD --chown=keycloak:keycloak https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/${properties["oracle-jdbc.version"]}/ojdbc11-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/ojdbc11.jar
+ADD --chown=keycloak:keycloak https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/orai18n.jar
+# Setting the build parameter for the database:
+ENV KC_DB=oracle
+# Add all other build parameters needed, for example enable health and metrics:
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+# To be able to use the image with the Keycloak Operator, it needs to be optimized, which requires Keycloak's build step:
+RUN /opt/keycloak/bin/kc.sh build
+----
++
+See the <@links.server id="containers" /> {section} for details on how to build optimized images.
+
+Then continue configuring the database as described in the next section.
+
 == Configuring a database
 
 For each supported database, the server provides some opinionated defaults to simplify database configuration. You complete the configuration by providing some key settings such as the database host and credentials.

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -78,6 +78,16 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-oracle</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.oracle.database.jdbc</groupId>
+                    <artifactId>ojdbc11</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.oracle.database.nls</groupId>
+                    <artifactId>orai18n</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -726,5 +736,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- this is a temporary profile to allow building a Keycloak distribution with proprietary drivers.
+            It will be removed for Keycloak 23 -->
+            <id>includeProprietaryDependencies</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.oracle.database.jdbc</groupId>
+                    <artifactId>ojdbc11</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.oracle.database.nls</groupId>
+                    <artifactId>orai18n</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -736,23 +736,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <!-- this is a temporary profile to allow building a Keycloak distribution with proprietary drivers.
-            It will be removed for Keycloak 23 -->
-            <id>includeProprietaryDependencies</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ojdbc11</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>com.oracle.database.nls</groupId>
-                    <artifactId>orai18n</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
 </project>

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -44,6 +44,9 @@ quarkus.log.category."io.quarkus.config".level=off
 quarkus.log.category."io.quarkus.arc.processor.BeanArchives".level=off
 quarkus.log.category."io.quarkus.arc.processor.IndexClassLookupUtils".level=off
 quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
+# When excluding the Oracle JDBC driver, this avoids the warning
+# "Could not remove configured resources from the following artifacts as they were not found in the model:..."
+quarkus.log.category."io.quarkus.deployment.steps.ClassTransformingBuildStep".level=error
 
 # Set default directory name for the location of the transaction logs
 quarkus.transaction-manager.object-store.directory=${kc.home.dir:default}${file.separator}data${file.separator}transaction-logs

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -187,6 +187,31 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>includeProprietaryDependencies</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.oracle.database.jdbc</groupId>
+                                    <artifactId>ojdbc11</artifactId>
+                                    <version>${oracle-jdbc.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${auth.server.home}/providers</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.oracle.database.nls</groupId>
+                                    <artifactId>orai18n</artifactId>
+                                    <version>${oracle-jdbc.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${auth.server.home}/providers</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-testsuite-providers</id>
                         <phase>generate-resources</phase>
                         <goals>


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/22452
Extension of https://github.com/keycloak/keycloak/pull/22453

Provided approach for installing the Oracle JDBC driver seems to be correct; everything works as expected. 

Backported version for 22.x will be done soon.

@vmuzikar Could you please check it?





