### PR TITLE
Support for 'id_token_hint'

### DIFF
--- a/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
+++ b/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
@@ -269,7 +269,7 @@ public class KeycloakInstalled {
         // pass the id_token_hint so that sessions is invalidated for this particular session
         String logoutUrl = deployment.getLogoutUrl().clone()
                 .queryParam(OAuth2Constants.POST_LOGOUT_REDIRECT_URI, redirectUri)
-                .queryParam("id_token_hint", idTokenString)
+                .queryParam(OAuth2Constants.ID_TOKEN_HINT, idTokenString)
                 .build().toString();
 
         desktopProvider.browse(new URI(logoutUrl));

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -181,7 +181,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             String sessionId = userSession.getId();
             UriBuilder logoutUri = UriBuilder.fromUri(getConfig().getLogoutUrl())
                     .queryParam("state", sessionId);
-            if (idToken != null) logoutUri.queryParam("id_token_hint", idToken);
+            if (idToken != null) logoutUri.queryParam(OAuth2Constants.ID_TOKEN_HINT, idToken);
             String redirect = RealmsResource.brokerUrl(uriInfo)
                     .path(IdentityBrokerService.class, "getEndpoint")
                     .path(OIDCEndpoint.class, "logoutResponse")

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -96,7 +96,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
     public static final String UI_LOCALES_PARAM = OAuth2Constants.UI_LOCALES_PARAM;
     public static final String CLAIMS_PARAM = "claims";
     public static final String ACR_PARAM = "acr_values";
-    public static final String ID_TOKEN_HINT = "id_token_hint";
+    public static final String ID_TOKEN_HINT = OAuth2Constants.ID_TOKEN_HINT;
 
     public static final String LOGOUT_STATE_PARAM = "OIDC_LOGOUT_STATE_PARAM";
     public static final String LOGOUT_REDIRECT_URI = "OIDC_LOGOUT_REDIRECT_URI";

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -395,6 +395,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         paramAction.accept(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM, request.getCodeChallengeMethod());
         paramAction.accept(OIDCLoginProtocol.CODE_CHALLENGE_PARAM, request.getCodeChallenge());
         paramAction.accept(OIDCLoginProtocol.LOGIN_HINT_PARAM, request.getLoginHint());
+        paramAction.accept(OIDCLoginProtocol.ID_TOKEN_HINT, request.getIdTokenHint());
         paramAction.accept(OIDCLoginProtocol.NONCE_PARAM, request.getNonce());
         paramAction.accept(OIDCLoginProtocol.PROMPT_PARAM, request.getPrompt());
         paramAction.accept(OIDCLoginProtocol.RESPONSE_MODE_PARAM, request.getResponseMode());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
@@ -36,6 +36,7 @@ public class AuthorizationEndpointRequest {
     String state;
     String scope;
     String loginHint;
+    String idTokenHint;
     String display;
     String prompt;
     String nonce;
@@ -84,6 +85,10 @@ public class AuthorizationEndpointRequest {
 
     public String getLoginHint() {
         return loginHint;
+    }
+
+    public String getIdTokenHint() {
+        return idTokenHint;
     }
 
     public String getPrompt() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
@@ -59,6 +59,7 @@ public abstract class AuthzEndpointRequestParser {
         KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.STATE_PARAM);
         KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.SCOPE_PARAM);
         KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.LOGIN_HINT_PARAM);
+        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.ID_TOKEN_HINT);
         KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.PROMPT_PARAM);
         KNOWN_REQ_PARAMS.add(AdapterConstants.KC_IDP_HINT);
         KNOWN_REQ_PARAMS.add(Constants.KC_ACTION);
@@ -95,6 +96,7 @@ public abstract class AuthzEndpointRequestParser {
         request.state = replaceIfNotNull(request.state, getParameter(OIDCLoginProtocol.STATE_PARAM));
         request.scope = replaceIfNotNull(request.scope, getParameter(OIDCLoginProtocol.SCOPE_PARAM));
         request.loginHint = replaceIfNotNull(request.loginHint, getParameter(OIDCLoginProtocol.LOGIN_HINT_PARAM));
+        request.idTokenHint = replaceIfNotNull(request.idTokenHint, getParameter(OIDCLoginProtocol.ID_TOKEN_HINT));
         request.prompt = replaceIfNotNull(request.prompt, getParameter(OIDCLoginProtocol.PROMPT_PARAM));
         request.idpHint = replaceIfNotNull(request.idpHint, getParameter(AdapterConstants.KC_IDP_HINT));
         request.action = replaceIfNotNull(request.action, getParameter(Constants.KC_ACTION));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
@@ -607,7 +607,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
 
                 // test logout
                 response = childLogoutWebTarget(httpClient)
-                        .queryParam("id_token_hint", idToken)
+                        .queryParam(OAuth2Constants.ID_TOKEN_HINT, idToken)
                         .request()
                         .get();
                 response.close();
@@ -648,7 +648,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
 
                 // test logout
                 response = childLogoutWebTarget(httpClient)
-                        .queryParam("id_token_hint", idToken)
+                        .queryParam(OAuth2Constants.ID_TOKEN_HINT, idToken)
                         .request()
                         .get();
                 response.close();
@@ -688,7 +688,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
 
                 // test logout
                 response = childLogoutWebTarget(httpClient)
-                        .queryParam("id_token_hint", idToken)
+                        .queryParam(OAuth2Constants.ID_TOKEN_HINT, idToken)
                         .request()
                         .get();
                 response.close();
@@ -884,7 +884,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
 
                     // test logout
                     response = childLogoutWebTarget(httpClient)
-                            .queryParam("id_token_hint", idToken)
+                            .queryParam(OAuth2Constants.ID_TOKEN_HINT, idToken)
                             .request()
                             .get();
                     response.close();


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This change includes a support for 'id_token_id' optional param to avoid situation when it is being trimmed to max length defined for unknown params. 

**Work in progress**:  integration test and better verification still needed.

Closes #19355 

