### PR TITLE
Remove ambiguity for clients receiving backchannel logout tokens

### DIFF
--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -332,7 +332,8 @@ public class DefaultTokenManager implements TokenManager {
         token.addAudience(client.getClientId());
 
         OIDCAdvancedConfigWrapper oidcAdvancedConfigWrapper = OIDCAdvancedConfigWrapper.fromClientModel(client);
-        if (oidcAdvancedConfigWrapper.isBackchannelLogoutSessionRequired()){
+        if (oidcAdvancedConfigWrapper.isBackchannelLogoutSessionRequired() &&
+                clientSession.getNote(AuthenticationManager.BACKCHANNEL_LOGOUT_ALL_SESSIONS_FOR_USER) != null){
             token.setSid(clientSession.getUserSession().getId());
         }
         if (oidcAdvancedConfigWrapper.getBackchannelLogoutRevokeOfflineTokens()){

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -167,6 +167,8 @@ public class AuthenticationManager {
     public static final String KEYCLOAK_LOGOUT_PROTOCOL = "KEYCLOAK_LOGOUT_PROTOCOL";
     // Filled in case that logout was triggered with "initiating idp"
     public static final String LOGOUT_INITIATING_IDP = "LOGOUT_INITIATING_IDP";
+    // Flag to ensure backchannel logouts are sent without an "sid" claim to represent all sessions on the RP for the user should be logged out
+    public static final String BACKCHANNEL_LOGOUT_ALL_SESSIONS_FOR_USER = "BACKCHANNEL_LOGOUT_ALL_SESSIONS_FOR_USER";
 
     // Parameter of LogoutEndpoint
     public static final String INITIATING_IDP_PARAM = "initiating_idp";


### PR DESCRIPTION
Removes ambiguity for clients receiving backchannel logout tokens.

Unobtrusively implemented using a note on the user session. The token manager checks for the presence of this token and removes the session id claim.

Closes #22914

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
