### PR TITLE
Fix X509 client certificate login label

### DIFF
--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -608,4 +608,8 @@ ul#kc-totp-supported-apps {
     align-items: baseline;
     margin-bottom: 16px;
 }
+
+#certificate_subjectDN {
+    overflow-wrap: break-word
+}
 /* End Recovery codes */


### PR DESCRIPTION
Fix X509 client certificate login label.

Closes #25770

# Before

![Screenshot 2023-12-22 at 10 15 17](https://github.com/keycloak/keycloak/assets/60488810/bbc6395e-82fc-48ca-8845-415e9d0799af)

# After

![Screenshot 2023-12-22 at 10 19 38](https://github.com/keycloak/keycloak/assets/60488810/5cc9718c-10e7-4f7d-b9f2-d6cdb3e4a36e)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

