### PR TITLE
Make sure realm is available from session when migrating to 23

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo23_0_0.java
+++ b/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo23_0_0.java
@@ -25,6 +25,7 @@ import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlow;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.migration.ModelVersion;
+import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -43,7 +44,16 @@ public class MigrateTo23_0_0 implements Migration {
 
     @Override
     public void migrate(KeycloakSession session) {
-        session.realms().getRealmsStream().forEach(this::migrateRealm);
+        session.realms().getRealmsStream().forEach(realm -> {
+            KeycloakContext context = session.getContext();
+
+            try {
+                context.setRealm(realm);
+                migrateRealm(realm);
+            } finally {
+                context.setRealm(null);
+            }
+        });
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -67,6 +67,7 @@ import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.ProtocolMapperModel;
@@ -121,7 +122,13 @@ public class RepresentationToModel {
 
 
     public static void importRealm(KeycloakSession session, RealmRepresentation rep, RealmModel newRealm, boolean skipUserDependent) {
-        session.getProvider(DatastoreProvider.class).getExportImportManager().importRealm(rep, newRealm, skipUserDependent);
+        KeycloakContext context = session.getContext();
+        try {
+            context.setRealm(newRealm);
+            session.getProvider(DatastoreProvider.class).getExportImportManager().importRealm(rep, newRealm, skipUserDependent);
+        } finally {
+            context.setRealm(null);
+        }
     }
 
     public static void importRoles(RolesRepresentation realmRoles, RealmModel realm) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -31,6 +31,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,7 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 import org.keycloak.common.crypto.FipsMode;
 import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.model.StoreProvider;
+import org.keycloak.utils.StringUtil;
 
 public abstract class AbstractQuarkusDeployableContainer implements DeployableContainer<KeycloakQuarkusConfiguration> {
 
@@ -206,8 +208,37 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         }
 
         addStorageOptions(storeProvider, commands);
+        addFeaturesOption(commands);
 
         return commands;
+    }
+
+    protected void addFeaturesOption(List<String> commands) {
+        String defaultFeatures = configuration.getDefaultFeatures();
+
+        if (StringUtil.isBlank(defaultFeatures)) {
+            return;
+        }
+
+        if (commands.stream().anyMatch(List.of("import", "export")::contains)) {
+            return;
+        }
+
+        StringBuilder featuresOption = new StringBuilder("--features=").append(defaultFeatures);
+        Iterator<String> iterator = commands.iterator();
+
+        while (iterator.hasNext()) {
+            String command = iterator.next();
+
+            if (command.startsWith("--features")) {
+                featuresOption = new StringBuilder(command);
+                featuresOption.append(",").append(defaultFeatures);
+                iterator.remove();
+                break;
+            }
+        }
+
+        commands.add(featuresOption.toString());
     }
 
     protected List<String> configureArgs(List<String> commands) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusConfiguration.java
@@ -47,6 +47,8 @@ public class KeycloakQuarkusConfiguration implements ContainerConfiguration {
 
     private FipsMode fipsMode = FipsMode.valueOfOption(System.getProperty("auth.server.fips.mode"));
 
+    private String defaultFeatures;
+
     @Override
     public void validate() throws ConfigurationException {
         int basePort = getBindHttpPort();
@@ -228,5 +230,13 @@ public class KeycloakQuarkusConfiguration implements ContainerConfiguration {
 
     public void setFipsMode(FipsMode fipsMode) {
         this.fipsMode = fipsMode;
+    }
+
+    public void setDefaultFeatures(String defaultFeatures) {
+        this.defaultFeatures = defaultFeatures;
+    }
+
+    public String getDefaultFeatures() {
+        return defaultFeatures;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -73,6 +73,7 @@ public class KeycloakQuarkusServerDeployableContainer extends AbstractQuarkusDep
         commands.add(getCommand());
         commands.add("-v");
         commands.add(command);
+        addFeaturesOption(commands);
         if (args != null) {
             commands.addAll(Arrays.asList(args));
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -649,6 +649,7 @@
             <property name="javaOpts">-Xms512m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m
                 -Djava.net.preferIPv4Stack=true -Dauth.server.db.host=some
             </property>
+            <property name="defaultFeatures">${auth.server.feature}</property>
         </configuration>
     </container>
 

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1534,6 +1534,8 @@
                                     <auth.server.migration>true</auth.server.migration>
                                     <keycloak.migration.home>${containers.home}/auth-server-migration</keycloak.migration.home>
                                     <migration.import.props.previous>${migration.import.props.previous}</migration.import.props.previous>
+                                    <auth.server.feature>${auth.server.feature}</auth.server.feature>
+                                    <auth.server.feature>declarative-user-profile</auth.server.feature>
                                 </systemPropertyVariables>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
* Make sure migration runs within the context of a realm so that components can validate their configuration based on realm settings and data
* Make sure import runs within the context of a realm so that components can validate their configuration based on realm settings and data
* Allow enabling features when running migration tests and run the migration test on the current version with `declarative-user-profile` enabled

As we don't have the issue herein fixed in previous versions (the first two above) we can't run the migration server itself with the feature enabled.

Closes #25183

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
