### PR TITLE
Remove hidden inputs from update password form

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -5,17 +5,6 @@
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">
         <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
-            <input type="text" id="username" name="username" value="${username}" autocomplete="username"
-                   readonly="readonly" style="display:none;"/>
-            <div class="${properties.kcInputGroup!}">
-                <input type="password" id="password" name="password" autocomplete="current-password" style="display:none;"/>
-                <button class="pf-c-button pf-m-control" type="button" aria-label="${msg('showPassword')}"
-                        aria-controls="password"  data-password-toggle
-                        data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
-                    <i class="fa fa-eye" aria-hidden="true"></i>
-                </button>
-            </div>
-
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
                     <label for="password-new" class="${properties.kcLabelClass!}">${msg("passwordNew")}</label>


### PR DESCRIPTION
Removes the hidden `username` and `password` fields from the update password form. These hidden inputs are never actually used when submitted, and can therefore be safely removed.

Closes #24487