### PR TITLE
Improve ScheduledTask handling

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -342,7 +342,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
     protected void startGlobalStats(KeycloakSession session, int globalStatsIntervalSecs) {
         logger.debugf("Started Hibernate statistics with the interval %s seconds", globalStatsIntervalSecs);
         TimerProvider timer = session.getProvider(TimerProvider.class);
-        timer.scheduleTask(new HibernateStatsReporter(emf), globalStatsIntervalSecs * 1000, "ReportHibernateGlobalStats");
+        timer.scheduleTask(new HibernateStatsReporter(emf), globalStatsIntervalSecs * 1000);
     }
 
     void migration(MigrationStrategy strategy, boolean initializeEmpty, String schema, File databaseUpdateFile, Connection connection, KeycloakSession session) {

--- a/model/storage-private/src/main/java/org/keycloak/services/scheduled/ClearExpiredAdminEvents.java
+++ b/model/storage-private/src/main/java/org/keycloak/services/scheduled/ClearExpiredAdminEvents.java
@@ -19,12 +19,10 @@ package org.keycloak.services.scheduled;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Time;
-import org.keycloak.events.EventStoreProvider;
-import org.keycloak.events.EventStoreProviderFactory;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.provider.InvalidationHandler;
 import org.keycloak.storage.datastore.PeriodicEventInvalidation;
 import org.keycloak.timer.ScheduledTask;
+
 public class ClearExpiredAdminEvents implements ScheduledTask {
 
     protected static final Logger logger = Logger.getLogger(ClearExpiredAdminEvents.class);
@@ -34,7 +32,7 @@ public class ClearExpiredAdminEvents implements ScheduledTask {
         long currentTimeMillis = Time.currentTimeMillis();
         session.invalidate(PeriodicEventInvalidation.JPA_EVENT_STORE);
         long took = Time.currentTimeMillis() - currentTimeMillis;
-        logger.debugf("ClearExpiredEvents finished in %d ms", took);
+        logger.debugf("%s finished in %d ms", getTaskName(), took);
     }
 
 }

--- a/model/storage-private/src/main/java/org/keycloak/services/scheduled/ClearExpiredUserSessions.java
+++ b/model/storage-private/src/main/java/org/keycloak/services/scheduled/ClearExpiredUserSessions.java
@@ -39,7 +39,11 @@ public class ClearExpiredUserSessions implements ScheduledTask {
         session.sessions().removeAllExpired();
 
         long took = Time.currentTimeMillis() - currentTimeMillis;
-        logger.debugf("ClearExpiredUserSessions finished in %d ms", took);
+        logger.debugf("%s finished in %d ms", getTaskName(), took);
     }
 
+    @Override
+    public String getTaskName() {
+        return TASK_NAME;
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/timer/TaskRunner.java
+++ b/server-spi-private/src/main/java/org/keycloak/timer/TaskRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.keycloak.timer;
 
-import org.keycloak.models.KeycloakSessionTask;
-
 /**
- * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ * Wrapper around {@link ScheduledTask}.
  */
-public interface ScheduledTask extends KeycloakSessionTask {
+public interface TaskRunner extends Runnable {
 
+    /**
+     * Returns the task.
+     * @return
+     */
+    ScheduledTask getTask();
+
+    /**
+     * Name of the task.
+     * @return
+     */
     default String getTaskName() {
-        return getClass().getSimpleName();
+        return getTask().getTaskName();
     }
-
 }

--- a/server-spi-private/src/main/java/org/keycloak/timer/TimerProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/timer/TimerProvider.java
@@ -26,8 +26,15 @@ public interface TimerProvider extends Provider {
 
     public void schedule(Runnable runnable, long intervalMillis, String taskName);
 
+    default void schedule(TaskRunner runner, long intervalMillis) {
+        schedule(runner, intervalMillis, runner.getTaskName());
+    }
+
     public void scheduleTask(ScheduledTask scheduledTask, long intervalMillis, String taskName);
 
+    public default void scheduleTask(ScheduledTask scheduledTask, long intervalMillis) {
+        scheduleTask(scheduledTask, intervalMillis, scheduledTask.getTaskName());
+    }
 
     /**
      * Cancel task and return the details about it, so it can be eventually restored later

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/sync/SyncFederationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/sync/SyncFederationTest.java
@@ -91,16 +91,15 @@ public class SyncFederationTest extends AbstractAuthTest {
             DummyUserFederationProviderFactory dummyFedFactory = (DummyUserFederationProviderFactory) sessionFactory.getProviderFactory(UserStorageProvider.class, DummyUserFederationProviderFactory.PROVIDER_NAME);
 
             // Assert that after some period was DummyUserFederationProvider triggered
-            UserStorageSyncManager usersSyncManager = new UserStorageSyncManager();
             sleep(1800);
 
             // Cancel timer
-            usersSyncManager.notifyToRefreshPeriodicSync(session, appRealm, dummyModel, true);
+            UserStorageSyncManager.notifyToRefreshPeriodicSync(session, appRealm, dummyModel, true);
             log.infof("Notified sync manager about cancel periodic sync");
 
             // This sync is here just to ensure that we have lock (doublecheck that periodic sync, which was possibly triggered before canceling timer is finished too)
             while (true) {
-                SynchronizationResult result = usersSyncManager.syncChangedUsers(session.getKeycloakSessionFactory(), appRealm.getId(), dummyModel);
+                SynchronizationResult result = UserStorageSyncManager.syncChangedUsers(session.getKeycloakSessionFactory(), appRealm.getId(), dummyModel);
                 if (result.isIgnored()) {
                     log.infof("Still waiting for lock before periodic sync is finished", result.toString());
                     sleep(1000);


### PR DESCRIPTION
This PR introduces a String getTaskName() default method to the ScheduledTask interface and adjusts callsites to use the implementation derived task-name where possible.

Previously, ScheduledTask names were passed around seperately, which lead to unhelpful debug messages.
We now give ScheduledTask implementations control over their task-name which allows for more flexible naming.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
