### PR TITLE
Entering a single space in a regex password policy makes admin interface unusable.

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/RegexPatternsPasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/RegexPatternsPasswordPolicyProvider.java
@@ -57,6 +57,8 @@ public class RegexPatternsPasswordPolicyProvider implements PasswordPolicyProvid
     public Object parseConfig(String value) {
         if (value == null) {
             throw new PasswordPolicyConfigException("Config required");
+        } else if(value.trim().isEmpty()) {
+            throw new PasswordPolicyConfigException("White space not acepted");
         }
         try {
             return Pattern.compile(value);


### PR DESCRIPTION
close #20411

Hi team, I have added a simple validation on RegexPatternsPasswordPolicyProvider to avoid white spaces on regex