### PR TITLE
Implement load shedding

### DIFF
--- a/docs/documentation/release_notes/topics/23_0_0.adoc
+++ b/docs/documentation/release_notes/topics/23_0_0.adoc
@@ -66,3 +66,7 @@ The Map Store has been an experimental feature in previous releases.
 Starting with this release, it is removed and users should continue to use the current JPA store.
 See the migration guide for details.
 
+= Load Shedding support
+
+Keycloak now features `http-max-queued-requests` option to allow proper rejecting of incoming requests under high load.
+For details refer to the https://www.keycloak.org/server/configuration-production[production guide].

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -26,6 +26,17 @@ Apart from <@links.server id="hostname"/>, production environments usually inclu
 
 For details on configuring proxy communication modes in {project_name}, see <@links.server id="reverseproxy"/>. That {section} also recommends which paths should be hidden from public access and which paths should be exposed so that {project_name} can secure your applications.
 
+== Limit the number of queued requests
+
+A production environment should protect itself from an overload situation, so that it responds to as many valid requests as possible, and to continue regular operations once the situation returns to normal again.
+One way of doing this is rejecting additional requests once a certain threshold is reached.
+
+Load shedding should be implemented on all levels, including the load balancers in your environment.
+In addition to that, there is a feature in Keycloak to limit the number of requests that can't be processed right away and need to be queued.
+By default, there is no limit set.
+Set the option `http-max-queued-requests` to limit the number of queued requests to a given threshold matching your environment.
+Any request that exceeds this limit would return with an immediate `503 Server not Available` response.
+
 == Production grade database
 The database used by {project_name} is crucial for the overall performance, availability, reliability and integrity of {project_name}. For details on how to configure a supported database, see <@links.server id="db"/>.
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -110,4 +110,11 @@ public class HttpOptions {
             .description("Enables or disables the HTTP/s and Socket serving.")
             .defaultValue(Boolean.TRUE)
             .build();
+
+    public static final Option<Integer> HTTP_MAX_QUEUED_REQUESTS = new OptionBuilder<>("http-max-queued-requests", Integer.class)
+            .category(OptionCategory.HTTP)
+            .description("Maximum number of queued HTTP requests. " +
+                         "Use this to shed load in an overload situation. Excess requests will return a \"503 Server not Available\" response.")
+            .build();
+
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -101,6 +101,10 @@ final class HttpPropertyMappers {
                         .mapFrom(SecurityOptions.FIPS_MODE.getKey())
                         .transformer(HttpPropertyMappers::resolveKeyStoreType)
                         .paramLabel("type")
+                        .build(),
+                fromOption(HttpOptions.HTTP_MAX_QUEUED_REQUESTS)
+                        .to("quarkus.thread-pool.queue-size")
+                        .paramLabel("requests")
                         .build()
         };
     }

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResource.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.resource.realm;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.services.resource.RealmResourceProvider;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class TestRealmResource implements RealmResourceProvider {
+    protected static final Logger logger = Logger.getLogger(TestRealmResource.class);
+    
+    @Override
+    public Object getResource() {
+        return this;
+    }
+
+    @Path("slow")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response slowResource() throws Exception {
+        final int sleep = 5000;
+        logger.info("Sleeping for " + sleep + " millis");
+        Thread.sleep(sleep);
+        logger.info("Waking up...");
+        return Response.noContent().build();
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResourceFactory.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResourceFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.resource.realm;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class TestRealmResourceFactory implements RealmResourceProviderFactory {
+    public static final String ID = "test-resources";
+
+    @Override
+    public RealmResourceProvider create(KeycloakSession session) {
+        return new TestRealmResource();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResourceTestProvider.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResourceTestProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.resource.realm;
+
+import org.keycloak.it.TestProvider;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class TestRealmResourceTestProvider implements TestProvider {
+
+    @Override
+    public Class[] getClasses() {
+        return new Class[] {TestRealmResource.class, TestRealmResourceFactory.class};
+    }
+
+    @Override
+    public Map<String, String> getManifestResources() {
+        return Collections.singletonMap("org.keycloak.services.resource.RealmResourceProviderFactory", "services/org.keycloak.services.resource.RealmResourceProviderFactory");
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/resources/org/keycloak/it/resource/realm/org.keycloak.services.resource.RealmResourceProviderFactory
+++ b/quarkus/tests/integration/src/test-providers/resources/org/keycloak/it/resource/realm/org.keycloak.services.resource.RealmResourceProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2023 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.it.resource.realm.TestRealmResourceFactory

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.TestProvider;
+import org.keycloak.it.resource.realm.TestRealmResourceTestProvider;
+import org.keycloak.it.utils.KeycloakDistribution;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+@DistributionTest(keepAlive = true)
+@RawDistOnly(reason = "Containers are immutable")
+public class HttpDistTest {
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    public void maxQueuedRequestsTest(KeycloakDistribution dist) {
+        dist.setQuarkusProperty("quarkus.thread-pool.max-threads", "1");
+        dist.run("start-dev", "--http-max-queued-requests=1");
+
+        // run requests async
+        List<CompletableFuture<Integer>> statusCodesFuture = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            statusCodesFuture.add(CompletableFuture.supplyAsync(() ->
+                    when().get("/realms/master/test-resources/slow").getStatusCode()));
+        }
+        List<Integer> statusCodes = statusCodesFuture.stream().map(CompletableFuture::join).toList();
+
+        assertThat("Some of the requests should be properly rejected", statusCodes, hasItem(503));
+        assertThat("None of the requests should throw an unhandled exception", statusCodes, not(hasItem(500)));
+    }
+}

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
@@ -121,6 +121,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
@@ -116,6 +116,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
@@ -121,6 +121,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
@@ -116,6 +116,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
@@ -122,6 +122,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
@@ -117,6 +117,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
@@ -122,6 +122,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
@@ -117,6 +117,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.unix.approved.txt
@@ -81,6 +81,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.windows.approved.txt
@@ -74,6 +74,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.unix.approved.txt
@@ -81,6 +81,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.windows.approved.txt
@@ -74,6 +74,9 @@ HTTP/TLS:
 --http-enabled <true|false>
                      Enables the HTTP listener. Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-max-queued-requests <requests>
+                     Maximum number of queued HTTP requests. Use this to shed load in an overload
+                       situation. Excess requests will return a "503 Server not Available" response.
 --http-port <port>   The used HTTP port. Default: 8080.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.


### PR DESCRIPTION
Closes #23340

~~Requires: https://github.com/keycloak/keycloak/pull/24639~~

With the recent fixes in Quarkus, we can rely with load shedding on their implementation with high enough confidence.

This PR also includes a small smoke test to at least check the option is mapped properly. It does not aim to perform full verification of this feature as it's implemented in Quarkus.