### PR TITLE
Client roles should be mapped to any claim name

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
@@ -96,12 +96,6 @@ abstract class AbstractUserRoleMappingMapper extends AbstractOIDCProtocolMapper 
             if (matcher.find()) {
                 protocolClaim = matcher.replaceAll(clientId);
             }
-            if (!(protocolClaim.endsWith("roles") || protocolClaim.startsWith(clientId) || protocolClaim.endsWith(clientId))) {
-                // the claim name does not reference the current client, do not map roles
-                // or if the claim does not end with roles suffix, do not map roles.
-                // the role suffix is used to move roles to a single location other than the default location (e.g.: realm_access and resource_access claims)
-                return;
-            }
         }
 
         List<String> split = splitClaimPath(protocolClaim);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
@@ -959,7 +959,9 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
         );
         assertRolesString(testAppScopeMappings,
           "test-app-allowed-by-scope",      // from direct assignment to roleRichUser, present as scope allows it
-          "test-app-disallowed-by-scope"   // from direct assignment to /roleRichGroup/level2group, present as scope allows it
+          "test-app-disallowed-by-scope",   // from direct assignment to /roleRichGroup/level2group, present as scope allows it
+          "customer-admin-composite-role",  // from the other application
+          "customer-admin"
         );
 
         // Revert


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/22349

Fixes a regression introduced by https://github.com/keycloak/keycloak/pull/22861. It's just in main, so no need to send anything to 22.0 branch.

The PR changes the test to act as before the fix (tested with branch relase/22.0, same behavior) and allow to map the client role mapper to any claim (not limited by the clientId value or roles).
