### PR TITLE
Unify CLI handling across guides

### DIFF
--- a/docs/documentation/server_admin/topics/vault.adoc
+++ b/docs/documentation/server_admin/topics/vault.adoc
@@ -32,7 +32,7 @@ All built-in providers support the configuration of key resolvers. A key resolve
 
 [source,bash]
 ----
-kc.[sh.bat] start --spi-vault-file-key-resolvers=REALM_UNDERSCORE_KEY,KEY_ONLY
+kc.[sh|bat] start --spi-vault-file-key-resolvers=REALM_UNDERSCORE_KEY,KEY_ONLY
 ----
 
 The resolvers run in the same order you declare them in the configuration. For each resolver, {project_name} uses the last entry name the resolver produces, which combines the realm with the vault key to search for the vault's secret. If {project_name} finds a secret, it returns the secret. If not, {project_name} uses the next resolver. This search continues until {project_name} finds a non-empty secret or runs out of resolvers. If {project_name} finds no secret, {project_name} returns an empty secret.


### PR DESCRIPTION
Closes #23856

When running a command like 

```
mvn clean install -Dguides.linuxOnly=true
```

this will render docs like 

![image](https://github.com/keycloak/keycloak/assets/3957921/871a5294-eefe-44b6-8693-b4c93b4e4e53)

instead of previously rendering

![image](https://github.com/keycloak/keycloak/assets/3957921/b3a81535-081f-4e6b-b117-38f5904557e9)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
