### PR TITLE
Fix failure in identity_providers_test.spec.ts after old LinkedId provider was deprecated

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
@@ -80,7 +80,7 @@ describe("Identity provider test", () => {
         { testName: "Gitlab", displayName: "Gitlab", alias: "gitlab" },
         { testName: "Google", displayName: "Google", alias: "google" },
         { testName: "Instagram", displayName: "Instagram", alias: "instagram" },
-        { testName: "Linkedin", displayName: "LinkedIn", alias: "linkedin" },
+        { testName: "LinkedIn OpenID Connect", displayName: "LinkedIn OpenID Connect", alias: "linkedin-openid-connect" },
         { testName: "Microsoft", displayName: "Microsoft", alias: "microsoft" },
         {
           testName: "Openshift-v3",
@@ -177,8 +177,8 @@ describe("Identity provider test", () => {
     it("create and delete provider by item details", () => {
       createProviderPage
         .clickCreateDropdown()
-        .clickItem("linkedin")
-        .fill("linkedin", "123")
+        .clickItem("linkedin-openid-connect")
+        .fill("linkedin-openid-connect", "123")
         .clickAdd();
       masthead.checkNotificationMessage(createSuccessMsg, true);
 


### PR DESCRIPTION
Closes #23118
