### PR TITLE
Tolerate secrets being missing (22.0)

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
@@ -155,7 +155,8 @@ public class WatchedSecretsStore extends OperatorManagedResource {
 
     private Set<Secret> fetchCurrentSecrets(Set<String> secretsNames) {
         return secretsNames.stream()
-                .map(n -> client.secrets().inNamespace(getNamespace()).withName(n).require())
+                .map(n -> client.secrets().inNamespace(getNamespace()).withName(n).get())
+                .filter(n -> n != null)
                 .collect(Collectors.toSet());
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpecBuilder;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.quarkus.logging.Log;
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -94,6 +95,30 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
             k8sclient.resource(kc).delete();
             Awaitility.await()
                     .untilAsserted(() -> assertThat(k8sclient.apps().statefulSets().inNamespace(namespace).withName(deploymentName).get()).isNull());
+        } catch (Exception e) {
+            savePodLogs();
+            throw e;
+        }
+    }
+
+    @Test
+    public void testKeycloakDeploymentBeforeSecret() {
+        try {
+            var kc = getDefaultKeycloakDeployment();
+            var deploymentName = kc.getMetadata().getName();
+            deployKeycloak(k8sclient, kc, false, false);
+
+            // Check Operator has deployed Keycloak and the statefulset exists, this allows for the watched secret to be picked up
+            Log.info("Checking Operator has deployed Keycloak deployment");
+            Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);
+            Resource<Keycloak> keycloakResource = k8sclient.resources(Keycloak.class).withName(deploymentName);
+            // expect no errors and not ready, which means we'll keep reconciling
+            Awaitility.await().untilAsserted(() -> {
+                assertThat(stsResource.get()).isNotNull();
+                Keycloak keycloak = keycloakResource.get();
+                CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.HAS_ERRORS, false);
+                CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.READY, false);
+            });
         } catch (Exception e) {
             savePodLogs();
             throw e;


### PR DESCRIPTION
If any secret was missing, the reconcile would error out. After doing this a number of times, the controller would stop trying and end up in a state where the operator would need restarting, or the resource would need recreating, to continue reconciliation.

This fix stops the reconcile from erroring out so the operator will reconcile continuously until the secrets are all present.

The fix is different than the fix for 23.0 because 23.0 has changed how secrets are handled.

Fixes #22170

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
