### PR TITLE
Fix groups permissions

### DIFF
--- a/js/apps/admin-ui/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/js/apps/admin-ui/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -18,6 +18,7 @@ import { KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
 import { ResourcesKey, Row, ServiceRole } from "./RoleMapping";
 import { getAvailableRoles } from "./queries";
 import { getAvailableClientRoles } from "./resource";
+import {useSubGroups} from "../../groups/SubGroupsContext";
 
 type AddRoleMappingModalProps = {
   id: string;
@@ -32,17 +33,20 @@ type AddRoleMappingModalProps = {
 type FilterType = "roles" | "clients";
 
 export const AddRoleMappingModal = ({
-  id,
-  name,
-  type,
-  isRadio = false,
-  isLDAPmapper,
-  onAssign,
-  onClose,
-}: AddRoleMappingModalProps) => {
+                                      id,
+                                      name,
+                                      type,
+                                      isRadio = false,
+                                      isLDAPmapper,
+                                      onAssign,
+                                      onClose,
+                                    }: AddRoleMappingModalProps) => {
   const { t } = useTranslation(type);
   const { hasAccess } = useAccess();
-  const canViewRealmRoles = hasAccess("view-realm") || hasAccess("query-users");
+  const { currentGroup } = useSubGroups();
+  const canViewRealmRoles = hasAccess("view-realm") ||
+    hasAccess("query-users") ||
+    currentGroup()?.access?.manage;
 
   const [searchToggle, setSearchToggle] = useState(false);
 

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -87,8 +87,8 @@ export default function GroupsSection() {
           const group =
             i !== "search"
               ? await fetchAdminUI<GroupRepresentation | undefined>(
-                  "ui-ext/groups/" + i,
-                )
+                "ui-ext/groups/" + i,
+              )
               : { name: t("searchGroups"), id: "search" };
           if (group) {
             groups.push(group);
@@ -160,21 +160,21 @@ export default function GroupsSection() {
                 dropdownItems={
                   id && canManageGroup
                     ? [
-                        <DropdownItem
-                          data-testid="renameGroupAction"
-                          key="renameGroup"
-                          onClick={() => setRename(currentGroup())}
-                        >
-                          {t("renameGroup")}
-                        </DropdownItem>,
-                        <DropdownItem
-                          data-testid="deleteGroup"
-                          key="deleteGroup"
-                          onClick={toggleDeleteOpen}
-                        >
-                          {t("deleteGroup")}
-                        </DropdownItem>,
-                      ]
+                      <DropdownItem
+                        data-testid="renameGroupAction"
+                        key="renameGroup"
+                        onClick={() => setRename(currentGroup())}
+                      >
+                        {t("renameGroup")}
+                      </DropdownItem>,
+                      <DropdownItem
+                        data-testid="deleteGroup"
+                        key="deleteGroup"
+                        onClick={toggleDeleteOpen}
+                      >
+                        {t("deleteGroup")}
+                      </DropdownItem>,
+                    ]
                     : undefined
                 }
               />
@@ -199,7 +199,6 @@ export default function GroupsSection() {
                   >
                     <GroupTable
                       refresh={refresh}
-                      canViewDetails={canViewDetails}
                     />
                   </Tab>
                   {canViewMembers && (
@@ -243,7 +242,9 @@ export default function GroupsSection() {
                 </Tabs>
               )}
               {subGroups.length === 0 && (
-                <GroupTable refresh={refresh} canViewDetails={canViewDetails} />
+                <GroupTable
+                  refresh={refresh}
+                />
               )}
             </DrawerContentBody>
           </DrawerContent>

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -67,7 +67,8 @@ export default function GroupsSection() {
     hasAccess("manage-authorization", "manage-users", "manage-clients");
   const canManageGroup =
     hasAccess("manage-users") || currentGroup()?.access?.manage;
-  const canManageRoles = hasAccess("manage-users");
+  const canManageRoles =
+    hasAccess("manage-users") || currentGroup()?.access?.manage;
   const canViewDetails =
     hasAccess("query-groups", "view-users") ||
     hasAccess("manage-users", "query-groups");


### PR DESCRIPTION
Groups page had a couple issues related to fine grains permissions feature:
1. Users with `manage` permission for a group should see the action menu (3 dots icon) for that group's row
2. A group name should have navigation (Link) enabled when users has one of the following permissions: `manage`, `manage-members`, `manage-membership`, `view-members`.

Before:

![image](https://github.com/keycloak/keycloak/assets/105205108/40e1286a-0a5f-4571-aca3-15f5898d90ae)


After:

![image](https://github.com/keycloak/keycloak/assets/105205108/4727501a-a50a-488a-bbb9-8e8cd4389e4e)

