### PR TITLE
Update the Keycloak SAML adapter subsystem to no longer use the AttributeDefinition#getAttributeMarshaller method

### DIFF
--- a/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
@@ -141,6 +141,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
             <scope>test</scope>

--- a/adapters/saml/wildfly/wildfly-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/pom.xml
@@ -87,6 +87,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
             <scope>test</scope>

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakSubsystemParser.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakSubsystemParser.java
@@ -498,7 +498,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
             writer.writeAttribute(Constants.XML.ENTITY_ID, sp.getName());
             ModelNode spAttributes = sp.getValue();
             for (SimpleAttributeDefinition attr : ServiceProviderDefinition.ATTRIBUTES) {
-                attr.getAttributeMarshaller().marshallAsAttribute(attr, spAttributes, false, writer);
+                attr.getMarshaller().marshallAsAttribute(attr, spAttributes, false, writer);
             }
             writeKeys(writer, spAttributes.get(Constants.Model.KEY));
             writePrincipalNameMapping(writer, spAttributes);
@@ -521,7 +521,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
 
             ModelNode idpAttributes = idp.getValue();
             for (SimpleAttributeDefinition attr : IdentityProviderDefinition.ATTRIBUTES) {
-                attr.getAttributeMarshaller().marshallAsAttribute(attr, idpAttributes, false, writer);
+                attr.getMarshaller().marshallAsAttribute(attr, idpAttributes, false, writer);
             }
 
             writeSingleSignOn(writer, idpAttributes.get(Constants.Model.SINGLE_SIGN_ON));
@@ -539,7 +539,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
         writer.writeStartElement(Constants.XML.SINGLE_SIGN_ON);
         for (SimpleAttributeDefinition attr : SingleSignOnDefinition.ATTRIBUTES) {
-            attr.getAttributeMarshaller().marshallAsAttribute(attr, model, false, writer);
+            attr.getMarshaller().marshallAsAttribute(attr, model, false, writer);
         }
         writer.writeEndElement();
     }
@@ -550,7 +550,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
         writer.writeStartElement(Constants.XML.SINGLE_LOGOUT);
         for (SimpleAttributeDefinition attr : SingleLogoutDefinition.ATTRIBUTES) {
-            attr.getAttributeMarshaller().marshallAsAttribute(attr, model, false, writer);
+            attr.getMarshaller().marshallAsAttribute(attr, model, false, writer);
         }
         writer.writeEndElement();
     }
@@ -569,10 +569,10 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
 
             ModelNode keyAttributes = key.getValue();
             for (SimpleAttributeDefinition attr : KeyDefinition.ATTRIBUTES) {
-                attr.getAttributeMarshaller().marshallAsAttribute(attr, keyAttributes, false, writer);
+                attr.getMarshaller().marshallAsAttribute(attr, keyAttributes, false, writer);
             }
             for (SimpleAttributeDefinition attr : KeyDefinition.ELEMENTS) {
-                attr.getAttributeMarshaller().marshallAsElement(attr, keyAttributes, false, writer);
+                attr.getMarshaller().marshallAsElement(attr, keyAttributes, false, writer);
             }
             writeKeyStore(writer, keyAttributes.get(Constants.Model.KEY_STORE));
 
@@ -599,7 +599,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
             return;
         }
         writer.writeStartElement(Constants.XML.ALLOWED_CLOCK_SKEW);
-        AllowedClockSkew.ALLOWED_CLOCK_SKEW_UNIT.getAttributeMarshaller().marshallAsAttribute(AllowedClockSkew.ALLOWED_CLOCK_SKEW_UNIT, allowedClockSkew, false, writer);
+        AllowedClockSkew.ALLOWED_CLOCK_SKEW_UNIT.getMarshaller().marshallAsAttribute(AllowedClockSkew.ALLOWED_CLOCK_SKEW_UNIT, allowedClockSkew, false, writer);
         ModelNode allowedClockSkewValue = allowedClockSkew.get(Constants.Model.ALLOWED_CLOCK_SKEW_VALUE);
         char[] chars = allowedClockSkewValue.asString().toCharArray();
         writer.writeCharacters(chars, 0, chars.length);
@@ -612,7 +612,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
         writer.writeStartElement(Constants.XML.KEY_STORE);
         for (SimpleAttributeDefinition attr : KeyStoreDefinition.ATTRIBUTES) {
-            attr.getAttributeMarshaller().marshallAsAttribute(attr, model, false, writer);
+            attr.getMarshaller().marshallAsAttribute(attr, model, false, writer);
         }
         writePrivateKey(writer, model);
         writeCertificate(writer, model);
@@ -626,7 +626,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
         writer.writeStartElement(Constants.XML.CERTIFICATE);
         SimpleAttributeDefinition attr = KeyStoreCertificateDefinition.CERTIFICATE_ALIAS;
-        attr.getAttributeMarshaller().marshallAsAttribute(attr, model, false, writer);
+        attr.getMarshaller().marshallAsAttribute(attr, model, false, writer);
         writer.writeEndElement();
     }
 
@@ -639,7 +639,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
         writer.writeStartElement(Constants.XML.PRIVATE_KEY);
         for (SimpleAttributeDefinition attr : KeyStorePrivateKeyDefinition.ATTRIBUTES) {
-            attr.getAttributeMarshaller().marshallAsAttribute(attr, model, false, writer);
+            attr.getMarshaller().marshallAsAttribute(attr, model, false, writer);
         }
         writer.writeEndElement();
     }

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
@@ -31,9 +31,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <wildfly.version>27.0.0.Final</wildfly.version>
+        <wildfly.version>29.0.0.Final</wildfly.version>
         <wildfly.build-tools.version>1.2.13.Final</wildfly.build-tools.version>
-        <wildfly.core.version>19.0.0.Final</wildfly.core.version>
+        <wildfly.core.version>21.1.0.Final</wildfly.core.version>
 
         <feature-pack.resources.directory>${basedir}/../../saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources</feature-pack.resources.directory>
         <version.org.wildfly.galleon-plugins>6.4.0.Final</version.org.wildfly.galleon-plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,12 @@
                 <version>${apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>${wildfly.common.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-controller</artifactId>
                 <version>${wildfly.core.version}</version>


### PR DESCRIPTION
The `AttributeDefinition#getAttributeMarshaller` method has been removed in WildFly Core 21.1.0.Final and later.

This PR makes it possible to use the `keycloak-saml-adapter-galleon-pack` with WildFly 29 and later when using the Keycloak SAML adapter subsystem configuration to secure SAML applications.

Closes https://github.com/keycloak/keycloak/issues/22593


