### PR TITLE
fix: added PATCH and PUT methods to get FormBodyHandler

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/KeycloakHandlerChainCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/KeycloakHandlerChainCustomizer.java
@@ -17,7 +17,9 @@
 
 package org.keycloak.quarkus.runtime.integration.resteasy;
 
+import static jakarta.ws.rs.HttpMethod.PATCH;
 import static jakarta.ws.rs.HttpMethod.POST;
+import static jakarta.ws.rs.HttpMethod.PUT;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,7 +53,10 @@ public final class KeycloakHandlerChainCustomizer implements HandlerChainCustomi
 
         switch (phase) {
             case BEFORE_METHOD_INVOKE:
-                if (POST.equalsIgnoreCase(resourceMethod.getHttpMethod())) {
+                if (!resourceMethod.isFormParamRequired() && 
+                    (PATCH.equalsIgnoreCase(resourceMethod.getHttpMethod()) ||
+                     POST.equalsIgnoreCase(resourceMethod.getHttpMethod()) ||
+                     PUT.equalsIgnoreCase(resourceMethod.getHttpMethod()))) {
                     handlers.add(formBodyHandler);
                 }
                 handlers.add(TRANSACTIONAL_SESSION_HANDLER);


### PR DESCRIPTION
Fixes the issue of `PATCH` and `PUT` methods not getting a `FormBodyHandler` that was introduced in the transition to Resteasy Reactive. While the core Keycloak code only uses `POST` methods in processing `multipart/form-data`, REST extensions may use `PATCH` and `PUT`. This fix enables that.

cc @pedroigor @rmartinc 
closes #24986
