### PR TITLE
Attach js-adapter to maven uploads and rewrite version to semver compatible if needed

### DIFF
--- a/js/libs/keycloak-js/pom.xml
+++ b/js/libs/keycloak-js/pom.xml
@@ -21,7 +21,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>false</skip>
                 </configuration>
             </plugin>
             <plugin>
@@ -70,6 +70,27 @@
                 <configuration>
                     <installDirectory>../..</installDirectory>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>${project.basedir}/assembly.xml
+                                    <file>target/keycloak-js-${project.version}.tgz</file>
+                                    <type>tar.gz</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/set-version.sh
+++ b/set-version.sh
@@ -2,6 +2,13 @@
 
 NEW_VERSION=$1
 
+# Convert NPM version to semver compatible if needed
+if [[ $NEW_VERSION =~ [0-9]+.[0-9]+.[0-9]+.[a-z] ]]; then
+  NEW_NPM_VERSION=$(echo $NEW_VERSION | awk -F '.' '{ print $1"."$2"."$3"+"$4 }')
+else
+  NEW_NPM_VERSION=$NEW_VERSION
+fi
+
 # Maven
 mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
 
@@ -13,12 +20,12 @@ cd docs/documentation
 SHORT_VERSION=`echo $NEW_VERSION | awk -F '.' '{ print $1"."$2 }'`
 sed -i 's/:project_version: .*/:project_version: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 sed -i 's/:project_versionMvn: .*/:project_versionMvn: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
-sed -i 's/:project_versionNpm: .*/:project_versionNpm: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
+sed -i 's/:project_versionNpm: .*/:project_versionNpm: '$NEW_NPM_VERSION'/' topics/templates/document-attributes.adoc
 sed -i 's/:project_versionDoc: .*/:project_versionDoc: '$NEW_VERSION'/' topics/templates/document-attributes.adoc
 cd -
 
 # Keycloak JS
-echo "$(jq '. += {"version": "'$NEW_VERSION'"}' js/libs/keycloak-js/package.json)" > js/libs/keycloak-js/package.json
+echo "$(jq '. += {"version": "'$NEW_NPM_VERSION'"}' js/libs/keycloak-js/package.json)" > js/libs/keycloak-js/package.json
 
 # Keycloak Admin Client
-echo "$(jq '. += {"version": "'$NEW_VERSION'"}' js/libs/keycloak-admin-client/package.json)" > js/libs/keycloak-admin-client/package.json
+echo "$(jq '. += {"version": "'$NEW_NPM_VERSION'"}' js/libs/keycloak-admin-client/package.json)" > js/libs/keycloak-admin-client/package.json


### PR DESCRIPTION
Updates `set-version.sh` to check if version is not semver compliant, and rewrites for NPM packages if needed.

For example `22.0.3.redhat-00001` will be rewritten to `22.0.3+redhat-00001`.

Also attaches the JS adapter tarball to Maven, which makes it available in local repository with `mvn install` and also includes it in artifacts uploaded to Maven repository for a release.

Closes #23312
