### PR TITLE
fix: the transformed value should always be returned

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
@@ -4,14 +4,13 @@ import io.smallrye.config.ConfigSourceInterceptorContext;
 
 import java.util.Optional;
 
-import static java.util.Optional.of;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 import static org.keycloak.quarkus.runtime.integration.QuarkusPlatform.addInitializationException;
 
 import org.keycloak.config.ProxyOptions;
 import org.keycloak.quarkus.runtime.Messages;
 
-final class ProxyPropertyMappers {
+public final class ProxyPropertyMappers {
 
     private ProxyPropertyMappers(){}
 
@@ -40,20 +39,23 @@ final class ProxyPropertyMappers {
         };
     }
 
-    private static Optional<String> getValidProxyModeValue(Optional<String> value, ConfigSourceInterceptorContext context) {
-        String mode = value.get();
-
-        switch (mode) {
-            case "none":
-            case "passthrough":
-                return of(Boolean.FALSE.toString());
-            case "edge":
-            case "reencrypt":
-                return of(Boolean.TRUE.toString());
-            default:
-                addInitializationException(Messages.invalidProxyMode(mode));
-                return of(Boolean.FALSE.toString());
+    public static boolean getValidProxyModeValue(String mode) {
+        try {
+            switch (ProxyOptions.Mode.valueOf(mode)) {
+                case none:
+                case passthrough:
+                    return false;
+                default:
+                    return true;
+            }
+        } catch (IllegalArgumentException e) {
+            addInitializationException(Messages.invalidProxyMode(mode));
+            return false;
         }
+    }
+
+    private static Optional<String> getValidProxyModeValue(Optional<String> value, ConfigSourceInterceptorContext context) {
+        return Optional.of(String.valueOf(getValidProxyModeValue(value.get())));
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/hostname/DefaultHostnameProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/hostname/DefaultHostnameProvider.java
@@ -17,20 +17,6 @@
 
 package org.keycloak.quarkus.runtime.hostname;
 
-import static org.keycloak.common.util.UriUtils.checkUrl;
-import static org.keycloak.urls.UrlType.ADMIN;
-import static org.keycloak.urls.UrlType.LOCAL_ADMIN;
-import static org.keycloak.urls.UrlType.BACKEND;
-import static org.keycloak.urls.UrlType.FRONTEND;
-import static org.keycloak.utils.StringUtil.isNotBlank;
-
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.common.enums.SslRequired;
@@ -39,9 +25,26 @@ import org.keycloak.config.HostnameOptions;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.mappers.ProxyPropertyMappers;
 import org.keycloak.urls.HostnameProvider;
 import org.keycloak.urls.HostnameProviderFactory;
 import org.keycloak.urls.UrlType;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import static org.keycloak.common.util.UriUtils.checkUrl;
+import static org.keycloak.urls.UrlType.ADMIN;
+import static org.keycloak.urls.UrlType.BACKEND;
+import static org.keycloak.urls.UrlType.FRONTEND;
+import static org.keycloak.urls.UrlType.LOCAL_ADMIN;
+import static org.keycloak.utils.StringUtil.isNotBlank;
 
 public final class DefaultHostnameProvider implements HostnameProvider, HostnameProviderFactory {
 
@@ -285,7 +288,7 @@ public final class DefaultHostnameProvider implements HostnameProvider, Hostname
         }
 
         defaultPath = config.get("path", frontEndBaseUri == null ? null : frontEndBaseUri.getPath());
-        noProxy = Configuration.getConfigValue("kc.proxy").getValue().equals("false");
+        noProxy = ProxyPropertyMappers.getValidProxyModeValue(Configuration.getConfigValue("kc.proxy").getValue());
         defaultTlsPort = Integer.parseInt(httpPort);
 
         if (defaultTlsPort == DEFAULT_HTTPS_PORT_VALUE) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -247,11 +247,12 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         URL contextRoot = new URL(getBaseUrl(suiteContext) + "/auth/realms/master/");
         HttpURLConnection connection;
         long startTime = System.currentTimeMillis();
+        Exception ex = null;
 
         while (true) {
             if (System.currentTimeMillis() - startTime > getStartTimeout()) {
                 stop();
-                throw new IllegalStateException("Timeout [" + getStartTimeout() + "] while waiting for Quarkus server");
+                throw new IllegalStateException("Timeout [" + getStartTimeout() + "] while waiting for Quarkus server", ex);
             }
 
             try {
@@ -275,6 +276,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
 
                 connection.disconnect();
             } catch (Exception ignore) {
+                ex = ignore;
             }
         }
 
@@ -304,12 +306,15 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
 
     private SSLSocketFactory createInsecureSslSocketFactory() throws IOException {
         TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+            @Override
             public void checkClientTrusted(final X509Certificate[] chain, final String authType) {
             }
 
+            @Override
             public void checkServerTrusted(final X509Certificate[] chain, final String authType) {
             }
 
+            @Override
             public X509Certificate[] getAcceptedIssuers() {
                 return null;
             }


### PR DESCRIPTION
There is an inconsistency in the mapping logic such that when you explicitly set a property, the untransformed value can be returned.  This change is to always return the transformed value.

closes #24757

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
