### PR TITLE
Remove old RESTEasy Classic configuration property

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -22,11 +22,6 @@ quarkus.datasource.metrics.enabled=${quarkus.micrometer.enabled}
 # Default transaction timeout
 quarkus.transaction-manager.default-transaction-timeout=300
 
-# The JAX-RS application is programmatically registered at build time.
-# When indexing classes, both KeycloakApplication and QuarkusKeycloakApplication are indexed and multuple
-# application classes are no longer supported by resteasy extension
-quarkus.resteasy.ignore-application-classes=true
-
 # Ignore split packages for Keycloak related packages
 quarkus.arc.ignored-split-packages=org.keycloak.*
 


### PR DESCRIPTION
Closes #23358

The warning is not present anymore. 

@vmuzikar or @pedroigor Could you take a look at this small change? Thanks