### PR TITLE
Disable uploading heapdumps on Windows runners (#23665)

### DIFF
--- a/.github/actions/upload-heapdumps/action.yml
+++ b/.github/actions/upload-heapdumps/action.yml
@@ -6,6 +6,8 @@ runs:
   steps:
     - id: upload-jvm-heapdumps
       name: Upload JVM Heapdumps
+      # Windows runners are running into https://github.com/actions/upload-artifact/issues/240
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v3
       with:
         name: jvm-heap-dumps


### PR DESCRIPTION
Closes #23661