### PR TITLE
Fix redirect uri for cordova adapter

### DIFF
--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -1391,7 +1391,9 @@ function Keycloak (config) {
                 return formatCordovaOptions(cordovaOptions);
             };
 
-            var cordovaRedirectUri = kc.redirectUri || 'http://localhost';
+            var getCordovaRedirectUri = function() {
+                return kc.redirectUri || 'http://localhost';
+            }
             
             return {
                 login: function(options) {
@@ -1409,7 +1411,7 @@ function Keycloak (config) {
                     };
 
                     ref.addEventListener('loadstart', function(event) {
-                        if (event.url.indexOf(cordovaRedirectUri) == 0) {
+                        if (event.url.indexOf(getCordovaRedirectUri()) == 0) {
                             var callback = parseCallback(event.url);
                             processCallback(callback, promise);
                             closeBrowser();
@@ -1419,7 +1421,7 @@ function Keycloak (config) {
 
                     ref.addEventListener('loaderror', function(event) {
                         if (!completed) {
-                            if (event.url.indexOf(cordovaRedirectUri) == 0) {
+                            if (event.url.indexOf(getCordovaRedirectUri()) == 0) {
                                 var callback = parseCallback(event.url);
                                 processCallback(callback, promise);
                                 closeBrowser();
@@ -1451,13 +1453,13 @@ function Keycloak (config) {
                     var error;
 
                     ref.addEventListener('loadstart', function(event) {
-                        if (event.url.indexOf(cordovaRedirectUri) == 0) {
+                        if (event.url.indexOf(getCordovaRedirectUri()) == 0) {
                             ref.close();
                         }
                     });
 
                     ref.addEventListener('loaderror', function(event) {
-                        if (event.url.indexOf(cordovaRedirectUri) == 0) {
+                        if (event.url.indexOf(getCordovaRedirectUri()) == 0) {
                             ref.close();
                         } else {
                             error = true;
@@ -1483,7 +1485,7 @@ function Keycloak (config) {
                     var cordovaOptions = createCordovaOptions(options);
                     var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
                     ref.addEventListener('loadstart', function(event) {
-                        if (event.url.indexOf(cordovaRedirectUri) == 0) {
+                        if (event.url.indexOf(getCordovaRedirectUri()) == 0) {
                             ref.close();
                             var oauth = parseCallback(event.url);
                             processCallback(oauth, promise);
@@ -1497,7 +1499,7 @@ function Keycloak (config) {
                     if (typeof accountUrl !== 'undefined') {
                         var ref = cordovaOpenWindowWrapper(accountUrl, '_blank', 'location=no');
                         ref.addEventListener('loadstart', function(event) {
-                            if (event.url.indexOf(cordovaRedirectUri) == 0) {
+                            if (event.url.indexOf(getCordovaRedirectUri()) == 0) {
                                 ref.close();
                             }
                         });
@@ -1507,7 +1509,7 @@ function Keycloak (config) {
                 },
 
                 redirectUri: function(options) {
-                    return cordovaRedirectUri;
+                    return getCordovaRedirectUri();
                 }
             }
         }


### PR DESCRIPTION
- For cordova adapter redirect uri is always empty because adapter is loaded before parsing the init options. 
- This patch allows custom redirect uri for cordova adapter. 

Closes #24732