### PR TITLE
fix: permissions tab should be only shown with the correct rights

### DIFF
--- a/js/apps/admin-ui/src/user/UsersSection.tsx
+++ b/js/apps/admin-ui/src/user/UsersSection.tsx
@@ -13,11 +13,17 @@ import {
 } from "../components/routable-tabs/RoutableTabs";
 import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
 import "./user-section.css";
+import { useAccess } from "../context/access/Access";
 
 export default function UsersSection() {
   const { t } = useTranslation();
   const { realm: realmName } = useRealm();
+  const { hasAccess } = useAccess();
   const isFeatureEnabled = useIsFeatureEnabled();
+
+  const canViewPermissions =
+    isFeatureEnabled(Feature.AdminFineGrainedAuthz) &&
+    hasAccess("manage-authorization", "manage-users", "manage-clients");
 
   const useTab = (tab: UserTab) =>
     useRoutableTab(
@@ -60,7 +66,7 @@ export default function UsersSection() {
           >
             <UserDataTable />
           </Tab>
-          {isFeatureEnabled(Feature.AdminFineGrainedAuthz) && (
+          {canViewPermissions && (
             <Tab
               id="permissions"
               data-testid="permissionsTab"


### PR DESCRIPTION
This PR makes sure the permissions-tab on the Users-page is not shown for users that do not have access to these permissions. I changed this to use the same check as the Groups-tab: https://github.com/keycloak/keycloak/blob/main/js/apps/admin-ui/src/groups/GroupsSection.tsx#L65.

Closes https://github.com/keycloak/keycloak/issues/26039