### PR TITLE
Fix minor typo in "Configuring Keycloak" docs page

### DIFF
--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -9,7 +9,7 @@ summary="Understand how to configure and start Keycloak">
 This {section} explains the configuration methods for Keycloak and how to start and apply the preferred configuration. It includes configuration guidelines for optimizing Keycloak for faster startup and low memory footprint.
 
 == Configuring sources for Keycloak
-Keycloak loads the configuration from four sources, which are listed here in order of application. 
+Keycloak loads the configuration from five sources, which are listed here in order of application. 
 
 . Command-line parameters
 . Environment variables


### PR DESCRIPTION
Fix minor typo in "Configuring Keycloak" docs page

Closes #23460

(cherry picked from commit b031aba42905176222dfa36f080ab33fcbe15360)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
