### PR TITLE
Fix for test SSSDUserProfileTest.test05MixedInternalDBUserProfile

### DIFF
--- a/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDUserProfileTest.java
@@ -239,7 +239,7 @@ public class SSSDUserProfileTest extends AbstractBaseSSSDTest {
             // for admin firstName and lastName remains removed, the rest editable
             UserResource testResource = ApiUtil.findUserByUsernameId(testRealm(), "test-user@localhost");
             UserRepresentation test = testResource.toRepresentation(true);
-            assertUser(test, "test-user@localhost", "test-user@localhost", "Tom", "Brady", null);
+            assertUser(test, "test-user@localhost", "test-user@localhost", null, null, null);
             assertProfileAttributes(test, null, false, "username", "email", "postal_code");
             Assert.assertNull(test.getUserProfileMetadata().getAttributeMetadata(UserModel.FIRST_NAME));
             Assert.assertNull(test.getUserProfileMetadata().getAttributeMetadata(UserModel.LAST_NAME));


### PR DESCRIPTION
Closes #25566

Just fixing a SSSD test for UserProfile. The PR https://github.com/keycloak/keycloak/pull/25482 changed UP and adapted some tests but the SSSD was not included (because it was not detected :wink:).
