### PR TITLE
Fix for Admin UI group view shows attributes of previously viewed group

### DIFF
--- a/js/apps/admin-ui/src/groups/components/GroupTree.tsx
+++ b/js/apps/admin-ui/src/groups/components/GroupTree.tsx
@@ -316,6 +316,7 @@ export const GroupTree = ({
 
             if (canViewDetails || subGroups.at(-1)?.access?.view) {
               navigate(toGroups({ realm, id: item.id }));
+              refresh();
             } else {
               addAlert(t("noViewRights"), AlertVariant.warning);
               navigate(toGroups({ realm }));


### PR DESCRIPTION
Fixes #24187 

Added `refresh()` function inside `onSelect` function in TreeView.
