### PR TITLE
Remove lowercase for the hostname as recommended/advised by OAuth spec

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-23_0_2.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-23_0_2.adoc
@@ -1,0 +1,7 @@
+= Valid redirect URIs for clients are always compared with exact string matching
+
+Version 1.8.0 introduced a lower-case for the hostname and scheme when comparing a redirect URI with the specified valid redirects for a client. Unfortunately it did not fully work in all the protocols, and, for example, the host was lower-cased for `http` but not for `https`. As https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-protecting-redirect-based-f[OAuth 2.0 Security Best Current Practice] advises to compare URIs using exact string matching, {project_name} will follow the recommendation and for now on valid redirects are compared with exact case even for the hostname and scheme.
+
+For realms relying on the old behavior, the valid redirect URIs for their clients should now hold separate entries for each URI that should be recognized by the server.
+
+Although it introduces more steps and verbosity when configuring clients, the new behavior enables more secure deployments as pattern-based checks are frequently the cause of security issues. Not only due to how they are implemented but also how they are configured.

--- a/docs/documentation/upgrading/topics/keycloak/changes.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes.adoc
@@ -1,5 +1,9 @@
 == Migration Changes
 
+=== Migrating to 23.0.2
+
+include::changes-23_0_2.adoc[leveloffset=3]
+
 === Migrating to 23.0.0
 
 include::changes-23_0_0.adoc[leveloffset=3]

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -72,8 +72,10 @@ public class RedirectUtils {
             if (validRedirect.startsWith("/")) {
                 validRedirect = relativeToAbsoluteURI(session, rootUrl, validRedirect);
                 logger.debugv("replacing relative valid redirect with: {0}", validRedirect);
+                resolveValidRedirects.add(validRedirect);
+            } else {
+                resolveValidRedirects.add(validRedirect);
             }
-            resolveValidRedirects.add(lowerCaseHostname(validRedirect));
         }
         return resolveValidRedirects;
     }
