### PR TITLE
Update messages_de.properties

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
@@ -221,7 +221,7 @@ invalidPasswordNotUsernameMessage=Ungültiges Passwort: Es darf nicht gleich sei
 invalidPasswordNotEmailMessage=Ungültiges Passwort: darf nicht identisch mit der E-Mail-Adresse sein.
 invalidPasswordRegexPatternMessage=Ungültiges Passwort: Es entspricht nicht dem Regex-Muster.
 invalidPasswordHistoryMessage=Ungültiges Passwort: Es darf nicht einem der letzten {0} Passwörter entsprechen.
-invalidPasswordBlacklistedMessage=Ungültiges Passwort: Das Passwort steht auf der Blockliste (schwarzen Liste).
+invalidPasswordBlacklistedMessage=Ungültiges Passwort: Das Passwort steht auf der Blockliste.
 invalidPasswordGenericMessge=Ungültiges Passwort: Das neue Passwort verletzt die Passwort-Richtlinien.
 
 # Authorization

--- a/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
@@ -9,24 +9,24 @@ doLink=Verknüpfen
 noAccessMessage=Zugriff verweigert
 
 personalInfoSidebarTitle=Persönliche Informationen
-accountSecuritySidebarTitle=Konto Sicherheit
+accountSecuritySidebarTitle=Kontosicherheit
 signingInSidebarTitle=Anmeldung
-deviceActivitySidebarTitle=Geräte Aktivität
+deviceActivitySidebarTitle=Geräteaktivität
 linkedAccountsSidebarTitle=Verknüpfte Konten
 
 editAccountHtmlTitle=Benutzerkonto bearbeiten
 personalInfoHtmlTitle=Persönliche Informationen
 federatedIdentitiesHtmlTitle=Föderierte Identitäten
-accountLogHtmlTitle=Benutzerkonto Log
-changePasswordHtmlTitle=Passwort Ändern
+accountLogHtmlTitle=Benutzerkonto-Protokoll
+changePasswordHtmlTitle=Passwort ändern
 deviceActivityHtmlTitle=Geräteaktivität
 sessionsHtmlTitle=Sitzungen
-accountManagementTitle=Keycloak Benutzerkontoverwaltung
+accountManagementTitle=Keycloak-Benutzerkontoverwaltung
 authenticatorTitle=Mehrfachauthentifizierung
 applicationsHtmlTitle=Applikationen
 linkedAccountsHtmlTitle=Verknüpfte Konten
 
-accountManagementWelcomeMessage=Willkommen bei der Keycloak Kontoverwaltung
+accountManagementWelcomeMessage=Willkommen bei der Keycloak-Kontoverwaltung
 personalInfoIntroMessage=Grundlegende Informationen verwalten
 accountSecurityTitle=Kontosicherheit
 accountSecurityIntroMessage=Passwort und Kontozugriff verwalten
@@ -34,12 +34,12 @@ applicationsIntroMessage=App-Berechtigung für den Zugriff auf Ihr Konto verwalt
 resourceIntroMessage=Ressourcen mit Teammitgliedern teilen
 passwordLastUpdateMessage=Ihr Passwort wurde aktualisiert am
 updatePasswordTitle=Passwort aktualisieren
-updatePasswordMessageTitle=WÄhlen Sie ein sicheres Passwort
+updatePasswordMessageTitle=Wählen Sie ein sicheres Passwort
 updatePasswordMessage=Ein sicheres Passwort besteht aus einer Kombination aus Zahlen, Buchstaben und Sonderzeichen. Es ist schwer zu erraten, hat keine Ähnlichkeit mit einem echten Wort, und wird nur für dieses Konto verwendet.
 personalSubTitle=Ihre persönlichen Informationen
 personalSubMessage=Verwalten Sie folgende Informationen: Vorname, Nachname und E-Mail-Adresse
 
-authenticatorCode=One-time Code
+authenticatorCode=Einmalcode
 email=E-Mail
 firstName=Vorname
 givenName=Vorname
@@ -53,7 +53,7 @@ passwordNew=Neues Passwort
 username=Benutzername
 address=Adresse
 street=Straße
-region=Staat, Provinz, Region
+region=Bundesland, Kanton oder Region
 postal_code=PLZ
 locality=Stadt oder Ortschaft
 country=Land
