### PR TITLE
Fix for empty realm name issue during api update

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
@@ -97,8 +97,9 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.UserStorageUtil;
 import org.keycloak.storage.federated.UserFederatedStorageProvider;
-import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.ReservedCharValidator;
+import org.keycloak.utils.StringUtil;
 import org.keycloak.validation.ValidationUtil;
 
 import jakarta.ws.rs.core.MediaType;
@@ -651,7 +652,12 @@ public class LegacyExportImportManager implements ExportImportManager {
 
 
     public static void renameRealm(RealmModel realm, String name) {
-        if (name.equals(realm.getName())) return;
+        if (name.equals(realm.getName())) {
+            return;
+        }
+        if (StringUtil.isBlank(name)) {
+            throw new ModelException("Realm name cannot be empty");
+        }
 
         String oldName = realm.getName();
 

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -26,6 +26,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.ImpersonationConstants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.OTPPolicy;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
@@ -61,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.keycloak.utils.ReservedCharValidator;
+import org.keycloak.utils.StringUtil;
 
 /**
  * Per request object
@@ -514,6 +516,9 @@ public class RealmManager {
             id = KeycloakModelUtils.generateId();
         } else {
             ReservedCharValidator.validate(id);
+        }
+        if (StringUtil.isBlank(rep.getRealm())) {
+            throw new ModelException("Realm name cannot be empty");
         }
 
         RealmModel realm = model.createRealm(id, rep.getRealm());

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -30,6 +30,7 @@ import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.StripSecretsUtils;
@@ -167,6 +168,8 @@ public class RealmsAdminResource {
             logger.error("Password policy not met for user " + e.getUsername(), e);
             if (session.getTransactionManager().isActive()) session.getTransactionManager().setRollbackOnly();
             throw ErrorResponse.error("Password policy not met. See logs for details", Response.Status.BAD_REQUEST);
+        } catch (ModelException e) {
+            throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
@@ -58,7 +58,6 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.auth.page.AuthRealm;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.events.TestEventsListenerProviderFactory;
-import org.keycloak.testsuite.model.StoreProvider;
 import org.keycloak.testsuite.runonserver.RunHelpers;
 import org.keycloak.testsuite.updaters.Creator;
 import org.keycloak.testsuite.util.AdminEventPaths;
@@ -96,6 +95,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
@@ -213,11 +213,13 @@ public class RealmTest extends AbstractAdminTest {
         Assert.assertNames(adminClient.realms().findAll(), "master", AuthRealm.TEST, REALM_NAME);
     }
 
-    @Test(expected = BadRequestException.class)
-    public void createRealmRejectReservedChar() {
+    @Test
+    public void createRealmRejectReservedCharOrEmptyName() {
         RealmRepresentation rep = new RealmRepresentation();
         rep.setRealm("new-re;alm");
-        adminClient.realms().create(rep);
+        assertThrows(BadRequestException.class, () -> adminClient.realms().create(rep));
+        rep.setRealm("");
+        assertThrows(BadRequestException.class, () -> adminClient.realms().create(rep));
     }
 
     /**
@@ -460,11 +462,13 @@ public class RealmTest extends AbstractAdminTest {
         checkRealmEventsConfigRepresentation(repOrig, actual);
     }
 
-    @Test(expected = BadRequestException.class)
-    public void updateRealmWithReservedCharInName() {
+    @Test
+    public void updateRealmWithReservedCharInNameOrEmptyName() {
         RealmRepresentation rep = realm.toRepresentation();
         rep.setRealm("fo#o");
-        realm.update(rep);
+        assertThrows(BadRequestException.class, () -> realm.update(rep));
+        rep.setRealm("");
+        assertThrows(BadRequestException.class, () -> realm.update(rep));
     }
     
     @Test


### PR DESCRIPTION
Added a check to ignore renaming if it is an empty string.

Closes #17449

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
