### PR TITLE
Refactor tests to use new LinkedIn provider

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -294,7 +294,7 @@ jobs:
       - name: Start Keycloak server
         run: |
           tar xfvz keycloak-999.0.0-SNAPSHOT.tar.gz
-          keycloak-999.0.0-SNAPSHOT/bin/kc.sh start-dev --features=admin-fine-grained-authz,declarative-user-profile,linkedin-oauth &> ~/server.log &
+          keycloak-999.0.0-SNAPSHOT/bin/kc.sh start-dev --features=admin-fine-grained-authz,declarative-user-profile &> ~/server.log &
         env:
           KEYCLOAK_ADMIN: admin
           KEYCLOAK_ADMIN_PASSWORD: admin

--- a/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
@@ -80,7 +80,11 @@ describe("Identity provider test", () => {
         { testName: "Gitlab", displayName: "Gitlab", alias: "gitlab" },
         { testName: "Google", displayName: "Google", alias: "google" },
         { testName: "Instagram", displayName: "Instagram", alias: "instagram" },
-        { testName: "Linkedin", displayName: "LinkedIn", alias: "linkedin" },
+        {
+          testName: "LinkedIn OpenID Connect",
+          displayName: "LinkedIn OpenID Connect",
+          alias: "linkedin-openid-connect",
+        },
         { testName: "Microsoft", displayName: "Microsoft", alias: "microsoft" },
         {
           testName: "Openshift-v3",
@@ -177,8 +181,8 @@ describe("Identity provider test", () => {
     it("create and delete provider by item details", () => {
       createProviderPage
         .clickCreateDropdown()
-        .clickItem("linkedin")
-        .fill("linkedin", "123")
+        .clickItem("linkedin-openid-connect")
+        .fill("linkedin-openid-connect", "123")
         .clickAdd();
       masthead.checkNotificationMessage(createSuccessMsg, true);
 


### PR DESCRIPTION
Removes the deprecated `linkedin-oauth` profile, and modifies the E2E tests so they can pass with the new LinkedIn provider.