### PR TITLE
switching the operator role to clusterrole for ingresses config

### DIFF
--- a/operator/overlays/default-namespace/kustomization.yaml
+++ b/operator/overlays/default-namespace/kustomization.yaml
@@ -5,3 +5,15 @@ resources:
 - ../../target
 
 namespace: default
+
+transformers:
+- |-
+  apiVersion: builtin
+  kind: NamespaceTransformer
+  metadata:
+    name: notImportantHere
+    namespace: default
+  setRoleBindingSubjects: allServiceAccounts
+  fieldSpecs:
+  - path: metadata/namespace
+    create: true

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -58,6 +58,12 @@ rules:
       - delete
       - patch
       - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keycloak-operator-clusterrole
+rules:
   - apiGroups:
       - config.openshift.io
     resources:
@@ -78,3 +84,18 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: keycloak-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: keycloak-operator
+  name: keycloak-operator-clusterrole-binding
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: keycloak-operator-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-operator
+    namespace: keycloak

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -63,7 +64,11 @@ public final class K8sUtils {
     }
 
     public static List<HasMetadata> set(KubernetesClient client, InputStream stream) {
-        return client.load(stream).items().stream().map(i -> set(client, i)).collect(Collectors.toList());
+        return set(client, stream, Function.identity());
+    }
+
+    public static List<HasMetadata> set(KubernetesClient client, InputStream stream, Function<HasMetadata, HasMetadata> modifier) {
+        return client.load(stream).items().stream().map(modifier).map(i -> set(client, i)).collect(Collectors.toList());
     }
 
     public static <T extends HasMetadata> T set(KubernetesClient client, T hasMetadata) {


### PR DESCRIPTION
The permissioning of a cluster-wide resource does not work correctly unless both a ClusterRole and ClusterRoleBinding are used.  That will get correctly picked up in the csv generation as clusterPermissions.  The only downside is that the ClusterRoleBinding in the target/kubernetes/kubernetes.yaml will have an invalid ClusterRoleBinding subject, unless we set the namespace - which I've set to keycloak as that already matches the README.  Direct usage of the generated manifests will not not work correctly for anything other than targeting the keycloak namespace.  Kustomize can still be used to switch the target namespace, it just needs a little more knowledge about where to set the namespace.  Similarly for the BaseOperatorTests we have to take responsibility for setting the namespace to the current one.

An ancillary change is that in the logs shared by @miquelsi there were too many attempts at logging the pod logs.  The issue is that once quarkus sets the test failure state - it stays set for the entire test class, it's not on a per test method basis.  So some additional filtering was added to make sure the test failure came from the current test method.

closes #23629

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
