### PR TITLE
Fix group manage permissions

### DIFF
--- a/js/apps/admin-ui/src/groups/GroupTable.tsx
+++ b/js/apps/admin-ui/src/groups/GroupTable.tsx
@@ -44,7 +44,6 @@ export const GroupTable = ({
   const id = getLastId(location.pathname);
 
   const { hasAccess } = useAccess();
-  const isManager = hasAccess("manage-users") || currentGroup()?.access?.manage;
 
   const loader = async (first?: number, max?: number) => {
     const params: Record<string, string> = {
@@ -147,7 +146,7 @@ export const GroupTable = ({
           </>
         }
         actions={
-          !isManager
+          (!hasAccess("manage-users") && !group.access?.manage)
             ? []
             : [
                 {


### PR DESCRIPTION
This PR attempts to fix an issue with fine-grain permissions of groups.
The context action menu (three dots) of a group should be visible for users with "manage" permission associated with that group.

In the image below we can see the context action menu is available in the groups tree, but not in the groups table:
![image](https://github.com/keycloak/keycloak/assets/105205108/ea2a7ac1-4e93-44ce-ac7a-37294f7dec92)