### PR TITLE
adds the ability to set the default groups via kcadm

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
@@ -138,6 +138,7 @@ public class LegacyExportImportManager implements ExportImportManager {
         this.session = session;
     }
 
+    @Override
     public void exportRealm(RealmModel realm, ExportOptions options, ExportAdapter callback) {
         callback.setType(MediaType.APPLICATION_JSON);
         callback.writeToOutputStream(outputStream -> {
@@ -409,11 +410,7 @@ public class LegacyExportImportManager implements ExportImportManager {
         if (rep.getGroups() != null) {
             importGroups(newRealm, rep);
             if (rep.getDefaultGroups() != null) {
-                for (String path : rep.getDefaultGroups()) {
-                    GroupModel found = KeycloakModelUtils.findGroupByPath(session, newRealm, path);
-                    if (found == null) throw new RuntimeException("default group in realm rep doesn't exist: " + path);
-                    newRealm.addDefaultGroup(found);
-                }
+                KeycloakModelUtils.setDefaultGroups(session, newRealm, rep.getDefaultGroups().stream());
             }
         }
 
@@ -728,6 +725,9 @@ public class LegacyExportImportManager implements ExportImportManager {
             }
         }
 
+        if (rep.getDefaultGroups() != null) {
+            KeycloakModelUtils.setDefaultGroups(session, realm, rep.getDefaultGroups().stream());
+        }
         if (rep.getDisplayName() != null) realm.setDisplayName(rep.getDisplayName());
         if (rep.getDisplayNameHtml() != null) realm.setDisplayNameHtml(rep.getDisplayNameHtml());
         if (rep.isEnabled() != null) realm.setEnabled(rep.isEnabled());

--- a/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
+++ b/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
@@ -414,11 +414,7 @@ public class MapExportImportManager implements ExportImportManager {
         if (rep.getGroups() != null) {
             importGroups(newRealm, rep);
             if (rep.getDefaultGroups() != null) {
-                for (String path : rep.getDefaultGroups()) {
-                    GroupModel found = KeycloakModelUtils.findGroupByPath(session, newRealm, path);
-                    if (found == null) throw new RuntimeException("default group in realm rep doesn't exist: " + path);
-                    newRealm.addDefaultGroup(found);
-                }
+                KeycloakModelUtils.setDefaultGroups(session, newRealm, rep.getDefaultGroups().stream());
             }
         }
 
@@ -1018,6 +1014,9 @@ public class MapExportImportManager implements ExportImportManager {
             }
         }
 
+        if (rep.getDefaultGroups() != null) {
+            KeycloakModelUtils.setDefaultGroups(session, realm, rep.getDefaultGroups().stream());
+        }
         if (rep.getDisplayName() != null) realm.setDisplayName(rep.getDisplayName());
         if (rep.getDisplayNameHtml() != null) realm.setDisplayNameHtml(rep.getDisplayNameHtml());
         if (rep.isEnabled() != null) realm.setEnabled(rep.isEnabled());

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -1062,9 +1062,9 @@ public final class KeycloakModelUtils {
 
     /**
      * Returns <code>true</code> if given realm has attribute {@link Constants#REALM_ATTR_USERNAME_CASE_SENSITIVE}
-     * set and its value is <code>true</code>. Otherwise default value of it is returned. The default setting 
+     * set and its value is <code>true</code>. Otherwise default value of it is returned. The default setting
      * can be seen at {@link Constants#REALM_ATTR_USERNAME_CASE_SENSITIVE_DEFAULT}.
-     * 
+     *
      * @param realm
      * @return See the description
      * @throws NullPointerException if <code>realm</code> is <code>null</code>
@@ -1072,4 +1072,21 @@ public final class KeycloakModelUtils {
     public static boolean isUsernameCaseSensitive(RealmModel realm) {
         return realm.getAttribute(REALM_ATTR_USERNAME_CASE_SENSITIVE, REALM_ATTR_USERNAME_CASE_SENSITIVE_DEFAULT);
     }
+
+    /**
+     * Sets the default groups on the realm
+     * @param session
+     * @param realm
+     * @param groups
+     * @throws RuntimeException if a group does not exist
+     */
+    public static void setDefaultGroups(KeycloakSession session, RealmModel realm, Stream<String> groups) {
+        realm.getDefaultGroupsStream().collect(Collectors.toList()).forEach(realm::removeDefaultGroup);
+        groups.forEach(path -> {
+            GroupModel found = KeycloakModelUtils.findGroupByPath(session, realm, path);
+            if (found == null) throw new RuntimeException("default group in realm rep doesn't exist: " + path);
+            realm.addDefaultGroup(found);
+        });
+    }
+
 }


### PR DESCRIPTION
Closes #19125

@vmuzikar I see Mockito like logic in SessionExpirationUtilsTest and dummy RealmModel implementations in IdentityBrokerStateTestHelpers that could be used to test most of this down at the KeycloakModelUtilsTest level.  Alternatively / additionally, where are the tests of kcadm calls?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
