### PR TITLE
Fix generated OpenAPI spec

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -20,6 +20,7 @@ package org.keycloak.representations.idm;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.util.JsonSerialization;
@@ -154,9 +155,11 @@ public class RealmRepresentation {
     // Client Policies/Profiles
 
     @JsonProperty("clientProfiles")
+    @Schema(implementation = ClientProfilesRepresentation.class)
     protected JsonNode clientProfiles;
 
     @JsonProperty("clientPolicies")
+    @Schema(implementation = ClientPoliciesRepresentation.class)
     protected JsonNode clientPolicies;
 
     protected List<UserRepresentation> users;

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <docker.maven.plugin.version>0.40.3</docker.maven.plugin.version>
         <verifier.plugin.version>1.1</verifier.plugin.version>
         <shade.plugin.version>3.4.1</shade.plugin.version>
-        <smallrye.openapi.generator.plugin.version>3.1.2</smallrye.openapi.generator.plugin.version>
+        <smallrye.openapi.generator.plugin.version>3.6.2</smallrye.openapi.generator.plugin.version>
         <openapi.generator.plugin.version>6.3.0</openapi.generator.plugin.version>
 
         <!-- Surefire Settings -->


### PR DESCRIPTION
Fixes #23733.

With this update, endpoints returning a `Stream<T>` are handled correctly by the OpenAPI generator and the generated spec correctly contains `"schema": {"type": "array", "items": {"$ref": "..."}}` instead of the previous `"schema": {"type": "object"}`. This also makes sure the correct types are displayed in the HTML API docs.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
