### PR TITLE
Update the logic of the policy providers 

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/permission/ScopePolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/permission/ScopePolicyProvider.java
@@ -38,7 +38,7 @@ public class ScopePolicyProvider extends AbstractPermissionProvider {
         logger.debugv("Scope policy {} evaluating using parent class", evaluation.getPolicy().getName());
         DefaultEvaluation defaultEvaluation = DefaultEvaluation.class.cast(evaluation);
         Map<Policy, Map<Object, Decision.Effect>> decisionCache = defaultEvaluation.getDecisionCache();
-        Policy policy = defaultEvaluation.getParentPolicy();
+        Policy policy = defaultEvaluation.getPolicy();
         Map<Object, Decision.Effect> decisions = decisionCache.computeIfAbsent(policy, p -> new HashMap<>());
         ResourcePermission permission = evaluation.getPermission();
 

--- a/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
@@ -106,29 +106,21 @@ public class UserManagedPermissionUtil {
 
         userPolicyRep.setName(KeycloakModelUtils.generateId());
         userPolicyRep.addUser(ticket.getRequester());
-
+        userPolicyRep.setOwner(ticket.getOwner());
         Policy userPolicy = policyStore.create(ticket.getResourceServer(), userPolicyRep);
 
-        userPolicy.setOwner(ticket.getOwner());
-
         PolicyRepresentation policyRep = new PolicyRepresentation();
-
         policyRep.setName(KeycloakModelUtils.generateId());
         policyRep.setType("uma");
         policyRep.addPolicy(userPolicy.getId());
-
-        Policy policy = policyStore.create(ticket.getResourceServer(), policyRep);
-
-        policy.setOwner(ticket.getOwner());
-        policy.addResource(ticket.getResource());
-
+        policyRep.setOwner(ticket.getOwner());
+        policyRep.addResource(ticket.getResource().getId());
         Scope scope = ticket.getScope();
-
         if (scope != null) {
-            policy.addScope(scope);
+            policyRep.addScope(scope.getId());
         }
 
-        return policy;
+        return policyStore.create(ticket.getResourceServer(), policyRep);
     }
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionResultCollector.java
@@ -21,6 +21,6 @@ package org.keycloak.authorization.policy.evaluation;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public abstract class DecisionResultCollector extends AbstractDecisionCollector {
+public class DecisionResultCollector extends AbstractDecisionCollector {
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/Evaluation.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/Evaluation.java
@@ -80,4 +80,17 @@ public interface Evaluation {
     Effect getEffect();
 
     void setEffect(Effect effect);
+    
+    PolicyProvider getPolicyProvider();
+
+    /**
+     * The priority policies of this type should have when being considered among decisions in
+     * {@link org.keycloak.authorization.policy.evaluation.DecisionPermissionCollector}
+     * A value of 1 is the lowest priority and any number > 1 is a higher priority.
+     * (e.g. a policy with priority 2 will override the results of a policy of priority 1)
+     * @return the priority of the policy
+     */
+    default Integer getPriority() {
+        return 1;
+    }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -49,6 +49,7 @@ import org.keycloak.authorization.admin.representation.PolicyEvaluationResponseB
 import org.keycloak.authorization.attribute.Attributes;
 import org.keycloak.authorization.common.DefaultEvaluationContext;
 import org.keycloak.authorization.common.KeycloakIdentity;
+import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
@@ -331,23 +332,12 @@ public class PolicyEvaluationService {
         }
 
         @Override
-        protected boolean isGranted(Result.PolicyResult policyResult) {
-            if (super.isGranted(policyResult)) {
-                policyResult.setEffect(Effect.PERMIT);
-                return true;
-            }
-            return false;
+        protected void grantPermission(AuthorizationProvider authorizationProvider, Set<Permission> permissions, ResourcePermission permission, Collection<Scope> grantedScopes, ResourceServer resourceServer, AuthorizationRequest request) {
+            super.grantPermission(authorizationProvider, permissions, permission, grantedScopes, resourceServer, request);
         }
 
-        @Override
-        protected void grantPermission(AuthorizationProvider authorizationProvider, Set<Permission> permissions, ResourcePermission permission, Collection<Scope> grantedScopes, ResourceServer resourceServer, AuthorizationRequest request, Result result) {
-            result.setStatus(Effect.PERMIT);
-            result.getPermission().getScopes().retainAll(grantedScopes);
-            super.grantPermission(authorizationProvider, permissions, permission, grantedScopes, resourceServer, request, result);
-        }
-
-        public Collection<Result> getResults() {
-            return results.values();
+        public Map<ResourcePermission, Map<Policy, Result>> getPolicyResults() {
+            return policyResults;
         }
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
@@ -72,7 +72,8 @@ public class PolicyEvaluationResponseBuilder {
 
         response.setRpt(accessToken);
 
-        Collection<Result> results = decision.getResults();
+
+        Collection<Result> results = decision.getPolicyResults().values().stream().flatMap(m -> m.values().stream()).collect(Collectors.toList());
 
         if (results.stream().anyMatch(evaluationResult -> evaluationResult.getEffect().equals(Decision.Effect.DENY))) {
             response.setStatus(DecisionEffect.DENY);
@@ -117,7 +118,7 @@ public class PolicyEvaluationResponseBuilder {
 
             List<PolicyEvaluationResponse.PolicyResultRepresentation> policies = new ArrayList<>();
 
-            for (Result.PolicyResult policy : result.getResults()) {
+            for (Result policy : results) {
                 PolicyResultRepresentation policyRep = toRepresentation(policy, authorization);
 
                 if ("resource".equals(policy.getPolicy().getType())) {
@@ -177,7 +178,7 @@ public class PolicyEvaluationResponseBuilder {
         return response;
     }
 
-    private static PolicyEvaluationResponse.PolicyResultRepresentation toRepresentation(Result.PolicyResult result, AuthorizationProvider authorization) {
+    private static PolicyEvaluationResponse.PolicyResultRepresentation toRepresentation(Result result, AuthorizationProvider authorization) {
         PolicyEvaluationResponse.PolicyResultRepresentation policyResultRep = new PolicyEvaluationResponse.PolicyResultRepresentation();
 
         PolicyRepresentation representation = new PolicyRepresentation();
@@ -238,7 +239,7 @@ public class PolicyEvaluationResponseBuilder {
             policyResultRep.setStatus(DecisionEffect.PERMIT);
         }
 
-        policyResultRep.setAssociatedPolicies(result.getAssociatedPolicies().stream().map(policy1 -> toRepresentation(policy1, authorization)).collect(Collectors.toList()));
+        policyResultRep.setAssociatedPolicies(result.getNestedResults().stream().map(policy1 -> toRepresentation(policy1, authorization)).collect(Collectors.toList()));
 
         return policyResultRep;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationTest.java
@@ -143,7 +143,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         // evaluation should succeed with the default context as it uses the current time as the date to be compared.
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
         provider.evaluate(evaluation);
         Assert.assertEquals(Effect.PERMIT, evaluation.getEffect());
 
@@ -151,7 +151,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         long contextTime = System.currentTimeMillis() + 5400000;
         Map<String,Collection<String>> attributes = new HashMap<>();
         attributes.put("kc.time.date_time", Arrays.asList(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(contextTime))));
-        evaluation = createEvaluation(session, authorization, null, resourceServer, policy, attributes);
+        evaluation = createEvaluation(session, authorization, null, resourceServer, policy, attributes, provider);
         provider.evaluate(evaluation);
         Assert.assertEquals(Effect.DENY, evaluation.getEffect());
     }
@@ -175,7 +175,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -188,7 +188,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -200,7 +200,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -212,7 +212,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -224,7 +224,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -236,7 +236,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -248,7 +248,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -260,7 +260,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -272,7 +272,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -298,7 +298,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -311,7 +311,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -337,7 +337,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -349,7 +349,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -375,7 +375,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -388,7 +388,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         provider = authorization.getProvider(policy.getType());
 
-        evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -414,7 +414,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -440,7 +440,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -466,7 +466,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -498,7 +498,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -528,7 +528,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         resource.setAttribute("a1", Arrays.asList("1", "2"));
         resource.setAttribute("a2", Arrays.asList("3"));
 
-        DefaultEvaluation evaluation = createEvaluation(session, authorization, resource, resourceServer, policy);
+        DefaultEvaluation evaluation = createEvaluation(session, authorization, resource, resourceServer, policy, provider);
 
         provider.evaluate(evaluation);
 
@@ -624,18 +624,19 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         Assert.assertEquals(0, permissions.size());
     }
 
-    private static DefaultEvaluation createEvaluation(KeycloakSession session, AuthorizationProvider authorization, ResourceServer resourceServer, Policy policy) {
-        return createEvaluation(session, authorization, null, resourceServer, policy);
+    private static DefaultEvaluation createEvaluation(KeycloakSession session, AuthorizationProvider authorization, ResourceServer resourceServer, Policy policy, PolicyProvider policyProvider) {
+        return createEvaluation(session, authorization, null, resourceServer, policy, policyProvider);
     }
 
-    private static DefaultEvaluation createEvaluation(KeycloakSession session, AuthorizationProvider authorization, Resource resource, ResourceServer resourceServer, Policy policy) {
-        return createEvaluation(session, authorization, resource, resourceServer, policy, null);
+    private static DefaultEvaluation createEvaluation(KeycloakSession session, AuthorizationProvider authorization, Resource resource, ResourceServer resourceServer, Policy policy, PolicyProvider policyProvider) {
+        return createEvaluation(session, authorization, resource, resourceServer, policy, null, policyProvider);
     }
 
     private static DefaultEvaluation createEvaluation(KeycloakSession session, AuthorizationProvider authorization,
                                                       Resource resource, ResourceServer resourceServer, Policy policy,
-                                                      Map<String, Collection<String>> contextAttributes) {
-        return new DefaultEvaluation(new ResourcePermission(resource, null, resourceServer), createEvaluationContext(session, contextAttributes), policy, evaluation -> {}, authorization, null);
+                                                      Map<String, Collection<String>> contextAttributes,
+                                                      PolicyProvider policyProvider) {
+        return new DefaultEvaluation(new ResourcePermission(resource, null, resourceServer), createEvaluationContext(session, contextAttributes), policy, evaluation -> {}, authorization, null, policyProvider);
     }
 
     private static DefaultEvaluationContext createEvaluationContext(KeycloakSession session, Map<String, Collection<String>> contextAttributes) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
@@ -474,12 +474,14 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
         resource = addResource("Resource A", "marta", true);
 
+        // add a permission bound to the created resource that only allows the owner "marta" access
         permission.setName(resource.getName() + " Permission");
         permission.addResource(resource.getId());
         permission.addPolicy("Only Owner Policy");
 
         getClient(getRealm()).authorization().permissions().resource().create(permission).close();
 
+        // marta has access and the rpt is valid without any upgrading
         AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {});
         String rpt = response.getToken();
 
@@ -504,12 +506,14 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
 
         }
 
+        // attempting to authorize with a ticket caused the creation of a ticket
         PermissionResource permissionResource = getAuthzClient().protection().permission();
         List<PermissionTicketRepresentation> permissionTickets = permissionResource.findByResource(resource.getId());
 
         assertFalse(permissionTickets.isEmpty());
         assertEquals(1, permissionTickets.size());
 
+        // grant the requested ticket for kolo
         for (PermissionTicketRepresentation ticket : permissionTickets) {
             assertFalse(ticket.isGranted());
 
@@ -527,6 +531,7 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
             assertTrue(ticket.isGranted());
         }
 
+        // kolo should now have access because the ticket was granted
         response = authorize("kolo", "password", resource.getId(), new String[] {});
         rpt = response.getToken();
 


### PR DESCRIPTION
…to evaluate associated policies at the policy level instead of at the collection level. Update surrounding logic to handle the shift in behavior and provide access to context info where needed. Create a concrete priority queue for policies that allow for deterministic processing to take place resolves keycloak/keycloak#25510

