### PR TITLE
Enhancing Lightweight access token M2

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2969,3 +2969,5 @@ authenticatorRefConfig.value.help=Add a custom reference name for the authentica
 authenticatorRefConfig.value.label=Authenticator Reference
 authenticatorRefConfig.maxAge.help=The max age in seconds that the authenticator reference value is good for in an SSO session. When the Authentication Method Reference (AMR) protocol mapper is used, the AMR will only be considered valid and populated in the token if the authenticator execution was completed within the specified max age.
 authenticatorRefConfig.maxAge.label=Authenticator Reference Max Age
+includeInLightweight.label=Add to lightweight access token
+includeInLightweight.tooltip=Should the claim be added to the lightweight access token?

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -163,4 +163,5 @@ public final class Constants {
 
     public static final String SESSION_NOTE_LIGHTWEIGHT_USER = "keycloak.userModel";
 
+    public static final String USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED = "client.use.lightweight.access.token.enabled";
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oidc.mappers;
 
 import org.keycloak.Config;
 import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ProtocolMapperModel;
@@ -80,10 +81,16 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
         return token;
     }
 
+    boolean getShouldUseLightweightToken(KeycloakSession session) {
+        Object attributeValue = session.getAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED);
+        return (attributeValue != null) ? (boolean) attributeValue : false;
+    }
+
     public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
                                             UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
-
-        if (!OIDCAttributeMapperHelper.includeInAccessToken(mappingModel)){
+        boolean shouldUseLightweightToken = getShouldUseLightweightToken(session);
+        boolean includeInAccessToken = shouldUseLightweightToken ?  OIDCAttributeMapperHelper.includeInLightweightAccessToken(mappingModel) : OIDCAttributeMapperHelper.includeInAccessToken(mappingModel);
+        if (!includeInAccessToken){
             return token;
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AllowedWebOriginsProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AllowedWebOriginsProtocolMapper.java
@@ -83,8 +83,9 @@ public class AllowedWebOriginsProtocolMapper extends AbstractOIDCProtocolMapper 
     @Override
     public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
                                             UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
-
-        if (!includeInAccessToken(mappingModel)){
+        boolean shouldUseLightweightToken = getShouldUseLightweightToken(session);
+        boolean includeInAccessToken = shouldUseLightweightToken ?  OIDCAttributeMapperHelper.includeInLightweightAccessToken(mappingModel) : includeInAccessToken(mappingModel);
+        if (!includeInAccessToken){
             return token;
         }
         setWebOrigin(token, session, clientSessionCtx);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceResolveProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceResolveProtocolMapper.java
@@ -88,7 +88,9 @@ public class AudienceResolveProtocolMapper extends AbstractOIDCProtocolMapper im
     @Override
     public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
                                             UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
-        if (!includeInAccessToken(mappingModel)){
+        boolean shouldUseLightweightToken = getShouldUseLightweightToken(session);
+        boolean includeInAccessToken = shouldUseLightweightToken ?  OIDCAttributeMapperHelper.includeInLightweightAccessToken(mappingModel) : includeInAccessToken(mappingModel);
+        if (!includeInAccessToken){
             return token;
         }
         setAudience(token, clientSessionCtx, session);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -71,6 +71,12 @@ public class OIDCAttributeMapperHelper {
     public static final String INCLUDE_IN_INTROSPECTION_LABEL = "includeInIntrospection.label";
     public static final String INCLUDE_IN_INTROSPECTION_HELP_TEXT = "includeInIntrospection.tooltip";
 
+    public static final String INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN = "lightweight.claim";
+
+    public static final String INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN_LABEL = "includeInLightweight.label";
+
+    public static final String INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN_HELP_TEXT = "includeInLightweight.tooltip";
+
     private static final Logger logger = Logger.getLogger(OIDCAttributeMapperHelper.class);
 
     /**
@@ -392,6 +398,10 @@ public class OIDCAttributeMapperHelper {
         return "true".equals(includeInIntrospection);
     }
 
+    public static boolean includeInLightweightAccessToken(ProtocolMapperModel mappingModel) {
+        return "true".equals(mappingModel.getConfig().get(INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN));
+    }
+
     public static void addAttributeConfig(List<ProviderConfigProperty> configProperties, Class<? extends ProtocolMapper> protocolMapperClass) {
         addTokenClaimNameConfig(configProperties);
         addJsonTypeConfig(configProperties);
@@ -443,6 +453,14 @@ public class OIDCAttributeMapperHelper {
             property.setDefaultValue("true");
             property.setHelpText(INCLUDE_IN_ACCESS_TOKEN_HELP_TEXT);
             configProperties.add(property);
+
+            ProviderConfigProperty property2 = new ProviderConfigProperty();
+            property2.setName(INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN);
+            property2.setLabel(INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN_LABEL);
+            property2.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+            property2.setDefaultValue("false");
+            property2.setHelpText(INCLUDE_IN_LIGHTWEIGHT_ACCESS_TOKEN_HELP_TEXT);
+            configProperties.add(property2);
         }
 
         if (UserInfoTokenMapper.class.isAssignableFrom(protocolMapperClass)) {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/UseLightweightAccessTokenExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/UseLightweightAccessTokenExecutor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+
+public class UseLightweightAccessTokenExecutor implements ClientPolicyExecutorProvider<ClientPolicyExecutorConfigurationRepresentation> {
+    private final KeycloakSession session;
+
+    public UseLightweightAccessTokenExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public String getProviderId() {
+        return UseLightweightAccessTokenExecutorFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case TOKEN_REQUEST:
+            case TOKEN_REFRESH:
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
+            case SERVICE_ACCOUNT_TOKEN_REQUEST:
+            case BACKCHANNEL_TOKEN_REQUEST:
+            case DEVICE_TOKEN_REQUEST:
+                session.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, true);
+                break;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/UseLightweightAccessTokenExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/UseLightweightAccessTokenExecutorFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+public class UseLightweightAccessTokenExecutorFactory implements ClientPolicyExecutorProviderFactory {
+    public static final String PROVIDER_ID = "use-lightweight-access-token";
+
+    @Override
+    public String getHelpText() {
+        return "Use lightweight access token";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new UseLightweightAccessTokenExecutor(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public boolean isSupported() {
+        return true;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -23,3 +23,4 @@ org.keycloak.services.clientpolicy.executor.RegistrationAccessTokenRotationDisab
 org.keycloak.services.clientpolicy.executor.RejectImplicitGrantExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureParContentsExecutorFactory
 org.keycloak.services.clientpolicy.executor.DPoPBindEnforcerExecutorFactory
+org.keycloak.services.clientpolicy.executor.UseLightweightAccessTokenExecutorFactory


### PR DESCRIPTION
Lightweight access token support follows milestone #21186.
Since M0,1 have already been implemented, I will implement milestone 2.
Details of the M2 specification can be found in #23724.

closes #23724 
