### PR TITLE
Convert database errors to 500 HTTP status response  instead of 400.

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -401,7 +401,7 @@ public class LDAPIdentityStore implements IdentityStore {
         } catch (ModelException me) {
             throw me;
         } catch (Exception e) {
-            throw new ModelException(e);
+            throw new ModelException("Error updating password", e);
         }
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -114,7 +114,7 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
             try {
                 data = JsonSerialization.readValue(model.getData(), PersistentClientSessionData.class);
             } catch (IOException ioe) {
-                throw new ModelException(ioe);
+                throw new ModelException("Error restoring session", ioe);
             }
         }
 
@@ -127,7 +127,7 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
             String updatedData = JsonSerialization.writeValueAsString(getData());
             this.model.setData(updatedData);
         } catch (IOException ioe) {
-            throw new ModelException(ioe);
+            throw new ModelException("Error persisting session", ioe);
         }
 
         return this.model;

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
@@ -158,7 +158,7 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             try {
                 data = JsonSerialization.readValue(model.getData(), PersistentUserSessionData.class);
             } catch (IOException ioe) {
-                throw new ModelException(ioe);
+                throw new ModelException("Error restoring session", ioe);
             }
         }
 
@@ -171,7 +171,7 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             String updatedData = JsonSerialization.writeValueAsString(getData());
             this.model.setData(updatedData);
         } catch (IOException ioe) {
-            throw new ModelException(ioe);
+            throw new ModelException("Error persisting session", ioe);
         }
 
         return this.model;

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
@@ -36,8 +36,4 @@ public class ClientTypeException extends ModelException {
     public ClientTypeException(String message, Throwable cause) {
         super(message, cause);
     }
-
-    public ClientTypeException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/server-spi/src/main/java/org/keycloak/models/ModelDuplicateException.java
+++ b/server-spi/src/main/java/org/keycloak/models/ModelDuplicateException.java
@@ -40,10 +40,6 @@ public class ModelDuplicateException extends ModelException {
         super(message, cause);
     }
 
-    public ModelDuplicateException(Throwable cause) {
-        super(cause);
-    }
-
     public String getDuplicateFieldName() {
         return duplicateFieldName;
     }

--- a/server-spi/src/main/java/org/keycloak/models/ModelException.java
+++ b/server-spi/src/main/java/org/keycloak/models/ModelException.java
@@ -40,10 +40,6 @@ public class ModelException extends RuntimeException {
         super(message, cause);
     }
 
-    public ModelException(Throwable cause) {
-        super(cause);
-    }
-
     public Object[] getParameters() {
         return parameters;
     }

--- a/server-spi/src/main/java/org/keycloak/models/ModelIllegalStateException.java
+++ b/server-spi/src/main/java/org/keycloak/models/ModelIllegalStateException.java
@@ -42,8 +42,4 @@ public class ModelIllegalStateException extends ModelException {
     public ModelIllegalStateException(String message, Throwable cause) {
         super(message, cause);
     }
-
-    public ModelIllegalStateException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/server-spi/src/main/java/org/keycloak/policy/PasswordPolicyNotMetException.java
+++ b/server-spi/src/main/java/org/keycloak/policy/PasswordPolicyNotMetException.java
@@ -38,7 +38,7 @@ public class PasswordPolicyNotMetException extends ModelException {
         super(message);
         this.username = username;
     }
-    
+
     public PasswordPolicyNotMetException(String message, String username, Throwable cause) {
         super(message, cause);
         this.username = username;
@@ -46,10 +46,6 @@ public class PasswordPolicyNotMetException extends ModelException {
 
     public PasswordPolicyNotMetException(String message, Throwable cause) {
         super(message, cause);
-    }
-
-    public PasswordPolicyNotMetException(Throwable cause) {
-        super(cause);
     }
 
     public String getUsername() {

--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -13,6 +13,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionTaskWithResult;
 import org.keycloak.models.KeycloakTransaction;
 import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -126,7 +127,9 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
                 || throwable instanceof ModelValidationException) {
             status = Response.Status.BAD_REQUEST.getStatusCode();
         }
-
+        if (throwable instanceof ModelIllegalStateException) {
+            status = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+        }
         if (throwable instanceof ModelDuplicateException) {
             status = Response.Status.CONFLICT.getStatusCode();
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientRoleMappingsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientRoleMappingsResource.java
@@ -32,11 +32,13 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleMapperModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.storage.ReadOnlyException;
 
@@ -173,6 +175,9 @@ public class ClientRoleMappingsResource {
                 auth.roles().requireMapRole(roleModel);
                 user.grantRole(roleModel);
             }
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException | ReadOnlyException me) {
             logger.warn(me.getMessage(), me);
             throw new ErrorResponseException("invalid_request", "Could not add user role mappings!", Response.Status.BAD_REQUEST);
@@ -212,6 +217,9 @@ public class ClientRoleMappingsResource {
                 auth.roles().requireMapRole(roleModel);
                 try {
                     user.deleteRoleMapping(roleModel);
+                } catch (ModelIllegalStateException e) {
+                    logger.error(e.getMessage(), e);
+                    throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
                 } catch (ModelException | ReadOnlyException me) {
                     logger.warn(me.getMessage(), me);
                     throw new ErrorResponseException("invalid_request", "Could not remove user role mappings!", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -28,6 +28,7 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
@@ -157,6 +158,9 @@ public class ClientScopeResource {
                 realm.removeClientScope(clientScope.getId());
                 adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
                 return Response.noContent().build();
+            } catch (ModelIllegalStateException e) {
+                logger.error(e.getMessage(), e);
+                throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
             } catch (ModelException me) {
                 throw ErrorResponse.error(me.getMessage(), Response.Status.BAD_REQUEST);
             }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -31,6 +31,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.StripSecretsUtils;
@@ -167,6 +168,9 @@ public class RealmsAdminResource {
             logger.error("Password policy not met for user " + e.getUsername(), e);
             if (session.getTransactionManager().isActive()) session.getTransactionManager().setRollbackOnly();
             throw ErrorResponse.error("Password policy not met. See logs for details", Response.Status.BAD_REQUEST);
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException e) {
             throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
@@ -31,6 +31,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.RoleMapperModel;
@@ -39,6 +40,7 @@ import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.ClientMappingsRepresentation;
 import org.keycloak.representations.idm.MappingsRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
@@ -243,6 +245,9 @@ public class RoleMapperResource {
                 auth.roles().requireMapRole(roleModel);
                 roleMapper.grantRole(roleModel);
             }
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException | ReadOnlyException me) {
             logger.warn(me.getMessage(), me);
             throw new ErrorResponseException("invalid_request", "Could not add user role mappings!", Response.Status.BAD_REQUEST);
@@ -283,6 +288,9 @@ public class RoleMapperResource {
                 auth.roles().requireMapRole(roleModel);
                 try {
                     roleMapper.deleteRoleMapping(roleModel);
+                } catch (ModelIllegalStateException e) {
+                    logger.error(e.getMessage(), e);
+                    throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
                 } catch (ModelException | ReadOnlyException me) {
                     logger.warn(me.getMessage(), me);
                     throw new ErrorResponseException("invalid_request", "Could not remove user role mappings!", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -48,6 +48,7 @@ import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserCredentialModel;
@@ -229,6 +230,9 @@ public class UserResource {
             Properties messages = AdminRoot.getMessages(session, realm, auth.adminAuth().getToken().getLocale());
             throw new ErrorResponseException(e.getMessage(), MessageFormat.format(messages.getProperty(e.getMessage(), e.getMessage()), e.getParameters()),
                     Status.BAD_REQUEST);
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException me) {
             logger.warn("Could not update user!", me);
             session.getTransactionManager().setRollbackOnly();
@@ -696,6 +700,9 @@ public class UserResource {
             Properties messages = AdminRoot.getMessages(session, realm, auth.adminAuth().getToken().getLocale());
             throw new ErrorResponseException(e.getMessage(), MessageFormat.format(messages.getProperty(e.getMessage(), e.getMessage()), e.getParameters()),
                     Status.BAD_REQUEST);
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException e) {
             logger.warn("Could not update user password.", e);
             Properties messages = AdminRoot.getMessages(session, realm, auth.adminAuth().getToken().getLocale());
@@ -1015,6 +1022,9 @@ public class UserResource {
                 user.leaveGroup(group);
                 adminEvent.operation(OperationType.DELETE).resource(ResourceType.GROUP_MEMBERSHIP).representation(ModelToRepresentation.toRepresentation(group, true)).resourcePath(session.getContext().getUri()).success();
             }
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException me) {
             Properties messages = AdminRoot.getMessages(session, realm, auth.adminAuth().getToken().getLocale());
             throw new ErrorResponseException(me.getMessage(), MessageFormat.format(messages.getProperty(me.getMessage(), me.getMessage()), me.getParameters()),

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -31,6 +31,7 @@ import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
@@ -164,6 +165,9 @@ public class UsersResource {
             Properties messages = AdminRoot.getMessages(session, realm, auth.adminAuth().getToken().getLocale());
             throw new ErrorResponseException(e.getMessage(), MessageFormat.format(messages.getProperty(e.getMessage(), e.getMessage()), e.getParameters()),
                     Response.Status.BAD_REQUEST);
+        } catch (ModelIllegalStateException e) {
+            logger.error(e.getMessage(), e);
+            throw ErrorResponse.error(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
         } catch (ModelException me){
             logger.warn("Could not create user", me);
             throw ErrorResponse.error("Could not create user", Response.Status.BAD_REQUEST);


### PR DESCRIPTION
Closes #25993

This PR fixes #25993 where PostgreSQL deadlock caused Keycloak to respond with `400` error and leak SQL statement details in response body.

**Background**

Currently database errors are converted into `ModelException` ([link](https://github.com/keycloak/keycloak/blob/0f48027ffb14d8147a87c9b36b5ae5aeae87db4a/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java#L99)). The exception is handled as client error in places like `RealmAdminResource` ([link](https://github.com/keycloak/keycloak/blob/0f47071a299c0084ea4247deca06fc06500bf8af/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java#L470-L471)) and `400 Bad Request` response is sent to the client. Sometimes also `500 Internal Server Error` is returned (see [exception mapper](https://github.com/keycloak/keycloak/blob/42f0488d76c15ea83beb235d144f1de2076908e1/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java#L117)) when `ModelException` is not specifically catched. Which one is sent, depends on how/when the original exception happens.

The current approach is problematic because:

1. The `400` response implies that client sent bad request. Client should not retry bad request. However, database error can very well be temporary and client should retry in this case. Therefore sending `500` response would be more appropriate.
2. The [`PersistenceExceptionConverter`](https://github.com/keycloak/keycloak/blob/0f48027ffb14d8147a87c9b36b5ae5aeae87db4a/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java#L99) includes the original database exception as cause, and as an example, [`RealmAdminResource`](https://github.com/keycloak/keycloak/blob/0f47071a299c0084ea4247deca06fc06500bf8af/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java#L471) includes the exception message as response body sent to the client. This leaks database details to client, which is not desirable. Nothing too sensitive is sent since hibernate uses prepared statements, so this is not a security issue.

Fixes #25993