### PR TITLE
removes quarkus-openshift since it's not being utilized

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -80,10 +80,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-openshift</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client</artifactId>
             <exclusions>
             	<exclusion>

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -9,7 +9,6 @@ operator.keycloak.image-pull-policy=Always
 
 # https://quarkus.io/guides/deploying-to-kubernetes#environment-variables-from-keyvalue-pairs
 quarkus.kubernetes.env.vars.operator-keycloak-image=${operator.keycloak.image}
-quarkus.openshift.env.vars.operator-keycloak-image=${operator.keycloak.image}
 
 # Bundle config
 quarkus.operator-sdk.bundle.package-name=keycloak-operator


### PR DESCRIPTION
We don't need direct idomatic deployment to openshift, and having to duplicate the specification of things in the application.properties file for both openshift and kubernetes is burdensome, so it seems best to just remove the dependency.

We still pick up the ability to use the openshift client / model via the operator sdk.

Closes #10963

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
