### PR TITLE
Optimize Keycloak Dockerfile for Efficiency and Clarity

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -1,36 +1,34 @@
+# Use Red Hat's UBI (Universal Base Image) as a build stage named 'ubi-micro-build'
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 
+# Set environment variable for Keycloak version and download link
 ENV KEYCLOAK_VERSION 999.0.0-SNAPSHOT
 ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
 
-RUN dnf install -y tar gzip
+# Install necessary packages, add and unpack Keycloak, then clean up in one layer
+RUN dnf install -y tar gzip && \
+    ADD $KEYCLOAK_DIST /tmp/keycloak/ && \
+    (cd /tmp/keycloak && tar -xvf /tmp/keycloak/keycloak-*.tar.gz && rm /tmp/keycloak/keycloak-*.tar.gz) || true && \
+    mv /tmp/keycloak/keycloak-* /opt/keycloak && \
+    mkdir -p /opt/keycloak/data && \
+    chmod -R g+rwX /opt/keycloak && \
+    dnf clean all
 
-ADD $KEYCLOAK_DIST /tmp/keycloak/
-
-# The next step makes it uniform for local development and upstream built.
-# If it is a local tar archive then it is unpacked, if from remote is just downloaded.
-RUN (cd /tmp/keycloak && \
-    tar -xvf /tmp/keycloak/keycloak-*.tar.gz && \
-    rm /tmp/keycloak/keycloak-*.tar.gz) || true
-
-RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
-RUN chmod -R g+rwX /opt/keycloak
-
+# Add the UBI null script and execute it in one layer
 ADD ubi-null.sh /tmp/
 RUN bash /tmp/ubi-null.sh java-17-openjdk-headless glibc-langpack-en findutils
 
+# Use Red Hat's UBI Micro as the final base image
 FROM registry.access.redhat.com/ubi9-micro
 ENV LANG en_US.UTF-8
 
 COPY --from=ubi-micro-build /tmp/null/rootfs/ /
 COPY --from=ubi-micro-build --chown=1000:0 /opt/keycloak /opt/keycloak
 
+# Add keycloak user and group in one layer
 RUN echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 
 USER 1000
-
-EXPOSE 8080
-EXPOSE 8443
-
+EXPOSE 8080 8443
 ENTRYPOINT [ "/opt/keycloak/bin/kc.sh" ]


### PR DESCRIPTION
### **Optimization of the Keycloak Dockerfile**

#### **Description**:
This merge request introduces several optimizations to the Keycloak Dockerfile, aiming to streamline the build process, reduce the number of layers, and potentially decrease the final image size.

#### **Changes Made**:

1. **Comments**:
   - **Before**: The Dockerfile had minimal explanatory comments.
   - **After**: Added descriptive comments for each section to provide clarity on the purpose and functionality of each step.

2. **Command Grouping**:
   - **Before**:
     - Separate `RUN` commands for installing packages, adding and unpacking Keycloak, moving directories, and adjusting permissions.
   - **After**:
     - Grouped related commands into a single `RUN` command to reduce the number of layers, making the build process more efficient.

3. **Cache Cleanup**:
   - **Before**: No cache cleanup was performed after package installations.
   - **After**: Added `dnf clean all` at the end of the `RUN` command to clear the cache post package installation, aiming to reduce the image size.

4. **Port Exposure**:
   - **Before**: 
     - Separate `EXPOSE` commands for ports 8080 and 8443.
   - **After**: 
     - Combined the ports into a single `EXPOSE` command for clarity and layer reduction.

#### **Reason for Changes**:
The primary motivation behind these changes is to enhance the efficiency of the Docker image build process. By grouping related commands, we not only reduce the number of layers but also make the Dockerfile more readable. The addition of comments aids in understanding the purpose of each step, especially for contributors unfamiliar with the Dockerfile's specifics. Lastly, cleaning up the cache post package installation can lead to a smaller image size, which is beneficial for deployments.

---

Please review the changes and let me know if any further adjustments are required. Looking forward to your feedback!

---