### PR TITLE
Use email verification instead of executing action for `send-verify-email` endpoint

### DIFF
--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserResource.java
@@ -269,6 +269,30 @@ public interface UserResource {
     @Path("send-verify-email")
     void sendVerifyEmail(@QueryParam("client_id") String clientId);
 
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("client_id") String clientId, @QueryParam("redirect_uri") String redirectUri);
+
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("lifespan") Integer lifespan);
+
+    /**
+     * Send an email-verification email to the user
+     *
+     * An email contains a link the user can click to verify their email address.
+     * The redirectUri and clientId parameters are optional. The default for the
+     * redirect is the account client. The default for the lifespan is 12 hours.
+     *
+     * @param redirectUri Redirect uri
+     * @param clientId Client id
+     * @param lifespan Number of seconds after which the generated token expires
+     * @return
+     */
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("client_id") String clientId, @QueryParam("redirect_uri") String redirectUri, @QueryParam("lifespan") Integer lifespan);
+
     @GET
     @Path("sessions")
     List<UserSessionRepresentation> getUserSessions();

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/verifyemail/VerifyEmailActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/verifyemail/VerifyEmailActionToken.java
@@ -29,6 +29,7 @@ public class VerifyEmailActionToken extends DefaultActionToken {
     public static final String TOKEN_TYPE = "verify-email";
 
     private static final String JSON_FIELD_ORIGINAL_AUTHENTICATION_SESSION_ID = "oasid";
+    private static final String JSON_FIELD_REDIRECT_URI = "reduri";
 
     @JsonProperty(value = JSON_FIELD_ORIGINAL_AUTHENTICATION_SESSION_ID)
     private String originalAuthenticationSessionId;
@@ -48,5 +49,19 @@ public class VerifyEmailActionToken extends DefaultActionToken {
 
     public void setCompoundOriginalAuthenticationSessionId(String originalAuthenticationSessionId) {
         this.originalAuthenticationSessionId = originalAuthenticationSessionId;
+    }
+
+    @JsonProperty(value = JSON_FIELD_REDIRECT_URI)
+    public String getRedirectUri() {
+        return (String) getOtherClaims().get(JSON_FIELD_REDIRECT_URI);
+    }
+
+    @JsonProperty(value = JSON_FIELD_REDIRECT_URI)
+    public final void setRedirectUri(String redirectUri) {
+        if (redirectUri == null) {
+            getOtherClaims().remove(JSON_FIELD_REDIRECT_URI);
+        } else {
+            setOtherClaims(JSON_FIELD_REDIRECT_URI, redirectUri);
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/verifyemail/VerifyEmailActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/verifyemail/VerifyEmailActionTokenHandler.java
@@ -26,6 +26,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserModel.RequiredAction;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.services.Urls;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
@@ -106,6 +108,13 @@ public class VerifyEmailActionTokenHandler extends AbstractActionTokenHandler<Ve
         user.setEmailVerified(true);
         user.removeRequiredAction(RequiredAction.VERIFY_EMAIL);
         authSession.removeRequiredAction(RequiredAction.VERIFY_EMAIL);
+
+        String redirectUri = RedirectUtils.verifyRedirectUri(tokenContext.getSession(), token.getRedirectUri(), authSession.getClient());
+        if (redirectUri != null) {
+            authSession.setAuthNote(AuthenticationManager.SET_REDIRECT_URI_AFTER_REQUIRED_ACTIONS, "true");
+            authSession.setRedirectUri(redirectUri);
+            authSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, redirectUri);
+        }
 
         event.success();
 


### PR DESCRIPTION
Closes #15190

Add support for `send-verify-email` endpoint to use the `email-verification.ftl` instead of `executeActions.ftl`

Also introduce a new parameter `lifespan` to be able to override the default lifespan value (12 hours)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
