### PR TITLE
Add support for passing acr_values in auth requests in keycloak.js (#9383)

### DIFF
--- a/docs/documentation/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -370,6 +370,7 @@ to {project_name} will contain the scope parameter `scope=openid address phone`.
 * enableLogging - Enables logging messages from Keycloak to the console (default is `false`).
 * pkceMethod - The method for Proof Key Code Exchange (https://datatracker.ietf.org/doc/html/rfc7636[PKCE]) to use. Configuring this value enables the PKCE mechanism. Available options:
     - "S256" - The SHA256 based PKCE method
+* acrValues - Generates the `acr_values` parameter which refers to authentication context class reference and allows clients to declare the required assurance level requirements, e.g. authentication mechanisms. See https://openid.net/specs/openid-connect-modrna-authentication-1_0.html#acr_values[Section 4. acr_values request values and level of assurance in OpenID Connect MODRNA Authentication Profile 1.0].
 * messageReceiveTimeout - Set a timeout in milliseconds for waiting for message responses from the Keycloak server. This is used, for example, when waiting for a message during 3rd party cookies check. The default value is 10000.
 * locale - When onLoad is 'login-required', sets the 'ui_locales' query param in compliance with https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[section 3.1.2.1 of the OIDC 1.0 specification].
 
@@ -393,6 +394,7 @@ provider instead. More info in the link:{adminguide_link}#_client_suggested_idp[
 * acr - Contains the information about `acr` claim, which will be sent inside `claims` parameter to the {project_name} server. Typical usage
 is for step-up authentication. Example of use `{ values: ["silver", "gold"], essential: true }`. See OpenID Connect specification
 and link:{adminguide_link}#_step-up-flow[Step-up authentication documentation] for more details.
+* acrValues - Generates the `acr_values` parameter which refers to authentication context class reference and allows clients to declare the required assurance level requirements, e.g. authentication mechanisms. See https://openid.net/specs/openid-connect-modrna-authentication-1_0.html#acr_values[Section 4. acr_values request values and level of assurance in OpenID Connect MODRNA Authentication Profile 1.0].
 * action - If value is `register` then user is redirected to registration page, if the value is `UPDATE_PASSWORD` then the user will be redirected to the reset password page (if not authenticated will send user to login page first and redirect after authenticated), otherwise to login page.
 * locale - Sets the 'ui_locales' query param in compliance with https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[section 3.1.2.1 of the OIDC 1.0 specification].
 * cordovaOptions - Specifies the arguments that are passed to the Cordova in-app-browser (if applicable). Options `hidden` and `location` are not affected by these arguments. All available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/. Example of use: `{ zoom: "no", hardwareback: "yes" }`;

--- a/js/libs/keycloak-js/dist/keycloak.d.ts
+++ b/js/libs/keycloak-js/dist/keycloak.d.ts
@@ -176,6 +176,13 @@ export interface KeycloakInitOptions {
 	pkceMethod?: KeycloakPkceMethod;
 
 	/**
+	 * Configures the 'acr_values' query param in compliance with section 3.1.2.1
+	 * of the OIDC 1.0 specification.
+	 * Used to tell Keycloak what level of authentication the user needs.
+	 */
+	acrValues?: string;
+
+	/**
 	 * Enables logging messages from Keycloak to the console.
 	 * @default false
 	 */
@@ -249,6 +256,13 @@ export interface KeycloakLoginOptions {
 	 * Sets the `acr` claim of the ID token sent inside the `claims` parameter. See section 5.5.1 of the OIDC 1.0 specification.
 	 */
 	acr?: Acr;
+
+	/**
+	 * Configures the 'acr_values' query param in compliance with section 3.1.2.1
+	 * of the OIDC 1.0 specification.
+	 * Used to tell Keycloak what level of authentication the user needs.
+	 */
+	acrValues?: string;
 
 	/**
 	 * Used to tell Keycloak which IDP the user wants to authenticate with.

--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -150,6 +150,10 @@ function Keycloak (config) {
                 kc.scope = initOptions.scope;
             }
 
+            if (typeof initOptions.acrValues === 'string') {
+                kc.acrValues = initOptions.acrValues;
+            }
+
             if (typeof initOptions.messageReceiveTimeout === 'number' && initOptions.messageReceiveTimeout > 0) {
                 kc.messageReceiveTimeout = initOptions.messageReceiveTimeout;
             } else {
@@ -459,6 +463,10 @@ function Keycloak (config) {
         if (options && options.acr) {
             var claimsParameter = buildClaimsParameter(options.acr);
             url += '&claims=' + encodeURIComponent(claimsParameter);
+        }
+
+        if ((options && options.acrValues) || kc.acrValues) {
+            url += '&acr_values=' + encodeURIComponent(options.acrValues || kc.acrValues);
         }
 
         if (kc.pkceMethod) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JSObjectBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JSObjectBuilder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.keycloak.util.JsonSerialization;
 
@@ -100,6 +101,12 @@ public class JSObjectBuilder {
 
     private JSObjectBuilder pkceMethod(String method) {
         arguments.put("pkceMethod", method);
+        return this;
+    }
+
+    public JSObjectBuilder acrValues(String value) {
+        Objects.requireNonNull(value, "value");
+        arguments.put("acrValues", value);
         return this;
     }
 


### PR DESCRIPTION
Added acrValues to login and init options.

Fixes #9383

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
