### PR TITLE
Increased socket timeout for DBAllocator operations to 30s.

### DIFF
--- a/testsuite/db-allocator-plugin/src/main/java/org/keycloak/testsuite/dballocator/client/DBAllocatorServiceClient.java
+++ b/testsuite/db-allocator-plugin/src/main/java/org/keycloak/testsuite/dballocator/client/DBAllocatorServiceClient.java
@@ -25,8 +25,6 @@ import org.jboss.logging.Logger;
 
 public class DBAllocatorServiceClient {
 
-    private static final int TIMEOUT = 10_000;
-
     private final Client restClient;
     private final URI allocatorServletURI;
     private final BackoffRetryPolicy retryPolicy;
@@ -42,9 +40,9 @@ public class DBAllocatorServiceClient {
 
     private final ApacheHttpClient43Engine createEngine() {
         RequestConfig reqConfig = RequestConfig.custom()
-                .setConnectTimeout(TIMEOUT)
-                .setSocketTimeout(TIMEOUT)
-                .setConnectionRequestTimeout(TIMEOUT)
+                .setConnectTimeout(10_000)
+                .setSocketTimeout(30_000) // how long to wait for data 
+                .setConnectionRequestTimeout(10_000)
                 .build();
         CloseableHttpClient httpClient = HttpClientBuilder.create()
                 .setDefaultRequestConfig(reqConfig)


### PR DESCRIPTION
Closes #24636 
Signed-off-by:Tomas Kyjovsky <tkyjovsk@redhat.com>
