### PR TITLE
fix non-POSIX usage of expr in kc.sh

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -54,7 +54,7 @@ do
     case "$1" in
       --debug)
           DEBUG_MODE=true
-          if [ -n "$2" ] && expr "$2" : '[0-9]\+$' >/dev/null; then
+          if [ -n "$2" ] && expr "$2" : '[0-9]\{0,\}$' >/dev/null; then
               DEBUG_PORT=$2
               shift
           fi


### PR DESCRIPTION
replaces \+ by \{1,\} in regular expression for better POSIX compatibility

fixes issue #26165