### PR TITLE
Do not join offline user sessions with online client sessions

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -46,14 +46,14 @@ import java.io.Serializable;
         @NamedQuery(name="findUserSessionsByUserId", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
                 " AND sess.realmId = :realmId AND sess.userId = :userId ORDER BY sess.userSessionId"),
         @NamedQuery(name="findUserSessionsByClientId", query="SELECT sess FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +
-                " ON sess.userSessionId = clientSess.userSessionId AND clientSess.clientId = :clientId WHERE sess.offline = :offline " +
+                " ON sess.userSessionId = clientSess.userSessionId AND clientSess.clientId = :clientId WHERE sess.offline = :offline AND clientSess.offline = :offline " +
                 " AND sess.realmId = :realmId ORDER BY sess.userSessionId"),
         @NamedQuery(name="findUserSessionsByExternalClientId", query="SELECT sess FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +
-                " ON sess.userSessionId = clientSess.userSessionId AND clientSess.clientStorageProvider = :clientStorageProvider AND clientSess.externalClientId = :externalClientId WHERE sess.offline = :offline " +
+                " ON sess.userSessionId = clientSess.userSessionId AND clientSess.clientStorageProvider = :clientStorageProvider AND clientSess.externalClientId = :externalClientId WHERE sess.offline = :offline AND clientSess.offline = :offline " +
                 " AND sess.realmId = :realmId ORDER BY sess.userSessionId"),
         @NamedQuery(name="findClientSessionsClientIds", query="SELECT clientSess.clientId, clientSess.externalClientId, clientSess.clientStorageProvider, count(clientSess)" +
                 " FROM PersistentClientSessionEntity clientSess INNER JOIN PersistentUserSessionEntity sess ON clientSess.userSessionId = sess.userSessionId " +
-                " WHERE sess.offline = :offline AND sess.realmId = :realmId " +
+                " WHERE sess.offline = :offline AND clientSess.offline = :offline AND sess.realmId = :realmId " +
                 " GROUP BY clientSess.clientId, clientSess.externalClientId, clientSess.clientStorageProvider")
 
 })


### PR DESCRIPTION
The findUserSessions* names queries have an INNER JOIN. When offline sessions are used, the client automatically gets an online sessions with the same ID as well. The inner join now returns 2 rows instead of one. This results in an IllegalStateException in the JpaUserSessionPersisterProvider

This patch adds another condition to the queries to select only those sessions which have the same value in the offline column in the database.

Closes #26134

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