@@ -114,7 +116,7 @@ public class RedirectUtils {
             // Make the validations against fully decoded and normalized redirect-url. This also allows wildcards (case when client configured "Valid redirect-urls" contain wildcards)
             String decodedRedirectUri = decodeRedirectUri(redirectUri);
             URI decodedRedirect = toUri(decodedRedirectUri);
-            decodedRedirectUri = getNormalizedRedirectUri(decodedRedirect, true);
+            decodedRedirectUri = getNormalizedRedirectUri(decodedRedirect);
             if (decodedRedirectUri == null) return null;
 
             String r = decodedRedirectUri;
@@ -139,25 +141,21 @@ public class RedirectUtils {
             }
 
             // Return the original redirectUri, which can be partially encoded - for example http://localhost:8280/foo/bar%20bar%2092%2F72/3 . Just make sure it is normalized
-            redirectUri = getNormalizedRedirectUri(originalRedirect, false);
+            redirectUri = getNormalizedRedirectUri(originalRedirect);
 
             // We try to check validity also for original (encoded) redirectUrl, but just in case it exactly matches some "Valid Redirect URL" specified for client (not wildcards allowed)
             if (valid == null) {
                 valid = matchesRedirects(resolveValidRedirects, redirectUri, false);
             }
 
-            if (valid != null && !originalRedirect.isAbsolute()) {
-                // return absolute if the original URI is relative
-                if (!redirectUri.startsWith("/")) {
-                    redirectUri = "/" + redirectUri;
-                }
+            if (valid != null && redirectUri.startsWith("/")) {
                 redirectUri = relativeToAbsoluteURI(session, rootUrl, redirectUri);
             }
 
             String scheme = decodedRedirect.getScheme();
             if (valid != null && scheme != null) {
                 // check the scheme is valid, it should be http(s) or explicitly allowed by the validation
-                if (!valid.startsWith(scheme.toLowerCase() + ":") && !"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+                if (!valid.startsWith(scheme + ":") && !"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
                     logger.debugf("Invalid URI because scheme is not allowed: %s", redirectUri);
                     valid = null;
                 }
@@ -176,7 +174,7 @@ public class RedirectUtils {
     private static URI toUri(String redirectUri) {
         URI uri = null;
         if (redirectUri != null) {
-            try {
+        try {
                 uri = URI.create(redirectUri);
             } catch (IllegalArgumentException cause) {
                 logger.debug("Invalid redirect uri", cause);
@@ -187,13 +185,11 @@ public class RedirectUtils {
         return uri;
     }
 
-    private static String getNormalizedRedirectUri(URI uri, boolean lower) {
+    private static String getNormalizedRedirectUri(URI uri) {
         String redirectUri = null;
         if (uri != null) {
             redirectUri = uri.normalize().toString();
-            if (lower) {
-                redirectUri = lowerCaseHostname(redirectUri);
-            }
+            redirectUri = lowerCaseHostname(redirectUri);
         }
         return redirectUri;
     }
@@ -208,11 +204,9 @@ public class RedirectUtils {
             KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(redirectUri, false).preserveDefaultPort();
             String origQuery = uriBuilder.getQuery();
             String origFragment = uriBuilder.getFragment();
-            String origUserInfo = uriBuilder.getUserInfo();
             String encodedRedirectUri = uriBuilder
                     .replaceQuery(null)
                     .fragment(null)
-                    .userInfo(null)
                     .buildAsString();
             String decodedRedirectUri = null;
 
@@ -223,7 +217,6 @@ public class RedirectUtils {
                     return KeycloakUriBuilder.fromUri(decodedRedirectUri, false).preserveDefaultPort()
                             .replaceQuery(origQuery)
                             .fragment(origFragment)
-                            .userInfo(origUserInfo)
                             .buildAsString();
                 } else {
                     // Next attempt
@@ -238,15 +231,12 @@ public class RedirectUtils {
     }
 
     private static String lowerCaseHostname(String redirectUri) {
-        // lower case host and scheme which are case-insensitive by spec
-        KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(redirectUri, false).preserveDefaultPort();
-        if (uriBuilder.getScheme() != null) {
-            uriBuilder.scheme(uriBuilder.getScheme().toLowerCase());
+        int n = redirectUri.indexOf('/', 7);
+        if (n == -1) {
+            return redirectUri.toLowerCase();
+        } else {
+            return redirectUri.substring(0, n).toLowerCase() + redirectUri.substring(n);
         }
-        if (uriBuilder.getHost() != null) {
-            uriBuilder.host(uriBuilder.getHost().toLowerCase());
-        }
-        return uriBuilder.buildAsString();
     }
 
     private static String relativeToAbsoluteURI(KeycloakSession session, String rootUrl, String relative) {

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -142,4 +142,36 @@ public class RedirectUtilsTest {
         Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/path<less/", set, false));
         Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/path/index.jsp?param=v1 v2", set, false));
     }
+
+    @Test
+    // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-protecting-redirect-based-f
+    // OAuth recommends/advises exact matching string comparison for URIs
+    public void testverifyCaseIsSensitive() {
+        Set<String> set = Stream.of(
+                "https://keycloak.org/*",
+                "http://KeyCloak.org/*",
+                "no.host.Name.App:/Test"
+        ).collect(Collectors.toSet());
+
+        Assert.assertEquals("https://keycloak.org/index.html", RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/index.html", set, false));
+        Assert.assertEquals("http://KeyCloak.org/index.html", RedirectUtils.verifyRedirectUri(session, null, "http://KeyCloak.org/index.html", set, false));
+        Assert.assertEquals("no.host.Name.App:/Test", RedirectUtils.verifyRedirectUri(session, null, "no.host.Name.App:/Test", set, false));
+
+        Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://KeyCloak.org/index.html", set, false));
+        Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "http://keycloak.org/index.html", set, false));
+        Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "HTTPS://keycloak.org/index.html", set, false));
+        Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "no.host.Name.app:/Test", set, false));
+        Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "no.host.Name.App:/test", set, false));
+    }
+
+    @Test
+    public void testRelativeRedirectUri() {
+        Set<String> set = Stream.of(
+                "*"
+        ).collect(Collectors.toSet());
+
+        Assert.assertEquals("https://keycloak.org/path", RedirectUtils.verifyRedirectUri(session, "https://keycloak.org", "/path", set, false));
+        Assert.assertEquals("https://keycloak.org/path", RedirectUtils.verifyRedirectUri(session, "https://keycloak.org", "path", set, false));
+    }
+
 }

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -142,36 +142,4 @@ public class RedirectUtilsTest {
         Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/path<less/", set, false));
         Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, "https://keycloak.org/path/index.jsp?param=v1 v2", set, false));
     }
-
-    @Test
-    public void testRelativeRedirectUri() {
-        Set<String> set = Stream.of(
-                "*"
-        ).collect(Collectors.toSet());
-
-        Assert.assertEquals("https://keycloak.org/path", RedirectUtils.verifyRedirectUri(session, "https://keycloak.org", "/path", set, false));
-        Assert.assertEquals("https://keycloak.org/path", RedirectUtils.verifyRedirectUri(session, "https://keycloak.org", "path", set, false));
-    }
-
-    @Test
-    public void testVerifyDifferentCase() {
-        Set<String> set = Stream.of(
-                "no.host.Name.App://TEST",
-                "no.host.Name.App:/Path/*",
-                "HTTPS://KeyCloak.org/*",
-                "HTTP://KeyCloak.org/with%20space/*",
-                "HTTP://KeyCloak.org/áéíóú",
-                "custom:*"
-        ).collect(Collectors.toSet());
-
-        Assert.assertEquals("no.host.Name.App://test", RedirectUtils.verifyRedirectUri(session, null, "no.host.Name.App://test", set, false));
-        Assert.assertEquals("no.host.name.app://Test", RedirectUtils.verifyRedirectUri(session, null, "no.host.name.app://Test", set, false));
-        Assert.assertEquals("no.host.name.app:/Path", RedirectUtils.verifyRedirectUri(session, null, "no.host.name.app:/Path", set, false));
-        Assert.assertEquals("https://KEYCLOAK.ORG/Test", RedirectUtils.verifyRedirectUri(session, null, "https://KEYCLOAK.ORG/Test", set, false));
-        Assert.assertEquals("https://KEYCLOAK.ORG", RedirectUtils.verifyRedirectUri(session, null, "https://KEYCLOAK.ORG", set, false));
-        Assert.assertEquals("CUSTOM:test", RedirectUtils.verifyRedirectUri(session, null, "CUSTOM:test", set, false));
-        Assert.assertEquals("Custom://userInfo@KeyCLOAK.org/Path", RedirectUtils.verifyRedirectUri(session, null, "Custom://userInfo@KeyCLOAK.org/Path", set, false));
-        Assert.assertEquals("Custom://user%20Info@keycloak.ORG", RedirectUtils.verifyRedirectUri(session, null, "Custom://user%20Info@keycloak.ORG", set, false));
-        Assert.assertEquals("http://keycloak.org/áéíóú", RedirectUtils.verifyRedirectUri(session, null, "http://keycloak.org/áéíóú", set, false));
-    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
@@ -382,11 +382,11 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
         oauth.clientId("test-dash");
 
         checkRedirectUri("http://with-dash.example.local", true);
-        checkRedirectUri("http://wiTh-dAsh.example.local", true);
+        checkRedirectUri("http://wiTh-dAsh.example.local", false);
         checkRedirectUri("http://with-dash.example.local/foo", true);
-        checkRedirectUri("http://wiTh-dAsh.example.local/foo", true);
+        checkRedirectUri("http://wiTh-dAsh.example.local/foo", false);
         checkRedirectUri("http://with-dash.example.local/foo", true);
-        checkRedirectUri("http://wiTh-dAsh.example.local/foo", true);
+        checkRedirectUri("http://wiTh-dAsh.example.local/foo", false);
         checkRedirectUri("http://wiTh-dAsh.example.local/Foo", false);
         checkRedirectUri("http://wiTh-dAsh.example.local/foO", false);
     }
@@ -395,8 +395,9 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
     public void testDifferentCaseInScheme() throws IOException {
         oauth.clientId("test-dash");
 
-        checkRedirectUri("HTTP://with-dash.example.local", true);
-        checkRedirectUri("Http://wiTh-dAsh.example.local", true);
+        checkRedirectUri("http://with-dash.example.local", true);
+        checkRedirectUri("HTTP://with-dash.example.local", false);
+        checkRedirectUri("Http://wiTh-dAsh.example.local", false);
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/25001
Backport to 23 of: https://github.com/keycloak/keycloak/pull/25115
Plain cherrypick for the two commits: b6cdcb3c27d5db5562a24a15b40f50a1043313bb and 3bc028fe2d4aa2477d227365dd270a999bd50c44
