### PR TITLE
Modify 'keycloak' group ID in Dockerfile

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -25,8 +25,8 @@ ENV LANG en_US.UTF-8
 COPY --from=ubi-micro-build /tmp/null/rootfs/ /
 COPY --from=ubi-micro-build --chown=1000:0 /opt/keycloak /opt/keycloak
 
-RUN echo "keycloak:x:0:root" >> /etc/group && \
-    echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
+RUN echo "keycloak:x:1000:" >> /etc/group && \
+    echo "keycloak:x:1000:1000:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 
 USER 1000
 


### PR DESCRIPTION
The group ID for 'keycloak' user in the Docker image has been adjusted from root to non-root. This change enhances security.

Related PRs:
keycloak/keycloak-containers#258
keycloak/keycloak-containers#259

The workaround involving the root group was initially designed for WildFly/OpenShift. Currently, this is no longer necessary.
