### PR TITLE
12406 you are already logged in

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -79,6 +79,8 @@ public final class Constants {
     public static final String EXECUTION = "execution";
     public static final String CLIENT_ID = "client_id";
     public static final String TAB_ID = "tab_id";
+
+    public static final String SKIP_LOGOUT = "skip_logout";
     public static final String KEY = "key";
 
     public static final String KC_ACTION = "kc_action";

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -47,6 +47,7 @@ import org.keycloak.services.ErrorPage;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.services.managers.UserSessionManager;
@@ -68,6 +69,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForModification;
 
@@ -930,6 +932,11 @@ public class AuthenticationProcessor {
         authSession.clearExecutionStatus();
         authSession.clearUserSessionNotes();
         authSession.clearAuthNotes();
+
+        Set<String> requiredActions = authSession.getRequiredActions();
+        for (String reqAction : requiredActions) {
+            authSession.removeRequiredAction(reqAction);
+        }
 
         authSession.setAction(CommonClientSessionModel.Action.AUTHENTICATE.name());
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/AuthenticationStateCookie.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/AuthenticationStateCookie.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.forms.login.freemarker;
+
+import java.io.IOException;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.ws.rs.core.UriInfo;
+import org.jboss.logging.Logger;
+import org.keycloak.common.ClientConnection;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.util.CookieHelper;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * Non http-only cookie with tracking remaining authSessions in current root authentication session
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class AuthenticationStateCookie {
+
+    private static final Logger logger = Logger.getLogger(AuthenticationStateCookie.class);
+
+    public static final String KC_AUTH_STATE = "KC_AUTH_STATE";
+
+    @JsonProperty("authSessionId")
+    private String authSessionId;
+
+    @JsonProperty("remainingTabs")
+    private Set<String> remainingTabs;
+
+    public String getAuthSessionId() {
+        return authSessionId;
+    }
+
+    public void setAuthSessionId(String authSessionId) {
+        this.authSessionId = authSessionId;
+    }
+
+    public Set<String> getRemainingTabs() {
+        return remainingTabs;
+    }
+
+    public void setRemainingTabs(Set<String> remainingTabs) {
+        this.remainingTabs = remainingTabs;
+    }
+
+    public static void generateAndSetCookie(KeycloakSession session, RealmModel realm, RootAuthenticationSessionModel rootAuthSession) {
+        UriInfo uriInfo = session.getContext().getHttpRequest().getUri();
+        String path = AuthenticationManager.getRealmCookiePath(realm, uriInfo);
+        boolean secureOnly = realm.getSslRequired().isRequired(session.getContext().getConnection());
+
+        // 1 minute by default. Same timeout, which is used for client to complete "authorization code" flow
+        // Very short timeout should be OK as when this cookie is set, other existing browser tabs are supposed to be refreshed immediatelly by JS script
+        // and login user automatically. No need to have cookie living any further
+        int cookieMaxAge = realm.getAccessCodeLifespan();
+
+        AuthenticationStateCookie cookie = new AuthenticationStateCookie();
+        cookie.setAuthSessionId(rootAuthSession.getId());
+        cookie.setRemainingTabs(rootAuthSession.getAuthenticationSessions().keySet());
+
+        try {
+            String encoded = JsonSerialization.writeValueAsString(cookie);
+            logger.tracef("Generating new %s cookie. Cookie: %s, Cookie lifespan: %d", KC_AUTH_STATE, encoded, cookieMaxAge);
+
+            CookieHelper.addCookie(KC_AUTH_STATE, encoded, path, null, null, cookieMaxAge, secureOnly, false, session);
+        } catch (IOException ioe) {
+            throw new IllegalStateException("Exception thrown when encoding cookie", ioe);
+        }
+    }
+
+    public static void expireCookie(RealmModel realm, KeycloakSession session) {
+        UriInfo uriInfo = session.getContext().getHttpRequest().getUri();
+        String path = AuthenticationManager.getRealmCookiePath(realm, uriInfo);
+        boolean secureOnly = realm.getSslRequired().isRequired(session.getContext().getConnection());
+        CookieHelper.addCookie(KC_AUTH_STATE, "", path, null, null, 0, secureOnly, false, session);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("AuthenticationStateCookie [ ")
+                .append("authSessionId=" + authSessionId)
+                .append(", remainingTabs=" + remainingTabs)
+                .append(" ]")
+                .toString();
+    }
+}

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -19,11 +19,7 @@ package org.keycloak.forms.login.freemarker;
 import static org.keycloak.models.UserModel.RequiredAction.UPDATE_PASSWORD;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,7 +34,6 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -237,8 +232,6 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
             if ((AuthenticationSessionModel.Action.AUTHENTICATE.name().equals(authenticationSession.getAction())) ||
                 (AuthenticationSessionModel.Action.REQUIRED_ACTIONS.name().equals(authenticationSession.getAction())) ||
                 (AuthenticationSessionModel.Action.OAUTH_GRANT.name().equals(authenticationSession.getAction()))) {
-                UrlBean urlBean = (UrlBean) attributes.get("url");
-                addScript(urlBean.getResourcesPath() + "/js/authChecker.js");
                 setAttribute("authenticationSession", new AuthenticationSessionBean(authenticationSession.getParentSession().getId(), authenticationSession.getTabId()));
             }
         }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationSessionBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationSessionBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.forms.login.freemarker.model;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class AuthenticationSessionBean {
+
+    private final String authSessionId;
+    private final String tabId;
+
+    public AuthenticationSessionBean(String authSessionId, String tabId) {
+        this.authSessionId = authSessionId;
+        this.tabId = tabId;
+    }
+
+    public String getAuthSessionId() {
+        return authSessionId;
+    }
+
+    public String getTabId() {
+        return tabId;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
@@ -57,7 +57,11 @@ public class UrlBean {
     }
 
     public String getLoginRestartFlowUrl() {
-        return Urls.realmLoginRestartPage(baseURI, realm).toString();
+        return Urls.realmLoginRestartPage(baseURI, realm, false).toString();
+    }
+
+    public String getSsoLoginInOtherTabsUrl() {
+        return Urls.realmLoginRestartPage(baseURI, realm, true).toString();
     }
 
     public boolean hasAction()  {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -279,7 +279,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
                 session.clientPolicy().triggerOnEvent(new ImplicitHybridTokenResponse(authSession, clientSessionCtx, responseBuilder));
             } catch (ClientPolicyException cpe) {
                 event.error(cpe.getError());
-                new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authSession, true);
+                new AuthenticationSessionManager(session).removeTabIdInAuthenticationSession(realm, authSession);
                 redirectUri.addParam(OAuth2Constants.ERROR_DESCRIPTION, cpe.getError());
                 if (!clientConfig.isExcludeIssuerFromAuthResponse()) {
                     redirectUri.addParam(OAuth2Constants.ISSUER, clientSession.getNote(OIDCLoginProtocol.ISSUER));
@@ -333,12 +333,9 @@ public class OIDCLoginProtocol implements LoginProtocol {
             redirectUri.addParam(OAuth2Constants.STATE, state);
         }
 
-        if (error == Error.PASSIVE_LOGIN_REQUIRED || error == Error.PASSIVE_INTERACTION_REQUIRED) {
-            // passive check error, just delete the tabId maintaining session and don't reset the restart cookie
-            new AuthenticationSessionManager(session).removeTabIdInAuthenticationSession(realm, authSession);
-        } else {
-            new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authSession, true);
-        }
+        // Remove authenticationSession from current tab
+        new AuthenticationSessionManager(session).removeTabIdInAuthenticationSession(realm, authSession);
+
         return redirectUri.build();
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -584,8 +584,8 @@ public class TokenManager {
         clientSession.setNote(Constants.LEVEL_OF_AUTHENTICATION, String.valueOf(new AcrStore(authSession).getLevelOfAuthenticationFromCurrentAuthentication()));
         clientSession.setTimestamp(userSession.getLastSessionRefresh());
 
-        // Remove authentication session now
-        new AuthenticationSessionManager(session).removeAuthenticationSession(userSession.getRealm(), authSession, true);
+        // Remove authentication session now (just current tab, not whole "rootAuthenticationSession" in case we have more browser tabs with "authentications in progress")
+        new AuthenticationSessionManager(session).updateAuthenticationSessionAfterSuccessfulAuthentication(userSession.getRealm(), authSession);
 
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndClientScopeIds(clientSession, clientScopeIds, session);
         return clientSessionCtx;

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -236,7 +236,8 @@ public class SamlProtocol implements LoginProtocol {
                 );
             }
         } finally {
-            new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authSession, true);
+            // Remove authenticationSession of current browser tab
+            new AuthenticationSessionManager(session).removeTabIdInAuthenticationSession(realm, authSession);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/Urls.java
+++ b/services/src/main/java/org/keycloak/services/Urls.java
@@ -160,8 +160,9 @@ public class Urls {
         return loginActionsBase(baseUri).path(LoginActionsService.class, "authenticate").build(realmName);
     }
 
-    public static URI realmLoginRestartPage(URI baseUri, String realmId) {
+    public static URI realmLoginRestartPage(URI baseUri, String realmId, boolean skipLogout) {
         return loginActionsBase(baseUri).path(LoginActionsService.class, "restartSession")
+                .queryParam(Constants.SKIP_LOGOUT, String.valueOf(skipLogout))
                 .build(realmId);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AppPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AppPage.java
@@ -53,6 +53,10 @@ public class AppPage extends AbstractPage {
         clickLink(accountLink);
     }
 
+    public WebElement getAccountLink() {
+        return accountLink;
+    }
+
     public enum RequestType {
         AUTH_RESPONSE, LOGOUT_REQUEST, APP_REQUEST
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -21,8 +21,8 @@ import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.actiontoken.resetcred.ResetCredentialsActionToken;
 import org.jboss.arquillian.graphene.page.Page;
-import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
@@ -30,14 +30,13 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.utils.SystemClientUtil;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.admin.ApiUtil;
-import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
 import org.keycloak.testsuite.federation.kerberos.AbstractKerberosTest;
 import org.keycloak.testsuite.pages.AppPage;
@@ -82,10 +81,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
-import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
@@ -1144,34 +1141,6 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    public void resetPasswordLinkNewTabAndProperRedirectAccount() throws IOException {
-        final String REQUIRED_URI = getAuthServerRoot() + "realms/test/account/login-redirect?path=applications";
-        final String REDIRECT_URI = getAuthServerRoot() + "realms/test/account/login-redirect?path=applications";
-        final String CLIENT_ID = "account";
-        final String ACCOUNT_MANAGEMENT_TITLE = "Keycloak Account Management";
-
-        try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
-            assertThat(tabUtil.getCountOfTabs(), Matchers.is(1));
-
-            oauth.redirectUri(REDIRECT_URI);
-            oauth.clientId(CLIENT_ID);
-
-            loginPage.open();
-            resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, false, REDIRECT_URI, REQUIRED_URI);
-            assertThat(driver.getTitle(), Matchers.equalTo(ACCOUNT_MANAGEMENT_TITLE));
-
-            String logoutUrl = oauth.getLogoutUrl().build();
-            driver.navigate().to(logoutUrl);
-            logoutConfirmPage.assertCurrent();
-            logoutConfirmPage.confirmLogout();
-
-            loginPage.open();
-            resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, true, REDIRECT_URI, REQUIRED_URI);
-            assertThat(driver.getTitle(), Matchers.equalTo(ACCOUNT_MANAGEMENT_TITLE));
-        }
-    }
-
-    @Test
     public void resetPasswordLinkNewTabAndProperRedirectClient() throws IOException {
         final String REDIRECT_URI = getAuthServerRoot() + "realms/master/app/auth";
         final String CLIENT_ID = "test-app";
@@ -1184,7 +1153,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
             assertThat(tabUtil.getCountOfTabs(), Matchers.is(1));
 
             loginPage.open();
-            resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, false, REDIRECT_URI);
+            resetPasswordInNewTab(defaultUser, CLIENT_ID, REDIRECT_URI);
             assertThat(driver.getCurrentUrl(), Matchers.containsString(REDIRECT_URI));
 
             String logoutUrl = oauth.getLogoutUrl().build();
@@ -1193,7 +1162,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
             logoutConfirmPage.confirmLogout();
 
             loginPage.open();
-            resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, true, REDIRECT_URI);
+            resetPasswordInNewTab(defaultUser, CLIENT_ID, REDIRECT_URI);
             assertThat(driver.getCurrentUrl(), Matchers.containsString(REDIRECT_URI));
         }
     }
