### PR TITLE
fix: all mappings should use getValidProxyModeValue

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
@@ -25,17 +25,17 @@ final class ProxyPropertyMappers {
                 fromOption(ProxyOptions.PROXY_FORWARDED_HOST)
                         .to("quarkus.http.proxy.enable-forwarded-host")
                         .mapFrom("proxy")
-                        .transformer(ProxyPropertyMappers::getResolveEnableForwardedHost)
+                        .transformer(ProxyPropertyMappers::getValidProxyModeValue)
                         .build(),
                 fromOption(ProxyOptions.PROXY_FORWARDED_HEADER_ENABLED)
                         .to("quarkus.http.proxy.allow-forwarded")
                         .mapFrom("proxy")
-                        .transformer(ProxyPropertyMappers::getResolveEnableForwardedHost)
+                        .transformer(ProxyPropertyMappers::getValidProxyModeValue)
                         .build(),
                 fromOption(ProxyOptions.PROXY_X_FORWARDED_HEADER_ENABLED)
                         .to("quarkus.http.proxy.allow-x-forwarded")
                         .mapFrom("proxy")
-                        .transformer(ProxyPropertyMappers::getResolveEnableForwardedHost)
+                        .transformer(ProxyPropertyMappers::getValidProxyModeValue)
                         .build()
         };
     }
@@ -54,10 +54,6 @@ final class ProxyPropertyMappers {
                 addInitializationException(Messages.invalidProxyMode(mode));
                 return of(Boolean.FALSE.toString());
         }
-    }
-
-    private static Optional<String> getResolveEnableForwardedHost(Optional<String> proxy, ConfigSourceInterceptorContext context) {
-        return of(String.valueOf(!ProxyOptions.Mode.none.name().equals(proxy)));
     }
 
 }


### PR DESCRIPTION
Removes the incompatible comparison by reusing the same transformation.  We validated there is no security risk here - even if these properties are true, quarkus.http.proxy.proxy-address-forwarding must be true for them to have an affect.

closes #24630

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
