### PR TITLE
Change email checkserveridentity prop as angus mail sets it to true by default

### DIFF
--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -185,8 +185,6 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
     }
 
     private void setupTruststore(Properties props) {
-        boolean checkServerIdentity = true;
-
         JSSETruststoreConfigurator configurator = new JSSETruststoreConfigurator(session);
 
         SSLSocketFactory factory = configurator.getSSLSocketFactory();
@@ -194,12 +192,8 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
             props.put("mail.smtp.ssl.socketFactory", factory);
             if (configurator.getProvider().getPolicy() == HostnameVerificationPolicy.ANY) {
                 props.setProperty("mail.smtp.ssl.trust", "*");
-                checkServerIdentity = false;
+                props.put("mail.smtp.ssl.checkserveridentity", Boolean.FALSE.toString());
             }
-        }
-
-        if (checkServerIdentity) {
-            props.put("mail.smtp.ssl.checkserveridentity", "true");
         }
     }
 

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProvider.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProvider.java
@@ -34,7 +34,7 @@ public class FileTruststoreProvider implements TruststoreProvider {
     private final Map<X500Principal, X509Certificate> rootCertificates;
     private final Map<X500Principal, X509Certificate> intermediateCertificates;
 
-    FileTruststoreProvider(KeyStore truststore, HostnameVerificationPolicy policy, Map<X500Principal, X509Certificate> rootCertificates, Map<X500Principal, X509Certificate> intermediateCertificates) {
+    public FileTruststoreProvider(KeyStore truststore, HostnameVerificationPolicy policy, Map<X500Principal, X509Certificate> rootCertificates, Map<X500Principal, X509Certificate> intermediateCertificates) {
         this.policy = policy;
         this.truststore = truststore;
         this.rootCertificates = rootCertificates;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
@@ -25,6 +25,7 @@ import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.components.TestProvider;
 import org.keycloak.testsuite.rest.representation.AuthenticatorState;
+import org.keycloak.truststore.HostnameVerificationPolicy;
 import org.keycloak.utils.MediaType;
 
 import jakarta.ws.rs.Consumes;
@@ -406,6 +407,15 @@ public interface TestingResource {
     @Path("/disable-truststore-spi")
     @NoCache
     void disableTruststoreSpi();
+
+    /**
+     * Temporarily changes the trustore SPI with another hostname verification policy. Call reenableTruststoreSpi to revert.
+     * @param hostnamePolicy The hostname verification policy to set
+     */
+    @GET
+    @Path("/modify-truststore-spi-hostname-policy")
+    @NoCache
+    public void modifyTruststoreSpiHostnamePolicy(@QueryParam("hostnamePolicy") final HostnameVerificationPolicy hostnamePolicy);
 
     /**
      * Re-enable truststore SPI after it was temporarily disabled by {@link #disableTruststoreSpi()}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
@@ -164,4 +164,9 @@ public class RealmAttributeUpdater extends ServerResourceUpdater<RealmAttributeU
         rep.setOtpPolicyCodeReusable(isCodeReusable);
         return this;
     }
+
+    public RealmAttributeUpdater setSmtpServer(String name, String value) {
+        rep.getSmtpServer().put(name, value);
+        return this;
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TrustStoreEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TrustStoreEmailTest.java
@@ -20,6 +20,7 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
@@ -33,9 +34,12 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.auth.page.AuthRealm;
 import org.keycloak.testsuite.auth.page.login.OIDCLogin;
 import org.keycloak.testsuite.auth.page.login.VerifyEmail;
+import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.MailServerConfiguration;
+import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.SslMailServer;
+import org.keycloak.truststore.HostnameVerificationPolicy;
 
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.testsuite.util.MailAssert.assertEmailAndGetUrl;
@@ -81,10 +85,12 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
         SslMailServer.stop();
     }
 
-
     @Test
     public void verifyEmailWithSslEnabled() {
-        UserRepresentation user = ApiUtil.findUserByUsername(testRealm(), "test-user@localhost");
+        UserResource userResource = ApiUtil.findUserByUsernameId(testRealm(), "test-user@localhost");
+        UserRepresentation user = userResource.toRepresentation();
+        user.setEmailVerified(false);
+        userResource.update(user);
 
         SslMailServer.startWithSsl(this.getClass().getClassLoader().getResource(SslMailServer.PRIVATE_KEY).getFile());
         driver.navigate().to(oauth.getLoginFormUrl());
@@ -126,11 +132,11 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
                 .removeDetail(Details.REDIRECT_URI)
                 .assertEvent();
 
-        assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
+        assertCurrentUrlStartsWith(OAuthClient.APP_AUTH_ROOT);
         AccountHelper.logout(testRealm(), user.getUsername());
         driver.navigate().to(oauth.getLoginFormUrl());
         testRealmLoginPage.form().login(user.getUsername(), "password");
-        assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
+        assertCurrentUrlStartsWith(OAuthClient.APP_AUTH_ROOT);
     }
 
     @Test
@@ -162,11 +168,9 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
     public void verifyEmailWithSslWrongHostname() throws Exception {
         UserRepresentation user = ApiUtil.findUserByUsername(testRealm(), "test-user@localhost");
 
-        RealmRepresentation realmRep = testRealm().toRepresentation();
-        realmRep.getSmtpServer().put("host", "localhost.localdomain");
-        testRealm().update(realmRep);
-
-        try {
+        try (RealmAttributeUpdater updater = new RealmAttributeUpdater(testRealm())
+                .setSmtpServer("host", "localhost.localdomain")
+                .update()) {
             SslMailServer.startWithSsl(this.getClass().getClassLoader().getResource(SslMailServer.PRIVATE_KEY).getFile());
             driver.navigate().to(oauth.getLoginFormUrl());
             loginPage.form().login(user.getUsername(), "password");
@@ -186,9 +190,18 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
             // Email wasn't send, but we won't notify end user about that. Admin is aware due to the error in the logs and the SEND_VERIFY_EMAIL_ERROR event.
             assertEquals("You need to verify your email address to activate your account.",
                     testRealmVerifyEmailPage.feedbackMessage().getText());
+        }
+    }
+
+    @Test
+    public void verifyEmailWithSslWrongHostnameButAnyHostnamePolicy() throws Exception {
+        testingClient.testing().modifyTruststoreSpiHostnamePolicy(HostnameVerificationPolicy.ANY);
+        try (RealmAttributeUpdater updater = new RealmAttributeUpdater(testRealm())
+                .setSmtpServer("host", "localhost.localdomain")
+                .update()) {
+            verifyEmailWithSslEnabled();
         } finally {
-            realmRep.getSmtpServer().put("host", "localhost");
-            testRealm().update(realmRep);
+            testingClient.testing().reenableTruststoreSpi();
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/22395

Just adding the `mail.smtp.ssl.checkserveridentity` to `false` if hostname validation is ANY. Now angus sets that property to true by default (secure by default). Test added to test hostname validation ANY and different name. The `FileTruststoreProvider` constructor was changed to public for testing it (let me know if you prefer a static method in the factory or something different).