### PR TITLE
Remove leftover namespaces from translation keys

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/i18n_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/i18n_test.spec.ts
@@ -134,7 +134,6 @@ describe("i18n tests", () => {
 
     goToUserFederationPage();
 
-    // check key "user-federation:addProvider_other"
     providersPage.assertCardContainsText("ldap", "Add Ldap providers");
   });
 

--- a/js/apps/admin-ui/src/authentication/EmptyExecutionState.tsx
+++ b/js/apps/admin-ui/src/authentication/EmptyExecutionState.tsx
@@ -69,7 +69,7 @@ export const EmptyExecutionState = ({
               <Title headingLevel="h2" size={TitleSizes.md}>
                 {t(`${section}Title`)}
               </Title>
-              <p>{t(`authentication-help:${section}`)}</p>
+              <p>{t(section)}</p>
             </FlexItem>
             <Flex alignSelf={{ default: "alignSelfCenter" }}>
               <FlexItem>

--- a/js/apps/admin-ui/src/authentication/policies/PolicyRow.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/PolicyRow.tsx
@@ -45,7 +45,7 @@ export const PolicyRow = ({
       labelIcon={
         <HelpItem
           helpText={t(`passwordPoliciesHelp.${id}`)}
-          fieldLabelId={`authentication:${id}`}
+          fieldLabelId={id!}
         />
       }
     >

--- a/js/apps/admin-ui/src/clients/add/SamlConfig.tsx
+++ b/js/apps/admin-ui/src/clients/add/SamlConfig.tsx
@@ -27,12 +27,7 @@ export const Toggle = ({ name, label }: ToggleProps) => {
       hasNoPaddingTop
       label={t(label)}
       fieldId={label}
-      labelIcon={
-        <HelpItem
-          helpText={t(`${label}Help`)}
-          fieldLabelId={`clients:${label}`}
-        />
-      }
+      labelIcon={<HelpItem helpText={t(`${label}Help`)} fieldLabelId={label} />}
     >
       <Controller
         name={name}

--- a/js/apps/admin-ui/src/clients/advanced/TokenLifespan.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/TokenLifespan.tsx
@@ -49,9 +49,7 @@ export const TokenLifespan = ({
     <FormGroup
       label={t(id)}
       fieldId={id}
-      labelIcon={
-        <HelpItem helpText={t(`${id}Help`)} fieldLabelId={`clients:${id}`} />
-      }
+      labelIcon={<HelpItem helpText={t(`${id}Help`)} fieldLabelId={id} />}
     >
       <Controller
         name={name}

--- a/js/apps/admin-ui/src/clients/authorization/PermissionDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/PermissionDetails.tsx
@@ -184,7 +184,7 @@ export default function PermissionDetails() {
         titleKey={
           permissionId
             ? permission.name!
-            : `clients:create${toUpperCase(permissionType)}BasedPermission`
+            : `create${toUpperCase(permissionType)}BasedPermission`
         }
         dropdownItems={
           permissionId

--- a/js/apps/admin-ui/src/clients/authorization/policy/Time.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Time.tsx
@@ -132,12 +132,7 @@ const FromTo = ({ name, ...rest }: NumberControlProps) => {
     <FormGroup
       label={t(name)}
       fieldId={name}
-      labelIcon={
-        <HelpItem
-          helpText={t(`${name}Help`)}
-          fieldLabelId={`clients:${name}`}
-        />
-      }
+      labelIcon={<HelpItem helpText={t(`${name}Help`)} fieldLabelId={name} />}
     >
       <Split hasGutter>
         <SplitItem>

--- a/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
+++ b/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
@@ -91,7 +91,7 @@ export const Credentials = ({ client, save, refresh }: CredentialsProps) => {
       addAlert(t(`${message}Success`), AlertVariant.success);
       return data;
     } catch (error) {
-      addError(`clients:${message}Error`, error);
+      addError(`${message}Error`, error);
     }
   }
 

--- a/js/apps/admin-ui/src/clients/keys/Certificate.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Certificate.tsx
@@ -39,12 +39,7 @@ export const Certificate = ({ keyInfo, plain = false }: CertificateProps) => {
     <FormGroup
       label={t("certificate")}
       fieldId={id}
-      labelIcon={
-        <HelpItem
-          helpText={t("certificateHelp")}
-          fieldLabelId={`clients:${id}`}
-        />
-      }
+      labelIcon={<HelpItem helpText={t("certificateHelp")} fieldLabelId={id} />}
     >
       <CertificateDisplay id={id} keyInfo={keyInfo} />
     </FormGroup>

--- a/js/apps/admin-ui/src/clients/keys/SamlKeys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/SamlKeys.tsx
@@ -95,10 +95,7 @@ const KeySection = ({
         <FormAccess role="manage-clients" isHorizontal>
           <FormGroup
             labelIcon={
-              <HelpItem
-                helpText={t(`${key}Help`)}
-                fieldLabelId={`clients:${key}`}
-              />
+              <HelpItem helpText={t(`${key}Help`)} fieldLabelId={key} />
             }
             label={t(key)}
             fieldId={key}

--- a/js/apps/admin-ui/src/clients/scopes/ClientScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/ClientScopes.tsx
@@ -241,7 +241,7 @@ export const ClientScopes = ({
       <KeycloakDataTable
         key={key}
         loader={loader}
-        ariaLabelKey={`clients:clientScopeList-${key}`}
+        ariaLabelKey={`clientScopeList-${key}`}
         searchPlaceholderKey={
           searchType === "name" ? "searchByName" : undefined
         }

--- a/js/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
+++ b/js/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
@@ -90,7 +90,7 @@ export const GroupPickerDialog = ({
         if (!navigation.map(({ id }) => id).includes(groupId)) {
           group = await adminClient.groups.findOne({ id: groupId });
           if (!group) {
-            throw new Error(t("common:notFound"));
+            throw new Error(t("notFound"));
           }
         }
         if (group?.id) {

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -81,9 +81,7 @@ export const UserSelect = ({
     <FormGroup
       label={t(label!)}
       isRequired={isRequired}
-      labelIcon={
-        <HelpItem helpText={helpText!} fieldLabelId={`clients:${label}`} />
-      }
+      labelIcon={<HelpItem helpText={helpText!} fieldLabelId={label!} />}
       fieldId={name!}
       validated={errors[name!] ? "error" : "default"}
       helperTextInvalid={t("required")}

--- a/js/apps/admin-ui/src/events/EventsSection.tsx
+++ b/js/apps/admin-ui/src/events/EventsSection.tsx
@@ -312,7 +312,7 @@ export default function EventsSection() {
                                 );
                               }}
                             >
-                              {t(`realm-settings:eventTypes.${chip}.name`)}
+                              {t(`eventTypes.${chip}.name`)}
                             </Chip>
                           ))}
                         </ChipGroup>
@@ -320,7 +320,7 @@ export default function EventsSection() {
                     >
                       {events?.enabledEventTypes?.map((option) => (
                         <SelectOption key={option} value={option}>
-                          {t(`realm-settings:eventTypes.${option}.name`)}
+                          {t(`eventTypes.${option}.name`)}
                         </SelectOption>
                       ))}
                     </Select>
@@ -437,7 +437,7 @@ export default function EventsSection() {
                           key={entry}
                           onClick={() => removeFilterValue(key, entry)}
                         >
-                          {t(`realm-settings:eventTypes.${entry}.name`)}
+                          {t(`eventTypes.${entry}.name`)}
                         </Chip>
                       ))
                     )}

--- a/js/apps/admin-ui/src/realm-settings/DefaultGroupsTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/DefaultGroupsTab.tsx
@@ -132,7 +132,7 @@ export const DefaultsGroupsTab = () => {
       {enabled && (
         <Popover
           bodyContent={
-            <Trans i18nKey="realm-settings-help:defaultGroups">
+            <Trans i18nKey="defaultGroups">
               {" "}
               <Link to={toUserFederation({ realm })} />.
             </Trans>

--- a/js/apps/admin-ui/src/realm-settings/GeneralTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/GeneralTab.tsx
@@ -94,7 +94,7 @@ export const RealmSettingsGeneralTab = ({
               required: { value: true, message: t("required") },
               pattern: {
                 value: /^[a-zA-Z0-9-_]+$/,
-                message: t("realm:invalidRealmName"),
+                message: t("invalidRealmName"),
               },
             }}
             defaultValue=""

--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicyCondition.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicyCondition.tsx
@@ -229,9 +229,7 @@ export default function NewClientPolicyCondition() {
                     <SelectOption
                       selected={condition.id === field.value}
                       description={t(
-                        `realm-settings-help:${camelCase(
-                          condition.id.replace(/-/g, " "),
-                        )}`,
+                        camelCase(condition.id.replace(/-/g, " ")),
                       )}
                       key={condition.id}
                       value={condition}

--- a/js/apps/admin-ui/src/realm-settings/event-config/EventConfigForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/event-config/EventConfigForm.tsx
@@ -161,7 +161,7 @@ export const EventConfigForm = ({
         labelIcon={
           <HelpItem
             helpText={t(`${type}-clearEventsHelp`)}
-            fieldLabelId={`realm-settings:clear-${type}-events`}
+            fieldLabelId={`clear-${type}-events`}
           />
         }
       >

--- a/js/apps/admin-ui/src/realm-settings/event-config/EventsTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/event-config/EventsTab.tsx
@@ -78,7 +78,7 @@ export const EventsTab = ({ realm }: EventsTabProps) => {
         }
         addAlert(t(`${type}-events-cleared`), AlertVariant.success);
       } catch (error) {
-        addError(`realm-settings:${type}-events-cleared-error`, error);
+        addError(`${type}-events-cleared-error`, error);
       }
     },
   });

--- a/js/apps/admin-ui/src/realm-settings/security-defences/Time.tsx
+++ b/js/apps/admin-ui/src/realm-settings/security-defences/Time.tsx
@@ -23,12 +23,7 @@ export const Time = ({
       style={style}
       label={t(name)}
       fieldId={name}
-      labelIcon={
-        <HelpItem
-          helpText={t(`${name}Help`)}
-          fieldLabelId={`realm-settings:${name}`}
-        />
-      }
+      labelIcon={<HelpItem helpText={t(`${name}Help`)} fieldLabelId={name} />}
       validated={
         errors[name] ? ValidatedOptions.error : ValidatedOptions.default
       }

--- a/js/apps/admin-ui/src/realm/routes/AddRealm.tsx
+++ b/js/apps/admin-ui/src/realm/routes/AddRealm.tsx
@@ -10,7 +10,7 @@ const NewRealmForm = lazy(() => import("../add/NewRealmForm"));
 export const AddRealmRoute: AppRouteObject = {
   path: "/:realm/add-realm",
   element: <NewRealmForm />,
-  breadcrumb: (t) => t("realm:createRealm"),
+  breadcrumb: (t) => t("createRealm"),
   handle: {
     access: "view-realm",
   },


### PR DESCRIPTION
There were still leftover namespaces in some of the translation keys of the Admin Console. This PR removes the last of them.