### PR TITLE
PubKeySignRegisterTest failures in WebAuthn tests

### DIFF
--- a/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/registration/PubKeySignRegisterTest.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/registration/PubKeySignRegisterTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.crypto.Algorithm.ES256;
 import static org.keycloak.crypto.Algorithm.ES512;
-import static org.keycloak.crypto.Algorithm.RS256;
+import static org.keycloak.crypto.Algorithm.RS384;
 import static org.keycloak.crypto.Algorithm.RS512;
 
 /**
@@ -61,7 +61,7 @@ public class PubKeySignRegisterTest extends AbstractWebAuthnVirtualTest {
 
     @Test
     public void publicKeySignaturesRSA() {
-        assertPublicKeyAlgorithms(false, null, Lists.newArrayList(RS256, ES512));
+        assertPublicKeyAlgorithms(false, null, Lists.newArrayList(RS384, ES512));
     }
 
     @Test


### PR DESCRIPTION
Fixes #9693

Detailed analysis was made by @rmartinc 

The test case works with Chrome versions <120. For the latest releases, a bug[1][2] is present there and affecting the tool for the virtual authenticators - used for WebAuthn testing in Keycloak. 

For the affected test case, we don't really care about the specific RS; it just needs to be invalid in terms of empty WebAuthn configuration. 

For proper behavior of the test case in older and newer chromedrivers, the RS384 is used. 

In summary, it's only test-related and not a bug in Keycloak. 

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1489492&q=RS256&can=1
[2] https://chromiumdash.appspot.com/commit/0fab259d3bfb2c50b7546aa07fdfd720f0810289
