### PR TITLE
Marking wildfly-common with compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -677,7 +677,6 @@
                 <groupId>org.wildfly.common</groupId>
                 <artifactId>wildfly-common</artifactId>
                 <version>${wildfly.common.quarkus.aligned.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
The `wildfly-common` dependency is marked as `provided` scope and causes the embedded server to not work anymore. See https://github.com/keycloak/keycloak/pull/22824/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R679.

I can override the scope within the `keycloak-junit5` module and use the default scope but I'm wondering about the reasoning for marking this one with scope `provided`.

I can create an issue if you think it deserves one.

@pskopek @fjuma Wdyt?