@@ -64,30 +64,30 @@ phoneNumberVerified=Telefonnummer verifiziert
 gender=Geschlecht
 birthday=Geburtsdatum
 zoneinfo=Zeitzone
-gssDelegationCredential=GSS delegierte Berechtigung
+gssDelegationCredential=GSS-delegierte Berechtigung
 
 profileScopeConsentText=Nutzerkonto
-emailScopeConsentText=E-Mail Adresse
+emailScopeConsentText=E-Mail-Adresse
 addressScopeConsentText=Adresse
 phoneScopeConsentText=Telefonnummer
-offlineAccessScopeConsentText=Offline Zugriff
+offlineAccessScopeConsentText=Offlinezugriff
 samlRoleListScopeConsentText=Meine Rollen
 rolesScopeConsentText=Nutzerrollen
 
 role_admin=Admin
-role_realm-admin=Realm Admin
+role_realm-admin=Realm-Admin
 role_create-realm=Realm erstellen
 role_view-realm=Realm ansehen
 role_view-users=Benutzer ansehen
 role_view-applications=Applikationen ansehen
 role_view-clients=Clients ansehen
 role_view-events=Events ansehen
-role_view-identity-providers=Identity Provider ansehen
+role_view-identity-providers=Identitätsprovider ansehen
 role_view-consent=Zustimmungen anzeigen
 role_manage-realm=Realm verwalten
 role_manage-users=Benutzer verwalten
 role_manage-applications=Applikationen verwalten
-role_manage-identity-providers=Identity Provider verwalten
+role_manage-identity-providers=Identitätsprovider verwalten
 role_manage-clients=Clients verwalten
 role_manage-events=Events verwalten
 role_view-profile=Profile ansehen
@@ -99,7 +99,7 @@ role_offline-access=Offline-Zugriff
 role_uma_authorization=Berechtigungen einholen
 client_account=Clientkonto
 client_account-console=Accountkonsole
-client_security-admin-console=Security Adminkonsole
+client_security-admin-console=Security-Adminkonsole
 client_admin-cli=Admin CLI
 client_realm-management=Realm-Management
 client_broker=Broker
@@ -127,7 +127,7 @@ federatedIdentity=Föderierte Identität
 authenticator=Mehrfachauthentifizierung
 device-activity=Geräteaktivität
 sessions=Sitzungen
-log=Log
+log=Protokoll
 
 application=Applikation
 availablePermissions=verfügbare Berechtigungen
@@ -141,10 +141,10 @@ offlineToken=Offline-Token
 revoke=Berechtigung widerrufen
 
 configureAuthenticators=Mehrfachauthentifizierung konfigurieren
-mobile=Mobil
+mobile=Smartphone
 totpStep1=Installieren Sie eine der folgenden Applikationen auf Ihrem Smartphone:
 totpStep2=Öffnen Sie die Applikation und scannen Sie den Barcode.
-totpStep3=Geben Sie den von der Applikation generierten One-time Code ein und klicken Sie auf Speichern.
+totpStep3=Geben Sie den von der Applikation generierten Einmalcode ein und klicken Sie auf Speichern.
 totpStep3DeviceName=Geben Sie einen Gerätenamen an, um die Verwaltung Ihrer OTP-Geräte zu erleichtern.
 
 totpManualStep2=Öffnen Sie die Applikation und geben Sie den folgenden Schlüssel ein.
@@ -177,11 +177,11 @@ missingPasswordMessage=Bitte geben Sie ein Passwort ein.
 notMatchPasswordMessage=Die Passwörter sind nicht identisch.
 invalidUserMessage=Ungültiger Nutzer
 
-missingTotpMessage=Bitte geben Sie den One-time Code ein.
+missingTotpMessage=Bitte geben Sie den Einmalcode ein.
 missingTotpDeviceNameMessage=Bitte geben Sie einen Gerätenamen an.
 invalidPasswordExistingMessage=Das aktuelle Passwort ist ungültig.
 invalidPasswordConfirmMessage=Die Passwortbestätigung ist nicht identisch.
-invalidTotpMessage=Ungültiger One-time Code.
+invalidTotpMessage=Ungültiger Einmalcode.
 
 usernameExistsMessage=Der Benutzername existiert bereits.
 emailExistsMessage=Die E-Mail-Adresse existiert bereits.
