### PR TITLE
Fix not-reported flaky tests

### DIFF
--- a/.github/actions/upload-flaky-tests/action.yml
+++ b/.github/actions/upload-flaky-tests/action.yml
@@ -17,7 +17,7 @@ runs:
         FLAKES=""
         SEP=""
         for dir in $(find -type d -name 'surefire-reports*'); do
-          for i in $(grep -l '<flakyFailure' $dir/TEST-*.xml); do
+          for i in $(grep -l -E '<flakyFailure|<flakyError' $dir/TEST-*.xml); do
             FLAKES="$FLAKES$SEP$i"
             SEP=$'\n'
           done


### PR DESCRIPTION
In the current state, not all flaky tests are reported. The reason for that is that sometimes the failed attempt is reported as a failure and sometimes as an error. The current `upload-flaky-test` is looking only for `<flakyFailure` string in surefire-reports, however, we need to search also for `<flakyError`.

More info here: https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html#output-flaky-re-run-information-in-test-report-xml

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
