### PR TITLE
KeycloakErrorHandler NullPointerException String.toLowerCase() because message is null

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java
@@ -81,7 +81,7 @@ public class PersistenceExceptionConverter implements InvocationHandler {
     public static ModelException convert(Throwable t) {
         final Predicate<Throwable> checkDuplicationMessage = throwable -> {
             final String message = throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage();
-            return message.toLowerCase().contains("duplicate");
+            return message == null ? false : message.toLowerCase().contains("duplicate");
         };
 
         Predicate<Throwable> throwModelDuplicateEx = throwable ->


### PR DESCRIPTION
Closes #22958
Signed-off-by: Douglas Palmer <dpalmer@redhat.com>
