### PR TITLE
Add openapi annotations to the UserProfileResource

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
@@ -24,17 +24,22 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import jakarta.ws.rs.Path;
-import org.eclipse.microprofile.openapi.annotations.Operation;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
 import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -75,7 +80,8 @@ public class UserProfileResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(description = "Get the configuration for the user profile")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UPConfig.class)))
     public String getConfiguration() {
         auth.requireAnyAdminRole();
         return session.getProvider(UserProfileProvider.class).getConfiguration();
@@ -85,7 +91,7 @@ public class UserProfileResource {
     @Path("/metadata")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(description = "Get the UserProfileMetadata from the configuration")
     public UserProfileMetadata getMetadata() {
         auth.requireAnyAdminRole();
         UserProfile profile = session.getProvider(UserProfileProvider.class).create(UserProfileContext.USER_API, Collections.emptyMap());
@@ -94,9 +100,12 @@ public class UserProfileResource {
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
-    public Response update(String text) {
+    @Operation(description = "Set the configuration for the user profile")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UPConfig.class)))
+    public Response update(
+            @RequestBody(content = @Content(schema = @Schema(implementation = UPConfig.class))) String text) {
         auth.realm().requireManageRealm();
         UserProfileProvider t = session.getProvider(UserProfileProvider.class);
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/9318

Annotating `UserProfileResource` to not show String but the real `UPConfig` class that is really used internally. There is a sample of the produced api in the issue.
