### PR TITLE
Include `react` and `react-dom` as external dependencies

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build Keycloak
         run: |
-          ./mvnw clean install --batch-mode --errors -DskipTests -DskipTestsuite -DskipExamples -DskipAccount2 -DskipCommon -Pdistribution
+          ./mvnw clean install --batch-mode --errors -DskipTests -DskipTestsuite -DskipExamples -DskipAccount2 -Pdistribution
           mv ./quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz ./keycloak-999.0.0-SNAPSHOT.tar.gz
 
       - name: Upload Keycloak dist

--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -90,7 +90,19 @@
                         </replacement>
                         <replacement>
                             <token><![CDATA[<title>Keycloak account console</title>]]></token>
-                            <value xml:space="preserve"><![CDATA[<title>${properties.title!"Keycloak account console"}</title>]]></value>
+                            <value xml:space="preserve">
+<![CDATA[
+    <title>${properties.title!"Keycloak account console"}</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "${resourceCommonUrl}/vendor/react/react.production.min.js",
+          "react/jsx-runtime": "${resourceCommonUrl}/vendor/react/react-jsx-runtime.production.min.js",
+          "react-dom": "${resourceCommonUrl}/vendor/react-dom/react-dom.production.min.js"
+        }
+      }
+    </script>
+]]></value>
                         </replacement>
                         <replacement>
                             <token><![CDATA[</body>]]></token>

--- a/js/apps/account-ui/vite.config.ts
+++ b/js/apps/account-ui/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     target: "esnext",
     modulePreload: false,
     cssMinify: "lightningcss",
+    rollupOptions: {
+      external: ["react", "react/jsx-runtime", "react-dom"],
+    },
   },
   plugins: [react(), checker({ typescript: true })],
 });

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -132,7 +132,19 @@
                         </replacement>
                         <replacement>
                             <token><![CDATA[<title>Keycloak Administration UI</title>]]></token>
-                            <value xml:space="preserve"><![CDATA[<title>${properties.title!"Keycloak Administration UI"}</title>]]></value>
+                            <value xml:space="preserve">
+<![CDATA[
+    <title>${properties.title!"Keycloak Administration UI"}</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "${resourceCommonUrl}/vendor/react/react.production.min.js",
+          "react/jsx-runtime": "${resourceCommonUrl}/vendor/react/react-jsx-runtime.production.min.js",
+          "react-dom": "${resourceCommonUrl}/vendor/react-dom/react-dom.production.min.js"
+        }
+      }
+    </script>
+]]></value>
                         </replacement>
                         <replacement>
                             <token><![CDATA[</body>]]></token>

--- a/js/apps/admin-ui/vite.config.ts
+++ b/js/apps/admin-ui/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     target: "esnext",
     modulePreload: false,
     cssMinify: "lightningcss",
+    rollupOptions: {
+      external: ["react", "react/jsx-runtime", "react-dom"],
+    },
   },
   plugins: [react(), checker({ typescript: true })],
   test: {

--- a/themes/.gitignore
+++ b/themes/.gitignore
@@ -1,1 +1,2 @@
 web_modules
+vendor

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -207,6 +207,16 @@
                                     <workingDirectory>${dir.common}</workingDirectory>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>pnpm-build-common</id>
+                                <goals>
+                                    <goal>pnpm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run build</arguments>
+                                    <workingDirectory>${dir.common}</workingDirectory>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/themes/src/main/resources/theme/keycloak/common/resources/package.json
+++ b/themes/src/main/resources/theme/keycloak/common/resources/package.json
@@ -1,12 +1,23 @@
 {
   "name": "keycloak-npm-dependencies",
-  "version": "1.0.0",
-  "description": "Keycloak NPM Dependencies",
-  "license": "Apache-2.0",
-  "repository": "https://github.com/keycloak/keycloak",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm build:clean && rollup --config",
+    "build:clean": "shx rm -rf vendor"
+  },
   "dependencies": {
     "jquery": "^3.7.1",
-    "patternfly": "^3.59.5"
+    "patternfly": "^3.59.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
-  "packageManager": "pnpm@8.10.0"
+  "packageManager": "pnpm@8.10.0",
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^5.0.5",
+    "@rollup/plugin-terser": "^0.4.4",
+    "rollup": "^4.5.0",
+    "shx": "^0.3.4"
+  }
 }

--- a/themes/src/main/resources/theme/keycloak/common/resources/pnpm-lock.yaml
+++ b/themes/src/main/resources/theme/keycloak/common/resources/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -11,228 +11,517 @@ dependencies:
   patternfly:
     specifier: ^3.59.5
     version: 3.59.5
+  react:
+    specifier: ^18.2.0
+    version: 18.2.0
+  react-dom:
+    specifier: ^18.2.0
+    version: 18.2.0(react@18.2.0)
+
+devDependencies:
+  '@rollup/plugin-commonjs':
+    specifier: ^25.0.7
+    version: 25.0.7(rollup@4.5.0)
+  '@rollup/plugin-node-resolve':
+    specifier: ^15.2.3
+    version: 15.2.3(rollup@4.5.0)
+  '@rollup/plugin-replace':
+    specifier: ^5.0.5
+    version: 5.0.5(rollup@4.5.0)
+  '@rollup/plugin-terser':
+    specifier: ^0.4.4
+    version: 0.4.4(rollup@4.5.0)
+  rollup:
+    specifier: ^4.5.0
+    version: 4.5.0
+  shx:
+    specifier: ^0.3.4
+    version: 0.3.4
 
 packages:
