### PR TITLE
Use session ID rather than broker session ID

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/light/LightweightUserAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/light/LightweightUserAdapter.java
@@ -18,11 +18,10 @@ package org.keycloak.models.light;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
-import org.keycloak.common.util.Base64;
 import org.keycloak.models.ClientScopeModel;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.SubjectCredentialManager;
@@ -35,11 +34,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -80,17 +79,18 @@ public class LightweightUserAdapter extends AbstractInMemoryUserAdapter {
     }
 
     public static String getLightweightUserId(String id) {
-        try {
-            return id == null || id.length() < ID_PREFIX.length()
-              ? null
-              : new String(Base64.decode(id.substring(ID_PREFIX.length())), StandardCharsets.UTF_8);
-        } catch (IOException ex) {
-            return null;
-        }
+        return id == null || id.length() < ID_PREFIX.length()
+          ? null
+          : id.substring(ID_PREFIX.length());
     }
 
     public LightweightUserAdapter(KeycloakSession session, String id) {
-        super(session, null, ID_PREFIX + Base64.encodeBytes(id.getBytes(StandardCharsets.UTF_8)));
+        super(session, null, ID_PREFIX + (id == null ? SecretGenerator.getInstance().randomString(16) : id));
+    }
+
+    public void setOwningUserSessionId(String id) {
+        this.id = ID_PREFIX + (id == null ? UUID.randomUUID().toString() : id);
+        update();
     }
 
     protected LightweightUserAdapter() {

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -37,6 +37,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.models.utils.AuthenticationFlowResolver;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -1079,6 +1080,11 @@ public class AuthenticationProcessor {
 
                 userSession = new UserSessionManager(session).createUserSession(authSession.getParentSession().getId(), realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()
                         , remember, brokerSessionId, brokerUserId, persistenceState);
+
+                if (isLightweightUser(userSession.getUser())) {
+                    LightweightUserAdapter lua = (LightweightUserAdapter) userSession.getUser();
+                    lua.setOwningUserSessionId(userSession.getId());
+                }
             } else if (userSession.getUser() == null || !AuthenticationManager.isSessionValid(realm, userSession)) {
                 userSession.restartSession(realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()
                         , remember, brokerSessionId, brokerUserId);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpCreateUserIfUniqueAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpCreateUserIfUniqueAuthenticator.java
@@ -75,7 +75,7 @@ public class IdpCreateUserIfUniqueAuthenticator extends AbstractIdpAuthenticator
             logger.debugf("Transient brokering requested. Recording user details for account '%s' and from identity provider '%s' .",
                     username, brokerContext.getIdpConfig().getAlias());
 
-            federatedUser = new LightweightUserAdapter(session, brokerContext.getBrokerSessionId());
+            federatedUser = new LightweightUserAdapter(session, context.getAuthenticationSession().getParentSession().getId());
             federatedUser.setUsername(username);
         } else if (duplication == null) {
             logger.debugf("No duplication detected. Creating account for user '%s' and linking with identity provider '%s' .",

--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -576,7 +576,7 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
             }
 
             if (context.getIdpConfig().isTransientUsers()) {
-                user = new LightweightUserAdapter(session, UUID.randomUUID().toString());
+                user = new LightweightUserAdapter(session, context.getAuthenticationSession().getParentSession().getId());
             } else {
                 user = session.users().addUser(realm, username);
             }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -230,8 +230,10 @@ public class UsersResource {
     public UserResource user(final @PathParam("id") String id) {
         UserModel user = null;
         if (LightweightUserAdapter.isLightweightUser(id)) {
-            UserSessionModel userSession = session.sessions().getUserSessionByBrokerSessionId(realm, LightweightUserAdapter.getLightweightUserId(id));
-            user = userSession.getUser();
+            UserSessionModel userSession = session.sessions().getUserSession(realm, LightweightUserAdapter.getLightweightUserId(id));
+            if (userSession != null) {
+                user = userSession.getUser();
+            }
         } else {
             user = session.users().getUserById(realm, id);
         }


### PR DESCRIPTION
This change bases lightweight user ID on user session rather than broker session ID since that may be unset in broker context, especially with some social providers.

Closes: #24455

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
