### PR TITLE
SAML ECP does not work on the latest WF/EAP8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ quarkus/data/*.db
 /adapters/saml/jakarta-servlet-filter/src/
 /adapters/oidc/jakarta-servlet-filter/src/
 /adapters/saml/wildfly-elytron-jakarta/src/
+/adapters/saml/core-jakarta/src/
 /adapters/saml/wildfly/wildfly-jakarta-subsystem/src/
 /.metadata/
 

--- a/adapters/saml/core-jakarta/pom.xml
+++ b/adapters/saml/core-jakarta/pom.xml
@@ -1,85 +1,60 @@
-<?xml version="1.0"?>
-<!--
-  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
-  ~ and other contributors as indicated by the @author tags.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
--->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
         <version>999.0.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>keycloak-saml-jakarta-servlet-filter-adapter</artifactId>
-    <name>Keycloak SAML Jakarta Servlet Filter</name>
-    <description/>
+    <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
+    <name>Keycloak SAML Client Adapter Core Jakarta</name>
 
-    <!--
-    NOTE: This maven module is generated using original: servlet-filter
-          @see: ${jakarta-transformer-sources}
-          Reason is the transition to Jakarta APIs.
-    -->
     <properties>
-        <jakarta-transformer-sources>${project.basedir}/../servlet-filter/src</jakarta-transformer-sources>
+        <timestamp>${maven.build.timestamp}</timestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+
+        <jakarta-transformer-sources>${project.basedir}/../core/src</jakarta-transformer-sources>
         <jakarta-transformer-target>${project.basedir}/src</jakarta-transformer-target>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-jakarta-servlet-adapter-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
+            <artifactId>keycloak-saml-core-public</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-saml-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-saml-adapter-api-public</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
+            <artifactId>keycloak-common</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-crypto-default</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -87,13 +62,23 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>transform</id>

--- a/adapters/saml/pom.xml
+++ b/adapters/saml/pom.xml
@@ -33,6 +33,7 @@
     <modules>
         <module>core-public</module>
         <module>core</module>
+        <module>core-jakarta</module>
         <module>jetty</module>
         <module>undertow</module>
         <module>tomcat</module>

--- a/adapters/saml/wildfly-elytron-jakarta/pom.xml
+++ b/adapters/saml/wildfly-elytron-jakarta/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
@@ -158,7 +158,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessor.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessor.java
@@ -64,14 +64,19 @@ public abstract class KeycloakDependencyProcessor implements DeploymentUnitProce
 
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+
+        addCoreModules(moduleSpecification, moduleLoader);
         addCommonModules(moduleSpecification, moduleLoader);
         addPlatformSpecificModules(phaseContext, moduleSpecification, moduleLoader);
+    }
+
+    protected void addCoreModules(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_CORE_ADAPTER, false, false, false, false));
     }
 
     private void addCommonModules(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {
         // ModuleDependency(ModuleLoader moduleLoader, ModuleIdentifier identifier, boolean optional, boolean export, boolean importServices, boolean userSpecified)
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_JBOSS_CORE_ADAPTER, false, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_CORE_ADAPTER, false, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_API_ADAPTER, false, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_COMMON, false, false, false, false));
     }

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessorWildFly.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessorWildFly.java
@@ -33,15 +33,23 @@ import org.jboss.modules.ModuleLoader;
  */
 public class KeycloakDependencyProcessorWildFly extends KeycloakDependencyProcessor {
 
+    private static final ModuleIdentifier KEYCLOAK_CORE_JAKARTA_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-adapter-core-jakarta");
     private static final ModuleIdentifier KEYCLOAK_ELYTRON_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-wildfly-elytron-adapter");
     private static final ModuleIdentifier KEYCLOAK_ELYTRON_JAKARTA_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-wildfly-elytron-jakarta-adapter");
 
     @Override
+    protected void addCoreModules(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {
+        if (isJakarta()) {
+            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_CORE_JAKARTA_ADAPTER, false, false, false, false));
+        } else {
+            super.addCoreModules(moduleSpecification, moduleLoader);
+        }
+    }
+
+    @Override
     protected void addPlatformSpecificModules(DeploymentPhaseContext phaseContext, ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {
         if (isElytronEnabled(phaseContext)) {
-            ClassLoader classLoader = getClass().getClassLoader();
-            String classLoaderName = (classLoader instanceof ModuleClassLoader ? ((ModuleClassLoader)classLoader).getName() : "");
-            if (classLoaderName.contains("jakarta")) {
+            if (isJakarta()) {
                 moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_ELYTRON_JAKARTA_ADAPTER, true, false, false, false));
             } else {
                 moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, KEYCLOAK_ELYTRON_ADAPTER, true, false, false, false));
@@ -49,5 +57,11 @@ public class KeycloakDependencyProcessorWildFly extends KeycloakDependencyProces
         } else {
             throw new RuntimeException("Legacy WildFly security layer is no longer supported by the Keycloak WildFly adapter");
         }
