### PR TITLE
Revert "Ignore JDBC Drivers artifacts"

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -18,7 +18,6 @@
 package org.keycloak.config.database;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -50,12 +49,6 @@ public final class Database {
         }
 
         return false;
-    }
-
-    public static Optional<Vendor> getVendorByDbKind(String dbKind) {
-        return Arrays.stream(Vendor.values())
-                .filter(v -> v.isOfKind(dbKind))
-                .findAny();
     }
 
     public static Optional<String> getDatabaseKind(String alias) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -17,13 +17,9 @@
 package org.keycloak.quarkus.runtime.configuration;
 
 import org.keycloak.common.Profile;
-import org.keycloak.config.database.Database;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.keycloak.quarkus.runtime.Environment.getCurrentOrCreateFeatureProfile;
 
@@ -33,12 +29,9 @@ import static org.keycloak.quarkus.runtime.Environment.getCurrentOrCreateFeature
 public class IgnoredArtifacts {
 
     public static Set<String> getDefaultIgnoredArtifacts() {
-        return Stream.of(
-                        fips(),
-                        jdbcDrivers()
-                )
-                .flatMap(Collection::stream)
-                .collect(Collectors.toUnmodifiableSet());
+        return new Builder()
+                .append(fips())
+                .build();
     }
 
     // FIPS
@@ -63,71 +56,23 @@ public class IgnoredArtifacts {
         return isFipsEnabled ? FIPS_ENABLED : FIPS_DISABLED;
     }
 
-    // JDBC Drivers
-    public static final Set<String> JDBC_H2 = Set.of(
-            "io.quarkus:quarkus-jdbc-h2",
-            "io.quarkus:quarkus-jdbc-h2-deployment",
-            "com.h2database:h2"
-    );
+    /**
+     * Builder for artifacts aggregation
+     */
+    private static final class Builder {
+        private final Set<String> finalIgnoredArtifacts;
 
-    public static final Set<String> JDBC_POSTGRES = Set.of(
-            "io.quarkus:quarkus-jdbc-postgresql",
-            "io.quarkus:quarkus-jdbc-postgresql-deployment",
-            "org.postgresql:postgresql"
-    );
+        public Builder() {
+            this.finalIgnoredArtifacts = new HashSet<>();
+        }
 
-    public static final Set<String> JDBC_MARIADB = Set.of(
-            "io.quarkus:quarkus-jdbc-mariadb",
-            "io.quarkus:quarkus-jdbc-mariadb-deployment",
-            "org.mariadb.jdbc:mariadb-java-client"
-    );
+        public Builder append(Set<String> ignoredArtifacts) {
+            finalIgnoredArtifacts.addAll(ignoredArtifacts);
+            return this;
+        }
 
-    public static final Set<String> JDBC_MYSQL = Set.of(
-            "io.quarkus:quarkus-jdbc-mysql",
-            "io.quarkus:quarkus-jdbc-mysql-deployment",
-            "mysql:mysql-connector-java"
-    );
-
-    public static final Set<String> JDBC_MSSQL = Set.of(
-            "io.quarkus:quarkus-jdbc-mssql",
-            "io.quarkus:quarkus-jdbc-mssql-deployment",
-            "com.microsoft.sqlserver:mssql-jdbc"
-    );
-
-    public static final Set<String> JDBC_ORACLE = Set.of(
-            "io.quarkus:quarkus-jdbc-oracle",
-            "io.quarkus:quarkus-jdbc-oracle-deployment",
-            "com.oracle.database.jdbc:ojdbc11",
-            "com.oracle.database.nls:orai18n"
-    );
-
-    public static final Set<String> JDBC_DRIVERS = Stream.of(
-                    JDBC_H2,
-                    JDBC_POSTGRES,
-                    JDBC_MARIADB,
-                    JDBC_MYSQL,
-                    JDBC_MSSQL,
-                    JDBC_ORACLE
-            )
-            .flatMap(Collection::stream)
-            .collect(Collectors.toUnmodifiableSet());
-
-    private static Set<String> jdbcDrivers() {
-        final Database.Vendor vendor = Configuration.getOptionalValue("quarkus.datasource.db-kind")
-                .flatMap(Database::getVendorByDbKind)
-                .orElse(Database.Vendor.H2);
-
-        final Set<String> jdbcArtifacts = switch (vendor) {
-            case H2 -> JDBC_H2;
-            case MYSQL -> JDBC_MYSQL;
-            case MARIADB -> JDBC_MARIADB;
-            case POSTGRES -> JDBC_POSTGRES;
-            case MSSQL -> JDBC_MSSQL;
-            case ORACLE -> JDBC_ORACLE;
-        };
-
-        final Set<String> allJdbcDrivers = new HashSet<>(JDBC_DRIVERS);
-        allJdbcDrivers.removeAll(jdbcArtifacts);
-        return allJdbcDrivers;
+        public Set<String> build() {
+            return finalIgnoredArtifacts;
+        }
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
@@ -17,27 +17,15 @@
 
 package org.keycloak.quarkus.runtime.configuration.test;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.keycloak.common.Profile;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
-import org.keycloak.config.DatabaseOptions;
 import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
-import java.util.HashSet;
 import java.util.Properties;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_H2;
-import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_MARIADB;
-import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_MSSQL;
-import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_MYSQL;
-import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_ORACLE;
-import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_POSTGRES;
 
 public class IgnoredArtifactsTest {
 
@@ -60,53 +48,5 @@ public class IgnoredArtifactsTest {
 
         var ignoredArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
         assertThat(ignoredArtifacts.containsAll(IgnoredArtifacts.FIPS_ENABLED), is(true));
-    }
-
-    @Test
-    public void jdbcH2() {
-        assertJdbc("h2", JDBC_H2);
-    }
-
-    @Test
-    public void jdbcMssql() {
-        assertJdbc("mssql", JDBC_MSSQL);
-    }
-
-    @Test
-    public void jdbcMariadb() {
-        assertJdbc("mariadb", JDBC_MARIADB);
-    }
-
-    @Test
-    public void jdbcMysql() {
-        assertJdbc("mysql", JDBC_MYSQL);
-    }
-
-    @Test
-    public void jdbcOracle() {
-        assertJdbc("oracle", JDBC_ORACLE);
-    }
-
-    @Test
-    public void jdbcPostgres() {
-        assertJdbc("postgres", JDBC_POSTGRES);
-    }
-
-    private void assertJdbc(String vendor, Set<String> notIgnored) {
-        System.setProperty(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + DatabaseOptions.DB.getKey(), vendor);
-        try {
-            final var resultArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
-            assertThat(String.format("Ignored artifacts does not comply with the specified artifacts for '%s' JDBC driver", vendor),
-                    resultArtifacts,
-                    not(CoreMatchers.hasItems(notIgnored.toArray(new String[0]))));
-
-            final var includedArtifacts = new HashSet<>(IgnoredArtifacts.JDBC_DRIVERS);
-            includedArtifacts.removeAll(notIgnored);
-            assertThat("Ignored artifacts does not contain items for the other JDBC drivers",
-                    resultArtifacts,
-                    CoreMatchers.hasItems(includedArtifacts.toArray(new String[0])));
-        } finally {
-            System.setProperty(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + DatabaseOptions.DB.getKey(), "");
-        }
     }
 }


### PR DESCRIPTION
Reverts keycloak/keycloak#22443

Simple `kc.sh start-dev` fails with:
```
ERROR: Unexpected error when starting the server in (development) mode
Error details:
java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:70)
	at org.keycloak.quarkus.runtime.KeycloakMain.start(KeycloakMain.java:117)
	at org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.run(AbstractStartCommand.java:33)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2026)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at org.keycloak.quarkus.runtime.cli.Picocli.parseAndRun(Picocli.java:119)
	at org.keycloak.quarkus.runtime.KeycloakMain.main(KeycloakMain.java:107)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:61)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:32)
Caused by: java.lang.ClassNotFoundException: io.quarkus.jdbc.mssql.runtime.MsSQLAgroalConnectionConfigurer
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:115)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:65)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:467)
	at io.quarkus.jdbc.mssql.runtime.MsSQLAgroalConnectionConfigurer_Bean.<init>(Unknown Source)
	at io.quarkus.arc.setup.Default_ComponentsProvider.addBeans2(Unknown Source)
	at io.quarkus.arc.setup.Default_ComponentsProvider.getComponents(Unknown Source)
	at io.quarkus.arc.impl.ArcContainerImpl.<init>(ArcContainerImpl.java:125)
	at io.quarkus.arc.Arc.initialize(Arc.java:39)
	at io.quarkus.arc.runtime.ArcRecorder.initContainer(ArcRecorder.java:47)
	at io.quarkus.deployment.steps.ArcProcessor$generateResources844392269.deploy_0(Unknown Source)
	at io.quarkus.deployment.steps.ArcProcessor$generateResources844392269.deploy(Unknown Source)
	... 25 more
```

We need to investigate further, reverting for now given close 23 release.