### PR TITLE
Fix incorrect preview feature reference (keycloak#24966).

### DIFF
--- a/docs/documentation/securing_apps/topics/token-exchange/token-exchange.adoc
+++ b/docs/documentation/securing_apps/topics/token-exchange/token-exchange.adoc
@@ -9,7 +9,7 @@ include::../templates/techpreview.adoc[]
 
 [NOTE]
 ====
-To use more than the <<_internal-token-to-internal-token-exchange,Internal Token to Internal Token Exchange>> flow, also enable the `admin_fine_grained_authz` feature.
+To use more than the <<_internal-token-to-internal-token-exchange,Internal Token to Internal Token Exchange>> flow, also enable the `admin-fine-grained-authz` feature.
 For details, see the https://www.keycloak.org/server/features[Enabling and disabling features] {section}.
 ====
 


### PR DESCRIPTION
Fixes incorrect reference of the `admin-fine-grained-authz` feature in the token exchange docs topic.

Closes #24966.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
