### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/actions/archive-surefire-reports/action.yml
+++ b/.github/actions/archive-surefire-reports/action.yml
@@ -37,7 +37,7 @@ runs:
     - id: upload-surefire-linux
       name: Upload Surefire reports
       if: (!cancelled() && contains(fromJSON(inputs.release-branches), github.ref) && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name))
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: surefire-${{ inputs.job-id }}
         path: |

--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -75,7 +75,7 @@ runs:
     - id: upload-keycloak-maven-repository
       name: Upload Keycloak Maven artifacts
       if: inputs.upload-m2-repo == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: m2-keycloak.tzts
         path: m2-keycloak.tzts
@@ -84,7 +84,7 @@ runs:
     - id: upload-keycloak-dist
       name: Upload Keycloak dist
       if: inputs.upload-dist == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: keycloak-dist
         path: quarkus/dist/target/keycloak*.tar.gz

--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - id: download-keycloak
       name: Download Keycloak Maven artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: m2-keycloak.tzts
 

--- a/.github/actions/upload-flaky-tests/action.yml
+++ b/.github/actions/upload-flaky-tests/action.yml
@@ -47,7 +47,6 @@ runs:
           echo "EOF" >> $GITHUB_OUTPUT
         fi
 
-    # Use v3 as uploads with the v4 version of the plugin seems not to be downloadable with the current GitHub Application we're using
     - uses: actions/upload-artifact@v3
       if: ${{ steps.flaky-tests.outputs.flakes }}
       with:

--- a/.github/actions/upload-heapdumps/action.yml
+++ b/.github/actions/upload-heapdumps/action.yml
@@ -8,7 +8,7 @@ runs:
       name: Upload JVM Heapdumps
       # Windows runners are running into https://github.com/actions/upload-artifact/issues/240
       if: runner.os != 'Windows'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: jvm-heap-dumps
         path: '**/java_pid*.hprof'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,7 +59,7 @@ jobs:
 
       - id: upload-keycloak-documentation
         name: Upload Keycloak documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: keycloak-documentation
           path: docs/documentation/dist/target/*.zip

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -56,7 +56,7 @@ jobs:
           mv ./quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz ./keycloak-999.0.0-SNAPSHOT.tar.gz
 
       - name: Upload Keycloak dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: keycloak
           path: keycloak-999.0.0-SNAPSHOT.tar.gz
@@ -201,7 +201,7 @@ jobs:
           working-directory: js
 
       - name: Download Keycloak server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: keycloak
 
@@ -229,7 +229,7 @@ jobs:
         env:
           KEYCLOAK_SERVER: http://localhost:8080
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: account-ui-playwright-report
@@ -238,7 +238,7 @@ jobs:
 
       - name: Upload server logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: account-ui-server-log
           path: ~/server.log
@@ -284,7 +284,7 @@ jobs:
         working-directory: js
 
       - name: Download Keycloak server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: keycloak
 
@@ -324,7 +324,7 @@ jobs:
 
       - name: Upload server logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: admin-ui-server-log-${{ matrix.container }}-${{ matrix.browser }}
           path: ~/server.log

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Download keycloak distribution
         id: download-keycloak-dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: keycloak-dist
           path: quarkus/container
@@ -121,7 +121,7 @@ jobs:
 
       - name: Download keycloak distribution
         id: download-keycloak-dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: keycloak-dist
           path: quarkus/container
@@ -177,7 +177,7 @@ jobs:
 
       - name: Download keycloak distribution
         id: download-keycloak-dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: keycloak-dist
           path: quarkus/container


### PR DESCRIPTION
This reverts commit 04e7f9a245cbdc030cae400879dac63a27535dd4.

Revert "Updating actions as well, not only workflows"

This reverts commit dea0f3c3dbe1000451194dc58a499b02631f0ed1.

Revert "Don't upgrade flaky test upload as flaky tests are not reported"

This reverts commit f13e2bce9ef07a39507cf35b66146a4a594200e1.

Closes #25853

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
