### PR TITLE
Fix CRL verification failing due to client cert not being in chain

### DIFF
--- a/services/src/main/java/org/keycloak/utils/CRLUtils.java
+++ b/services/src/main/java/org/keycloak/utils/CRLUtils.java
@@ -51,7 +51,7 @@ public final class CRLUtils {
      * @throws GeneralSecurityException if some error in validation happens. Typically certificate not valid, or CRL signature not valid
      */
     public static void check(X509Certificate[] certs, X509CRL crl, KeycloakSession session) throws GeneralSecurityException {
-        if (certs.length < 2) {
+        if (certs.length < 1) {
             throw new GeneralSecurityException("Not possible to verify signature on CRL. X509 certificate doesn't have CA chain available on it");
         }
 
@@ -59,7 +59,7 @@ public final class CRLUtils {
         X509Certificate crlSignatureCertificate = null;
 
         // Try to find the certificate in the CA chain, which was used to sign the CRL
-        for (int i=1 ; i<certs.length ; i++) {
+        for (int i=0 ; i<certs.length ; i++) {
             X509Certificate currentCACert = certs[i];
             if (crlIssuerPrincipal.equals(currentCACert.getSubjectX500Principal())) {
                 crlSignatureCertificate = currentCACert;


### PR DESCRIPTION
Fixes CRL check enforcing a cert chain length of 2. There is a valid use case for a client cert to only be signed by a single root CA. Today this would result in a `certs.length` of 1 and throw a `GeneralSecurityException` if CRL checking is turned on. The enforcement of `certs.length > 2` when CRL checking is turned on appears to be a bug. There is more context on the issue this solves in the linked ticket. 

closes: https://github.com/keycloak/keycloak/issues/19853