### PR TITLE
adds a default hostname on openshift if one is not specified

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -126,6 +126,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj-core.version}</version>

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetSpecFluent.TemplateNested
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.quarkus.logging.Log;
 
 import org.keycloak.common.util.CollectionUtil;
@@ -76,14 +77,14 @@ public class KeycloakDeployment extends OperatorManagedResource<StatefulSet> {
 
     private boolean migrationInProgress;
 
-    public KeycloakDeployment(KubernetesClient client, Config config, Keycloak keycloakCR, StatefulSet existingDeployment, String adminSecretName) {
+    public KeycloakDeployment(KubernetesClient client, Config config, Keycloak keycloakCR, StatefulSet existingDeployment, String adminSecretName, Context<Keycloak> context) {
         super(client, keycloakCR);
         this.operatorConfig = config;
         this.keycloakCR = keycloakCR;
         this.adminSecretName = adminSecretName;
         this.existingDeployment = existingDeployment;
         this.baseDeployment = createBaseDeployment();
-        this.distConfigurator = new KeycloakDistConfigurator(keycloakCR, baseDeployment, client);
+        this.distConfigurator = new KeycloakDistConfigurator(keycloakCR, baseDeployment, client, context);
         this.distConfigurator.configureDistOptions();
         // after the distConfiguration, we can add the remaining default / additionalConfig
         addRemainingEnvVars();

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -25,7 +25,9 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.quarkus.logging.Log;
+
 import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
@@ -57,11 +59,13 @@ public class KeycloakDistConfigurator {
     private final Keycloak keycloakCR;
     private final StatefulSet deployment;
     private final KubernetesClient client;
+    private final Context<Keycloak> context;
 
-    public KeycloakDistConfigurator(Keycloak keycloakCR, StatefulSet deployment, KubernetesClient client) {
+    public KeycloakDistConfigurator(Keycloak keycloakCR, StatefulSet deployment, KubernetesClient client, Context<Keycloak> context) {
         this.keycloakCR = keycloakCR;
         this.deployment = deployment;
         this.client = client;
+        this.context = context;
     }
 
     /**
@@ -93,7 +97,7 @@ public class KeycloakDistConfigurator {
 
     public void configureHostname() {
         optionMapper(keycloakCR.getSpec().getHostnameSpec())
-                .mapOption("hostname", HostnameSpec::getHostname)
+                .mapOption("hostname", hns -> KeycloakIngressDependentResource.getHostname(keycloakCR, context).orElse(null))
                 .mapOption("hostname-admin", HostnameSpec::getAdmin)
                 .mapOption("hostname-admin-url", HostnameSpec::getAdminUrl)
                 .mapOption("hostname-strict", HostnameSpec::isStrict)

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsController.java
@@ -49,7 +49,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT_NAMESPACE;
 
@@ -57,8 +56,7 @@ import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT
 @ControllerConfiguration(namespaces = WATCH_CURRENT_NAMESPACE, labelSelector = Constants.KEYCLOAK_COMPONENT_LABEL + "=" + WatchedSecrets.WATCHED_SECRETS_LABEL_VALUE)
 public class WatchedSecretsController implements Reconciler<Secret>, EventSourceInitializer<Secret>, WatchedSecrets {
 
-    @Inject
-    KubernetesClient client;
+    private volatile KubernetesClient client;
 
     private final SimpleInboundEventSource eventSource = new SimpleInboundEventSource();
 
@@ -67,6 +65,7 @@ public class WatchedSecretsController implements Reconciler<Secret>, EventSource
     @Override
     public Map<String, EventSource> prepareEventSources(EventSourceContext<Secret> context) {
         this.secrets = context.getPrimaryCache();
+        this.client = context.getClient();
         return Map.of();
     }
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakStatus.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakStatus.java
@@ -38,6 +38,7 @@ public class KeycloakStatus implements ObservedGenerationAware {
     @StatusReplicas
     private Integer instances;
     private Long observedGeneration;
+    private String hostname;
 
     private List<KeycloakStatusCondition> conditions;
 
@@ -87,6 +88,14 @@ public class KeycloakStatus implements ObservedGenerationAware {
         this.observedGeneration = generation;
     }
 
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -95,6 +104,7 @@ public class KeycloakStatus implements ObservedGenerationAware {
         return Objects.equals(getConditions(), status.getConditions())
                 && Objects.equals(getInstances(), status.getInstances())
                 && Objects.equals(getSelector(), status.getSelector())
+                && Objects.equals(getHostname(), status.getHostname())
                 && Objects.equals(getObservedGeneration(), status.getObservedGeneration());
     }
 

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -5,9 +5,6 @@ metadata:
 rules:
   - apiGroups:
       - apps
-      # Extensions enabled for backward compatibility:
-      # https://github.com/fabric8io/kubernetes-client/issues/3996
-      - extensions
     resources:
       - statefulsets
     verbs:
@@ -61,6 +58,14 @@ rules:
       - delete
       - patch
       - update
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -80,7 +80,8 @@ import static org.keycloak.operator.testsuite.utils.K8sUtils.getResourceFromFile
 
 public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
 
-  public static final String QUARKUS_KUBERNETES_DEPLOYMENT_TARGET = "quarkus.kubernetes.deployment-target";
+  private static final String POSTGRESQL_NAME = "postgresql-db";
+public static final String QUARKUS_KUBERNETES_DEPLOYMENT_TARGET = "quarkus.kubernetes.deployment-target";
   public static final String OPERATOR_DEPLOYMENT_PROP = "test.operator.deployment";
   public static final String TARGET_KUBERNETES_GENERATED_YML_FOLDER = "target/kubernetes/";
   public static final String OPERATOR_KUBERNETES_IP = "test.operator.kubernetes.ip";
@@ -205,7 +206,7 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
     // Check DB has deployed and ready
     Log.info("Checking Postgres is running");
     Awaitility.await()
-            .untilAsserted(() -> assertThat(k8sclient.apps().statefulSets().inNamespace(namespace).withName("postgresql-db").get().getStatus().getReadyReplicas()).isEqualTo(1));
+            .untilAsserted(() -> assertThat(k8sclient.apps().statefulSets().inNamespace(namespace).withName(POSTGRESQL_NAME).get().getStatus().getReadyReplicas()).isEqualTo(1));
   }
 
   protected static void deployDBSecret() {
@@ -214,18 +215,8 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
 
   protected static void deleteDB() {
     // Delete the Postgres StatefulSet
-    k8sclient.apps().statefulSets().inNamespace(namespace).withName("postgresql-db").delete();
-    Awaitility.await()
-            .ignoreExceptions()
-            .untilAsserted(() -> {
-              Log.infof("Waiting for postgres to be deleted");
-              assertThat(k8sclient
-                      .apps()
-                      .statefulSets()
-                      .inNamespace(namespace)
-                      .withName("postgresql-db")
-                      .get()).isNull();
-            });
+    Log.infof("Waiting for postgres to be deleted");
+    k8sclient.apps().statefulSets().inNamespace(namespace).withName(POSTGRESQL_NAME).withTimeout(2, TimeUnit.MINUTES).delete();
   }
 
   // TODO improve this (preferably move to JOSDK)
@@ -284,7 +275,7 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
           if (operatorDeployment == OperatorDeployment.remote) {
               logFailed(k8sclient.apps().deployments().withName("keycloak-operator"), Deployment::getStatus);
           }
-          logFailed(k8sclient.apps().statefulSets().withName("example-kc"), StatefulSet::getStatus);
+          logFailed(k8sclient.apps().statefulSets().withName(POSTGRESQL_NAME), StatefulSet::getStatus);
       } finally {
           cleanup();
       }
@@ -292,7 +283,7 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
 
   private <T extends HasMetadata, R extends Resource<T> & Loggable> void logFailed(R resource, Function<T, Object> statusExtractor) {
       var instance = resource.get();
-      if (resource.isReady()) {
+      if (instance == null || resource.isReady()) {
           return;
       }
       Log.warnf("%s failed to become ready %s", instance.getMetadata().getName(), Serialization.asYaml(statusExtractor.apply(instance)));

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -83,7 +83,7 @@ public class KeycloakDistConfiguratorTest {
     public void featuresEmptyLists() {
         final Keycloak keycloak = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr-with-empty-list.yml", Keycloak.class);
         final StatefulSet deployment = getBasicKcDeployment();
-        final KeycloakDistConfigurator distConfig = new KeycloakDistConfigurator(keycloak, deployment, null);
+        final KeycloakDistConfigurator distConfig = new KeycloakDistConfigurator(keycloak, deployment, null, null);
 
         final List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         distConfig.configureFeatures();
@@ -127,7 +127,7 @@ public class KeycloakDistConfiguratorTest {
     public void missingHostname() {
         final Keycloak keycloak = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr-with-empty-list.yml", Keycloak.class);
         final StatefulSet deployment = getBasicKcDeployment();
-        final KeycloakDistConfigurator distConfig = new KeycloakDistConfigurator(keycloak, deployment, null);
+        final KeycloakDistConfigurator distConfig = new KeycloakDistConfigurator(keycloak, deployment, null, null);
 
         final List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
 
@@ -149,7 +149,7 @@ public class KeycloakDistConfiguratorTest {
     private void testFirstClassCitizen(String crName, Map<String, String> expectedValues, Consumer<KeycloakDistConfigurator> config) {
         final Keycloak keycloak = K8sUtils.getResourceFromFile(crName, Keycloak.class);
         final StatefulSet deployment = getBasicKcDeployment();
-        final KeycloakDistConfigurator distConfig = new KeycloakDistConfigurator(keycloak, deployment, null);
+        final KeycloakDistConfigurator distConfig = new KeycloakDistConfigurator(keycloak, deployment, null, null);
 
         final Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         assertThat(container).isNotNull();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -40,7 +40,6 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.UnsupportedSpec;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -92,7 +91,7 @@ public class PodTemplateTest {
 
         kc.setSpec(keycloakSpecBuilder.build());
 
-        var deployment = new KeycloakDeployment(null, config, kc, existingDeployment, "dummy-admin");
+        var deployment = new KeycloakDeployment(null, config, kc, existingDeployment, "dummy-admin", null);
 
         return deployment.getReconciledResource().get();
     }


### PR DESCRIPTION
Here's a rough proposal to address the issue of supporting no host name on openshift.

The simplest approach is just to emulate what the route logic would do and choose a host name of the form route-service.appsdomain

We should also propogate the hostname into the status for easy retrieval, which is not fully wired in here.

How this could be refined:
- we'll likely want to use an informer, rather than checking support and looking up the openshift ingress every time.  Alternatively we would want to poll for changes to the appsdomain.
- we may only want to do this if the ingress classname is explicitly set to openshift-default.

Closes #21741

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
