### PR TITLE
Use default namespace for i18next

### DIFF
--- a/js/apps/account-ui/src/i18n.ts
+++ b/js/apps/account-ui/src/i18n.ts
@@ -6,7 +6,6 @@ import { environment } from "./environment";
 import { joinPath } from "./utils/joinPath";
 
 const DEFAULT_LOCALE = "en";
-const DEFAULT_NAMESPACE = "translation";
 
 // This type is aliased to any, so that we can find all the places where we use it.
 // In the future all casts to this type should be removed from the code, so
@@ -14,9 +13,7 @@ const DEFAULT_NAMESPACE = "translation";
 export type TFuncKey = any;
 
 export const i18n = createInstance({
-  defaultNS: DEFAULT_NAMESPACE,
   fallbackLng: DEFAULT_LOCALE,
-  ns: [DEFAULT_NAMESPACE],
   interpolation: {
     escapeValue: false,
   },

--- a/js/apps/admin-ui/src/i18n/i18n.ts
+++ b/js/apps/admin-ui/src/i18n/i18n.ts
@@ -6,15 +6,11 @@ import { joinPath } from "../utils/joinPath";
 import { OverridesBackend } from "./OverridesBackend";
 
 export const DEFAULT_LOCALE = "en";
-export const DEFAULT_NAMESPACE = "translation";
 export const KEY_SEPARATOR = ".";
 
 export const i18n = createInstance({
   fallbackLng: DEFAULT_LOCALE,
-  defaultNS: DEFAULT_NAMESPACE,
-  fallbackNS: DEFAULT_NAMESPACE,
   keySeparator: KEY_SEPARATOR,
-  ns: DEFAULT_NAMESPACE,
   interpolation: {
     escapeValue: false,
   },


### PR DESCRIPTION
Removes the explicit setting of the namespace and fallback, as the default namespace is the same.