### PR TITLE
Updating the UP configuration needs to trigger an admin event

### DIFF
--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
@@ -21,6 +21,7 @@ package org.keycloak.representations.userprofile.config;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Configuration of the Attribute.
@@ -169,5 +170,29 @@ public class UPAttribute implements Cloneable {
         attr.setSelector(this.selector == null ? null : this.selector.clone());
         attr.setGroup(this.group);
         return attr;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttribute other = (UPAttribute) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.displayName, other.displayName)
+                && Objects.equals(this.group, other.group)
+                && Objects.equals(this.validations, other.validations)
+                && Objects.equals(this.annotations, other.annotations)
+                && Objects.equals(this.required, other.required)
+                && Objects.equals(this.permissions, other.permissions)
+                && Objects.equals(this.selector, other.selector);
     }
 }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributePermissions.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributePermissions.java
@@ -20,6 +20,7 @@ package org.keycloak.representations.userprofile.config;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -74,5 +75,23 @@ public class UPAttributePermissions implements Cloneable {
         Set<String> view = this.view == null ? null : new HashSet<>(this.view);
         Set<String> edit = this.edit == null ? null : new HashSet<>(this.edit);
         return new UPAttributePermissions(view, edit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(view, edit);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttributePermissions other = (UPAttributePermissions) obj;
+        return Objects.equals(this.view, other.view)
+                && Objects.equals(this.edit, other.edit);
     }
 }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeRequired.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeRequired.java
@@ -19,6 +19,7 @@
 package org.keycloak.representations.userprofile.config;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -82,4 +83,21 @@ public class UPAttributeRequired implements Cloneable {
         return new UPAttributeRequired(roles, scopes);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(roles, scopes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttributeRequired other = (UPAttributeRequired) obj;
+        return Objects.equals(this.roles, other.roles)
+                && Objects.equals(this.scopes, other.scopes);
+    }
 }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeSelector.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeSelector.java
@@ -19,6 +19,7 @@
 package org.keycloak.representations.userprofile.config;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -55,5 +56,22 @@ public class UPAttributeSelector implements Cloneable {
     @Override
     protected UPAttributeSelector clone() {
         return new UPAttributeSelector(scopes == null ? null : new HashSet<>(scopes));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scopes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttributeSelector other = (UPAttributeSelector) obj;
+        return Objects.equals(this.scopes, other.scopes);
     }
 }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPConfig.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPConfig.java
@@ -21,6 +21,7 @@ package org.keycloak.representations.userprofile.config;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -136,5 +137,24 @@ public class UPConfig implements Cloneable {
         }
 
         return cfg;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributes, groups, unmanagedAttributePolicy);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPConfig other = (UPConfig) obj;
+        return Objects.equals(this.attributes, other.attributes)
+                && Objects.equals(this.groups, other.groups)
+                && this.unmanagedAttributePolicy == other.unmanagedAttributePolicy;
     }
 }

--- a/core/src/main/java/org/keycloak/representations/userprofile/config/UPGroup.java
+++ b/core/src/main/java/org/keycloak/representations/userprofile/config/UPGroup.java
@@ -21,6 +21,7 @@ package org.keycloak.representations.userprofile.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Configuration of the attribute group.
@@ -81,5 +82,25 @@ public class UPGroup implements Cloneable {
         group.setDisplayDescription(displayDescription);
         group.setAnnotations(this.annotations == null ? null : new HashMap<>(this.annotations));
         return group;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPGroup other = (UPGroup) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.displayHeader, other.displayHeader)
