### PR TITLE
Ensure that the EncryptedKey is passed to the DecryptionKeyLocator for SAML

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
@@ -49,6 +49,11 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
     name: "config.wantAuthnRequestsSigned",
   });
 
+  const wantAssertionsEncrypted = useWatch({
+    control,
+    name: "config.wantAssertionsEncrypted",
+  });
+
   const validateSignature = useWatch({
     control,
     name: "config.validateSignature",
@@ -377,41 +382,6 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
             ></Controller>
           </FormGroup>
           <FormGroup
-            label={t("encryptionAlgorithm")}
-            labelIcon={
-              <HelpItem
-                helpText={t("encryptionAlgorithmHelp")}
-                fieldLabelId="identity-provider:encryptionAlgorithm"
-              />
-            }
-            fieldId="kc-encryptionAlgorithm"
-          >
-            <Controller
-              name="config.encryptionAlgorithm"
-              defaultValue="RSA-OAEP"
-              control={control}
-              render={({ field }) => (
-                <Select
-                  toggleId="kc-encryptionAlgorithm"
-                  onToggle={(isExpanded) =>
-                    setEncryptionAlgorithmDropdownOpen(isExpanded)
-                  }
-                  isOpen={encryptionAlgorithmDropdownOpen}
-                  onSelect={(_, value) => {
-                    field.onChange(value.toString());
-                    setEncryptionAlgorithmDropdownOpen(false);
-                  }}
-                  selections={field.value}
-                  variant={SelectVariant.single}
-                  isDisabled={readOnly}
-                >
-                  <SelectOption value="RSA-OAEP" />
-                  <SelectOption value="RSA1_5" />
-                </Select>
-              )}
-            ></Controller>
-          </FormGroup>
-          <FormGroup
             label={t("samlSignatureKeyName")}
             labelIcon={
               <HelpItem
@@ -461,6 +431,45 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         label="wantAssertionsEncrypted"
         isReadOnly={readOnly}
       />
+
+      {wantAssertionsEncrypted === "true" && (
+        <FormGroup
+          label={t("encryptionAlgorithm")}
+          labelIcon={
+            <HelpItem
+              helpText={t("encryptionAlgorithmHelp")}
+              fieldLabelId="encryptionAlgorithm"
+            />
+          }
+          fieldId="kc-encryptionAlgorithm"
+        >
+          <Controller
+            name="config.encryptionAlgorithm"
+            defaultValue="RSA-OAEP"
+            control={control}
+            render={({ field }) => (
+              <Select
+                toggleId="kc-encryptionAlgorithm"
+                onToggle={(isExpanded) =>
+                  setEncryptionAlgorithmDropdownOpen(isExpanded)
+                }
+                isOpen={encryptionAlgorithmDropdownOpen}
+                onSelect={(_, value) => {
+                  field.onChange(value.toString());
+                  setEncryptionAlgorithmDropdownOpen(false);
+                }}
+                selections={field.value}
+                variant={SelectVariant.single}
+                isDisabled={readOnly}
+              >
+                <SelectOption value="RSA-OAEP" />
+                <SelectOption value="RSA1_5" />
+              </Select>
+            )}
+          ></Controller>
+        </FormGroup>
+      )}
+
       <SwitchField
         field="config.forceAuthn"
         label="forceAuthentication"

--- a/services/src/main/java/org/keycloak/protocol/saml/SAMLDecryptionKeysLocator.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SAMLDecryptionKeysLocator.java
@@ -153,6 +153,7 @@ public class SAMLDecryptionKeysLocator implements XMLEncryptionUtil.DecryptionKe
         // Map keys to PrivateKey
         return keysStream
                 .map(KeyWrapper::getPrivateKey)
+                .filter(Objects::nonNull)
                 .map(Key::getEncoded)
                 .map(encoded -> {
                     try {


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/22974

Two little issues in SAML decryption of elements:

* The `EncyptedKey` sometimes is outside the `EncryptedData` (next sibling). And it was not passed to the `SAMLDecryptionKeysLocator`. So the locator couldn't filter by the encryption alg set in the response. This threw a NPE iterating the keys. Code also changed to not decode the `EncyptedKey` twice (if it was already inside the data) and to avoid keys without private key.
* Besides the admin console is showing/hiding the encryption algorithm property if the `wantAuthnRequestsSigned` is ON. That makes no sense, the encryption alg is only used to force the alg in decrypting the received elements, not when we sign the requests. I have moved it to show/hide when `wantAssertionsEncrypted` is ON. (I think that there is no lint or test errors, but I'm never sure. :smile: )

The combination of the two problems threw the NPE in the related issue. The alg was not forced (because the box was hidden and the user didn't see how to force it) and then the `EncryptedKey` was outside the `EncrypedData` in okta. Test added to modify the XML and be similar to the one produced by okta.
