### PR TITLE
Removing unnecessary property from auth-server-migration maven profile

### DIFF
--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1534,7 +1534,6 @@
                                     <auth.server.migration>true</auth.server.migration>
                                     <keycloak.migration.home>${containers.home}/auth-server-migration</keycloak.migration.home>
                                     <migration.import.props.previous>${migration.import.props.previous}</migration.import.props.previous>
-                                    <auth.server.feature>${auth.server.feature}</auth.server.feature>
                                     <auth.server.feature>declarative-user-profile</auth.server.feature>
                                 </systemPropertyVariables>
                             </configuration>


### PR DESCRIPTION
See https://github.com/keycloak/keycloak/pull/25325#discussion_r1417123890.