@@ -1274,114 +1243,72 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         submit.click();
     }
 
-    private void resetPasswordTwiceInNewTab(UserRepresentation user, String clientId, boolean shouldLogOut, String redirectUri) throws IOException {
-        resetPasswordTwiceInNewTab(user, clientId, shouldLogOut, redirectUri, redirectUri);
-    }
+    private void resetPasswordInNewTab(UserRepresentation user, String clientId, String redirectUri) throws IOException {
+        try (BrowserTabUtil browserTabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
+            events.clear();
 
-    private void resetPasswordTwiceInNewTab(UserRepresentation user, String clientId, boolean shouldLogOut, String redirectUri, String requiredUri) throws IOException {
-        events.clear();
-        updateForgottenPassword(user, clientId, redirectUri, requiredUri);
+            final int emailCount = greenMail.getReceivedMessages().length;
 
-        if (shouldLogOut) {
-            String sessionId = events.expectLogin().user(user.getId()).detail(Details.USERNAME, user.getUsername())
+            // In tab1 start "Forget password" flow and make sure the email is sent
+            loginPage.assertCurrent();
+            loginPage.resetPassword();
+
+            resetPasswordPage.assertCurrent();
+            resetPasswordPage.changePassword(user.getUsername());
+            WaitUtils.waitForPageToLoad();
+
+            assertEquals("You should receive an email shortly with further instructions.", loginPage.getSuccessMessage());
+
+            String tab1Url = driver.getCurrentUrl();
+
+            events.expectRequiredAction(EventType.SEND_RESET_PASSWORD)
+                    .user(user.getId())
+                    .client(clientId)
+                    .detail(Details.REDIRECT_URI, redirectUri)
+                    .detail(Details.USERNAME, user.getUsername())
+                    .detail(Details.EMAIL, user.getEmail())
+                    .session((String) null)
+                    .assertEvent();
+
+            assertEquals(emailCount + 1, greenMail.getReceivedMessages().length);
+
+            final MimeMessage message = greenMail.getReceivedMessages()[emailCount];
+            final String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
+
+            // Open link from email in the new tab
+            browserTabUtil.newTab(changePasswordUrl.trim());
+
+            // Change password in tab2
+            changePasswordOnUpdatePage(driver);
+
+            events.expectRequiredAction(EventType.UPDATE_PASSWORD)
                     .detail(Details.REDIRECT_URI, redirectUri)
                     .client(clientId)
-                    .assertEvent().getSessionId();
+                    .user(user.getId()).detail(Details.USERNAME, user.getUsername()).assertEvent();
 
-            String logoutUrl = oauth.getLogoutUrl().build();
-            driver.navigate().to(logoutUrl);
-            logoutConfirmPage.assertCurrent();
-            logoutConfirmPage.confirmLogout();
+            // User should be authenticated in current tab (tab2)
+            WaitUtils.waitUntilElement(appPage.getAccountLink()).is().clickable();
+            appPage.assertCurrent();
+            assertThat(driver.getCurrentUrl(), Matchers.containsString(redirectUri));
 
-            events.expectLogout(sessionId)
-                    .client("account")
-                    .user(user.getId())
-                    .removeDetail(Details.REDIRECT_URI)
-                    .assertEvent();
-        }
+            // Close tab2
+            assertThat(browserTabUtil.getCountOfTabs(), Matchers.equalTo(2));
+            browserTabUtil.closeTab(1);
+            assertThat(browserTabUtil.getCountOfTabs(), Matchers.equalTo(1));
 
-        BrowserTabUtil util = BrowserTabUtil.getInstanceAndSetEnv(driver);
-        assertThat(util.getCountOfTabs(), Matchers.equalTo(2));
-        util.closeTab(1);
-        assertThat(util.getCountOfTabs(), Matchers.equalTo(1));
+            if (driver instanceof HtmlUnitDriver) {
+                // With HtmlUnit, authChecker javascript doesn't work. Hence need to manually trigger "reset flow" endpoint
+                KeycloakUriBuilder builder = KeycloakUriBuilder.fromUri(tab1Url);
+                String resetFlowPath = builder
+                        .replacePath(builder.getPath().substring(0, builder.getPath().lastIndexOf('/') + 1) + LoginActionsService.RESTART_PATH)
+                        .queryParam(Constants.SKIP_LOGOUT, "true")
+                        .build().toString();
+                driver.navigate().to(resetFlowPath);
+            }
 
-        if (shouldLogOut) {
-            final ClientRepresentation client = testRealm().clients()
-                    .findByClientId(clientId)
-                    .stream()
-                    .findFirst()
-                    .orElse(null);
-
-            assertThat(client, Matchers.notNullValue());
-            updateForgottenPassword(user, clientId, getValidRedirectUriWithRootUrl(client.getRootUrl(), client.getRedirectUris()));
-        } else {
-            doForgotPassword(user.getUsername());
-        }
-    }
-
-    private void updateForgottenPassword(UserRepresentation user, String clientId, String redirectUri) throws IOException {
-        updateForgottenPassword(user, clientId, redirectUri, redirectUri);
-    }
-
-    private void updateForgottenPassword(UserRepresentation user, String clientId, String redirectUri, String requiredUri) throws IOException {
-        final int emailCount = greenMail.getReceivedMessages().length;
-
-        doForgotPassword(user.getUsername());
-        assertEquals("You should receive an email shortly with further instructions.", loginPage.getSuccessMessage());
-
-        events.expectRequiredAction(EventType.SEND_RESET_PASSWORD)
-                .user(user.getId())
-                .client(clientId)
-                .detail(Details.REDIRECT_URI, redirectUri)
-                .detail(Details.USERNAME, user.getUsername())
-                .detail(Details.EMAIL, user.getEmail())
-                .session((String) null)
-                .assertEvent();
-
-        assertEquals(emailCount + 1, greenMail.getReceivedMessages().length);
-
-        final MimeMessage message = greenMail.getReceivedMessages()[emailCount];
-        final String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
-
-        BrowserTabUtil util = BrowserTabUtil.getInstanceAndSetEnv(driver);
-        util.newTab(changePasswordUrl.trim());
-
-        changePasswordOnUpdatePage(driver);
-
-        events.expectRequiredAction(EventType.UPDATE_PASSWORD)
-                .detail(Details.REDIRECT_URI, redirectUri)
-                .client(clientId)
-                .user(user.getId()).detail(Details.USERNAME, user.getUsername()).assertEvent();
-
-        assertThat(driver.getCurrentUrl(), Matchers.containsString(requiredUri));
-    }
-
-    private void doForgotPassword(String username) {
-        loginPage.assertCurrent();
-        loginPage.resetPassword();
-
-        resetPasswordPage.assertCurrent();
-        resetPasswordPage.changePassword(username);
-        WaitUtils.waitForPageToLoad();
-    }
-
-    private String getValidRedirectUriWithRootUrl(String rootUrl, Collection<String> redirectUris) {
-        final boolean isRootUrlValid = isValidUrl(rootUrl);
-
-        return redirectUris.stream()
-                .map(uri -> isRootUrlValid && uri.startsWith("/") ? rootUrl + uri : uri)
-                .map(uri -> uri.startsWith("/") ? OAuthClient.AUTH_SERVER_ROOT + uri : uri)
-                .map(RedirectUtils::validateRedirectUriWildcard)
-                .findFirst()
-                .orElse(null);
-    }
-
-    private boolean isValidUrl(String url) {
-        try {
-            new URL(url);
-            return true;
-        } catch (MalformedURLException e) {
-            return false;
+            // User should be automatically authenticated in tab1 as well (due authChecker.js on real browsers like FF or Chrome)
+            WaitUtils.waitUntilElement(appPage.getAccountLink()).is().clickable();
+            appPage.assertCurrent();
         }
     }
 }

--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -1,0 +1,76 @@
+
+function kcAuthChecker() {
+    var authChecker = this;
+
+    // How often to check if KEYCLOAK_SESSION cookie was added in the other browser tab?
+    var checkIntervalMillisecs = 2000;
+
+    // 1 - unknown state or KEYCLOAK_SESSION present since beginning, 2 - cookie KEYCLOAK_SESSION not present, 3 - cookie KEYCLOAK_SESSION present after it
+    // was not present before (possible to move here from state 2, but not from 1. Reason are "re-authentication" scenarios where we want login screens displayed even if SSO cookie exists)
+    var sessionCookieState = 1;
+
+     function setupTimer(authSessionId, tabId, loginRestartUrl) {
+        setTimeout(function() {
+            authChecker.checkCookiesAndSetTimer(authSessionId, tabId, loginRestartUrl);
+        }, checkIntervalMillisecs);
+    }
+
+    authChecker.checkCookiesAndSetTimer = function(authSessionId, tabId, loginRestartUrl) {
+        var sessionCookie = getCookieByName("KEYCLOAK_SESSION");
+        if (sessionCookie) {
+            if (sessionCookieState == 2) {
+                sessionCookieState = 3;
+                console.log("kcAuthChecker: Cookie KEYCLOAK_SESSION added");
+            }
+        } else {
+            if (sessionCookieState == 1) {
+                sessionCookieState = 2;
+                console.log("kcAuthChecker: Cookie KEYCLOAK_SESSION not present");
+                document.kcAuthCheckerReady = true; // For tests
+            }
+        }
+
+        if (sessionCookieState == 3) {
+            checkAuthSession(authSessionId, tabId, loginRestartUrl);
+        } else {
+            setupTimer(authSessionId, tabId, loginRestartUrl);
+        }
+    }
+
+    function checkAuthSession(authSessionId, tabId, loginRestartUrl) {
+        var authCookieStr = getCookieByName("KC_AUTH_STATE");
+        if (authCookieStr) {
+            var authCookie = JSON.parse(authCookieStr);
+            if (authSessionId === authCookie.authSessionId && authCookie.remainingTabs.indexOf(tabId) > -1) {
+                loginRestartUrl = htmlDecode(loginRestartUrl);
+                window.location.href = loginRestartUrl;
+            } else {
+                console.log("kcAuthChecker: Cookie KC_AUTH_STATE present, but value does not match with authentication session parameters in current browser.");
+            }
+        } else {
+            console.log("kcAuthChecker: Cookie KC_AUTH_STATE not present");
+        }
+    }
+
+    function htmlDecode(input) {
+        var doc = new DOMParser().parseFromString(input, "text/html");
+        return doc.documentElement.textContent;
+    }
+
+    function getCookieByName(name) {
+        const cookies = {};
+        var cookiesVal = document.cookie.split(";");
+
+        cookiesVal.forEach(cookieFunc);
+
+        function cookieFunc(cookieVal) {
+            var cookieParsed = cookieVal.split("=");
+            if (cookieParsed.length == 2) {
+                cookies[cookieParsed[0].trim()] = cookieParsed[1].trim();
+            }
+        }
+
+        return cookies[name];
+    }
+
+}

--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -38,7 +38,7 @@ function checkAuthState(authSessionId, tabId, loginRestartUrl) {
     return;
   }
 
-  if (authState.authSessionId != authSessionId) {
+  if (authState.authSessionId !== authSessionId) {
     // The session ID does not match, exit.
     return;
   }
@@ -59,7 +59,9 @@ function getSession() {
   return getCookieByName("KEYCLOAK_SESSION");
 }
 
-const getAuthState = () => getCookieByName("KC_AUTH_STATE");
+function getAuthState() {
+  return getCookieByName("KC_AUTH_STATE");
+}
 
 function getCookieByName(name) {
   const cookies = new Map();

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -35,8 +35,14 @@
         </#list>
     </#if>
     <#if authenticationSession??>
-        <script type="text/javascript">
-            new kcAuthChecker().checkCookiesAndSetTimer("${authenticationSession.authSessionId}", "${authenticationSession.tabId}", "${url.ssoLoginInOtherTabsUrl}");
+        <script type="module">
+            import { checkCookiesAndSetTimer } from "${url.resourcesPath}/js/authChecker.js";
+
+            checkCookiesAndSetTimer(
+              "${authenticationSession.authSessionId}",
+              "${authenticationSession.tabId}",
+              "${url.ssoLoginInOtherTabsUrl}"
+            );
         </script>
     </#if>
 </head>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -34,6 +34,11 @@
             <script src="${script}" type="text/javascript"></script>
         </#list>
     </#if>
+    <#if authenticationSession??>
+        <script type="text/javascript">
+            new kcAuthChecker().checkCookiesAndSetTimer("${authenticationSession.authSessionId}", "${authenticationSession.tabId}", "${url.ssoLoginInOtherTabsUrl}");
+        </script>
+    </#if>
 </head>
 
 <body class="${properties.kcBodyClass!}">


### PR DESCRIPTION
Closes #12406 
This is the draft for fixing "You are already logged-in" for most of the cases and makes the usability around this better.

Some more info about the issue also in https://issues.redhat.com/browse/KEYCLOAK-5179

This prototype uses approach we discussed with @stianst and it works like this:

1) In current Keycloak main, when user is authenticated in some browser tab (EG. tab1), the whole `RootAuthenticationSessionModel` is removed from the `authenticationSessions` cache. This means that other browser tabs are screwed and cannot continue with authentication due the corresponding authentication sessions removed

2) This PR uses the approach when it does not remove whole `RootAuthenticationSessionModel`, but just single `AuthenticationSessionModel` of the current browser tab. The root session (together with KC_RESTART cookie) is removed just when there are no other browser tabs opened (which means no more `AuthenticationSessionModel` in this root auth session). There is also new cookie `KC_AUTH_STATE` added, which contains some context about remaining authentication sessions (tabs).

3) There is small JS `authChecker.js` added to login theme screens. It checks every 2 seconds the presence of the cookie `KC_SESSION_STATE`. When this cookie was added, it means that some other browser tab successfully authenticated user. Then it checks if current `tabId` matches with some remaining tabId from authentication session. If yes, it redirects immediatelly to LoginActionsService endpoint for `restartFlow`, which effectively means that this browser tab should be authenticated immediatelly due the SSO

