### PR TITLE
Add PatternFly 5 to the 'common' Keycloak theme

### DIFF
--- a/themes/src/main/resources/theme/keycloak/common/resources/package.json
+++ b/themes/src/main/resources/theme/keycloak/common/resources/package.json
@@ -6,6 +6,7 @@
     "build:clean": "shx rm -rf vendor"
   },
   "dependencies": {
+    "@patternfly-v5/patternfly": "npm:@patternfly/patternfly@^5.1.0",
     "@patternfly/patternfly": "^4.224.5",
     "@patternfly/react-core": "^4.278.1",
     "jquery": "^3.7.1",

--- a/themes/src/main/resources/theme/keycloak/common/resources/pnpm-lock.yaml
+++ b/themes/src/main/resources/theme/keycloak/common/resources/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@patternfly-v5/patternfly':
+    specifier: npm:@patternfly/patternfly@^5.1.0
+    version: /@patternfly/patternfly@5.1.0
   '@patternfly/patternfly':
     specifier: ^4.224.5
     version: 4.224.5
@@ -85,6 +88,10 @@ packages:
 
   /@patternfly/patternfly@4.224.5:
     resolution: {integrity: sha512-io0huj+LCP5FgDZJDaLv1snxktTYs8iCFz/W1VDRneYoebNHLmGfQdF7Yn8bS6PF7qmN6oJKEBlq3AjmmE8vdA==}
+    dev: false
+
+  /@patternfly/patternfly@5.1.0:
+    resolution: {integrity: sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA==}
     dev: false
 
   /@patternfly/react-core@4.278.1(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
Adds PatternFly 5 to the dependencies of the 'common' Keycloak theme, so it can be included by other themes in the future. The dependency is aliased under `@patternfly-v5`, so that it can co-exist with PatternFly 4 until we are ready to move away from v4.