### PR TITLE
Update webauth4j to 0.21.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <spring-boot26.version>2.6.1</spring-boot26.version>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.21.0.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.21.5.RELEASE</webauthn4j.version>
         <org.apache.kerby.kerby-asn1.version>2.0.3</org.apache.kerby.kerby-asn1.version>
 
         <!-- WildFly Galleon Build related properties -->


### PR DESCRIPTION
Closes #22464

(cherry picked from commit ec2728c55c468ce3ba29af6de4cb6a1fd15e3324)

