### PR TITLE
Fix issue with overlapping WebElements in SocialLoginTest#PaypalLogin

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/PayPalLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/PayPalLoginPage.java
@@ -17,11 +17,11 @@
 
 package org.keycloak.testsuite.pages.social;
 
+import org.keycloak.testsuite.util.WaitUtils;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-
-import static org.keycloak.testsuite.util.UIUtils.clickLink;
 
 /**
  * @author Petter Lysne (petterlysne at hotmail dot com)
@@ -44,23 +44,27 @@ public class PayPalLoginPage extends AbstractSocialLoginPage {
 
     @Override
     public void login(String user, String password) {
+        JavascriptExecutor executor = (JavascriptExecutor) driver;
         try {
             usernameInput.clear(); // to remove pre-filled email
             usernameInput.sendKeys(user);
 
+            WaitUtils.pause(3000);
             try {
-                clickLink(nextButton);  // sometimes the login process is just a one step,
-                                        // sometimes it's two steps so we need to click the 'Next' button
+                executor.executeScript("arguments[0].click();", nextButton); // sometimes the login process is just a one step,
+                                                                                // sometimes it's two steps so we need to click the 'Next' button
             }
             catch (NoSuchElementException e) {
                 // one step login process, no need to click the 'Next' button
             }
 
             passwordInput.sendKeys(password);
-            clickLink(loginButton);
+            WaitUtils.pause(3000);
+            executor.executeScript("arguments[0].click();", loginButton);
         }
         catch (NoSuchElementException e) {
-            clickLink(continueLoginButton); // already logged in, just need to confirm it
+            WaitUtils.pause(3000);
+            executor.executeScript("arguments[0].click();", continueLoginButton); // already logged in, just need to confirm it
         }
     }
 }


### PR DESCRIPTION
Closes #23960

Changing means of clicking in test case to JavascriptExecutor in order to avoid WebElement being unclickable due to overlapping WebElements. 

Reference jenkins run: https://master-jenkins/job/universal-test-pipeline-server/3151/testReport/junit/org.keycloak.testsuite.broker/SocialLoginTest/paypalLogin/
