### PR TITLE
External to Internal Token exchange fails with Null pointer Exception…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -588,7 +588,7 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
 
             if (! context.getIdpConfig().isTransientUsers()) {
                 FederatedIdentityModel federatedIdentityModel = new FederatedIdentityModel(context.getIdpConfig().getAlias(), context.getId(),
-                        context.getUsername(), context.getToken());
+                        context.getModelUsername(), context.getToken());
                 session.users().addFederatedIdentity(realm, user, federatedIdentityModel);
             }
 


### PR DESCRIPTION
… if the user is not yet registered (first time token exchange)

Closes #16059

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
