### PR TITLE
doc: adding a note about config expressions

### DIFF
--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -143,9 +143,16 @@ You can use only a https://github.com/keycloak/keycloak/blob/main/quarkus/runtim
 
 . Use the `[-cf|--config-file]` command line parameter to include that file.
 
-Similarly, you can also store Quarkus properies in a Java KeyStore.
+Similarly, you can also store Quarkus properties in a Java KeyStore.
 
 Note that some Quarkus properties are already mapped in the {project_name} configuration, such as `quarkus.http.port` and similar essential properties. If the property is used by Keycloak, defining that property key in `quarkus.properties` has no effect. The Keycloak configuration value takes precedence over the Quarkus property value.
+
+=== Using special characters in values
+
+Keycloak depends upon Quarkus / MicroProfile for processing configuration values. Be aware that value expressions are supported - for example `$\{some_key}`, will evaluate to the value of some_key.
+
+To disable expression evaluation, the `\` character is used as an escape character. In particular it must be used to escape the usage of `$` characters when they appear to define a expression or are repeated. For example if you want the configuration value `my$$password`, use `my\$\$password` instead.  Note that the `\` character requires additional escaping or quoting when using most unix shells, or when it appears in properties files.  
+For example bash single quotes will preserve the single backslash `--db-password='my\$\$password'`, or with bash double quotes you will need an additional backslash `--db-password="my\\$\\$password"`. Similarly in a properties file backslash characters must themselves be escaped: `kc.db-password=my\\$\\$password`
 
 == Starting {project_name}
 You can start {project_name} in `development mode` or `production mode`. Each mode offers different defaults for the intended environment.

--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -149,10 +149,10 @@ Note that some Quarkus properties are already mapped in the {project_name} confi
 
 === Using special characters in values
 
-Keycloak depends upon Quarkus / MicroProfile for processing configuration values. Be aware that value expressions are supported - for example `$\{some_key}`, will evaluate to the value of some_key.
+{project_name} depends upon Quarkus and MicroProfile for processing configuration values. Be aware that value expressions are supported. For example, `$\{some_key}` evaluates to the value of `some_key`.
 
-To disable expression evaluation, the `\` character is used as an escape character. In particular it must be used to escape the usage of `$` characters when they appear to define a expression or are repeated. For example if you want the configuration value `my$$password`, use `my\$\$password` instead.  Note that the `\` character requires additional escaping or quoting when using most unix shells, or when it appears in properties files.  
-For example bash single quotes will preserve the single backslash `--db-password='my\$\$password'`, or with bash double quotes you will need an additional backslash `--db-password="my\\$\\$password"`. Similarly in a properties file backslash characters must themselves be escaped: `kc.db-password=my\\$\\$password`
+To disable expression evaluation, the `\` character functions as an escape character. In particular, it must be used to escape the usage of `$` characters when they appear to define an expression or are repeated. For example, if you want the configuration value `my$$password`, use `my\$\$password` instead.  Note that the `\` character requires additional escaping or quoting when using most unix shells, or when it appears in properties files.
+For example, bash single quotes preserve the single backslash `--db-password='my\$\$password'`. Also, with bash double quotes, you need an additional backslash `--db-password="my\\$\\$password"`. Similarly in a properties file, backslash characters must also be escaped: `kc.db-password=my\\$\\$password`
 
 == Starting {project_name}
 You can start {project_name} in `development mode` or `production mode`. Each mode offers different defaults for the intended environment.


### PR DESCRIPTION
I'm not sure if there's even more nuance to express here as some locations we may specifically look at the raw values instead.

There hasn't been any follow up on https://github.com/smallrye/smallrye-config/issues/1056 to know if the $$ behavior is expected.

fix: #19831

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
