### PR TITLE
Deploy JavaScript adapter to Maven repository

### DIFF
--- a/js/libs/keycloak-js/assembly.xml
+++ b/js/libs/keycloak-js/assembly.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/target</directory>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>keycloak-*.tgz</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/js/libs/keycloak-js/pom.xml
+++ b/js/libs/keycloak-js/pom.xml
@@ -21,7 +21,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>false</skip>
                 </configuration>
             </plugin>
             <plugin>
@@ -70,6 +70,50 @@
                 <configuration>
                     <installDirectory>../..</installDirectory>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>ca.szc.maven</groupId>
+                <artifactId>jsonpath-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>update-version</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>modify</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/package.json</file>
+                            <modifications>
+                                <modification>
+                                    <expression>$.version</expression>
+                                    <value>${project.version}</value>
+                                </modification>
+                            </modifications>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>${project.basedir}/assembly.xml
+                                    <file>target/keycloak-js-${project.version}.tgz</file>
+                                    <type>tar.gz</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This commit adds keycloak-js-adapter.tar.gz to the list of artifacts uploaded to Maven repository

Closes #23312