### PR TITLE
fix: providing an error description

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -85,7 +85,8 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             OAuth2ErrorRepresentation error = new OAuth2ErrorRepresentation();
 
             error.setError(getErrorCode(throwable));
-            
+            error.setErrorDescription("For more on this error consult the server log at the debug level.");
+
             return Response.status(statusCode)
                     .header(HttpHeaders.CONTENT_TYPE, jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE.toString())
                     .entity(error)
@@ -125,11 +126,11 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
         if (throwable instanceof JsonProcessingException) {
             status = Response.Status.BAD_REQUEST.getStatusCode();
         }
-        
+
         if (throwable instanceof ModelDuplicateException) {
             status = Response.Status.CONFLICT.getStatusCode();
         }
-        
+
         return status;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
@@ -197,7 +197,9 @@ public class ClientAttributeCertificateResource {
         CertificateRepresentation info = new CertificateRepresentation();
         MultivaluedMap<String, FormPartValue> uploadForm = session.getContext().getHttpRequest().getMultiPartFormParameters();
         FormPartValue keystoreFormatPart = uploadForm.getFirst("keystoreFormat");
-        if (keystoreFormatPart == null) throw new BadRequestException();
+        if (keystoreFormatPart == null) {
+            throw new BadRequestException("keystoreFormat cannot be null");
+        }
         String keystoreFormat = keystoreFormatPart.asString();
         FormPartValue inputParts = uploadForm.getFirst("file");
         if (keystoreFormat.equals(CERTIFICATE_PEM)) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -145,7 +145,7 @@ public class ComponentResource {
         } catch (ComponentValidationException e) {
             return localizedErrorResponse(e);
         } catch (IllegalArgumentException e) {
-            throw new BadRequestException(e);
+            throw new BadRequestException("Invalid provider type or no such provider", e);
         }
     }
 
@@ -184,7 +184,7 @@ public class ComponentResource {
         } catch (ComponentValidationException e) {
             return localizedErrorResponse(e);
         } catch (IllegalArgumentException e) {
-            throw new BadRequestException();
+            throw new BadRequestException("Invalid provider type or no such provider", e);
         }
     }
     @DELETE

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -143,7 +143,7 @@ public class RoleContainerResource extends RoleResource {
         auth.roles().requireManage(roleContainer);
 
         if (rep.getName() == null) {
-            throw new BadRequestException();
+            throw new BadRequestException("role has no name");
         }
 
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
@@ -26,7 +26,6 @@ import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.MediaType;
 import org.openqa.selenium.By;
 
-import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -38,10 +37,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
+import jakarta.ws.rs.core.Response;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.utils.MediaType.APPLICATION_JSON;
@@ -95,7 +97,7 @@ public class UncaughtErrorPageTest extends AbstractKeycloakTest {
 
             OAuth2ErrorRepresentation error = JsonSerialization.readValue(response.getEntity().getContent(), OAuth2ErrorRepresentation.class);
             assertEquals(OAuthErrorException.INVALID_REQUEST, error.getError());
-            assertNull(error.getErrorDescription());
+            assertNotNull(error.getErrorDescription());
         }
     }
 
@@ -115,7 +117,7 @@ public class UncaughtErrorPageTest extends AbstractKeycloakTest {
 
             OAuth2ErrorRepresentation error = JsonSerialization.readValue(response.getEntity().getContent(), OAuth2ErrorRepresentation.class);
             assertEquals(OAuthErrorException.INVALID_REQUEST, error.getError());
-            assertNull(error.getErrorDescription());
+            assertNotNull(error.getErrorDescription());
         }
     }
 


### PR DESCRIPTION
An error description is not currently provided, which means that users must have debug level logging enabled on the server to understand why requests are failing.

The proposal here is to add an error description based upon the underlying exception message. If however that is not desirable - if there's a concern it may leak too much information - then we can instead have the description inform the user about enabling debug / checking the log.

The other thing that was noticed here is that we're generally not using valid oauth 2 error codes. Here as well I'm not sure if that was intentional - if we're just reusing the oauth 2 error object generally and not expecting the codes to be meaningful here.

closes: #25746

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
