### PR TITLE
Retrieve ClientConnection by invoking getConnection() instead of getContextObject()

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/AbstractCibaEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/AbstractCibaEndpoint.java
@@ -67,7 +67,7 @@ public abstract class AbstractCibaEndpoint {
     }
 
     protected void checkSsl() {
-        ClientConnection clientConnection = session.getContext().getContextObject(ClientConnection.class);
+        ClientConnection clientConnection = session.getContext().getConnection();
         RealmModel realm = session.getContext().getRealm();
 
         if (!session.getContext().getUri().getBaseUri().getScheme().equals("https") && realm.getSslRequired().isRequired(clientConnection)) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/AbstractParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/AbstractParEndpoint.java
@@ -48,7 +48,7 @@ public abstract class AbstractParEndpoint {
     }
 
     protected void checkSsl() {
-        ClientConnection clientConnection = session.getContext().getContextObject(ClientConnection.class);
+        ClientConnection clientConnection = session.getContext().getConnection();
 
         if (!session.getContext().getUri().getBaseUri().getScheme().equals("https") && realm.getSslRequired().isRequired(clientConnection)) {
             throw new CorsErrorResponseException(cors.allowAllOrigins(), OAuthErrorException.INVALID_REQUEST, "HTTPS required", Response.Status.FORBIDDEN);


### PR DESCRIPTION
Fixes #25231