### PR TITLE
Add Galleon layer metadata to the SAML Galleon feature-pack

### DIFF
--- a/distribution/galleon-feature-packs/pom.xml
+++ b/distribution/galleon-feature-packs/pom.xml
@@ -32,6 +32,7 @@
 
     <modules>
         <module>saml-adapter-galleon-pack</module>
+        <module>saml-adapter-galleon-pack-layer-metadata-tests</module>
     </modules>
 </project>
 

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
@@ -1,0 +1,120 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+~ Copyright 2023 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>galleon-feature-packs-parent</artifactId>
+        <version>999.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.keycloak</groupId>
+    <artifactId>keycloak-saml-adapter-galleon-pack-layers-metadata-tests</artifactId>
+
+    <name>Keycloak Galleon Feature Pack: SAML Adapter Layer Metadata Tests</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
+        <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-galleon-pack</artifactId>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <scope>test</scope>
+            <version>${version.org.jboss.shrinkwrap}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+            <version>${version.org.jboss.shrinkwrap}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.glow</groupId>
+            <artifactId>wildfly-glow-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.glow</groupId>
+            <artifactId>wildfly-glow-maven-resolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <version>${version.jakarta.ejb.jakarta-ejb-api}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-provisioning-xml</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.testOutputDirectory}/glow/${project.version}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/test/resources/glow/latest</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <excludes>
+                    <exclude>glow/latest/*</exclude>
+                </excludes>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
+</project>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/java/org/keycloak/test/saml/adapter/galleon/pack/layer/metadata/EjbLiteAnnotationUsage.java
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/java/org/keycloak/test/saml/adapter/galleon/pack/layer/metadata/EjbLiteAnnotationUsage.java
@@ -1,0 +1,7 @@
+package org.keycloak.test.saml.adapter.galleon.pack.layer.metadata;
+
+import jakarta.ejb.Stateless;
+
+@Stateless
+public class EjbLiteAnnotationUsage {
+}

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/java/org/keycloak/test/saml/adapter/galleon/pack/layer/metadata/KeycloakSamlAdapterLayerMetaDataTestCase.java
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/java/org/keycloak/test/saml/adapter/galleon/pack/layer/metadata/KeycloakSamlAdapterLayerMetaDataTestCase.java
@@ -1,0 +1,93 @@
+package org.keycloak.test.saml.adapter.galleon.pack.layer.metadata;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.glow.Arguments;
+import org.wildfly.glow.GlowMessageWriter;
+import org.wildfly.glow.GlowSession;
+import org.wildfly.glow.ScanResults;
+import org.wildfly.glow.maven.MavenResolver;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class KeycloakSamlAdapterLayerMetaDataTestCase {
+
+    private static final String URL_PROPERTY = "wildfly-glow-galleon-feature-packs-url";
+    private static final Path ARCHIVES_PATH = Paths.get("target/glow-archives");
+    private static final String WEB_XML = "<web-app>" +
+                "  <login-config>" +
+                "    <auth-method>KEYCLOAK-SAML</auth-method>" +
+                "  </login-config>" +
+                "</web-app>";
+    @BeforeClass
+    public static void prepareArchivesDirectory() throws Exception {
+        Path glowXmlPath = Paths.get("target/test-classes/glow");
+        System.out.println(glowXmlPath.toUri());
+        System.setProperty(URL_PROPERTY, glowXmlPath.toUri().toString());
+        if (Files.exists(ARCHIVES_PATH)) {
+            Files.walkFileTree(ARCHIVES_PATH, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        Files.createDirectories(ARCHIVES_PATH);
+    }
+
+
+    private static Path createWebArchive(String archiveName, String xmlName, String xmlContents, Class<?>... classes) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class);
+        Asset asset = new StringAsset(xmlContents);
+        war.addAsWebInfResource(asset, xmlName);
+        war.addClasses(classes);
+        ZipExporter exporter = war.as(ZipExporter.class);
+        Path path = ARCHIVES_PATH.resolve(archiveName);
+        exporter.exportTo(path.toFile());
+        return path;
+    }
+
+    @Test
+    public void testKeycloakDetected() throws Exception {
+        Path p = createWebArchive("test.war", "web.xml", WEB_XML);
+        Arguments arguments = Arguments.scanBuilder().setBinaries(Collections.singletonList(p)).build();
+        ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+        Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
+        Assert.assertTrue(foundLayers.toString(), foundLayers.contains("keycloak-saml") && 
+                foundLayers.contains("keycloak-client-saml") && 
+                !foundLayers.contains("keycloak-client-saml-ejb"));
+    }
+    
+    @Test
+    public void testKeycloakEJBDetected() throws Exception {
+        Path p = createWebArchive("test-ejb.war", "web.xml", WEB_XML, EjbLiteAnnotationUsage.class);
+        Arguments arguments = Arguments.scanBuilder().setBinaries(Collections.singletonList(p)).build();
+        ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+        Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
+        Assert.assertTrue(foundLayers.toString(), foundLayers.contains("keycloak-saml") && 
+                foundLayers.contains("keycloak-client-saml") && 
+                foundLayers.contains("keycloak-client-saml-ejb"));
+    }
+}

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/resources/glow/latest/provisioning-bare-metal.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/resources/glow/latest/provisioning-bare-metal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly:wildfly-ee-galleon-pack:${upstream.wildfly.version}"/>
+    <feature-pack location="org.keycloak:keycloak-saml-adapter-galleon-pack:${project.version}"/>
+</installation>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/resources/glow/versions.yaml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/src/test/resources/glow/versions.yaml
@@ -1,0 +1,2 @@
+latest: ${project.version}
+versions: ${project.version}

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-saml-ejb/layer-spec.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-saml-ejb/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="keycloak-client-saml-ejb">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="keycloak-client-saml-ejb">
+    <props>
+        <prop name="org.wildfly.rule.inclusion-mode" value="all-dependencies"/>
+    </props>
     <dependencies>
         <layer name="keycloak-client-saml"/>
         <layer name="ejb-lite"/>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-saml/layer-spec.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-saml/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="keycloak-client-saml">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="keycloak-client-saml">
+    <props>
+        <prop name="org.wildfly.rule.inclusion-mode" value="all-dependencies"/>
+    </props>
     <dependencies>
         <layer name="keycloak-saml"/>
     </dependencies>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-saml/layer-spec.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-saml/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="keycloak-saml">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="keycloak-saml">
+    <props>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/login-config/auth-method,KEYCLOAK-SAML"/>
+    </props>
     <dependencies>
         <layer name="ee"/>
         <layer name="elytron"/>

--- a/pom.xml
+++ b/pom.xml
@@ -221,9 +221,12 @@
         <org.apache.kerby.kerby-asn1.version>2.0.3</org.apache.kerby.kerby-asn1.version>
 
         <!-- WildFly Galleon Build related properties -->
-        <org.wildfly.galleon-plugins.version>6.4.2.Final</org.wildfly.galleon-plugins.version>
-        <org.jboss.galleon.version>5.1.0.Final</org.jboss.galleon.version>
+        <org.wildfly.galleon-plugins.version>6.5.2.Final</org.wildfly.galleon-plugins.version>
+        <org.jboss.galleon.version>5.2.2.Final</org.jboss.galleon.version>
         <org.wildfly.maven.plugins.licenses-plugin.version>2.3.1.Final</org.wildfly.maven.plugins.licenses-plugin.version>
+        
+        <!-- Used to test SAML Galleon feature-pack layers discovery -->
+        <version.org.wildfly.glow>1.0.0.Alpha8</version.org.wildfly.glow>
 
         <!-- Galleon -->
         <galleon.fork.embedded>true</galleon.fork.embedded>
@@ -1345,6 +1348,12 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-saml-adapter-galleon-pack</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-saml-tomcat-adapter-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1724,6 +1733,20 @@
                 <groupId>org.jboss.spec.javax.servlet</groupId>
                 <artifactId>jboss-servlet-api_4.0_spec</artifactId>
                 <version>${jboss-servlet-api_4.0_spec}</version>
+            </dependency>
+            
+            <!-- Galleon layer testing with WildFly Glow -->
+            <dependency>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-core</artifactId>
+                <scope>test</scope>
+                <version>${version.org.wildfly.glow}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-maven-resolver</artifactId>
+                <scope>test</scope>
+                <version>${version.org.wildfly.glow}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
NOTE: This should only impact SAML Galleon feature-pack for WildFly, not EAP.

Introduce the usage of metadata in the Galleon layers of SAML feature-pack. Required by [WildFly Glow](https://github.com/wildfly/wildfly-glow) tooling. 

The discovery rules are: 
* If the web.xml file contains the xml element  /web-app/login-config/auth-method with KEYCLOAK-SAML value, the keycloak-saml layer is included.
* If the keycloak-saml layer is included, then the keycloak-client-saml layer is included.
* If the WildFly ejb-lite Galleon layer and  keycloak-client-saml are included, then the keycloak-client-saml-ejb is included.

Some unit tests have been added.

Closes #24912 
