### PR TITLE
Workaround to allow percent chars in getGroupByPath via PathSegment

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -716,6 +716,23 @@ public final class KeycloakModelUtils {
         return getGroupModel(session.groups(), realm, null, split, 0);
     }
 
+    /**
+     * Finds group by path. Variant when you have the path already separated by
+     * group names.
+     *
+     * @param session Keycloak session
+     * @param realm The realm
+     * @param path Path The path hierarchy of groups
+     *
+     * @return {@code GroupModel} corresponding to the given {@code path} or {@code null} if no group was found
+     */
+    public static GroupModel findGroupByPath(KeycloakSession session, RealmModel realm, String[] path) {
+        if (path == null || path.length == 0) {
+            return null;
+        }
+        return getGroupModel(session.groups(), realm, null, path, 0);
+    }
+
     private static GroupModel getGroupModel(GroupProvider groupProvider, RealmModel realm, GroupModel parent, String[] split, int index) {
         StringBuilder nameBuilder = new StringBuilder();
         for (int i = index; i < split.length; i++) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -49,6 +49,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
@@ -1080,7 +1081,8 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
     @Operation()
-    public GroupRepresentation getGroupByPath(@PathParam("path") String path) {
+    public GroupRepresentation getGroupByPath(@PathParam("path") List<PathSegment> pathSegments) {
+        String[] path = pathSegments.stream().map(PathSegment::getPath).toArray(String[]::new);
         GroupModel found = KeycloakModelUtils.findGroupByPath(session, realm, path);
         if (found == null) {
             throw new NotFoundException("Group path does not exist");


### PR DESCRIPTION
Closes #25111

Just using `PathSegment` instead of normal `PathParam`. Note this is a workaround to fix resteasy-reactive issue https://github.com/quarkusio/quarkus/issues/35960. The fix is already merged in quarkus main. If it's backported to 3.2.x this PR is not needed, except the test, having it would be nice to avoid the issue to reappear. So sending the PR just in case. I'm setting the hold label to merge it by mistake.