### PR TITLE
The fix solves the problem when integrating on the infinispan jdbc pe…

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/CacheDecorators.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/CacheDecorators.java
@@ -25,6 +25,9 @@ import org.infinispan.context.Flag;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public class CacheDecorators {
+    // Patch:Begin
+    private static final boolean IGNORE_SKIP_CACHE_STORE = Boolean.getBoolean("keycloak.infinispan.ignoreSkipCacheStore");
+    // Patch:End
 
     /**
      * Adds {@link Flag#CACHE_MODE_LOCAL} flag to the cache.
@@ -50,6 +53,11 @@ public class CacheDecorators {
      * @return Cache with the flags applied.
      */
     public static <K, V> AdvancedCache<K, V> skipCacheStore(Cache<K, V> cache) {
+        // Patch:Begin
+        if (IGNORE_SKIP_CACHE_STORE) {
+            return cache.getAdvancedCache();
+        }
+        // Patch:End
         return cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_STORE);
     }
 


### PR DESCRIPTION
Closes #24766
Closes #10803

The fix solves the problem when integrating on the infinispan jdbc persistent store.

Symptoms of the problem: when saving sessions to ISPN, they should be saved transparently to jdbc persistent storage, but this was not happening. Finally, I found out that the cache is accessed through a decorator that prevents saving to jdbc storage with the flag: Flag.SKIP_CACHE_STORE. The fix consists in the fact that the administrator has the option to run KC even with a parameter that ignores the given flag.

private static final boolean IGNORE_SKIP_CACHE_STORE = Boolean.getBoolean("keycloak.infinispan.ignoreSkipCacheStore");