### PR TITLE
[Keycloak-js] Expose processCallback, parseCallback and createPromise to custom adapters 

### DIFF
--- a/js/libs/keycloak-js/dist/keycloak.d.ts
+++ b/js/libs/keycloak-js/dist/keycloak.d.ts
@@ -52,6 +52,17 @@ export interface Acr {
 	essential: boolean;
 }
 
+export interface KeycloakFactoryAdapter {
+	processCallback: (oauth: unknown, promise: unknown) => void;
+	parseCallback: (url: string) => object;
+	createPromise: () => {
+	  setSuccess: (result?: unknown) => void;
+	  setError: (result?: unknown) => void;
+	  promise: Promise<unknown>;
+	};
+	kc: Keycloak;
+}
+
 export interface KeycloakInitOptions {
 	/**
 	 * Adds a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)
@@ -97,18 +108,7 @@ export interface KeycloakInitOptions {
 	'cordova' |
 	'cordova-native' |
 	KeycloakAdapter |
-	(
-		(
-			processCallback: (oauth: unknown, promise: unknown) => void,
-			parseCallback: (url: string) => object,
-			createPromise: () => {
-				setSuccess: (result?: unknown) => void;
-				setError: (result?: unknown) => void;
-				promise: Promise<unknown>;
-			},
-			kc: Keycloak,
-		) => KeycloakAdapter
-	);
+	((params: KeycloakFactoryAdapter) => KeycloakAdapter);
 	
 	/**
 	 * Specifies an action to do on load.

--- a/js/libs/keycloak-js/dist/keycloak.d.ts
+++ b/js/libs/keycloak-js/dist/keycloak.d.ts
@@ -92,7 +92,23 @@ export interface KeycloakInitOptions {
 	 * });
 	 * ```
 	 */
-	adapter?: 'default' | 'cordova' | 'cordova-native' | KeycloakAdapter;
+	adapter?:
+	'default' |
+	'cordova' |
+	'cordova-native' |
+	KeycloakAdapter |
+	(
+		(
+			processCallback: (oauth: unknown, promise: unknown) => void,
+			parseCallback: (url: string) => object,
+			createPromise: () => {
+				setSuccess: (result?: unknown) => void;
+				setError: (result?: unknown) => void;
+				promise: Promise<unknown>;
+			},
+			kc: Keycloak,
+		) => KeycloakAdapter
+	);
 	
 	/**
 	 * Specifies an action to do on load.

--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -63,6 +63,13 @@ function Keycloak (config) {
 
         if (initOptions && adapters.indexOf(initOptions.adapter) > -1) {
             adapter = loadAdapter(initOptions.adapter);
+        } else if (initOptions && typeof initOptions.adapter === 'function') {
+            adapter = initOptions.adapter({
+                processCallback,
+                parseCallback,
+                createPromise,
+                kc,
+            });
         } else if (initOptions && typeof initOptions.adapter === "object") {
             adapter = initOptions.adapter;
         } else {


### PR DESCRIPTION
Possible solution to issue https://github.com/keycloak/keycloak-js/issues/27.

I'm adding a new way to create adapters, which is a factory function (receive as parameters all the required internal KC methods like processCallback, parseCallback, createPromise, and KC instance) and must return a KeycloakAdapter object.

This is a preliminary PR, we need to work on tests, documentation, etc. but the idea is pretty clear.