### PR TITLE
Remove backward compatibility for ECDSA tokens

### DIFF
--- a/core/src/main/java/org/keycloak/crypto/ECDSAAlgorithm.java
+++ b/core/src/main/java/org/keycloak/crypto/ECDSAAlgorithm.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.crypto;
+
+import java.io.IOException;
+import org.keycloak.common.crypto.CryptoIntegration;
+
+/**
+ *
+ * @author rmartinc
+ */
+public enum ECDSAAlgorithm {
+    ES256(64),
+    ES384(96),
+    ES512(132);
+
+    private final int signatureLength;
+
+    ECDSAAlgorithm(int signatureLength) {
+        this.signatureLength = signatureLength;
+    }
+
+    public int getSignatureLength() {
+        return this.signatureLength;
+    }
+
+    public static int getSignatureLength(String alg) {
+        return valueOf(alg).getSignatureLength();
+    }
+
+    public static byte[] concatenatedRSToASN1DER(final byte[] signature, int signLength) throws IOException {
+        return CryptoIntegration.getProvider().getEcdsaCryptoProvider().concatenatedRSToASN1DER(signature, signLength);
+    }
+
+    public static byte[] asn1derToConcatenatedRS(final byte[] derEncodedSignatureValue, int signLength) throws IOException {
+        return CryptoIntegration.getProvider().getEcdsaCryptoProvider().asn1derToConcatenatedRS(derEncodedSignatureValue, signLength);
+    }
+}

