### PR TITLE
Build Account Console v2 for Cypress tests on CI

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build Keycloak
         run: |
-          ./mvnw clean install --batch-mode --errors -DskipTests -DskipTestsuite -DskipExamples -DskipAccount2 -Pdistribution
+          ./mvnw clean install --batch-mode --errors -DskipTests -DskipTestsuite -DskipExamples -Pdistribution
           mv ./quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz ./keycloak-999.0.0-SNAPSHOT.tar.gz
 
       - name: Upload Keycloak dist


### PR DESCRIPTION
Looks like some times the Account Console v2 isn't build on CI when the Cypress tests are running. This causes the tests to [fail randomly](https://cloud.cypress.io/projects/j4yhox/runs/d4c802c5-902e-45f4-ba92-9784d3b4a725/test-results/d41b3bf1-a9cd-4c1e-8a9c-0df6edd830f4/replay?att=1&pc=4428.532__network-calls&ts=1700644140955.71). This PR forces a re-build every time.

Closes #24968