### PR TITLE
ExternalLinksTest fails for StackApps link

### DIFF
--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -36,6 +36,7 @@ https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-
 https://issues.redhat.com/secure/CreateIssueDetails*
 https://developer.paypal.com/developer/applications
 https://account.live.com/developers/applications/create
+https://stackapps.com/apps/oauth/register
 https://developer.twitter.com/apps/
 https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update
 https://github.com/keycloak/keycloak/blob/main/docs/tests.md#kerberos-server


### PR DESCRIPTION
Fixes #23386

We could edit the `LinkUtils` class to determine whether the response code is 403 with the new `ignored-link-forbidden`, but I think we'd create unnecessary logic in addition. 

The links for other providers are also included in the file.