--- a/core/src/main/java/org/keycloak/crypto/ECDSASignatureSignerContext.java
+++ b/core/src/main/java/org/keycloak/crypto/ECDSASignatureSignerContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.crypto;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class ECDSASignatureSignerContext extends AsymmetricSignatureSignerContext {
+
+    public ECDSASignatureSignerContext(KeyWrapper key) throws SignatureException {
+        super(key);
+    }
+
+    @Override
+    public byte[] sign(byte[] data) throws SignatureException {
+        try {
+            int size = ECDSAAlgorithm.getSignatureLength(getAlgorithm());
+            return ECDSAAlgorithm.asn1derToConcatenatedRS(super.sign(data), size);
+        } catch (Exception e) {
+            throw new SignatureException("Signing failed", e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/crypto/ClientECDSASignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ClientECDSASignatureVerifierContext.java
@@ -34,12 +34,8 @@ public class ClientECDSASignatureVerifierContext extends AsymmetricSignatureVeri
     @Override
     public boolean verify(byte[] data, byte[] signature) throws VerificationException {
         try {
-            /*
-            Fallback for backwards compatibility of ECDSA signed tokens which were issued in previous versions.
-            TODO remove by https://issues.jboss.org/browse/KEYCLOAK-11911
-             */
-            int expectedSize = ECDSASignatureProvider.ECDSA.valueOf(getAlgorithm()).getSignatureLength();
-            byte[] derSignature = expectedSize != signature.length && signature[0] == 0x30 ? signature : ECDSASignatureProvider.concatenatedRSToASN1DER(signature, expectedSize);
+            int expectedSize = ECDSAAlgorithm.getSignatureLength(getAlgorithm());
+            byte[] derSignature = ECDSAAlgorithm.concatenatedRSToASN1DER(signature, expectedSize);
             return super.verify(data, derSignature);
         } catch (Exception e) {
             throw new VerificationException("Signing failed", e);

--- a/services/src/main/java/org/keycloak/crypto/ECDSASignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/ECDSASignatureProvider.java
@@ -1,10 +1,7 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.models.KeycloakSession;
-
-import java.io.IOException;
 
 public class ECDSASignatureProvider implements SignatureProvider {
 
@@ -41,29 +38,5 @@ public class ECDSASignatureProvider implements SignatureProvider {
     @Override
     public boolean isAsymmetricAlgorithm() {
         return true;
-    }
-
-    public static byte[] concatenatedRSToASN1DER(final byte[] signature, int signLength) throws IOException {
-        return CryptoIntegration.getProvider().getEcdsaCryptoProvider().concatenatedRSToASN1DER(signature, signLength);
-    }
-
-    public static byte[] asn1derToConcatenatedRS(final byte[] derEncodedSignatureValue, int signLength) throws IOException {
-        return CryptoIntegration.getProvider().getEcdsaCryptoProvider().asn1derToConcatenatedRS(derEncodedSignatureValue, signLength);
-    }
-
-    public enum ECDSA {
-        ES256(64),
-        ES384(96),
-        ES512(132);
-
-        private final int signatureLength;
-
-        ECDSA(int signatureLength) {
-            this.signatureLength = signatureLength;
-        }
-
-        public int getSignatureLength() {
-            return this.signatureLength;
-        }
     }
 }

--- a/services/src/main/java/org/keycloak/crypto/ServerECDSASignatureSignerContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerECDSASignatureSignerContext.java
@@ -2,7 +2,7 @@ package org.keycloak.crypto;
 
 import org.keycloak.models.KeycloakSession;
 
-public class ServerECDSASignatureSignerContext extends AsymmetricSignatureSignerContext {
+public class ServerECDSASignatureSignerContext extends ECDSASignatureSignerContext {
 
     public ServerECDSASignatureSignerContext(KeycloakSession session, String algorithm) throws SignatureException {
         super(ServerAsymmetricSignatureSignerContext.getKey(session, algorithm));
@@ -10,15 +10,5 @@ public class ServerECDSASignatureSignerContext extends AsymmetricSignatureSigner
 
     public ServerECDSASignatureSignerContext(KeyWrapper key) {
         super(key);
-    }
-
-    @Override
-    public byte[] sign(byte[] data) throws SignatureException {
-        try {
-            int size = ECDSASignatureProvider.ECDSA.valueOf(getAlgorithm()).getSignatureLength();
-            return ECDSASignatureProvider.asn1derToConcatenatedRS(super.sign(data), size);
-        } catch (Exception e) {
-            throw new SignatureException("Signing failed", e);
-        }
     }
 }

--- a/services/src/main/java/org/keycloak/crypto/ServerECDSASignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerECDSASignatureVerifierContext.java
@@ -15,12 +15,8 @@ public class ServerECDSASignatureVerifierContext extends  AsymmetricSignatureVer
     @Override
     public boolean verify(byte[] data, byte[] signature) throws VerificationException {
         try {
-            /*
-            Fallback for backwards compatibility of ECDSA signed tokens which were issued in previous versions.
-            TODO remove by https://issues.jboss.org/browse/KEYCLOAK-11911
-             */
-            int expectedSize = ECDSASignatureProvider.ECDSA.valueOf(getAlgorithm()).getSignatureLength();
-            byte[] derSignature = expectedSize != signature.length && signature[0] == 0x30 ? signature : ECDSASignatureProvider.concatenatedRSToASN1DER(signature, expectedSize);
+            int expectedSize = ECDSAAlgorithm.getSignatureLength(getAlgorithm());
+            byte[] derSignature = ECDSAAlgorithm.concatenatedRSToASN1DER(signature, expectedSize);
             return super.verify(data, derSignature);
         } catch (Exception e) {
             throw new VerificationException("Signing failed", e);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -40,7 +40,7 @@ import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
-import org.keycloak.crypto.ECDSASignatureProvider;
+import org.keycloak.crypto.ECDSAAlgorithm;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -1318,12 +1318,12 @@ public class AccessTokenTest extends AbstractKeycloakTest {
     }
 
     private void validateTokenECDSASignature(String expectedAlg) {
-        assertThat(ECDSASignatureProvider.ECDSA.values(), hasItemInArray(ECDSASignatureProvider.ECDSA.valueOf(expectedAlg)));
+        assertThat(ECDSAAlgorithm.values(), hasItemInArray(ECDSAAlgorithm.valueOf(expectedAlg)));
 
         try {
             TokenSignatureUtil.changeRealmTokenSignatureProvider(adminClient, expectedAlg);
             TokenSignatureUtil.changeClientAccessTokenSignatureProvider(ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app"), expectedAlg);
-            validateTokenSignatureLength(ECDSASignatureProvider.ECDSA.valueOf(expectedAlg).getSignatureLength());
+            validateTokenSignatureLength(ECDSAAlgorithm.getSignatureLength(expectedAlg));
         } finally {
             TokenSignatureUtil.changeRealmTokenSignatureProvider(adminClient, Algorithm.RS256);
             TokenSignatureUtil.changeClientAccessTokenSignatureProvider(ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app"), Algorithm.RS256);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
@@ -57,7 +57,7 @@ import org.keycloak.common.util.UriUtils;
 import org.keycloak.common.util.KeystoreUtil.KeystoreFormat;
 import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.crypto.Algorithm;
-import org.keycloak.crypto.ECDSASignatureProvider;
+import org.keycloak.crypto.ECDSAAlgorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.events.Details;
@@ -398,7 +398,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
     private void testECDSASignatureLength(String clientSignedToken, String alg) {
         String encodedSignature = clientSignedToken.split("\\.",3)[2];
         byte[] signature = Base64Url.decode(encodedSignature);
-        assertEquals(ECDSASignatureProvider.ECDSA.valueOf(alg).getSignatureLength(), signature.length);
+        assertEquals(ECDSAAlgorithm.getSignatureLength(alg), signature.length);
     }
 
     private String getClientSignedToken(String alg) throws Exception {


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/23734

There were issues in the CI associated to adapters/tests that used ECDSA tokens to authenticate. The client side was not adding the R+S and using normal DER via `AsymmetricSignatureSignerContext`. Changes:

* Creating a `ECDSASignatureSignerContext` in the core sub-project extending the `AsymmetricSignatureSignerContext`. I created also a `ECDSAAlgorithm` enumeration that incorporates some method that previously were in the services project.
* `JWTClientCredentialsProvider` now uses one or the other signer context.
* Tests modified to use the new classes.
