### PR TITLE
Simplify obtaining Keycloak Quarkus configuration

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/CacheBuildSteps.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/CacheBuildSteps.java
@@ -27,10 +27,8 @@ import java.nio.file.Paths;
 import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.infinispan.commons.util.FileLookupFactory;
-import org.keycloak.config.MetricsOptions;
 import org.keycloak.quarkus.runtime.KeycloakRecorder;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 import org.keycloak.quarkus.runtime.storage.legacy.infinispan.CacheManagerFactory;
 
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -72,16 +70,12 @@ public class CacheBuildSteps {
                         .scope(ApplicationScoped.class)
                         .unremovable()
                         .setRuntimeInit()
-                        .runtimeValue(recorder.createCacheInitializer(config, isMetricsEnabled(), shutdownContext)).done());
+                        .runtimeValue(recorder.createCacheInitializer(config, KeycloakConfiguration.isMetricsEnabled(), shutdownContext)).done());
             } catch (Exception cause) {
                 throw new RuntimeException("Failed to read clustering configuration from [" + url + "]", cause);
             }
         } else {
             throw new IllegalArgumentException("Option 'configFile' needs to be specified");
         }
-    }
-
-    private boolean isMetricsEnabled() {
-        return Configuration.getOptionalBooleanValue(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX.concat(MetricsOptions.METRICS_ENABLED.getKey())).orElse(false);
     }
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsJpaStoreEnabled.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsJpaStoreEnabled.java
@@ -17,13 +17,9 @@
 
 package org.keycloak.quarkus.deployment;
 
-import static org.keycloak.config.StorageOptions.STORAGE;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
-import java.util.Optional;
 import java.util.function.BooleanSupplier;