+
+  /@jridgewell/gen-mapping@0.3.3:
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.20
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array@1.1.2:
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.20
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.20:
+    resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /@rollup/plugin-commonjs@25.0.7(rollup@4.5.0):
+    resolution: {integrity: sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.5(rollup@4.5.0)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.30.5
+      rollup: 4.5.0
+    dev: true
+
+  /@rollup/plugin-node-resolve@15.2.3(rollup@4.5.0):
+    resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.5(rollup@4.5.0)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.8
+      rollup: 4.5.0
+    dev: true
+
+  /@rollup/plugin-replace@5.0.5(rollup@4.5.0):
+    resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.5(rollup@4.5.0)
+      magic-string: 0.30.5
+      rollup: 4.5.0
+    dev: true
+
+  /@rollup/plugin-terser@0.4.4(rollup@4.5.0):
+    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      rollup: 4.5.0
+      serialize-javascript: 6.0.1
+      smob: 1.4.1
+      terser: 5.24.0
+    dev: true
+
+  /@rollup/pluginutils@5.0.5(rollup@4.5.0):
+    resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 4.5.0
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi@4.5.0:
+    resolution: {integrity: sha512-OINaBGY+Wc++U0rdr7BLuFClxcoWaVW3vQYqmQq6B3bqQ/2olkaoz+K8+af/Mmka/C2yN5j+L9scBkv4BtKsDA==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.5.0:
+    resolution: {integrity: sha512-UdMf1pOQc4ZmUA/NTmKhgJTBimbSKnhPS2zJqucqFyBRFPnPDtwA8MzrGNTjDeQbIAWfpJVAlxejw+/lQyBK/w==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.5.0:
+    resolution: {integrity: sha512-L0/CA5p/idVKI+c9PcAPGorH6CwXn6+J0Ys7Gg1axCbTPgI8MeMlhA6fLM9fK+ssFhqogMHFC8HDvZuetOii7w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.5.0:
+    resolution: {integrity: sha512-QZCbVqU26mNlLn8zi/XDDquNmvcr4ON5FYAHQQsyhrHx8q+sQi/6xduoznYXwk/KmKIXG5dLfR0CvY+NAWpFYQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.5.0:
+    resolution: {integrity: sha512-VpSQ+xm93AeV33QbYslgf44wc5eJGYfYitlQzAi3OObu9iwrGXEnmu5S3ilkqE3Pr/FkgOiJKV/2p0ewf4Hrtg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.5.0:
+    resolution: {integrity: sha512-OrEyIfpxSsMal44JpEVx9AEcGpdBQG1ZuWISAanaQTSMeStBW+oHWwOkoqR54bw3x8heP8gBOyoJiGg+fLY8qQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.5.0:
+    resolution: {integrity: sha512-1H7wBbQuE6igQdxMSTjtFfD+DGAudcYWhp106z/9zBA8OQhsJRnemO4XGavdzHpGhRtRxbgmUGdO3YQgrWf2RA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.5.0:
+    resolution: {integrity: sha512-FVyFI13tXw5aE65sZdBpNjPVIi4Q5mARnL/39UIkxvSgRAIqCo5sCpCELk0JtXHGee2owZz5aNLbWNfBHzr71Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.5.0:
+    resolution: {integrity: sha512-eBPYl2sLpH/o8qbSz6vPwWlDyThnQjJfcDOGFbNjmjb44XKC1F5dQfakOsADRVrXCNzM6ZsSIPDG5dc6HHLNFg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.5.0:
+    resolution: {integrity: sha512-xaOHIfLOZypoQ5U2I6rEaugS4IYtTgP030xzvrBf5js7p9WI9wik07iHmsKaej8Z83ZDxN5GyypfoyKV5O5TJA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.5.0:
+    resolution: {integrity: sha512-Al6quztQUrHwcOoU2TuFblUQ5L+/AmPBXFR6dUvyo4nRj2yQRK0WIUaGMF/uwKulvRcXkpHe3k9A8Vf93VDktA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.5.0:
+    resolution: {integrity: sha512-8kdW+brNhI/NzJ4fxDufuJUjepzINqJKLGHuxyAtpPG9bMbn8P5mtaCcbOm0EzLJ+atg+kF9dwg8jpclkVqx5w==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@types/c3@0.6.4:
     resolution: {integrity: sha512-W7i7oSmHsXYhseZJsIYexelv9HitGsWdQhx3mcy4NWso+GedpCYr02ghpkNvnZ4oTIjNeISdrOnM70s7HiuV+g==}
     requiresBuild: true
     dependencies:
-      '@types/d3': 4.13.13
+      '@types/d3': 4.13.15
     dev: false
     optional: true
 
-  /@types/d3-array@1.2.10:
-    resolution: {integrity: sha512-b47UQ8RWEDdWdpxTdeppAZ1pyy64PMiLawItciimtvqBS1+FqUi3tk7iG0UT/6vQKMhuHpsMVVOadj71Q7vUcQ==}
+  /@types/d3-array@1.2.12:
+    resolution: {integrity: sha512-zIq9wCg/JO7MGC6vq3HRDaVYkqgSPIDjpo3JhAQxl7PHYVPA5D9SMiBfjW/ZoAvPd2a+rkovqBg0nS0QOChsJQ==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-axis@1.0.17:
-    resolution: {integrity: sha512-sQEfX7/mokx3ncUs6mpuicw+XFc6Drt/H9Axwc73KcCAmUdrdnexvBZGeZiyTjYw7RnA0DpOwrUwWfz8OfiS5Q==}
+  /@types/d3-axis@1.0.19:
+    resolution: {integrity: sha512-rXxE2jJYv6kar/6YWS8rM0weY+jjvnJvBxHKrIUqt3Yzomrfbf5tncpKG6jq6Aaw6TZyBcb1bxEWc0zGzcmbiw==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-selection': 1.4.4
+      '@types/d3-selection': 1.4.6
     dev: false
     optional: true
 
-  /@types/d3-brush@1.1.6:
-    resolution: {integrity: sha512-eAqaEzE6zA1JbslrEHvDXMjADV5LyrIfK00YkgmxVKodvrPiw6JxVBseySO3YE3UNIZ/jBplE9NDIlpY7t5pwQ==}
+  /@types/d3-brush@1.1.8:
+    resolution: {integrity: sha512-tPVjYAjJt02fgazF9yiX/309sj6qhIiIopLuHhP4FFFq9VKqu9NQBeCK3ger0RHVZGs9RKaSBUWyPUzii5biGQ==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-selection': 1.4.4
+      '@types/d3-selection': 1.4.6
     dev: false
     optional: true
 
-  /@types/d3-chord@1.0.12:
-    resolution: {integrity: sha512-JVjVlm+XxkScLWTogtELXPX/to9G9UOs6NIs9mNZI9e4AHIpA3K3vNCESoZd049iBQEGF+wAf1wGnByyv/kXVw==}
+  /@types/d3-chord@1.0.14:
+    resolution: {integrity: sha512-W9rCIbSAhwtmydW5iGg9dwTQIi3SGBOh68/T3ke3PyOgejuSLozmtAMaWNViGaGJCeuM4aFJHTUHQvMedl4ugA==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-collection@1.0.11:
-    resolution: {integrity: sha512-PN9XeRw8FyadFGrmK1f6VDo95sbJ1cKqGy9nyUzdC2xUdYSYmvJGLBcg/DUfS2a1Zh4tTqgE10HebuN/r8qSpw==}
+  /@types/d3-collection@1.0.13:
+    resolution: {integrity: sha512-v0Rgw3IZebRyamcwVmtTDCZ8OmQcj4siaYjNc7wGMZT7PmdSHawGsCOQMxyLvZ7lWjfohYLK0oXtilMOMgfY8A==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-color@1.4.3:
-    resolution: {integrity: sha512-jcHMwBcuuQ1LPt43jdbOhdOFczfDfhzvAZ1+1L0KiXPv4VqGsWAltxfxUDvtSuIMsvTZ2eeua+tOtxI6qqxYUg==}
+  /@types/d3-color@1.4.5:
+    resolution: {integrity: sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-dispatch@1.0.10:
-    resolution: {integrity: sha512-QDjKymeWL+SNmHVlLO7e9/zgR59I1uKC+FockA7EifxfpzmkBnqapzOUGDgi5bt8WBUg10mhTzWAyqruuixSGQ==}
+  /@types/d3-dispatch@1.0.12:
+    resolution: {integrity: sha512-vrhleoVNhGJGx7GQZ4207lYGyMbW/yj/iJTSvLKyfAp8nXFF+19dnMpPN/nEVs6fudIsQc7ZelBFUMe3aJDmKw==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-drag@1.2.6:
-    resolution: {integrity: sha512-vG4mVNCKKYee3+C0p/Qk4q0W0zBU4tG9ub1DltjZ2edLK/5SKssu3f1IqzuDSPnAMs5oFYLsI6yd4phUZ1KAlg==}
+  /@types/d3-drag@1.2.8:
+    resolution: {integrity: sha512-QM6H8E6r9/51BcE4NEluQ0f9dTECCTDEALJSQIWn183+Mtz/6KvEjOxW8VzKYSnhhL+qMljMKKA1WOUUf/4Qhw==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-selection': 1.4.4
+      '@types/d3-selection': 1.4.6
     dev: false
     optional: true
 
-  /@types/d3-dsv@1.2.5:
-    resolution: {integrity: sha512-ds8/wXUEuLxRubqhr0ksAv7eVBTWiW74rSf4w2BAb+FmaFAKj3j7BFU38Lp9H/uWfrFsTvEAC6c2GfqQgrb/Yw==}
+  /@types/d3-dsv@1.2.8:
+    resolution: {integrity: sha512-x1m1s0lVstZQ5/Kzp4bVIMee3fFuDm+hphVnvrYA7wU16XqwgbCBfeVvHYZzVQQIy4jyi3MEtgduLVuwIRCKLQ==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-ease@1.0.11:
-    resolution: {integrity: sha512-wUigPL0kleGZ9u3RhzBP07lxxkMcUjL5IODP42mN/05UNL+JJCDnpEPpFbJiPvLcTeRKGIRpBBJyP/1BNwYsVA==}
+  /@types/d3-ease@1.0.13:
+    resolution: {integrity: sha512-VAA4H8YNaNN0+UNIlpkwkLOj7xL5EGdyiQpdlAvOIRHckjGFCLK8eMoUd4+IMNEhQgweq0Yk/Dfzr70xhUo6hA==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-force@1.2.5:
-    resolution: {integrity: sha512-1TB2IqtkPXsr7zUgPORayl2xsl28X4WMwlpaw2BLKTQpJ5ePO1t6TkM4spbTwoqc6dWipVTwg0gdOVrbzGQPNQ==}
+  /@types/d3-force@1.2.7:
+    resolution: {integrity: sha512-zySqZfnxn67RVEGWzpD9dQA0AbNIp4Rj0qGvAuUdUNfGLrwuGCbEGAGze5hEdNaHJKQT2gTqr6j+qAzncm11ew==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-format@1.4.3:
-    resolution: {integrity: sha512-Rp3dUYGqPSn4RY+GDW1GfY++JoFvnXU2E+5pU0/4iYLVgdwt029lRlAsAeHk9lJvq3UXl10l09Cmmj2G1wnNlA==}
+  /@types/d3-format@1.4.5:
+    resolution: {integrity: sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-geo@1.12.5:
-    resolution: {integrity: sha512-YRqBbphH5XZuNtsVsjWKDZZYparpwxDlEiQSdROePXJYZ+Ibi4UwCkSA3hIH484c/kvUv8Dpx5ViefKTLsC1Ow==}
+  /@types/d3-geo@1.12.7:
+    resolution: {integrity: sha512-QetZrWWjuMfCe0BHLjD+dOThlgk7YGZ2gj+yhFAbDN5TularNBEQiBs5/CIgX0+IBDjt7/fbkDd5V70J1LjjKA==}
+    requiresBuild: true
     dependencies:
-      '@types/geojson': 7946.0.11
+      '@types/geojson': 7946.0.13
     dev: false
     optional: true
 
-  /@types/d3-hierarchy@1.1.9:
-    resolution: {integrity: sha512-OmR+pfqnz0qd+gaDJUoJBBzhvZQOwtNAjhXSztBbBDtyUXkzGsPlEv4KSGJ2zm5lNPtxG7v8Zifixk0jpFPlCQ==}
+  /@types/d3-hierarchy@1.1.11:
+    resolution: {integrity: sha512-lnQiU7jV+Gyk9oQYk0GGYccuexmQPTp08E0+4BidgFdiJivjEvf+esPSdZqCZ2C7UwTWejWpqetVaU8A+eX3FA==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-interpolate@1.4.3:
-    resolution: {integrity: sha512-eosrP1F0BPnpok+3/dK12/ZusskELe2mZBJfuynIhTw6oCpNcBsVHEJ2dyfTMkm1mv+OX7vQ4G89sYqh9+jHWg==}
+  /@types/d3-interpolate@1.4.5:
+    resolution: {integrity: sha512-k9L18hXXv7OvK4PqW1kSFYIzasGOvfhPUWmHFkoZ8/ci99EAmY4HoF6zMefrHl0SGV7XYc7Qq2MNh8dK3edg5A==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-color': 1.4.3
+      '@types/d3-color': 1.4.5
     dev: false
     optional: true
 
-  /@types/d3-path@1.0.9:
-    resolution: {integrity: sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==}
+  /@types/d3-path@1.0.11:
+    resolution: {integrity: sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-polygon@1.0.8:
-    resolution: {integrity: sha512-1TOJPXCBJC9V3+K3tGbTqD/CsqLyv/YkTXAcwdsZzxqw5cvpdnCuDl42M4Dvi8XzMxZNCT9pL4ibrK2n4VmAcw==}
+  /@types/d3-polygon@1.0.10:
+    resolution: {integrity: sha512-+hbHsFdCMs23vk9p/SpvIkHkCpl0vxkP2qWR2vEk0wRi0BXODWgB/6aHnfrz/BeQnk20XzZiQJIZ+11TGxuYMQ==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-quadtree@1.0.10:
-    resolution: {integrity: sha512-mtSpFuOo7ZzOpZlGok8jyaPIqLYm3yKwipnXWKp3g0Oq6locFNQEDgkWytIrALWuoZezTAER31jHDbee6V5XJg==}
+  /@types/d3-quadtree@1.0.12:
+    resolution: {integrity: sha512-PmbQ3LzAXMCFA15TXhnph9JOG4fB20tbu8ObcRPJ8J6gudbXTL6bzw0OnLfG/stey2+re8YQA0efA4S6pPkpig==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-queue@3.0.8:
-    resolution: {integrity: sha512-1FWOiI/MYwS5Z1Sa9EvS1Xet3isiVIIX5ozD6iGnwHonGcqL+RcC1eThXN5VfDmAiYt9Me9EWNEv/9J9k9RIKQ==}
+  /@types/d3-queue@3.0.10:
+    resolution: {integrity: sha512-kYb7UeXKaOWJIkPx1Rx79+D/3wx69XXpkQ8+MWctAu4CUTdVnSOF/AKqC9bgf42sDuL1Fj0eeQSyU62HRqRHWg==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-random@1.1.3:
-    resolution: {integrity: sha512-XXR+ZbFCoOd4peXSMYJzwk0/elP37WWAzS/DG+90eilzVbUSsgKhBcWqylGWe+lA2ubgr7afWAOBaBxRgMUrBQ==}
+  /@types/d3-random@1.1.5:
+    resolution: {integrity: sha512-gB5CR+7xYMj56pt5zmSyDBjTNMEy96PdfUb2qBaAT9bmPcf4P/YHfhhTI5y8JoiqaSRLJY+3mqtaE9loBgB6Ng==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-request@1.0.7:
-    resolution: {integrity: sha512-iuCiazM5ssApxydw58Ev5Ew9/mI6aaxenxh/6S1s/r2kRTr9bJHP78b5bFShqL4ksli1i+cm0NdWp08D1oGg7A==}
+  /@types/d3-request@1.0.9:
+    resolution: {integrity: sha512-gD2991YKzdQu5lJGhWHEjptxQvWRZKwZF3QdWqjnqrWfVd15e7/WuL6X2Pl/4sRyLKaXWbB2xuk1tSBPVLlNhg==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-dsv': 1.2.5
+      '@types/d3-dsv': 1.2.8
     dev: false
     optional: true
 
-  /@types/d3-scale@1.0.19:
-    resolution: {integrity: sha512-Rvx9TqN/FZyRaZMd3hWWTDJzbGOhPZahtrhZxKvTSpq/cvUYggj+pO4aQdtlF11Vyo1D6ZNXltBgtg8TuU2aGw==}
+  /@types/d3-scale@1.0.21:
+    resolution: {integrity: sha512-J6HW1HWAYQ/BSZQIVO9azryu2Q9B8BE8aC9z+t10lwTt9u6V5CJvNKH9wtG1WI0QWuxmeBlc58Jr0Dltm4PNNw==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-time': 1.1.2
+      '@types/d3-time': 1.1.4
     dev: false
     optional: true
 
-  /@types/d3-selection@1.4.4:
-    resolution: {integrity: sha512-nbt9x1vP2C1Wz0JxZ2aSYFvJQIukc1QdL1zGHe5O989bDHpgrVz1mgmA/8n+vapb7g3mjUPe2YoLrqEalmtxKA==}
+  /@types/d3-selection@1.4.6:
+    resolution: {integrity: sha512-0MhJ/LzJe6/vQVxiYJnvNq5CD/MF6Qy0dLp4BEQ6Dz8oOaB0EMXfx1GGeBFSW+3VzgjaUrxK6uECDQj9VLa/Mg==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-shape@1.3.9:
-    resolution: {integrity: sha512-NX8FSlYqN4MPjiOwJAu5a3y6iEj7lS8nb8zP5dQpHOWh24vMJLTXno7c7wm72SfTFNAalfvZVsatMUrEa686gg==}
+  /@types/d3-shape@1.3.11:
+    resolution: {integrity: sha512-1V8rNOM46ogRa/aI8suk8ayhYehLicIG+yZZ8D34iymbltQuZQWs4IJBNj8cF7+4bb1AigARjaOtM2+js0rLTw==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-path': 1.0.9
+      '@types/d3-path': 1.0.11
     dev: false
     optional: true
 
-  /@types/d3-time-format@2.3.2:
-    resolution: {integrity: sha512-H1j8FCj8t2EU9+Ndv4jTIqXcPID1UZJpyw3O/W1cZWFl2lj3fSyYqXeTZ9Nhv4nP4XCzRId4C73F0rCBEnuBDg==}
+  /@types/d3-time-format@2.3.4:
+    resolution: {integrity: sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-time@1.1.2:
-    resolution: {integrity: sha512-CHxXBqjSFt/w7OiGIy84L2nbzNwWhBaK6xyeAAWqKLgKlHY38vg33BMFMTCT8YOYeinNIQIQPjGvZLO8Z9M8WA==}
+  /@types/d3-time@1.1.4:
+    resolution: {integrity: sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-timer@1.0.10:
-    resolution: {integrity: sha512-ZnAbquVqy+4ZjdW0cY6URp+qF/AzTVNda2jYyOzpR2cPT35FTXl78s15Bomph9+ckOiI1TtkljnWkwbIGAb6rg==}
+  /@types/d3-timer@1.0.12:
+    resolution: {integrity: sha512-Tv9tkA4y3UvGQnrHyYAQhf5x/297FuYwotS4UW2TpwLblvRahbyL8r9HFYTJLPfPRqS63hwlqRItjKGmKtJxNg==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-transition@1.3.3:
-    resolution: {integrity: sha512-G6/XOldxri7B6RlfbtZObrMfxnUUKAIoxxo4E/dlYclX9Zhs7HtHuWrf/iIsrQGYGmqYk2BMqziHvm9gQTBwdQ==}
+  /@types/d3-transition@1.3.5:
+    resolution: {integrity: sha512-gVj9AXXkoj0yKr1jsPJFkKoYTEmSdaYh8W7XBeRIhcspFX9b3MSwLxTerVHeEPXer9kYLvZfAINk8HcjWhwZSQ==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-selection': 1.4.4
+      '@types/d3-selection': 1.4.6
     dev: false
     optional: true
 
-  /@types/d3-voronoi@1.1.10:
-    resolution: {integrity: sha512-OOnVvmmth88o/MM3hCrGGBPtwKuU5vj0XLdL5GXtda1JgzyORb43nAUw/tA0ifkijvrXS/vy4Faw8Iy6dpmbWg==}
+  /@types/d3-voronoi@1.1.12:
+    resolution: {integrity: sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /@types/d3-zoom@1.8.5:
-    resolution: {integrity: sha512-h79/ayrjJUaXNuTvO1L4pAwBCe1kzLywoE1zjRmHsFftxtHzWco5od9Lv7FCtcwuhSOp1SKS2q3RWolcdJhLOw==}
+  /@types/d3-zoom@1.8.7:
+    resolution: {integrity: sha512-HJWci3jXwFIuFKDqGn5PmuwrhZvuFdrnUmtSKCLXFAWyf2lAIUKMKh1/lHOkWBl/f4KVupGricJiqkQy+cVTog==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-interpolate': 1.4.3
-      '@types/d3-selection': 1.4.4
+      '@types/d3-interpolate': 1.4.5
+      '@types/d3-selection': 1.4.6
     dev: false
     optional: true
 
-  /@types/d3@4.13.13:
-    resolution: {integrity: sha512-mE36wbr1+ynofS/hv4AOmvnLnfi982vNQ84YFabHeUKqyCPsUR73uLjLCZNFQrHEELZ1HVzwW7QwMp5nZyKSOQ==}
+  /@types/d3@4.13.15:
+    resolution: {integrity: sha512-D1yRBsDCC8BBUHfl7DHfEXAX1+RkwdmrwTSMB+dhCPuzIyj4dc3b+fkKnvMWj7tqx3YeoM/QsZnZ13IkkbhTUw==}
+    requiresBuild: true
     dependencies:
-      '@types/d3-array': 1.2.10
-      '@types/d3-axis': 1.0.17
-      '@types/d3-brush': 1.1.6
-      '@types/d3-chord': 1.0.12
-      '@types/d3-collection': 1.0.11
-      '@types/d3-color': 1.4.3
-      '@types/d3-dispatch': 1.0.10
-      '@types/d3-drag': 1.2.6
-      '@types/d3-dsv': 1.2.5
-      '@types/d3-ease': 1.0.11
-      '@types/d3-force': 1.2.5
-      '@types/d3-format': 1.4.3
-      '@types/d3-geo': 1.12.5
-      '@types/d3-hierarchy': 1.1.9
-      '@types/d3-interpolate': 1.4.3
-      '@types/d3-path': 1.0.9
-      '@types/d3-polygon': 1.0.8
-      '@types/d3-quadtree': 1.0.10
-      '@types/d3-queue': 3.0.8
-      '@types/d3-random': 1.1.3
-      '@types/d3-request': 1.0.7
-      '@types/d3-scale': 1.0.19
-      '@types/d3-selection': 1.4.4
-      '@types/d3-shape': 1.3.9
-      '@types/d3-time': 1.1.2
-      '@types/d3-time-format': 2.3.2
-      '@types/d3-timer': 1.0.10
-      '@types/d3-transition': 1.3.3
-      '@types/d3-voronoi': 1.1.10
-      '@types/d3-zoom': 1.8.5
+      '@types/d3-array': 1.2.12
+      '@types/d3-axis': 1.0.19
+      '@types/d3-brush': 1.1.8
+      '@types/d3-chord': 1.0.14
+      '@types/d3-collection': 1.0.13
+      '@types/d3-color': 1.4.5
+      '@types/d3-dispatch': 1.0.12
+      '@types/d3-drag': 1.2.8
+      '@types/d3-dsv': 1.2.8
+      '@types/d3-ease': 1.0.13
+      '@types/d3-force': 1.2.7
+      '@types/d3-format': 1.4.5
+      '@types/d3-geo': 1.12.7
+      '@types/d3-hierarchy': 1.1.11
+      '@types/d3-interpolate': 1.4.5
+      '@types/d3-path': 1.0.11
+      '@types/d3-polygon': 1.0.10
+      '@types/d3-quadtree': 1.0.12
+      '@types/d3-queue': 3.0.10
+      '@types/d3-random': 1.1.5
+      '@types/d3-request': 1.0.9
+      '@types/d3-scale': 1.0.21
+      '@types/d3-selection': 1.4.6
+      '@types/d3-shape': 1.3.11
+      '@types/d3-time': 1.1.4
+      '@types/d3-time-format': 2.3.4
+      '@types/d3-timer': 1.0.12
+      '@types/d3-transition': 1.3.5
+      '@types/d3-voronoi': 1.1.12
+      '@types/d3-zoom': 1.8.7
     dev: false
     optional: true
 
-  /@types/geojson@7946.0.11:
-    resolution: {integrity: sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==}
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
+  /@types/geojson@7946.0.13:
+    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+    requiresBuild: true
     dev: false
     optional: true
+
+  /@types/resolve@1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+    dev: true
+
+  /acorn@8.11.2:
+    resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
   /bootstrap-datepicker@1.10.0:
     resolution: {integrity: sha512-lWxtSYddAQOpbAO8UhYhHLcK6425eWoSjb5JDvZU3ePHEPF6A3eUr51WKaFy4PccU19JRxUG6wEU3KdhtKfvpg==}
@@ -285,6 +574,28 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
+  /brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
+
+  /buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+    dev: true
+
   /c3@0.4.24:
     resolution: {integrity: sha512-mVCFtN5ZWUT5UE7ilFQ7KBQ7TUCdKIq6KsDt1hH/1m6gC1tBjvzFTO7fqhaiWHfhNOjjM7makschdhg6DkWQMA==}
     requiresBuild: true
@@ -293,15 +604,29 @@ packages:
     dev: false
     optional: true
 
+  /commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
+
+  /commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+    dev: true
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
   /d3@3.5.17:
     resolution: {integrity: sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg==}
+    requiresBuild: true
     dev: false
     optional: true
 
-  /datatables.net-bs@1.13.6:
-    resolution: {integrity: sha512-ohESuDtcrrNH56vGTErMUQklkzOVvKC5wyuaDApMruYc542IvESfalMOWKOChcAhGkhyXP9P9ZEr0AaDqQ7+Qw==}
+  /datatables.net-bs@1.13.8:
+    resolution: {integrity: sha512-KJ1ePUXVHi/l3qP+r2uan3NJPIwtHP2hep9H7oP2UrEEq9Ibkhm5HHr6Pce+qpQbMd1x0584Grxydz4Zx/SqBg==}
+    requiresBuild: true
     dependencies:
-      datatables.net: 1.13.6
+      datatables.net: 1.13.8
       jquery: 3.7.1
     dev: false
     optional: true
@@ -310,7 +635,7 @@ packages:
     resolution: {integrity: sha512-+DPim/DhbSIqr2rhRvYNrAMFNZgl372PiKEAv5YeyjYMzc8+6kX8Vinpb3Bg0PDgEdPqEWqJ6H18pBCKhXppgg==}
     requiresBuild: true
     dependencies:
-      datatables.net-bs: 1.13.6
+      datatables.net-bs: 1.13.8
       datatables.net-colreorder: 1.7.0
       jquery: 3.7.1
     dev: false
@@ -318,8 +643,9 @@ packages:
 
   /datatables.net-colreorder@1.7.0:
     resolution: {integrity: sha512-Vyysfxe2kfjeuPJJMGRQ2jHVOfoadyBYKzizbOHzR2bhTVsIYjrbEhUA1H24TISE17SdR77X0RmcUvS/h/Bifw==}
+    requiresBuild: true
     dependencies:
-      datatables.net: 1.13.6
+      datatables.net: 1.13.8
       jquery: 3.7.1
     dev: false
     optional: true
@@ -328,17 +654,23 @@ packages:
     resolution: {integrity: sha512-C3XDi7wpruGjDXV36dc9hN/FrAX9GOFvBZ7+KfKJTBNkGFbbhdzHS91SMeGiwRXPYivAyxfPTcVVndVaO83uBQ==}
     requiresBuild: true
     dependencies:
-      datatables.net: 1.13.6
+      datatables.net: 1.13.8
       jquery: 3.7.1
     dev: false
     optional: true
 
-  /datatables.net@1.13.6:
-    resolution: {integrity: sha512-rHNcnW+yEP9me82/KmRcid5eKrqPqW3+I/p1TwqCW3c/7GRYYkDyF6aJQOQ9DNS/pw+nyr4BVpjyJ3yoZXiFPg==}
+  /datatables.net@1.13.8:
+    resolution: {integrity: sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==}
+    requiresBuild: true
     dependencies:
       jquery: 3.7.1
     dev: false
     optional: true
+
+  /deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /drmonty-datatables-colvis@1.1.2:
     resolution: {integrity: sha512-1kL4fbsBEkQQTl83eQ8G/vRGcCiM6Hn3O8Tp473tG4YSsBDcxETDDSxb8qC+fQjHZ3jUCptWj3lG/L8rI6NBNw==}
@@ -364,6 +696,10 @@ packages:
     dev: false
     optional: true
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /font-awesome-sass@4.7.0:
     resolution: {integrity: sha512-apO2Nw3XP/Zv7fLxa+MnPnvJ/GdkH6qWrLrtN5oQrFL7RPprzHKROjN94jgyoxM+T7PQBhY9F/SwOKbBaLyXxg==}
     requiresBuild: true
@@ -375,11 +711,95 @@ packages:
     engines: {node: '>=0.10.3'}
     dev: false
 
+  /fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: true
+
+  /glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+    dev: true
+
   /google-code-prettify@1.0.5:
     resolution: {integrity: sha512-Y47Bw63zJKCuqTuhTZC1ct4e/0ADuMssxXhnrP8QHq71tE2aYBKG6wQwXr8zya0zIUd0mKN3XTlI5AME4qm6NQ==}
     requiresBuild: true
     dev: false
     optional: true
+
+  /hasown@2.0.0:
+    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: true
+
+  /inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
+    dev: true
+
+  /is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
+  /is-core-module@2.13.1:
+    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
+    dependencies:
+      hasown: 2.0.0
+    dev: true
+
+  /is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
+  /is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 1.0.5
+    dev: true
 
   /jquery-match-height@0.7.2:
     resolution: {integrity: sha512-qSyC0GBc4zUlgBcxfyyumJSVUm50T6XuJEIz59cKaI28VXMUT95mZ6KiIjhMIMbG8IiJhh65FtQO1XD42TAcwg==}
@@ -395,6 +815,41 @@ packages:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
     dev: false
 
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
+
   /moment-timezone@0.4.1:
     resolution: {integrity: sha512-5cNPVUwaVJDCe9JM8m/qz17f9SkaI8rpnRUyDJi2K5HAd6EwhuQ3n5nLclZkNC/qJnomKgQH2TIu70Gy2dxFKA==}
     requiresBuild: true
@@ -405,8 +860,24 @@ packages:
 
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+    requiresBuild: true
     dev: false
     optional: true
+
+  /once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
 
   /patternfly-bootstrap-combobox@1.1.7:
     resolution: {integrity: sha512-6KptS6UnS8jOwLuqsjokiNUYjOf3G4bSahiSHhkQMdfvG0b4sZkUgOFWdMJ8zBXaZGVe8T324GQoXqiJdJxMuw==}
@@ -440,7 +911,7 @@ packages:
       bootstrap-touchspin: 3.1.1
       c3: 0.4.24
       d3: 3.5.17
-      datatables.net: 1.13.6
+      datatables.net: 1.13.8
       datatables.net-colreorder: 1.7.0
       datatables.net-colreorder-bs: 1.3.3
       datatables.net-select: 1.2.7
@@ -454,3 +925,138 @@ packages:
       patternfly-bootstrap-combobox: 1.1.7
       patternfly-bootstrap-treeview: 2.1.10
     dev: false
+
+  /picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.0
+    dev: false
+
+  /react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
+
+  /rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      resolve: 1.22.8
+    dev: true
+
+  /resolve@1.22.8:
+    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.13.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /rollup@4.5.0:
+    resolution: {integrity: sha512-41xsWhzxqjMDASCxH5ibw1mXk+3c4TNI2UjKbLxe6iEzrSQnqOzmmK8/3mufCPbzHNJ2e04Fc1ddI35hHy+8zg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.5.0
+      '@rollup/rollup-android-arm64': 4.5.0
+      '@rollup/rollup-darwin-arm64': 4.5.0
+      '@rollup/rollup-darwin-x64': 4.5.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.5.0
+      '@rollup/rollup-linux-arm64-gnu': 4.5.0
+      '@rollup/rollup-linux-arm64-musl': 4.5.0
+      '@rollup/rollup-linux-x64-gnu': 4.5.0
+      '@rollup/rollup-linux-x64-musl': 4.5.0
+      '@rollup/rollup-win32-arm64-msvc': 4.5.0
+      '@rollup/rollup-win32-ia32-msvc': 4.5.0
+      '@rollup/rollup-win32-x64-msvc': 4.5.0
+      fsevents: 2.3.3
+    dev: true
+
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
+
+  /serialize-javascript@6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
+  /shelljs@0.8.5:
+    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
+    dev: true
+
+  /shx@0.3.4:
+    resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.8.5
+    dev: true
+
+  /smob@1.4.1:
+    resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
+    dev: true
+
+  /source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
+  /source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /terser@5.24.0:
+    resolution: {integrity: sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.11.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: true
+
+  /wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true

--- a/themes/src/main/resources/theme/keycloak/common/resources/rollup.config.js
+++ b/themes/src/main/resources/theme/keycloak/common/resources/rollup.config.js
@@ -1,0 +1,40 @@
+import { defineConfig } from "rollup";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import replace from "@rollup/plugin-replace";
+import terser from "@rollup/plugin-terser";
+
+const plugins = [
+  nodeResolve(),
+  commonjs(),
+  replace({
+    preventAssignment: true,
+    // React depends on process.env.NODE_ENV to determine which code to include for production.
+    // This ensures that no additional code meant for development is included in the build.
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  }),
+  terser(),
+];
+
+export default defineConfig([
+  {
+    input: [
+      "node_modules/react/cjs/react.production.min.js",
+      "node_modules/react/cjs/react-jsx-runtime.production.min.js",
+    ],
+    output: {
+      dir: "vendor/react",
+      format: "es",
+    },
+    plugins,
+  },
+  {
+    input: "node_modules/react-dom/cjs/react-dom.production.min.js",
+    output: {
+      dir: "vendor/react-dom",
+      format: "es",
+    },
+    external: ["react"],
+    plugins,
+  },
+]);


### PR DESCRIPTION
Includes `react` and `react-dom` as external dependencies, so that they can be loaded from the 'common' resources, avoiding duplicating these dependencies between the projects that include them as dependencies.

Essentially what this does is prevent import statements to `react` and `react-dom` from being converted and leaves them intact as they were in the source code. This then allows us to load them from the 'common' resources using an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap):

```html
<script type="importmap">
  {
    "imports": {
      "react": "${resourceCommonUrl}/vendor/react/react.production.min.js",
      "react/jsx-runtime": "${resourceCommonUrl}/vendor/react/react-jsx-runtime.production.min.js",
      "react-dom": "${resourceCommonUrl}/vendor/react-dom/react-dom.production.min.js"
    }
  }
</script>
```

This also helps users that want to customize the Account Console (v2) using a custom [`content.json`](https://github.com/keycloak/keycloak/blob/73d5a2c553365108ad6711e81365ec04faf1d078/themes/src/main/resources/theme/keycloak.v2/account/resources/content.json#L4) as they can directly import React using `import {} from 'react'`, rather than needing to specify a relative path.