### PR TITLE
fix: persist refreshed token set

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -241,6 +241,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
                 }
                 model.setToken(response);
                 tokenResponse = newResponse;
+                session.users().updateFederatedIdentity(authorizedClient.getRealm(), tokenSubject, model);
             } else if (exp != null) {
                 tokenResponse.setExpiresIn(exp - Time.currentTime());
             }


### PR DESCRIPTION
Closes #19599

When using `token-exchange` feature, token is correctly refreshed with the refresh token, but the new token set is only persisted in the session. If the cache expires or Keycloak is restarted, subsequent token-exchange request will result in failure because it will use the old refresh token from the database that was already consumed.