### PR TITLE
Remove unnecessary tooltip on device activity page

### DIFF
--- a/js/apps/account-ui/src/account-security/DeviceActivity.tsx
+++ b/js/apps/account-ui/src/account-security/DeviceActivity.tsx
@@ -15,7 +15,6 @@ import {
   Split,
   SplitItem,
   Title,
-  Tooltip,
 } from "@patternfly/react-core";
 import {
   DesktopIcon,
@@ -115,17 +114,14 @@ const DeviceActivity = () => {
           </Title>
         </SplitItem>
         <SplitItem>
-          <Tooltip content={t("refreshPage")}>
-            <Button
-              aria-describedby="refresh page"
-              id="refresh-page"
-              variant="link"
-              onClick={() => refresh()}
-              icon={<SyncAltIcon />}
-            >
-              {t("refreshPage")}
-            </Button>
-          </Tooltip>
+          <Button
+            id="refresh-page"
+            variant="link"
+            onClick={() => refresh()}
+            icon={<SyncAltIcon />}
+          >
+            {t("refreshPage")}
+          </Button>
 
           {(devices.length > 1 || devices[0].sessions.length > 1) && (
             <ContinueCancelModal


### PR DESCRIPTION
Removes a tooltip that just repeats the same text as the label of the button itself.

Closes #26032

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
