### PR TITLE
fix: removing the hard expectation of setting the restart condition

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.controllers.WatchedSecrets;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
-import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpecBuilder;
 
@@ -37,16 +36,11 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.keycloak.operator.testsuite.utils.CRAssert.assertKeycloakStatusCondition;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
 
 /**
@@ -172,38 +166,10 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         var toBeRestarted = crsToBeRestarted.stream().collect(Collectors.toMap(Function.identity(), k -> getStatefulSet(k).getStatus().getUpdateRevision()));
         var notToBeRestarted = crsNotToBeRestarted.stream().collect(Collectors.toMap(Function.identity(), k -> getStatefulSet(k).getStatus().getUpdateRevision()));
 
-        CompletableFuture<?> restartsCompleted = null;
-        ConcurrentSkipListSet<String> names = new ConcurrentSkipListSet<>(crsToBeRestarted.stream().map(k -> k.getMetadata().getName()).collect(Collectors.toSet()));
-        if (restartExpected) {
-            restartsCompleted = k8sclient.resources(Keycloak.class).informOnCondition(keycloaks -> {
-                for (Keycloak kc : keycloaks) {
-                    if (!names.contains(kc.getMetadata().getName())) {
-                        continue;
-                    }
-                    try {
-                        assertKeycloakStatusCondition(kc.getStatus(), KeycloakStatusCondition.ROLLING_UPDATE, true, null, null);
-                        names.remove(kc.getMetadata().getName());
-                    } catch (Throwable e) {
-                        // not rolling
-                    }
-                }
-                return names.isEmpty();
-            });
-        }
-
         action.run();
-
-        if (restartsCompleted != null) {
-            try {
-                restartsCompleted.get(5, TimeUnit.MINUTES);
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                throw new RuntimeException(names + " did not restart before an exception occurred", e);
-            }
-        }
 
         Set<Keycloak> allCrs = new HashSet<>(crsToBeRestarted);
         allCrs.addAll(crsNotToBeRestarted);
-        assertRollingUpdate(allCrs, false);
 
         if (restartExpected) {
             Awaitility.await()
@@ -228,16 +194,6 @@ public class WatchedSecretsTest extends BaseOperatorTest {
                         });
                     });
         }
-    }
-
-    private void assertRollingUpdate(Set<Keycloak> crs, boolean expectedStatus) {
-        Awaitility.await()
-                .untilAsserted(() -> {
-                    for (var cr : crs) {
-                        Keycloak kc = k8sclient.resource(cr).get();
-                        assertKeycloakStatusCondition(kc, KeycloakStatusCondition.ROLLING_UPDATE, expectedStatus);
-                    }
-                });
     }
 
     private Secret getDbSecret() {


### PR DESCRIPTION
@vmuzikar it would be simplest to remove the check for the rolling condition altogether - what we really care about is that that the statefulset has been rolled.  However unlikely if there is an issue with the operator statefulset informer, or the test client keycloak informer during exactly when the restart is expected, the condition could be missed.

The other contributing factor here is that the probes are delayed, if they were enabled that would potentially lengthen the time between when the roll starts and completes such that the event is unlikely to be missed.

I put this under the old issue, but can of course create a new one if needed.

closes #24797

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
