### PR TITLE
Quarkus IT that use Oracle DB don't work with -Dproduct

### DIFF
--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -71,9 +71,21 @@
             <artifactId>bctls-fips</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- JDBC Drivers -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -92,10 +92,21 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
         </dependency>
+
+        <!-- JDBC Drivers -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-http-shared</artifactId>

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -389,9 +389,12 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
             if (!inited || (reCreate || !dPath.toFile().exists())) {
                 FileUtil.deleteDirectory(dPath);
                 ZipUtils.unzip(distFile.toPath(), distRootPath);
+
                 if (System.getProperty("product") != null) {
-                    // MS SQL Server driver might be excluded if running as a product build
+                    // JDBC drivers might be excluded if running as a product build
                     copyProvider(dPath, "com.microsoft.sqlserver", "mssql-jdbc");
+                    copyProvider(dPath, "com.oracle.database.jdbc", "ojdbc11");
+                    copyProvider(dPath, "com.oracle.database.nls", "orai18n");
                 }
             }
 


### PR DESCRIPTION
Fixes #23058

We can improve the process around the JDBC drivers' copies to `providers` in a follow-up task. 