### PR TITLE
Update method visibility to allow overridding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,4 @@ node_modules
 .sdkmanrc
 
 # JENV
-*.java-version
+.java-version

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ node_modules
 
 # SDKMAM environment file
 .sdkmanrc
+
+# JENV
+*.java-version

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -403,7 +403,7 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
         return name;
     }
 
-    private List<String> normalizeAttributeValues(String name, Object value) {
+    protected List<String> normalizeAttributeValues(String name, Object value) {
         List<String> values;
 
         if (value instanceof String) {

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -60,7 +60,7 @@ import org.keycloak.validate.ValidationError;
  */
 public class DefaultAttributes extends HashMap<String, List<String>> implements Attributes {
 
-    private static Logger logger = Logger.getLogger(DefaultAttributes.class);
+    private static final Logger logger = Logger.getLogger(DefaultAttributes.class);
 
     /**
      * To reference dynamic attributes that can be configured as read-only when setting up the provider.
@@ -403,6 +403,9 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
         return name;
     }
 
+    /**
+     * Intentionally kept to protected visibility to allow for custom normalization logic while clients adopt User Profile
+     */
     protected List<String> normalizeAttributeValues(String name, Object value) {
         List<String> values;
 


### PR DESCRIPTION
Hello, with some of the updates to UserProfile we have found that some of our custom code is breaking due to the fact that some of our attributes (what KC now refers to as "unmanaged" attributes) are not strings. I'm recommending that we update this method to allow for custom implementations to avoid having to do large refactors for the time being, although I do realize that we'll need to make adjustments to use strings in the future.

Let me know if you have any questions or other thoughts around this. Thanks!

Closes #25681 