### PR TITLE
Start of MS-SQL fails in CI

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -569,7 +569,7 @@
                 <docker.database.skip>false</docker.database.skip>
                 <docker.database.postStart>/opt/mssql-tools/bin/sqlcmd -e -U sa -P vEry5tron9Pwd -d master -Q CREATE\ DATABASE\ ${keycloak.connectionsJpa.database}</docker.database.postStart>
                 <docker.database.cmd>/bin/sh -c /opt/mssql/bin/sqlservr</docker.database.cmd>
-                <docker.database.wait-for-log-regex>(?si)SQL Server is now ready for client connections.*Service Broker manager has started</docker.database.wait-for-log-regex>
+                <docker.database.wait-for-log-regex>(?si)SQL Server is now ready for client connections.</docker.database.wait-for-log-regex>
                 <keycloak.storage.connections.vendor>mssql</keycloak.storage.connections.vendor>
                 <keycloak.connectionsJpa.driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</keycloak.connectionsJpa.driver>
                 <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>


### PR DESCRIPTION
Closes #24846

After the cumulative update 10 for SQL Server[1] from 16.11.2023, the representation of the start message has changed. As we're using the `2022-latest` tag, we're affected by these changes. 

In the testsuite, we're expecting a particular message, but as the message has slightly changed, the condition is not met. Thus, the timeout occurs. 

Old message:
`SQL Server is now ready for client connections.*Service Broker manager has started`

New message:
`SQL Server is now ready for client connections. This is an informational message; no user action is required.`

IMHO, it's sufficient to verify that only the first sentence is present in the log. 

[1] https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate10