### PR TITLE
Add 'consent' prompt option to KeycloakLoginOptions

### DIFF
--- a/js/libs/keycloak-js/dist/keycloak.d.ts
+++ b/js/libs/keycloak-js/dist/keycloak.d.ts
@@ -220,9 +220,11 @@ export interface KeycloakLoginOptions {
 	 * Keycloak. To only authenticate to the application if the user is already
 	 * logged in and not display the login page if the user is not logged in, set
 	 * this option to `'none'`. To always require re-authentication and ignore
-	 * SSO, set this option to `'login'`.
+	 * SSO, set this option to `'login'`. To always prompt the user for consent,
+	 * set this option to `'consent'`. This ensures that consent is requested,
+	 * even if it has been given previously.
 	 */
-	prompt?: 'none'|'login';
+	prompt?: 'none' | 'login' | 'consent';
 
 	/**
 	 * If value is `'register'` then user is redirected to registration page,


### PR DESCRIPTION
This commit adds the 'consent' prompt option to KeycloakLoginOptions, allowing applications to always prompt the user for consent, even if it has been given previously. This provides greater control over user consent in the authentication flow.

Closes #23447

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
