### PR TITLE
Use JDK LdapName and Rdn instead of our classes

### DIFF
--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -77,6 +77,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -231,7 +231,7 @@ public class LDAPUtils {
      */
     public static void addMember(LDAPStorageProvider ldapProvider, MembershipType membershipType, String memberAttrName, String memberChildAttrName, LDAPObject ldapParent, LDAPObject ldapChild) {
         String membership = getMemberValueOfChildObject(ldapChild, membershipType, memberChildAttrName);
-        ldapProvider.getLdapIdentityStore().addMemberToGroup(ldapParent.getDn().toString(), memberAttrName, membership);
+        ldapProvider.getLdapIdentityStore().addMemberToGroup(ldapParent.getDn().getLdapName(), memberAttrName, membership);
     }
 
     /**
@@ -246,7 +246,7 @@ public class LDAPUtils {
      */
     public static void deleteMember(LDAPStorageProvider ldapProvider, MembershipType membershipType, String memberAttrName, String memberChildAttrName, LDAPObject ldapParent, LDAPObject ldapChild) {
         String userMembership = getMemberValueOfChildObject(ldapChild, membershipType, memberChildAttrName);
-        ldapProvider.getLdapIdentityStore().removeMemberFromGroup(ldapParent.getDn().toString(), memberAttrName, userMembership);
+        ldapProvider.getLdapIdentityStore().removeMemberFromGroup(ldapParent.getDn().getLdapName(), memberAttrName, userMembership);
     }
 
     /**
@@ -333,7 +333,7 @@ public class LDAPUtils {
 
     private static LDAPQuery createLdapQueryForRangeAttribute(LDAPStorageProvider ldapProvider, LDAPObject ldapObject, String name) {
         LDAPQuery q = new LDAPQuery(ldapProvider);
-        q.setSearchDn(ldapObject.getDn().toString());
+        q.setSearchDn(ldapObject.getDn().getLdapName());
         q.setSearchScope(SearchControls.OBJECT_SCOPE);
         q.addReturningLdapAttribute(name + ";range=" + (ldapObject.getCurrentRange(name) + 1) + "-*");
         return q;

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/LDAPQuery.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/LDAPQuery.java
@@ -22,6 +22,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.Condition;
 import org.keycloak.storage.ldap.idm.query.Sort;
@@ -32,6 +33,7 @@ import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
 import javax.naming.NamingException;
 import javax.naming.directory.SearchControls;
 import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.LdapName;
 
 import java.util.*;
 
@@ -54,7 +56,7 @@ public class LDAPQuery implements AutoCloseable {
     private int limit;
     private PaginationContext paginationContext;
     private LDAPContextManager ldapContextManager;
-    private String searchDn;
+    private LdapName searchDn;
     private final Set<Condition> conditions = new LinkedHashSet<>();
     private final Set<Sort> ordering = new LinkedHashSet<>();
 
@@ -84,6 +86,11 @@ public class LDAPQuery implements AutoCloseable {
     }
 
     public LDAPQuery setSearchDn(String searchDn) {
+        this.searchDn = LDAPDn.fromString(searchDn).getLdapName();
+        return this;
+    }
+
+    public LDAPQuery setSearchDn(LdapName searchDn) {
         this.searchDn = searchDn;
         return this;
     }
@@ -117,7 +124,7 @@ public class LDAPQuery implements AutoCloseable {
         return unmodifiableSet(this.ordering);
     }
 
-    public String getSearchDn() {
+    public LdapName getSearchDn() {
         return this.searchDn;
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/IdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/IdentityStore.java
@@ -17,16 +17,16 @@
 
 package org.keycloak.storage.ldap.idm.store;
 
+import java.util.List;
 import java.util.Set;
+import javax.naming.AuthenticationException;
+import javax.naming.ldap.LdapName;
 import org.keycloak.models.ModelException;
 import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.representations.idm.LDAPCapabilityRepresentation;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
 import org.keycloak.storage.ldap.mappers.LDAPOperationDecorator;
-
-import javax.naming.AuthenticationException;
-import java.util.List;
 
 /**
  * IdentityStore representation providing minimal SPI
@@ -74,7 +74,7 @@ public interface IdentityStore {
      * @param memberAttrName The member attribute name
      * @param value The value (it can be uid or dn depending the group type)
      */
-    public void addMemberToGroup(String groupDn, String memberAttrName, String value);
+    public void addMemberToGroup(LdapName groupDn, String memberAttrName, String value);
 
     /**
      * Removes a member from a group.
@@ -82,7 +82,7 @@ public interface IdentityStore {
      * @param memberAttrName The member attribute name
      * @param value The value (it can be uid or dn depending the group type)
      */
-    public void removeMemberFromGroup(String groupDn, String memberAttrName, String value);
+    public void removeMemberFromGroup(LdapName groupDn, String memberAttrName, String value);
 
     // Identity query
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 import javax.naming.directory.AttributeInUseException;
 import javax.naming.directory.NoSuchAttributeException;
 import javax.naming.directory.SchemaViolationException;
+import javax.naming.ldap.LdapName;
 
 /**
  * An IdentityStore implementation backed by an LDAP directory
@@ -97,18 +98,17 @@ public class LDAPIdentityStore implements IdentityStore {
             throw new ModelException("Can't add object with already assigned uuid");
         }
 
-        String entryDN = ldapObject.getDn().toString();
         BasicAttributes ldapAttributes = extractAttributesForSaving(ldapObject, true);
-        this.operationManager.createSubContext(entryDN, ldapAttributes);
+        this.operationManager.createSubContext(ldapObject.getDn().getLdapName(), ldapAttributes);
         ldapObject.setUuid(getEntryIdentifier(ldapObject));
 
         if (logger.isDebugEnabled()) {
-            logger.debugf("Type with identifier [%s] and dn [%s] successfully added to LDAP store.", ldapObject.getUuid(), entryDN);
+            logger.debugf("Type with identifier [%s] and dn [%s] successfully added to LDAP store.", ldapObject.getUuid(), ldapObject.getDn());
         }
     }
 
     @Override
-    public void addMemberToGroup(String groupDn, String memberAttrName, String value) {
+    public void addMemberToGroup(LdapName groupDn, String memberAttrName, String value) {
         // do not check EMPTY_MEMBER_ATTRIBUTE_VALUE, we save one useless query
         // the value will be there forever for objectclasses that enforces the attribute as MUST
         BasicAttribute attr = new BasicAttribute(memberAttrName, value);
@@ -123,7 +123,7 @@ public class LDAPIdentityStore implements IdentityStore {
     }
 
     @Override
-    public void removeMemberFromGroup(String groupDn, String memberAttrName, String value) {
+    public void removeMemberFromGroup(LdapName groupDn, String memberAttrName, String value) {
         BasicAttribute attr = new BasicAttribute(memberAttrName, value);
         ModificationItem item = new ModificationItem(DirContext.REMOVE_ATTRIBUTE, attr);
         try {
@@ -152,17 +152,16 @@ public class LDAPIdentityStore implements IdentityStore {
         BasicAttributes updatedAttributes = extractAttributesForSaving(ldapObject, false);
         NamingEnumeration<Attribute> attributes = updatedAttributes.getAll();
 
-        String entryDn = ldapObject.getDn().toString();
-        this.operationManager.modifyAttributes(entryDn, attributes);
+        this.operationManager.modifyAttributes(ldapObject.getDn().getLdapName(), attributes);
 
         if (logger.isDebugEnabled()) {
-            logger.debugf("Type with identifier [%s] and DN [%s] successfully updated to LDAP store.", ldapObject.getUuid(), entryDn);
+            logger.debugf("Type with identifier [%s] and DN [%s] successfully updated to LDAP store.", ldapObject.getUuid(), ldapObject.getDn());
         }
     }
 
     protected void checkRename(LDAPObject ldapObject) {
         LDAPDn.RDN firstRdn = ldapObject.getDn().getFirstRdn();
-        String oldDn = ldapObject.getDn().toString();
+        LdapName oldDn = ldapObject.getDn().getLdapName();
 
         // Detect which keys will need to be updated in RDN, which are new keys to be added, and which are to be removed
         List<String> toUpdateKeys = firstRdn.getAllKeys();
@@ -218,20 +217,20 @@ public class LDAPIdentityStore implements IdentityStore {
             LDAPDn newLdapDn = ldapObject.getDn().getParentDn();
             newLdapDn.addFirst(firstRdn);
 
-            String newDn = newLdapDn.toString();
+            LdapName newDn = newLdapDn.getLdapName();
 
             logger.debugf("Renaming LDAP Object. Old DN: [%s], New DN: [%s]", oldDn, newDn);
 
             // In case, that there is conflict (For example already existing "CN=John Anthony"), the different DN is returned
             newDn = this.operationManager.renameEntry(oldDn, newDn, true);
 
-            ldapObject.setDn(LDAPDn.fromString(newDn));
+            ldapObject.setDn(LDAPDn.fromLdapName(newDn));
         }
     }
 
     @Override
     public void remove(LDAPObject ldapObject) {
-        this.operationManager.removeEntry(ldapObject.getDn().toString());
+        this.operationManager.removeEntry(ldapObject.getDn().getLdapName());
 
         if (logger.isDebugEnabled()) {
             logger.debugf("Type with identifier [%s] and DN [%s] successfully removed from LDAP store.", ldapObject.getUuid(), ldapObject.getDn().toString());
@@ -248,7 +247,7 @@ public class LDAPIdentityStore implements IdentityStore {
         List<LDAPObject> results = new ArrayList<>();
 
         try {
-            String baseDN = identityQuery.getSearchDn();
+            LdapName baseDN = identityQuery.getSearchDn();
 
             for (Condition condition : identityQuery.getConditions()) {
 
@@ -281,7 +280,7 @@ public class LDAPIdentityStore implements IdentityStore {
 
             for (SearchResult result : search) {
                 // don't add the branch in subtree search
-                if (identityQuery.getSearchScope() != SearchControls.SUBTREE_SCOPE || !result.getNameInNamespace().equalsIgnoreCase(baseDN)) {
+                if (identityQuery.getSearchScope() != SearchControls.SUBTREE_SCOPE || !baseDN.equals(new LdapName(result.getNameInNamespace()))) {
                     results.add(populateAttributedType(result, identityQuery));
                 }
             }
@@ -314,7 +313,7 @@ public class LDAPIdentityStore implements IdentityStore {
             attrs.add("supportedExtension");
             attrs.add("supportedFeatures");
             List<SearchResult> searchResults = operationManager
-                .search("", "(objectClass=*)", Collections.unmodifiableCollection(attrs), SearchControls.OBJECT_SCOPE);
+                .search(new LdapName(Collections.emptyList()), "(objectClass=*)", Collections.unmodifiableCollection(attrs), SearchControls.OBJECT_SCOPE);
             if (searchResults.size() != 1) {
                 throw new ModelException("Could not query root DSE: unexpected result size");
             }
@@ -343,36 +342,32 @@ public class LDAPIdentityStore implements IdentityStore {
 
     @Override
     public void validatePassword(LDAPObject user, String password) throws AuthenticationException {
-        String userDN = user.getDn().toString();
-
         if (logger.isTraceEnabled()) {
-            logger.tracef("Using DN [%s] for authentication of user", userDN);
+            logger.tracef("Using DN [%s] for authentication of user", user.getDn());
         }
 
-        operationManager.authenticate(userDN, password);
+        operationManager.authenticate(user.getDn().getLdapName(), password);
     }
 
     @Override
     public void updatePassword(LDAPObject user, String password, LDAPOperationDecorator passwordUpdateDecorator) {
-        String userDN = user.getDn().toString();
-
         if (logger.isDebugEnabled()) {
-            logger.debugf("Using DN [%s] for updating LDAP password of user", userDN);
+            logger.debugf("Using DN [%s] for updating LDAP password of user", user.getDn());
         }
 
         if (getConfig().isActiveDirectory()) {
-            updateADPassword(userDN, password, passwordUpdateDecorator);
+            updateADPassword(user.getDn().getLdapName(), password, passwordUpdateDecorator);
             return;
         }
 
         try {
             if (config.useExtendedPasswordModifyOp()) {
-                operationManager.passwordModifyExtended(userDN, password, passwordUpdateDecorator);
+                operationManager.passwordModifyExtended(user.getDn().getLdapName(), password, passwordUpdateDecorator);
             } else {
                 ModificationItem[] mods = new ModificationItem[1];
                 BasicAttribute mod0 = new BasicAttribute(LDAPConstants.USER_PASSWORD_ATTRIBUTE, password);
                 mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, mod0);
-                operationManager.modifyAttributes(userDN, mods, passwordUpdateDecorator);
+                operationManager.modifyAttributes(user.getDn().getLdapName(), mods, passwordUpdateDecorator);
             }
         } catch (ModelException me) {
             throw me;
@@ -381,7 +376,7 @@ public class LDAPIdentityStore implements IdentityStore {
         }
     }
 
-    private void updateADPassword(String userDN, String password, LDAPOperationDecorator passwordUpdateDecorator) {
+    private void updateADPassword(LdapName userDN, String password, LDAPOperationDecorator passwordUpdateDecorator) {
         try {
             // Replace the "unicdodePwd" attribute with a new value
             // Password must be both Unicode and a quoted string
@@ -617,7 +612,7 @@ public class LDAPIdentityStore implements IdentityStore {
 
             String rdn = ldapObject.getDn().getFirstRdn().toString(false);
             String filter = "(" + EscapeStrategy.DEFAULT.escape(rdn) + ")";
-            List<SearchResult> search = this.operationManager.search(ldapObject.getDn().toString(), filter, Arrays.asList(uuidAttrName), SearchControls.OBJECT_SCOPE);
+            List<SearchResult> search = this.operationManager.search(ldapObject.getDn().getLdapName(), filter, Arrays.asList(uuidAttrName), SearchControls.OBJECT_SCOPE);
             Attribute id = search.get(0).getAttributes().get(getConfig().getUuidLDAPAttributeName());
 
             if (id == null) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -87,7 +87,7 @@ public class LDAPOperationManager {
      * @param dn
      * @param attribute
      */
-    public void modifyAttribute(String dn, Attribute attribute) {
+    public void modifyAttribute(LdapName dn, Attribute attribute) {
         ModificationItem[] mods = new ModificationItem[]{new ModificationItem(DirContext.REPLACE_ATTRIBUTE, attribute)};
         modifyAttributes(dn, mods, null);
     }
@@ -101,7 +101,7 @@ public class LDAPOperationManager {
      * @param dn
      * @param attributes
      */
-    public void modifyAttributes(String dn,  NamingEnumeration<Attribute> attributes) {
+    public void modifyAttributes(LdapName dn,  NamingEnumeration<Attribute> attributes) {
         try {
             List<ModificationItem> modItems = new ArrayList<>();
             while (attributes.hasMore()) {
@@ -125,7 +125,7 @@ public class LDAPOperationManager {
      * @param dn
      * @param attribute
      */
-    public void removeAttribute(String dn, Attribute attribute) {
+    public void removeAttribute(LdapName dn, Attribute attribute) {
         ModificationItem[] mods = new ModificationItem[]{new ModificationItem(DirContext.REMOVE_ATTRIBUTE, attribute)};
         modifyAttributes(dn, mods, null);
     }
@@ -138,7 +138,7 @@ public class LDAPOperationManager {
      * @param dn
      * @param attribute
      */
-    public void addAttribute(String dn, Attribute attribute) {
+    public void addAttribute(LdapName dn, Attribute attribute) {
         ModificationItem[] mods = new ModificationItem[]{new ModificationItem(DirContext.ADD_ATTRIBUTE, attribute)};
         modifyAttributes(dn, mods, null);
     }
@@ -148,7 +148,7 @@ public class LDAPOperationManager {
      * Removes the object from the LDAP tree
      * </p>
      */
-    public void removeEntry(final String entryDn) {
+    public void removeEntry(final LdapName entryDn) {
         try {
             execute(new LdapOperation<SearchResult>() {
 
@@ -185,25 +185,25 @@ public class LDAPOperationManager {
      *                 attempt to rename to "CN=John Doe", but there is already existing "CN=John Doe", we will try "CN=John Doe0"
      * @return the non-conflicting DN, which was used in the end
      */
-    public String renameEntry(String oldDn, String newDn, boolean fallback) {
+    public LdapName renameEntry(LdapName oldDn, LdapName newDn, boolean fallback) {
         try {
-            String newNonConflictingDn = execute(new LdapOperation<String>() {
+            LdapName newNonConflictingDn = execute(new LdapOperation<LdapName>() {
 
                 @Override
-                public String execute(LdapContext context) throws NamingException {
-                    String dn = newDn;
+                public LdapName execute(LdapContext context) throws NamingException {
+                    LdapName dn = newDn;
 
                     // Max 5 attempts for now
                     int max = 5;
                     for (int i=0 ; i<max ; i++) {
                         try {
-                            context.rename(new LdapName(oldDn), new LdapName(dn));
+                            context.rename(oldDn, dn);
                             return dn;
                         } catch (NameAlreadyBoundException ex) {
                             if (!fallback) {
                                 throw ex;
                             } else {
-                                String failedDn = dn;
+                                LdapName failedDn = dn;
                                 if (i<max) {
                                     dn = findNextDNForFallback(newDn, i);
                                     logger.warnf("Failed to rename DN [%s] to [%s]. Will try to fallback to DN [%s]", oldDn, failedDn, dn);
@@ -234,18 +234,18 @@ public class LDAPOperationManager {
         }
     }
 
-    private String findNextDNForFallback(String newDn, int counter) {
-        LDAPDn dn = LDAPDn.fromString(newDn);
+    private LdapName findNextDNForFallback(LdapName newDn, int counter) {
+        LDAPDn dn = LDAPDn.fromLdapName(newDn);
         LDAPDn.RDN firstRdn = dn.getFirstRdn();
         String rdnAttrName = firstRdn.getAllKeys().get(0);
         String rdnAttrVal = firstRdn.getAttrValue(rdnAttrName);
         LDAPDn parentDn = dn.getParentDn();
         parentDn.addFirst(rdnAttrName, rdnAttrVal + counter);
-        return parentDn.toString();
+        return parentDn.getLdapName();
     }
 
 
-    public List<SearchResult> search(final String baseDN, final String filter, Collection<String> returningAttributes, int searchScope) throws NamingException {
+    public List<SearchResult> search(final LdapName baseDN, final String filter, Collection<String> returningAttributes, int searchScope) throws NamingException {
         final List<SearchResult> result = new ArrayList<>();
         final SearchControls cons = getSearchControls(returningAttributes, searchScope);
 
@@ -253,7 +253,7 @@ public class LDAPOperationManager {
             return execute(new LdapOperation<List<SearchResult>>() {
                 @Override
                 public List<SearchResult> execute(LdapContext context) throws NamingException {
-                    NamingEnumeration<SearchResult> search = context.search(new LdapName(baseDN), filter, cons);
+                    NamingEnumeration<SearchResult> search = context.search(baseDN, filter, cons);
 
                     while (search.hasMoreElements()) {
                         result.add(search.nextElement());
@@ -284,7 +284,7 @@ public class LDAPOperationManager {
         }
     }
 
-    public List<SearchResult> searchPaginated(final String baseDN, final String filter, final LDAPQuery identityQuery) throws NamingException {
+    public List<SearchResult> searchPaginated(final LdapName baseDN, final String filter, final LDAPQuery identityQuery) throws NamingException {
         final List<SearchResult> result = new ArrayList<>();
         final SearchControls cons = getSearchControls(identityQuery.getReturningLdapAttributes(), identityQuery.getSearchScope());
 
@@ -303,7 +303,7 @@ public class LDAPOperationManager {
                         PagedResultsControl pagedControls = new PagedResultsControl(identityQuery.getLimit(), cookie, Control.CRITICAL);
                         context.setRequestControls(new Control[] { pagedControls });
 
-                        NamingEnumeration<SearchResult> search = context.search(new LdapName(baseDN), filter, cons);
+                        NamingEnumeration<SearchResult> search = context.search(baseDN, filter, cons);
 
                         while (search.hasMoreElements()) {
                             result.add(search.nextElement());
@@ -401,7 +401,7 @@ public class LDAPOperationManager {
         return ldapIdFilter;
     }
 
-    public SearchResult lookupById(final String baseDN, final String id, final Collection<String> returningAttributes) {
+    public SearchResult lookupById(final LdapName baseDN, final String id, final Collection<String> returningAttributes) {
         final String filter = getFilterById(id);
 
         try {
@@ -411,7 +411,7 @@ public class LDAPOperationManager {
 
                 @Override
                 public SearchResult execute(LdapContext context) throws NamingException {
-                    NamingEnumeration<SearchResult> search = context.search(new LdapName(baseDN), filter, cons);
+                    NamingEnumeration<SearchResult> search = context.search(baseDN, filter, cons);
 
                     try {
                         if (search.hasMoreElements()) {
@@ -450,21 +450,21 @@ public class LDAPOperationManager {
      *
      * @param dn
      */
-    private void destroySubcontext(LdapContext context, final String dn) {
+    private void destroySubcontext(LdapContext context, final LdapName dn) {
         try {
             NamingEnumeration<Binding> enumeration = null;
 
             try {
-                enumeration = context.listBindings(new LdapName(dn));
+                enumeration = context.listBindings(dn);
 
                 while (enumeration.hasMore()) {
                     Binding binding = enumeration.next();
                     String name = binding.getNameInNamespace();
 
-                    destroySubcontext(context, name);
+                    destroySubcontext(context, new LdapName(name));
                 }
 
-                context.unbind(new LdapName(dn));
+                context.unbind(dn);
             } finally {
                 try {
                     enumeration.close();
@@ -486,7 +486,7 @@ public class LDAPOperationManager {
      * @throws AuthenticationException if authentication is not successful
      *
      */
-    public void authenticate(String dn, String password) throws AuthenticationException {
+    public void authenticate(LdapName dn, String password) throws AuthenticationException {
 
         if (password == null || password.isEmpty()) {
             throw new AuthenticationException("Empty password used");
@@ -503,7 +503,7 @@ public class LDAPOperationManager {
 
             if(!this.config.isStartTls()) {
                 env.put(Context.SECURITY_AUTHENTICATION, "simple");
-                env.put(Context.SECURITY_PRINCIPAL, dn);
+                env.put(Context.SECURITY_PRINCIPAL, dn.toString());
                 env.put(Context.SECURITY_CREDENTIALS, password);
             }
 
@@ -515,7 +515,7 @@ public class LDAPOperationManager {
                     sslSocketFactory = provider.getSSLSocketFactory();
                 }
 
-                tlsResponse = LDAPContextManager.startTLS(authCtx, "simple", dn, password.toCharArray(), sslSocketFactory);
+                tlsResponse = LDAPContextManager.startTLS(authCtx, "simple", dn.toString(), password.toCharArray(), sslSocketFactory);
 
                 // Exception should be already thrown by LDAPContextManager.startTLS if "startTLS" could not be established, but rather do some additional check
                 if (tlsResponse == null) {
@@ -557,7 +557,7 @@ public class LDAPOperationManager {
         }
     }
 
-    public void modifyAttributesNaming(final String dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) throws NamingException {
+    public void modifyAttributesNaming(final LdapName dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) throws NamingException {
         if (logger.isTraceEnabled()) {
             logger.tracef("Modifying attributes for entry [%s]: [", dn);
 
@@ -585,7 +585,7 @@ public class LDAPOperationManager {
 
             @Override
             public Void execute(LdapContext context) throws NamingException {
-                context.modifyAttributes(new LdapName(dn), mods);
+                context.modifyAttributes(dn, mods);
                 return null;
             }
 
@@ -600,7 +600,7 @@ public class LDAPOperationManager {
         }, decorator);
     }
 
-    public void modifyAttributes(final String dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) {
+    public void modifyAttributes(final LdapName dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) {
         try {
             modifyAttributesNaming(dn, mods, decorator);
         } catch (NamingException e) {
@@ -608,7 +608,7 @@ public class LDAPOperationManager {
         }
     }
 
-    public void createSubContext(final String name, final Attributes attributes) {
+    public void createSubContext(final LdapName name, final Attributes attributes) {
         try {
             if (logger.isTraceEnabled()) {
                 logger.tracef("Creating entry [%s] with attributes: [", name);
@@ -633,7 +633,7 @@ public class LDAPOperationManager {
             execute(new LdapOperation<Void>() {
                 @Override
                 public Void execute(LdapContext context) throws NamingException {
-                    DirContext subcontext = context.createSubcontext(new LdapName(name), attributes);
+                    DirContext subcontext = context.createSubcontext(name, attributes);
 
                     subcontext.close();
 
@@ -659,7 +659,7 @@ public class LDAPOperationManager {
         return this.config.getUuidLDAPAttributeName();
     }
 
-    public Attributes getAttributes(final String entryUUID, final String baseDN, Set<String> returningAttributes) {
+    public Attributes getAttributes(final String entryUUID, final LdapName baseDN, Set<String> returningAttributes) {
         SearchResult search = lookupById(baseDN, entryUUID, returningAttributes);
 
         if (search == null) {
@@ -689,10 +689,10 @@ public class LDAPOperationManager {
      * @param decorator A decorator to apply to the ldap operation.
      */
 
-    public void passwordModifyExtended(String dn, String password, LDAPOperationDecorator decorator) {
+    public void passwordModifyExtended(LdapName dn, String password, LDAPOperationDecorator decorator) {
         try {
             execute(context -> {
-                PasswordModifyRequest modifyRequest = new PasswordModifyRequest(dn, null, password);
+                PasswordModifyRequest modifyRequest = new PasswordModifyRequest(dn.toString(), null, password);
                 return context.extendedOperation(modifyRequest);
             }, decorator);
         } catch (NamingException e) {

--- a/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/model/LDAPDnTest.java
+++ b/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/model/LDAPDnTest.java
@@ -17,8 +17,8 @@
 
 package org.keycloak.storage.ldap.idm.model;
 
-import java.util.List;
-
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class LDAPDnTest {
         Assert.assertFalse(dn.isDescendantOf(LDAPDn.fromString("dc=keycloakk, dc=org")));
         Assert.assertFalse(dn.isDescendantOf(dn));
 
-        Assert.assertEquals("uid", dn.getFirstRdn().getAllKeys().get(0));
+        MatcherAssert.assertThat(dn.getFirstRdn().getAllKeys(), Matchers.containsInAnyOrder("uid"));
         Assert.assertEquals("uid=Johny\\,Depp\\+Pepp\\\\Foo", dn.getFirstRdn().toString());
         Assert.assertEquals("uid=Johny,Depp+Pepp\\Foo", dn.getFirstRdn().toString(false));
         Assert.assertEquals("Johny,Depp+Pepp\\Foo", dn.getFirstRdn().getAttrValue("uid"));
@@ -56,7 +56,7 @@ public class LDAPDnTest {
         LDAPDn dn = LDAPDn.fromString("dc=keycloak, dc=org");
         dn.addFirst("ou", "");
 
-        Assert.assertEquals("ou", dn.getFirstRdn().getAllKeys().get(0));
+        MatcherAssert.assertThat(dn.getFirstRdn().getAllKeys(), Matchers.containsInAnyOrder("ou"));
         Assert.assertEquals("", dn.getFirstRdn().getAttrValue("ou"));
 
         Assert.assertEquals("ou=,dc=keycloak,dc=org", dn.toString());
@@ -86,25 +86,32 @@ public class LDAPDnTest {
         dn.addFirst("cn", "Johny,Džýa ");
         Assert.assertEquals("cn=Johny\\,Džýa\\ ,dc=keycloak,dc=org", dn.toString());
         Assert.assertEquals("Johny,Džýa ", dn.getFirstRdn().getAttrValue("cn"));
+
+        dn = LDAPDn.fromString("CN=Test User\\\\,OU=Users,DC=example,DC=com");
+        Assert.assertEquals("CN=Test User\\\\,OU=Users,DC=example,DC=com", dn.toString());
+        Assert.assertEquals("Test User\\", dn.getFirstRdn().getAttrValue("CN"));
+
+        dn = LDAPDn.fromString("CN=Test User\\ ,OU=Users,DC=example,DC=com");
+        Assert.assertEquals("CN=Test User\\ ,OU=Users,DC=example,DC=com", dn.toString());
+        Assert.assertEquals("Test User ", dn.getFirstRdn().getAttrValue("CN"));
     }
 
     @Test
     public void testDNWithMultivaluedRDN() throws Exception {
-        LDAPDn dn = LDAPDn.fromString("uid=john+cn=John Do\\+eř,dc=keycloak+ou=foo, dc=org");
+        LDAPDn dn = LDAPDn.fromString("cn=John Do\\+eř+uid=john,dc=keycloak+ou=foo, dc=org");
 
-        Assert.assertEquals("uid=john+cn=John Do\\+eř", dn.getFirstRdn().toString());
-        List<String> keys = dn.getFirstRdn().getAllKeys();
-        Assert.assertEquals("uid", keys.get(0));
-        Assert.assertEquals("cn", keys.get(1));
+        Assert.assertEquals("cn=John Do\\+eř+uid=john", dn.getFirstRdn().toString());
+        MatcherAssert.assertThat(dn.getFirstRdn().getAllKeys(), Matchers.containsInAnyOrder("uid", "cn"));
         Assert.assertEquals("john", dn.getFirstRdn().getAttrValue("UiD"));
         Assert.assertEquals("John Do+eř", dn.getFirstRdn().getAttrValue("CN"));
 
         Assert.assertEquals("dc=keycloak+ou=foo,dc=org", dn.getParentDn().toString());
 
-        dn.getFirstRdn().setAttrValue("UID", "john2");
-        Assert.assertEquals("uid=john2+cn=John Do\\+eř", dn.getFirstRdn().toString());
+        LDAPDn.RDN rdn = dn.getFirstRdn();
+        rdn.setAttrValue("UID", "john2");
+        Assert.assertEquals("cn=John Do\\+eř+uid=john2", rdn.toString());
 
-        dn.getFirstRdn().setAttrValue("some", "somet+hing");
-        Assert.assertEquals("uid=john2+cn=John Do\\+eř+some=somet\\+hing", dn.getFirstRdn().toString());
+        rdn.setAttrValue("some", "somet+hing");
+        Assert.assertEquals("cn=John Do\\+eř+some=somet\\+hing+uid=john2", rdn.toString());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPNoMSADTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPNoMSADTest.java
@@ -158,7 +158,7 @@ public class LDAPNoMSADTest extends AbstractLDAPTest {
 
             // Assert DN was changed
             String rdnAttrName = ldapProvider.getLdapIdentityStore().getConfig().getRdnLdapAttribute();
-            Assert.assertEquals(rdnAttrName + "=johnkeycloak3+sn=Doe3", john2.getDn().getFirstRdn().toString());
+            Assert.assertEquals("sn=Doe3+" + rdnAttrName + "=johnkeycloak3", john2.getDn().getFirstRdn().toString());
         });
 
         // Update some user attributes not mapped to DN. DN won't be changed

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
@@ -190,7 +190,7 @@ public class UserSyncTest extends KeycloakModelTest {
             LDAPObject user1LdapObject = ldapFedProvider.loadLDAPUserByUsername(realm, "user1");
             LDAPOperationManager ldapOperationManager = new LDAPOperationManager(session, ldapFedProvider.getLdapIdentityStore().getConfig());
 
-            ldapOperationManager.removeAttribute(user1LdapObject.getDn().toString(), new BasicAttribute(LDAPConstants.STREET));
+            ldapOperationManager.removeAttribute(user1LdapObject.getDn().getLdapName(), new BasicAttribute(LDAPConstants.STREET));
             return null;
         });
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/21797
Closes https://github.com/keycloak/keycloak/issues/21818

Just a draft to see if we are interested in this (or something similar).

Looking those two issues about LDAP I wondered why we are using `LDAPDn` and `LDAPDn.RDN` instead of `LdapName` and `Rdn` default java classes. I did this quick test and it passed all the CI (https://github.com/rmartinc/keycloak/actions/runs/6380208154). Three commits are submitted with three different levels of replacement:

1.  `LDAPDn` and `LDAPDn.RDN` wrap the java `LdapName/Rdn` classes.
2. API change to use `LdapName` instead of `String` and avoid extra conversions (LdapDn/LdapName -> String -> LdapName).
3. Remove completely `LDAPDn` class. Use LdapName/Rdn instead and I moved the interesting `LDAPDn` methods to `LDAPUtils` class.

I'm changing a lot the API inside the ldap federation (not in point 1, just in 2 and 3). Don't know if we are interested in maintain compatiblity in those classes. I'm happy with 1 and 2 only. I just did 3 to see if it was feasible.

@keycloak/core @keycloak/store WDYT?