### PR TITLE
Keystore location does not work for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,10 @@ jobs:
     name: Quarkus UT
     needs: build
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
@@ -6,7 +6,6 @@ import org.keycloak.config.ConfigKeystoreOptions;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
@@ -50,11 +49,12 @@ final class ConfigKeystorePropertyMappers {
             throw new IllegalArgumentException("config-keystore-password must be specified");
         }
 
-        Optional<String> realPath = Optional.of(String.valueOf(Paths.get(path.getValue()).toAbsolutePath().normalize()));
-        if (!Files.exists(Path.of(realPath.get()))) {
-            throw new IllegalArgumentException("config-keystore path does not exist: " + realPath.get());
+        final Path realPath = Path.of(path.getValue()).toAbsolutePath().normalize();
+        if (!Files.exists(realPath)) {
+            throw new IllegalArgumentException("config-keystore path does not exist: " + realPath);
         }
-        return realPath;
+
+        return Optional.of(realPath.toUri().toString());
     }
 
     private static Optional<String> validatePassword(Optional<String> option, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -20,10 +20,11 @@ package org.keycloak.quarkus.runtime.configuration.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.keycloak.quarkus.runtime.Environment.isWindows;
 import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.CLI_ARGS;
 
-import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -266,7 +267,14 @@ public class ConfigurationTest {
         System.setProperty(CLI_ARGS, "--db=dev-file");
         SmallRyeConfig config = createConfig();
         assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
-        assertEquals("jdbc:h2:file:" + System.getProperty("user.home") + "/data/h2/keycloakdb;;AUTO_SERVER=TRUE;NON_KEYWORDS=VALUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+
+        // JDBC location treated as file:// URI
+        final String userHomeUri = Path.of(System.getProperty("user.home"))
+                .toUri()
+                .toString()
+                .replaceFirst(isWindows() ? "file:///" : "file://", "");
+
+        assertEquals("jdbc:h2:file:" + userHomeUri + "data/h2/keycloakdb;;AUTO_SERVER=TRUE;NON_KEYWORDS=VALUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty(CLI_ARGS, "--db=dev-mem");
         config = createConfig();


### PR DESCRIPTION
Fixes #22185
Closes #23208

Both commits are included in one PR as they would block each other.

- Quarkus UT for Windows does not work due to the Keystore location bug.
- We don't have any other option how to test the fix for the bug without running Quarkus UT on Windows. 

I've reproduced the issue on a Win machine and the fix resolves the issue. 