-import org.keycloak.config.StorageOptions;
 
 /***
  * Checks if JPA is enabled either for the legacy or the new store.
@@ -34,14 +30,6 @@ public class IsJpaStoreEnabled implements BooleanSupplier {
 
     @Override
     public boolean getAsBoolean() {
-        Optional<String> storage = getOptionalValue(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey()));
-
-        if (storage.isEmpty()) {
-            // legacy store
-            return true;
-        }
-
-        return StorageOptions.StorageType.jpa.name().equals(storage.orElse(null));
+        return KeycloakConfiguration.isJpa();
     }
-
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsLegacyStoreEnabled.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsLegacyStoreEnabled.java
@@ -17,9 +17,7 @@
 
 package org.keycloak.quarkus.deployment;
 
-import static org.keycloak.config.StorageOptions.STORAGE;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
 import java.util.function.BooleanSupplier;
 
@@ -30,7 +28,7 @@ public class IsLegacyStoreEnabled implements BooleanSupplier {
 
     @Override
     public boolean getAsBoolean() {
-        return getOptionalValue(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey())).isEmpty();
+        return KeycloakConfiguration.isLegacyJpa();
     }
 
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
@@ -16,7 +16,6 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.keycloak.config.StorageOptions;
 import org.keycloak.connections.jpa.updater.liquibase.lock.DummyLockService;
 
 import io.quarkus.deployment.annotations.BuildStep;
@@ -30,11 +29,9 @@ import liquibase.servicelocator.LiquibaseService;
 import liquibase.sqlgenerator.SqlGenerator;
 import org.keycloak.models.map.storage.jpa.liquibase.lockservice.KeycloakLockService;
 import org.keycloak.quarkus.runtime.KeycloakRecorder;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
-import static org.keycloak.config.StorageOptions.STORAGE;
 import static org.keycloak.quarkus.deployment.KeycloakProcessor.getDefaultDataSource;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
 
 class LiquibaseProcessor {
 
@@ -80,7 +77,7 @@ class LiquibaseProcessor {
             }
         }
 
-        if (StorageOptions.StorageType.jpa.name().equals(getOptionalValue(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey())).orElse(null))) {
+        if (KeycloakConfiguration.isMapJpa()) {
             services.put(LockService.class.getName(), Collections.singletonList(KeycloakLockService.class.getName()));
         } else {
             services.put(LockService.class.getName(), Collections.singletonList(DummyLockService.class.getName()));

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -65,6 +65,7 @@ import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
 import org.keycloak.quarkus.runtime.cli.command.StartDev;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 import org.keycloak.quarkus.runtime.configuration.QuarkusPropertiesConfigSource;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
@@ -553,7 +554,7 @@ public final class Picocli {
     }
 
     private static void checkChangesInBuildOptionsDuringAutoBuild() {
-        if (Configuration.isOptimized()) {
+        if (KeycloakConfiguration.isOptimized()) {
             List<PropertyMapper> buildOptions = stream(Configuration.getPropertyNames(true).spliterator(), false)
                     .sorted()
                     .map(PropertyMappers::getMapper)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -22,23 +22,20 @@ import static org.keycloak.quarkus.runtime.Environment.isDevMode;
 import static org.keycloak.quarkus.runtime.cli.Picocli.println;
 import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.getAllCliArgs;
 
-import org.keycloak.config.ClassLoaderOptions;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.Messages;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
 import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
 import io.quarkus.bootstrap.runner.RunnerClassLoader;
 
 import io.quarkus.runtime.configuration.ProfileManager;
-import io.smallrye.config.ConfigValue;
-import org.keycloak.utils.StringUtil;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import java.util.List;
+import java.util.Optional;
 
 @Command(name = Build.NAME,
         header = "Creates a new and optimized server image.",
@@ -92,13 +89,9 @@ public final class Build extends AbstractCommand implements Runnable {
     }
 
     private static void configureBuildClassLoader() {
-        ConfigValue ignoredArtifacts = Configuration.getCurrentBuiltTimeProperty(
-                MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + ClassLoaderOptions.IGNORE_ARTIFACTS.getKey());
-
-        if (ignoredArtifacts != null && StringUtil.isNotBlank(ignoredArtifacts.getValue())) {
-            // ignored artifacts must be set prior to starting re-augmentation
-            System.setProperty("quarkus.class-loading.removed-artifacts", ignoredArtifacts.getValue());
-        }
+        Optional<String> ignoredArtifacts = KeycloakConfiguration.getIgnoredArtifacts();
+        // ignored artifacts must be set prior to starting re-augmentation
+        ignoredArtifacts.ifPresent(s -> System.setProperty("quarkus.class-loading.removed-artifacts", s));
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -21,7 +21,6 @@ import static org.keycloak.quarkus.runtime.Environment.getProfileOrDefault;
 import static org.keycloak.quarkus.runtime.cli.Picocli.ARG_PREFIX;
 
 import java.util.Optional;
-import java.util.Properties;
 
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
@@ -32,8 +31,6 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-
 /**
  * The entry point for accessing the server configuration
  */
