### PR TITLE
Add Cloud Native team as Admin CLI codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@
 /quarkus/                                                   @keycloak/cloud-native-maintainers @keycloak/maintainers
 /docs/guides/server/                                        @keycloak/cloud-native-maintainers @keycloak/maintainers
 /docs/guides/operator/                                      @keycloak/cloud-native-maintainers @keycloak/maintainers
+/integration/client-cli/admin-cli                           @keycloak/cloud-native-maintainers @keycloak/maintainers
 
 ###################################################################################################
 # Store (@keycloak/store-maintainers)


### PR DESCRIPTION
The Cloud Native team is [responsible](https://github.com/keycloak/keycloak/blob/5b1b3ca11be8526482c1cfc3a441c747b107a991/.github/teams.yml#L2) for maintaining the Admin CLI client. This PR reflects this in the codeowners file as well.