### PR TITLE
Enabling dynamic options to provider property configuration

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
@@ -30,6 +30,8 @@ public class ComponentTypeRepresentation {
     protected List<ConfigPropertyRepresentation> properties;
 
     protected Map<String, Object> metadata = new HashMap<>();
+    private String displayType;
+    private String displayCategory;
 
 
     public String getId() {
@@ -68,5 +70,21 @@ public class ComponentTypeRepresentation {
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    public void setDisplayType(String displayType) {
+        this.displayType = displayType;
+    }
+
+    public String getDisplayType() {
+        return displayType;
+    }
+
+    public void setDisplayCategory(String displayCategory) {
+        this.displayCategory = displayCategory;
+    }
+
+    public String getDisplayCategory() {
+        return displayCategory;
     }
 }

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ComponentsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ComponentsResource.java
@@ -17,6 +17,7 @@
 package org.keycloak.admin.client.resource;
 
 import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.ComponentTypeRepresentation;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -64,5 +65,8 @@ public interface ComponentsResource {
     @DELETE
     ComponentResource removeComponent(@PathParam("id") String id);
 
-
+    @GET
+    @Path("/{spiId}/{factoryId}/metadata")
+    @Produces(MediaType.APPLICATION_JSON)
+    ComponentTypeRepresentation getMetadata(@PathParam("spiId") String spiId, @PathParam("factoryId") String factoryId);
 }

--- a/js/libs/keycloak-admin-client/src/defs/componentTypeRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/componentTypeRepresentation.ts
@@ -5,6 +5,8 @@ import type { ConfigPropertyRepresentation } from "./configPropertyRepresentatio
  */
 export default interface ComponentTypeRepresentation {
   id: string;
+  displayType: string;
+  displayCategory: string;
   helpText: string;
   properties: ConfigPropertyRepresentation[];
   metadata: { [index: string]: any };

--- a/js/libs/keycloak-admin-client/src/resources/components.ts
+++ b/js/libs/keycloak-admin-client/src/resources/components.ts
@@ -60,6 +60,12 @@ export class Components extends Resource<{ realm?: string }> {
     queryParamKeys: ["type"],
   });
 
+  public metadata = this.makeRequest<{ spiId: string; factoryId: string }>({
+    method: "GET",
+    path: "/{spiId}/{factoryId}/metadata",
+    urlParamKeys: ["spiId", "factoryId"],
+  });
+
   constructor(client: KeycloakAdminClient) {
     super(client, {
       path: "/admin/realms/{realm}/components",

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -882,21 +882,41 @@ public class ModelToRepresentation {
     }
 
     public static List<ConfigPropertyRepresentation> toRepresentation(List<ProviderConfigProperty> configProperties) {
+        return toRepresentation(null, configProperties);
+    }
+
+    public static List<ConfigPropertyRepresentation> toRepresentation(KeycloakSession session, List<ProviderConfigProperty> configProperties) {
         List<ConfigPropertyRepresentation> propertiesRep = new LinkedList<>();
         for (ProviderConfigProperty prop : configProperties) {
-            ConfigPropertyRepresentation propRep = toRepresentation(prop);
+            ConfigPropertyRepresentation propRep = toRepresentation(session, prop);
             propertiesRep.add(propRep);
         }
         return propertiesRep;
     }
 
     public static ConfigPropertyRepresentation toRepresentation(ProviderConfigProperty prop) {
+        return toRepresentation(null, prop);
+    }
+
+    public static ConfigPropertyRepresentation toRepresentation(KeycloakSession session, ProviderConfigProperty prop) {
         ConfigPropertyRepresentation propRep = new ConfigPropertyRepresentation();
         propRep.setName(prop.getName());
         propRep.setLabel(prop.getLabel());
-        propRep.setType(prop.getType());
+
+        if (session == null) {
+            propRep.setType(prop.getType());
+        } else {
+            propRep.setType(prop.getType(session));
+        }
+
         propRep.setDefaultValue(prop.getDefaultValue());
-        propRep.setOptions(prop.getOptions());
+
+        if (session == null) {
+            propRep.setOptions(prop.getOptions());
+        } else {
+            propRep.setOptions(prop.getOptions(session));
+        }
+
         propRep.setHelpText(prop.getHelpText());
         propRep.setSecret(prop.isSecret());
         propRep.setRequired(prop.isRequired());

--- a/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapper.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapper.java
@@ -31,8 +31,6 @@ import org.keycloak.provider.ProviderFactory;
  */
 public interface ProtocolMapper extends Provider, ProviderFactory<ProtocolMapper>,ConfiguredProvider {
     String getProtocol();
-    String getDisplayCategory();
-    String getDisplayType();
 
     /**
      * Priority of this protocolMapper implementation. Lower goes first.

--- a/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapperSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapperSpi.java
@@ -26,6 +26,8 @@ import org.keycloak.provider.Spi;
  */
 public class ProtocolMapperSpi implements Spi {
 
+    public static final String ID = "protocol-mapper";
+
     @Override
     public boolean isInternal() {
         return true;
@@ -33,7 +35,7 @@ public class ProtocolMapperSpi implements Spi {
 
     @Override
     public String getName() {
-        return "protocol-mapper";
+        return ID;
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/provider/ConfiguredProvider.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ConfiguredProvider.java
@@ -24,6 +24,26 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public interface ConfiguredProvider {
+
+    /**
+     * Returns the category for this provider so that it can be used to group it together
+     * with others when rendering forms.
+     *
+     * @return the provider category. Can be {@code null}.
+     */
+    default String getDisplayCategory() {
+        return null;
+    }
+
+    /**
+     * Returns the user-friendly name for this provider when rendering forms.
+     *
+     * @return the name for this provider. Defaults to the full-qualified class name.
+     */
+    default String getDisplayType() {
+        return getClass().getName();
+    }
+
     String getHelpText();
 
     List<ProviderConfigProperty> getConfigProperties();

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.services.resources.admin;
 
+import static java.util.Optional.ofNullable;
+import static org.keycloak.models.utils.ModelToRepresentation.toRepresentation;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -30,14 +33,17 @@ import org.keycloak.component.SubComponentFactory;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.models.utils.StripSecretsUtils;
+import org.keycloak.provider.ConfiguredProvider;
 import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.ComponentTypeRepresentation;
 import org.keycloak.representations.idm.ConfigPropertyRepresentation;
@@ -61,9 +67,11 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -122,7 +130,7 @@ public class ComponentResource {
                 .filter(component -> Objects.isNull(name) || Objects.equals(component.getName(), name))
                 .map(component -> {
                     try {
-                        return ModelToRepresentation.toRepresentation(session, component, false);
+                        return toRepresentation(session, component, false);
                     } catch (Exception e) {
                         logger.error("Failed to get component list for component model" + component.getName() + "of realm " + realm.getName());
                         return ModelToRepresentation.toRepresentationWithoutConfig(component);
@@ -166,7 +174,7 @@ public class ComponentResource {
         if (model == null) {
             throw new NotFoundException("Could not find component");
         }
-        ComponentRepresentation rep = ModelToRepresentation.toRepresentation(session, model, false);
+        ComponentRepresentation rep = toRepresentation(session, model, false);
         return rep;
     }
 
@@ -288,5 +296,51 @@ public class ComponentResource {
         rep.setProperties(propReps);
         rep.setMetadata(metadata);
         return rep;
+    }
+
+    @GET
+    @Path("/{spiId}/{factoryId}/metadata")
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
+    @Operation(summary = "Returns the metadata for a provider for a given SPI and factory id.")
+    public ComponentTypeRepresentation getMetadata(@PathParam("spiId") String spiId, @PathParam("factoryId") String factoryId) {
+        auth.realm().requireViewRealm();
+
+        if (spiId == null) {
+            throw new BadRequestException("Spi id not provided");
+        }
+
+        if (factoryId == null) {
+            throw new BadRequestException("Factory id not provided");
+        }
+
+        KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
+        Spi spi = sessionFactory.getSpis().stream().filter(s -> spiId.equals(s.getName())).findAny()
+                .orElseThrow(() -> new NotFoundException(new NotFoundException("No SPI found with the given id [" + spiId + "]")));
+        ProviderFactory<? extends Provider> factory = Optional.ofNullable(sessionFactory.getProviderFactory(spi.getProviderClass(), factoryId))
+                .orElseThrow(() -> new NotFoundException("No factory found for SPI [" + spiId + "] and factory id [" + factoryId + "]"));
+
+        if (factory instanceof ConfiguredProvider) {
+            return toComponentTypeRepresentation((ConfiguredProvider) factory);
+        }
+
+        return null;
+    }
+
+    private ComponentTypeRepresentation toComponentTypeRepresentation(ConfiguredProvider factoryConfig) {
+        ComponentTypeRepresentation metadata = new ComponentTypeRepresentation();
+
+        metadata.setId(((ProviderFactory<?>) factoryConfig).getId());
+        metadata.setDisplayType(factoryConfig.getDisplayType());
+        metadata.setDisplayCategory(factoryConfig.getDisplayCategory());
+        metadata.setHelpText(factoryConfig.getHelpText());
+
+        List<ProviderConfigProperty> configProperties = ofNullable(factoryConfig.getConfigProperties())
+                .orElse(Collections.emptyList());
+
+        metadata.setProperties(toRepresentation(session, configProperties));
+
+        return metadata;
     }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/oidc/mapper/TestOIDCProtocolMapper.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/oidc/mapper/TestOIDCProtocolMapper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.oidc.mapper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class TestOIDCProtocolMapper implements ProtocolMapper {
+
+    public static final String ID = "test-oidc-mapper";
+
+    @Override
+    public String getProtocol() {
+        return OIDCLoginProtocol.LOGIN_PROTOCOL;
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "My Display Category";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "My Display Type";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "My Help Text";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        List<ProviderConfigProperty> properties = new ArrayList<>();
+        ProviderConfigProperty dynamicProperty = new ProviderConfigProperty();
+
+        dynamicProperty.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
+        dynamicProperty.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
+        dynamicProperty.setHelpText(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_HELP_TEXT);
+        dynamicProperty.setTypeResolver(session -> {
+            RealmModel realm = session.getContext().getRealm();
+
+            if (realm.getAttribute("is-dynamic-options", Boolean.FALSE)) {
+                return ProviderConfigProperty.LIST_TYPE;
+            }
+
+            return ProviderConfigProperty.STRING_TYPE;
+        });
+
+        dynamicProperty.setOptionsResolver(session -> {
+            RealmModel realm = session.getContext().getRealm();
+
+            if (realm.getAttribute("is-dynamic-options", Boolean.FALSE)) {
+                return Collections.singleton("dynamic-value");
+            }
+
+            return Collections.emptySet();
+        });
+
+        properties.add(dynamicProperty);
+
+        return properties;
+    }
+
+    @Override
+    public ProtocolMapper create(KeycloakSession session) {
+        return new TestOIDCProtocolMapper();
+    }
+
+    @Override
+    public void init(Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -1,0 +1,18 @@
+#
+# Copyright 2023 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.testsuite.oidc.mapper.TestOIDCProtocolMapper


### PR DESCRIPTION
* Allow to dynamically resolve the property type using a `KeycloakSession`. This one is only needed because we still need to support both static and declarative user profiles. We can definetly remove it once the static user profile is removed.
* Allow to dynamically resolve the options for a `LIST`property type using a `KeycloakSession`

These changes are related to #24250 so that we can dynamically render mapper properties based on the attributes defined in the user profile configuration for a given realm.

For that, a new endpoint was added at `/admin/realms/{realm}/components/{spiId}/{factoryId}/metadata` that returns the metadata for a provider based on its id. The protocol mapper UI is also updated to use this new endpoint when rendering both creation and update pages.

In the future, we want to actually improve the Provider Configuration API to support use cases to dynamically build options based on a realm. See https://github.com/keycloak/keycloak/issues/24287.

The approach taken in this PR makes it possible to move forward with #24250 without additional (and unrelated) changes to other places where the Provider Configuration API is used.

