### PR TITLE
Remove `clientSecret` field from Keycloak JS

### DIFF
--- a/js/libs/keycloak-js/dist/keycloak.d.ts
+++ b/js/libs/keycloak-js/dist/keycloak.d.ts
@@ -463,11 +463,6 @@ declare class Keycloak {
 	/**
 	* @private Undocumented.
 	*/
-	clientSecret?: string;
-
-	/**
-	* @private Undocumented.
-	*/
 	redirectUri?: string;
 
 	/**


### PR DESCRIPTION
Removes the `clientSecret` field from the types of Keycloak JS, as we no longer support authenticating clients using secrets. This functionality has already been removed, but it looks like the types were forgotten.