### PR TITLE
Introduce ProtocolMapper.getEffectiveModel to make sure values displa…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapper.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/ProtocolMapper.java
@@ -54,4 +54,20 @@ public interface ProtocolMapper extends Provider, ProviderFactory<ProtocolMapper
     default void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel client, ProtocolMapperModel mapperModel) throws ProtocolMapperConfigException {
     };
 
+    /**
+     * Get effective configuration of protocol mapper. Effective configuration takes "default values" of the options into consideration
+     * and hence it is the configuration, which would be actually used when processing this protocolMapper during issuing tokens/assertions.
+     *
+     * So for instance, when configuration option "introspection.token.claim" is unset in the protocolMapperModel, but default value of this option is supposed to be "true", then
+     * effective config returned by this method will contain "introspection.token.claim" config option with value "true" . If the "introspection.token.claim" is set, then the
+     * default value is typically ignored in the effective configuration, but this can depend on the implementation of particular protocol mapper.
+     *
+     * @param session
+     * @param realm
+     * @param protocolMapperModel
+     */
+    default ProtocolMapperModel getEffectiveModel(KeycloakSession session, RealmModel realm, ProtocolMapperModel protocolMapperModel) {
+        return protocolMapperModel;
+    }
+
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
@@ -22,12 +22,20 @@ import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
+
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN;
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN;
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION;
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -154,5 +162,23 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
     protected void setClaim(AccessTokenResponse accessTokenResponse, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession,
                             ClientSessionContext clientSessionCtx) {
 
+    }
+
+    @Override
+    public ProtocolMapperModel getEffectiveModel(KeycloakSession session, RealmModel realm, ProtocolMapperModel protocolMapperModel) {
+        // Effectively clone
+        ProtocolMapperModel copy = RepresentationToModel.toModel(ModelToRepresentation.toRepresentation(protocolMapperModel));
+
+        // UserInfo - if not set, default value is the same as includeInIDToken
+        if (copy.getConfig().get(INCLUDE_IN_ID_TOKEN) != null) {
+            copy.getConfig().put(INCLUDE_IN_USERINFO, String.valueOf(OIDCAttributeMapperHelper.includeInUserInfo(protocolMapperModel)));
+        }
+
+        // Introspection - if not set, default value is the same as includeInAccessToken
+        if (copy.getConfig().get(INCLUDE_IN_ACCESS_TOKEN) != null) {
+            copy.getConfig().put(INCLUDE_IN_INTROSPECTION, String.valueOf(OIDCAttributeMapperHelper.includeInIntrospection(protocolMapperModel)));
+        }
+
+        return copy;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AllowedWebOriginsProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AllowedWebOriginsProtocolMapper.java
@@ -28,7 +28,10 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.utils.WebOriginsUtils;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -118,6 +121,17 @@ public class AllowedWebOriginsProtocolMapper extends AbstractOIDCProtocolMapper 
         }
 
         return "true".equals(includeInIntrospection);
+    }
+
+    @Override
+    public ProtocolMapperModel getEffectiveModel(KeycloakSession session, RealmModel realm, ProtocolMapperModel protocolMapperModel) {
+        // Effectively clone
+        ProtocolMapperModel copy = RepresentationToModel.toModel(ModelToRepresentation.toRepresentation(protocolMapperModel));
+
+        copy.getConfig().put(INCLUDE_IN_ACCESS_TOKEN, String.valueOf(includeInAccessToken(copy)));
+        copy.getConfig().put(INCLUDE_IN_INTROSPECTION, String.valueOf(includeInIntrospection(copy)));
+
+        return copy;
     }
 
     private void setWebOrigin(AccessToken token, KeycloakSession session, ClientSessionContext clientSessionCtx) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceResolveProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceResolveProtocolMapper.java
