### PR TITLE
Make base theme hidden for admin and account UIs.

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/realm_settings_tabs_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/realm_settings_tabs_test.spec.ts
@@ -126,7 +126,6 @@ describe("Realm settings tabs tests", () => {
 
     realmSettingsPage.selectLoginThemeType("keycloak");
     realmSettingsPage.selectAccountThemeType("keycloak");
-    realmSettingsPage.selectAdminThemeType("base");
     realmSettingsPage.selectEmailThemeType("base");
 
     realmSettingsPage.saveThemes();

--- a/js/apps/admin-ui/src/realm-settings/ThemesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/ThemesTab.tsx
@@ -120,15 +120,17 @@ export const RealmSettingsThemesTab = ({
                 placeholderText="Select a theme"
                 data-testid="select-account-theme"
               >
-                {themeTypes.account.map((theme, idx) => (
-                  <SelectOption
-                    selected={theme.name === field.value}
-                    key={`account-theme-${idx}`}
-                    value={theme.name}
-                  >
-                    {t(`${theme.name}`)}
-                  </SelectOption>
-                ))}
+                {themeTypes.account
+                  .filter((theme) => theme.name !== "base")
+                  .map((theme, idx) => (
+                    <SelectOption
+                      selected={theme.name === field.value}
+                      key={`account-theme-${idx}`}
+                      value={theme.name}
+                    >
+                      {t(`${theme.name}`)}
+                    </SelectOption>
+                  ))}
               </Select>
             )}
           />
@@ -162,15 +164,17 @@ export const RealmSettingsThemesTab = ({
                 placeholderText="Select a theme"
                 data-testid="select-admin-theme"
               >
-                {themeTypes.admin.map((theme, idx) => (
-                  <SelectOption
-                    selected={theme.name === field.value}
-                    key={`admin-theme-${idx}`}
-                    value={theme.name}
-                  >
-                    {t(`${theme.name}`)}
-                  </SelectOption>
-                ))}
+                {themeTypes.admin
+                  .filter((theme) => theme.name !== "base")
+                  .map((theme, idx) => (
+                    <SelectOption
+                      selected={theme.name === field.value}
+                      key={`admin-theme-${idx}`}
+                      value={theme.name}
+                    >
+                      {t(`${theme.name}`)}
+                    </SelectOption>
+                  ))}
               </Select>
             )}
           />


### PR DESCRIPTION
Fixes #21421 

This just provides a quick patch for the issue above so users don't see the problem any longer.  It just removes the base theme from the dropdown.

The real fix will come when we solve https://github.com/keycloak/keycloak/issues/22671.
