### PR TITLE
PermissionTicketService: Check if UMA is enabled on resource, if not reject the request.

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
@@ -87,6 +87,8 @@ public class PermissionTicketService {
         
         if (!resource.getOwner().equals(this.identity.getId()))
             throw new ErrorResponseException("not_authorised", "permissions for [" + representation.getResource() + "] can be only created by the owner", Response.Status.FORBIDDEN);
+        if (!resource.isOwnerManagedAccess())
+            throw new ErrorResponseException("invalid_permission", "permission can only be created for resources with user-managed access enabled", Response.Status.BAD_REQUEST);
         
         UserModel user = null;
         if(representation.getRequester() != null)


### PR DESCRIPTION
Checks if UMA is enabled on the resource to prevent undefined behavior that occurs when it is not enabled and authorization rules are evaluated.

Closes #24422