### PR TITLE
Fix compilation error with ServerInfoAdminResource

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -113,7 +113,7 @@ public class ServerInfoAdminResource {
                                 Collectors.toMap(
                                         ClientSignatureVerifierProvider::isAsymmetricAlgorithm,
                                         clientSignatureVerifier -> Collections.singletonList(clientSignatureVerifier.getAlgorithm()),
-                                        (l1, l2) -> listCombiner(l1, l2)
+                                        (l1, l2) -> ServerInfoAdminResource.<String>listCombiner(l1, l2)
                                                 .stream()
                                                 .sorted()
                                                 .collect(Collectors.toList()),

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -113,10 +113,12 @@ public class ServerInfoAdminResource {
                                 Collectors.toMap(
                                         ClientSignatureVerifierProvider::isAsymmetricAlgorithm,
                                         clientSignatureVerifier -> Collections.singletonList(clientSignatureVerifier.getAlgorithm()),
-                                        (l1, l2) -> ServerInfoAdminResource.<String>listCombiner(l1, l2)
-                                                .stream()
-                                                .sorted()
-                                                .collect(Collectors.toList()),
+                                        (l1, l2) -> {
+                                            List<String> result = listCombiner(l1, l2);
+                                            return result.stream()
+                                                    .sorted()
+                                                    .collect(Collectors.toList());
+                                        },
                                         HashMap::new
                                 )
                         );


### PR DESCRIPTION
This change fixes following type inference error when compiling the code with Eclipse JDT compiler:

* Type mismatch: cannot convert from Map<Boolean,Object> to Map<Boolean,List<String>>

The fix allows developers to use vscode or Eclipse to work on Keycloak code. 

Fixes #24962
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