4) User experience is, that after authentication in tab1, authentication in all other browser tabs (tab2, tab3 etc) is automatically done as well and corresponding browser tabs are redirected to the applications

5) This should also effectively remove all remaining authenticationSessions from the "root authentication session" (due they are authenticated by SSO) and hence effectively also cleanup root authentication session.

6) There are still some limitations. For instance when user click "Login with Facebook" in tab1 and then authenticate in tab2 and then go back to tab1 with Facebook login screen (IDP login screen in general), user won't be authenticated due after redirect from Facebook, the authenticationSession may not exists (The `authChecker.js` was not triggered for this tab due user is on Facebook screen and not on any Keycloak screen). Another challenges could be timeouts (EG. user want to authenticate in tab1, then next day going to tab2, which starts new authentication session (session from tab1 already timed-out). Then tab1 won't be authenticated due it used completely different authenticationSession from previous day etc. We will see if we need to improve these scenarios as well.


### Follow-ups?

- Make sure that when some tab is authenticated, the `RootAuthenticationSessionModel` is available only for 1 minute instead of current default timeout (30 minutes)? 1 minute should be enough to trigger JS in remaining browser tabs and at the same time, it should save some memory for the corner cases when remaining authentication sessions are not able to finish authentication (For instance when browser tab was redirected to some IDP or to some other 3rd party screen).

- Better handling of concurrency when updating same entity in `InfinispanAuthenticationSessionAdapter` ? With changes in this PR, it can happen more likely that multiple concurrent transactions will try to update same `RootAuthenticationSessionEntity`. This could be due the fact that after authentication in tab1, all the remaining tabs are trying to authenticate at the same time and hence possibly updating same `RootAuthenticationSessionEntity` at the same time. So I wonder if we want to add something to prevent "lost updates" (or in other words using "conditional replace" operation when calling cache.replace on authenticationSessions infinispan cache), which can be likely done by leverage `InfinispanChangeLogBasedTransaction` similarly like for instance userSessions are using.
