### PR TITLE
Make Keycloak.updateToken minValidity parameter optional

### DIFF
--- a/js/libs/keycloak-js/dist/keycloak.d.ts
+++ b/js/libs/keycloak-js/dist/keycloak.d.ts
@@ -578,6 +578,7 @@ declare class Keycloak {
 	* If the token expires within `minValidity` seconds, the token is refreshed.
 	* If the session status iframe is enabled, the session status is also
 	* checked.
+	* @param minValidity If not specified, `5` is used.
 	* @returns A promise to set functions that can be invoked if the token is
 	*          still valid, or if the token is no longer valid.
 	* @example
@@ -592,7 +593,7 @@ declare class Keycloak {
 	*   alert('Failed to refresh the token, or the session has expired');
 	* });
 	*/
-	updateToken(minValidity: number): Promise<boolean>;
+	updateToken(minValidity?: number): Promise<boolean>;
 
 	/**
 	* Clears authentication state, including tokens. This can be useful if


### PR DESCRIPTION
In the JavaScript adapter documentation it's said that `minValidity` in `updateToken` is optional, while it's not.

<img width="706" alt="Screenshot 2023-09-07 at 12 10 39" src="https://github.com/keycloak/keycloak/assets/22116465/3ae0cf2d-0407-4ae1-8afb-a5bff335839f">

Closes #23149
