### PR TITLE
Add ability to deploy js adapter to maven repository.

### DIFF
--- a/get-version.sh
+++ b/get-version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-mvn help:evaluate -Dexpression=project.version -q -DforceStdout -pl .
+mvn help:evaluate -Dexpression=project.version -DforceStdout --quiet --non-recursive -pl .

--- a/js/libs/keycloak-js/pom.xml
+++ b/js/libs/keycloak-js/pom.xml
@@ -73,4 +73,63 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>deploy-js-to-maven-repo</id>
+            <activation>
+                <property>
+                    <name>deploy-js-to-maven-repo</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>get-npm-package-version</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <exportAntProperties>true</exportAntProperties>
+                                    <target>
+                                        <exec executable="jq">
+                                            <arg line="--raw-output '.version' package.json"/>
+                                            <redirector outputProperty="nodejs.package.version"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-keycloak-js-adapter-to-maven-repo</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>deploy-file</goal>
+                                </goals>
+                                <configuration>
+                                    <generatePom>true</generatePom>
+                                    <artifactId>keycloak-js-adapter</artifactId>
+                                    <groupId>${project.groupId}</groupId>
+                                    <version>${project.version}</version>
+                                    <packaging>tgz</packaging>
+                                    <file>target/keycloak-js-${nodejs.package.version}.tgz</file>
+                                    <url>${maven.deploy.url}</url>
+                                    <repositoryId>${maven.repository.id}</repositoryId>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,24 +1,32 @@
 #!/bin/bash -e
 
 NEW_VERSION=$1
+NEW_NPM_VERSION=${2:-${1}}
 
-# Maven
-mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
+if [ $NEW_VERSION == 'use_current' ] ; then
+  # obtain NEW_VERSION from maven pom file
+  # - useful for downstream projects which already set the version in pom files
+  NEW_VERSION=$(./get-version.sh)
+  NEW_NPM_VERSION=$(echo $NEW_VERSION | awk -F '.' '{ print $1"."$2"."$3"-"$4 }')
+else
+  # Maven
+  mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
+fi
 
 # Docker
 sed -i "s/ENV KEYCLOAK_VERSION .*/ENV KEYCLOAK_VERSION $NEW_VERSION/" quarkus/container/Dockerfile
 
 # Documentation
 cd docs/documentation
-SHORT_VERSION=`echo $NEW_VERSION | awk -F '.' '{ print $1"."$2 }'`
+SHORT_VERSION=`echo $NEW_NPM_VERSION | awk -F '.' '{ print $1"."$2 }'`
 sed -i 's/:project_version: .*/:project_version: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 sed -i 's/:project_versionMvn: .*/:project_versionMvn: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
-sed -i 's/:project_versionNpm: .*/:project_versionNpm: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
+sed -i 's/:project_versionNpm: .*/:project_versionNpm: '$NEW_NPM_VERSION'/' topics/templates/document-attributes.adoc
 sed -i 's/:project_versionDoc: .*/:project_versionDoc: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 cd -
 
 # Keycloak JS
-echo "$(jq '. += {"version": "'$NEW_VERSION'"}' js/libs/keycloak-js/package.json)" > js/libs/keycloak-js/package.json
+echo "$(jq '. += {"version": "'$NEW_NPM_VERSION'"}' js/libs/keycloak-js/package.json)" > js/libs/keycloak-js/package.json
 
 # Keycloak Admin Client
-echo "$(jq '. += {"version": "'$NEW_VERSION'"}' js/libs/keycloak-admin-client/package.json)" > js/libs/keycloak-admin-client/package.json
+echo "$(jq '. += {"version": "'$NEW_NPM_VERSION'"}' js/libs/keycloak-admin-client/package.json)" > js/libs/keycloak-admin-client/package.json


### PR DESCRIPTION
Closes #23312

This change will allow any downstream build to deploy keycloak-js-adapter tgz archive to maven repository by setting following properties:
- deploy-js-to-maven-repo
- maven.deploy.url
- maven.repository.id

Change is set-version.sh script allows to use different version string for node package (as version string in maven and npm are not compatible).
