### PR TITLE
fix: subgroups clickopen not working

### DIFF
--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -129,7 +129,7 @@ export default function GroupsSection() {
         />
       )}
       <PageSection variant={PageSectionVariants.light} className="pf-u-p-0">
-        <Drawer isInline isExpanded={open} key={key} position="left">
+        <Drawer isInline isExpanded={open} position="left">
           <DrawerContent
             panelContent={
               <DrawerPanelContent isResizable>
@@ -142,7 +142,7 @@ export default function GroupsSection() {
               </DrawerPanelContent>
             }
           >
-            <DrawerContentBody>
+            <DrawerContentBody key={key}>
               <Tooltip content={open ? t("hide") : t("show")}>
                 <Button
                   aria-label={open ? t("hide") : t("show")}


### PR DESCRIPTION
This PR makes sure that the `refresh`-call introduced in https://github.com/keycloak/keycloak/pull/24244 will only update the groups page and not the treeview, because this will continuously rerender the treeview, therefore always closing the opened subgroups when clicking. It also made sure subgroups were never visible in the tree anymore.

Closes https://github.com/keycloak/keycloak/issues/26036
