### PR TITLE
Fixes for LDAP group membership and search in chunks

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -203,6 +203,20 @@ public class LDAPConfig {
         return Boolean.parseBoolean(pagination);
     }
 
+    public int getMaxConditions() {
+        String string = config.getFirst(LDAPConstants.MAX_CONDITIONS);
+        if (string != null) {
+            try {
+                int max = Integer.parseInt(string);
+                if (max > 0) {
+                    return max;
+                }
+            } catch (NumberFormatException e) {
+            }
+        }
+        return LDAPConstants.DEFAULT_MAX_CONDITIONS;
+    }
+
     public int getBatchSizeForSync() {
         String pageSizeConfig = config.getFirst(LDAPConstants.BATCH_SIZE_FOR_SYNC);
         return pageSizeConfig!=null ? Integer.parseInt(pageSizeConfig) : LDAPConstants.DEFAULT_BATCH_SIZE_FOR_SYNC;

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -61,6 +61,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.naming.NameNotFoundException;
 import javax.naming.directory.AttributeInUseException;
 import javax.naming.directory.NoSuchAttributeException;
 import javax.naming.directory.SchemaViolationException;
@@ -284,6 +285,12 @@ public class LDAPIdentityStore implements IdentityStore {
                     results.add(populateAttributedType(result, identityQuery));
                 }
             }
