### PR TITLE
Do not allow verifying email from a different account

### DIFF
--- a/docs/documentation/release_notes/topics/24_0_0.adoc
+++ b/docs/documentation/release_notes/topics/24_0_0.adoc
@@ -95,3 +95,17 @@ In this release, the server will render the update profile page when the user is
 first time using the `idp-review-user-profile.ftl` template.
 
 For more details, see link:{upgradingguide_link}[{upgradingguide_name}].
+
+= Performing actions on behalf of another user is not longer possible when the user is already authenticated
+
+In this release, you can no longer perform actions such as email verification if the user is already authenticated
+and the action is bound to another user. For instance, a user can not complete the verification email flow if the email link
+is bound to a different account.
+
+= Changes to the email verification flow
+
+In this release, if a user tries to follow the link to verify the email and the email was previously verified, a proper message
+will be shown.
+
+In addition to that, a new error (`EMAIL_ALREADY_VERIFIED`) event will be fired to indicate an attempt to verify an already verified email. You can
+use this event to track possible attempts to hijack user accounts in case the link has leaked or to alert users if they do not recognize the action.

--- a/server-spi-private/src/main/java/org/keycloak/events/Errors.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Errors.java
@@ -45,6 +45,7 @@ public interface Errors {
     String USERNAME_MISSING = "username_missing";
     String USERNAME_IN_USE = "username_in_use";
     String EMAIL_IN_USE = "email_in_use";
+    String EMAIL_ALREADY_VERIFIED = "email_already_verified";
 
     String INVALID_REDIRECT_URI = "invalid_redirect_uri";
     String INVALID_CODE = "invalid_code";

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -109,6 +109,7 @@ public class Messages {
     public static final String LINK_IDP = "linkIdpMessage";
 
     public static final String EMAIL_VERIFIED = "emailVerifiedMessage";
+    public static final String EMAIL_VERIFIED_ALREADY = "emailVerifiedAlreadyMessage";
 
     public static final String EMAIL_SENT = "emailSentMessage";
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -909,13 +909,14 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         assertTrue(adminClient.realm(bc.consumerRealmName()).users().get(consumerUser.getId()).toRepresentation().isEmailVerified());
 
         driver.navigate().to(url);
-        waitForPage(driver, "you are already logged in.", false);
+        waitForPage(driver, "your email address has been verified already.", false);
         AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), "consumer");
 
         driver.navigate().to(url);
-        waitForPage(driver, "confirm linking the account testuser of identity provider " + bc.getIDPAlias() + " with your account.", false);
-        proceedPage.clickProceedLink();
-        waitForPage(driver, "you successfully verified your email. please go back to your original browser and continue there with the login.", false);
+        waitForPage(driver, "your email address has been verified already.", false);
+
+        driver2.navigate().to(url);
+        waitForPage(driver, "your email address has been verified already.", false);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -92,7 +92,7 @@ import static org.keycloak.storage.UserStorageProviderModel.EVICTION_HOUR;
 import static org.keycloak.storage.UserStorageProviderModel.EVICTION_MINUTE;
 import static org.keycloak.storage.UserStorageProviderModel.IMPORT_ENABLED;
 import static org.keycloak.storage.UserStorageProviderModel.MAX_LIFESPAN;
-import static org.keycloak.testsuite.actions.RequiredActionEmailVerificationTest.getPasswordResetEmailLink;
+import static org.keycloak.testsuite.actions.RequiredActionEmailVerificationTest.getEmailLink;
 
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlDoesntStartWith;
 
@@ -393,7 +393,7 @@ public class UserStorageTest extends AbstractAuthTest {
 
             MimeMessage message = greenMail.getReceivedMessages()[0];
 
-            String verificationUrl = getPasswordResetEmailLink(message);
+            String verificationUrl = getEmailLink(message);
 
             driver.navigate().to(verificationUrl.trim());
 

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -353,6 +353,7 @@ realmSupportsNoCredentialsMessage=Realm does not support any credential type.
 credentialSetupRequired=Cannot login, credential setup required.
 identityProviderNotUniqueMessage=Realm supports multiple identity providers. Could not determine which identity provider should be used to authenticate with.
 emailVerifiedMessage=Your email address has been verified.
+emailVerifiedAlreadyMessage=Your email address has been verified already.
 staleEmailVerificationLink=The link you clicked is an old stale link and is no longer valid.  Maybe you have already verified your email.
 identityProviderAlreadyLinkedMessage=Federated identity returned by {0} is already linked to another user.
 confirmAccountLinking=Confirm linking the account {0} of identity provider {1} with your account.


### PR DESCRIPTION
Closes #14776

* Make sure users can not run actions on behalf of others. The driven use case here is email verification which blocks users from verifying email from a different account.
* Add a proper message and a specific event when an email verification action is attempted but the email is already verified. This PR removes the generic and unclear "you are already logged in" message from the login action service in favor of encapsulating the logic within each token handler (broker and and regular email verification token handlers)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
