### PR TITLE
fix: adding the kube ca cert to the truststores

### DIFF
--- a/docs/documentation/release_notes/topics/24_0_0.adoc
+++ b/docs/documentation/release_notes/topics/24_0_0.adoc
@@ -24,6 +24,10 @@ spec:
 
 Currently only Secrets are supported.
 
+== Trust Kubernetes CA
+
+The cert for the Kubernetes CA is added automatically to your Keycloak pods managed by the operator.
+
 = Automatic certificate management for SAML identity providers
 
 The SAML identity providers can now be configured to automatically download the signing certificates from the IDP entity metadata descriptor endpoint. In order to use the new feature the option `Metadata descriptor URL` should be configured in the provider (URL where the IDP metadata information with the certificates is published) and `Use metadata descriptor URL` needs to be `ON`. The certificates are automatically downloaded and cached in the `public-key-storage` SPI from that URL. The certificates can also be reloaded or imported from the admin console, using the action combo in the provider page.

--- a/docs/documentation/release_notes/topics/24_0_0.adoc
+++ b/docs/documentation/release_notes/topics/24_0_0.adoc
@@ -26,7 +26,7 @@ Currently only Secrets are supported.
 
 == Trust Kubernetes CA
 
-The cert for the Kubernetes CA is added automatically to your Keycloak pods managed by the operator.
+The cert for the Kubernetes CA is added automatically to your {project_name} Pods managed by the Operator.
 
 = Automatic certificate management for SAML identity providers
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -363,7 +363,7 @@ public class PodTemplateTest {
     }
 
     @Test
-    public void testDefaultArgs() {
+    public void testDefaults() {
         // Arrange
         PodTemplateSpec additionalPodTemplate = null;
 
@@ -372,6 +372,7 @@ public class PodTemplateTest {
 
         // Assert
         assertThat(podTemplate.getSpec().getContainers().get(0).getArgs()).doesNotContain(KeycloakDeploymentDependentResource.OPTIMIZED_ARG);
+        assertThat(podTemplate.getSpec().getContainers().get(0).getEnv().stream().anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRUSTSTORE_PATHS)));
     }
 
     @Test
@@ -386,6 +387,22 @@ public class PodTemplateTest {
 
         // Assert
         assertThat(podTemplate.getSpec().getContainers().get(0).getArgs()).doesNotContain(KeycloakDeploymentDependentResource.OPTIMIZED_ARG);
+    }
+
+    @Test
+    public void testAdditionalOptionTruststorePath() {
+        // Arrange
+        PodTemplateSpec additionalPodTemplate = null;
+
+        // Act
+        var podTemplate = getDeployment(additionalPodTemplate, null,
+                s -> s.addToAdditionalOptions(new ValueOrSecret(KeycloakDeploymentDependentResource.KC_TRUSTSTORE_PATHS, "/something")))
+                .getSpec().getTemplate();
+
+        // Assert
+        assertThat(podTemplate.getSpec().getContainers().get(0).getEnv().stream()
+                .anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRUSTSTORE_PATHS)
+                        && envVar.getValue().equals("/something")));
     }
 
     @Test


### PR DESCRIPTION
The only issue here is that we're not monitoring the file, so a rotation will require a manual restart of the keycloak instances. We could have the operator watch the kube-root-ca.crt configmap and restart the keycloaks.

closes #10794

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
