### PR TITLE
Add version field to shared package's package.json

### DIFF
--- a/js/libs/ui-shared/package.json
+++ b/js/libs/ui-shared/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ui-shared",
+  "version": "0.0.0",
   "type": "module",
   "main": "./dist/ui-shared.js",
   "types": "./dist/ui-shared.d.ts",

--- a/js/package.json
+++ b/js/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.2.2",
     "wireit": "^0.13.0"
   },
-  "packageManager": "pnpm@8.6.12",
+  "packageManager": "pnpm@8.7.1",
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix"
   }

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
 
         <!-- Frontend -->
         <node.version>v18.17.1</node.version>
-        <pnpm.version>8.6.12</pnpm.version>
+        <pnpm.version>8.7.1</pnpm.version>
     </properties>
 
     <url>http://keycloak.org</url>


### PR DESCRIPTION
Resolves issue reported to pnpm https://github.com/pnpm/pnpm/issues/6994 Also bump pnpm version to latest to showcase functionality

Version is required due to this internal check in pnpm: https://github.com/pnpm/pnpm/blob/main/pkg-manifest/exportable-manifest/src/index.ts#L71 Without it, pnpm reports no manifest found and expects users to complete install

Admittedly this package is not published (To my knowledge) and versioning is not strictly required (or has semver enforced) but is expected by tools like pnpm for validation purposes.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
