### PR TITLE
Fix broken assertion in Cypress tests

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
@@ -93,7 +93,8 @@ const userImportingDisabledFailMessage =
   "User federation provider could not be saved: Can not disable Importing users when LDAP provider mode is UNSYNCED";
 
 const ldapTestSuccessMsg = "Successfully connected to LDAP";
-const ldapTestFailMsg = "Error when trying to connect to LDAP: 'SocketReset'";
+const ldapTestFailMsg =
+  "Error when trying to connect to LDAP: 'CommunicationError'";
 
 describe("User Federation LDAP tests", () => {
   beforeEach(() => {


### PR DESCRIPTION
Looks like a regression (or just a change) was introduced elsewhere, not sure where but I suspect #25323. This should fix the Cypress tests.