### PR TITLE
Add support for OpenAPI and Swagger UI

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/OpenapiOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OpenapiOptions.java
@@ -1,0 +1,18 @@
+package org.keycloak.config;
+
+public class OpenapiOptions {
+
+    public static final Option OPENAPI_ENABLE = new OptionBuilder<>("openapi-enable", Boolean.class)
+            .category(OptionCategory.OPENAPI)
+            .description("Enable the openapi endpoint.")
+            .defaultValue(false)
+            .buildTime(true)
+            .build();
+
+    public static final Option OPENAPI_SWAGGER_UI_ENABLE = new OptionBuilder<>("openapi-swagger-ui-enable", Boolean.class)
+            .category(OptionCategory.OPENAPI)
+            .description("Enable Swagger UI endpoint.")
+            .defaultValue(false)
+            .buildTime(true)
+            .build();
+}

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
@@ -18,6 +18,7 @@ public enum OptionCategory {
     SECURITY("Security", 120, ConfigSupportLevel.SUPPORTED),
     EXPORT("Export", 130, ConfigSupportLevel.SUPPORTED),
     IMPORT("Import", 140, ConfigSupportLevel.SUPPORTED),
+    OPENAPI("OpenAPI", 150, ConfigSupportLevel.SUPPORTED),
     GENERAL("General", 999, ConfigSupportLevel.SUPPORTED);
 
     private final String heading;

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -159,6 +159,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-logging-json-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -99,6 +99,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-logging-json</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
 
         <!-- SmallRye -->
         <dependency>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/OpenapiPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/OpenapiPropertyMappers.java
@@ -1,0 +1,24 @@
+package org.keycloak.quarkus.runtime.configuration.mappers;
+
+import org.keycloak.config.OpenapiOptions;
+
+import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
+
+final class OpenapiPropertyMappers {
+
+    private OpenapiPropertyMappers(){}
+
+    public static PropertyMapper[] getOpenapiPropertyMappers() {
+        return new PropertyMapper[] {
+                fromOption(OpenapiOptions.OPENAPI_ENABLE)
+                        .to("quarkus.smallrye-openapi.enable")
+                        .paramLabel("openapi")
+                        .build(),
+                fromOption(OpenapiOptions.OPENAPI_SWAGGER_UI_ENABLE)
+                        .to("quarkus.swagger-ui.enable")
+                        .paramLabel("swagger-ui")
+                        .build()
+        };
+    }
+}
+

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -41,6 +41,7 @@ public final class PropertyMappers {
         MAPPERS.addAll(ExportPropertyMappers.getMappers());
         MAPPERS.addAll(ImportPropertyMappers.getMappers());
         MAPPERS.addAll(TruststorePropertyMappers.getMappers());
+        MAPPERS.addAll(OpenapiPropertyMappers.getOpenapiPropertyMappers());
     }
 
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -49,3 +49,15 @@ quarkus.http.limits.max-form-attribute-size=32768
 
 # Configure the content-types that should be recognized as file parts when processing multipart form requests
 quarkus.http.body.multipart.file-content-types=application/octet-stream
+
+# Enable/Disable the openapi endpoint
+quarkus.smallrye-openapi.enable=false
+
+# Disable validation url
+quarkus.swagger-ui.validator-url=none
+
+# Include by default swagger ui in all modes
+quarkus.swagger-ui.always-include=true
+
+# Enable/Disable enabling of swagger ui endpoint
+quarkus.swagger-ui.enable=false


### PR DESCRIPTION
Add support for OpenAPI documentation and Swagger UI:
1. Helps to list all exposed API as same as documentation for them
2. Having `/openapi` endpoint allows to integrate keycloak inside infrastructure where services follow approach [code first documentation](https://swagger.io/blog/code-first-vs-design-first-api/) and share API through endpoints

What is outside of this PR(not blocker):
1. [Refactoring of Accounts API](https://github.com/keycloak/keycloak/issues/13203#issuecomment-1876220056) to be compatible with API documentation generation tools
2. Better description of security scheme for proper support of `Try it out` functionality