### PR TITLE
Load user profile handle error

### DIFF
--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -594,7 +594,9 @@ function Keycloak (config) {
                     kc.userInfo = JSON.parse(req.responseText);
                     promise.setSuccess(kc.userInfo);
                 } else {
-                    promise.setError();
+                    promise.setError({
+                        status: req.status,
+                    });
                 }
             }
         }

--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -567,7 +567,9 @@ function Keycloak (config) {
                     kc.profile = JSON.parse(req.responseText);
                     promise.setSuccess(kc.profile);
                 } else {
-                    promise.setError();
+                    promise.setError({
+                        status: req.status,
+                    });
                 }
             }
         }


### PR DESCRIPTION
Area
keycloak-js

Description
Currently, loadUserInfo function doesn't not given error info to client if any error happen

Details
In my personal use case client site pulling userinfo to check current info status, admin site can disable or delete user and then force their session to logged out. so we need to check when loadUserInfo return 401 (unauthorize) system will notify to user and let them to login page.

```js
.loadUserProfile().catch(e => {
    if (e.status === 401) {
       //this case will notify user
    } else {
      // in any inconsistent cases like, network unstable, system down...
    }
});
```

Closes keycloak/keycloak-js#12