### PR TITLE
Create terms and conditions execution when registration form is added

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -63,6 +63,7 @@ public class DefaultAuthenticationFlows {
         if (realm.getFlowByAlias(SAML_ECP_FLOW) == null) samlEcpProfile(realm);
         if (realm.getFlowByAlias(DOCKER_AUTH) == null) dockerAuthenticationFlow(realm);
     }
+
     public static void migrateFlows(RealmModel realm) {
         if (realm.getFlowByAlias(BROWSER_FLOW) == null) browserFlow(realm, true);
         if (realm.getFlowByAlias(DIRECT_GRANT_FLOW) == null) directGrantFlow(realm, true);
@@ -135,15 +136,13 @@ public class DefaultAuthenticationFlows {
         //execution.setAuthenticatorConfig(captchaConfig.getId());
         realm.addAuthenticatorExecution(execution);
 
-        if (!migrate) {
-            execution = new AuthenticationExecutionModel();
-            execution.setParentFlow(registrationFormFlow.getId());
-            execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
-            execution.setAuthenticator("registration-terms-and-conditions");
-            execution.setPriority(70);
-            execution.setAuthenticatorFlow(false);
-            realm.addAuthenticatorExecution(execution);
-        }
+        execution = new AuthenticationExecutionModel();
+        execution.setParentFlow(registrationFormFlow.getId());
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+        execution.setAuthenticator("registration-terms-and-conditions");
+        execution.setPriority(70);
+        execution.setAuthenticatorFlow(false);
+        realm.addAuthenticatorExecution(execution);
     }
 
     public static void browserFlow(RealmModel realm) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
@@ -200,6 +200,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "Registration User Profile Creation", "registration-user-creation", false, 1, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED});
         addExecInfo(execs, "Password Validation", "registration-password-action", false, 1, 1, REQUIRED, null, new String[]{REQUIRED, DISABLED});
         addExecInfo(execs, "Recaptcha", "registration-recaptcha-action", true, 1, 2, DISABLED, null, new String[]{REQUIRED, DISABLED});
+        addExecInfo(execs, "Terms and conditions", "registration-terms-and-conditions", false, 1, 3, DISABLED, null, new String[]{REQUIRED, DISABLED});
         expected.add(new FlowExecutions(flow, execs));
 
         flow = newFlow("reset credentials", "Reset credentials for a user if they forgot their password or something", "basic-flow", true, true);


### PR DESCRIPTION
Closes #21730

When adding the terms&condition execution to the registration form (issue #8750), it was added only when migration was false. This makes no sense as the method is just called when the registration flow doesn't exist. It should be always created with the terms&Conditions step included if that point is reached. If the realm was migrated from a previous version and the registration flow is there, it will just remain the same. So, with this PR, new realms or imported realms without flows are created with the new step, and existing realms from previous versions or imported realms with flows already defined will remain the same as before (if the step was not there is never added).
