### PR TITLE
Do not initialize barrier build items for deployment

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/ConfigBuildItem.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/ConfigBuildItem.java
@@ -1,6 +1,26 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.keycloak.quarkus.deployment;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.EmptyBuildItem;
 
-public final class ConfigBuildItem extends SimpleBuildItem {
+/**
+ * A barrier build item that can be consumed by other build steps when Keycloak configurations is initialized
+ */
+public final class ConfigBuildItem extends EmptyBuildItem {
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.BootstrapConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -212,22 +213,21 @@ class KeycloakProcessor {
 
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
-    ConfigBuildItem initConfig(KeycloakRecorder recorder) {
+    @Produce(ConfigBuildItem.class)
+    void initConfig(KeycloakRecorder recorder) {
         Config.init(new MicroProfileConfigProvider());
         recorder.initConfig();
-        return new ConfigBuildItem();
     }
 
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     @Consume(ConfigBuildItem.class)
-    ProfileBuildItem configureProfile(KeycloakRecorder recorder) {
+    @Produce(ProfileBuildItem.class)
+    void configureProfile(KeycloakRecorder recorder) {
         Profile profile = getCurrentOrCreateFeatureProfile();
 
         // record the features so that they are not calculated again at runtime
         recorder.configureProfile(profile.getName(), profile.getFeatures());
-
-        return new ProfileBuildItem();
     }
 
     /**
@@ -351,7 +351,8 @@ class KeycloakProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     @Consume(ProfileBuildItem.class)
-    KeycloakSessionFactoryPreInitBuildItem configureKeycloakSessionFactory(KeycloakRecorder recorder, List<PersistenceXmlDescriptorBuildItem> descriptors) {
+    @Produce(KeycloakSessionFactoryPreInitBuildItem.class)
+    void configureKeycloakSessionFactory(KeycloakRecorder recorder, List<PersistenceXmlDescriptorBuildItem> descriptors) {
         Map<Spi, Map<Class<? extends Provider>, Map<String, Class<? extends ProviderFactory>>>> factories = new HashMap<>();
         Map<Class<? extends Provider>, String> defaultProviders = new HashMap<>();
         Map<String, ProviderFactory> preConfiguredProviders = new HashMap<>();
@@ -380,8 +381,6 @@ class KeycloakProcessor {
         }
 
         recorder.configSessionFactory(factories, defaultProviders, preConfiguredProviders, loadThemesFromClassPath(), Environment.isRebuild());
-
-        return new KeycloakSessionFactoryPreInitBuildItem();
     }
 
     private List<ClasspathThemeProviderFactory.ThemesRepresentation> loadThemesFromClassPath() {

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakSessionFactoryPreInitBuildItem.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakSessionFactoryPreInitBuildItem.java
@@ -17,11 +17,11 @@
 
 package org.keycloak.quarkus.deployment;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.EmptyBuildItem;
 
 /**
  * A symbolic build item that can be consumed by other build steps when the {@link org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory}
  * is pre-initialized.
  */
-public final class KeycloakSessionFactoryPreInitBuildItem extends SimpleBuildItem {
+public final class KeycloakSessionFactoryPreInitBuildItem extends EmptyBuildItem {
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/ProfileBuildItem.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/ProfileBuildItem.java
@@ -1,6 +1,26 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.keycloak.quarkus.deployment;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.EmptyBuildItem;
 
-public final class ProfileBuildItem extends SimpleBuildItem {
+/**
+ * A barrier build item that can be consumed by other build steps when Keycloak profile is initialized
+ */
+public final class ProfileBuildItem extends EmptyBuildItem {
 }


### PR DESCRIPTION
Closes #22725

We don't have to instantiate build items, which don't contain any data and are used only as barriers for execution order.

Check it here: https://quarkus.io/guides/writing-extensions#empty-build-items

