### PR TITLE
Add 'scope' field to KeycloakAdminClient

### DIFF
--- a/js/libs/keycloak-admin-client/src/client.ts
+++ b/js/libs/keycloak-admin-client/src/client.ts
@@ -49,6 +49,7 @@ export class KeycloakAdminClient {
   // Members
   public baseUrl: string;
   public realmName: string;
+  public scope?: string;
   public accessToken?: string;
   public refreshToken?: string;
 
@@ -84,6 +85,7 @@ export class KeycloakAdminClient {
     const { accessToken, refreshToken } = await getToken({
       baseUrl: this.baseUrl,
       realmName: this.realmName,
+      scope: this.scope,
       credentials,
       requestOptions: this.#requestOptions,
     });

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -20,6 +20,7 @@ export interface Credentials {
 export interface Settings {
   realmName?: string;
   baseUrl?: string;
+  scope?: string;
   credentials: Credentials;
   requestOptions?: RequestInit;
 }


### PR DESCRIPTION
It is an optional property, can be passed when requesting the optional scopes.

Closes #19586