### PR TITLE
Update web element of the LinkedIn login page

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/LinkedInLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/LinkedInLoginPage.java
@@ -31,7 +31,7 @@ public class LinkedInLoginPage extends AbstractSocialLoginPage {
     @FindBy(id = "password")
     private WebElement passwordInput;
 
-    @FindBy(xpath = "//button[text() = 'Sign in']")
+    @FindBy(xpath = "//button[(@type='submit') and (@aria-label='Sign in')]")
     private WebElement loginButton;
 
     @FindBy(name = "action")


### PR DESCRIPTION
Rely on the `type` and `aria-label` tags to more clearly specify the login button instead of relying on `text()`. The `text()` changed from `Sign in` to `‎ Sign in‎ ` (leading and trailing space) and it may change to something else over time.