### PR TITLE
fix: update client's client scope via REST api

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -457,28 +457,7 @@ public class RepresentationToModel {
             addClientScopeToClient(realm, client, clientTemplateName, true);
         }
 
-        if (resourceRep.getDefaultClientScopes() != null || resourceRep.getOptionalClientScopes() != null) {
-            // First remove all default/built in client scopes
-            for (ClientScopeModel clientScope : client.getClientScopes(true).values()) {
-                client.removeClientScope(clientScope);
-            }
-
-            // First remove all default/built in client scopes
-            for (ClientScopeModel clientScope : client.getClientScopes(false).values()) {
-                client.removeClientScope(clientScope);
-            }
-        }
-
-        if (resourceRep.getDefaultClientScopes() != null) {
-            for (String clientScopeName : resourceRep.getDefaultClientScopes()) {
-                addClientScopeToClient(realm, client, clientScopeName, true);
-            }
-        }
-        if (resourceRep.getOptionalClientScopes() != null) {
-            for (String clientScopeName : resourceRep.getOptionalClientScopes()) {
-                addClientScopeToClient(realm, client, clientScopeName, false);
-            }
-        }
+        updateClientScopes(resourceRep, client);
 
         if (resourceRep.isFullScopeAllowed() != null) {
             client.setFullScopeAllowed(resourceRep.isFullScopeAllowed());
@@ -580,6 +559,8 @@ public class RepresentationToModel {
             }
         }
 
+        updateClientScopes(rep, resource);
+
         if (resource.isPublicClient() || resource.isBearerOnly()) {
             resource.setSecret(null);
         } else {
@@ -620,6 +601,32 @@ public class RepresentationToModel {
             session.getKeycloakSessionFactory().publish(event);
         }
     }
+
+    private static void updateClientScopes(ClientRepresentation representation, ClientModel clientModelResource) {
+        if (representation.getDefaultClientScopes() != null || representation.getOptionalClientScopes() != null) {
+            // First remove all default/built in client scopes
+            for (ClientScopeModel clientScope :  clientModelResource.getClientScopes(true).values()) {
+                 clientModelResource.removeClientScope(clientScope);
+            }
+
+            // First remove all default/built in client scopes
+            for (ClientScopeModel clientScope :  clientModelResource.getClientScopes(false).values()) {
+                 clientModelResource.removeClientScope(clientScope);
+            }
+        }
+
+        if (representation.getDefaultClientScopes() != null) {
+            for (String clientScopeName : representation.getDefaultClientScopes()) {
+                addClientScopeToClient( clientModelResource.getRealm(),  clientModelResource, clientScopeName, true);
+            }
+        }
+        if (representation.getOptionalClientScopes() != null) {
+            for (String clientScopeName : representation.getOptionalClientScopes()) {
+                addClientScopeToClient( clientModelResource.getRealm(),  clientModelResource, clientScopeName, false);
+            }
+        }
+    }
+
 
     public static void updateClientProtocolMappers(ClientRepresentation rep, ClientModel resource) {
 

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicy.java
@@ -84,6 +84,14 @@ public class ClientScopesClientRegistrationPolicy implements ClientRegistrationP
 
         checkClientScopesAllowed(requestedDefaultScopeNames, allowedDefaultScopeNames);
         checkClientScopesAllowed(requestedOptionalScopeNames, allowedOptionalScopeNames);
+
+        // Add already presented scopes again, so we don't lose them in the update.
+        if (requestedDefaultScopeNames != null) {
+            requestedDefaultScopeNames.addAll(clientModel.getClientScopes(true).keySet());
+        }
+        if (requestedOptionalScopeNames != null) {
+            requestedOptionalScopeNames.addAll(clientModel.getClientScopes(false).keySet());
+        }
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -828,6 +828,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         ClientRepresentation clientRep = ApiUtil.findClientByClientId(realm, "test-app").toRepresentation();
         realm.clients().get(clientRep.getId()).addDefaultClientScope(clientScopeId);
         clientRep.setFullScopeAllowed(false);
+        clientRep = ApiUtil.findClientByClientId(realm, "test-app").toRepresentation();
         realm.clients().get(clientRep.getId()).update(clientRep);
 
         {


### PR DESCRIPTION
RepresentationToModel: fix for updating client scopes.
ClientScopeTest: new test for this fix

AccessTokenTest: fix for failed test
ClientScopesClientRegistrationPolicy: fix beforeUpdate method to not loose clientScopes

Closes: #24920

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
