### PR TITLE
User Profile: If required roles ('user') and reqired scopes are set, …

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -296,6 +296,17 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
             if (rc != null) {
                 if (rc.isAlways() || UPConfigUtils.isRoleForContext(context, rc.getRoles())) {
                     required = AttributeMetadata.ALWAYS_TRUE;
+
+                    // If scopes are configured, we will use scope-based selector and require the attribute just if scope is
+                    // in current authenticationSession (either default scope or by 'scope' parameter)
+                    if (rc.getScopes() != null && !rc.getScopes().isEmpty()) {
+                        if (UPConfigUtils.canBeAuthFlowContext(context)) {
+                            required = (c) -> requestedScopePredicate(c, rc.getScopes());
+                        } else {
+                            // Scopes not available for admin and account contexts
+                            required = AttributeMetadata.ALWAYS_FALSE;
+                        }
+                    }
                 } else if (UPConfigUtils.canBeAuthFlowContext(context) && rc.getScopes() != null && !rc.getScopes().isEmpty()) {
                     // for contexts executed from auth flow and with configured scopes requirement
                     // we have to create required validation with scopes based selector

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/AbstractUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/AbstractUserProfileTest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Before;
+import org.keycloak.OAuth2Constants;
 import org.keycloak.common.Profile;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ClientModel;
@@ -214,7 +215,11 @@ public abstract class AbstractUserProfileTest extends AbstractTestRealmKeycloakT
 
             @Override
             public String getClientNote(String name) {
-                return null;
+                if (OAuth2Constants.SCOPE.equals(name) && scopes != null && !scopes.isEmpty()) {
+                    return String.join(" ", scopes);
+                } else {
+                    return null;
+                }
             }
 
             @Override


### PR DESCRIPTION
…the required scopes have no effect

closes #25475

Description of the change:
 - When setting `Required when` is selected as `Always`, then only the "role" presence is sufficient to make this attribute REQUIRED
 - When setting `Required when` is selected as `Scopes are requested` with some scopes being present, then the "scope" is required together with "role" to this attribute being required. This effectively means that for the contexts without scopes (admin console, account console), the specified attribute won't be required as the requested scopes are not present
 - In relation to this, I've added validation that if some required scopes are configured, then also role `user` should be configured. Otherwise the attributes will never be required as when role `user` is not used, the `scopes` selector is never applied. So this is just some prevention against misconfiguration  
