### PR TITLE
Allow running of UI development server against local build quarkus distribution of keycloak

### DIFF
--- a/js/apps/keycloak-server/README.md
+++ b/js/apps/keycloak-server/README.md
@@ -18,5 +18,13 @@ pnpm run start
 
 This will download the [Nightly version](https://github.com/keycloak/keycloak/releases/tag/nightly) of the Keycloak server and run it locally on port `8180`. If a previously downloaded version was found in the `server/` directory then that one will be used instead. If you want to download the latest Nightly version you can remove the server directory before running the command to start the server.
 
+If you want to run with a local quarkus distribution of keycloak for development purposes, you can do so by running this command instead: 
+
+```bash
+pnpm run local
+```
+
 In order for the development version of the Admin UI to work you will have to import a custom client to the Keycloak server. This is only required during development as the development server for the Admin UI runs on a different port. This client will be imported automatically under the name `security-admin-console-v2` when the Keycloak server starts.
+
+This client only allows redirects from/to "localhost:8080" so be sure either modify the client json in `./scripts` or only attempt to authenticate and redirect from that address
 

--- a/js/apps/keycloak-server/README.md
+++ b/js/apps/keycloak-server/README.md
@@ -21,8 +21,10 @@ This will download the [Nightly version](https://github.com/keycloak/keycloak/re
 If you want to run with a local quarkus distribution of keycloak for development purposes, you can do so by running this command instead: 
 
 ```bash
-pnpm run local
+pnpm run start -- --local
 ```
+
+**All other arguments will be passed through to the underlying keycloak script**
 
 In order for the development version of the Admin UI to work you will have to import a custom client to the Keycloak server. This is only required during development as the development server for the Admin UI runs on a different port. This client will be imported automatically under the name `security-admin-console-v2` when the Keycloak server starts.
 

--- a/js/apps/keycloak-server/README.md
+++ b/js/apps/keycloak-server/README.md
@@ -18,7 +18,7 @@ pnpm run start
 
 This will download the [Nightly version](https://github.com/keycloak/keycloak/releases/tag/nightly) of the Keycloak server and run it locally on port `8180`. If a previously downloaded version was found in the `server/` directory then that one will be used instead. If you want to download the latest Nightly version you can remove the server directory before running the command to start the server.
 
-If you want to run with a local quarkus distribution of keycloak for development purposes, you can do so by running this command instead: 
+If you want to run with a local Quarkus distribution of Keycloak for development purposes, you can do so by running this command instead: 
 
 ```bash
 pnpm run start -- --local

--- a/js/apps/keycloak-server/README.md
+++ b/js/apps/keycloak-server/README.md
@@ -24,7 +24,7 @@ If you want to run with a local Quarkus distribution of Keycloak for development
 pnpm run start -- --local
 ```
 
-**All other arguments will be passed through to the underlying keycloak script**
+**All other arguments will be passed through to the underlying Keycloak server.**
 
 In order for the development version of the Admin UI to work you will have to import a custom client to the Keycloak server. This is only required during development as the development server for the Admin UI runs on a different port. This client will be imported automatically under the name `security-admin-console-v2` when the Keycloak server starts.
 

--- a/js/apps/keycloak-server/package.json
+++ b/js/apps/keycloak-server/package.json
@@ -3,11 +3,19 @@
   "type": "module",
   "scripts": {
     "start": "wireit",
-    "clear-data": "rm -r ./server/data"
+    "local": "wireit",
+    "clear-data": "rm -r ./server/data",
+    "clear-server": "rm -r ./server"
   },
   "wireit": {
     "start": {
       "command": "./scripts/start-server.js",
+      "dependencies": [
+        "../../libs/keycloak-admin-client:build"
+      ]
+    },
+    "local": {
+      "command": "./scripts/start-server.js --local",
       "dependencies": [
         "../../libs/keycloak-admin-client:build"
       ]

--- a/js/apps/keycloak-server/package.json
+++ b/js/apps/keycloak-server/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "scripts": {
     "start": "wireit",
-    "local": "wireit",
     "delete-data": "rm -r ./server/data",
     "delete-server": "rm -r ./server"
   },

--- a/js/apps/keycloak-server/package.json
+++ b/js/apps/keycloak-server/package.json
@@ -13,12 +13,6 @@
       "dependencies": [
         "../../libs/keycloak-admin-client:build"
       ]
-    },
-    "local": {
-      "command": "./scripts/start-server.js --local",
-      "dependencies": [
-        "../../libs/keycloak-admin-client:build"
-      ]
     }
   },
   "dependencies": {

--- a/js/apps/keycloak-server/package.json
+++ b/js/apps/keycloak-server/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "wireit",
     "local": "wireit",
-    "clear-data": "rm -r ./server/data",
-    "clear-server": "rm -r ./server"
+    "delete-data": "rm -r ./server/data",
+    "delete-server": "rm -r ./server"
   },
   "wireit": {
     "start": {

--- a/js/apps/keycloak-server/scripts/start-server.js
+++ b/js/apps/keycloak-server/scripts/start-server.js
@@ -18,7 +18,7 @@ const LOCAL_DIST_NAME = "keycloak-999.0.0-SNAPSHOT.tar.gz";
 const SCRIPT_EXTENSION = process.platform === "win32" ? ".bat" : ".sh";
 const ADMIN_USERNAME = "admin";
 const ADMIN_PASSWORD = "admin";
-const AUTH_DELAY = 5000;
+const AUTH_DELAY = 10000;
 const AUTH_RETRY_LIMIT = 3;
 
 const options = {
@@ -30,9 +30,7 @@ const options = {
 await startServer();
 
 async function startServer() {
-  let { values: scriptArgs, args: keycloakArgs } = handleArgs(
-    process.argv.slice(2),
-  );
+  let { scriptArgs, keycloakArgs } = handleArgs(process.argv.slice(2));
 
   await downloadServer(scriptArgs.local);
 
@@ -70,7 +68,7 @@ function handleArgs(args) {
   });
   // we need to remove the args that belong to the script so that we can pass the rest through to keycloak
   tokens
-    .filter((token) => options.hasOwn(token.name))
+    .filter((token) => Object.hasOwn(options, token.name))
     .forEach((token) => {
       let tokenRaw = token.rawName;
       if (token.value) {
@@ -78,7 +76,7 @@ function handleArgs(args) {
       }
       args.splice(args.indexOf(tokenRaw), 1);
     });
-  return { values, args };
+  return { scriptArgs: values, keycloakArgs: args };
 }
 
 async function downloadServer(local) {
@@ -89,10 +87,12 @@ async function downloadServer(local) {
     return;
   }
 
-  var assetStream;
+  let assetStream;
   if (local) {
-    console.info("Looking for " + LOCAL_DIST_NAME + " at " + LOCAL_QUARKUS);
-    assetStream = fs.createReadStream(LOCAL_QUARKUS + "/" + LOCAL_DIST_NAME);
+    console.info(`Looking for ${LOCAL_DIST_NAME} at ${LOCAL_QUARKUS}`);
+    assetStream = fs.createReadStream(
+      path.join(LOCAL_QUARKUS, LOCAL_DIST_NAME),
+    );
   } else {
     console.info("Downloading and extracting server…");
     const nightlyAsset = await getNightlyAsset();


### PR DESCRIPTION
Currently it's only possible to pull a nightly version of keycloak to test the UI, this makes it hard to test changes on the server that affect the UI before running them through GHA. Extensions here allow taking the local tarball build of the quarkus distribution instead of the nightly tarball
