### PR TITLE
Removal of LGPL-2.1 licensed org.jboss.metadata.jboss-metadata-web dependency for CNCF compliance

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -144,6 +144,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-deployment</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.metadata</groupId>
+                    <artifactId>jboss-metadata-web</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Closes #24714

Relates to: https://github.com/keycloak/keycloak/pull/24686

Before we go ahead with the merge, I want to get the approval from the @keycloak/cloud-native to ensure that this change won't break anything. I've already tried it out, which you can see here: https://github.com/keycloak-poc/keycloak/pull/2. It seems that all the checks are passing in the pipeline.

If the team realizes that's not possible to remove we can close the proposed change here.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
