### PR TITLE
fix: groups should be clickable when user has view-access on the group

### DIFF
--- a/js/apps/admin-ui/src/groups/GroupTable.tsx
+++ b/js/apps/admin-ui/src/groups/GroupTable.tsx
@@ -188,7 +188,7 @@ export const GroupTable = ({ refresh: viewRefresh }: GroupTableProps) => {
             name: "name",
             displayKey: "groupName",
             cellRenderer: (group) =>
-              group.access.view ? (
+              group.access?.view ? (
                 <Link key={group.id} to={`${location.pathname}/${group.id}`}>
                   {group.name}
                 </Link>

--- a/js/apps/admin-ui/src/groups/GroupTable.tsx
+++ b/js/apps/admin-ui/src/groups/GroupTable.tsx
@@ -22,13 +22,9 @@ import { adminClient } from "../admin-client";
 
 type GroupTableProps = {
   refresh: () => void;
-  canViewDetails: boolean;
 };
 
-export const GroupTable = ({
-  refresh: viewRefresh,
-  canViewDetails,
-}: GroupTableProps) => {
+export const GroupTable = ({ refresh: viewRefresh }: GroupTableProps) => {
   const { t } = useTranslation();
 
   const [selectedRows, setSelectedRows] = useState<GroupRepresentation[]>([]);
@@ -192,7 +188,7 @@ export const GroupTable = ({
             name: "name",
             displayKey: "groupName",
             cellRenderer: (group) =>
-              canViewDetails ? (
+              group.access.view ? (
                 <Link key={group.id} to={`${location.pathname}/${group.id}`}>
                   {group.name}
                 </Link>

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -197,10 +197,7 @@ export default function GroupsSection() {
                     eventKey={0}
                     title={<TabTitleText>{t("childGroups")}</TabTitleText>}
                   >
-                    <GroupTable
-                      refresh={refresh}
-                      canViewDetails={canViewDetails}
-                    />
+                    <GroupTable refresh={refresh} />
                   </Tab>
                   {canViewMembers && (
                     <Tab
@@ -238,9 +235,7 @@ export default function GroupsSection() {
                   )}
                 </Tabs>
               )}
-              {subGroups.length === 0 && (
-                <GroupTable refresh={refresh} canViewDetails={canViewDetails} />
-              )}
+              {subGroups.length === 0 && <GroupTable refresh={refresh} />}
             </DrawerContentBody>
           </DrawerContent>
         </Drawer>


### PR DESCRIPTION
This PR fixes an issue where a user with limited rights (set with fine grained permissions) can not click on subgroups it has access to. 

With the current way of checking, a user can only click on a subgroup when it has manage-access of the parent group. I have changed this to check the actual view-rights of the subgroup.

Additionally, the `canViewDetails` property is now unused, so I removed that.

Closes: https://github.com/keycloak/keycloak/issues/26040