### PR TITLE
Modify quarkus-container-image-docker dependency in operator

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -104,6 +104,7 @@
         <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-container-image-docker</artifactId>
+          <optional>true</optional>
         </dependency>
 
         <!-- Keycloak -->


### PR DESCRIPTION
This removes from the runtime assembly archives, while still leaving it available at build time

Closes #24581

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
