### PR TITLE
doc: adding notes about header priority

### DIFF
--- a/docs/guides/migration/migrating-to-quarkus.adoc
+++ b/docs/guides/migration/migrating-to-quarkus.adoc
@@ -103,4 +103,8 @@ $ kubectl get keycloaks.k8s.keycloak.org
 The new operator doesn't support Client, User and Realm CRDs directly. Instead, it provides one CRD to perform a https://www.keycloak.org/operator/realm-import.html[Realm import].
 Using this new CR you can import Users, Clients and more through the wrapping Realm.
 
+== Priority of X-Forwarded-* Headers
+
+In Quarkus the X-Forwarded-Port header takes precedence over any port included in the X-Forwarded-Host. This differs from the WildFly distribution where a port included in X-Forwarded-Host had priority over X-Forwarded-Port.
+
 </@tmpl.guide>

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -27,6 +27,8 @@ WARNING: If either `forwarded` or `xforwarded` is selected, make sure your rever
 Take extra precautions to ensure that the client address is properly set by your reverse proxy via the `Forwarded` or `X-Forwarded-For` headers.
 If this header is incorrectly configured, rogue clients can set this header and trick {project_name} into thinking the client is connected from a different IP address than the actual address. This precaution can be more critical if you do any deny or allow listing of IP addresses.
 
+NOTE: When using the `xforwarded` setting, the `X-Forwarded-Port` takes precedence over any port included in the `X-Forwarded-Host`.
+
 == Proxy modes
 NOTE: The support for setting proxy modes is deprecated and will be removed in a future {project_name} release. Consider configuring accepted reverse proxy headers instead as described in the chapter above. For migration instructions consult the https://www.keycloak.org/docs/latest/upgrading/index.html#deprecated-proxy-option[Upgrading Guide].
 


### PR DESCRIPTION
@vmuzikar are you good with the retroactive change all the way back to the 17 migration, or is there a better place to note this?

I think I was getting my wires crossed with this doc update and the one about spaces in the cli key - do you want this one reflected in the downstream docs?

closes: #23023

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
