### PR TITLE
Fix lowerCaseHostname to lower-case scheme and host properly

### DIFF
--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -142,4 +142,36 @@ public class RedirectUtilsTest {
         Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/path<less/", set, false));
         Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/path/index.jsp?param=v1 v2", set, false));
     }
+
+    @Test
+    public void testRelativeRedirectUri() {
+        Set<String> set = Stream.of(
+                "*"
+        ).collect(Collectors.toSet());
+
+        Assert.assertEquals("https://keycloak.org/path", RedirectUtils.verifyRedirectUri(session, "https://keycloak.org", "/path", set, false));
+        Assert.assertEquals("https://keycloak.org/path", RedirectUtils.verifyRedirectUri(session, "https://keycloak.org", "path", set, false));
+    }
+
+    @Test
+    public void testVerifyDifferentCase() {
+        Set<String> set = Stream.of(
+                "no.host.Name.App://TEST",
+                "no.host.Name.App:/Path/*",
+                "HTTPS://KeyCloak.org/*",
+                "HTTP://KeyCloak.org/with%20space/*",
+                "HTTP://KeyCloak.org/áéíóú",
+                "custom:*"
+        ).collect(Collectors.toSet());
+
+        Assert.assertEquals("no.host.Name.App://test", RedirectUtils.verifyRedirectUri(session, null, "no.host.Name.App://test", set, false));
+        Assert.assertEquals("no.host.name.app://Test", RedirectUtils.verifyRedirectUri(session, null, "no.host.name.app://Test", set, false));
+        Assert.assertEquals("no.host.name.app:/Path", RedirectUtils.verifyRedirectUri(session, null, "no.host.name.app:/Path", set, false));
+        Assert.assertEquals("https://KEYCLOAK.ORG/Test", RedirectUtils.verifyRedirectUri(session, null, "https://KEYCLOAK.ORG/Test", set, false));
+        Assert.assertEquals("https://KEYCLOAK.ORG", RedirectUtils.verifyRedirectUri(session, null, "https://KEYCLOAK.ORG", set, false));
+        Assert.assertEquals("CUSTOM:test", RedirectUtils.verifyRedirectUri(session, null, "CUSTOM:test", set, false));
+        Assert.assertEquals("Custom://userInfo@KeyCLOAK.org/Path", RedirectUtils.verifyRedirectUri(session, null, "Custom://userInfo@KeyCLOAK.org/Path", set, false));
+        Assert.assertEquals("Custom://user%20Info@keycloak.ORG", RedirectUtils.verifyRedirectUri(session, null, "Custom://user%20Info@keycloak.ORG", set, false));
+        Assert.assertEquals("http://keycloak.org/áéíóú", RedirectUtils.verifyRedirectUri(session, null, "http://keycloak.org/áéíóú", set, false));
+    }
 }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/24792

The `lowerCaseHostname` previously was assuming that the scheme was `http` (starting at 7 until next char `/`). That created issues with other custom schemes and does not lower the the host in case of `https`. The PR uses `KeycloakUriBuilder` to perform the lower in the passed redirect URI to verify and in the valid redirect URIs defined (scheme and host which are the parts are case-insensitive by spec). This way I think we are covering al the cases that are working now. I have added several unit tests to check this is working. CI passes OK.
