### PR TITLE
Align wildfly-core and wildfly version for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,9 @@
 
         <project.build-time>${timestamp}</project.build-time>
 
+        <!-- core version for app-server-wildfly/eap tests, should match wildfly/eap server -->
+        <tests.wildfly.core.version>19.0.1.Final</tests.wildfly.core.version>
+
         <!-- Upstream WildFly Versions -->
         <upstream.wildfly.version>29.0.0.Final</upstream.wildfly.version>
         <upstream.wildfly.build-tools.version>1.2.13.Final</upstream.wildfly.build-tools.version>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -527,6 +527,7 @@
             <properties>
                 <app.server>wildfly</app.server> <!--in case the profile is called directly-->
                 <app.server.skip.unpack>false</app.server.skip.unpack>
+                <wildfly.core.version>${tests.wildfly.core.version}</wildfly.core.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -563,6 +564,7 @@
             <properties>
                 <app.server>eap</app.server> <!--in case the profile is called directly-->
                 <app.server.skip.unpack>false</app.server.skip.unpack>
+                <wildfly.core.version>${tests.wildfly.core.version}</wildfly.core.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
Setting wildfly-core aligned with the version of wildfly tested. The recent upgrade of version to 21 broke the app-server-wildfly adapter tests. Going back to 19 for the tests.

Closes https://github.com/keycloak/keycloak/issues/23342
