### PR TITLE
Fix for issue #24035

### DIFF
--- a/js/apps/admin-ui/src/groups/components/GroupTree.tsx
+++ b/js/apps/admin-ui/src/groups/components/GroupTree.tsx
@@ -52,6 +52,8 @@ const GroupTreeContextMenu = ({
   const [createOpen, toggleCreateOpen] = useToggle();
   const [moveOpen, toggleMoveOpen] = useToggle();
   const [deleteOpen, toggleDeleteOpen] = useToggle();
+  const navigate = useNavigate();
+  const { realm } = useRealm();
 
   return (
     <>
@@ -60,6 +62,7 @@ const GroupTreeContextMenu = ({
           id={group.id}
           rename={group}
           refresh={() => {
+            navigate(toGroups({ realm }));
             refresh();
           }}
           handleModalToggle={toggleRenameOpen}
@@ -79,7 +82,10 @@ const GroupTreeContextMenu = ({
         show={deleteOpen}
         toggleDialog={toggleDeleteOpen}
         selectedRows={[group]}
-        refresh={refresh}
+        refresh={() => {
+          navigate(toGroups({ realm }));
+          refresh();
+        }}
       />
       <Dropdown
         toggle={<KebabToggle onToggle={toggleOpen} />}


### PR DESCRIPTION
Added 'navigate(toGroups({ realm }));' to 'DeleteGroup' component and rename 'GroupsModal' component in GroupTree.tsx

Closes #24035 