### PR TITLE
Show client id and secret field only on social identity providers

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
@@ -46,6 +46,13 @@ export default function AddIdentityProvider() {
     }
   }, [serverInfo, providerId]);
 
+  const isSocialIdentityProvider = useMemo(() => {
+    const namespace = "org.keycloak.broker.social.SocialIdentityProvider";
+    const componentTypes = serverInfo.componentTypes?.[namespace] ?? [];
+
+    return componentTypes.some(({ id }) => id === providerId);
+  }, [serverInfo, providerId]);
+
   const {
     handleSubmit,
     formState: { isDirty },
@@ -90,7 +97,10 @@ export default function AddIdentityProvider() {
           onSubmit={handleSubmit(onSubmit)}
         >
           <FormProvider {...form}>
-            <GeneralSettings id={providerId} />
+            <GeneralSettings
+              id={providerId}
+              showClientIdSecret={isSocialIdentityProvider}
+            />
             {providerInfo && (
               <DynamicComponents
                 stringify

--- a/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -181,6 +181,13 @@ export default function DetailSettings() {
     }
   }, [serverInfo, providerId]);
 
+  const isSocialIdentityProvider = useMemo(() => {
+    const namespace = "org.keycloak.broker.social.SocialIdentityProvider";
+    const componentTypes = serverInfo.componentTypes?.[namespace] ?? [];
+
+    return componentTypes.some(({ id }) => id === providerId);
+  }, [serverInfo, providerId]);
+
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
   const { realm } = useRealm();
@@ -338,7 +345,11 @@ export default function DetailSettings() {
         >
           {!isOIDC && !isSAML && (
             <>
-              <GeneralSettings create={false} id={alias} />
+              <GeneralSettings
+                create={false}
+                id={alias}
+                showClientIdSecret={isSocialIdentityProvider}
+              />
               {providerInfo && (
                 <DynamicComponents
                   stringify

--- a/js/apps/admin-ui/src/identity-providers/add/GeneralSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/GeneralSettings.tsx
@@ -4,16 +4,20 @@ import { DisplayOrder } from "../component/DisplayOrder";
 
 type GeneralSettingsProps = {
   id: string;
+  showClientIdSecret?: boolean;
   create?: boolean;
 };
 
 export const GeneralSettings = ({
   create = true,
+  showClientIdSecret = true,
   id,
-}: GeneralSettingsProps) => (
-  <>
-    <RedirectUrl id={id} />
-    <ClientIdSecret create={create} />
-    <DisplayOrder />
-  </>
-);
+}: GeneralSettingsProps) => {
+  return (
+    <>
+      <RedirectUrl id={id} />
+      {showClientIdSecret && <ClientIdSecret create={create} />}
+      <DisplayOrder />
+    </>
+  );
+};


### PR DESCRIPTION
This implementation will check to see if the provider implements org.keycloak.broker.social.SocialIdentityProvider and only show the client id and secret field if it does. Also added the Display name field so that an alternative friendly name can be set.

Closes: #21891
