### PR TITLE
added default field type

### DIFF
--- a/js/apps/admin-ui/src/user/components/DefaultComponent.tsx
+++ b/js/apps/admin-ui/src/user/components/DefaultComponent.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from "react-i18next";
+import { MultiLineInput } from "../../components/multi-line-input/MultiLineInput";
+import { UserProfileFieldProps } from "../UserProfileFields";
+import { fieldName, label } from "../utils";
+import { UserProfileGroup } from "./UserProfileGroup";
+
+export const DefaultComponent = ({
+  form,
+  attribute,
+}: UserProfileFieldProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <UserProfileGroup form={form} attribute={attribute}>
+      <MultiLineInput
+        aria-label={label(attribute, t)}
+        name={fieldName(attribute)!}
+        addButtonLabel={t("addMultivaluedLabel", {
+          fieldLabel: label(attribute, t),
+        })}
+      />
+    </UserProfileGroup>
+  );
+};

--- a/js/apps/admin-ui/src/user/components/MultiInputComponent.tsx
+++ b/js/apps/admin-ui/src/user/components/MultiInputComponent.tsx
@@ -4,7 +4,7 @@ import { UserProfileFieldProps } from "../UserProfileFields";
 import { fieldName, label } from "../utils";
 import { UserProfileGroup } from "./UserProfileGroup";
 
-export const DefaultComponent = ({
+export const MultiInputComponent = ({
   form,
   attribute,
 }: UserProfileFieldProps) => {


### PR DESCRIPTION
default will now render a text input
and a multiline input for when there is no `inputType`, which makes more sense then a multi select with no options

fixes: #23911

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
