### PR TITLE
Use LinkedIn instead of LinkedIn OpenID Connect for better UI experience

### DIFF
--- a/docs/documentation/server_admin/topics/identity-broker/social/linked-in.adoc
+++ b/docs/documentation/server_admin/topics/identity-broker/social/linked-in.adoc
@@ -5,7 +5,7 @@
 
 .Procedure
 . Click *Identity Providers* in the menu.
-. From the `Add provider` list, select `LinkedIn OpenID Connect`.
+. From the `Add provider` list, select `LinkedIn`.
 +
 .Add identity provider
 image:images/linked-in-add-identity-provider.png[Add Identity Provider]

--- a/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/identity_providers_test.spec.ts
@@ -83,8 +83,8 @@ describe("Identity provider test", () => {
         { testName: "Google", displayName: "Google", alias: "google" },
         { testName: "Instagram", displayName: "Instagram", alias: "instagram" },
         {
-          testName: "LinkedIn OpenID Connect",
-          displayName: "LinkedIn OpenID Connect",
+          testName: "LinkedIn",
+          displayName: "LinkedIn",
           alias: "linkedin-openid-connect",
         },
         { testName: "Microsoft", displayName: "Microsoft", alias: "microsoft" },

--- a/services/src/main/java/org/keycloak/social/linkedin/LinkedInOIDCIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/linkedin/LinkedInOIDCIdentityProviderFactory.java
@@ -55,7 +55,7 @@ public class LinkedInOIDCIdentityProviderFactory extends AbstractIdentityProvide
 
     @Override
     public String getName() {
-        return "LinkedIn OpenID Connect";
+        return "LinkedIn";
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -919,7 +919,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
         response = realm.identityProviders().getIdentityProviders("linkedin-openid-connect");
         Assert.assertEquals("Status", 200, response.getStatus());
         body = response.readEntity(Map.class);
-        assertProviderInfo(body, "linkedin-openid-connect", "LinkedIn OpenID Connect");
+        assertProviderInfo(body, "linkedin-openid-connect", "LinkedIn");
 
         response = realm.identityProviders().getIdentityProviders("microsoft");
         Assert.assertEquals("Status", 200, response.getStatus());


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/24659

Just renaming `LinkedIn OpenID Connect` to `LinkedIn` back again (the older provider if activated is called `LinkedIn (deprecated)`). UX issues with the long name. I think I modified all the affected tests. I have not added any note to upgrading guide as it's just the name, I didn't detect any change because of the rename.
