### PR TITLE
Fix syntax error and make minifying the theme possible

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
@@ -160,7 +160,7 @@
                 `@page { size: auto;  margin-top: 0; }
                 body { width: 480px; }
                 div { list-style-type: none; font-family: monospace }
-                p:first-of-type { margin-top: 48px }`
+                p:first-of-type { margin-top: 48px }`;
 
             return printFileContent =
                 "<html><style>" + styles + "</style><body>" +


### PR DESCRIPTION
When minifying a theme which is based on the base theme, the missing semicolon leads to an js syntax error
(renders the backup recovery codes printing, downloading, ... unusable)