### PR TITLE
Link to AdminGuide from REST-API Doc

### DIFF
--- a/docs/documentation/server_development/topics/admin-rest-api.adoc
+++ b/docs/documentation/server_development/topics/admin-rest-api.adoc
@@ -2,7 +2,7 @@
 
 {project_name} comes with a fully functional Admin REST API with all features provided by the Admin Console.
 
-To invoke the API you need to obtain an access token with the appropriate permissions. The required permissions are described in the Server Administration Guide.
+To invoke the API you need to obtain an access token with the appropriate permissions. The required permissions are described in the link:{adminguide_link}[{adminguide_name}].
 
 You can obtain a token by enabling authentication for your application using {project_name}; see the Securing Applications and Services Guide. You can also use direct access grant to obtain an access token.
 


### PR DESCRIPTION
It is more practical for a user to click the link, instead of opening the overview-Page and searching for the appropriate link.

Therefore I added a link from the REST-API Doc to the Admin Guide instead of just referencing it in the text.

(Note: I haven't opened an Issue because this is a very small improvement that wouldn't be worth the time writing a proper issue. I hope that this is okay for you.)