### PR TITLE
Could not format default value for log formats

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -638,7 +638,10 @@ public final class Picocli {
             transformedDesc.append(" Possible values are: " + String.join(", ", mapper.getExpectedValues()) + ".");
         }
 
-        mapper.getDefaultValue().map(d -> " Default: " + d + ".").ifPresent(transformedDesc::append);
+        mapper.getDefaultValue()
+                .map(d -> d.toString().replaceAll("%", "%%")) // escape formats
+                .map(d -> " Default: " + d + ".")
+                .ifPresent(transformedDesc::append);
 
         mapper.getDeprecatedMetadata().ifPresent(deprecatedMetadata -> {
             List<String> deprecatedDetails = new ArrayList<>();


### PR DESCRIPTION
Closes #25908 

Log after providing these changes (no warnings about these formats):
```
Start the server.

Usage: 

kc.sh start [OPTIONS]

Use this command to run the server in production.

Options:

-h, --help           This help message.
--help-all           This same help message but with additional options.
--import-realm       Import realms during startup by reading any realm configuration file from the
                       'data/import' directory.
--optimized          Use this option to achieve an optimal startup time if you have previously
                       built a server image using the 'build' command.
-v, --verbose        Print out error details when running this command.

```