### PR TITLE
Update messages_de.properties

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
@@ -237,7 +237,7 @@ noAccessMessage=Kein Zugriff
 
 invalidPasswordMinLengthMessage=Ungültiges Passwort: Es muss mindestens {0} Zeichen lang sein.
 invalidPasswordMinDigitsMessage=Ungültiges Passwort: Es muss mindestens {0} Zahl(en) beinhalten.
-invalidPasswordMinLowerCaseCharsMessage=Ungültiges Passwort\: Es muss mindestens {0} Kleinbuchstaben beinhalten.
+invalidPasswordMinLowerCaseCharsMessage=Ungültiges Passwort: Es muss mindestens {0} Kleinbuchstaben beinhalten.
 invalidPasswordMinUpperCaseCharsMessage=Ungültiges Passwort: Es muss mindestens {0} Großbuchstaben beinhalten.
 invalidPasswordMinSpecialCharsMessage=Ungültiges Passwort: Es muss mindestens {0} Sonderzeichen beinhalten.
 invalidPasswordNotUsernameMessage=Ungültiges Passwort: Es darf nicht gleich sein wie der Benutzername.


### PR DESCRIPTION
In the value of invalidPasswordMinLowerCaseCharsMessage there was a superfluous \. Removed it: "Passwort\\:" ->"Passwort:"

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
