### PR TITLE
Fix for Not-working link during adding a SAML Identity provider #22892

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/SamlGeneralSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/SamlGeneralSettings.tsx
@@ -81,7 +81,7 @@ export const SamlGeneralSettings = ({
       >
         <FormattedLink
           title={t("samlEndpointsLabel")}
-          href={`${environment.authUrl}/realms/${realm}/broker/${alias}/endpoint/descriptor`}
+          href={`${environment.authUrl}/realms/${realm}/protocol/${alias}/descriptor`}
           isInline
         />
       </FormGroup>


### PR DESCRIPTION
The descriptor URL was changed from  `${environment.authUrl}/realms/${realm}/broker/${alias}/endpoint/descriptor`  to `${environment.authUrl}/realms/${realm}/protocol/${alias}/descriptor`

Closes https://github.com/keycloak/keycloak/issues/22892