### PR TITLE
fix: remove common-compress

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -95,6 +95,10 @@
                     <groupId>com.aayushatharva.brotli4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
The dependency is not needed by the keycloak operator.

closes #23331

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
