### PR TITLE
FullNameLDAPStoreMapper removes values for other attributes

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/FullNameLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/FullNameLDAPStorageMapper.java
@@ -142,7 +142,7 @@ public class FullNameLDAPStorageMapper extends AbstractLDAPStorageMapper {
 
                 @Override
                 public void setAttribute(String name, List<String> values) {
-                    String valueToSet = (values != null && values.size() > 0) ? values.get(0) : null;
+                    String valueToSet = (values != null && !values.isEmpty()) ? values.get(0) : null;
                     if (UserModel.FIRST_NAME.equals(name)) {
                         this.firstName = valueToSet;
                         setFullNameToLDAPObject();
@@ -150,7 +150,7 @@ public class FullNameLDAPStorageMapper extends AbstractLDAPStorageMapper {
                         this.lastName = valueToSet;
                         setFullNameToLDAPObject();
                     }
-                    super.setSingleAttribute(name, valueToSet);
+                    super.setAttribute(name, values);
                 }
 
                 @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPTestAsserts.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPTestAsserts.java
@@ -17,6 +17,10 @@
 
 package org.keycloak.testsuite.federation.ldap;
 
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -31,19 +35,20 @@ import org.keycloak.storage.user.SynchronizationResult;
  */
 public class LDAPTestAsserts {
 
-    public static UserModel assertUserImported(UserProvider userProvider, RealmModel realm, String username, String expectedFirstName, String expectedLastName, String expectedEmail, String expectedPostalCode) {
+    public static UserModel assertUserImported(UserProvider userProvider, RealmModel realm, String username, String expectedFirstName, String expectedLastName, String expectedEmail, String... expectedPostalCode) {
         UserModel user = userProvider.getUserByUsername(realm, username);
         assertLoaded(user, username, expectedFirstName, expectedLastName, expectedEmail, expectedPostalCode);
         return user;
     }
 
 
-    public static void assertLoaded(UserModel user, String username, String expectedFirstName, String expectedLastName, String expectedEmail, String expectedPostalCode) {
+    public static void assertLoaded(UserModel user, String username, String expectedFirstName, String expectedLastName, String expectedEmail, String... expectedPostalCode) {
         Assert.assertNotNull(user);
         Assert.assertEquals(expectedFirstName, user.getFirstName());
         Assert.assertEquals(expectedLastName, user.getLastName());
         Assert.assertEquals(expectedEmail, user.getEmail());
-        Assert.assertEquals(expectedPostalCode, user.getFirstAttribute("postal_code"));
+        MatcherAssert.assertThat(expectedPostalCode == null? Collections.emptyList() : Arrays.asList(expectedPostalCode),
+                Matchers.containsInAnyOrder(user.getAttributeStream("postal_code").toArray(String[]::new)));
     }
 
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/22526

The full name mapper only passes the first value to the underlying mappers in the `setAttribute` method removing the extra values. Plain fix and tests modifications.

@mposolda @keycloak/store
