### PR TITLE
Upgrade TypeScript to latest version for Account Console v2

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/src/package.json
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-postcss": "^2.5.0",
     "shx": "^0.3.4",
     "snowpack": "^1.7.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.2.2"
   },
   "packageManager": "pnpm@8.10.0"
 }

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/pnpm-lock.yaml
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/pnpm-lock.yaml
@@ -74,8 +74,8 @@ devDependencies:
     specifier: ^1.7.1
     version: 1.7.1
   typescript:
-    specifier: ^4.7.4
-    version: 4.9.5
+    specifier: ^5.2.2
+    version: 5.2.2
 
 packages:
 
@@ -4588,9 +4588,9 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/tsconfig.json
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/tsconfig.json
@@ -12,7 +12,8 @@
     "strictNullChecks": true,
     "jsx": "react",
     "suppressImplicitAnyIndexErrors": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "ignoreDeprecations": "5.0"
   },
   "include": [
     "./app/**/*.ts?"


### PR DESCRIPTION
Upgrades the TypeScript version for Account Console v2 be the same version as the rest of the project. This change is needed to land https://github.com/keycloak/keycloak/pull/24537