### PR TITLE
Fix issue with web UI of client-scope protocol mappers with custom IDs

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
@@ -186,6 +186,7 @@ export default function EditClientScope() {
           realm,
           id: clientScope!.id!,
           mapperId: mapper.id!,
+          mode: "create",
         }),
       );
     } else {
@@ -257,7 +258,12 @@ export default function EditClientScope() {
               onAdd={addMappers}
               onDelete={onDelete}
               detailLink={(id) =>
-                toMapper({ realm, id: clientScope.id!, mapperId: id! })
+                toMapper({
+                  realm,
+                  id: clientScope.id!,
+                  mapperId: id!,
+                  mode: "update",
+                })
               }
             />
           </Tab>

--- a/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
@@ -36,7 +36,7 @@ export default function MappingDetails() {
   const { t } = useTranslation();
   const { addAlert, addError } = useAlerts();
 
-  const { id, mapperId } = useParams<MapperParams>();
+  const { id, mapperId, mode } = useParams<MapperParams>();
   const form = useForm();
   const {
     register,
@@ -53,8 +53,7 @@ export default function MappingDetails() {
   const navigate = useNavigate();
   const { realm } = useRealm();
   const serverInfo = useServerInfo();
-  const isGuid = /^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$/;
-  const isUpdating = !!mapperId.match(isGuid);
+  const isUpdating = mode === "update";
 
   const isOnClientScope = !!useMatch(MapperRoute.path);
   const toDetails = () =>

--- a/js/apps/admin-ui/src/client-scopes/routes/Mapper.tsx
+++ b/js/apps/admin-ui/src/client-scopes/routes/Mapper.tsx
@@ -7,12 +7,13 @@ export type MapperParams = {
   realm: string;
   id: string;
   mapperId: string;
+  mode: string;
 };
 
 const MappingDetails = lazy(() => import("../details/MappingDetails"));
 
 export const MapperRoute: AppRouteObject = {
-  path: "/:realm/client-scopes/:id/mappers/:mapperId",
+  path: "/:realm/client-scopes/:id/mappers/:mapperId/:mode",
   element: <MappingDetails />,
   breadcrumb: (t) => t("mappingDetails"),
   handle: {

--- a/js/apps/admin-ui/src/clients/routes/Mapper.tsx
+++ b/js/apps/admin-ui/src/clients/routes/Mapper.tsx
@@ -7,6 +7,7 @@ export type MapperParams = {
   realm: string;
   id: string;
   mapperId: string;
+  mode: string;
 };
 
 const MappingDetails = lazy(
@@ -14,7 +15,7 @@ const MappingDetails = lazy(
 );
 
 export const MapperRoute: AppRouteObject = {
-  path: "/:realm/clients/:id/clientScopes/dedicated/mappers/:mapperId",
+  path: "/:realm/clients/:id/clientScopes/dedicated/mappers/:mapperId/:mode",
   element: <MappingDetails />,
   breadcrumb: (t) => t("mappingDetails"),
   handle: {

--- a/js/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
@@ -60,6 +60,7 @@ export default function DedicatedScopes() {
           realm,
           id: client.id!,
           mapperId: mapper.id!,
+          mode: "create",
         }),
       );
     } else {
@@ -122,7 +123,7 @@ export default function DedicatedScopes() {
               onAdd={addMappers}
               onDelete={onDeleteMapper}
               detailLink={(mapperId) =>
-                toMapper({ realm, id: client.id!, mapperId })
+                toMapper({ realm, id: client.id!, mapperId, mode: "update" })
               }
             />
           </Tab>


### PR DESCRIPTION
The path parameter mapperId is used on the same path to distinguish both the protocol mapper id during creation and the mapper id during modification of a client-scope mapper. The distinction is made by reading the GUID format, which causes the user interface to crash in the case of a custom format for mapper id. I have added '/create' and '/update' to the end of the path to distinguish the two modes without using the GUID regexp anymore.

Closes #23516

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
