### PR TITLE
Please ignore: Improve logging in case of OIDC Identity provider errors:

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
@@ -248,6 +248,13 @@ public class SimpleHttp {
         }
     }
 
+    /**
+     * @return the URL without params
+     */
+    public String getUrl() {
+        return url;
+    }
+
     private Response makeRequest() throws IOException {
 
         HttpRequestBase httpRequest = createHttpRequest();

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -185,6 +185,8 @@ public class Messages {
 
     public static final String IDENTITY_PROVIDER_MISSING_STATE_ERROR = "identityProviderMissingStateMessage";
 
+    public static final String IDENTITY_PROVIDER_MISSING_CODE_OR_ERROR_ERROR = "identityProviderMissingCodeOrErrorMessage";
+
     public static final String IDENTITY_PROVIDER_INVALID_RESPONSE = "identityProviderInvalidResponseMessage";
 
     public static final String IDENTITY_PROVIDER_INVALID_SIGNATURE = "identityProviderInvalidSignatureMessage";

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -343,6 +343,7 @@ cookieNotFoundMessage=Cookie not found. Please make sure cookies are enabled in 
 insufficientLevelOfAuthentication=The requested level of authentication has not been satisfied.
 identityProviderUnexpectedErrorMessage=Unexpected error when authenticating with identity provider
 identityProviderMissingStateMessage=Missing state parameter in response from identity provider.
+identityProviderMissingCodeOrErrorMessage=Missing code or error parameter in response from identity provider.
 identityProviderInvalidResponseMessage=Invalid response from identity provider.
 identityProviderInvalidSignatureMessage=Invalid signature in response from identity provider.
 identityProviderNotFoundMessage=Could not find an identity provider with the identifier.


### PR DESCRIPTION
- log the full Redirection URL, when it contains an error parameter, or does not contain the state or code parameter
- log the token endpoint URL (without - possibly confidential - params) and response body, when the token endpoint does not return a success response

Closes #TODO-keycloak-issue

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
