### PR TITLE
Add a property to the User Profile Email Validator for max length of the local part

### DIFF
--- a/docs/documentation/server_admin/topics/users/user-profile.adoc
+++ b/docs/documentation/server_admin/topics/users/user-profile.adoc
@@ -202,7 +202,8 @@ image:images/user-profile-validation.png[]
 
 |email
 |Check if the value has a valid e-mail format.
-| None
+|
+*max-local-length*: an integer to define the maximum length for the local part of the email. It defaults to 64 per specification.
 
 |local-date
 |Check if the value has a valid format based on the realm and/or user locale.
@@ -293,7 +294,9 @@ The JSON schema is defined as follows:
         "edit": [ "admin", "user" ]
       },
       "validations": {
-        "email": {},
+        "email": {
+          "max-local-length": 64
+        },
         "length": {
           "max": 255
         }

--- a/server-spi-private/src/main/java/org/keycloak/utils/EmailValidationUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/EmailValidationUtil.java
@@ -7,7 +7,15 @@ import org.keycloak.Config;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
+/**
+ * Email Validator Utility to check email inputs based on
+ * <a href="https://github.com/hibernate/hibernate-validator/blob/8.0.1.Final/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/AbstractEmailValidator.java">
+ * hibernate-validator implementation</a>.
+ */
 public class EmailValidationUtil {
+
+    public static final int MAX_LOCAL_PART_LENGTH = 64;
+
     private static final String LOCAL_PART_ATOM = "[a-z0-9!#$%&'*+/=?^_`{|}~\u0080-\uFFFF-]";
     private static final String LOCAL_PART_INSIDE_QUOTES_ATOM = "(?:[a-z0-9!#$%&'*.(),<>\\[\\]:;  @+/=?^_`{|}~\u0080-\uFFFF-]|\\\\\\\\|\\\\\\\")";
     /**
@@ -32,6 +40,10 @@ public class EmailValidationUtil {
 
 
     public static boolean isValidEmail(String value) {
+        return isValidEmail(value, Config.scope("user-profile-declarative-user-profile").getInt(MAX_EMAIL_LOCAL_PART_LENGTH, MAX_LOCAL_PART_LENGTH));
+    }
+
+    public static boolean isValidEmail(String value, int maxEmailLocalPartLength) {
         if ( value == null || value.length() == 0 ) {
             return false;
         }
@@ -49,16 +61,16 @@ public class EmailValidationUtil {
         String localPart = stringValue.substring( 0, splitPosition );
         String domainPart = stringValue.substring( splitPosition + 1 );
 
-        if ( !isValidEmailLocalPart( localPart ) ) {
+        if ( !isValidEmailLocalPart( localPart, maxEmailLocalPartLength ) ) {
             return false;
         }
 
         return isValidEmailDomainAddress( domainPart );
     }
 
-    private static boolean isValidEmailLocalPart(String localPart) {
+    private static boolean isValidEmailLocalPart(String localPart, int maxEmailLocalPartLength) {
 
-        if ( localPart.length() > Config.scope("user-profile-declarative-user-profile").getInt(MAX_EMAIL_LOCAL_PART_LENGTH,64) ) {
+        if ( localPart.length() >  maxEmailLocalPartLength) {
             return false;
         }
         Matcher matcher = LOCAL_PART_PATTERN.matcher( localPart );

--- a/server-spi-private/src/test/java/org/keycloak/validate/BuiltinValidatorsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/validate/BuiltinValidatorsTest.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.validate.validators.DoubleValidator;
+import org.keycloak.validate.validators.EmailValidator;
 import org.keycloak.validate.validators.IntegerValidator;
 import org.keycloak.validate.validators.LengthValidator;
 import org.keycloak.validate.validators.OptionsValidator;
@@ -138,6 +139,18 @@ public class BuiltinValidatorsTest {
 
         Assert.assertFalse(validator.validate(" ", "email").isValid());
         Assert.assertFalse(validator.validate("adminATexample.org", "email").isValid());
+
+        Assert.assertTrue(validator.validate("username@keycloak.org", "email", (ValidatorConfig) null).isValid());
+        Assert.assertTrue(validator.validate("abcd012345678901234567890123456789012345678901234567890123456789@keycloak.org", "email").isValid());
+        Assert.assertFalse(validator.validate("abcde012345678901234567890123456789012345678901234567890123456789@keycloak.org", "email").isValid());
+        Assert.assertTrue(validator.validate("abcdef0123456789@keycloak.org", "email",
+                new ValidatorConfig(ImmutableMap.of(EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, "16"))).isValid());
+        Assert.assertFalse(validator.validate("abcdefg0123456789@keycloak.org", "email",
+                new ValidatorConfig(ImmutableMap.of(EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, 16))).isValid());
+        Assert.assertTrue(validator.validate("ab012345678901234567890123456789@keycloak.org", "email",
+                new ValidatorConfig(ImmutableMap.of(EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, "32"))).isValid());
+        Assert.assertFalse(validator.validate("abc012345678901234567890123456789@keycloak.org", "email",
+                new ValidatorConfig(ImmutableMap.of(EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, 32))).isValid());
     }
 
     @Test

--- a/server-spi-private/src/test/java/org/keycloak/validate/ValidatorTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/validate/ValidatorTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.validate.validators.EmailValidator;
 import org.keycloak.validate.validators.LengthValidator;
 import org.keycloak.validate.validators.NotBlankValidator;
 import org.keycloak.validate.validators.ValidatorConfigValidator;
@@ -193,6 +194,24 @@ public class ValidatorTest {
         Assert.assertFalse(validator.validateConfig(session, configFromMap(Collections.singletonMap("min", null))).isValid());
         Assert.assertFalse(validator.validateConfig(session, configFromMap(Collections.singletonMap("min", "a"))).isValid());
         Assert.assertTrue(validator.validateConfig(session, configFromMap(Collections.singletonMap("min", "123"))).isValid());
+    }
+
+    @Test
+    public void validateEmailValidator() {
+        SimpleValidator validator = Validators.emailValidator();
+
+        Assert.assertTrue(validator.validateConfig(session, null).isValid());
+        Assert.assertTrue(validator.validateConfig(session, ValidatorConfig.EMPTY).isValid());
+        Assert.assertTrue(validator.validateConfig(session, configFromMap(Collections.singletonMap(
+                EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, 128))).isValid());
+        Assert.assertTrue(validator.validateConfig(session, configFromMap(Collections.singletonMap(
+                EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, "128"))).isValid());
+        Assert.assertFalse(validator.validateConfig(session, configFromMap(Collections.singletonMap(
+                EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, null))).isValid());
+        Assert.assertFalse(validator.validateConfig(session, configFromMap(Collections.singletonMap(
+                EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, "a"))).isValid());
+        Assert.assertFalse(validator.validateConfig(session, configFromMap(Collections.singletonMap(
+                EmailValidator.MAX_LOCAL_PART_LENGTH_PROPERTY, ""))).isValid());
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/24273

The property `max-local-length` is added to the email validator to allow modification of the maximum length of the local part of the email. If the property is not defined in the validator the default value is the same max used now (64 by default). Unit tests added and one integration test modified to test the new property.