### PR TITLE
fix: corrects the db property handling and null mapped values

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -60,13 +60,11 @@ final class DatabasePropertyMappers {
                         .build(),
                 fromOption(DatabaseOptions.DB_USERNAME)
                         .to("quarkus.datasource.username")
-                        .mapFrom("db")
                         .transformer(DatabasePropertyMappers::resolveUsername)
                         .paramLabel("username")
                         .build(),
                 fromOption(DatabaseOptions.DB_PASSWORD)
                         .to("quarkus.datasource.password")
-                        .mapFrom("db")
                         .transformer(DatabasePropertyMappers::resolvePassword)
                         .paramLabel("password")
                         .isMasked(true)
@@ -137,7 +135,7 @@ final class DatabasePropertyMappers {
             return of("sa");
         }
 
-        return Database.getDatabaseKind(value.get()).isEmpty() ? value : null;
+        return value;
     }
 
     private static Optional<String> resolvePassword(Optional<String> value, ConfigSourceInterceptorContext context) {
@@ -145,7 +143,7 @@ final class DatabasePropertyMappers {
             return of("password");
         }
 
-        return Database.getDatabaseKind(value.get()).isEmpty() ? value : null;
+        return value;
     }
 
     private static boolean isDevModeDatabase(ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -18,7 +18,6 @@
 package org.keycloak.quarkus.runtime.configuration.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.quarkus.runtime.Environment.isWindows;
 import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.CLI_ARGS;
@@ -293,6 +292,8 @@ public class ConfigurationTest {
         System.setProperty(CLI_ARGS, "--db=dev-mem" + ARG_SEPARATOR + "--db-username=other");
         config = createConfig();
         assertEquals("sa", config.getConfigValue("quarkus.datasource.username").getValue());
+        // should be untransformed
+        assertEquals("other", config.getConfigValue("kc.db-username").getValue());
 
         System.setProperty(CLI_ARGS, "--db=postgres" + ARG_SEPARATOR + "--db-username=other");
         config = createConfig();
@@ -300,17 +301,20 @@ public class ConfigurationTest {
 
         System.setProperty(CLI_ARGS, "--db=postgres");
         config = createConfig();
+        // username should not be set, either as the quarkus or kc property
         assertEquals(null, config.getConfigValue("quarkus.datasource.username").getValue());
+        assertEquals(null, config.getConfigValue("kc.db-username").getValue());
     }
 
     @Test
     public void testDatabaseKindProperties() {
-        System.setProperty(CLI_ARGS, "--db=postgres" + ARG_SEPARATOR + "--db-url=jdbc:postgresql://localhost/keycloak");
+        System.setProperty(CLI_ARGS, "--db=postgres" + ARG_SEPARATOR + "--db-url=jdbc:postgresql://localhost/keycloak" + ARG_SEPARATOR + "--db-username=postgres");
         SmallRyeConfig config = createConfig();
         assertEquals("org.hibernate.dialect.PostgreSQLDialect",
             config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:postgresql://localhost/keycloak", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("postgresql", config.getConfigValue("quarkus.datasource.db-kind").getValue());
+        assertEquals("postgres", config.getConfigValue("quarkus.datasource.username").getValue());
     }
 
     @Test


### PR DESCRIPTION
The issue seems to be triggered by having the db username match one of the database kinds - that will cause the mapper to return null, and we'll get the NPE in the calling logic.  The two changes here are to prevent the npe, and the other is to remove the  logic checking for a db kind from the username and password mappers.

@vmuzikar this will need to be backported as well

cc @pedroigor 

closes #25010

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
