### PR TITLE
Remove `@types/flat` from dependencies

### DIFF
--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -95,7 +95,6 @@
     "@testing-library/react": "^14.0.0",
     "@types/dagre": "^0.7.49",
     "@types/file-saver": "^2.0.5",
-    "@types/flat": "^5.0.2",
     "@types/lodash-es": "^4.17.9",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       '@types/file-saver':
         specifier: ^2.0.5
         version: 2.0.5
-      '@types/flat':
-        specifier: ^5.0.2
-        version: 5.0.2
       '@types/lodash-es':
         specifier: ^4.17.9
         version: 4.17.9
@@ -1823,10 +1820,6 @@ packages:
 
   /@types/file-saver@2.0.5:
     resolution: {integrity: sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==}
-    dev: true
-
-  /@types/flat@5.0.2:
-    resolution: {integrity: sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==}
     dev: true
 
   /@types/geojson@7946.0.10:


### PR DESCRIPTION
Removes the types for `flat`, as these are now [included by default](https://github.com/hughsk/flat/releases/tag/v6.0.0).