### PR TITLE
Do not allow removing username and email from user profile configuration

### DIFF
--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
@@ -49,6 +49,26 @@ public class UPAttribute {
         this.name = name != null ? name.trim() : null;
     }
 
+    public UPAttribute(String name, UPGroup group) {
+        this(name);
+        this.group = group.getName();
+    }
+
+    public UPAttribute(String name, UPAttributePermissions permissions, UPAttributeRequired required, UPAttributeSelector selector) {
+        this(name);
+        this.permissions = permissions;
+        this.required = required;
+        this.selector = selector;
+    }
+
+    public UPAttribute(String name, UPAttributePermissions permissions, UPAttributeRequired required) {
+        this(name, permissions, required, null);
+    }
+
+    public UPAttribute(String name, UPAttributePermissions permissions) {
+        this(name, permissions, null);
+    }
+
     public String getName() {
         return name;
     }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributePermissions.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributePermissions.java
@@ -33,6 +33,15 @@ public class UPAttributePermissions {
     private Set<String> view = Collections.emptySet();
     private Set<String> edit = Collections.emptySet();
 
+    public UPAttributePermissions() {
+        // for reflection
+    }
+
+    public UPAttributePermissions(Set<String> view, Set<String> edit) {
+        this.view = view;
+        this.edit = edit;
+    }
+
     public Set<String> getView() {
         return view;
     }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeRequired.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeRequired.java
@@ -33,6 +33,15 @@ public class UPAttributeRequired {
     private Set<String> roles;
     private Set<String> scopes;
 
+    public UPAttributeRequired() {
+        // for reflection
+    }
+
+    public UPAttributeRequired(Set<String> roles, Set<String> scopes) {
+        this.roles = roles;
+        this.scopes = scopes;
+    }
+
     /**
      * Check if this config means that the attribute is ALWAYS required.
      * 

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeSelector.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeSelector.java
@@ -30,6 +30,14 @@ public class UPAttributeSelector {
 
     private Set<String> scopes;
 
+    public UPAttributeSelector() {
+        // for reflection
+    }
+
+    public UPAttributeSelector(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
     public Set<String> getScopes() {
         return scopes;
     }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPConfig.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPConfig.java
@@ -50,14 +50,19 @@ public class UPConfig {
         this.attributes = attributes;
     }
 
-    public UPConfig addAttribute(UPAttribute attribute) {
+    public UPConfig addOrReplaceAttribute(UPAttribute attribute) {
         if (attributes == null) {
             attributes = new ArrayList<>();
         }
 
+        removeAttribute(attribute.getName());
         attributes.add(attribute);
 
         return this;
+    }
+
+    public boolean removeAttribute(String name) {
+        return attributes != null && attributes.removeIf(attribute -> attribute.getName().equals(name));
     }
 
     public List<UPGroup> getGroups() {

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPGroup.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPGroup.java
@@ -33,6 +33,14 @@ public class UPGroup {
     private String displayDescription;
     private Map<String, Object> annotations;
 
+    public UPGroup() {
+        // for reflection
+    }
+
+    public UPGroup(String name) {
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/js/apps/admin-ui/cypress/e2e/realm_settings_user_profile_enabled.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/realm_settings_user_profile_enabled.spec.ts
@@ -131,6 +131,8 @@ describe("User profile tabs", () => {
   {
     "attributes": [
       {
+  "name": "email"{downArrow},
+      {
   "name": "username",
   "validations": {
     "length": {

--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
@@ -191,6 +191,7 @@ export const AttributesTab = () => {
           {
             title: t("delete"),
             isActionable: ({ name }) => !RESTRICTED_ATTRIBUTES.includes(name!),
+            isDisabled: RESTRICTED_ATTRIBUTES.includes(name!),
             onClick: (_key, _idx, component) => {
               setAttributeToDelete(component.name);
               toggleDeleteDialog();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTestWithUserProfile.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTestWithUserProfile.java
@@ -61,7 +61,7 @@ public class UserTestWithUserProfile extends UserTest {
         UPConfig upConfig = realm.users().userProfile().getConfiguration();
 
         for (String name : managedAttributes) {
-            upConfig.addAttribute(createAttributeMetadata(name));
+            upConfig.addOrReplaceAttribute(createAttributeMetadata(name));
         }
 
         VerifyProfileTest.setUserProfileConfiguration(realm, JsonSerialization.writeValueAsString(upConfig));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/userprofile/UserProfileAdminTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/userprofile/UserProfileAdminTest.java
@@ -44,6 +44,7 @@ import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.representations.userprofile.config.UPGroup;
 import org.keycloak.testsuite.util.JsonTestUtils;
+import org.keycloak.userprofile.config.UPConfigUtils;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -66,7 +67,7 @@ public class UserProfileAdminTest extends AbstractAdminTest {
 
     @Test
     public void testSetDefaultConfig() {
-        UPConfig config = new UPConfig().addAttribute(new UPAttribute("test"));
+        UPConfig config = UPConfigUtils.parseDefaultConfig().addOrReplaceAttribute(new UPAttribute("test"));
         UserProfileResource userProfile = testRealm().users().userProfile();
         userProfile.update(config);
         getCleanup().addCleanup(() -> testRealm().users().userProfile().update(null));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -47,6 +47,7 @@ import org.keycloak.testsuite.runonserver.RunHelpers;
 import org.keycloak.testsuite.util.JsonTestUtils;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.userprofile.DeclarativeUserProfileProvider;
+import org.keycloak.util.JsonSerialization;
 
 import java.io.File;
 import java.io.IOException;
@@ -273,8 +274,8 @@ public class ExportImportTest extends AbstractKeycloakTest {
         realmRes.update(realmRep);
 
         //add some non-default config
-        VerifyProfileTest.setUserProfileConfiguration(realmRes, VerifyProfileTest.CONFIGURATION_FOR_USER_EDIT);
-        
+        UPConfig persistedConfig = VerifyProfileTest.setUserProfileConfiguration(realmRes, VerifyProfileTest.CONFIGURATION_FOR_USER_EDIT);
+
         //export
         TestingExportImportResource exportImport = testingClient.testing().exportImport();
         exportImport.setProvider(SingleFileExportProviderFactory.PROVIDER_ID);
@@ -297,7 +298,7 @@ public class ExportImportTest extends AbstractKeycloakTest {
         MultivaluedHashMap<String, String> config = userProfileComponents.get(0).getConfig();
         assertThat(config, notNullValue());
         assertThat(config.size(), equalTo(1));
-        JsonTestUtils.assertJsonEquals(config.getFirst(DeclarativeUserProfileProvider.UP_COMPONENT_CONFIG_KEY), VerifyProfileTest.CONFIGURATION_FOR_USER_EDIT, UPConfig.class);
+        JsonTestUtils.assertJsonEquals(config.getFirst(DeclarativeUserProfileProvider.UP_COMPONENT_CONFIG_KEY), JsonSerialization.writeValueAsString(persistedConfig), UPConfig.class);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiWithUserProfileTest.java
@@ -108,7 +108,7 @@ public class LDAPAdminRestApiWithUserProfileTest extends LDAPAdminRestApiTest {
 
         attribute.setPermissions(permissions);
 
-        upConfig.addAttribute(attribute);
+        upConfig.addOrReplaceAttribute(attribute);
 
         setUserProfileConfiguration(testRealm(), writeValueAsString(upConfig));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/AbstractUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/AbstractUserProfileTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractUserProfileTest extends AbstractTestRealmKeycloakT
             Map<String, Object> validatorConfig = new HashMap<>();
             validatorConfig.put("min", 3);
             attribute.addValidation("length", validatorConfig);
-            config.addAttribute(attribute);
+            config.addOrReplaceAttribute(attribute);
         }
         String newConfig = JsonSerialization.writeValueAsString(config);
         return newConfig;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/config/UPConfigParserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/config/UPConfigParserTest.java
@@ -198,7 +198,7 @@ public class UPConfigParserTest extends AbstractTestRealmKeycloakTest {
         UPConfig config = loadValidConfig();
         //we run this test without KeycloakSession so validator configs are not validated here
 
-        UPAttribute attConfig = config.getAttributes().get(1);
+        UPAttribute attConfig = config.getAttributes().get(2);
 
         attConfig.setName(null);
         List<String> errors = validate(session, config);
@@ -209,7 +209,7 @@ public class UPConfigParserTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals(1, errors.size());
 
         // duplicate attribute name
-        attConfig.setName("firstName");
+        attConfig.setName("lastName");
         errors = validate(session, config);
         Assert.assertEquals(1, errors.size());
 


### PR DESCRIPTION
* Do not allow removing the `username` and `email` attributes from both UI and on the server side
* Initially, we discussed to also avoid removing `firstName` and `lastName` attributes. But I think we can keep the current behavior where both are also removable. Perhaps better for backward compatibility as there is no good reason (yet) to block removing these attributes
* Most of the changes are updating tests to make sure we re-add the `username` and `email` whenever needed

I did not like how the server is returning the validation messages because they are not supporting multiple messages and localization. I would like to work on this in a follow-up.

Closes #25147

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
