### PR TITLE
Testing Keycloak with nightly Quarkus releases

### DIFF
--- a/.github/scripts/prepare-quarkus-next.sh
+++ b/.github/scripts/prepare-quarkus-next.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -xeuo pipefail
+
+git checkout -b new-quarkus-next origin/main
+
+if ! grep -q '<repositories>' pom.xml; then
+  sed -i '/<\/project>/i \
+          <repositories> \
+          </repositories>' pom.xml
+fi
+
+# Insert the <repository> element before the closing </repositories> tag
+sed -i '/<\/repositories>/i \
+        <repository> \
+        <id>sonatype-snapshots</id> \
+        <name>Sonatype Snapshots</name> \
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url> \
+        <snapshots> \
+            <enabled>true</enabled> \
+            <updatePolicy>daily</updatePolicy> \
+        </snapshots> \
+        <releases> \
+            <enabled>false</enabled> \
+        </releases> \
+        </repository>' pom.xml
+
+./mvnw -B versions:set-property -Dproperty=quarkus.version -DnewVersion=999-SNAPSHOT
+./mvnw -B versions:set-property -Dproperty=quarkus.build.version -DnewVersion=999-SNAPSHOT
+git commit -am "Set quarkus version to 999-SNAPSHOT"
+
+snapshot_version_hash=$(git log origin/quarkus-next --grep="Set quarkus version to 999-SNAPSHOT" --format="%H" -n 1)
+commits_to_cherry_pick=$(git rev-list --right-only --no-merges --reverse new-quarkus-next...origin/quarkus-next | grep -vE "$snapshot_version_hash" || echo "")
+
+if [ -z "$commits_to_cherry_pick" ]; then
+  echo "Nothing to cherry-pick."
+else
+  for commit in $commits_to_cherry_pick
+  do
+    if git cherry-pick "$commit"; then
+      echo "Successfully cherry-picked $commit"
+    else
+      echo "Failed to cherry-pick $commit"
+      exit 1
+    fi
+  done
+fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - quarkus-next
   pull_request:
      branches: [main]
   workflow_dispatch:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - quarkus-next
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/guides.yml
+++ b/.github/workflows/guides.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - quarkus-next
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - quarkus-next
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/quarkus-next.yml
+++ b/.github/workflows/quarkus-next.yml
@@ -1,0 +1,58 @@
+name: Quarkus Next
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  # Only cancel jobs for PR updates
+  group: quarkus-next-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-quarkus-next-branch:
+    name: Update quarkus-next branch
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Cherry-pick additional commits in quarkus-next
+        run: |
+          ${GITHUB_WORKSPACE}/.github/scripts/prepare-quarkus-next.sh
+
+      - name: Push changes
+        run: |
+          git push -f origin HEAD:quarkus-next
+
+  run-matrix-with-quarkus-next:
+    name: Run workflow matrix with the quarkus-next branch
+    runs-on: ubuntu-latest
+    needs:
+      - update-quarkus-next-branch
+
+    strategy:
+      matrix:
+        workflow:
+          - ci.yml
+          - operator-ci.yml
+
+    steps:
+      - name: Run workflow with the nightly Quarkus release
+        run: gh workflow run -R ${{ github.repository }} ${{ matrix.workflow }} -r quarkus-next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
@@ -23,8 +23,6 @@
         <spring-boot-adapter-jetty>false</spring-boot-adapter-jetty>
         <spring.boot.tomcat.adapter.artifactId>keycloak-tomcat-adapter</spring.boot.tomcat.adapter.artifactId>
 
-        <jetty.version/>
-
         <app.server.debug.port>5006</app.server.debug.port>
         <app.server.debug.suspend>n</app.server.debug.suspend>
     </properties>


### PR DESCRIPTION
* added a new job to our schedule-nightly workflow
* added a new step to the build action that handles the repo preparation

Closes #23322

This is the PoC described in the #22750. The primary requirement to not introduce any new workflow, but rather extend some of the existing ones, is met.
 Last week I discussed with @vmuzikar whether it's necessary to introduce a separate branch. This hasn't been finally decided yet. It depends on how many issues will appear in the future that are somehow unique (which means that we won't be able to fix them in the upstream/main directly).

For now, I come up with the solution that doesn't require a separate branch and the poms are adjusted on the fly.

Compared to the Quarkus LTS version in the upstream main there are already changes that cause the build step to fail (I reproduced the same compilation error even locally with quarkus-platform-bom version 3.3.0 and above)[1].
One of the possible improvements in the next iteration would be to come up with some form of a report for such case (shortened error message + artifacts version diff (SNAPSHOT vs. LTS and regular paced release). We could enhance keycloak-github-bot for this purpose.

The next improvement could be to introduce `quarkus.version` input type for the schedule-nigthly (manual) workflow[2]. I already used the same mechanism to pass a parameter among workflows from the nightly matrix:
![image](https://github.com/keycloak/keycloak/assets/12138171/39c4df47-6a79-441f-a99b-3a536eff9b77)
Possibility to also specify a quarkus version can be nice to have improvement.

Let me know what do you think about the approach and possible enhancements. Feedback is very welcomed, as always 😉.

[1]  https://github.com/Pepo48/keycloak/actions/runs/6254570950/job/16982387289#step:3:1247
[2] https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/