### PR TITLE
Remove mention to add-user-keycloak since it was already removed

### DIFF
--- a/docs/documentation/server_admin/topics/realms/proc-using-admin-console.adoc
+++ b/docs/documentation/server_admin/topics/realms/proc-using-admin-console.adoc
@@ -15,7 +15,7 @@ For example, for localhost, use this URL: http://localhost:8080{kc_admins_path}/
 .Login page
 image:images/login-page.png[Login page]
 
-. Enter the username and password you created on the Welcome Page or the `add-user-keycloak` script in the bin directory.
+. Enter the username and password you created on the Welcome Page or through environment variables as per https://www.keycloak.org/server/configuration#_creating_the_initial_admin_user[Creating the initial admin user] guide.
 This action displays the Admin Console.
 +
 .Admin Console


### PR DESCRIPTION
Since `add-user-keycloak.sh` is no longer included in the Quarkus distribution, remove mention to that script from the documents.
https://www.keycloak.org/migration/migrating-to-quarkus#_setup_of_initial_users