### PR TITLE
Add userProfileEnabled attribute to realm response if admin can view users

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -117,7 +118,7 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.ExportImportManager;
 import org.keycloak.storage.LegacyStoreSyncEvent;
-import org.keycloak.utils.GroupUtils;
+import org.keycloak.userprofile.DeclarativeUserProfileProvider;
 import org.keycloak.utils.ProfileHelper;
 import org.keycloak.utils.ReservedCharValidator;
 
@@ -384,6 +385,12 @@ public class RealmAdminResource {
 
             if (auth.users().canView()) {
                 rep.setRegistrationEmailAsUsername(realm.isRegistrationEmailAsUsername());
+                if (realm.getAttribute(DeclarativeUserProfileProvider.REALM_USER_PROFILE_ENABLED, Boolean.FALSE)) {
+                    // add the user profile attribute if enabled
+                    Map<String, String> attrs = Optional.ofNullable(rep.getAttributes()).orElse(new HashMap<>());
+                    attrs.put(DeclarativeUserProfileProvider.REALM_USER_PROFILE_ENABLED, Boolean.TRUE.toString());
+                    rep.setAttributes(attrs);
+                }
             }
 
             if (auth.realm().canViewIdentityProviders()) {


### PR DESCRIPTION
closes https://github.com/keycloak/keycloak/issues/19093

Adding the attribute `userProfileEnabled` to the realm response when the admin has `view-realm` permission and it is enabled. It is needed to correctly show the user profile pages in the UI. I'm doing the same that @pedroigor did in https://github.com/keycloak/keycloak/issues/17591. I tested that the UI displays the correct User Profile edit/create page when the `userProfileEnabled` is received as `true`.