### PR TITLE
Ensure OIDC prompt=login gets correctly mapped to SAML ForceAuthN during identity brokering

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -130,8 +130,8 @@ public class OIDCLoginProtocol implements LoginProtocol {
 
     // https://tools.ietf.org/html/rfc7636#section-4.1
     public static final int PKCE_CODE_VERIFIER_MIN_LENGTH = 43;
-    public static final int PKCE_CODE_VERIFIER_MAX_LENGTH = 128;    
-    
+    public static final int PKCE_CODE_VERIFIER_MAX_LENGTH = 128;
+
     // https://tools.ietf.org/html/rfc7636#section-6.2.2
     public static final String PKCE_METHOD_PLAIN = "plain";
     public static final String PKCE_METHOD_S256 = "S256";
@@ -199,7 +199,6 @@ public class OIDCLoginProtocol implements LoginProtocol {
         this.event = event;
         return this;
     }
-
 
     @Override
     public Response authenticated(AuthenticationSessionModel authSession, UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
@@ -269,7 +268,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
                 if (responseType.hasResponseType(OIDCResponseType.CODE)) {
                     responseBuilder.generateCodeHash(code);
                 }
-                
+
                 // Financial API - Part 2: Read and Write API Security Profile
                 // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
                 if (state != null && !state.isEmpty())
@@ -404,7 +403,6 @@ public class OIDCLoginProtocol implements LoginProtocol {
         return LogoutUtil.sendResponseAfterLogoutFinished(session, logoutSession);
     }
 
-
     @Override
     public boolean requireReauthentication(UserSessionModel userSession, AuthenticationSessionModel authSession) {
         return isPromptLogin(authSession) || isAuthTimeExpired(userSession, authSession) || isReAuthRequiredForKcAction(userSession, authSession);
@@ -416,6 +414,9 @@ public class OIDCLoginProtocol implements LoginProtocol {
     }
 
     protected boolean isAuthTimeExpired(UserSessionModel userSession, AuthenticationSessionModel authSession) {
+        if (userSession == null) {
+            return false;
+        }
         String authTime = userSession.getNote(AuthenticationManager.AUTH_TIME);
         String maxAge = authSession.getClientNote(OIDCLoginProtocol.MAX_AGE_PARAM);
         if (maxAge == null) {
@@ -435,7 +436,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
     }
 
     protected boolean isReAuthRequiredForKcAction(UserSessionModel userSession, AuthenticationSessionModel authSession) {
-        if (authSession.getClientNote(Constants.KC_ACTION) != null) {
+        if (userSession != null && authSession.getClientNote(Constants.KC_ACTION) != null) {
             String providerId = authSession.getClientNote(Constants.KC_ACTION);
             RequiredActionProvider requiredActionProvider = this.session.getProvider(RequiredActionProvider.class, providerId);
             String authTime = userSession.getNote(AuthenticationManager.AUTH_TIME);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlForceAuthnBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlForceAuthnBrokerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.testsuite.broker;
+
+import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
+import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
+import org.keycloak.saml.processing.api.saml.v2.request.SAML2Request;
+import org.keycloak.testsuite.saml.AbstractSamlTest;
+import org.keycloak.testsuite.updaters.IdentityProviderAttributeUpdater;
+import org.keycloak.testsuite.util.SamlClient;
+import org.keycloak.testsuite.util.SamlClient.Binding;
+import org.keycloak.testsuite.util.SamlClientBuilder;
+import java.io.Closeable;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+
+/**
+ * @author phamann
+ */
+public final class KcSamlForceAuthnBrokerTest extends AbstractBrokerTest {
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return KcSamlBrokerConfiguration.INSTANCE;
+    }
+
+    // Issue #25980
+    @Test
+    public void testForceAuthnNotSentInRequest() throws Exception {
+        // If no ForceAuthn is sent in SAML AuthnRequest the value should be
+        // read from the IdP configuration.
+        try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(identityProviderResource)
+            .setAttribute(SAMLIdentityProviderConfig.FORCE_AUTHN, "false")
+            .update())
+        {
+            // Build the login request document
+            AuthnRequestType loginRep = SamlClient.createLoginRequestDocument(AbstractSamlTest.SAML_CLIENT_ID_SALES_POST, getConsumerRoot() + "/sales-post/saml", null);
+            Document doc = SAML2Request.convert(loginRep);
+            new SamlClientBuilder()
+                .authnRequest(getConsumerSamlEndpoint(bc.consumerRealmName()), doc, Binding.POST)
+                .build()   // Request to consumer IdP
+                .login()
+                .idp(bc.getIDPAlias())
+                .build()
+                .processSamlResponse(Binding.POST)    // AuthnRequest to producer IdP
+                  .targetAttributeSamlRequest()
+                  .transformDocument((document) -> {
+                    try
+                    {
+                        // Find the AuthnRequest ForceAuthN attribute
+                        String attrValue = document.getDocumentElement().getAttributes().getNamedItem("ForceAuthn").getNodeValue();
+                        Assert.assertEquals("Unexpected ForceAuthn attribute value", "false", attrValue);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new RuntimeException(ex);
+                    }
+                  })
+                  .build()
+                .execute();
+        }
+    }
+
+    // Issue #25980
+    @Test
+    public void testForceAuthnSentInRequest() throws Exception {
+        // If ForceAuthn=true is sent in SAML AuthnRequest it should be
+        // forwarded to IdP regardless of the IdP ForceAuthn configuration.
+        try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(identityProviderResource)
+            .setAttribute(SAMLIdentityProviderConfig.FORCE_AUTHN, "false")
+            .update())
+        {
+            // Build the login request document
+            AuthnRequestType loginRep = SamlClient.createLoginRequestDocument(AbstractSamlTest.SAML_CLIENT_ID_SALES_POST, getConsumerRoot() + "/sales-post/saml", null);
+            loginRep.setForceAuthn(true); // Set ForceAuthN in authentication request
+            Document doc = SAML2Request.convert(loginRep);
+            new SamlClientBuilder()
+                .authnRequest(getConsumerSamlEndpoint(bc.consumerRealmName()), doc, Binding.POST)
+                .build()   // Request to consumer IdP
+                .login()
+                .idp(bc.getIDPAlias())
+                .build()
+                .processSamlResponse(Binding.POST)    // AuthnRequest to producer IdP
+                  .targetAttributeSamlRequest()
+                  .transformDocument((document) -> {
+                    try
+                    {
+                        // Find the AuthnRequest ForceAuthN attribute
+                        String attrValue = document.getDocumentElement().getAttributes().getNamedItem("ForceAuthn").getNodeValue();
+                        Assert.assertEquals("Unexpected ForceAuthn attribute value", "true", attrValue);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new RuntimeException(ex);
+                    }
+                  })
+                  .build()
+                .execute();
+        }
+    }
+}


### PR DESCRIPTION
Closes #25980

---

### Summary 
Keycloak doesn't correctly map OIDC `prompt=login` to a SAML ForceAuthN during identity brokering.
Detail

The OIDC specification states that when a server receives a prompt=login authentication request parameter the server:

    The Authorization Server SHOULD prompt the End-User for reauthentication.

The SAML protocol has an equivilent behaviour in the form of `ForceAuthN`.

Therefore, when a client initiates an OIDC authentication request with the protocol `prompt=login` parameter and the request results in a SAML identity broker redirection (for instance, using the Identity Provider Redirector), Keycloak should map the OIDC `prompt=login` to a SAML ForceAuthN XML attribute. This ensures that the external SAML provider also prompts the user for reauthentication regardless of session state.

Currently, the SAMLIdentityProvider logic will ignore any dynamic state in the request context, such as the OIDC parameter, and instead reads from the Identity Provider configuration value to build the SAML request using `ForceAuthN`. Therefore, `ForceAuthN` will only be sent if the IdP has been permanently configured to do so, which makes it hard for clients to conditionally opt-in to the behaviour.

This is a common scenario for step-up authentication flows when an OIDC client needs to ensure that the user is reauthenticated regardless of their session state.

### Fix

Refactor the logic in the `SAMLIdentityProvider#performLogin()` method to conditionally override the IdP forceAuthN value based on the authentication session state and whether `prompt=login` was passed.
