### PR TITLE
Fix flaky testPersistenceMultipleNodesClientSessionsAtRandomNode

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -983,6 +983,9 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
             long lifespan = lifespanMsCalculator.apply(currentRealm, client, sessionEntity);
             long maxIdle = maxIdleTimeMsCalculator.apply(currentRealm, client, sessionEntity);
 
+            log.tracef("Lifespan of sessionId=%s to be imported to the cache %d ms", id, lifespan);
+            log.tracef("Max idle of sessionId=%s to be imported to the cache %d ms", id, maxIdle);
+
             if (lifespan != SessionTimeouts.ENTRY_EXPIRED_FLAG
                     && maxIdle != SessionTimeouts.ENTRY_EXPIRED_FLAG) {
                 if (cache instanceof RemoteCache) {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Infinispan.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Infinispan.java
@@ -50,6 +50,8 @@ import org.keycloak.timer.TimerProviderFactory;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.keycloak.testsuite.model.session.OfflineSessionPersistenceTest.SESSIONS_OWNERS_SYSTEM_PROPERTY;
+
 /**
  *
  * @author hmlnarik
@@ -96,6 +98,7 @@ public class Infinispan extends KeycloakModelParameters {
                 .config("clustered", "true")
                 .config("useKeycloakTimeService", "true")
                 .config("nodeName", "node-" + NODE_COUNTER.incrementAndGet())
+                .config("sessionsOwners", "${" + SESSIONS_OWNERS_SYSTEM_PROPERTY + ":2}")
                 .spi(UserLoginFailureSpi.NAME)
                 .provider(InfinispanUserLoginFailureProviderFactory.PROVIDER_ID)
                 .config("stalledTimeoutInSeconds", "10")

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
@@ -78,6 +78,7 @@ public class UserSessionPersisterProviderTest extends KeycloakModelTest {
     @Override
     public void createEnvironment(KeycloakSession s) {
         RealmModel realm = createRealm(s, "test");
+        realm.setOfflineSessionMaxLifespanEnabled(true);
         realm.setOfflineSessionIdleTimeout(Constants.DEFAULT_OFFLINE_SESSION_IDLE_TIMEOUT);
         realm.setOfflineSessionMaxLifespan(Constants.DEFAULT_OFFLINE_SESSION_MAX_LIFESPAN);
         realm.setDefaultRole(s.roles().addRealmRole(realm, Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + realm.getName()));


### PR DESCRIPTION
Closes #21665

I ran this change in my branch, where I  executed `store model tests` stage in GHA 70 times. `testPersistenceMultipleNodesClientSessionsAtRandomNode` wasn't flaky anymore. 

This was the only reliable way of fixing the flakynes for me. Any attempt where I tried to reduce/delay/synchronize node restarts didn't fix it. 

I wasn't able to reproduce it locally, not even after many many iterations or reducing number of threads. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
