### PR TITLE
KEYCLOAK-18725 Honor pairwise subject identifier for LogoutToken in backchannel logouts

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -136,8 +137,16 @@ public class ProtocolMapperUtils {
     }
 
     public static Stream<Entry<ProtocolMapperModel, ProtocolMapper>> getSortedProtocolMappers(KeycloakSession session, ClientSessionContext ctx, Predicate<Entry<ProtocolMapperModel, ProtocolMapper>> filter) {
+        return getEntryStream(session, filter, ctx.getProtocolMappersStream());
+    }
+
+    public static Stream<Entry<ProtocolMapperModel, ProtocolMapper>> getSortedProtocolMappers(KeycloakSession session, ClientModel client, Predicate<Entry<ProtocolMapperModel, ProtocolMapper>> filter) {
+        return getEntryStream(session, filter, client.getProtocolMappersStream());
+    }
+
+    private static Stream<Entry<ProtocolMapperModel, ProtocolMapper>> getEntryStream(KeycloakSession session, Predicate<Entry<ProtocolMapperModel, ProtocolMapper>> filter, Stream<ProtocolMapperModel> protocolMappersStream) {
         KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
-        return ctx.getProtocolMappersStream()
+        return protocolMappersStream
                 .<Entry<ProtocolMapperModel, ProtocolMapper>>map(mapperModel -> {
                     ProtocolMapper mapper = (ProtocolMapper) sessionFactory.getProviderFactory(ProtocolMapper.class, mapperModel.getProtocolMapper());
                     if (mapper == null) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractPairwiseSubMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractPairwiseSubMapper.java
@@ -101,7 +101,7 @@ public abstract class AbstractPairwiseSubMapper extends AbstractOIDCProtocolMapp
         return configProperties;
     }
 
-    private String getSectorIdentifier(ClientModel client, ProtocolMapperModel mappingModel) {
+    public String getSectorIdentifier(ClientModel client, ProtocolMapperModel mappingModel) {
         String sectorIdentifierUri = PairwiseSubMapperHelper.getSectorIdentifierUri(mappingModel);
         if (sectorIdentifierUri != null && !sectorIdentifierUri.isEmpty()) {
             return PairwiseSubMapperUtils.resolveValidSectorIdentifier(sectorIdentifierUri);

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -198,14 +198,15 @@ public class ResourceAdminManager {
         return StringPropertyReplacer.replaceProperties(absoluteURI);
     }
 
-    protected Response sendBackChannelLogoutRequestToClientUri(ClientModel resource,
+    protected Response sendBackChannelLogoutRequestToClientUri(ClientModel client,
                                                               AuthenticatedClientSessionModel clientSessionModel, String managementUrl) {
         UserModel user = clientSessionModel.getUserSession().getUser();
 
-        LogoutToken logoutToken = session.tokens().initLogoutToken(resource, user, clientSessionModel);
+        LogoutToken logoutToken = session.tokens().initLogoutToken(client, user, clientSessionModel);
+
         String token = session.tokens().encode(logoutToken);
         if (logger.isDebugEnabled())
-            logger.debugv("logout resource {0} url: {1} sessionIds: ", resource.getClientId(), managementUrl);
+            logger.debugv("logout client {0} url: {1} sessionIds: ", client.getClientId(), managementUrl);
         HttpPost post = null;
         try {
             post = new HttpPost(managementUrl);
@@ -229,7 +230,7 @@ public class ResourceAdminManager {
                 }
             }
         } catch (IOException e) {
-            ServicesLogger.LOGGER.logoutFailed(e, resource.getClientId());
+            ServicesLogger.LOGGER.logoutFailed(e, client.getClientId());
             return Response.serverError().build();
         } finally {
             if (post != null) {


### PR DESCRIPTION
Previously LogoutTokens did contain the original subject identifier, even if a pairwise subject identifier was configured for the client. We now honor configured pairwise subject identifiers for backchannel logouts.

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>
(cherry picked from commit 8c26f31ce2e0b9d3893c5898680347fc6e518aeb)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
