### PR TITLE
Update cs+sk login messages - fixes #25962

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_cs.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_cs.properties
@@ -353,6 +353,7 @@ realmSupportsNoCredentialsMessage=Realm nepodporuje žádný typ pověření.
 credentialSetupRequired=Není možné se přihlásit, je vyžadována konfigurace přístupových údajů.
 identityProviderNotUniqueMessage=Realm podporuje více poskytovatelů identity. Nelze určit, s jakým zprostředkovatelem identity se má ověřit.
 emailVerifiedMessage=Vaše e-mailová adresa byla ověřena.
+emailVerifiedAlreadyMessage=Vaše e-mailová adresa již byla ověřena.
 staleEmailVerificationLink=Odkaz, na který jste klikli, je starý odkaz a již není platný. Možná jste již ověřili svůj e-mail?
 identityProviderAlreadyLinkedMessage=Federovaná identita vrácená {0} je již propojena s jiným uživatelem.
 confirmAccountLinking=Potvrďte propojení účtu {0} poskytovatele identity {1} s vaším účtem.
@@ -434,7 +435,7 @@ openshift.scope.list-projects=Seznam projektů
 saml.post-form.title=Přesměrování přihlášení
 saml.post-form.message=Přesměrovávám, čekejte prosím.
 saml.post-form.js-disabled=JavaScript není povolený. Důrazně doporučujeme jej povolit. Pro pokračování stiskněte tlačítko níže.
-#saml.artifactResolutionServiceInvalidResponse=Nepovedlo se resolve artifact.
+saml.artifactResolutionServiceInvalidResponse=Nepovedlo se rozpoznat SAML artefakt.
 
 #authenticators
 otp-display-name=Autentizační Aplikace

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
@@ -353,6 +353,7 @@ realmSupportsNoCredentialsMessage=Realm nepodporuje žiadny typ poverenia.
 credentialSetupRequired=Nie je môžné sa prihlásiť, vyžaduje sa nastavenie prihlasovacích údajov.
 identityProviderNotUniqueMessage=Realm podporuje viacerých poskytovateľov identity. Nepodarilo sa určiť, ktorý poskytovateľ totožnosti sa má používať na autentifikáciu.
 emailVerifiedMessage=Vaša e-mailová adresa bola overená.
+emailVerifiedAlreadyMessage=Vaša e-mailová adresa už bola overená.
 staleEmailVerificationLink=Odkaz, na ktorý ste klikli, je starý odkaz a už nie je platný. Možno ste už overili svoj e-mail?
 identityProviderAlreadyLinkedMessage=Federatívna identita vrátená {0} je už prepojená s iným používateľom.
 confirmAccountLinking=Potvrďte prepojenie účtu {0} poskytovateľa totožnosti {1} s vaším účtom.
@@ -434,7 +435,7 @@ openshift.scope.list-projects=Zoznam projektov
 saml.post-form.title=Presmerovanie overenia
 saml.post-form.message=Presmerovanie, počkajte prosím.
 saml.post-form.js-disabled=JavaScript je vypnutý. Dôrazne odporúčame ho zapnúť. Ak chcete pokračovať, kliknite na tlačidlo nižšie. 
-saml.artifactResolutionServiceInvalidResponse=Použitie SAML Artifact zlyhalo.
+saml.artifactResolutionServiceInvalidResponse=Rozpoznanie SAML Artefaktu zlyhalo.
 
 #authenticators
 otp-display-name=Authenticator Application


### PR DESCRIPTION
Fixes #25962

Localization of a new login message `emailVerifiedAlreadyMessage` from 
* Issue #14776 
* PR #25711

Improved translation of `saml.artifactResolutionServiceInvalidResponse`