### PR TITLE
On invalid submission, IdpUsernamePasswordForm sends back the user to the standard UsernamePasswordForm template

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.authentication.authenticators.broker;
 
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.AuthenticationFlowException;
@@ -25,6 +26,7 @@ import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 
@@ -48,6 +50,20 @@ public class IdpUsernamePasswordForm extends UsernamePasswordForm {
         return setupForm(context, formData, getExistingUser(context))
                 .setStatus(Response.Status.OK)
                 .createLoginUsernamePassword();
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, String error, String field) {
+        LoginFormsProvider form = setupForm(context, new MultivaluedHashMap<>(), getExistingUser(context))
+                .setExecution(context.getExecution().getId());
+        if (error != null) {
+            if (field != null) {
+                form.addError(new FormMessage(field, error));
+            } else {
+                form.setError(error);
+            }
+        }
+        return createLoginForm(form);
     }
 
     @Override


### PR DESCRIPTION
Fix #25934
