### PR TITLE
Fixes login flow in Microsoft social login test 

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/MicrosoftLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/MicrosoftLoginPage.java
@@ -35,6 +35,9 @@ public class MicrosoftLoginPage extends AbstractSocialLoginPage {
     @FindBy(id = "idSIButton9")
     private WebElement submitButton;
 
+    @FindBy(xpath = "//input[contains(@class,'btn-primary')]")
+    private WebElement appAccessButton;
+
     @Override
     public void login(String user, String password) {
         WaitUtils.pause(5000); // we need to take it a bit slower
@@ -49,6 +52,24 @@ public class MicrosoftLoginPage extends AbstractSocialLoginPage {
         }
         catch (NoSuchElementException e) {
             log.info("Already logged in to Microsoft IdP, no need to enter password");
+        }
+
+        // While logging into the app for the first time user is asked if he wants to stay signed in
+        try {
+            WaitUtils.pause(3000);
+            submitButton.click();
+        }
+        catch (NoSuchElementException e) {
+            log.info("User already allowed in the app");
+        }
+
+        // The app requires user consent for access to their information
+        try {
+            WaitUtils.pause(3000);
+            appAccessButton.click();
+        }
+        catch (NoSuchElementException e) {
+            log.info("App already has access to user information");
         }
     }
 }


### PR DESCRIPTION
- Resolves #22657 

Fixes the issue where first time login required additional approvals in dialog windows.

Reference Jenkins run: https://master-jenkins.redhat.com/job/universal-test-pipeline-server/3007/testReport/org.keycloak.testsuite.broker/SocialLoginTest/