### PR TITLE
Fix for Not-working link during adding a SAML Identity provider #22892

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/SamlGeneralSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/SamlGeneralSettings.tsx
@@ -68,23 +68,25 @@ export const SamlGeneralSettings = ({
         data-testid="displayName"
       />
       <DisplayOrder />
-      <FormGroup
-        label={t("endpoints")}
-        fieldId="endpoints"
-        labelIcon={
-          <HelpItem
-            helpText={t("identity-providers-help:alias")}
-            fieldLabelId="identity-providers:alias"
+      {isAliasReadonly ? (
+        <FormGroup
+          label={t("endpoints")}
+          fieldId="endpoints"
+          labelIcon={
+            <HelpItem
+              helpText={t("identity-providers-help:alias")}
+              fieldLabelId="identity-providers:alias"
+            />
+          }
+          className="keycloak__identity-providers__saml_link"
+        >
+          <FormattedLink
+            title={t("samlEndpointsLabel")}
+            href={`${environment.authUrl}/realms/${realm}/broker/${alias}/endpoint/descriptor`}
+            isInline
           />
-        }
-        className="keycloak__identity-providers__saml_link"
-      >
-        <FormattedLink
-          title={t("samlEndpointsLabel")}
-          href={`${environment.authUrl}/realms/${realm}/broker/${alias}/endpoint/descriptor`}
-          isInline
-        />
-      </FormGroup>
+        </FormGroup>
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/22892

The SAML 2.0 Service Provider Metadata link in the UI is not present when adding the SAML identify provider in RH-SSO,  but in the latest Keycloak version we have it , thus causing the above-mentioned issue.  

Adding  a conditional statement in SamlGeneralSettings.tsx resolves the issue.