### PR TITLE
Deduplicate attribute group entries in selection in admin ui (#24067)

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
@@ -134,15 +134,19 @@ export const AttributesTab = () => {
                 >
                   {t("allGroups")}
                 </SelectOption>,
-                ...config
-                  .attributes!.filter((attr) => !!attr.group)
-                  .map((attr) => (
-                    <SelectOption
-                      key={attr.group}
-                      data-testid={`${attr.group}-option`}
-                      value={attr.group}
-                    />
-                  )),
+                ...[
+                  ...new Set(
+                    config
+                      .attributes!.filter((attr) => !!attr.group)
+                      .map((attr) => attr.group),
+                  ),
+                ].map((group) => (
+                  <SelectOption
+                    key={group}
+                    data-testid={`${group}-option`}
+                    value={group}
+                  />
+                )),
               ]}
             </Select>
           </ToolbarItem>


### PR DESCRIPTION
Previously, the list of attribute groups was derived from the attributes without removing duplicates from the resulting list. This yielded in multiple repeated attribute group entries.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