@@ -41,7 +38,6 @@ public final class Configuration {
 
     public static final char OPTION_PART_SEPARATOR_CHAR = '-';
     public static final String OPTION_PART_SEPARATOR = String.valueOf(OPTION_PART_SEPARATOR_CHAR);
-    private static final String KC_OPTIMIZED = NS_KEYCLOAK_PREFIX + "optimized";
 
     private Configuration() {
 
@@ -95,16 +91,8 @@ public final class Configuration {
         return getConfig().getConfigValue(propertyName);
     }
 
-    public static ConfigValue getKcConfigValue(String propertyName) {
-        return getConfigValue(NS_KEYCLOAK_PREFIX.concat(propertyName));
-    }
-
     public static Optional<String> getOptionalValue(String name) {
         return getConfig().getOptionalValue(name, String.class);
-    }
-
-    public static Optional<String> getOptionalKcValue(String propertyName) {
-        return getOptionalValue(NS_KEYCLOAK_PREFIX.concat(propertyName));
     }
 
     public static Optional<Boolean> getOptionalBooleanValue(String name) {
@@ -193,14 +181,6 @@ public final class Configuration {
         }
 
         return value;
-    }
-
-    public static boolean isOptimized() {
-        return Configuration.getRawPersistedProperty(KC_OPTIMIZED).isPresent();
-    }
-
-    public static void markAsOptimized(Properties properties) {
-        properties.put(Configuration.KC_OPTIMIZED, Boolean.TRUE.toString());
     }
 
     public static ConfigValue getCurrentBuiltTimeProperty(String name) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfiguration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.configuration;
+
+import io.smallrye.config.ConfigValue;
+import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.config.ClassLoaderOptions;
+import org.keycloak.config.DatabaseOptions;
+import org.keycloak.config.HealthOptions;
+import org.keycloak.config.MetricsOptions;
+import org.keycloak.config.SecurityOptions;
+import org.keycloak.config.StorageOptions;
+import org.keycloak.config.database.Database;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.keycloak.config.StorageOptions.STORAGE;
+import static org.keycloak.config.StorageOptions.STORAGE_JPA_DB;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getRawPersistedProperty;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+
+/**
+ * Most frequently used Keycloak configuration properties
+ */
+public class KeycloakConfiguration {
+    private static final String KC_OPTIMIZED = NS_KEYCLOAK_PREFIX + "optimized";
+
+    public static Optional<String> getKcOptionalValue(String propertyName) {
+        return Configuration.getOptionalValue(NS_KEYCLOAK_PREFIX.concat(propertyName));
+    }
+
+    public static boolean isOptimized() {
+        return getRawPersistedProperty(KC_OPTIMIZED).isPresent();
+    }
+
+    public static void markAsOptimized(Properties properties) {
+        properties.put(KC_OPTIMIZED, Boolean.TRUE.toString());
+    }
+
+    public static boolean isMetricsEnabled() {
+        return getKcBooleanValue(MetricsOptions.METRICS_ENABLED.getKey());
+    }
+
+    public static boolean isHealthEnabled() {
+        return getKcBooleanValue(HealthOptions.HEALTH_ENABLED.getKey());
+    }
+
+    public static Optional<FipsMode> getFipsMode() {
+        return getKcOptionalValue(SecurityOptions.FIPS_MODE.getKey()).map(FipsMode::valueOfOption);
+    }
+
+    public static Optional<String> getIgnoredArtifacts() {
+        return getKcCurrentBuiltTimeProperty(ClassLoaderOptions.IGNORE_ARTIFACTS.getKey());
+    }
+
+    /* DB */
+    public static boolean isLegacyJpa() {
+        return getKcBooleanValue(STORAGE.getKey());
+    }
+
+    public static boolean isMapJpa() {
+        Optional<String> storage = getStorage();
+        return storage.isPresent() && storage.get().equals(StorageOptions.StorageType.jpa.name());
+    }
+
+    public static boolean isJpa() {
+        // JPA legacy or JPA map
+        return isLegacyJpa() || isMapJpa();
+    }
+
+    public static Optional<Database.Vendor> getJpaDbVendor() {
+        return getKcOptionalValue(DatabaseOptions.DB.getKey()).flatMap(StorageOptions::getDatabaseVendor);
+    }
+
+    public static Optional<Database.Vendor> getMapJpaDbVendor() {
+        return getKcOptionalValue(STORAGE_JPA_DB.getKey()).flatMap(StorageOptions::getDatabaseVendor);
+    }
+
+    public static Optional<String> getStorage() {
+        return getKcOptionalValue(STORAGE.getKey());
+    }
+
+    public static Optional<String> getDbDialect() {
+        return getKcOptionalValue(DatabaseOptions.DB_DIALECT.getKey());
+    }
+
+    public static Optional<String> getDbSchema() {
+        return getKcOptionalValue(DatabaseOptions.DB_SCHEMA.getKey());
+    }
+
+    /* Internal */
+    private static boolean getKcBooleanValue(String propertyName) {
+        return Configuration.getOptionalBooleanValue(NS_KEYCLOAK_PREFIX.concat(propertyName)).orElse(false);
+    }
+
+    private static Optional<String> getKcCurrentBuiltTimeProperty(String propertyName) {
+        return Optional.ofNullable(Configuration.getCurrentBuiltTimeProperty(NS_KEYCLOAK_PREFIX.concat(propertyName))).map(ConfigValue::getValue);
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
@@ -40,7 +40,6 @@ import io.smallrye.config.AbstractLocationConfigSourceLoader;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.common.utils.ConfigSourceUtil;
 
-import static org.keycloak.common.util.StringPropertyReplacer.replaceProperties;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getMappedPropertyName;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
@@ -13,10 +13,8 @@ import java.util.Set;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.config.ClassLoaderOptions;
-import org.keycloak.config.StorageOptions;
 import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
 final class ClassLoaderPropertyMappers {
 
@@ -44,8 +42,7 @@ final class ClassLoaderPropertyMappers {
                         "org.keycloak:keycloak-crypto-fips1402", "org.bouncycastle:bc-fips", "org.bouncycastle:bctls-fips", "org.bouncycastle:bcpkix-fips"));
             }
 
-            Optional<String> storage = Configuration.getOptionalValue(
-                    MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + StorageOptions.STORAGE.getKey());
+            Optional<String> storage = KeycloakConfiguration.getStorage();
 
             if (storage.isEmpty()) {
                 ignoredArtifacts.add("org.keycloak:keycloak-model-map-jpa");

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/FeaturePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/FeaturePropertyMappers.java
@@ -1,20 +1,17 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
+import io.smallrye.config.ConfigSourceInterceptorContext;
 import org.keycloak.common.Profile;
 import org.keycloak.config.FeatureOptions;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-
-import static java.util.Optional.of;
-import static org.keycloak.config.StorageOptions.STORAGE;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import io.smallrye.config.ConfigSourceInterceptorContext;
+import static java.util.Optional.of;
+import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 final class FeaturePropertyMappers {
 
@@ -34,7 +31,7 @@ final class FeaturePropertyMappers {
     }
 
     private static Optional<String> transformFeatures(Optional<String> features, ConfigSourceInterceptorContext context) {
-        if (Configuration.getOptionalValue(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey())).isEmpty()) {
+        if (KeycloakConfiguration.isLegacyJpa()) {
             return features;
         }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -1,18 +1,13 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
-import io.smallrye.config.ConfigValue;
-
-import org.keycloak.config.StorageOptions;
 import org.keycloak.config.TransactionOptions;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-
-import static java.util.Optional.of;
-import static org.keycloak.config.StorageOptions.STORAGE;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
 import java.util.Optional;
+
+import static java.util.Optional.of;
+import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 public class TransactionPropertyMappers {
 
@@ -31,9 +26,8 @@ public class TransactionPropertyMappers {
 
     private static Optional<String> getQuarkusTransactionsValue(Optional<String> txValue, ConfigSourceInterceptorContext context) {
         boolean isXaEnabled = Boolean.parseBoolean(txValue.get());
-        ConfigValue storage = context.proceed(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey()));
 
-        if (storage != null && StorageOptions.StorageType.jpa.name().equals(storage.getValue())) {
+        if (KeycloakConfiguration.isMapJpa()) {
             isXaEnabled = true;
         }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaMapStorageProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaMapStorageProviderFactory.java
@@ -17,9 +17,6 @@
 
 package org.keycloak.quarkus.runtime.storage.database.jpa;
 
-import static org.keycloak.config.StorageOptions.STORAGE;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-
 import java.lang.annotation.Annotation;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -29,7 +26,7 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.keycloak.config.StorageOptions.StorageType;
 import org.keycloak.models.map.storage.jpa.JpaMapStorageProviderFactory;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.KeycloakConfiguration;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.PersistenceUnit;
@@ -85,6 +82,6 @@ public class QuarkusJpaMapStorageProviderFactory extends JpaMapStorageProviderFa
 
     @Override
     public boolean isSupported() {
-        return StorageType.jpa.name().equals(Configuration.getOptionalValue(NS_KEYCLOAK_PREFIX + STORAGE.getKey()).orElse(null));
+        return KeycloakConfiguration.isMapJpa();
     }
 }


### PR DESCRIPTION
This PR should simplify gathering information about Keycloak configuration.

I'd like to avoid statements like:
`StorageOptions.StorageType.jpa.name().equals(getOptionalValue(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey())).orElse(null))`

as we can query the configuration like this: `KeycloakConfiguration.isMapJpa()`.