### PR TITLE
Change language name to own language

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
@@ -249,7 +249,7 @@ describe("Realm settings events tab tests", () => {
     cy.get(realmSettingsPage.supportedLocalesTypeahead)
       .click()
       .get(".pf-c-select__menu-item")
-      .contains("dansk")
+      .contains("Danish")
       .click();
     cy.get("#kc-l-supported-locales").click();
 
@@ -265,7 +265,7 @@ describe("Realm settings events tab tests", () => {
     masthead.checkNotificationMessage(
       "Success! The message bundle has been added.",
     );
-    realmSettingsPage.setDefaultLocale("dansk");
+    realmSettingsPage.setDefaultLocale("Danish");
     cy.findByTestId("localization-tab-save").click();
   });
 

--- a/js/apps/admin-ui/src/realm-settings/LocalizationTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/LocalizationTab.tsx
@@ -74,9 +74,11 @@ export type BundleForm = {
   messageBundle: KeyValueType;
 };
 
-const localeToDisplayName = (locale: string) => {
+const localeToDisplayName = (locale: string, displayLocale: string) => {
   try {
-    return new Intl.DisplayNames([locale], { type: "language" }).of(locale);
+    return new Intl.DisplayNames([displayLocale], { type: "language" }).of(
+      locale,
+    );
   } catch (error) {
     return locale;
   }
@@ -308,14 +310,14 @@ export const LocalizationTab = ({ save, realm }: LocalizationTabProps) => {
   const options = [
     <SelectGroup label={t("defaultLocale")} key="group1">
       <SelectOption key={DEFAULT_LOCALE} value={DEFAULT_LOCALE}>
-        {localeToDisplayName(DEFAULT_LOCALE)}
+        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.getLocale())}
       </SelectOption>
     </SelectGroup>,
     <Divider key="divider" />,
     <SelectGroup label={t("supportedLocales")} key="group2">
       {watchSupportedLocales.map((locale) => (
         <SelectOption key={locale} value={locale}>
-          {localeToDisplayName(locale)}
+          {localeToDisplayName(locale, whoAmI.getLocale())}
         </SelectOption>
       ))}
     </SelectGroup>,
@@ -450,7 +452,7 @@ export const LocalizationTab = ({ save, realm }: LocalizationTabProps) => {
                           key={locale}
                           value={locale}
                         >
-                          {localeToDisplayName(locale)}
+                          {localeToDisplayName(locale, whoAmI.getLocale())}
                         </SelectOption>
                       ))}
                     </Select>
@@ -475,10 +477,11 @@ export const LocalizationTab = ({ save, realm }: LocalizationTabProps) => {
                       }}
                       selections={
                         field.value
-                          ? localeToDisplayName(field.value)
+                          ? localeToDisplayName(field.value, whoAmI.getLocale())
                           : realm.defaultLocale !== ""
                             ? localeToDisplayName(
                                 realm.defaultLocale || DEFAULT_LOCALE,
+                                whoAmI.getLocale(),
                               )
                             : t("placeholderText")
                       }
@@ -493,7 +496,7 @@ export const LocalizationTab = ({ save, realm }: LocalizationTabProps) => {
                           key={`default-locale-${idx}`}
                           value={locale}
                         >
-                          {localeToDisplayName(locale)}
+                          {localeToDisplayName(locale, whoAmI.getLocale())}
                         </SelectOption>
                       ))}
                     </Select>
@@ -565,9 +568,15 @@ export const LocalizationTab = ({ save, realm }: LocalizationTabProps) => {
                     }}
                     selections={
                       selectMenuValueSelected
-                        ? localeToDisplayName(selectMenuLocale)
+                        ? localeToDisplayName(
+                            selectMenuLocale,
+                            whoAmI.getLocale(),
+                          )
                         : realm.defaultLocale !== ""
-                          ? localeToDisplayName(DEFAULT_LOCALE)
+                          ? localeToDisplayName(
+                              DEFAULT_LOCALE,
+                              whoAmI.getLocale(),
+                            )
                           : t("placeholderText")
                     }
                   >


### PR DESCRIPTION
when picking you own locale this makes sense
but when configuring a realm for others it does not
changing it so that language names are in the users language

fixes: #24611
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
