### PR TITLE
Add caret to regex expressions in federation-sssd-setup.sh to avoid comments

### DIFF
--- a/.github/scripts/run-ipa-tests.sh
+++ b/.github/scripts/run-ipa-tests.sh
@@ -2,22 +2,8 @@
 
 set -o pipefail
 
-echo "Modifying /etc/sssd/sssd.conf file"
-if ! grep -q ^ldap_user_extra_attrs /etc/sssd/sssd.conf; then
-  sed -i '/ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' /etc/sssd/sssd.conf
-fi
-if ! grep -q ^user_attributes /etc/sssd/sssd.conf; then
-  sed -i '/allowed_uids/a user_attributes = +mail, +telephoneNumber, +givenname, +sn' /etc/sssd/sssd.conf
-fi
-
-systemctl restart sssd
-sss_cache -E
-
-echo "Creating /etc/pam.d/keycloak file for PAM"
-cat >/etc/pam.d/keycloak <<EOF
-auth    required   pam_sss.so
-account required   pam_sss.so
-EOF
+echo "Executing federation-sssd-setup.sh to prepare SSSD and PAM"
+quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
 
 if [[ "true" == "$1" ]]; then
   echo "Adding users and groups for the test"

--- a/quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
+++ b/quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
@@ -7,19 +7,19 @@ if [ -f "$SSSD_FILE" ];
 then
 
   if ! grep -q ^ldap_user_extra_attrs $SSSD_FILE; then
-    sed -i '/ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' $SSSD_FILE
+    sed -i '/^ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' $SSSD_FILE
   fi
 
-  if ! grep -q ^services.*ifp.* /etc/sssd/sssd.conf; then
+  if ! grep -q ^services.*ifp.* $SSSD_FILE; then
     sed -i '/^services/ s/$/, ifp/' $SSSD_FILE
   fi
 
   if ! grep -q ^allowed_uids $SSSD_FILE; then
-    sed -i '/\[ifp\]/a allowed_uids = root' $SSSD_FILE
+    sed -i '/^\[ifp\]/a allowed_uids = root' $SSSD_FILE
   fi
 
   if ! grep -q ^user_attributes $SSSD_FILE; then
-    sed -i '/allowed_uids/a user_attributes = +mail, +telephoneNumber, +givenname, +sn' $SSSD_FILE
+    sed -i '/^allowed_uids/a user_attributes = +mail, +telephoneNumber, +givenname, +sn' $SSSD_FILE
   fi
 
   systemctl restart sssd


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/23128

Just adding the ^ to regex to avoid comments. I have added the execution of the script to the SSSD testing to (at least) perform a little execution of it inside our TS.