### PR TITLE
fix: moves jgroups.dns.query to a system property

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
@@ -120,8 +120,11 @@ public class KeycloakRealmImportJobDependentResource extends KubernetesDependent
 
         var runBuild = !keycloakContainer.getArgs().contains(KeycloakDeploymentDependentResource.OPTIMIZED_ARG) ? "/opt/keycloak/bin/kc.sh --verbose build && " : "";
 
+        String jgroupsDNSQuery = keycloakContainer.getArgs().stream()
+                .filter(s -> s.startsWith(KeycloakDeploymentDependentResource.JGROUPS_DNS_QUERY_PARAM))
+                .reduce((s1, s2) -> s2).map(" "::concat).orElse("");
         var commandArgs = List.of("-c",
-                runBuild + "/opt/keycloak/bin/kc.sh --verbose import --optimized --file='" + importMntPath + realmName + "-realm.json' " + override);
+                runBuild + "/opt/keycloak/bin/kc.sh --verbose import --optimized --file='" + importMntPath + realmName + "-realm.json' " + override + jgroupsDNSQuery);
 
         keycloakContainer.setCommand(command);
         keycloakContainer.setArgs(commandArgs);

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
@@ -120,11 +120,8 @@ public class KeycloakRealmImportJobDependentResource extends KubernetesDependent
 
         var runBuild = !keycloakContainer.getArgs().contains(KeycloakDeploymentDependentResource.OPTIMIZED_ARG) ? "/opt/keycloak/bin/kc.sh --verbose build && " : "";
 
-        String jgroupsDNSQuery = keycloakContainer.getArgs().stream()
-                .filter(s -> s.startsWith(KeycloakDeploymentDependentResource.JGROUPS_DNS_QUERY_PARAM))
-                .reduce((s1, s2) -> s2).map(" "::concat).orElse("");
         var commandArgs = List.of("-c",
-                runBuild + "/opt/keycloak/bin/kc.sh --verbose import --optimized --file='" + importMntPath + realmName + "-realm.json' " + override + jgroupsDNSQuery);
+                runBuild + "/opt/keycloak/bin/kc.sh --verbose import --optimized --file='" + importMntPath + realmName + "-realm.json' " + override);
 
         keycloakContainer.setCommand(command);
         keycloakContainer.setArgs(commandArgs);

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
@@ -38,6 +38,7 @@ import org.keycloak.operator.Utils;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.keycloak.operator.controllers.KeycloakDistConfigurator.getKeycloakOptionEnvVarName;
 
@@ -76,7 +77,9 @@ public class KeycloakRealmImportJobDependentResource extends KubernetesDependent
 
         var cacheEnvVarName = getKeycloakOptionEnvVarName("cache");
         var healthEnvVarName = getKeycloakOptionEnvVarName("health-enabled");
-        envvars.removeIf(e -> e.getName().equals(cacheEnvVarName) || e.getName().equals(healthEnvVarName));
+        var cacheStackEnvVarName = getKeycloakOptionEnvVarName("cache-stack");
+        var toRemove = Set.of(cacheEnvVarName, healthEnvVarName, cacheStackEnvVarName);
+        envvars.removeIf(e -> toRemove.contains(e.getName()));
 
         // The Job should not connect to the cache
         envvars.add(new EnvVarBuilder().withName(cacheEnvVarName).withValue("local").build());

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -319,6 +319,8 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
               logFailed(k8sclient.apps().deployments().withName("keycloak-operator"), Deployment::getStatus);
           }
           logFailed(k8sclient.apps().statefulSets().withName(POSTGRESQL_NAME), StatefulSet::getStatus);
+          k8sclient.pods().withLabel("app", "keycloak-realm-import").list().getItems().stream()
+                  .forEach(pod -> logFailed(k8sclient.pods().resource(pod), Pod::getStatus));
       } finally {
           cleanup();
       }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -489,7 +489,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                 .list()
                 .getItems();
 
-        assertThat(pods.get(0).getSpec().getContainers().get(0).getArgs()).containsExactly("--verbose", "start", "--optimized");
+        assertThat(pods.get(0).getSpec().getContainers().get(0).getArgs()).endsWith("--verbose", "start", "--optimized");
     }
 
     @Test
@@ -512,7 +512,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                 .list()
                 .getItems();
 
-        assertThat(pods.get(0).getSpec().getContainers().get(0).getArgs()).containsExactly("--verbose", "start", "--optimized");
+        assertThat(pods.get(0).getSpec().getContainers().get(0).getArgs()).endsWith("--verbose", "start", "--optimized");
         assertThat(pods.get(0).getSpec().getImagePullSecrets().size()).isEqualTo(1);
         assertThat(pods.get(0).getSpec().getImagePullSecrets().get(0).getName()).isEqualTo(imagePullSecretName);
     }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -194,8 +194,8 @@ public class PodTemplateTest {
         // Assert
         assertEquals(1, podTemplate.getSpec().getContainers().get(0).getCommand().size());
         assertEquals(command, podTemplate.getSpec().getContainers().get(0).getCommand().get(0));
-        assertEquals(1, podTemplate.getSpec().getContainers().get(0).getArgs().size());
-        assertEquals(arg, podTemplate.getSpec().getContainers().get(0).getArgs().get(0));
+        assertEquals(2, podTemplate.getSpec().getContainers().get(0).getArgs().size());
+        assertEquals(arg, podTemplate.getSpec().getContainers().get(0).getArgs().get(1));
     }
 
     @Test


### PR DESCRIPTION
This makes the assumption we can always update command to support this.  My assumption is that this does not need to be picked up by the import logic.

closes #21830

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