@@ -26,7 +26,10 @@ import java.util.Map;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -122,6 +125,17 @@ public class AudienceResolveProtocolMapper extends AbstractOIDCProtocolMapper im
         }
 
         return "true".equals(includeInIntrospection);
+    }
+
+    @Override
+    public ProtocolMapperModel getEffectiveModel(KeycloakSession session, RealmModel realm, ProtocolMapperModel protocolMapperModel) {
+        // Effectively clone
+        ProtocolMapperModel copy = RepresentationToModel.toModel(ModelToRepresentation.toRepresentation(protocolMapperModel));
+
+        copy.getConfig().put(INCLUDE_IN_ACCESS_TOKEN, String.valueOf(includeInAccessToken(copy)));
+        copy.getConfig().put(INCLUDE_IN_INTROSPECTION, String.valueOf(includeInIntrospection(copy)));
+
+        return copy;
     }
 
     private void setAudience(AccessToken token, ClientSessionContext clientSessionCtx, KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
@@ -113,7 +113,7 @@ public class ProtocolMappersResource {
 
         return client.getProtocolMappersStream()
                 .filter(mapper -> isEnabled(session, mapper) && Objects.equals(mapper.getProtocol(), protocol))
-                .map(ModelToRepresentation::toRepresentation);
+                .map(this::toEffectiveProtocolMapperRep);
     }
 
     /**
@@ -182,7 +182,7 @@ public class ProtocolMappersResource {
 
         return client.getProtocolMappersStream()
                 .filter(mapper -> isEnabled(session, mapper))
-                .map(ModelToRepresentation::toRepresentation);
+                .map(this::toEffectiveProtocolMapperRep);
     }
 
     /**
@@ -202,6 +202,17 @@ public class ProtocolMappersResource {
 
         ProtocolMapperModel model = client.getProtocolMapperById(id);
         if (model == null) throw new NotFoundException("Model not found");
+        return toEffectiveProtocolMapperRep(model);
+    }
+
+    private ProtocolMapperRepresentation toEffectiveProtocolMapperRep(ProtocolMapperModel model) {
+        ProtocolMapper mapper = (ProtocolMapper) session.getKeycloakSessionFactory().getProviderFactory(ProtocolMapper.class, model.getProtocolMapper());
+        if (mapper == null) {
+            logger.warnf("Protocol mapper provider '%s' not found. Configured on mapper with ID '%s'", model.getProtocolMapper(), model.getId());
+            throw new NotFoundException("Protocol mapper provider not found");
+        }
+
+        model = mapper.getEffectiveModel(session, realm, model);
         return ModelToRepresentation.toRepresentation(model);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
@@ -461,7 +461,7 @@ public class ExportImportUtil {
         Assert.assertTrue(includeInIdToken == null || Boolean.parseBoolean(includeInIdToken) == false);
     }
 
-    private static ProtocolMapperRepresentation findMapperByName(List<ProtocolMapperRepresentation> mappers, String type, String name) {
+    public static ProtocolMapperRepresentation findMapperByName(List<ProtocolMapperRepresentation> mappers, String type, String name) {
         if (mappers == null) {
             return null;
         }


### PR DESCRIPTION
…yed in the admin console UI are 'effective' values used when processing mappers

closes #24718

- PR introduces method `getEffectiveModel` on `ProtocolMapper` interface. This allows to "decorate" ProtocolMapperModel downloaded from DB with the "effective" default values. So for example if `include in introspection` configuration option is not present on the protocolMapper from the DB, but default value for `include in introspection` is then the "effective" will return true.

- This allows that admin console UI can display "effective" values, so display same values for configuration options `Include in XY`, which are used by default during protocol mappers processing when issuing tokens/assertions.

- Effective values might be needed as in some cases, the protocolMapper in the DB does not have the `include in XY` options set (can be usually when migrating from previous version or when protocolMapper is directly updated by admin REST API request with some of the config options removed)

- Updated admin REST API behaviour in `ProtocolMappersResource` to reflect this.
