### PR TITLE
Replace static text with reference to translation in Applications page #24527

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/account/messages/messages_en.properties
@@ -136,6 +136,7 @@ policy=Privacy policy
 applicationType=Application type
 status=Status
 logo=Logo
+hasAccessTo=Has access to
 
 #Delete account page
 doDelete=Delete

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
@@ -220,7 +220,7 @@ export class ApplicationsPage extends React.Component<ApplicationsPageProps, App
                       {application.consent &&
                         <React.Fragment>
                           <DescriptionListGroup>
-                            <DescriptionListTerm>Has access to</DescriptionListTerm>
+                            <DescriptionListTerm>{Msg.localize('hasAccessTo')}</DescriptionListTerm>
                             {application.consent.grantedScopes.map((scope: GrantedScope, scopeIndex: number) => {
                                 return (
                                   <React.Fragment key={'scope-' + scopeIndex} >


### PR DESCRIPTION
In this commit static text has been replaced by reference to translation. Currently only English value has been provided.

Closes #24527
