### PR TITLE
Re-enable Federated Access Token in user sessions

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -513,6 +513,7 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
 
         // this must exist so that we can obtain access token from user session if idp's store tokens is off
         userSession.setNote(IdentityProvider.EXTERNAL_IDENTITY_PROVIDER, externalIdpModel.get().getAlias());
+        userSession.setNote(IdentityProvider.FEDERATED_ACCESS_TOKEN, subjectToken);
 
         context.addSessionNotesToUserSession(userSession);
 


### PR DESCRIPTION
Closes #25290

Reference run after: https://master-jenkins.com/job/universal-test-pipeline-server/3346/testReport/

Reference run before: https://master-jenkins.com/job/universal-test-pipeline-server/3343/testReport/org.keycloak.testsuite.broker/SocialLoginTest/


