### PR TITLE
Added missing dependencies to themes/pom.xml

### DIFF
--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -22,6 +22,19 @@
         <maven.build.cache.exclude.4>${project.basedir}/src/main/resources/theme/keycloak.v2/account/src/web_modules</maven.build.cache.exclude.4>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-ui</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-account-ui</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <resources>
             <resource>

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -26,12 +26,10 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-ui</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-account-ui</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
This PR adds dependency to `keycloak-admin-ui` and `keycloak-account-ui` modules. Both modules contribute files to `themes` and are therefore dependencies for `themes`

Closes #24571, but only with the precondition that #24537 is also merged and it would resolve concurrent node and pnpm install execution https://github.com/keycloak/keycloak/pull/24537#discussion_r1389486794 