### PR TITLE
Use version range for CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2.21.6
+        uses: github/codeql-action/init@v2
         with:
           languages: java
 
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/build-keycloak
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2.21.6
+        uses: github/codeql-action/analyze@v2
         with:
           wait-for-processing: true
         env:
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2.21.6
+        uses: github/codeql-action/init@v2
         env:
           CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"finalize":["--no-run-unnecessary-builds"]}}'
         with:
@@ -80,7 +80,7 @@ jobs:
           source-root: themes/src/main/
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2.21.6
+        uses: github/codeql-action/analyze@v2
         with:
           wait-for-processing: true
         env:

--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -27,7 +27,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Quarkus scanner results to GitHub
-        uses: github/codeql-action/upload-sarif@v2.21.6
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: quarkus-report.sarif
           category: snyk-quarkus-report
@@ -41,7 +41,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Operator scanner results to GitHub
-        uses: github/codeql-action/upload-sarif@v2.21.6
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: operator-report.sarif
           category: snyk-operator-report

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -31,6 +31,6 @@ jobs:
           timeout: 15m
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2.21.6
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
Replaces the fixed version for the CodeQL GitHub Action with a ranged version. This mitigates the need to constantly update this version, as it will simply use the latest in the v2 range.