### PR TITLE
add correct typescript type to `responseData` field in case if `NetworkError` occured

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -1,8 +1,19 @@
-export type NetworkErrorOptions = { response: Response; responseData: unknown };
+type ResponseData =
+  | string
+  | number
+  | boolean
+  | null
+  | ResponseData[]
+  | { [key: string]: ResponseData };
+
+export type NetworkErrorOptions = {
+  response: Response;
+  responseData: ResponseData;
+};
 
 export class NetworkError extends Error {
   response: Response;
-  responseData: unknown;
+  responseData: ResponseData;
 
   constructor(message: string, options: NetworkErrorOptions) {
     super(message);
@@ -28,7 +39,7 @@ export async function fetchWithError(
   return response;
 }
 
-export async function parseResponse(response: Response): Promise<any> {
+export async function parseResponse(response: Response): Promise<ResponseData> {
   if (!response.body) {
     return "";
   }


### PR DESCRIPTION
`ResponseData` is basically type of parsed JSON returned by `JSON.parse` or `""` which is returned by `parseResponse` function.
So this new type should cover all possible scenarios eliminating use of `any` and `unknown`.
In this case consumer will know that `responseData` is simply result of `JSON.parse` thus without any functions, circular dependencies and so on. `""` could be also result of `JSON.parse` for example: `JSON.parse('""')` so we cover all possible cases.

This PR brings very small but still an improvement for typescript support :)
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