@@ -198,13 +198,13 @@ successGrantRevokedMessage=Berechtigung erfolgreich widerrufen.
 accountUpdatedMessage=Ihr Benutzerkonto wurde aktualisiert.
 accountPasswordUpdatedMessage=Ihr Passwort wurde aktualisiert.
 
-missingIdentityProviderMessage=Identity Provider nicht angegeben.
+missingIdentityProviderMessage=Identitätsprovider nicht angegeben.
 invalidFederatedIdentityActionMessage=Ungültige oder fehlende Aktion.
-identityProviderNotFoundMessage=Angegebener Identity Provider nicht gefunden.
+identityProviderNotFoundMessage=Angegebener Identitätsprovider nicht gefunden.
 federatedIdentityLinkNotActiveMessage=Diese Identität ist nicht mehr aktiv.
 federatedIdentityRemovingLastProviderMessage=Sie können den letzten Eintrag nicht entfernen, da Sie kein Passwort haben.
-identityProviderRedirectErrorMessage=Fehler bei der Weiterleitung zum Identity Provider.
-identityProviderRemovedMessage=Identity Provider erfolgreich entfernt.
+identityProviderRedirectErrorMessage=Fehler bei der Weiterleitung zum Identitätsprovider.
+identityProviderRemovedMessage=Identitätsprovider erfolgreich entfernt.
 identityProviderAlreadyLinkedMessage=Die föderierte Identität von {0} ist bereits einem anderen Benutzer zugewiesen.
 staleCodeAccountMessage=Diese Seite ist nicht mehr gültig, bitte versuchen Sie es noch einmal.
 consentDenied=Einverständnis verweigert.
@@ -213,7 +213,7 @@ accountDisabledMessage=Ihr Benutzerkonto ist gesperrt, bitte kontaktieren Sie de
 
 accountTemporarilyDisabledMessage=Ihr Benutzerkonto ist temporär gesperrt, bitte kontaktieren Sie den Admin oder versuchen Sie es später noch einmal.
 invalidPasswordMinLengthMessage=Ungültiges Passwort: Es muss mindestens {0} Zeichen lang sein.
-invalidPasswordMinLowerCaseCharsMessage=Ungültiges Passwort\: Es muss mindestens {0} Kleinbuchstaben beinhalten.
+invalidPasswordMinLowerCaseCharsMessage=Ungültiges Passwort: Es muss mindestens {0} Kleinbuchstaben beinhalten.
 invalidPasswordMinDigitsMessage=Ungültiges Passwort: Es muss mindestens {0} Zahl(en) beinhalten.
 invalidPasswordMinUpperCaseCharsMessage=Ungültiges Passwort: Es muss mindestens {0} Großbuchstaben beinhalten.
 invalidPasswordMinSpecialCharsMessage=Ungültiges Passwort: Es muss mindestens {0} Sonderzeichen beinhalten.
@@ -221,7 +221,7 @@ invalidPasswordNotUsernameMessage=Ungültiges Passwort: Es darf nicht gleich sei
 invalidPasswordNotEmailMessage=Ungültiges Passwort: darf nicht identisch mit der E-Mail-Adresse sein.
 invalidPasswordRegexPatternMessage=Ungültiges Passwort: Es entspricht nicht dem Regex-Muster.
 invalidPasswordHistoryMessage=Ungültiges Passwort: Es darf nicht einem der letzten {0} Passwörter entsprechen.
-invalidPasswordBlacklistedMessage=Ungültiges Passwort: Das Passwort steht auf der Blocklist (schwarzen Liste).
+invalidPasswordBlacklistedMessage=Ungültiges Passwort: Das Passwort steht auf der Blockliste (schwarzen Liste).
 invalidPasswordGenericMessge=Ungültiges Passwort: Das neue Passwort verletzt die Passwort-Richtlinien.
 
 # Authorization
@@ -251,13 +251,13 @@ owner=Besitzender
 resourcesSharedWithMe=Mit mir geteilte Ressourcen
 permissionRequestion=Genehmigungsanfrage
 permission=Genehmigung
-shares=teilt(en)
-notBeingShared=Diese Ressource wird nicht freigegeben.
+shares=teilt/teilen
+notBeingShared=Diese Ressource wurde nicht freigegeben.
 notHaveAnyResource=Sie haben keine Ressourcen
