### PR TITLE
Use common TSConfig base for Account Console v2

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/account-page/AccountPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/account-page/AccountPage.tsx
@@ -237,10 +237,10 @@ export class AccountPage extends React.Component<AccountPageProps, AccountPageSt
                                 </TextInput>
                                 {this.isUpdateEmailActionEnabled && (!this.isRegistrationEmailAsUsername || this.isEditUserNameAllowed) &&
                                     <KeycloakContext.Consumer>
-                                        { (keycloak: KeycloakService) => (
+                                        { (keycloak) => (
                                             <Button id="update-email-btn"
                                                     variant="link"
-                                                    onClick={() => this.handleEmailUpdate(keycloak)}
+                                                    onClick={() => this.handleEmailUpdate(keycloak!)}
                                                     icon={<ExternalLinkSquareAltIcon/>}
                                                     iconPosition="right">
                                                 <Msg msgKey="updateEmail" />
@@ -357,11 +357,11 @@ export class AccountPage extends React.Component<AccountPageProps, AccountPageSt
                             </GridItem>
                             <GridItem span={4}>
                                 <KeycloakContext.Consumer>
-                                    {(keycloak: KeycloakService) => (
+                                    {(keycloak) => (
                                         <Button
                                             id="delete-account-btn"
                                             variant="danger"
-                                            onClick={() => this.handleDelete(keycloak)}
+                                            onClick={() => this.handleDelete(keycloak!)}
                                             className="delete-button"
                                         >
                                             <Msg msgKey="doDelete" />

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/device-activity-page/DeviceActivityPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/device-activity-page/DeviceActivityPage.tsx
@@ -239,13 +239,13 @@ export class DeviceActivityPage extends React.Component<DeviceActivityPageProps,
               </SplitItem>
               <SplitItem>
               <KeycloakContext.Consumer>
-                { (keycloak: KeycloakService) => (
+                { (keycloak) => (
                     this.isShowSignOutAll(this.state.devices) &&
                       <ContinueCancelModal buttonTitle='signOutAllDevices'
                                     buttonId='sign-out-all'
                                     modalTitle='signOutAllDevices'
                                     modalMessage='signOutAllDevicesWarning'
-                                    onContinue={() => this.signOutAll(keycloak)}
+                                    onContinue={() => this.signOutAll(keycloak!)}
                       />
                 )}
               </KeycloakContext.Consumer>

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/MyResourcesPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/MyResourcesPage.tsx
@@ -139,8 +139,8 @@ export class MyResourcesPage extends React.Component<MyResourcesPageProps, MyRes
     }
 
     private fetchShareRequests(resource: Resource): void {
-        this.context!.doGet('/resources/' + resource._id + '/permissions/requests')
-            .then((response: HttpResponse<Permission[]>) => {
+        this.context!.doGet<Permission[]>('/resources/' + resource._id + '/permissions/requests')
+            .then((response) => {
                 resource.shareRequests = response.data || [];
                 if (resource.shareRequests.length > 0) {
                     this.forceUpdate();
@@ -203,7 +203,7 @@ export class MyResourcesPage extends React.Component<MyResourcesPageProps, MyRes
         return (
             <ContentPage title="resources" onRefresh={this.fetchInitialResources.bind(this)}>
                 <PageSection variant={PageSectionVariants.light}>
-                    <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+                    <Tabs activeKey={this.state.activeTabKey} onSelect={(event, index) => this.handleTabClick(index as number)}>
                         {this.makeTab(0, 'myResources', this.state.myResources, false)}
                         {this.makeTab(1, 'sharedwithMe', this.state.sharedWithMe, true)}
                     </Tabs>
@@ -258,7 +258,7 @@ export class MyResourcesPage extends React.Component<MyResourcesPageProps, MyRes
         }
     }
 
-    private handleTabClick = (event: React.MouseEvent<HTMLInputElement>, tabIndex: number) => {
+    private handleTabClick = (tabIndex: number) => {
         if (this.state.activeTabKey === tabIndex) return;
 
         this.setState({

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/PermissionRequest.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/PermissionRequest.tsx
@@ -88,7 +88,7 @@ export class PermissionRequest extends React.Component<PermissionRequestProps, P
             ContentAlert.success(Msg.localize('shareSuccess'));
             this.props.onClose();
         } catch (e) {
-            console.error('Could not update permissions', e.error);
+            console.error('Could not update permissions', (e as any).error);
         }
     };
 

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/PermissionSelect.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/PermissionSelect.tsx
@@ -50,17 +50,22 @@ export class PermissionSelect extends React.Component<PermissionSelectProps, Per
     };
   }
 
-  private onSelect = (_event: React.MouseEvent | React.ChangeEvent, selection: ScopeValue): void => {
+  private onSelect = (event: React.MouseEvent | React.ChangeEvent, value: string | SelectOptionObject): void => {
     const { selected } = this.state;
     const { onSelect } = this.props;
-    if (selected.includes(selection)) {
+
+    if (!(value instanceof ScopeValue)) {
+      return;
+    }
+
+    if (selected.includes(value)) {
       this.setState(
-        prevState => ({ selected: prevState.selected.filter(item => item !== selection) }),
+        prevState => ({ selected: prevState.selected.filter(item => item !== value) }),
         () => onSelect(this.state.selected.map(sv => sv.value))
       );
     } else {
       this.setState(
-        prevState => ({ selected: [...prevState.selected, selection] }),
+        prevState => ({ selected: [...prevState.selected, value] }),
         () => onSelect(this.state.selected.map(sv => sv.value))
       );
     }

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/ResourcesTable.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/my-resources-page/ResourcesTable.tsx
@@ -91,8 +91,8 @@ export class ResourcesTable extends AbstractResourcesTable<CollapsibleResourcesT
     }
 
     private fetchPermissions(resource: Resource, row: number): void {
-        this.context!.doGet(`/resources/${encodeURIComponent(resource._id)}/permissions`)
-            .then((response: HttpResponse<Permission[]>) => {
+        this.context!.doGet<Permission[]>(`/resources/${encodeURIComponent(resource._id)}/permissions`)
+            .then((response) => {
                 const newPermissions: Map<number, Permission[]> = new Map(this.state.permissions);
                 newPermissions.set(row, response.data || []);
                 this.setState({ permissions: newPermissions });

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
@@ -128,8 +128,8 @@ class SigningInPage extends React.Component<
     }
 
     private getCredentialContainers(): void {
-        this.context!.doGet("/credentials").then(
-            (response: HttpResponse<CredentialContainer[]>) => {
+        this.context!.doGet<CredentialContainer[]>("/credentials").then(
+            (response) => {
                 const allContainers: CredContainerMap = new Map();
                 const containers: CredentialContainer[] = response.data || [];
                 containers.forEach((container) => {

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/package.json
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/package.json
@@ -6,7 +6,7 @@
     "build": "snowpack --optimize && pnpm run check-types && pnpm run babel && pnpm run move-web_modules && pnpm run copy-pf-resources",
     "babel": "babel --source-maps --extensions \".js,.ts,.tsx\" app/ --out-dir ../resources/",
     "babel:watch": "pnpm run babel -- --watch",
-    "check-types": "tsc --noImplicitAny --strictNullChecks --jsx react -p ./",
+    "check-types": "tsc",
     "check-types:watch": "pnpm run check-types -- -w",
     "move-web_modules": "shx mv web_modules ../../../keycloak/common/resources",
     "copy-pf-resources": "pnpm run move-app-css && pnpm run copy-base-css && pnpm run copy-fonts && pnpm run copy-pficon && pnpm run copy-addons",

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/tsconfig.json
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/tsconfig.json
@@ -1,21 +1,9 @@
 {
+  "extends": "../../../../../../../../js/tsconfig.json",
+  "include": ["app"],
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "noEmit": true,
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": [ "es2015", "dom", "dom.iterable" ],
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "jsx": "react",
     "suppressImplicitAnyIndexErrors": true,
-    "skipLibCheck": true,
-    "ignoreDeprecations": "5.0"
-  },
-  "include": [
-    "./app/**/*.ts?"
-  ]
+    "ignoreDeprecations": "5.0",
+    "jsx": "react"
+  }
 }


### PR DESCRIPTION
Changes the TSConfig for the Account Console v2, so that it extends the 'common' base TSConfig in the `js` directory. Since this change results in a stricter config some code changes were required. Needed to land #24537