### PR TITLE
Creation of Realm with no name

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
@@ -153,6 +153,7 @@ public class LegacyExportImportManager implements ExportImportManager {
         RealmRepresentation rep;
         try {
             rep = JsonSerialization.readValue(requestBody, RealmRepresentation.class);
+            verifyRealmName(rep.getRealm());
         } catch (IOException e) {
             throw new ModelException("unable to read contents from stream", e);
         }
@@ -166,7 +167,7 @@ public class LegacyExportImportManager implements ExportImportManager {
         convertDeprecatedApplications(session, rep);
         convertDeprecatedClientTemplates(rep);
 
-        newRealm.setName(rep.getRealm());
+        newRealm.setName(verifyRealmName(rep.getRealm()));
         if (rep.getDisplayName() != null) newRealm.setDisplayName(rep.getDisplayName());
         if (rep.getDisplayNameHtml() != null) newRealm.setDisplayNameHtml(rep.getDisplayNameHtml());
         if (rep.isEnabled() != null) newRealm.setEnabled(rep.isEnabled());

--- a/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
+++ b/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
@@ -173,7 +173,7 @@ public class MapExportImportManager implements ExportImportManager {
         convertDeprecatedApplications(session, rep);
         convertDeprecatedClientTemplates(rep);
 
-        newRealm.setName(rep.getRealm());
+        newRealm.setName(verifyRealmName(rep.getRealm()));
         if (rep.getDisplayName() != null) newRealm.setDisplayName(rep.getDisplayName());
         if (rep.getDisplayNameHtml() != null) newRealm.setDisplayNameHtml(rep.getDisplayNameHtml());
         if (rep.isEnabled() != null) newRealm.setEnabled(rep.isEnabled());
@@ -509,12 +509,14 @@ public class MapExportImportManager implements ExportImportManager {
                 inputData = requestBody.readAllBytes();
             }
             rep = JsonSerialization.readValue(new ByteArrayInputStream(inputData), RealmRepresentation.class);
+            verifyRealmName(rep.getRealm());
         } catch (IOException e) {
             /* This is a re-try when unrecognized property is being imported, it may happen e.g. when using admin client of newer version 
                in heterogenous cluster (during zero-downtime upgrade) and the request lands into older version of kc. */
             if (e instanceof UnrecognizedPropertyException && inputData != null) {
                 try {
                     rep = JsonSerialization.mapper.copy().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).readValue(new ByteArrayInputStream(inputData), RealmRepresentation.class);
+                    verifyRealmName(rep.getRealm());
                     logger.warnf("%s during an import!", e.getMessage().indexOf(",") > 0 ? e.getMessage().substring(0, e.getMessage().indexOf(",")) : "Unrecognized field");
                 } catch (IOException ex) {
                     throw new ModelException("unable to read contents from stream", ex);

--- a/server-spi-private/src/main/java/org/keycloak/storage/ExportImportManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/ExportImportManager.java
@@ -19,13 +19,17 @@ package org.keycloak.storage;
 
 import org.keycloak.exportimport.ExportAdapter;
 import org.keycloak.exportimport.ExportOptions;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.partialimport.PartialImportResults;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
+import jakarta.ws.rs.BadRequestException;
+
 import java.io.InputStream;
+import java.util.regex.Pattern;
 
 /**
  * Manage importing and updating of realms for the legacy store.
@@ -44,4 +48,15 @@ public interface ExportImportManager {
     void exportRealm(RealmModel realm, ExportOptions options, ExportAdapter callback);
 
     RealmModel importRealm(InputStream requestBody);
+    
+    default String verifyRealmName(String realmName) {
+        String specialCharacter = "[~!@#$%^&*()+{}\\[\\]:;,.<>/?]";
+        Pattern pattern = Pattern.compile(specialCharacter);
+        if(realmName.trim().isEmpty()) {
+            throw new BadRequestException("Realm name can't contain empty space");
+        } else if (pattern.matcher(realmName).find()) {
+            throw new BadRequestException("Realm name can't contain special characters");
+        }
+        return realmName;
+    }
 }


### PR DESCRIPTION
closes #15848

hi team, I've updated the code to restrict (avoid) empty and special characters on realm name creation, using REST API. The only special characters allowed are `_`  and `-`, the same rule that we have on the front end side. 
