### PR TITLE
Remove `lodash` as a hard dependency from the Admin Client

### DIFF
--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "camelize-ts": "^3.0.0",
-    "lodash-es": "^4.17.21",
     "url-join": "^5.0.0",
     "url-template": "^3.1.1"
   },
@@ -49,6 +48,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.8",
     "chai": "^5.0.0",
+    "lodash-es": "^4.17.21",
     "mocha": "^10.2.0",
     "ts-node": "^10.9.2"
   },

--- a/js/libs/keycloak-admin-client/src/resources/agent.ts
+++ b/js/libs/keycloak-admin-client/src/resources/agent.ts
@@ -1,4 +1,3 @@
-import { isUndefined, last, omit, pick } from "lodash-es";
 import urlJoin from "url-join";
 import { parseTemplate } from "url-template";
 import type { KeycloakAdminClient } from "../client.js";
@@ -39,6 +38,16 @@ export interface RequestArgs {
   ignoredKeys?: string[];
   headers?: HeadersInit;
 }
+
+const pick = (value: Record<string, unknown>, keys: string[]) =>
+  Object.fromEntries(
+    Object.entries(value).filter(([key]) => keys.includes(key)),
+  );
+
+const omit = (value: Record<string, unknown>, keys: string[]) =>
+  Object.fromEntries(
+    Object.entries(value).filter(([key]) => !keys.includes(key)),
+  );
 
 export class Agent {
   #client: KeycloakAdminClient;
@@ -83,7 +92,9 @@ export class Agent {
 
       // Filter query parameters by queryParamKeys
       const queryParams =
-        queryParamKeys.length > 0 ? pick(payload, queryParamKeys) : undefined;
+        queryParamKeys.length > 0
+          ? (pick(payload, queryParamKeys) as any)
+          : undefined;
 
       // Add filtered payload parameters to base parameters
       const allUrlParamKeys = [...Object.keys(baseParams), ...urlParamKeys];
@@ -138,7 +149,7 @@ export class Agent {
 
       // Filter query parameters by queryParamKeys
       const queryParams = queryParamKeys
-        ? pick(query, queryParamKeys)
+        ? (pick(query, queryParamKeys) as any)
         : undefined;
 
       // Add filtered query parameters to base parameters
@@ -249,7 +260,7 @@ export class Agent {
           );
         }
 
-        const resourceId = last(locationHeader.split(SLASH));
+        const resourceId = locationHeader.split(SLASH).pop();
         if (!resourceId) {
           // throw an error to let users know the response is not expected
           throw new Error(
@@ -291,8 +302,7 @@ export class Agent {
     }
 
     Object.keys(keyMapping).some((key) => {
-      if (isUndefined(payload[key])) {
-        // Skip if undefined
+      if (typeof payload[key] === "undefined") {
         return false;
       }
       const newKey = keyMapping[key];

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -313,9 +313,6 @@ importers:
       camelize-ts:
         specifier: ^3.0.0
         version: 3.0.0
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       url-join:
         specifier: ^5.0.0
         version: 5.0.0
@@ -341,6 +338,9 @@ importers:
       chai:
         specifier: ^5.0.0
         version: 5.0.0
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       mocha:
         specifier: ^10.2.0
         version: 10.2.0
@@ -5355,7 +5355,6 @@ packages:
 
   /lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: false
 
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}


### PR DESCRIPTION
Removes Lodash from the Admin Client (as a direct dependency), as it is no longer actively maintained.