+    }
+
+    private boolean isJakarta() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String classLoaderName = (classLoader instanceof ModuleClassLoader ? ((ModuleClassLoader) classLoader).getName() : "");
+        return classLoaderName.contains("jakarta");
     }
 }

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
@@ -103,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/license/licenses.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/license/licenses.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-adapter-core-jakarta/main/module.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-adapter-core-jakarta/main/module.xml
@@ -19,12 +19,12 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.keycloak.keycloak-saml-adapter-core">
+<module xmlns="urn:jboss:module:1.3" name="org.keycloak.keycloak-saml-adapter-core-jakarta">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <artifact name="${org.keycloak:keycloak-saml-adapter-core}"/>
+        <artifact name="${org.keycloak:keycloak-saml-adapter-core-jakarta}"/>
     </resources>
     <dependencies>
         <module name="javax.api"/>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-undertow-adapter/main/module.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-undertow-adapter/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.keycloak.keycloak-saml-core-public"/>
         <module name="org.keycloak.keycloak-saml-core"/>
         <module name="org.keycloak.keycloak-saml-adapter-api-public"/>
-        <module name="org.keycloak.keycloak-saml-adapter-core"/>
+        <module name="org.keycloak.keycloak-saml-adapter-core-jakarta"/>
         <module name="org.keycloak.keycloak-common"/>
         <module name="org.apache.httpcomponents"/>
     </dependencies>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-wildfly-elytron-jakarta-adapter/main/module.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-wildfly-elytron-jakarta-adapter/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.keycloak.keycloak-saml-core-public"/>
         <module name="org.keycloak.keycloak-saml-core"/>
         <module name="org.keycloak.keycloak-saml-adapter-api-public"/>
-        <module name="org.keycloak.keycloak-saml-adapter-core"/>
+        <module name="org.keycloak.keycloak-saml-adapter-core-jakarta"/>
         <module name="org.keycloak.keycloak-common"/>
         <module name="org.apache.httpcomponents"/>
         <module name="org.infinispan"/>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/build.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/build.xml
@@ -64,8 +64,8 @@
             <maven-resource group="org.keycloak" artifact="keycloak-saml-adapter-api-public"/>
         </module-def>
 
-        <module-def name="org.keycloak.keycloak-saml-adapter-core">
-            <maven-resource group="org.keycloak" artifact="keycloak-saml-adapter-core"/>
+        <module-def name="org.keycloak.keycloak-saml-adapter-core-jakarta">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-adapter-core-jakarta"/>
         </module-def>
 
         <module-def name="org.keycloak.keycloak-jboss-adapter-core">

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/pom.xml
@@ -106,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources/modules/org/keycloak/keycloak-saml-adapter-core-jakarta/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources/modules/org/keycloak/keycloak-saml-adapter-core-jakarta/main/module.xml
@@ -19,7 +19,7 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.keycloak.keycloak-saml-adapter-core">
+<module xmlns="urn:jboss:module:1.3" name="org.keycloak.keycloak-saml-adapter-core-jakarta">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources/modules/org/keycloak/keycloak-saml-undertow-adapter/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources/modules/org/keycloak/keycloak-saml-undertow-adapter/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.keycloak.keycloak-saml-core-public"/>
         <module name="org.keycloak.keycloak-saml-core"/>
         <module name="org.keycloak.keycloak-saml-adapter-api-public"/>
-        <module name="org.keycloak.keycloak-saml-adapter-core"/>
+        <module name="org.keycloak.keycloak-saml-adapter-core-jakarta"/>
         <module name="org.keycloak.keycloak-common"/>
         <module name="org.apache.httpcomponents"/>
     </dependencies>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-elytron-jakarta-adapter/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-elytron-jakarta-adapter/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.keycloak.keycloak-saml-core-public"/>
         <module name="org.keycloak.keycloak-saml-core"/>
         <module name="org.keycloak.keycloak-saml-adapter-api-public"/>
-        <module name="org.keycloak.keycloak-saml-adapter-core"/>
+        <module name="org.keycloak.keycloak-saml-adapter-core-jakarta"/>
         <module name="org.keycloak.keycloak-common"/>
         <module name="org.apache.httpcomponents"/>
         <module name="org.infinispan"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1592,6 +1592,11 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-saml-adapter-core-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-saml-tomcat-adapter-core</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Fixes #24746

Tested on EAP8, and it works now. Created a new Jakarta module for saml-core as we don't probably want to change the behavior for the 22.0.x micro releases. 