### PR TITLE
Make UserStoragePrivateUtil usable with other datastore providers

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/UserStoragePrivateUtil.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/UserStoragePrivateUtil.java
@@ -26,6 +26,12 @@ import org.keycloak.storage.datastore.LegacyDatastoreProvider;
  */
 public class UserStoragePrivateUtil {
     public static UserProvider userLocalStorage(KeycloakSession session) {
-        return ((LegacyDatastoreProvider) session.getProvider(DatastoreProvider.class)).userLocalStorage();
+        DatastoreProvider datastoreProvider = session.getProvider(DatastoreProvider.class);
+        if(datastoreProvider instanceof LegacyDatastoreProvider) {
+            LegacyDatastoreProvider legacyDatastoreProvider = (LegacyDatastoreProvider) datastoreProvider;
+            return legacyDatastoreProvider.userLocalStorage();
+        } else {
+            return datastoreProvider.users();
+        }
     }
 }


### PR DESCRIPTION
This change is necessary to allow different implementations of DatastoreProvider to be used together with user federation and the default export/import implementation.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
