### PR TITLE
[Admin UI] In authentication flow details, sub-flow addition modal should display the flowType even if there is only one available

### DIFF
--- a/js/apps/admin-ui/src/authentication/components/modals/AddSubFlowModal.tsx
+++ b/js/apps/admin-ui/src/authentication/components/modals/AddSubFlowModal.tsx
@@ -59,12 +59,6 @@ export const AddSubFlowModal = ({
     [],
   );
 
-  useEffect(() => {
-    if (formProviders?.length === 1) {
-      setValue("provider", formProviders[0].id!);
-    }
-  }, [formProviders]);
-
   return (
     <Modal
       variant={ModalVariant.medium}
@@ -165,7 +159,7 @@ export const AddSubFlowModal = ({
             )}
           />
         </FormGroup>
-        {formProviders && formProviders.length > 1 && (
+        {formProviders && (
           <FormGroup
             label={t("flowType")}
             labelIcon={


### PR DESCRIPTION
Fix #25626
