### PR TITLE
Delete removed `spi-events-store-jpa-max-detail-length` property 

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
@@ -40,8 +40,5 @@ spi-password-policy-password-blacklist-blacklists-path=${kc.home.dir:}/dependenc
 # http client connection reuse settings
 spi-connections-http-client-default-reuse-connections=false
 
-# set max-length of event representation stored so the db can handle it
-spi-events-store-jpa-max-detail-length=2000
-
 # set known protocol ports for basicsamltest
 spi-login-protocol-saml-known-protocols=http=8180,https=8543


### PR DESCRIPTION
`spi-events-store-jpa-max-detail-length` was removed within #24296. This PR removes the property from `keycloak.conf` from testsuite.

Fixes #17258

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
