### PR TITLE
Ignore `target` directory when running ESLint

### DIFF
--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
   ignorePatterns: [
     "node_modules",
     "dist",
+    "target",
     "keycloak-theme",
     "server",
     // Keycloak JS follows a completely different and outdated style, so we'll exclude it for now.


### PR DESCRIPTION
Ignores the `target` directory when running ESLint to prevent it from linting compiled code.