### PR TITLE
fix: use name to find the admin secret

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/Utils.java
+++ b/operator/src/main/java/org/keycloak/operator/Utils.java
@@ -19,6 +19,11 @@ package org.keycloak.operator;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
@@ -27,6 +32,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -61,6 +68,13 @@ public final class Utils {
         var labels = new LinkedHashMap<>(Constants.DEFAULT_LABELS);
         labels.put(Constants.INSTANCE_LABEL, primary.getMetadata().getName());
         return labels;
+    }
+
+    public static <T extends HasMetadata> Optional<T> getByName(Class<T> clazz, Function<Keycloak, String> nameFunction, Keycloak primary, Context<Keycloak> context) {
+        InformerEventSource<T, Keycloak> ies = (InformerEventSource<T, Keycloak>) context
+                .eventSourceRetriever().getResourceEventSourceFor(clazz);
+    
+        return ies.get(new ResourceID(nameFunction.apply(primary), primary.getMetadata().getNamespace()));
     }
 
 }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ResourceDiscriminator;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.processing.dependent.Creator;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
@@ -13,10 +14,18 @@ import org.keycloak.operator.Constants;
 import org.keycloak.operator.Utils;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
+import java.util.Optional;
 import java.util.UUID;
 
-@KubernetesDependent(labelSelector = Constants.DEFAULT_LABELS_AS_STRING)
+@KubernetesDependent(labelSelector = Constants.DEFAULT_LABELS_AS_STRING, resourceDiscriminator = KeycloakAdminSecretDependentResource.NameResourceDiscriminator.class)
 public class KeycloakAdminSecretDependentResource extends KubernetesDependentResource<Secret, Keycloak> implements Creator<Secret, Keycloak>, GarbageCollected<Keycloak> {
+
+    public static class NameResourceDiscriminator implements ResourceDiscriminator<Secret, Keycloak> {
+        @Override
+        public Optional<Secret> distinguish(Class<Secret> resource, Keycloak primary, Context<Keycloak> context) {
+            return Utils.getByName(Secret.class, KeycloakAdminSecretDependentResource::getName, primary, context);
+        }
+    }
 
     public KeycloakAdminSecretDependentResource() {
         super(Secret.class);

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryServiceDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDiscoveryServiceDependentResource.java
@@ -37,7 +37,7 @@ public class KeycloakDiscoveryServiceDependentResource extends CRUDKubernetesDep
     public static class NameResourceDiscriminator implements ResourceDiscriminator<Service, Keycloak> {
         @Override
         public Optional<Service> distinguish(Class<Service> resource, Keycloak primary, Context<Keycloak> context) {
-            return KeycloakServiceDependentResource.getService(KeycloakDiscoveryServiceDependentResource::getName, primary, context);
+            return Utils.getByName(Service.class, KeycloakDiscoveryServiceDependentResource::getName, primary, context);
         }
     }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceDependentResource.java
@@ -25,8 +25,6 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ResourceDiscriminator;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
-import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.Utils;
@@ -34,7 +32,6 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import static org.keycloak.operator.crds.v2alpha1.CRDUtils.isTlsConfigured;
 
@@ -44,15 +41,8 @@ public class KeycloakServiceDependentResource extends CRUDKubernetesDependentRes
     public static class NameResourceDiscriminator implements ResourceDiscriminator<Service, Keycloak> {
         @Override
         public Optional<Service> distinguish(Class<Service> resource, Keycloak primary, Context<Keycloak> context) {
-            return getService(KeycloakServiceDependentResource::getServiceName, primary, context);
+            return Utils.getByName(Service.class, KeycloakServiceDependentResource::getServiceName, primary, context);
         }
-    }
-
-    public static Optional<Service> getService(Function<Keycloak, String> nameFunction, Keycloak primary, Context<Keycloak> context) {
-        InformerEventSource<Service, Keycloak> ies = (InformerEventSource<Service, Keycloak>) context
-                .eventSourceRetriever().getResourceEventSourceFor(Service.class);
-
-        return ies.get(new ResourceID(nameFunction.apply(primary), primary.getMetadata().getNamespace()));
     }
 
     public KeycloakServiceDependentResource() {


### PR DESCRIPTION
This ensures we'll always look for the approriate initial admin secret.  However it does not address directly the left over store secret.  We can:
- add some tech debt to delete in the operator, we can do it naively on every Keycloak event, or try to make run only at start
- just document that the admin should remove the old secrets
- don't worry about the left over secrets, they will go away when the keycloak instance or the namespace goes away.

closes: #25307

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
