### PR TITLE
Change arg of getSubGroups to briefRepresentation

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-23_0_3.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-23_0_3.adoc
@@ -1,0 +1,3 @@
+= Fix handling of Groups.getSubGroups briefRepresentation parameter
+
+Version 23.0.0 introduced a new endpoint getSubGroups ("children") on the Groups resource, where the meaning of the parameter briefRepresentation meant the retrieval of full representations of the sub groups. The meaning is now changed to return the brief representation.

--- a/docs/documentation/upgrading/topics/keycloak/changes.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes.adoc
@@ -4,6 +4,10 @@
 
 include::changes-24_0_0.adoc[leveloffset=3]
 
+=== Migrating to 23.0.3
+
+include::changes-23_0_3.adoc[leveloffset=3]
+
 === Migrating to 23.0.2
 
 include::changes-23_0_2.adoc[leveloffset=3]

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -159,12 +159,12 @@ public class GroupResource {
     @Operation( summary = "Return a paginated list of subgroups that have a parent group corresponding to the group on the URL")
     public Stream<GroupRepresentation> getSubGroups(@QueryParam("first") @DefaultValue("0") Integer first,
         @QueryParam("max") @DefaultValue("10") Integer max,
-        @QueryParam("briefRepresentation") @DefaultValue("false") Boolean full) {
+        @QueryParam("briefRepresentation") @DefaultValue("false") Boolean briefRepresentation) {
         this.auth.groups().requireView(group);
         boolean canViewGlobal = auth.groups().canView();
         return group.getSubGroupsStream(first, max)
             .filter(g -> canViewGlobal || auth.groups().canView(g))
-            .map(g -> GroupUtils.populateSubGroupCount(g, GroupUtils.toRepresentation(auth.groups(), g, full)));
+            .map(g -> GroupUtils.populateSubGroupCount(g, GroupUtils.toRepresentation(auth.groups(), g, !briefRepresentation)));
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -1096,6 +1096,30 @@ public class GroupTest extends AbstractGroupTest {
     }
 
     @Test
+    public void getSubGroups() throws Exception {
+        RealmResource realm = adminClient.realms().realm("test");
+
+        GroupRepresentation parent = new GroupRepresentation();
+        parent.setName("parent");
+        parent = createGroup(realm, parent);
+
+        GroupRepresentation child = new GroupRepresentation();
+        child.setName("child");
+        Map<String, List<String>> attributes = new HashMap<String, List<String>>();
+        attributes.put("attribute1", Arrays.asList("value1", "value2"));
+        child.setAttributes(attributes);
+
+        addSubGroup(realm, parent, child);
+
+        // Check brief and full retrieval of subgroups of parent
+        boolean briefRepresentation = true;
+        assertNull(realm.groups().group(parent.getId()).getSubGroups(null, null, briefRepresentation).get(0).getAttributes());
+
+        briefRepresentation = false;
+        assertThat(realm.groups().group(parent.getId()).getSubGroups(null, null, briefRepresentation).get(0).getAttributes().get("attribute1"), containsInAnyOrder("value1", "value2"));
+    }
+
+    @Test
     public void searchAndCountGroups() throws Exception {
         String firstGroupId = "";
 


### PR DESCRIPTION
Parameter name briefRepresentation should be briefRepresentation, not full. This way callers will by default get the full representation unless true is passed as value for briefRepresentation.

Fixes #25096

Mistake introduced in 23.0.0 in commit https://github.com/keycloak/keycloak/commit/69497382d8cc6c622e815184d9bc27cb0dc6a400#diff-d233e82db465ac2b1ad22b124ab0bae3714f02d58c108c29afbbb935653d3ceaR162.

I could not find a place to add an integration test for testing the endpoint with an external caller. If such a test exists please point me to it and I will add it.