+                && Objects.equals(this.displayDescription, other.displayDescription)
+                && Objects.equals(this.annotations, other.annotations);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java
@@ -186,5 +186,10 @@ public enum ResourceType {
     /**
      *
      */
-    , CUSTOM;
+    , CUSTOM
+
+    /**
+     * The user profile configuration
+     */
+    , USER_PROFILE;
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -70,7 +70,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.keycloak.models.Constants.SESSION_NOTE_LIGHTWEIGHT_USER;
 import static org.keycloak.models.utils.KeycloakModelUtils.findGroupByPath;
 import static org.keycloak.userprofile.UserProfileContext.USER_API;
 
@@ -460,7 +459,7 @@ public class UsersResource {
      */
     @Path("profile")
     public UserProfileResource userProfile() {
-        return new UserProfileResource(session, auth);
+        return new UserProfileResource(session, auth, adminEvent);
     }
 
     private Stream<UserRepresentation> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTestWithUserProfile.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTestWithUserProfile.java
@@ -51,13 +51,13 @@ public class UserTestWithUserProfile extends UserTest {
     public void onBefore() throws IOException {
         RealmRepresentation realmRep = realm.toRepresentation();
         VerifyProfileTest.disableDynamicUserProfile(realm);
-        assertAdminEvents.poll();
-        realm.update(realmRep);
-        assertAdminEvents.poll();
+        assertAdminEvents.poll(); // update realm
+        assertAdminEvents.poll(); // set UP configuration
         VerifyProfileTest.enableDynamicUserProfile(realmRep);
         realm.update(realmRep);
         assertAdminEvents.poll();
         VerifyProfileTest.setUserProfileConfiguration(realm, null);
+        assertAdminEvents.poll();
         UPConfig upConfig = realm.users().userProfile().getConfiguration();
 
         for (String name : managedAttributes) {
@@ -65,6 +65,7 @@ public class UserTestWithUserProfile extends UserTest {
         }
 
         VerifyProfileTest.setUserProfileConfiguration(realm, JsonSerialization.writeValueAsString(upConfig));
+        assertAdminEvents.poll();
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UIRealmResourceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UIRealmResourceTest.java
@@ -1,0 +1,152 @@
+/*
+ *
+ *  * Copyright 2023  Red Hat, Inc. and/or its affiliates
+ *  * and other contributors as indicated by the @author tags.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+package org.keycloak.testsuite.user.profile;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.BearerAuthFilter;
+import org.keycloak.admin.ui.rest.model.UIRealmRepresentation;
+import org.keycloak.common.Profile;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.AdminEventRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
+import org.keycloak.representations.userprofile.config.UPAttributeRequired;
+import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.util.AssertAdminEvents;
+import org.keycloak.userprofile.DeclarativeUserProfileProvider;
+import org.keycloak.userprofile.config.UPConfigUtils;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ *
+ * @author rmartinc
+ */
+@EnableFeature(value = Profile.Feature.DECLARATIVE_USER_PROFILE)
+public class UIRealmResourceTest extends AbstractTestRealmKeycloakTest {
+
+    @Rule
+    public AssertAdminEvents assertAdminEvents = new AssertAdminEvents(this);
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+        if (testRealm.getAttributes() == null) {
+            testRealm.setAttributes(new HashMap<>());
+        }
+        testRealm.getAttributes().put(DeclarativeUserProfileProvider.REALM_USER_PROFILE_ENABLED, Boolean.TRUE.toString());
+    }
+
+    @Test
+    public void testNoUpdateUserProfile() throws IOException {
+        RealmRepresentation rep = testRealm().toRepresentation();
+        updateRealmExt(toUIRealmRepresentation(rep, null));
+
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        assertAdminEvents.assertEmpty();
+    }
+
+    @Test
+    public void testSameUpdateUserProfile() throws IOException {
+        RealmRepresentation rep = testRealm().toRepresentation();
+        UPConfig upConfig = testRealm().users().userProfile().getConfiguration();
+
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        assertAdminEvents.assertEmpty();
+    }
+
+    @Test
+    public void testUpdateUserProfileModification() throws IOException {
+        RealmRepresentation rep = testRealm().toRepresentation();
+        UPConfig upConfig = testRealm().users().userProfile().getConfiguration();
+        upConfig.addOrReplaceAttribute(new UPAttribute("foo",
+                new UPAttributePermissions(Set.of(), Set.of(UPConfigUtils.ROLE_USER, UPConfigUtils.ROLE_ADMIN))));
+
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        AdminEventRepresentation adminEvent = assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        Assert.assertNotNull(adminEvent.getRepresentation());
+        adminEvent = assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, "ui-ext", ResourceType.USER_PROFILE);
+        Assert.assertEquals(upConfig, toUpConfig(adminEvent.getRepresentation()));
+
+        upConfig.getAttribute("foo").setDisplayName("Foo");
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        adminEvent = assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, "ui-ext", ResourceType.USER_PROFILE);
+        Assert.assertEquals(upConfig, toUpConfig(adminEvent.getRepresentation()));
+
+        upConfig.getAttribute("foo").setPermissions(new UPAttributePermissions(Set.of(), Set.of(UPConfigUtils.ROLE_USER)));
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        adminEvent = assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, "ui-ext", ResourceType.USER_PROFILE);
+        Assert.assertEquals(upConfig, toUpConfig(adminEvent.getRepresentation()));
+
+        upConfig.getAttribute("foo").setRequired(new UPAttributeRequired(Set.of(UPConfigUtils.ROLE_ADMIN, UPConfigUtils.ROLE_USER), Set.of()));
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        adminEvent = assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, "ui-ext", ResourceType.USER_PROFILE);
+        Assert.assertEquals(upConfig, toUpConfig(adminEvent.getRepresentation()));
+
+        upConfig.getAttribute("foo").setValidations(Map.of("length", Map.of("min", "3", "max", "128")));
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        adminEvent = assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, "ui-ext", ResourceType.USER_PROFILE);
+        Assert.assertEquals(upConfig, toUpConfig(adminEvent.getRepresentation()));
+
+        updateRealmExt(toUIRealmRepresentation(rep, upConfig));
+        assertAdminEvents.assertEvent(TEST_REALM_NAME, OperationType.UPDATE, Matchers.nullValue(String.class), ResourceType.REALM);
+        assertAdminEvents.assertEmpty();
+    }
+
+    private void updateRealmExt(UIRealmRepresentation rep) {
+        try (Client client = Keycloak.getClientProvider().newRestEasyClient(null, null, true)) {
+            Response response = client.target(suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth")
+                    .path("/admin/realms/" + rep.getRealm() + "/ui-ext")
+                    .register(new BearerAuthFilter(adminClient.tokenManager()))
+                    .request(MediaType.APPLICATION_JSON)
+                    .put(Entity.entity(rep, MediaType.APPLICATION_JSON));
+            Assert.assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private UIRealmRepresentation toUIRealmRepresentation(RealmRepresentation realm, UPConfig upConfig) throws IOException {
+        UIRealmRepresentation uiRealm = JsonSerialization.readValue(JsonSerialization.writeValueAsString(realm), UIRealmRepresentation.class);
+        uiRealm.setUpConfig(upConfig);
+        return uiRealm;
+    }
+
+    private UPConfig toUpConfig(String representation) throws IOException {
+        return JsonSerialization.readValue(representation, UPConfig.class);
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AdminEventPaths.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AdminEventPaths.java
@@ -36,6 +36,7 @@ import org.keycloak.admin.client.resource.RoleByIdResource;
 import org.keycloak.admin.client.resource.RoleMappingResource;
 import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.admin.client.resource.UserProfileResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
 
@@ -69,6 +70,12 @@ public class AdminEventPaths {
         return uri.toString();
     }
 
+    public static String userProfilePath() {
+        URI uri = UriBuilder.fromUri("").path(RealmResource.class, "users")
+                .path(UsersResource.class, "userProfile")
+                .build();
+        return uri.toString();
+    }
 
     // CLIENT RESOURCE
 


### PR DESCRIPTION
Close #23896

Just triggering an admin event for UP configuration updates. I have created a new resource type USER_PROFILE (let me know if you prefer a different resource name). Tests modified to check the admin event is generated correctly.
