### PR TITLE
Enable `github` reporter for Playwright

### DIFF
--- a/js/apps/account-ui/playwright.config.ts
+++ b/js/apps/account-ui/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: "html",
+  reporter: process.env.CI ? "github" : "list",
   use: {
     baseURL: process.env.CI
       ? "http://localhost:8080/realms/master/account/"


### PR DESCRIPTION
Enables the [GitHub Actions reporter](https://playwright.dev/docs/test-reporters#github-actions-annotations) for the Playwright tests of the Account Console. When tests fail they will be properly annotated by this reporter.