### PR TITLE
Ignoring link for stackapps registration

### DIFF
--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -42,3 +42,4 @@ https://github.com/keycloak/keycloak/blob/main/docs/tests.md#kerberos-server
 https://github.com/apache/felix-dev/tree/master/http#using-the-osgi-http-whiteboard
 https://github.com/keycloak/keycloak/blob/025778fe9c745316f80b53fe3052aeb314e868ef/js/apps/admin-ui/public/locales/en/dashboard.json#L3
 https://github.com/keycloak/keycloak/issues/new?*
+https://stackapps.com/apps/oauth/register


### PR DESCRIPTION
It now requires authentication.

Closes #23345

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
