### PR TITLE
operator: Replace dead documentation link

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
@@ -41,7 +41,7 @@ import io.quarkiverse.operatorsdk.bundle.runtime.SharedCSVMetadata;
     },
     links = {
         @CSVMetadata.Link(
-            url = "https://www.keycloak.org/docs/latest/server_installation/index.html#_operator",
+            url = "https://www.keycloak.org/guides#operator",
             name = "Documentation"
         ),
         @CSVMetadata.Link(


### PR DESCRIPTION
Before this patch, the documentation link generated for the Operator page resulted in a 404 Not Found on Github pages.

With this change, the documentation link points to the "Operator" anchor in the Keycloak docs index. Note that the operator docs don't seem to be versioned on the Keycloak website.

Fixes #24143