### PR TITLE
Allow duplicated keys in the HardcodedKeyLocator

### DIFF
--- a/saml-core/src/main/java/org/keycloak/rotation/HardcodedKeyLocator.java
+++ b/saml-core/src/main/java/org/keycloak/rotation/HardcodedKeyLocator.java
@@ -46,14 +46,14 @@ public class HardcodedKeyLocator implements KeyLocator, Iterable<Key> {
         Objects.requireNonNull(keys, "Keys must not be null");
         this.byName = Collections.emptyMap();
         this.byKey = Collections.unmodifiableMap(keys.stream().collect(
-                Collectors.toMap(k -> new KeyHash(k), k -> k)));
+                Collectors.toMap(k -> new KeyHash(k), k -> k, (k1, k2) -> k1)));
     }
 
     public HardcodedKeyLocator(Map<String, ? extends Key> keys) {
         Objects.requireNonNull(keys, "Keys must not be null");
         this.byName = Collections.unmodifiableMap(keys);
         this.byKey = Collections.unmodifiableMap(keys.values().stream().collect(
-                Collectors.toMap(k -> new KeyHash(k), k -> k)));
+                Collectors.toMap(k -> new KeyHash(k), k -> k, (k1, k2) -> k1)));
     }
 
     @Override

--- a/saml-core/src/test/java/org/keycloak/rotation/HardcodedKeyLocatorTest.java
+++ b/saml-core/src/test/java/org/keycloak/rotation/HardcodedKeyLocatorTest.java
@@ -139,4 +139,13 @@ public class HardcodedKeyLocatorTest {
         Assert.assertNotNull(found);
         Assert.assertEquals(cert1.getPublicKey(), found);
     }
+
+    @Test
+    public void testDuplicateKey() throws Exception {
+        KeyLocator locator = createLocatorWithoutName(cert1, cert1);
+        KeyInfo info = XMLSignatureUtil.createKeyInfo(null, null, cert1);
+        Key found = locator.getKey(info);
+        Assert.assertNotNull(found);
+        Assert.assertEquals(cert1.getPublicKey(), found);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/24961

This is a regression introduced by https://github.com/keycloak/keycloak/commit/cab7e50410d4f596a8b8c9b19bfa296a0761d8e2. Previously the `HarcodedKeyLocator` created a collection of keys, so there could be duplicated keys on it. Now it's a map and if you assign the same key twice in the `byKey` map it fails with the error described in the related issue. This happens when certificates are renewed. The fix just merge the first key as they are the same. If there is no time to include it for 23, I'll create a back-port for it.
