### PR TITLE
Ensure 'iss' is returned when 'prompt=none' and user is not authenticated, per RFC9207

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -50,6 +50,7 @@ import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.adapters.action.PushNotBeforeAction;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.ImplicitHybridTokenResponse;
 import org.keycloak.services.clientpolicy.context.TokenRefreshContext;
@@ -331,6 +332,12 @@ public class OIDCLoginProtocol implements LoginProtocol {
         }
         if (state != null) {
             redirectUri.addParam(OAuth2Constants.STATE, state);
+        }
+
+        // RFC 9207 support + compatibility flag
+        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(session.getContext().getClient());
+        if (!clientConfig.isExcludeIssuerFromAuthResponse()) {
+            redirectUri.addParam(OAuth2Constants.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
         }
 
         // Remove authenticationSession from current tab

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
@@ -263,6 +263,9 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
 
     @Test
     public void promptNoneNotLogged() {
+
+        String expectedIssuer = oauth.doWellKnownRequest(oauth.getRealm()).getIssuer();
+
         // Send request with prompt=none
         driver.navigate().to(oauth.getLoginFormUrl() + "&prompt=none");
 
@@ -273,6 +276,7 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
 
         // Assert error response was sent because not logged in
         OAuthClient.AuthorizationEndpointResponse resp = new OAuthClient.AuthorizationEndpointResponse(oauth);
+        Assert.assertEquals(expectedIssuer, resp.getIssuer());
         Assert.assertNull(resp.getCode());
         Assert.assertEquals(OAuthErrorException.LOGIN_REQUIRED, resp.getError());
 


### PR DESCRIPTION
Closes keycloak/keycloak#25584