### PR TITLE
Fix brute force wait time increment and quick login check

### DIFF
--- a/docs/documentation/server_admin/topics/threat/brute-force.adoc
+++ b/docs/documentation/server_admin/topics/threat/brute-force.adoc
@@ -87,8 +87,8 @@ When {project_name} disables a user, the user cannot log in until an administrat
 .. If the time between this failure and the last failure is greater than _Failure Reset Time_
 ... Reset `count`
 .. Increment `count`
-.. Calculate `wait` using _Wait Increment_ * (`count` / _Max Login Failures_). The division is an integer division rounded down to a whole number
-.. If `wait` equals 0 and the time between this failure and the last failure is less than _Quick Login Check Milliseconds_, set `wait` to _Minimum Quick Login Wait_.
+.. Calculate `wait` using _Wait Increment_ * (1 + `count` - _Max Login Failures_). The division is an integer division rounded down to a whole number
+.. If `wait` are less or equals 0 and the time between this failure and the last failure is less than _Quick Login Check Milliseconds_, set `wait` to _Minimum Quick Login Wait_.
 ... Temporarily disable the user for the smallest of `wait` and _Max Wait_ seconds
 
 `count` does not increment when a temporarily disabled account commits a login failure.

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -204,11 +204,11 @@ public class DefaultBruteForceProtector implements Runnable, BruteForceProtector
         userLoginFailure.incrementFailures();
         logger.debugv("new num failures: {0}", userLoginFailure.getNumFailures());
 
-        int waitSeconds = realm.getWaitIncrementSeconds() *  (userLoginFailure.getNumFailures() / realm.getFailureFactor());
+        int waitSeconds = realm.getWaitIncrementSeconds() * (1 + userLoginFailure.getNumFailures() - realm.getFailureFactor());
         logger.debugv("waitSeconds: {0}", waitSeconds);
         logger.debugv("deltaTime: {0}", deltaTime);
 
-        if (waitSeconds == 0) {
+        if (waitSeconds <= 0) {
             if (last > 0 && deltaTime < realm.getQuickLoginCheckMilliSeconds()) {
                 logger.debugv("quick login, set min wait seconds");
                 waitSeconds = realm.getMinimumQuickLoginWaitSeconds();


### PR DESCRIPTION
Currently the increase in waiting time is not occurring due to an error in the formula. That  also impacts check of quick login

closes #20353

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
