### PR TITLE
Fixes issue in login flow of SocialLoginTest#twitterLogin

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -387,6 +387,8 @@ public class SocialLoginTest extends AbstractKeycloakTest {
     public void twitterLogin() {
         setTestProvider(TWITTER);
         performLogin();
+        navigateToLoginPage();
+        assertUpdateProfile(false, false, true);
         appPage.assertCurrent();
     }
 


### PR DESCRIPTION
Introduces workaround where Twitter (X) doesn't redirect user into KC after login.

Additionally fixes issue of missing email on UpdateProfilePage for first-time-login.

Reference Jenkins run: https://master-jenkins.redhat.com/job/universal-test-pipeline-server/3034/testReport/org.keycloak.testsuite.broker/SocialLoginTest/
