### PR TITLE
Prevent NPE in AuthenticationManager.backchannelLogout (#23306)

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -288,7 +288,8 @@ public class AuthenticationManager {
 
         if (logger.isDebugEnabled()) {
             UserModel user = userSession.getUser();
-            logger.debugv("Logging out: {0} ({1}) offline: {2}", user.getUsername(), userSession.getId(),
+            String username = user == null ? null : user.getUsername();
+            logger.debugv("Logging out: {0} ({1}) offline: {2}", username, userSession.getId(),
                     userSession.isOffline());
         }
 


### PR DESCRIPTION
Previously, if the user was already removed from the userSession and the log level was set to DEBUG, then an NPE was triggered by the debug log statement during backchannelLogout.

Fixes #23306

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
