### PR TITLE
Make sure the context path from the base URI is respected when building TOTP URIs

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -316,7 +316,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
      */
     private UriBuilder getTotpUriBuilder() {
         return uriInfo.getBaseUriBuilder()
-                .replacePath(uriInfo.getRequestUri().getPath())
+                .path(uriInfo.getPath())
                 .replaceQuery(uriInfo.getRequestUri().getQuery());
     }
 


### PR DESCRIPTION
Closes #21542

* The URL was being built by replacing the whole path and losing the context path from the hostname provider. Instead, the current path for the required action should be appended.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
