### PR TITLE
Data too long for column 'DETAILS_JSON'

### DIFF
--- a/docs/documentation/server_admin/topics/events/login.adoc
+++ b/docs/documentation/server_admin/topics/events/login.adoc
@@ -171,17 +171,3 @@ You can exclude events by using the `--spi-events-listener-email-exclude-events`
 kc.[sh|bat] --spi-events-listener-email-exclude-events=UPDATE_TOTP,REMOVE_TOTP
 ----
 
-You can set a maximum length of each Event detail in the database by using the `--spi-events-store-jpa-max-detail-length` argument. This setting is useful if a detail (for example, redirect_uri) is long. For example:
-
-[source,bash]
-----
-kc.[sh|bat] --spi-events-store-jpa-max-detail-length=1000
-----
-
-Also you can set a maximum length of all Event's details by using the `--spi-events-store-jpa-max-field-length` argument. This setting is useful if you want to adhere to the underlying storage limitation. For example:
-
-[source,bash]
-----
-kc.[sh|bat] --spi-events-store-jpa-max-field-length=2500
-----
-

--- a/docs/documentation/upgrading/topics/keycloak/changes-23_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-23_0_0.adoc
@@ -141,3 +141,7 @@ Relying on RESTEasy Classic is not longer an option because it is not available 
 = Partial export requires manage-realm permission
 
 The endpoint `POST {keycloak server}/realms/{realm}/partial-export` and the corresponding action in the admin console now require `manage-realm` permission for execution instead of `view-realm`. This endpoint exports the realm configuration into a JSON file and the new permission is more appropriate. The parameters `exportGroupsAndRoles` and `exportClients`, which include the realm groups/roles and clients in the export respectively, continue managing the same permissions (`query-groups` and `view-clients`).
+
+= Removal of the options to trim the event's details length
+
+Since this release, Keycloak supports long value for `EventEntity` details column. Therefore, it no longer supports options for trimming event detail length `--spi-events-store-jpa-max-detail-length` and `--spi-events-store-jpa-max-field-length`.

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/AdminEventEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/AdminEventEntity.java
@@ -60,7 +60,7 @@ public class AdminEventEntity {
     @Column(name="RESOURCE_PATH")
     private String resourcePath;
 
-    @Column(name="REPRESENTATION", length = 25500)
+    @Column(name="REPRESENTATION")
     private String representation;
 
     @Column(name="ERROR")

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/EventEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/EventEntity.java
@@ -57,8 +57,12 @@ public class EventEntity {
     @Column(name="ERROR")
     private String error;
 
+    // This is the legacy field which is kept here to be able to read old events without the need to migrate them
     @Column(name="DETAILS_JSON", length = 2550)
     private String detailsJson;
+
+    @Column(name="DETAILS_JSON_LONG_VALUE")
+    private String detailsJsonLongValue;
 
     public String getId() {
         return id;
@@ -133,11 +137,11 @@ public class EventEntity {
     }
 
     public String getDetailsJson() {
-        return detailsJson;
+        return detailsJsonLongValue != null ? detailsJsonLongValue : detailsJson;
     }
 
     public void setDetailsJson(String detailsJson) {
-        this.detailsJson = detailsJson;
+        this.detailsJsonLongValue = detailsJson;
     }
 
 }

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProviderFactory.java
@@ -32,21 +32,15 @@ import org.keycloak.storage.datastore.PeriodicEventInvalidation;
 public class JpaEventStoreProviderFactory implements EventStoreProviderFactory, InvalidationHandler {
 
     public static final String ID = "jpa";
-    private int maxDetailLength;
-    private int maxFieldLength;
 
     @Override
     public EventStoreProvider create(KeycloakSession session) {
         JpaConnectionProvider connection = session.getProvider(JpaConnectionProvider.class);
-        return new JpaEventStoreProvider(session, connection.getEntityManager(), maxDetailLength, maxFieldLength);
+        return new JpaEventStoreProvider(session, connection.getEntityManager());
     }
 
     @Override
     public void init(Config.Scope config) {
-        maxDetailLength = config.getInt("max-detail-length", -1);
-        maxFieldLength = config.getInt("max-field-length", -1);
-        if (maxDetailLength != -1 && maxDetailLength < 3) throw new IllegalArgumentException("max-detail-length cannot be less that 3.");
-        if (maxFieldLength != -1 && maxFieldLength < 3) throw new IllegalArgumentException("max-field-length cannot be less that 3.");
     }
 
     @Override

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-23.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-23.0.0.xml
@@ -30,4 +30,11 @@
         <dropColumn tableName="COMPONENT_CONFIG" columnName="VALUE"/>
         <renameColumn tableName="COMPONENT_CONFIG" oldColumnName="VALUE_NEW" newColumnName="VALUE" columnDataType="NCLOB"/>
     </changeSet>
+
+    <changeSet author="keycloak" id="23.0.0-17258">
+        <addColumn tableName="EVENT_ENTITY">
+            <column name="DETAILS_JSON_LONG_VALUE" type="NCLOB" />
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/AdminEventTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/AdminEventTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.admin.event;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -45,6 +46,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertNull;
 import static org.keycloak.testsuite.auth.page.AuthRealm.MASTER;
 
@@ -165,6 +167,23 @@ public class AdminEventTest extends AbstractEventTest {
         assertThat(realm.getAdminEvents(null, null, null, null, null, null, null, null, null, null).size(), is(equalTo(100)));
         assertThat(realm.getAdminEvents(null, null, null, null, null, null, null, null, 0, 105).size(), is(equalTo(105)));
         assertThat(realm.getAdminEvents(null, null, null, null, null, null, null, null, 0, 1000).size(), is(greaterThanOrEqualTo(110)));
+    }
+
+    @Test
+    public void adminEventRepresentationLenght() {
+        RealmResource realm = adminClient.realms().realm("test");
+        AdminEventRepresentation event = new AdminEventRepresentation();
+        event.setOperationType(OperationType.CREATE.toString());
+        event.setAuthDetails(new AuthDetailsRepresentation());
+        event.setRealmId(realm.toRepresentation().getId());
+        String longValue = RandomStringUtils.random(30000, true, true);
+        event.setRepresentation(longValue);
+
+        testingClient.testing("test").onAdminEvent(event, true);
+        List<AdminEventRepresentation> adminEvents = realm.getAdminEvents(null, null, null, null, null, null, null, null, null, null);
+
+        assertThat(adminEvents, hasSize(1));
+        assertThat(adminEvents.get(0).getRepresentation(), equalTo(longValue));
     }
 
     @Test


### PR DESCRIPTION
Closes #17258

The PR adds new LOB column into a database `EVENT_ENTITY.DETAILS_JSON_LONG_VALUE`

As requested there is no migration of existing events. the value is stored either in original or new column based on the length of the value.

Options for trimming the events were removed from codebase as well as from documentation. A note in migration guide was added.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
