### PR TITLE
Unable to use < as part of a password (admin-cli)

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/KcAdmMain.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/KcAdmMain.java
@@ -84,19 +84,14 @@ public class KcAdmMain {
             StringBuilder b = new StringBuilder();
             for (String s : args) {
                 // quote if necessary
-                boolean needQuote = false;
-                needQuote = s.indexOf(' ') != -1 || s.indexOf('\"') != -1 || s.indexOf('\'') != -1;
                 b.append(' ');
-                if (needQuote) {
-                    b.append('\'');
-                }
+                s = s.replace("'", "\\'");
+                b.append('\'');
                 b.append(s);
-                if (needQuote) {
-                    b.append('\'');
-                }
+                b.append('\'');
             }
             console.setEcho(false);
-            
+
             console.execute("kcadm" + b.toString());
             
             console.start();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmTest.java
@@ -284,6 +284,14 @@ public class KcAdmTest extends AbstractAdmCliTest {
     }
 
     @Test
+    public void testUserLoginWithAngleBrackets() {
+        KcAdmExec exe = KcAdmExec.execute("config credentials --server " + serverUrl + " --realm test --user 'special>>character' --password '<password>'");
+
+        assertExitCodeAndStreamSizes(exe, 0, 0, 1);
+        Assert.assertEquals("stderr first line", "Logging into " + serverUrl + " as user special>>character of realm test", exe.stderrLines().get(0));
+    }
+
+    @Test
     public void testUserLoginWithDefaultConfigInteractive() throws IOException {
         /*
          *  Test user login with interaction - provide user password after prompted for it

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -194,10 +194,10 @@ public class ExportImportTest extends AbstractKeycloakTest {
         RealmResource testRealmRealm = adminClient.realm(TEST_REALM);
         ExportImportUtil.assertDataImportedInRealm(adminClient, testingClient, testRealmRealm.toRepresentation());
 
-        // There should be 4 files in target directory (1 realm, 12 users, 5 users per file)
+        // There should be 5 files in target directory (1 realm, 16 users, 5 users per file)
         // (+ additional user service-account-test-app-authz that should not be there ???)
         File[] files = new File(targetDirPath).listFiles();
-        assertEquals(4, files.length);
+        assertEquals(5, files.length);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
@@ -164,6 +164,18 @@
           "credentialData" : "{\"digits\":6,\"counter\":0,\"period\":30,\"algorithm\":\"HmacSHA1\",\"subType\":\"totp\"}"
         }
       ]
+    },
+    {
+      "username" : "special>>character",
+      "enabled": true,
+      "email" : "special-character@localhost",
+      "firstName": "Special",
+      "lastName": "Character",
+      "credentials" : [
+        { "type" : "password",
+          "value" : "<password>" }
+      ],
+      "realmRoles": ["user", "offline_access"]
     }
   ],
   "scopeMappings": [


### PR DESCRIPTION
* escaped angle bracket characters in password

Closes #21951 