### PR TITLE
Use Quarkus extension for picocli

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -150,6 +150,12 @@
             <artifactId>quarkus-logging-json-deployment</artifactId>
         </dependency>
 
+        <!-- CLI -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-picocli-deployment</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -108,8 +108,8 @@
 
         <!-- CLI -->
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-picocli</artifactId>
         </dependency>
 
         <!-- Keycloak -->


### PR DESCRIPTION
Closes #23857

The only transitive dependency for the extension is `info.picocli`.