+        } catch (NameNotFoundException e) {
+            if (identityQuery.getSearchScope() == SearchControls.OBJECT_SCOPE) {
+                // if searching in base (dn search) return empty as entry does not exist
+                return Collections.emptyList();
+            }
+            throw new ModelException("Querying of LDAP failed " + identityQuery, e);
         } catch (Exception e) {
             throw new ModelException("Querying of LDAP failed " + identityQuery, e);
         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.storage.ldap.mappers.membership;
 
-import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.storage.ldap.LDAPConfig;
@@ -25,17 +24,12 @@ import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.LDAPUtils;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
-import org.keycloak.storage.ldap.idm.query.Condition;
-import org.keycloak.storage.ldap.idm.query.EscapeStrategy;
-import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
-import org.keycloak.storage.ldap.idm.query.internal.LDAPQueryConditionsBuilder;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -59,8 +53,8 @@ public enum MembershipType {
                 String membershipLdapAttribute, LDAPDn requiredParentDn, String rdnAttr) {
             Set<String> allMemberships = LDAPUtils.getExistingMemberships(ldapProvider, membershipLdapAttribute, ldapGroup);
 
-            // Filter and keep just descendants of requiredParentDn
-            Set<LDAPDn> result = new HashSet<>();
+            // Filter and keep just descendants of requiredParentDn and with the correct RDN
+            Set<LDAPDn> result = new LinkedHashSet<>();
             for (String membership : allMemberships) {
                 LDAPDn childDn = LDAPDn.fromString(membership);
                 if (childDn.getFirstRdn().getAttrValue(rdnAttr) != null && childDn.isDescendantOf(requiredParentDn)) {
@@ -79,53 +73,14 @@ public enum MembershipType {
             LDAPDn usersDn = LDAPDn.fromString(ldapProvider.getLdapIdentityStore().getConfig().getUsersDn());
             Set<LDAPDn> userDns = getLDAPMembersWithParent(ldapProvider, ldapGroup, config.getMembershipLdapAttribute(), usersDn, ldapConfig.getRdnLdapAttribute());
 
-            if (userDns == null) {
+            if (userDns == null || userDns.size() <= firstResult) {
                 return Collections.emptyList();
             }
 
-            if (userDns.size() <= firstResult) {
-                return Collections.emptyList();
-            }
-
-            List<LDAPDn> dns = new ArrayList<>(userDns);
-            int max = Math.min(dns.size(), firstResult + maxResults);
-            dns = dns.subList(firstResult, max);
-
-            // If usernameAttrName is same like DN, we can just retrieve usernames from DNs
-            List<String> usernames = new LinkedList<>();
-            if (ldapConfig.getUsernameLdapAttribute().equals(ldapConfig.getRdnLdapAttribute())) {
-                for (LDAPDn userDn : dns) {
-                    String username = userDn.getFirstRdn().getAttrValue(ldapConfig.getRdnLdapAttribute());
-                    usernames.add(username);
-                }
-            } else {
-                LDAPQuery query = LDAPUtils.createQueryForUserSearch(ldapProvider, realm);
-                LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
-                List<Condition> orSubconditions = new ArrayList<>();
-                for (LDAPDn userDn : dns) {
-                    String firstRdnAttrValue = userDn.getFirstRdn().getAttrValue(ldapConfig.getRdnLdapAttribute());
-                    if (firstRdnAttrValue != null) {
-                        Condition condition = conditionsBuilder.equal(ldapConfig.getRdnLdapAttribute(), firstRdnAttrValue, EscapeStrategy.DEFAULT);
-                        orSubconditions.add(condition);
-                    }
-                }
-                Condition orCondition = conditionsBuilder.orCondition(orSubconditions.toArray(new Condition[] {}));
-                query.addWhereCondition(orCondition);
-                List<LDAPObject> ldapUsers = query.getResultList();
-                for (LDAPObject ldapUser : ldapUsers) {
-                    if (dns.contains(ldapUser.getDn())) {
-                        String username = LDAPUtils.getUsername(ldapUser, ldapConfig);
-                        usernames.add(username);
-                    }
-                }
-            }
-
-            // We have dns of users, who are members of our group. Load them now
-            return ldapProvider.loadUsersByUsernames(usernames, realm);
+            return ldapProvider.loadUsersByDNs(realm, userDns, firstResult, maxResults)
+                    .collect(Collectors.toList());
         }
-
     },
-
 
     /**
      * Used if LDAP role has it's members declared in form of pure user uids. For example ( "memberUid: john" )
@@ -150,40 +105,11 @@ public enum MembershipType {
                 return Collections.emptyList();
             }
 
-            List<String> uids = new ArrayList<>(memberUids);
-            int max = Math.min(memberUids.size(), firstResult + maxResults);
-            uids = uids.subList(firstResult, max);
-
             String membershipUserAttrName = groupMapper.getConfig().getMembershipUserLdapAttribute(ldapConfig);
 
-            List<String> usernames;
-            if (membershipUserAttrName.equals(ldapConfig.getUsernameLdapAttribute())) {
-                usernames = uids; // Optimized version. No need to
-            } else {
-                usernames = new LinkedList<>();
-
-                LDAPQuery query = LDAPUtils.createQueryForUserSearch(ldapProvider, realm);
-                LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
-
-                Condition[] orSubconditions = new Condition[uids.size()];
-                int index = 0;
-                for (String memberUid : uids) {
-                    Condition condition = conditionsBuilder.equal(membershipUserAttrName, memberUid, EscapeStrategy.DEFAULT);
-                    orSubconditions[index] = condition;
-                    index++;
-                }
-                Condition orCondition = conditionsBuilder.orCondition(orSubconditions);
-                query.addWhereCondition(orCondition);
-                List<LDAPObject> ldapUsers = query.getResultList();
-                for (LDAPObject ldapUser : ldapUsers) {
-                    String username = LDAPUtils.getUsername(ldapUser, ldapConfig);
-                    usernames.add(username);
-                }
-            }
-
-            return groupMapper.getLdapProvider().loadUsersByUsernames(usernames, realm);
+            return ldapProvider.loadUsersByUniqueAttribute(realm, membershipUserAttrName, memberUids, firstResult, maxResults)
+                    .collect(Collectors.toList());
         }
-
     };
 
     public abstract Set<LDAPDn> getLDAPSubgroups(CommonLDAPGroupMapper groupMapper, LDAPObject ldapGroup);

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -79,6 +79,8 @@ public class LDAPConstants {
     public static final String READ_TIMEOUT = "readTimeout";
     // Could be discovered by rootDse supportedControl: 1.2.840.113556.1.4.319
     public static final String PAGINATION = "pagination";
+    public static final String MAX_CONDITIONS = "maxConditions";
+    public static final int DEFAULT_MAX_CONDITIONS = 64;
 
     public static final String EDIT_MODE = "editMode";
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
@@ -721,10 +721,17 @@ public class LDAPGroupMapperTest extends AbstractLDAPTest {
             if (ldapConfig.isActiveDirectory() || LDAPConstants.VENDOR_RHDS.equals(ldapConfig.getVendor())) {
                 return;
             }
+            ctx.getLdapModel().getConfig().putSingle(LDAPConstants.MAX_CONDITIONS, "15");
 
             // create big grups that use ranged search
             String descriptionAttrName = getGroupDescriptionLDAPAttrName(ctx.getLdapProvider());
             LDAPObject bigGroup = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "biggroup", descriptionAttrName, "biggroup - description");
+            // create a non-exitent group member first to check pagination is OK
+            LDAPDn nonExistentDn = LDAPDn.fromString(ctx.getLdapProvider().getLdapIdentityStore().getConfig().getUsersDn());
+            nonExistentDn.addFirst(ctx.getLdapProvider().getLdapIdentityStore().getConfig().getRdnLdapAttribute(), "nonexistent");
+            LDAPObject nonExistentLdapUser = new LDAPObject();
+            nonExistentLdapUser.setDn(nonExistentDn);
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", bigGroup, nonExistentLdapUser);
             // create the users to use range search and add them to the group
             for (int i = 0; i < membersToTest; i++) {
                 String username = String.format("user%02d", i);
@@ -759,6 +766,18 @@ public class LDAPGroupMapperTest extends AbstractLDAPTest {
             for (int i = 0; i < membersToTest; i++) {
                 Assert.assertTrue("Group contains user " + i, usernames.contains(String.format("user%02d", i)));
             }
+            // check group members are paginated OK using page size 10
+            usernames.clear();
+            for (int i = 0; i < membersToTest; i += 10) {
+                groupMembers = session.users().getGroupMembersStream(appRealm, kcBigGroup, i, 10)
+                    .collect(Collectors.toList());
+                usernames.addAll(groupMembers.stream().map(u -> u.getUsername()).collect(Collectors.toSet()));
+                Assert.assertEquals("Incorrect number of users after pagination " + i, membersToTest < i + 10? membersToTest : i + 10, usernames.size());
+            }
+            for (int i = 0; i < membersToTest; i++) {
+                Assert.assertTrue("Group contains user after pagination " + i, usernames.contains(String.format("user%02d", i)));
+            }
+            ctx.getLdapModel().getConfig().remove(LDAPConstants.MAX_CONDITIONS);
         });
     }
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/23966

The LDAP membership search is modified to search using chunks for DN and UID members. The default chunk is 64 and I have not added the option in the UI to be configurable. If you think a different default is better or that the configuration in UI is necessary just let me know.

The test for `LDAPGroupMapperTest.test08_ldapOnlyGroupMappingsRanged` was modified to check the pagination is OK and all the users are returned after pagination.
