### PR TITLE
Remove org.jetbrains:annotations:jar from server distribution. (#23015)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,12 @@
                 <groupId>org.twitter4j</groupId>
                 <artifactId>twitter4j-core</artifactId>
                 <version>${twitter4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- QR Code Generator -->


### PR DESCRIPTION
This dependency is not needed in runtime.

Closes https://github.com/keycloak/keycloak/issues/23015
