### PR TITLE
Do not reset the user profile configuration on disable

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
@@ -706,11 +706,6 @@ public class LegacyExportImportManager implements ExportImportManager {
             renameRealm(realm, rep.getRealm());
         }
 
-        if (!Boolean.parseBoolean(rep.getAttributesOrEmpty().get("userProfileEnabled"))) {
-            UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
-            provider.setConfiguration(null);
-        }
-
         // Import attributes first, so the stuff saved directly on representation (displayName, bruteForce etc) has bigger priority
         if (rep.getAttributes() != null) {
             Set<String> attrsToRemove = new HashSet<>(realm.getAttributes().keySet());

--- a/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
+++ b/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
@@ -995,11 +995,6 @@ public class MapExportImportManager implements ExportImportManager {
             renameRealm(realm, rep.getRealm());
         }
 
-        if (!Boolean.parseBoolean(rep.getAttributesOrEmpty().get("userProfileEnabled"))) {
-            UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
-            provider.setConfiguration(null);
-        }
-
         // Import attributes first, so the stuff saved directly on representation (displayName, bruteForce etc) has bigger priority
         if (rep.getAttributes() != null) {
             Set<String> attrsToRemove = new HashSet<>(realm.getAttributes().keySet());


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/23527

Just removing reset configuration when `userProfileEnabled` is disabled. Tests modified accordingly and one added to ensure the configuration remains after disable/enable it.
