### PR TITLE
Add dedicated feature flag for oauth device grant flow (#23891)

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -95,8 +95,6 @@ public class Profile {
         LINKEDIN_OAUTH("LinkedIn Social Identity Provider based on OAuth", Type.DEPRECATED),
 
         DEVICE_FLOW("OAuth 2.0 Device Authorization Grant", Type.DEFAULT),
-
-        // Add new Feature above this line
         ;
 
         private final Type type;

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -92,7 +92,12 @@ public class Profile {
 
         DPOP("OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer", Type.PREVIEW),
 
-        LINKEDIN_OAUTH("LinkedIn Social Identity Provider based on OAuth", Type.DEPRECATED);
+        LINKEDIN_OAUTH("LinkedIn Social Identity Provider based on OAuth", Type.DEPRECATED),
+
+        DEVICE_FLOW("OAuth 2.0 Device Authorization Grant", Type.DEFAULT),
+
+        // Add new Feature above this line
+        ;
 
         private final Type type;
         private final String label;

--- a/js/apps/admin-ui/src/clients/add/CapabilityConfig.tsx
+++ b/js/apps/admin-ui/src/clients/add/CapabilityConfig.tsx
@@ -14,6 +14,7 @@ import { FormAccess } from "../../components/form/FormAccess";
 import { HelpItem } from "ui-shared";
 import { convertAttributeNameToForm } from "../../util";
 import { FormFields } from "../ClientDetails";
+import useIsFeatureEnabled, { Feature } from "../../utils/useIsFeatureEnabled";
 
 type CapabilityConfigProps = {
   unWrap?: boolean;
@@ -29,6 +30,7 @@ export const CapabilityConfig = ({
   const protocol = type || watch("protocol");
   const clientAuthentication = watch("publicClient");
   const authorization = watch("authorizationServicesEnabled");
+  const isFeatureEnabled = useIsFeatureEnabled();
 
   return (
     <FormAccess
@@ -215,31 +217,33 @@ export const CapabilityConfig = ({
                   )}
                 />
               </GridItem>
-              <GridItem lg={8} sm={6}>
-                <Controller
-                  name={convertAttributeNameToForm<
-                    Required<ClientRepresentation["attributes"]>
-                  >("attributes.oauth2.device.authorization.grant.enabled")}
-                  defaultValue={false}
-                  control={control}
-                  render={({ field }) => (
-                    <InputGroup>
-                      <Checkbox
-                        data-testid="oauth-device-authorization-grant"
-                        label={t("oauthDeviceAuthorizationGrant")}
-                        id="kc-oauth-device-authorization-grant"
-                        name="oauth2.device.authorization.grant.enabled"
-                        isChecked={field.value.toString() === "true"}
-                        onChange={field.onChange}
-                      />
-                      <HelpItem
-                        helpText={t("oauthDeviceAuthorizationGrantHelp")}
-                        fieldLabelId="oauthDeviceAuthorizationGrant"
-                      />
-                    </InputGroup>
-                  )}
-                />
-              </GridItem>
+              {isFeatureEnabled(Feature.DeviceFlow) && (
+                <GridItem lg={8} sm={6}>
+                  <Controller
+                    name={convertAttributeNameToForm<
+                      Required<ClientRepresentation["attributes"]>
+                    >("attributes.oauth2.device.authorization.grant.enabled")}
+                    defaultValue={false}
+                    control={control}
+                    render={({ field }) => (
+                      <InputGroup>
+                        <Checkbox
+                          data-testid="oauth-device-authorization-grant"
+                          label={t("oauthDeviceAuthorizationGrant")}
+                          id="kc-oauth-device-authorization-grant"
+                          name="oauth2.device.authorization.grant.enabled"
+                          isChecked={field.value.toString() === "true"}
+                          onChange={field.onChange}
+                        />
+                        <HelpItem
+                          helpText={t("oauthDeviceAuthorizationGrantHelp")}
+                          fieldLabelId="oauthDeviceAuthorizationGrant"
+                        />
+                      </InputGroup>
+                    )}
+                  />
+                </GridItem>
+              )}
               <GridItem lg={8} sm={6}>
                 <Controller
                   name={convertAttributeNameToForm<FormFields>(

--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -27,6 +27,7 @@ import {
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { useWhoAmI } from "../context/whoami/WhoAmI";
 import { convertToFormValues, sortProviders } from "../util";
+import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
 
 import "./realm-settings-section.css";
 
@@ -43,6 +44,7 @@ export const RealmSettingsTokensTab = ({
 }: RealmSettingsSessionsTabProps) => {
   const { t } = useTranslation();
   const serverInfo = useServerInfo();
+  const isFeatureEnabled = useIsFeatureEnabled();
   const { whoAmI } = useWhoAmI();
 
   const [defaultSigAlgDrpdwnIsOpen, setDefaultSigAlgDrpdwnOpen] =
@@ -127,77 +129,81 @@ export const RealmSettingsTokensTab = ({
             />
           </FormGroup>
 
-          <FormGroup
-            label={t("oAuthDeviceCodeLifespan")}
-            fieldId="oAuthDeviceCodeLifespan"
-            labelIcon={
-              <HelpItem
-                helpText={t("oAuthDeviceCodeLifespanHelp")}
-                fieldLabelId="oAuthDeviceCodeLifespan"
-              />
-            }
-          >
-            <Controller
-              name="oauth2DeviceCodeLifespan"
-              defaultValue={0}
-              control={form.control}
-              render={({ field }) => (
-                <TimeSelector
-                  id="oAuthDeviceCodeLifespan"
-                  data-testid="oAuthDeviceCodeLifespan"
-                  value={field.value || 0}
-                  onChange={field.onChange}
-                  units={["minute", "hour", "day"]}
+          {isFeatureEnabled(Feature.DeviceFlow) && (
+            <>
+              <FormGroup
+                label={t("oAuthDeviceCodeLifespan")}
+                fieldId="oAuthDeviceCodeLifespan"
+                labelIcon={
+                  <HelpItem
+                    helpText={t("oAuthDeviceCodeLifespanHelp")}
+                    fieldLabelId="oAuthDeviceCodeLifespan"
+                  />
+                }
+              >
+                <Controller
+                  name="oauth2DeviceCodeLifespan"
+                  defaultValue={0}
+                  control={form.control}
+                  render={({ field }) => (
+                    <TimeSelector
+                      id="oAuthDeviceCodeLifespan"
+                      data-testid="oAuthDeviceCodeLifespan"
+                      value={field.value || 0}
+                      onChange={field.onChange}
+                      units={["minute", "hour", "day"]}
+                    />
+                  )}
                 />
-              )}
-            />
-          </FormGroup>
-          <FormGroup
-            label={t("oAuthDevicePollingInterval")}
-            fieldId="oAuthDevicePollingInterval"
-            labelIcon={
-              <HelpItem
-                helpText={t("oAuthDevicePollingIntervalHelp")}
-                fieldLabelId="oAuthDevicePollingInterval"
-              />
-            }
-          >
-            <Controller
-              name="oauth2DevicePollingInterval"
-              defaultValue={0}
-              control={form.control}
-              render={({ field }) => (
-                <NumberInput
-                  id="oAuthDevicePollingInterval"
-                  value={field.value}
-                  min={0}
-                  onPlus={() => field.onChange(field.value || 0 + 1)}
-                  onMinus={() => field.onChange(field.value || 0 - 1)}
-                  onChange={(event) => {
-                    const newValue = Number(event.currentTarget.value);
-                    field.onChange(!isNaN(newValue) ? newValue : 0);
-                  }}
-                  placeholder={t("oAuthDevicePollingInterval")}
+              </FormGroup>
+              <FormGroup
+                label={t("oAuthDevicePollingInterval")}
+                fieldId="oAuthDevicePollingInterval"
+                labelIcon={
+                  <HelpItem
+                    helpText={t("oAuthDevicePollingIntervalHelp")}
+                    fieldLabelId="oAuthDevicePollingInterval"
+                  />
+                }
+              >
+                <Controller
+                  name="oauth2DevicePollingInterval"
+                  defaultValue={0}
+                  control={form.control}
+                  render={({ field }) => (
+                    <NumberInput
+                      id="oAuthDevicePollingInterval"
+                      value={field.value}
+                      min={0}
+                      onPlus={() => field.onChange(field.value || 0 + 1)}
+                      onMinus={() => field.onChange(field.value || 0 - 1)}
+                      onChange={(event) => {
+                        const newValue = Number(event.currentTarget.value);
+                        field.onChange(!isNaN(newValue) ? newValue : 0);
+                      }}
+                      placeholder={t("oAuthDevicePollingInterval")}
+                    />
+                  )}
                 />
-              )}
-            />
-          </FormGroup>
-          <FormGroup
-            label={t("shortVerificationUri")}
-            fieldId="shortVerificationUri"
-            labelIcon={
-              <HelpItem
-                helpText={t("shortVerificationUriTooltipHelp")}
-                fieldLabelId="shortVerificationUri"
-              />
-            }
-          >
-            <KeycloakTextInput
-              id="shortVerificationUri"
-              placeholder={t("shortVerificationUri")}
-              {...form.register("attributes.shortVerificationUri")}
-            />
-          </FormGroup>
+              </FormGroup>
+              <FormGroup
+                label={t("shortVerificationUri")}
+                fieldId="shortVerificationUri"
+                labelIcon={
+                  <HelpItem
+                    helpText={t("shortVerificationUriTooltipHelp")}
+                    fieldLabelId="shortVerificationUri"
+                  />
+                }
+              >
+                <KeycloakTextInput
+                  id="shortVerificationUri"
+                  placeholder={t("shortVerificationUri")}
+                  {...form.register("attributes.shortVerificationUri")}
+                />
+              </FormGroup>
+            </>
+          )}
         </FormAccess>
       </FormPanel>
       <FormPanel

--- a/js/apps/admin-ui/src/utils/useIsFeatureEnabled.ts
+++ b/js/apps/admin-ui/src/utils/useIsFeatureEnabled.ts
@@ -7,6 +7,7 @@ export enum Feature {
   Kerberos = "KERBEROS",
   DynamicScopes = "DYNAMIC_SCOPES",
   DPoP = "DPOP",
+  DeviceFlow = "DEVICE_FLOW",
 }
 
 export default function useIsFeatureEnabled() {

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
@@ -55,9 +55,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 HTTP/TLS:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
@@ -47,9 +47,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
@@ -55,9 +55,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 HTTP/TLS:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
@@ -47,9 +47,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.unix.approved.txt
@@ -66,9 +66,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Config:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.unix.approved.txt
@@ -58,9 +58,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.unix.approved.txt
@@ -129,9 +129,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Config:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.unix.approved.txt
@@ -121,9 +121,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.unix.approved.txt
@@ -66,9 +66,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Config:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.unix.approved.txt
@@ -58,9 +58,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.unix.approved.txt
@@ -129,9 +129,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Config:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.unix.approved.txt
@@ -121,9 +121,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
@@ -74,9 +74,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
@@ -82,9 +82,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
@@ -72,9 +72,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
@@ -80,9 +80,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
@@ -145,9 +145,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
@@ -137,9 +137,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
@@ -135,9 +135,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
@@ -143,9 +143,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
@@ -83,9 +83,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
@@ -75,9 +75,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
@@ -73,9 +73,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
@@ -81,9 +81,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
@@ -146,9 +146,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
@@ -138,9 +138,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
@@ -136,9 +136,9 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
@@ -144,9 +144,9 @@ Feature:
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, account3, admin-api, admin-fine-grained-authz, admin2,
                        authorization, ciba, client-policies, client-secret-rotation,
-                       declarative-user-profile, docker, dpop, dynamic-scopes, fips, impersonation,
-                       js-adapter, kerberos, linkedin-oauth, map-storage, par, preview,
-                       recovery-codes, scripts, step-up-authentication, token-exchange,
+                       declarative-user-profile, device-flow, docker, dpop, dynamic-scopes, fips,
+                       impersonation, js-adapter, kerberos, linkedin-oauth, map-storage, par,
+                       preview, recovery-codes, scripts, step-up-authentication, token-exchange,
                        update-email, web-authn.
 
 Hostname:

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -100,11 +100,15 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     public OIDCWellKnownProvider(KeycloakSession session, Map<String, Object> openidConfigOverride, boolean includeClientScopes) {
         DEFAULT_GRANT_TYPES_SUPPORTED = Stream.of(OAuth2Constants.AUTHORIZATION_CODE,
                 OAuth2Constants.IMPLICIT, OAuth2Constants.REFRESH_TOKEN, OAuth2Constants.PASSWORD, OAuth2Constants.CLIENT_CREDENTIALS,
-                OAuth2Constants.DEVICE_CODE_GRANT_TYPE,
                 OAuth2Constants.CIBA_GRANT_TYPE).collect(Collectors.toList());
         if (Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE)) {
             DEFAULT_GRANT_TYPES_SUPPORTED.add(OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
         }
+
+        if (Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
+            DEFAULT_GRANT_TYPES_SUPPORTED.add(OAuth2Constants.DEVICE_CODE_GRANT_TYPE);
+        }
+
         this.session = session;
         this.openidConfigOverride = openidConfigOverride;
         this.includeClientScopes = includeClientScopes;
@@ -127,9 +131,11 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         config.setIntrospectionEndpoint(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "token").path(TokenEndpoint.class, "introspect").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setUserinfoEndpoint(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "issueUserInfo").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setLogoutEndpoint(frontendUriBuilder.clone().path(OIDCLoginProtocolService.class, "logout").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
-        config.setDeviceAuthorizationEndpoint(frontendUriBuilder.clone().path(OIDCLoginProtocolService.class, "auth")
-            .path(AuthorizationEndpoint.class, "authorizeDevice").path(DeviceEndpoint.class, "handleDeviceRequest")
-            .build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
+        if (Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
+            config.setDeviceAuthorizationEndpoint(frontendUriBuilder.clone().path(OIDCLoginProtocolService.class, "auth")
+                    .path(AuthorizationEndpoint.class, "authorizeDevice").path(DeviceEndpoint.class, "handleDeviceRequest")
+                    .build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
+        }
         URI jwksUri = backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "certs").build(realm.getName(),
             OIDCLoginProtocol.LOGIN_PROTOCOL);
 
@@ -301,7 +307,9 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         mtls_endpoints.setTokenEndpoint(config.getTokenEndpoint());
         mtls_endpoints.setRevocationEndpoint(config.getRevocationEndpoint());
         mtls_endpoints.setIntrospectionEndpoint(config.getIntrospectionEndpoint());
-        mtls_endpoints.setDeviceAuthorizationEndpoint(config.getDeviceAuthorizationEndpoint());
+        if (Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
+            mtls_endpoints.setDeviceAuthorizationEndpoint(config.getDeviceAuthorizationEndpoint());
+        }
         mtls_endpoints.setRegistrationEndpoint(config.getRegistrationEndpoint());
         mtls_endpoints.setUserInfoEndpoint(config.getUserinfoEndpoint());
         mtls_endpoints.setBackchannelAuthenticationEndpoint(config.getBackchannelAuthenticationEndpoint());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -125,6 +125,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
      */
     @Path("device")
     public Object authorizeDevice() {
+        if (!Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
+            return null;
+        }
         return new DeviceEndpoint(session, event);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -309,17 +309,24 @@ public class TokenEndpoint {
             event.event(EventType.PERMISSION_TOKEN);
             action = Action.PERMISSION;
         } else if (grantType.equals(OAuth2Constants.DEVICE_CODE_GRANT_TYPE)) {
+            if (!Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
+                throw newUnsupportedGrantTypeException();
+            }
             event.event(EventType.OAUTH2_DEVICE_CODE_TO_TOKEN);
             action = Action.OAUTH2_DEVICE_CODE;
         } else if (grantType.equals(OAuth2Constants.CIBA_GRANT_TYPE)) {
             event.event(EventType.AUTHREQID_TO_TOKEN);
             action = Action.CIBA;
         } else {
-            throw new CorsErrorResponseException(cors, OAuthErrorException.UNSUPPORTED_GRANT_TYPE,
-                "Unsupported " + OIDCLoginProtocol.GRANT_TYPE_PARAM, Response.Status.BAD_REQUEST);
+            throw newUnsupportedGrantTypeException();
         }
 
         event.detail(Details.GRANT_TYPE, grantType);
+    }
+
+    private CorsErrorResponseException newUnsupportedGrantTypeException() {
+        return new CorsErrorResponseException(cors, OAuthErrorException.UNSUPPORTED_GRANT_TYPE,
+                "Unsupported " + OIDCLoginProtocol.GRANT_TYPE_PARAM, Status.BAD_REQUEST);
     }
 
     private void checkParameterDuplicated() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpointFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpointFactory.java
@@ -20,18 +20,20 @@
 package org.keycloak.protocol.oidc.grants.device.endpoints;
 
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resource.RealmResourceProviderFactory;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class DeviceEndpointFactory implements RealmResourceProviderFactory {
+public class DeviceEndpointFactory implements RealmResourceProviderFactory, EnvironmentDependentProviderFactory {
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
@@ -59,5 +61,10 @@ public class DeviceEndpointFactory implements RealmResourceProviderFactory {
     @Override
     public String getId() {
         return "device";
+    }
+
+    @Override
+    public boolean isSupported() {
+        return Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/KeycloakTestingClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/KeycloakTestingClient.java
@@ -79,9 +79,9 @@ public class KeycloakTestingClient implements AutoCloseable {
     }
 
     public void enableFeature(Profile.Feature feature) {
-        Set<Profile.Feature> disabledFeatures = testing().enableFeature(feature.toString());
-        Assert.assertFalse(disabledFeatures.contains(feature));
-        ProfileAssume.updateDisabledFeatures(disabledFeatures);
+        Set<Profile.Feature> enabledFeatures = testing().enableFeature(feature.toString());
+        Assert.assertFalse(enabledFeatures.contains(feature));
+        ProfileAssume.updateDisabledFeatures(enabledFeatures);
     }
 
     public void disableFeature(Profile.Feature feature) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/KeycloakTestingClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/KeycloakTestingClient.java
@@ -90,6 +90,15 @@ public class KeycloakTestingClient implements AutoCloseable {
         ProfileAssume.updateDisabledFeatures(disabledFeatures);
     }
 
+    /**
+     * Resets the feature to it's default setting.
+     *
+     * @param feature
+     */
+    public void resetFeature(Profile.Feature feature) {
+        testing().resetFeature(feature.toString());
+    }
+
     public TestApplicationResource testApp() { return target.proxy(TestApplicationResource.class); }
 
     public TestSamlApplicationResource testSamlApp() { return target.proxy(TestSamlApplicationResource.class); }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
@@ -344,6 +344,16 @@ public interface TestingResource {
     Set<Profile.Feature> disableFeature(@PathParam("feature") String feature);
 
     /**
+     * Resets the given feature to it's default state.
+     *
+     * @param feature
+     */
+    @POST
+    @Path("/reset-feature/{feature}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void resetFeature(@PathParam("feature") String feature);
+
+    /**
      * If property-value is null, the system property will be unset (removed) on the server
      */
     @GET

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
@@ -77,6 +77,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author <a href="mailto:h2-wada@nri.co.jp">Hiroyuki Wada</a>
  */
+@EnableFeature(value = Profile.Feature.DEVICE_FLOW, skipRestart = true)
 public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
 
     private static String userId;
@@ -999,7 +1000,6 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
     }
 
     @Test
-    @EnableFeature(value = Profile.Feature.DEVICE_FLOW, skipRestart = true)
     public void ensureDeviceFlowConfigPresentWhenDeviceFlowEnabled() {
 
         OIDCConfigurationRepresentation oidcConfigRep = oauth.doWellKnownRequest(REALM_NAME);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
@@ -1000,7 +1000,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
 
     @Test
     @EnableFeature(value = Profile.Feature.DEVICE_FLOW, skipRestart = true)
-    public void ensureDeviceFlowConfigNotPresentWhenDeviceFlowEnabled() {
+    public void ensureDeviceFlowConfigPresentWhenDeviceFlowEnabled() {
 
         OIDCConfigurationRepresentation oidcConfigRep = oauth.doWellKnownRequest(REALM_NAME);
         Assert.assertNotNull("deviceAuthorizationEndpoint should be not null", oidcConfigRep.getDeviceAuthorizationEndpoint());


### PR DESCRIPTION
The new flag "DEVICE_FLOW" is enabled by default for now. At a later stage we might disable the feature by default.

Users can now disable the device flow support for the whole server via: -Dkeycloak.profile.feature.device_flow=disabled
or
--features-disabled=device_flow

See discussion: https://github.com/keycloak/keycloak/discussions/23700

Fixes #23891

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
