### PR TITLE
Remove Oracle Database JDBC driver from the Keycloak distribution

### DIFF
--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -2,6 +2,7 @@
 <#import "/templates/kc.adoc" as kc>
 <#import "/templates/options.adoc" as opts>
 <#import "/templates/links.adoc" as links>
+<#import "/templates/profile.adoc" as profile>
 
 <@tmpl.guide
     title="Configuring the database"
@@ -26,6 +27,50 @@ The server has built-in support for different databases. You can query the avail
 
 By default, the server uses the `dev-file` database. This is the default database that the server will use to persist data and
 only exists for development use-cases. The `dev-file` database is not suitable for production use-cases, and must be replaced before deploying to production.
+
+<@profile.ifProduct>
+
+== Installing a database driver (Oracle)
+
+Database drivers are shipped as part of Keycloak except for the Oracle Database driver which needs to be installed separately.
+
+Install the Oracle Database driver if you want to connect to an Oracle Database, or skip this section if you want to connect to a different database.
+
+To install the Oracle Database driver for Keycloak:
+
+. Download the `ojdbc11` and `orai18n` JAR files from one of the following sources:
+
+.. *Zipped JDBC driver and Companion Jars* version ${properties["oracle-jdbc.version"]} from the https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html[Oracle driver download page].
+
+.. Maven Central via `link:++https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/${properties["oracle-jdbc.version"]}/ojdbc11-${properties["oracle-jdbc.version"]}.jar++[ojdbc11]` and `link:++https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar++[orai18n]`.
+
+.. Installation media recommended by the database vendor for the specific database in use.
+
+. When running the unzipped distribution: Place the `ojdbc11` and `orai18n` JAR files in Keycloak's `providers` folder
+
+. When running containers: Build a custom Keycloak image and add the JARs in the `providers` folder. When building a custom image for the Keycloak Operator, those images need to be optimized images with all build-time options of Keycloak set.
++
+A minimal Dockerfile to build an image which can be used with the Keycloak Operator and includes Oracle Database JDBC drivers downloaded from Maven Central looks like the following:
++
+[source,dockerfile]
+----
+FROM quay.io/keycloak/keycloak:latest
+ADD --chown=keycloak:keycloak https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/${properties["oracle-jdbc.version"]}/ojdbc11-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/ojdbc11.jar
+ADD --chown=keycloak:keycloak https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/orai18n.jar
+# Setting the build parameter for the database:
+ENV KC_DB=oracle
+# Add all other build parameters needed, for example enable health and metrics:
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+# To be able to use the image with the Keycloak Operator, it needs to be optimized, which requires Keycloak's build step:
+RUN /opt/keycloak/bin/kc.sh build
+----
++
+See the <@links.server id="containers" /> {section} for details on how to build optimized images.
+
+Then continue configuring the database as described in the next section.
+
+</@profile.ifProduct>
 
 == Configuring a database
 

--- a/docs/guides/templates/profile.adoc
+++ b/docs/guides/templates/profile.adoc
@@ -1,11 +1,11 @@
 <#macro ifProduct>
-ifdef::project_product[]
+ifeval::[{project_product}==true]
 <#nested>
 endif::[]
 </#macro>
 
 <#macro ifCommunity>
-ifndef::project_product[]
+ifeval::[{project_community}==true]
 <#nested>
 endif::[]
 </#macro>

--- a/docs/guides/templates/profile.adoc
+++ b/docs/guides/templates/profile.adoc
@@ -1,0 +1,11 @@
+<#macro ifProduct>
+ifdef::project_product[]
+<#nested>
+endif::[]
+</#macro>
+
+<#macro ifCommunity>
+ifndef::project_product[]
+<#nested>
+endif::[]
+</#macro>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -727,4 +727,25 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>product</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-oracle</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.oracle.database.jdbc</groupId>
+                            <artifactId>ojdbc11</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.oracle.database.nls</groupId>
+                            <artifactId>orai18n</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -44,6 +44,9 @@ quarkus.log.category."io.quarkus.config".level=off
 quarkus.log.category."io.quarkus.arc.processor.BeanArchives".level=off
 quarkus.log.category."io.quarkus.arc.processor.IndexClassLookupUtils".level=off
 quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
+# When excluding the Oracle JDBC driver, this avoids the warning
+# "Could not remove configured resources from the following artifacts as they were not found in the model:..."
+quarkus.log.category."io.quarkus.deployment.steps.ClassTransformingBuildStep".level=error
 
 # Set default directory name for the location of the transaction logs
 quarkus.transaction-manager.object-store.directory=${kc.home.dir:default}${file.separator}data${file.separator}transaction-logs

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -335,7 +335,44 @@
 
                 </plugins>
             </build>
+        </profile>
 
+        <profile>
+            <id>product</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>includeProprietaryDependencies</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>com.oracle.database.jdbc</groupId>
+                                            <artifactId>ojdbc11</artifactId>
+                                            <version>${oracle-jdbc.version}</version>
+                                            <type>jar</type>
+                                            <outputDirectory>${auth.server.home}/providers</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.oracle.database.nls</groupId>
+                                            <artifactId>orai18n</artifactId>
+                                            <version>${oracle-jdbc.version}</version>
+                                            <type>jar</type>
+                                            <outputDirectory>${auth.server.home}/providers</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
     </profiles>


### PR DESCRIPTION
Extended version for completion of requirements for 22.x release

Closes #22452

Requirements for 22.x backport:

- [x] The driver would remain in upstream included by default as it's a breaking change to do in a micro.
- [x] Introduce -DskipProprietary property to remove the driver. This would be used only by RHBK 22 pipelines. (Only the `product` profile is introduced; IMHO better approach)
- [x] Docs and testsuite would need to be adapted to reflect the different behaviour (driver included vs removed) between Keycloak and RHBK.

--------------------------
~~The `-DskipProprietary` property is present in the codebase, and moreover, it's possible to ignore the proprietary Oracle JDBC driver by specifying profile `-Pproduct`. It'll provide us better manageability around product builds as it will not be necessary to include all provided flags which distinguish the build approaches.~~

EDIT: Only the `product` profile is introduced.

The `-Pproduct` profile will need to be provided for other parts of Keycloak anyway. 

I'm not sure about the docs changes whether they should be first added to the `main` in a separate PR and then backported to 22 and used here. To be more specific, there will be a necessity for providing such a functionality even in later Keycloak releases. 

@vmuzikar @mhajas WDYT?