### PR TITLE
Fix for issue #16379

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -291,6 +291,8 @@ public class AuthenticationManagementResource {
             throw ErrorResponse.exists("Failed to update flow with empty alias name");
         }
 
+        ReservedCharValidator.validate(flow.getAlias());
+
         //check if updating a correct flow
         AuthenticationFlowModel checkFlow = realm.getAuthenticationFlowById(id);
         if (checkFlow == null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -361,6 +361,15 @@ public class FlowTest extends AbstractAuthenticationTest {
         } catch (ClientErrorException exception){
             //expoected
         }
+
+        //try to update old flow with an alias with illegal characters
+        testFlow.setAlias("New(Flow");
+        try {
+            authMgmtResource.updateFlow(found.getId(), testFlow);
+        } catch (ClientErrorException exception){
+            //expected
+        }
+
         flows = authMgmtResource.getFlows();
 
         //name should be the same for the old Flow


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/16379

Added `ReservedCharValidator.validate(flow.getAlias());` in the API to update an authentication flow in AuthenticationManagementResource.java