### PR TITLE
Fix set-version.sh's handling of NPM versions

### DIFF
--- a/js/libs/keycloak-js/pom.xml
+++ b/js/libs/keycloak-js/pom.xml
@@ -83,8 +83,8 @@
                         </goals>
                         <configuration>
                             <artifacts>
-                                <artifact>${project.basedir}/assembly.xml
-                                    <file>target/keycloak-js-${project.version}.tgz</file>
+                                <artifact>
+                                    <file>target/keycloak-js-${project.version.npm}.tgz</file>
                                     <type>tar.gz</type>
                                 </artifact>
                             </artifacts>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
     <packaging>pom</packaging>
 
     <properties>
+        <project.version.npm>999.0.0-SNAPSHOT</project.version.npm>
+
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
         <jboss.repo.nexusUrl>https://s01.oss.sonatype.org/</jboss.repo.nexusUrl>

--- a/set-version.sh
+++ b/set-version.sh
@@ -11,6 +11,7 @@ fi
 
 # Maven
 mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
+mvn versions:set-property --non-recursive -Dproperty=project.version.npm -DnewVersion="$NEW_NPM_VERSION"
 
 # Docker
 sed -i "s/ENV KEYCLOAK_VERSION .*/ENV KEYCLOAK_VERSION $NEW_VERSION/" quarkus/container/Dockerfile
@@ -29,3 +30,6 @@ echo "$(jq '. += {"version": "'$NEW_NPM_VERSION'"}' js/libs/keycloak-js/package.
 
 # Keycloak Admin Client
 echo "$(jq '. += {"version": "'$NEW_NPM_VERSION'"}' js/libs/keycloak-admin-client/package.json)" > js/libs/keycloak-admin-client/package.json
+
+echo "New Mvn Version: $NEW_VERSION" >&2
+echo "New NPM Version: $NEW_NPM_VERSION" >&2


### PR DESCRIPTION
This introduces a maven property, `project.version.npm`, to allow maven to know what NPM version is, in scenarios that it's not identical to `project.version`. This occurs when the set-version's semver translation code is activated

Closes #23635

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
