### PR TITLE
Windows Command  - need to use the backward Slash

### DIFF
--- a/docs/guides/getting-started/templates/start-keycloak-localhost.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-localhost.adoc
@@ -13,5 +13,5 @@ bin/kc.sh start-dev
 +
 [source,bash,subs="attributes+"]
 ----
-bin/kc.bat start-dev
+bin\kc.bat start-dev
 ----


### PR DESCRIPTION
(cherry picked from commit efe1adc0b12d7ce053a46e2279d67a007e5ac753)

Backport of #23196

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
