### PR TITLE
Update the UPDATE_EMAIL feature to rely on the user profile configuration when rendering templates and validating the email

### DIFF
--- a/docs/documentation/release_notes/topics/24_0_0.adoc
+++ b/docs/documentation/release_notes/topics/24_0_0.adoc
@@ -79,6 +79,7 @@ on the user profile configuration set to a realm:
 
 * `login-update-profile.ftl`
 * `register.ftl`
+* `update-email.ftl`
 
 For more details, see link:{upgradingguide_link}[{upgradingguide_name}].
 

--- a/docs/documentation/upgrading/topics/keycloak/changes-24_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-24_0_0.adoc
@@ -78,9 +78,10 @@ on the user profile configuration set to a realm:
 
 * `login-update-profile.ftl`
 * `register.ftl`
+* `update-email.ftl`
 
-These templates are responsible for rendering both update profile (when the `Update Profile` required action is enabled to a user)
-and registration pages, respectively.
+These templates are responsible for rendering the update profile (when the `Update Profile` required action is enabled to a user),
+the registration, and the update email (when the `UPDATE_EMAIL` feature is enabled) pages, respectively.
 
 If you use a custom theme to change these templates, they will function as expect because only the content is updated.
 However, we recommend you to take a look at how to configure a link:{adminguide_link}#user-profile[{declarative user profile}] and possibly avoid

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -164,6 +164,8 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 page = LoginFormsPages.LOGIN_UPDATE_PROFILE;
                 break;
             case UPDATE_EMAIL:
+                UpdateProfileContext updateEmailContext = new UserUpdateProfileContext(realm,user);
+                attributes.put("user",new ProfileBean(updateEmailContext,formData));
                 actionMessage = Messages.UPDATE_EMAIL;
                 page = LoginFormsPages.UPDATE_EMAIL;
                 break;
@@ -245,7 +247,10 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 attributes.put("user", new ProfileBean(userCtx, formData));
                 break;
             case UPDATE_EMAIL:
-                attributes.put("email", new EmailBean(user, formData));
+                EmailBean emailBean = new EmailBean(user, formData, session);
+                attributes.put("profile", emailBean);
+                // only for backward compatibility but should be removed once declarative user profile is supported
+                attributes.put("email", emailBean);
                 break;
             case LOGIN_IDP_LINK_CONFIRM:
             case LOGIN_IDP_LINK_EMAIL:

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/EmailBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/EmailBean.java
@@ -16,20 +16,40 @@
  */
 package org.keycloak.forms.login.freemarker.model;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-import org.keycloak.models.UserModel;
+import java.util.stream.Stream;
 
