### PR TITLE
Renaming providerId -> providerAlias w.r.t IdentityProvider references

### DIFF
--- a/core/src/main/java/org/keycloak/representations/account/LinkedAccountRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/account/LinkedAccountRepresentation.java
@@ -61,8 +61,8 @@ public class LinkedAccountRepresentation implements Comparable<LinkedAccountRepr
         return providerAlias;
     }
 
-    public void setProviderAlias(String providerId) {
-        this.providerAlias = providerId;
+    public void setProviderAlias(String providerAlias) {
+        this.providerAlias = providerAlias;
     }
 
     public String getProviderName() {

--- a/server-spi/src/main/java/org/keycloak/models/FederatedIdentityModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/FederatedIdentityModel.java
@@ -27,12 +27,12 @@ public class FederatedIdentityModel {
     private final String identityProvider;
     private final String userName;
 
-    public FederatedIdentityModel(String identityProvider, String userId, String userName) {
-        this(identityProvider, userId, userName, null);
+    public FederatedIdentityModel(String providerAlias, String userId, String userName) {
+        this(providerAlias, userId, userName, null);
     }
 
-    public FederatedIdentityModel(String providerId, String userId, String userName, String token) {
-        this.identityProvider = providerId;
+    public FederatedIdentityModel(String providerAlias, String userId, String userName, String token) {
+        this.identityProvider = providerAlias;
         this.userId = userId;
         this.userName = userName;
         this.token = token;

--- a/services/src/main/java/org/keycloak/services/Urls.java
+++ b/services/src/main/java/org/keycloak/services/Urls.java
@@ -44,13 +44,13 @@ public class Urls {
         return realmBase(baseUri).path(RealmsResource.class, "getAccountService");
     }
 
-    public static URI identityProviderAuthnResponse(URI baseUri, String providerId, String realmName) {
+    public static URI identityProviderAuthnResponse(URI baseUri, String providerAlias, String realmName) {
         return realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
                 .path(IdentityBrokerService.class, "getEndpoint")
-                .build(realmName, providerId);
+                .build(realmName, providerAlias);
     }
 
-    public static URI identityProviderAuthnRequest(URI baseUri, String providerId, String realmName, String accessCode, String clientId, String tabId) {
+    public static URI identityProviderAuthnRequest(URI baseUri, String providerAlias, String realmName, String accessCode, String clientId, String tabId) {
         UriBuilder uriBuilder = realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
                 .path(IdentityBrokerService.class, "performLogin");
 
@@ -64,25 +64,25 @@ public class Urls {
             uriBuilder.replaceQueryParam(Constants.TAB_ID, tabId);
         }
 
-        return uriBuilder.build(realmName, providerId);
+        return uriBuilder.build(realmName, providerAlias);
     }
 
-    public static URI identityProviderLinkRequest(URI baseUri, String providerId, String realmName) {
+    public static URI identityProviderLinkRequest(URI baseUri, String providerAlias, String realmName) {
         UriBuilder uriBuilder = realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
                 .replaceQuery(null)
                 .path(IdentityBrokerService.class, "clientInitiatedAccountLinking");
 
-        return uriBuilder.build(realmName, providerId);
+        return uriBuilder.build(realmName, providerAlias);
     }
 
-    public static URI identityProviderRetrieveToken(URI baseUri, String providerId, String realmName) {
+    public static URI identityProviderRetrieveToken(URI baseUri, String providerAlias, String realmName) {
         return realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
                 .path(IdentityBrokerService.class, "retrieveToken")
-                .build(realmName, providerId);
+                .build(realmName, providerAlias);
     }
 
-    public static URI identityProviderAuthnRequest(URI baseURI, String providerId, String realmName) {
-        return identityProviderAuthnRequest(baseURI, providerId, realmName, null, null, null);
+    public static URI identityProviderAuthnRequest(URI baseURI, String providerAlias, String realmName) {
+        return identityProviderAuthnRequest(baseURI, providerAlias, realmName, null, null, null);
     }
 
     public static URI identityProviderAfterFirstBrokerLogin(URI baseUri, String realmName, String accessCode, String clientId, String tabId) {

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -191,20 +191,20 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     /**
      * Closes off CORS preflight requests for account linking
      *
-     * @param providerId
+     * @param providerAlias
      * @return
      */
     @OPTIONS
-    @Path("/{provider_id}/link")
-    public Response clientIntiatedAccountLinkingPreflight(@PathParam("provider_id") String providerId) {
+    @Path("/{provider_alias}/link")
+    public Response clientIntiatedAccountLinkingPreflight(@PathParam("provider_alias") String providerAlias) {
         return Response.status(403).build(); // don't allow preflight
     }
 
 
     @GET
     @NoCache
-    @Path("/{provider_id}/link")
-    public Response clientInitiatedAccountLinking(@PathParam("provider_id") String providerId,
+    @Path("/{provider_alias}/link")
+    public Response clientInitiatedAccountLinking(@PathParam("provider_alias") String providerAlias,
                                                   @QueryParam("redirect_uri") String redirectUri,
                                                   @QueryParam("client_id") String clientId,
                                                   @QueryParam("nonce") String nonce,
@@ -253,7 +253,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 } catch (NoSuchAlgorithmException e) {
                     throw new ErrorPageException(session, Response.Status.INTERNAL_SERVER_ERROR, Messages.UNEXPECTED_ERROR_HANDLING_REQUEST);
                 }
-                String input = nonce + cookieResult.getSession().getId() + clientId + providerId;
+                String input = nonce + cookieResult.getSession().getId() + clientId + providerAlias;
                 byte[] check = md.digest(input.getBytes(StandardCharsets.UTF_8));
                 if (MessageDigest.isEqual(decoded, check)) {
                     clientSession = cs;
@@ -266,7 +266,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);
         }
 
-        event.detail(Details.IDENTITY_PROVIDER, providerId);
+        event.detail(Details.IDENTITY_PROVIDER, providerAlias);
 
         ClientModel accountService = this.realmModel.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
         if (!accountService.getId().equals(client.getId())) {
@@ -289,7 +289,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         }
 
 
-        IdentityProviderModel identityProviderModel = realmModel.getIdentityProviderByAlias(providerId);
+        IdentityProviderModel identityProviderModel = realmModel.getIdentityProviderByAlias(providerAlias);
         if (identityProviderModel == null) {
             event.error(Errors.UNKNOWN_IDENTITY_PROVIDER);
             UriBuilder builder = UriBuilder.fromUri(redirectUri)
@@ -320,14 +320,14 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         authSession.setProtocol(client.getProtocol());
         authSession.setRedirectUri(redirectUri);
         authSession.setClientNote(OIDCLoginProtocol.STATE_PARAM, UUID.randomUUID().toString());
-        authSession.setAuthNote(LINKING_IDENTITY_PROVIDER, cookieResult.getSession().getId() + clientId + providerId);
+        authSession.setAuthNote(LINKING_IDENTITY_PROVIDER, cookieResult.getSession().getId() + clientId + providerAlias);
 
         event.detail(Details.CODE_ID, userSession.getId());
         event.success();
 
         try {
-            IdentityProvider identityProvider = getIdentityProvider(session, realmModel, providerId);
-            Response response = identityProvider.performLogin(createAuthenticationRequest(providerId, clientSessionCode));
+            IdentityProvider<?> identityProvider = getIdentityProvider(session, realmModel, providerAlias);
+            Response response = identityProvider.performLogin(createAuthenticationRequest(providerAlias, clientSessionCode));
 
             if (response != null) {
                 if (isDebugEnabled()) {
@@ -336,9 +336,9 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 return response;
             }
         } catch (IdentityBrokerException e) {
-            return redirectToErrorPage(authSession, Response.Status.INTERNAL_SERVER_ERROR, Messages.COULD_NOT_SEND_AUTHENTICATION_REQUEST, e, providerId);
+            return redirectToErrorPage(authSession, Response.Status.INTERNAL_SERVER_ERROR, Messages.COULD_NOT_SEND_AUTHENTICATION_REQUEST, e, providerAlias);
         } catch (Exception e) {
-            return redirectToErrorPage(authSession, Response.Status.INTERNAL_SERVER_ERROR, Messages.UNEXPECTED_ERROR_HANDLING_REQUEST, e, providerId);
+            return redirectToErrorPage(authSession, Response.Status.INTERNAL_SERVER_ERROR, Messages.UNEXPECTED_ERROR_HANDLING_REQUEST, e, providerAlias);
         }
 
         return redirectToErrorPage(authSession, Response.Status.INTERNAL_SERVER_ERROR, Messages.COULD_NOT_PROCEED_WITH_AUTHENTICATION_REQUEST);
@@ -347,27 +347,27 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
 
     @POST
-    @Path("/{provider_id}/login")
-    public Response performPostLogin(@PathParam("provider_id") String providerId,
+    @Path("/{provider_alias}/login")
+    public Response performPostLogin(@PathParam("provider_alias") String providerAlias,
                                      @QueryParam(LoginActionsService.SESSION_CODE) String code,
                                      @QueryParam("client_id") String clientId,
                                      @QueryParam(Constants.TAB_ID) String tabId,
                                      @QueryParam(OIDCLoginProtocol.LOGIN_HINT_PARAM) String loginHint) {
-        return performLogin(providerId, code, clientId, tabId, loginHint);
+        return performLogin(providerAlias, code, clientId, tabId, loginHint);
     }
 
     @GET
     @NoCache
-    @Path("/{provider_id}/login")
-    public Response performLogin(@PathParam("provider_id") String providerId,
+    @Path("/{provider_alias}/login")
+    public Response performLogin(@PathParam("provider_alias") String providerAlias,
                                  @QueryParam(LoginActionsService.SESSION_CODE) String code,
                                  @QueryParam("client_id") String clientId,
                                  @QueryParam(Constants.TAB_ID) String tabId,
                                  @QueryParam(OIDCLoginProtocol.LOGIN_HINT_PARAM) String loginHint) {
-        this.event.detail(Details.IDENTITY_PROVIDER, providerId);
+        this.event.detail(Details.IDENTITY_PROVIDER, providerAlias);
 
         if (isDebugEnabled()) {
-            logger.debugf("Sending authentication request to identity provider [%s].", providerId);
+            logger.debugf("Sending authentication request to identity provider [%s].", providerAlias);
         }
 
         try {
@@ -375,22 +375,22 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
             ClientSessionCode<AuthenticationSessionModel> clientSessionCode = new ClientSessionCode<>(session, realmModel, authSession);
             clientSessionCode.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
-            IdentityProviderModel identityProviderModel = realmModel.getIdentityProviderByAlias(providerId);
+            IdentityProviderModel identityProviderModel = realmModel.getIdentityProviderByAlias(providerAlias);
             if (identityProviderModel == null) {
-                throw new IdentityBrokerException("Identity Provider [" + providerId + "] not found.");
+                throw new IdentityBrokerException("Identity Provider [" + providerAlias + "] not found.");
             }
             if (identityProviderModel.isLinkOnly()) {
-                throw new IdentityBrokerException("Identity Provider [" + providerId + "] is not allowed to perform a login.");
+                throw new IdentityBrokerException("Identity Provider [" + providerAlias + "] is not allowed to perform a login.");
             }
             if (clientSessionCode != null && clientSessionCode.getClientSession() != null && loginHint != null) {
                 clientSessionCode.getClientSession().setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
             }
 
-            IdentityProviderFactory providerFactory = getIdentityProviderFactory(session, identityProviderModel);
+            IdentityProviderFactory<?> providerFactory = getIdentityProviderFactory(session, identityProviderModel);
 
-            IdentityProvider identityProvider = providerFactory.create(session, identityProviderModel);
+            IdentityProvider<?> identityProvider = providerFactory.create(session, identityProviderModel);
 
-            Response response = identityProvider.performLogin(createAuthenticationRequest(providerId, clientSessionCode));
+            Response response = identityProvider.performLogin(createAuthenticationRequest(providerAlias, clientSessionCode));
 
             if (response != null) {
                 if (isDebugEnabled()) {
@@ -399,20 +399,20 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 return response;
             }
         } catch (IdentityBrokerException e) {
-            return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.COULD_NOT_SEND_AUTHENTICATION_REQUEST, e, providerId);
+            return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.COULD_NOT_SEND_AUTHENTICATION_REQUEST, e, providerAlias);
         } catch (Exception e) {
-            return redirectToErrorPage(Response.Status.INTERNAL_SERVER_ERROR, Messages.UNEXPECTED_ERROR_HANDLING_REQUEST, e, providerId);
+            return redirectToErrorPage(Response.Status.INTERNAL_SERVER_ERROR, Messages.UNEXPECTED_ERROR_HANDLING_REQUEST, e, providerAlias);
         }
 
         return redirectToErrorPage(Response.Status.INTERNAL_SERVER_ERROR, Messages.COULD_NOT_PROCEED_WITH_AUTHENTICATION_REQUEST);
     }
 
-    @Path("{provider_id}/endpoint")
-    public Object getEndpoint(@PathParam("provider_id") String providerId) {
+    @Path("{provider_alias}/endpoint")
+    public Object getEndpoint(@PathParam("provider_alias") String providerAlias) {
         IdentityProvider identityProvider;
 
         try {
-            identityProvider = getIdentityProvider(session, realmModel, providerId);
+            identityProvider = getIdentityProvider(session, realmModel, providerAlias);
         } catch (IdentityBrokerException e) {
             throw new NotFoundException(e.getMessage());
         }
@@ -420,7 +420,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         return identityProvider.callback(realmModel, this, event);
     }
 
-    @Path("{provider_id}/token")
+    @Path("{provider_alias}/token")
     @OPTIONS
     public Response retrieveTokenPreflight() {
         return Cors.add(this.request, Response.ok()).auth().preflight().build();
@@ -428,9 +428,9 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     @GET
     @NoCache
-    @Path("{provider_id}/token")
-    public Response retrieveToken(@PathParam("provider_id") String providerId) {
-        return getToken(providerId, false);
+    @Path("{provider_alias}/token")
+    public Response retrieveToken(@PathParam("provider_alias") String providerAlias) {
+        return getToken(providerAlias, false);
     }
 
     private boolean canReadBrokerToken(AccessToken token) {
@@ -439,7 +439,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         return brokerRoles != null && brokerRoles.isUserInRole(Constants.READ_TOKEN_ROLE);
     }
 
-    private Response getToken(String providerId, boolean forceRetrieval) {
+    private Response getToken(String providerAlias, boolean forceRetrieval) {
         this.event.event(EventType.IDENTITY_PROVIDER_RETRIEVE_TOKEN);
 
         try {
@@ -461,22 +461,22 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
                 }
                 if (!canReadBrokerToken(token)) {
-                    return corsResponse(forbidden("Client [" + clientModel.getClientId() + "] not authorized to retrieve tokens from identity provider [" + providerId + "]."), clientModel);
+                    return corsResponse(forbidden("Client [" + clientModel.getClientId() + "] not authorized to retrieve tokens from identity provider [" + providerAlias + "]."), clientModel);
 
                 }
 
-                IdentityProvider identityProvider = getIdentityProvider(session, realmModel, providerId);
-                IdentityProviderModel identityProviderConfig = getIdentityProviderConfig(providerId);
+                IdentityProvider identityProvider = getIdentityProvider(session, realmModel, providerAlias);
+                IdentityProviderModel identityProviderConfig = getIdentityProviderConfig(providerAlias);
 
                 if (identityProviderConfig.isStoreToken()) {
-                    FederatedIdentityModel identity = this.session.users().getFederatedIdentity(this.realmModel, authResult.getUser(), providerId);
+                    FederatedIdentityModel identity = this.session.users().getFederatedIdentity(this.realmModel, authResult.getUser(), providerAlias);
 
                     if (identity == null) {
-                        return corsResponse(badRequest("User [" + authResult.getUser().getId() + "] is not associated with identity provider [" + providerId + "]."), clientModel);
+                        return corsResponse(badRequest("User [" + authResult.getUser().getId() + "] is not associated with identity provider [" + providerAlias + "]."), clientModel);
                     }
 
                     if (identity.getToken() == null) {
-                        return corsResponse(notFound("No token stored for user [" + authResult.getUser().getId() + "] with associated identity provider [" + providerId + "]."), clientModel);
+                        return corsResponse(notFound("No token stored for user [" + authResult.getUser().getId() + "] with associated identity provider [" + providerAlias + "]."), clientModel);
                     }
 
                     this.event.success();
@@ -484,14 +484,14 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                     return corsResponse(identityProvider.retrieveToken(session, identity), clientModel);
                 }
 
-                return corsResponse(badRequest("Identity Provider [" + providerId + "] does not support this operation."), clientModel);
+                return corsResponse(badRequest("Identity Provider [" + providerAlias + "] does not support this operation."), clientModel);
             }
 
             return badRequest("Invalid token.");
         } catch (IdentityBrokerException e) {
-            return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.COULD_NOT_OBTAIN_TOKEN, e, providerId);
+            return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.COULD_NOT_OBTAIN_TOKEN, e, providerAlias);
         }  catch (Exception e) {
-            return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.UNEXPECTED_ERROR_RETRIEVING_TOKEN, e, providerId);
+            return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.UNEXPECTED_ERROR_RETRIEVING_TOKEN, e, providerAlias);
         }
     }
 
@@ -499,10 +499,10 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         IdentityProviderModel identityProviderConfig = context.getIdpConfig();
         AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
 
-        String providerId = identityProviderConfig.getAlias();
+        String providerAlias = identityProviderConfig.getAlias();
         if (!identityProviderConfig.isStoreToken()) {
             if (isDebugEnabled()) {
-                logger.debugf("Token will not be stored for identity provider [%s].", providerId);
+                logger.debugf("Token will not be stored for identity provider [%s].", providerAlias);
             }
             context.setToken(null);
         }
@@ -524,12 +524,12 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             target.preprocessFederatedIdentity(session, realmModel, mapper, context);
         });
 
-        FederatedIdentityModel federatedIdentityModel = new FederatedIdentityModel(providerId, context.getId(),
+        FederatedIdentityModel federatedIdentityModel = new FederatedIdentityModel(providerAlias, context.getId(),
                 context.getUsername(), context.getToken());
 
         this.event.event(EventType.IDENTITY_PROVIDER_LOGIN)
                 .detail(Details.REDIRECT_URI, authenticationSession.getRedirectUri())
-                .detail(Details.IDENTITY_PROVIDER, providerId)
+                .detail(Details.IDENTITY_PROVIDER, providerAlias)
                 .detail(Details.IDENTITY_PROVIDER_USERNAME, context.getUsername());
 
         UserModel federatedUser = this.session.users().getUserByFederatedIdentity(this.realmModel, federatedIdentityModel);
@@ -543,13 +543,13 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
         // Check if federatedUser is already authenticated (this means linking social into existing federatedUser account)
         UserSessionModel userSession = new AuthenticationSessionManager(session).getUserSession(authenticationSession);
-        if (shouldPerformAccountLinking(authenticationSession, userSession, providerId)) {
+        if (shouldPerformAccountLinking(authenticationSession, userSession, providerAlias)) {
             return performAccountLinking(authenticationSession, userSession, context, federatedIdentityModel, federatedUser);
         }
 
         if (federatedUser == null) {
 
-            logger.debugf("Federated user not found for provider '%s' and broker username '%s'", providerId, context.getUsername());
+            logger.debugf("Federated user not found for provider '%s' and broker username '%s'", providerAlias, context.getUsername());
             authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, context.getUsername());
 
             String username = context.getModelUsername();
@@ -654,14 +654,14 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 throw new IdentityBrokerException("Not found serialized context in clientSession");
             }
             BrokeredIdentityContext context = serializedCtx.deserialize(session, authSession);
-            String providerId = context.getIdpConfig().getAlias();
+            String providerAlias = context.getIdpConfig().getAlias();
 
-            event.detail(Details.IDENTITY_PROVIDER, providerId);
+            event.detail(Details.IDENTITY_PROVIDER, providerAlias);
             event.detail(Details.IDENTITY_PROVIDER_USERNAME, context.getUsername());
 
             // Ensure the first-broker-login flow was successfully finished
             String authProvider = authSession.getAuthNote(AbstractIdpAuthenticator.FIRST_BROKER_LOGIN_SUCCESS);
-            if (authProvider == null || !authProvider.equals(providerId)) {
+            if (authProvider == null || !authProvider.equals(providerAlias)) {
                 throw new IdentityBrokerException("Invalid request. Not found the flag that first-broker-login flow was finished");
             }
 
@@ -694,11 +694,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             String isRegisteredNewUser = authSession.getAuthNote(AbstractIdpAuthenticator.BROKER_REGISTERED_NEW_USER);
             if (Boolean.parseBoolean(isRegisteredNewUser)) {
 
-                logger.debugf("Registered new user '%s' after first login with identity provider '%s'. Identity provider username is '%s' . ", federatedUser.getUsername(), providerId, context.getUsername());
+                logger.debugf("Registered new user '%s' after first login with identity provider '%s'. Identity provider username is '%s' . ", federatedUser.getUsername(), providerAlias, context.getUsername());
 
                 context.getIdp().importNewUser(session, realmModel, federatedUser, context);
                 KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
-                realmModel.getIdentityProviderMappersByAliasStream(providerId).forEach(mapper -> {
+                realmModel.getIdentityProviderMappersByAliasStream(providerAlias).forEach(mapper -> {
                     IdentityProviderMapper target = (IdentityProviderMapper) sessionFactory
                             .getProviderFactory(IdentityProviderMapper.class, mapper.getIdentityProviderMapper());
                     target.importNewUser(session, realmModel, federatedUser, mapper, context);
@@ -716,7 +716,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                         .success();
 
             } else {
-                logger.debugf("Linked existing keycloak user '%s' with identity provider '%s' . Identity provider username is '%s' .", federatedUser.getUsername(), providerId, context.getUsername());
+                logger.debugf("Linked existing keycloak user '%s' with identity provider '%s' . Identity provider username is '%s' .", federatedUser.getUsername(), providerAlias, context.getUsername());
 
                 event.event(EventType.FEDERATED_IDENTITY_LINK)
                         .success();
@@ -795,11 +795,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     }
 
     private Response afterPostBrokerLoginFlowSuccess(AuthenticationSessionModel authSession, BrokeredIdentityContext context, boolean wasFirstBrokerLogin) {
-        String providerId = context.getIdpConfig().getAlias();
+        String providerAlias = context.getIdpConfig().getAlias();
         UserModel federatedUser = authSession.getAuthenticatedUser();
 
         if (wasFirstBrokerLogin) {
-            return finishBrokerAuthentication(context, federatedUser, authSession, providerId);
+            return finishBrokerAuthentication(context, federatedUser, authSession, providerAlias);
         } else {
 
             boolean firstBrokerLoginInProgress = (authSession.getAuthNote(AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE) != null);
@@ -811,23 +811,23 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
                 return afterFirstBrokerLogin(authSession);
             } else {
-                return finishBrokerAuthentication(context, federatedUser, authSession, providerId);
+                return finishBrokerAuthentication(context, federatedUser, authSession, providerAlias);
             }
         }
     }
 
 
-    private Response finishBrokerAuthentication(BrokeredIdentityContext context, UserModel federatedUser, AuthenticationSessionModel authSession, String providerId) {
+    private Response finishBrokerAuthentication(BrokeredIdentityContext context, UserModel federatedUser, AuthenticationSessionModel authSession, String providerAlias) {
         authSession.setAuthNote(AuthenticationProcessor.BROKER_SESSION_ID, context.getBrokerSessionId());
         authSession.setAuthNote(AuthenticationProcessor.BROKER_USER_ID, context.getBrokerUserId());
 
         this.event.user(federatedUser);
 
         context.getIdp().authenticationFinished(authSession, context);
-        authSession.setUserSessionNote(Details.IDENTITY_PROVIDER, providerId);
+        authSession.setUserSessionNote(Details.IDENTITY_PROVIDER, providerAlias);
         authSession.setUserSessionNote(Details.IDENTITY_PROVIDER_USERNAME, context.getUsername());
 
-        event.detail(Details.IDENTITY_PROVIDER, providerId)
+        event.detail(Details.IDENTITY_PROVIDER, providerAlias)
                 .detail(Details.IDENTITY_PROVIDER_USERNAME, context.getUsername());
 
         if (isDebugEnabled()) {
@@ -881,7 +881,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     }
 
 
-    private boolean shouldPerformAccountLinking(AuthenticationSessionModel authSession, UserSessionModel userSession, String providerId) {
+    private boolean shouldPerformAccountLinking(AuthenticationSessionModel authSession, UserSessionModel userSession, String providerAlias) {
         String noteFromSession = authSession.getAuthNote(LINKING_IDENTITY_PROVIDER);
         if (noteFromSession == null) {
             return false;
@@ -891,7 +891,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         if (userSession == null) {
             linkingValid = false;
         } else {
-            String expectedNote = userSession.getId() + authSession.getClient().getClientId() + providerId;
+            String expectedNote = userSession.getId() + authSession.getClient().getClientId() + providerAlias;
             linkingValid = expectedNote.equals(noteFromSession);
         }
 
@@ -1140,7 +1140,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         return null;
     }
 
-    private AuthenticationRequest createAuthenticationRequest(String providerId, ClientSessionCode<AuthenticationSessionModel> clientSessionCode) {
+    private AuthenticationRequest createAuthenticationRequest(String providerAlias, ClientSessionCode<AuthenticationSessionModel> clientSessionCode) {
         AuthenticationSessionModel authSession = null;
         IdentityBrokerState encodedState = null;
 
@@ -1150,11 +1150,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             encodedState = IdentityBrokerState.decoded(relayState, authSession.getClient().getId(), authSession.getClient().getClientId(), authSession.getTabId());
         }
 
-        return new AuthenticationRequest(this.session, this.realmModel, authSession, this.request, this.session.getContext().getUri(), encodedState, getRedirectUri(providerId));
+        return new AuthenticationRequest(this.session, this.realmModel, authSession, this.request, this.session.getContext().getUri(), encodedState, getRedirectUri(providerAlias));
     }
 
-    private String getRedirectUri(String providerId) {
-        return Urls.identityProviderAuthnResponse(this.session.getContext().getUri().getBaseUri(), providerId, this.realmModel.getName()).toString();
+    private String getRedirectUri(String providerAlias) {
+        return Urls.identityProviderAuthnResponse(this.session.getContext().getUri().getBaseUri(), providerAlias, this.realmModel.getName()).toString();
     }
 
     private Response redirectToErrorPage(AuthenticationSessionModel authSession, Response.Status status, String message, Object ... parameters) {
@@ -1241,11 +1241,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         throw ErrorResponse.error(message, Response.Status.NOT_FOUND);
     }
 
-    public static IdentityProvider getIdentityProvider(KeycloakSession session, RealmModel realm, String alias) {
+    public static IdentityProvider<?> getIdentityProvider(KeycloakSession session, RealmModel realm, String alias) {
         IdentityProviderModel identityProviderModel = realm.getIdentityProviderByAlias(alias);
 
         if (identityProviderModel != null) {
-            IdentityProviderFactory providerFactory = getIdentityProviderFactory(session, identityProviderModel);
+            IdentityProviderFactory<?> providerFactory = getIdentityProviderFactory(session, identityProviderModel);
 
             if (providerFactory == null) {
                 throw new IdentityBrokerException("Could not find factory for identity provider [" + alias + "].");
@@ -1257,7 +1257,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         throw new IdentityBrokerException("Identity Provider [" + alias + "] not found.");
     }
 
-    public static IdentityProviderFactory getIdentityProviderFactory(KeycloakSession session, IdentityProviderModel model) {
+    public static IdentityProviderFactory<?> getIdentityProviderFactory(KeycloakSession session, IdentityProviderModel model) {
         return Stream.concat(session.getKeycloakSessionFactory().getProviderFactoriesStream(IdentityProvider.class),
                 session.getKeycloakSessionFactory().getProviderFactoriesStream(SocialIdentityProvider.class))
                 .filter(providerFactory -> Objects.equals(providerFactory.getId(), model.getProviderId()))
@@ -1266,10 +1266,10 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 .orElse(null);
     }
 
-    private IdentityProviderModel getIdentityProviderConfig(String providerId) {
-        IdentityProviderModel model = this.realmModel.getIdentityProviderByAlias(providerId);
+    private IdentityProviderModel getIdentityProviderConfig(String providerAlias) {
+        IdentityProviderModel model = this.realmModel.getIdentityProviderByAlias(providerAlias);
         if (model == null) {
-            throw new IdentityBrokerException("Configuration for identity provider [" + providerId + "] not found.");
+            throw new IdentityBrokerException("Configuration for identity provider [" + providerAlias + "] not found.");
         }
         return model;
     }

--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -115,9 +115,9 @@ public class LinkedAccountsResource {
 
     private LinkedAccountRepresentation toLinkedAccountRepresentation(IdentityProviderModel provider, Set<String> socialIds,
                                                                       Stream<FederatedIdentityModel> identities) {
-        String providerId = provider.getAlias();
+        String providerAlias = provider.getAlias();
 
-        FederatedIdentityModel identity = getIdentity(identities, providerId);
+        FederatedIdentityModel identity = getIdentity(identities, providerAlias);
 
         String displayName = KeycloakModelUtils.getIdentityProviderDisplayName(session, provider);
         String guiOrder = provider.getConfig() != null ? provider.getConfig().get("guiOrder") : null;
@@ -125,7 +125,7 @@ public class LinkedAccountsResource {
         LinkedAccountRepresentation rep = new LinkedAccountRepresentation();
         rep.setConnected(identity != null);
         rep.setSocial(socialIds.contains(provider.getProviderId()));
-        rep.setProviderAlias(providerId);
+        rep.setProviderAlias(providerAlias);
         rep.setDisplayName(displayName);
         rep.setGuiOrder(guiOrder);
         rep.setProviderName(provider.getAlias());
@@ -135,16 +135,16 @@ public class LinkedAccountsResource {
         return rep;
     }
 
-    private FederatedIdentityModel getIdentity(Stream<FederatedIdentityModel> identities, String providerId) {
-        return identities.filter(model -> Objects.equals(model.getIdentityProvider(), providerId))
+    private FederatedIdentityModel getIdentity(Stream<FederatedIdentityModel> identities, String providerAlias) {
+        return identities.filter(model -> Objects.equals(model.getIdentityProvider(), providerAlias))
                 .findFirst().orElse(null);
     }
     
     @GET
-    @Path("/{providerId}")
+    @Path("/{providerAlias}")
     @Produces(MediaType.APPLICATION_JSON)
     @Deprecated
-    public Response buildLinkedAccountURI(@PathParam("providerId") String providerId, 
+    public Response buildLinkedAccountURI(@PathParam("providerAlias") String providerAlias,
                                      @QueryParam("redirectUri") String redirectUri) {
         auth.require(AccountRoles.MANAGE_ACCOUNT);
         
@@ -152,7 +152,7 @@ public class LinkedAccountsResource {
             ErrorResponse.error(Messages.INVALID_REDIRECT_URI, Response.Status.BAD_REQUEST);
         }
         
-        String errorMessage = checkCommonPreconditions(providerId);
+        String errorMessage = checkCommonPreconditions(providerAlias);
         if (errorMessage != null) {
             throw ErrorResponse.error(errorMessage, Response.Status.BAD_REQUEST);
         }
@@ -163,10 +163,10 @@ public class LinkedAccountsResource {
         try {
             String nonce = UUID.randomUUID().toString();
             MessageDigest md = MessageDigest.getInstance("SHA-256");
-            String input = nonce + auth.getSession().getId() +  ACCOUNT_CONSOLE_CLIENT_ID + providerId;
+            String input = nonce + auth.getSession().getId() +  ACCOUNT_CONSOLE_CLIENT_ID + providerAlias;
             byte[] check = md.digest(input.getBytes(StandardCharsets.UTF_8));
             String hash = Base64Url.encode(check);
-            URI linkUri = Urls.identityProviderLinkRequest(this.session.getContext().getUri().getBaseUri(), providerId, realm.getName());
+            URI linkUri = Urls.identityProviderLinkRequest(this.session.getContext().getUri().getBaseUri(), providerAlias, realm.getName());
             linkUri = UriBuilder.fromUri(linkUri)
                     .queryParam("nonce", nonce)
                     .queryParam("hash", hash)
@@ -189,17 +189,17 @@ public class LinkedAccountsResource {
     }
     
     @DELETE
-    @Path("/{providerId}")
+    @Path("/{providerAlias}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response removeLinkedAccount(@PathParam("providerId") String providerId) {
+    public Response removeLinkedAccount(@PathParam("providerAlias") String providerAlias) {
         auth.require(AccountRoles.MANAGE_ACCOUNT);
         
-        String errorMessage = checkCommonPreconditions(providerId);
+        String errorMessage = checkCommonPreconditions(providerAlias);
         if (errorMessage != null) {
             throw ErrorResponse.error(errorMessage, Response.Status.BAD_REQUEST);
         }
         
-        FederatedIdentityModel link = session.users().getFederatedIdentity(realm, user, providerId);
+        FederatedIdentityModel link = session.users().getFederatedIdentity(realm, user, providerAlias);
         if (link == null) {
             throw ErrorResponse.error(Messages.FEDERATED_IDENTITY_NOT_ACTIVE, Response.Status.BAD_REQUEST);
         }
@@ -208,10 +208,10 @@ public class LinkedAccountsResource {
         if (!(session.users().getFederatedIdentitiesStream(realm, user).count() > 1 || user.getFederationLink() != null || isPasswordSet())) {
             throw ErrorResponse.error(Messages.FEDERATED_IDENTITY_REMOVING_LAST_PROVIDER, Response.Status.BAD_REQUEST);
         }
-        
-        session.users().removeFederatedIdentity(realm, user, providerId);
 
-        logger.debugv("Social provider {0} removed successfully from user {1}", providerId, user.getUsername());
+        session.users().removeFederatedIdentity(realm, user, providerAlias);
+
+        logger.debugv("Social provider {0} removed successfully from user {1}", providerAlias, user.getUsername());
 
         event.event(EventType.REMOVE_FEDERATED_IDENTITY).client(auth.getClient()).user(auth.getUser())
                 .detail(Details.USERNAME, auth.getUser().getUsername())
@@ -222,14 +222,14 @@ public class LinkedAccountsResource {
         return Cors.add(request, Response.noContent()).auth().allowedOrigins(auth.getToken()).build();
     }
     
-    private String checkCommonPreconditions(String providerId) {
+    private String checkCommonPreconditions(String providerAlias) {
         auth.require(AccountRoles.MANAGE_ACCOUNT);
         
-        if (Validation.isEmpty(providerId)) {
+        if (Validation.isEmpty(providerAlias)) {
             return Messages.MISSING_IDENTITY_PROVIDER;
         }
         
-        if (!isValidProvider(providerId)) {
+        if (!isValidProvider(providerAlias)) {
             return Messages.IDENTITY_PROVIDER_NOT_FOUND;
         }
         
@@ -244,7 +244,7 @@ public class LinkedAccountsResource {
         return user.credentialManager().isConfiguredFor(PasswordCredentialModel.TYPE);
     }
     
-    private boolean isValidProvider(String providerId) {
-        return realm.getIdentityProvidersStream().anyMatch(model -> Objects.equals(model.getAlias(), providerId));
+    private boolean isValidProvider(String providerAlias) {
+        return realm.getIdentityProvidersStream().anyMatch(model -> Objects.equals(model.getAlias(), providerAlias));
     }
 }


### PR DESCRIPTION
- Updates to method contracts and code references to be more specific when referencing providerAlias
- Also noticed that some uses of the `IdentityProvider` / `IdentityProviderFactory` classes were missing their parameter definition. I didn't want to bloat this PR but I did suppress these warnings a little bit by adding the `<?>` generic. This isn't really much better than leaving them as they were - my thought is that `<?>` suppresses the warning and also would encourage implementers of some of these methods to be more reflective of what they are expecting, but I would be interested in hearing the thoughts of others who have more familiarity with the codebase and may already have some thoughts on how they would like for these to be handled.

Happy to discuss further - I took a scan of the surrounding code and think this is all pretty safe and encompassing, happy to add more updates if anyone finds more references to `providerId` in this context and also happy to back out any of these changes if requested!