### PR TITLE
Removal EPL-licensed org.eclipse.sisu.inject dependency for CNCF compliance

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -30,6 +30,10 @@
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.sisu</groupId>
+                    <artifactId>org.eclipse.sisu.inject</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Before we go ahead with the merge, I want to get the approval from the @keycloak/cloud-native team to ensure that this change won't break anything. I've already tried it out, which you can see here: https://github.com/keycloak-poc/keycloak/pull/1. It seems that all the checks are passing in the pipeline.

After talking with the Quarkus team, they mentioned that this dependency isn't required in the runtime. It's specifically used for the bootstrapping part and the Maven resolver. And that's part of 'lib/deployment' folder of the Keycloak mutable-jar distribution.

If the team realizes that's not possible to remove we can close the proposed change here.

Closes #24685

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
