### PR TITLE
Clean up Cypress configuration

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -21,11 +21,6 @@ node_modules
 *.sln
 *.sw?
 
-# Cypress
-assets
-**/cypress.env.json
-**/cypress/downloads
-
 # Optional eslint cache
 .eslintcache
 

--- a/js/apps/admin-ui/cypress.config.mjs
+++ b/js/apps/admin-ui/cypress.config.mjs
@@ -2,15 +2,11 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   projectId: "j4yhox",
-  screenshotsFolder: "assets/screenshots",
-  videosFolder: "assets/videos",
   chromeWebSecurity: false,
   viewportWidth: 1360,
   viewportHeight: 768,
   defaultCommandTimeout: 30000,
-  videoCompression: false,
   numTestsKeptInMemory: 30,
-  videoUploadOnPasses: false,
   experimentalMemoryManagement: true,
 
   retries: {


### PR DESCRIPTION
Cypress 13 introduces [Test Replay](https://docs.cypress.io/guides/cloud/debugging/test-replay), making the need to record video and screenshots obsolete. This PR removes the various config options related to capturing videos and screenshots.

For more information, see the [change-log for Cypress 13](https://docs.cypress.io/guides/references/changelog#13-0-0).