### PR TITLE
Enable `html` reporter for Playwright on CI

### DIFF
--- a/js/apps/account-ui/playwright.config.ts
+++ b/js/apps/account-ui/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? "github" : "list",
+  reporter: process.env.CI ? [["github"], ["html"]] : "list",
   use: {
     baseURL: process.env.CI
       ? "http://localhost:8080/realms/master/account/"


### PR DESCRIPTION
Restores the [`html`](https://playwright.dev/docs/test-reporters#html-reporter) reporter for Playwright on CI, so that the report can be downloaded from the GitHub Actions artifacts.