### PR TITLE
Provide option to enhance consent scope representation

### DIFF
--- a/core/src/main/java/org/keycloak/representations/account/ConsentScopeRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/account/ConsentScopeRepresentation.java
@@ -17,12 +17,14 @@
 
 package org.keycloak.representations.account;
 
+import java.util.Map;
+
 public class ConsentScopeRepresentation {
 
     private String id;
-
     private String name;
-
+    private String description;
+    private String protocol;
     private String displayTest;
 
     public ConsentScopeRepresentation() {
@@ -32,6 +34,13 @@ public class ConsentScopeRepresentation {
         this.id = id;
         this.name = name;
         this.displayTest = displayTest;
+    }
+
+    public ConsentScopeRepresentation(String id, String name, String description, String protocol) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.protocol = protocol;
     }
 
     public String getId() {
@@ -48,6 +57,22 @@ public class ConsentScopeRepresentation {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
     }
 
     public String getDisplayTest() {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -243,7 +243,7 @@ public class AccountRestService {
         representation.setEffectiveUrl(ResolveRelative.resolveRelativeUri(session, model.getRootUrl(), model.getBaseUrl()));
         UserConsentModel consentModel = consents.get(model.getClientId());
         if(consentModel != null) {
-            representation.setConsent(modelToRepresentation(consentModel));
+            representation.setConsent(modelToBriefRepresentation(consentModel));
             representation.setLogoUri(model.getAttribute(ClientModel.LOGO_URI));
             representation.setPolicyUri(model.getAttribute(ClientModel.POLICY_URI));
             representation.setTosUri(model.getAttribute(ClientModel.TOS_URI));
@@ -252,6 +252,13 @@ public class AccountRestService {
     }
 
     private ConsentRepresentation modelToRepresentation(UserConsentModel model) {
+        List<ConsentScopeRepresentation> grantedScopes = model.getGrantedClientScopes().stream()
+                .map(m -> new ConsentScopeRepresentation(m.getId(), m.getName(), m.getDescription(), m.getProtocol()))
+                .collect(Collectors.toList());
+        return new ConsentRepresentation(grantedScopes, model.getCreatedDate(), model.getLastUpdatedDate());
+    }
+
+    private ConsentRepresentation modelToBriefRepresentation(UserConsentModel model) {
         List<ConsentScopeRepresentation> grantedScopes = model.getGrantedClientScopes().stream()
                 .map(m -> new ConsentScopeRepresentation(m.getId(), m.getConsentScreenText()!= null ? m.getConsentScreenText() : m.getName(), StringPropertyReplacer.replaceProperties(m.getConsentScreenText(), getProperties())))
                 .collect(Collectors.toList());
@@ -275,7 +282,8 @@ public class AccountRestService {
     @Path("/applications/{clientId}/consent")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getConsent(final @PathParam("clientId") String clientId) {
+    public Response getConsent(final @PathParam("clientId") String clientId,
+            @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         checkAccountApiEnabled();
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_CONSENT, AccountRoles.MANAGE_CONSENT);
 
@@ -287,6 +295,10 @@ public class AccountRestService {
         UserConsentModel consent = UserConsentManager.getConsentByClient(session, realm, user, client.getId());
         if (consent == null) {
             return Response.noContent().build();
+        }
+
+        if (briefRepresentation) {
+            return Response.ok(modelToBriefRepresentation(consent)).build();
         }
 
         return Response.ok(modelToRepresentation(consent)).build();
@@ -384,7 +396,7 @@ public class AccountRestService {
             String scopeString = grantedConsent.getGrantedClientScopes().stream().map(cs->cs.getName()).collect(Collectors.joining(" "));
             event.detail(Details.SCOPE, scopeString).success();
             grantedConsent = UserConsentManager.getConsentByClient(session, realm, user, client.getId());
-            return Response.ok(modelToRepresentation(grantedConsent)).build();
+            return Response.ok(modelToBriefRepresentation(grantedConsent)).build();
         } catch (IllegalArgumentException e) {
             throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -1545,6 +1545,20 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertEquals(consentRepresentation1.getLastUpdatedDate(), consentRepresentation2.getLastUpdatedDate());
         assertEquals(consentRepresentation1.getCreatedDate(), consentRepresentation2.getCreatedDate());
         assertEquals(consentRepresentation1.getGrantedScopes().get(0).getId(), consentRepresentation2.getGrantedScopes().get(0).getId());
+
+        ConsentRepresentation enhancedConsentRepresentation = SimpleHttp
+                .doGet(getAccountUrl("applications/" + appId + "/consent"), httpClient)
+                .header("Accept", "application/json")
+                .param("briefRepresentation", "false")
+                .auth(tokenUtil.getToken())
+                .asJson(ConsentRepresentation.class);
+
+        ConsentScopeRepresentation enhancedScope = enhancedConsentRepresentation.getGrantedScopes().get(0);
+        ClientScopeRepresentation requestedScope = requestedScopes.get(0);
+
+        assertEquals(enhancedScope.getName(), requestedScope.getName());
+        assertEquals(enhancedScope.getDescription(), requestedScope.getDescription());
+        assertEquals(enhancedScope.getProtocol(), requestedScope.getProtocol());
     }
 
     @Test


### PR DESCRIPTION
Add a "briefRepresentation" query param to the "/applications/{clientId}/consent" endpoint (defaults to true).

If set to "false", the endpoint will provide an enhanced ConsentScopeRepresentation.

Closes #24436