-noResourcesSharedWithYou=Es werden keine Ressourcen mit Ihnen geteilt
-havePermissionRequestsWaitingForApproval=Sie haben {0} Genehmigungsanfrage(n), die auf die Genehmigung warten.
+noResourcesSharedWithYou=Es wurden keine Ressourcen mit Ihnen geteilt
+havePermissionRequestsWaitingForApproval=Sie haben {0} Genehmigungsanfrage(n), die auf Genehmigung warten.
 clickHereForDetails=Klicken Sie hier für Details.
-resourceIsNotBeingShared=Die Ressource wird nicht freigegeben
+resourceIsNotBeingShared=Die Ressource wurde nicht freigegeben
 
 # Applications
 applicationName=Anwendungsname
@@ -289,8 +289,8 @@ authenticatorFinishSetUpMessage=Jedes Mal, wenn Sie sich bei Ihrem Keycloak-Kont
 authenticatorSubTitle=Zwei-Faktor-Authentifizierung einrichten
 authenticatorSubMessage=Um die Sicherheit Ihres Kontos zu erhöhen, aktivieren Sie mindestens eine der verfügbaren Zwei-Faktor-Authentifizierungsmethoden.
 authenticatorMobileTitle=Handy-Authentifikator
-authenticatorMobileMessage=Verwenden Sie Authenticator-Anwendungen auf Ihrem Telefon, um Verifizierungscodes als Zwei-Faktor-Authentifizierung zu erhalten.
-authenticatorMobileFinishSetUpMessage=Die Authenticator-Anwendung wurde an Ihr Telefon gebunden.
+authenticatorMobileMessage=Verwenden Sie Authentifikator-Anwendungen auf Ihrem Telefon, um Verifizierungscodes als Zwei-Faktor-Authentifizierung zu erhalten.
+authenticatorMobileFinishSetUpMessage=Die Authentifikator-Anwendung wurde an Ihr Telefon gebunden.
 authenticatorActionSetup=Einrichten
 authenticatorSMSTitle=SMS-Code
 authenticatorSMSMessage=Keycloak sendet den Verifizierungscode an Ihr Telefon als Zwei-Faktor-Authentifizierung.
@@ -299,9 +299,9 @@ authenticatorDefaultStatus=Standard
 authenticatorChangePhone=Telefonnummer ändern
 
 #Authenticator - Mobile Authenticator setup
-authenticatorMobileSetupTitle=Handy-Authenticator-Setup
+authenticatorMobileSetupTitle=Handy-Authentifikator-Setup
 smscodeIntroMessage=Geben Sie Ihre Rufnummer ein und ein Verifizierungscode wird an Ihr Telefon gesendet.
-mobileSetupStep1=Installieren Sie eine Authenticator-Anwendung auf Ihrem Telefon. Die hier aufgeführten Anwendungen werden unterstützt.
+mobileSetupStep1=Installieren Sie eine Authentifikator-Anwendung auf Ihrem Telefon. Die hier aufgeführten Anwendungen werden unterstützt.
 mobileSetupStep2=Öffnen Sie die Anwendung und scannen Sie den Barcode:
 mobileSetupStep3=Geben Sie den von der Anwendung bereitgestellten Einmalcode ein und klicken Sie auf Speichern, um die Einrichtung abzuschließen.
 scanBarCode=Wollen Sie den Barcode scannen?
@@ -322,7 +322,7 @@ realmName=Realm
 doDownload=Herunterladen
 doPrint=Drucken
 generateNewBackupCodes=Neue Backup-Codes generieren
-backtoAuthenticatorPage=Zurück zur Authenticator-Seite
+backtoAuthenticatorPage=Zurück zur Authentifikator-Seite
 
 
 #Resources


### PR DESCRIPTION
Changes in this PR:

- Remove spaces in compound words
- Make terms more uniform
- Various language fixes

Some of these might be subjective, e.g. some people prefer keeping more English words instead of translating them into German (e.g. "One-time Code" vs. "Einmalcode", "Identity Provider" vs. "Identitätsprovider"). However:

- Spaces in compounds are generally not accepted in official German (although common in casual written language)
- Previously, there were inconsistencies: the translations used both "Geräte Aktivität" and "Geräteaktivität" (in different places), as well as both "Identity Provider" and "Identitätsprovider", etc.