### PR TITLE
fix: do not split on space for option errors

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-23_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-23_0_0.adoc
@@ -114,6 +114,18 @@ it must instead be individual arguments
 bin/kc.sh start --help
 ```
 
+Similarly instead of
+
+```
+bin/kc.sh build "--db postgres"
+```
+
+it must instead be individual arguments
+
+```
+bin/kc.sh build --db postgres
+```
+
 The usage of individual arguments is also required in Dockerfile run commands.
 
 = Removed RegistrationProfile form action

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
@@ -28,17 +28,17 @@ public class ShortErrorMessageHandler implements IParameterExceptionHandler {
             UnmatchedArgumentException uae = (UnmatchedArgumentException) ex;
 
             String[] unmatched = getUnmatchedPartsByOptionSeparator(uae,"=");
-            String original = uae.getUnmatched().get(0);
-            if (unmatched[0].equals(original)) {
-                unmatched = getUnmatchedPartsByOptionSeparator(uae," ");
-            }
-            
+
             String cliKey = unmatched[0];
 
             PropertyMapper<?> mapper = PropertyMappers.getMapper(cliKey);
 
             if (mapper == null || !(cmd.getCommand() instanceof AbstractCommand)) {
-                errorMessage = "Unknown option: '" + cliKey + "'";
+                if (cliKey.split("\\s").length > 1) {
+                    errorMessage = "Option: '" + cliKey + "' is not expected to contain whitespace, please remove any unnecessary quoting/escaping";
+                } else {
+                    errorMessage = "Unknown option: '" + cliKey + "'";
+                }
             } else {
                 AbstractCommand command = cmd.getCommand();
                 if (!command.getOptionCategories().contains(mapper.getCategory())) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/OptionValidationTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/OptionValidationTest.java
@@ -55,7 +55,7 @@ public class OptionValidationTest {
     }
 
     @Test
-    @Launch({"start", "--db-pasword mytestpw"})
+    @Launch({"start", "--db-pasword", "mytestpw"})
     public void failUnknownOptionWhitespaceSeparatorNotShowingValue(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         assertEquals("Unknown option: '--db-pasword'\n" +
@@ -79,5 +79,12 @@ public class OptionValidationTest {
         assertEquals("Unknown option: '--db-pasword'\n" +
                 "Possible solutions: --db-driver, --db-url, --db-url-host, --db-url-database, --db-url-port, --db-url-properties, --db-username, --db-password, --db-schema, --db-pool-initial-size, --db-pool-min-size, --db-pool-max-size, --db\n" +
                 "Try '" + KeycloakDistribution.SCRIPT_CMD + " start --help' for more information on the available options.", cliResult.getErrorOutput());
+    }
+
+    @Test
+    @Launch({ "start", "--db postgres" })
+    void failSingleParamWithSpace(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertError("Option: '--db postgres' is not expected to contain whitespace, please remove any unnecessary quoting/escaping");
     }
 }


### PR DESCRIPTION
There is a mismatch between the option parsing and the option error logic.  There are two possible resolutions. The first, shown here, is to just remove the check for space in the error handling.

The other, more involved fix, would be to update the option logic to split on space. Comparing to common linux handling:
awk "-f file" is interpretted as preserving the space - you'll get an exception that " file" cannot be found. It may not be worth heading down this path.

closes #25783

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