-public class EmailBean {
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.userprofile.UserProfileProvider;
+
+public class EmailBean extends AbstractUserProfileBean {
 
 	private final UserModel user;
-	private final MultivaluedMap<String, String> formData;
-
-	public EmailBean(UserModel user, MultivaluedMap<String, String> formData) {
+	public EmailBean(UserModel user, MultivaluedMap<String, String> formData, KeycloakSession session) {
+		super(formData);
 		this.user = user;
-		this.formData = formData;
+		init(session, false);
 	}
 
 	public String getValue() {
 		return formData != null ? formData.getFirst("email") : user.getEmail();
+	}
+
+	@Override
+	protected UserProfile createUserProfile(UserProfileProvider provider) {
+		return provider.create(UserProfileContext.UPDATE_EMAIL, user);
+	}
+
+	@Override
+	protected Stream<String> getAttributeDefaultValues(String name) {
+		return user.getAttributeStream(name);
+	}
+
+	@Override
+	public String getContext() {
+		return UserProfileContext.UPDATE_PROFILE.name();
 	}
 }

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
@@ -214,7 +214,7 @@ public class DeclarativeUserProfileProviderFactory implements UserProfileProvide
         addContextualProfileMetadata(configureUserProfile(createAccountProfile(ACCOUNT, readOnlyValidator)));
         addContextualProfileMetadata(configureUserProfile(createDefaultProfile(UPDATE_PROFILE, readOnlyValidator)));
         if (Profile.isFeatureEnabled(Profile.Feature.UPDATE_EMAIL)) {
-            addContextualProfileMetadata(configureUserProfile(createDefaultProfile(UPDATE_EMAIL, readOnlyValidator)));
+            addContextualProfileMetadata(configureUserProfile(createUpdateEmailProfile(UPDATE_EMAIL, readOnlyValidator)));
         }
         addContextualProfileMetadata(configureUserProfile(createRegistrationUserCreationProfile(readOnlyValidator)));
         addContextualProfileMetadata(configureUserProfile(createUserResourceValidation(config)));
@@ -377,6 +377,31 @@ public class DeclarativeUserProfileProviderFactory implements UserProfileProvide
                 new AttributeValidatorMetadata(UsernameHasValueValidator.ID),
                 new AttributeValidatorMetadata(DuplicateUsernameValidator.ID),
                 new AttributeValidatorMetadata(UsernameMutationValidator.ID)).setAttributeDisplayName("${username}");
+
+        metadata.addAttribute(UserModel.EMAIL, -1,
+                        DeclarativeUserProfileProviderFactory::editEmailCondition,
+                        DeclarativeUserProfileProviderFactory::readEmailCondition,
+                        new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_EMAIL, false)),
+                        new AttributeValidatorMetadata(DuplicateEmailValidator.ID),
+                        new AttributeValidatorMetadata(EmailExistsAsUsernameValidator.ID),
+                        new AttributeValidatorMetadata(EmailValidator.ID, ValidatorConfig.builder().config(EmailValidator.IGNORE_EMPTY_VALUE, true).build()))
+                .setAttributeDisplayName("${email}");
+
+        List<AttributeValidatorMetadata> readonlyValidators = new ArrayList<>();
+
+        readonlyValidators.add(createReadOnlyAttributeUnchangedValidator(readOnlyAttributesPattern));
+
+        if (readOnlyValidator != null) {
+            readonlyValidators.add(readOnlyValidator);
+        }
+
+        metadata.addAttribute(READ_ONLY_ATTRIBUTE_KEY, 1000, readonlyValidators);
+
+        return metadata;
+    }
+
+    private UserProfileMetadata createUpdateEmailProfile(UserProfileContext context, AttributeValidatorMetadata readOnlyValidator) {
+        UserProfileMetadata metadata = new UserProfileMetadata(context);
 
         metadata.addAttribute(UserModel.EMAIL, -1,
                         DeclarativeUserProfileProviderFactory::editEmailCondition,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractAppInitiatedActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractAppInitiatedActionUpdateEmailTest.java
@@ -128,7 +128,7 @@ public abstract class AbstractAppInitiatedActionUpdateEmailTest extends Abstract
 		emailUpdatePage.changeEmail("");
 		emailUpdatePage.assertCurrent();
 
-		Assert.assertEquals("Please specify email.", emailUpdatePage.getEmailError());
+		Assert.assertTrue(emailUpdatePage.getEmailError().contains("Please specify email."));
 
 		UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost");
 		Assert.assertEquals("test-user@localhost", user.getEmail());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
@@ -132,7 +132,7 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 		// assert that form holds submitted values during validation error
 		Assert.assertEquals("", updateEmailPage.getEmail());
 
-		Assert.assertEquals("Please specify email.", updateEmailPage.getEmailInputError());
+		Assert.assertTrue(updateEmailPage.getEmailInputError().contains("Please specify email."));
 
 		events.assertEmpty();
 	}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionUpdateEmailUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionUpdateEmailUserProfileTest.java
@@ -16,10 +16,27 @@
  */
 package org.keycloak.testsuite.actions;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.keycloak.userprofile.UserProfileConstants.ROLE_USER;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.UserProfileResource;
 import org.keycloak.common.Profile;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
+import org.keycloak.representations.userprofile.config.UPAttributeRequired;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.forms.VerifyProfileTest;
+import org.keycloak.validate.validators.LengthValidator;
 
 @EnableFeature(Profile.Feature.DECLARATIVE_USER_PROFILE)
 public class AppInitiatedActionUpdateEmailUserProfileTest extends AppInitiatedActionUpdateEmailTest {
@@ -28,5 +45,45 @@ public class AppInitiatedActionUpdateEmailUserProfileTest extends AppInitiatedAc
     public void configureTestRealm(RealmRepresentation testRealm) {
         super.configureTestRealm(testRealm);
         VerifyProfileTest.enableDynamicUserProfile(testRealm);
+    }
+
+    @Test
+    public void testCustomEmailValidator() throws Exception {
+        UserProfileResource userProfile = testRealm().users().userProfile();
+        UPConfig upConfig = userProfile.getConfiguration();
+        UPAttribute emailConfig = upConfig.getAttribute(UserModel.EMAIL);
+        emailConfig.addValidation(LengthValidator.ID, Map.of("min", "1", "max", "1"));
+        getCleanup().addCleanup(() -> {
+            emailConfig.getValidations().remove(LengthValidator.ID);
+            userProfile.update(upConfig);
+        });
+        userProfile.update(upConfig);
+
+        changeEmailUsingAIA("new@email.com");
+        assertTrue(emailUpdatePage.getEmailError().contains("Length must be between 1 and 1."));
+
+        emailConfig.getValidations().remove(LengthValidator.ID);
+        userProfile.update(upConfig);
+        changeEmailUsingAIA("new@email.com");
+        events.expect(EventType.UPDATE_EMAIL).detail(Details.PREVIOUS_EMAIL, "test-user@localhost")
+                .detail(Details.UPDATED_EMAIL, "new@email.com").assertEvent();
+    }
+
+    @Test
+    public void testOnlyEmailSupportedInContext() throws Exception {
+        UserProfileResource userProfile = testRealm().users().userProfile();
+        UPConfig upConfig = userProfile.getConfiguration();
+        String unexpectedAttributeName = "unexpectedAttribute";
+        upConfig.addOrReplaceAttribute(new UPAttribute(unexpectedAttributeName, new UPAttributePermissions(Set.of(), Set.of(ROLE_USER)), new UPAttributeRequired(Set.of(ROLE_USER), Set.of())));
+        getCleanup().addCleanup(() -> {
+            upConfig.removeAttribute(unexpectedAttributeName);
+            userProfile.update(upConfig);
+        });
+        userProfile.update(upConfig);
+
+        assertFalse(driver.getPageSource().contains(unexpectedAttributeName));
+        changeEmailUsingAIA("new@email.com");
+        events.expect(EventType.UPDATE_EMAIL).detail(Details.PREVIOUS_EMAIL, "test-user@localhost")
+                .detail(Details.UPDATED_EMAIL, "new@email.com").assertEvent();
     }
 }

--- a/themes/src/main/resources/theme/base/login/update-email.ftl
+++ b/themes/src/main/resources/theme/base/login/update-email.ftl
@@ -1,27 +1,12 @@
 <#import "template.ftl" as layout>
 <#import "password-commons.ftl" as passwordCommons>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('email'); section>
+<#import "user-profile-commons.ftl" as userProfileCommons>
+<@layout.registrationLayout displayMessage=messagesPerField.exists('global') displayRequiredFields=true; section>
     <#if section = "header">
         ${msg("updateEmailTitle")}
     <#elseif section = "form">
         <form id="kc-update-email-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
-            <div class="${properties.kcFormGroupClass!}">
-                <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="email" class="${properties.kcLabelClass!}">${msg("email")}</label>
-                </div>
-                <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="email" name="email" value="${(email.value!'')}"
-                           class="${properties.kcInputClass!}"
-                           aria-invalid="<#if messagesPerField.existsError('email')>true</#if>"
-                    />
-
-                    <#if messagesPerField.existsError('email')>
-                        <span id="input-error-email" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                            ${kcSanitize(messagesPerField.get('email'))?no_esc}
-                        </span>
-                    </#if>
-                </div>
-            </div>
+            <@userProfileCommons.userProfileFormFields/>
 
             <div class="${properties.kcFormGroupClass!}">
                 <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">


### PR DESCRIPTION
Closes #25704

* Make sure only the `email` attribute is supported by the `UPDATE_EMAIL` context
* Update the `update-email.ftl` to dynamically render user attributes (e.g.: only locale) based on the user profile configuration
* Make sure validation works when updating the `emai` attribute if executing the update email required action

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
