### PR TITLE
Adapter tests failing with Jakarta error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,8 @@
         <sun.xml.ws.version>4.0.0</sun.xml.ws.version>
         <sun.activation.version>1.2.2</sun.activation.version>
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
-        <undertow.version>2.2.24.Final</undertow.version>
+        <undertow.version>${undertow-legacy.version}</undertow.version>
+        <undertow-legacy.version>2.2.24.Final</undertow-legacy.version>
         <undertow-jakarta.version>2.3.2.Final</undertow-jakarta.version>
         <wildfly-elytron.version>2.2.0.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>

--- a/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
@@ -16,6 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <jetty.version>${jetty94.version}</jetty.version>
+        <undertow.version>${undertow-legacy.version}</undertow.version>
 
         <springboot-version>2.4</springboot-version>
 


### PR DESCRIPTION
Fixes #24176

I was able to reproduce it, and with this fix, the Spring Boot instance is properly started. The reason behind these changes is that we use the JavaEE version of Undertow for the Keycloak Undertow adapter, but in the testsuite, we use the JakartaEE version of Undertow to be able to run tests on `auth-server-undertow`.

There was only a clash between the used version for the Spring Boot test app as we need to use the JavaEE Undertow dependency because of the Keycloak adapter. 

I verify there's no other place we need to override it. 

@Aboullos @miquelsi Could you please check it?