### PR TITLE
Allow duplicated keys in the HardcodedKeyLocator

### DIFF
--- a/saml-core/src/main/java/org/keycloak/rotation/HardcodedKeyLocator.java
+++ b/saml-core/src/main/java/org/keycloak/rotation/HardcodedKeyLocator.java
@@ -46,14 +46,14 @@ public class HardcodedKeyLocator implements KeyLocator, Iterable<Key> {
         Objects.requireNonNull(keys, "Keys must not be null");
         this.byName = Collections.emptyMap();
         this.byKey = Collections.unmodifiableMap(keys.stream().collect(
-                Collectors.toMap(k -> new KeyHash(k), k -> k)));
+                Collectors.toMap(k -> new KeyHash(k), k -> k, (k1, k2) -> k1)));
     }
 
     public HardcodedKeyLocator(Map<String, ? extends Key> keys) {
         Objects.requireNonNull(keys, "Keys must not be null");
         this.byName = Collections.unmodifiableMap(keys);
         this.byKey = Collections.unmodifiableMap(keys.values().stream().collect(
-                Collectors.toMap(k -> new KeyHash(k), k -> k)));
+                Collectors.toMap(k -> new KeyHash(k), k -> k, (k1, k2) -> k1)));
     }
 
     @Override

--- a/saml-core/src/test/java/org/keycloak/rotation/HardcodedKeyLocatorTest.java
+++ b/saml-core/src/test/java/org/keycloak/rotation/HardcodedKeyLocatorTest.java
@@ -139,4 +139,13 @@ public class HardcodedKeyLocatorTest {
         Assert.assertNotNull(found);
         Assert.assertEquals(cert1.getPublicKey(), found);
     }
+
+    @Test
+    public void testDuplicateKey() throws Exception {
+        KeyLocator locator = createLocatorWithoutName(cert1, cert1);
+        KeyInfo info = XMLSignatureUtil.createKeyInfo(null, null, cert1);
+        Key found = locator.getKey(info);
+        Assert.assertNotNull(found);
+        Assert.assertEquals(cert1.getPublicKey(), found);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/24961
Backport to 22.0 of https://github.com/keycloak/keycloak/pull/24978
Cherry pick of e17295d04acb8d0c3c8e7f3cd18c832b3b555855
