### PR TITLE
Reset Password: skip if same as existing password

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -986,26 +986,27 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
             setTimeOffset(2000000);
             resetPassword("login-test", "password1");
 
-            resetPasswordInvalidPassword("login-test", "password1", "Invalid password: must not be equal to any of last 3 passwords.");
+            resetPasswordInvalidPassword("login-test", "password", "Invalid password: must not be equal to any of last 3 passwords.");
 
             setTimeOffset(4000000);
             resetPassword("login-test", "password2");
 
+            resetPasswordInvalidPassword("login-test", "password", "Invalid password: must not be equal to any of last 3 passwords.");
             resetPasswordInvalidPassword("login-test", "password1", "Invalid password: must not be equal to any of last 3 passwords.");
-            resetPasswordInvalidPassword("login-test", "password2", "Invalid password: must not be equal to any of last 3 passwords.");
 
             setTimeOffset(6000000);
-            resetPassword("login-test", "password3");
-
-            resetPasswordInvalidPassword("login-test", "password1", "Invalid password: must not be equal to any of last 3 passwords.");
-            resetPasswordInvalidPassword("login-test", "password2", "Invalid password: must not be equal to any of last 3 passwords.");
-            resetPasswordInvalidPassword("login-test", "password3", "Invalid password: must not be equal to any of last 3 passwords.");
-
-            setTimeOffset(8000000);
             resetPassword("login-test", "password");
         } finally {
             setTimeOffset(0);
         }
+    }
+
+    @Test
+    public void resetPasswordWithExistingPassword() throws IOException, MessagingException {
+        //Block passwords that are equal to previous passwords. Default value is 3.
+        setPasswordPolicy("passwordHistory");
+
+        resetPassword("login-test", "password");
     }
 
     @Test


### PR DESCRIPTION
## Motivation

There are tools like [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli) that updates the configuration state of a Keycloak instance to match a configuration file. This includes default users (which is extremely useful for testing).

Because the tools cannot check if a user's existing password already matches what is in the configuration file, all it can do is create the user if it doesn't already exist, otherwise update the user's password to what is in the configuration file.

With a **Not Recently Used** (**Password History**) policy, if the user exists and the user's existing password already matches what is in the configuration file, the update fails.

## Solution

Changing the Reset Password to skip if the new password is same as the existing password will allow such tools to work with a **Not Recently Used** (**Password History**) policy.

From the user's point of view, its as if the password has been reset. The only difference is that the new password is not added to the previous passwords again. Another option is to still update the credential, add a new password history, and remove old password histories, but not validate policies if the password is unchanged, to retain the same behavior.