### PR TITLE
Optionally accept RELATED_IMAGE_KEYCLOAK as the operand coordinate

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -4,11 +4,11 @@ quarkus.docker.dockerfile-jvm-path=Dockerfile
 quarkus.operator-sdk.crd.validate=false
 
 # Operator config
-operator.keycloak.image=quay.io/keycloak/keycloak:nightly
+operator.keycloak.image=${RELATED_IMAGE_KEYCLOAK:quay.io/keycloak/keycloak:nightly}
 operator.keycloak.image-pull-policy=Always
 
 # https://quarkus.io/guides/deploying-to-kubernetes#environment-variables-from-keyvalue-pairs
-quarkus.kubernetes.env.vars.operator-keycloak-image=${operator.keycloak.image}
+quarkus.kubernetes.env.vars.related-image-keycloak=${operator.keycloak.image}
 
 # Bundle config
 quarkus.operator-sdk.bundle.package-name=keycloak-operator


### PR DESCRIPTION
This changes the quarkus configuration of the operator so that if the RELATED_IMAGE_KEYCLOAK environment variable is present, it will be accepted over the default, or the existing configuration environment variable of OPERATOR_KEYCLOAK_IMAGE

Closes #24017

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
