### PR TITLE
Fix client assertion with invalid ES256, ES384, ES512 signatures

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -34,9 +34,9 @@ import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.Algorithm;
-import org.keycloak.crypto.AsymmetricSignatureProvider;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.MacSignatureSignerContext;
+import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -447,7 +447,7 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             }
         }
         String alg = getConfig().getClientAssertionSigningAlg() != null ? getConfig().getClientAssertionSigningAlg() : Algorithm.RS256;
-        return new AsymmetricSignatureProvider(session, alg).signer();
+        return session.getProvider(SignatureProvider.class, alg).signer();
     }
 
     protected static class Endpoint {


### PR DESCRIPTION
Closes #23721

This allows integration with IdPs that only allow client assertions with the  ES256, ES384 or ES512 signature algorithms.

The `KcOidcBrokerPrivateKeyJwtCustomSignAlgTest` already tests the scenario. This was passing even with the DER encoded signature due to the fallback logic in `ClientECDSASignatureVerifierContext` which accepts DER encoded signatures.

https://github.com/keycloak/keycloak/blob/9a93b9a2734d2f8c9192c68c39efa1f9d0359613/services/src/main/java/org/keycloak/crypto/ClientECDSASignatureVerifierContext.java#L35-L47
