### PR TITLE
Force reporters of bugs to agree to test against the latest Keycloak

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,11 +5,14 @@ body:
   - type: checkboxes
     attributes:
       label: Before reporting an issue
-      description: Please search to see if the issue is already reported, and try to reproduce the issue on the latest release.
+      description: |
+        Please search to see if the issue is already reported, and try to reproduce the issue on the latest release.
+
+        Any reported issues must be reproducible in the [latest](https://github.com/keycloak/keycloak/releases/latest) or [nightly](https://github.com/keycloak/keycloak/releases/nightly) version of Keycloak.
+
+        **⚠️ Failing to follow these guidelines may result in your issue being closed without action. ⚠️**
       options:
-        - label: I have searched existing issues
-          required: true
-        - label: I have reproduced the issue with the [latest nightly release](https://github.com/keycloak/keycloak/releases/tag/nightly)
+        - label: I have read and understood the above terms for submitting issues, and I understand that my issue may be closed without action if I do not follow them.
           required: true
   - type: dropdown
     id: area


### PR DESCRIPTION
Users that are reporting bugs are often [opening bugs](https://github.com/keycloak/keycloak/issues/24345) that are already fixed in older versions of Keycloak. The existing check-mark requiring users to test against the latest nightly version seems to be too confusing, so this PR:

- Forces users to confirm they tested against the latest nightly, or stable version.
- Forces users to confirm that if they did not do so, their issue will be closed.

Naturally, if a user is off by a small patch version we can simply ask them to re-test in the latest version. But we should be clear that we do not offer support on old majors.