### PR TITLE
Ignore query parameters while testing the LinkedIn profile picture URL

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -540,7 +540,12 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         assertEquals(1, users.size());
         assertNotNull(users.get(0).getAttributes());
         assertNotNull(users.get(0).getAttributes().get(attrName));
-        assertEquals(expectedValue, users.get(0).getAttributes().get(attrName).get(0));
+        String attrValue = users.get(0).getAttributes().get(attrName).get(0);
+        if (currentTestProvider.equals(LINKEDIN) && attrName.equals("picture")) {
+            assertTrue(attrValue.contains(expectedValue));
+        } else {
+            assertEquals(expectedValue, attrValue);
+        }
     }
 
     private void assertUpdateProfile(boolean firstName, boolean lastName, boolean email) {


### PR DESCRIPTION
The query parameters of the LinkedIn profile picture URL are changing over time, and they are not necessary for testing purposes. This solutions checks if the picture URL provided in the `social.properties` file is contained in the obtained URL ignoring the query parameters.