### PR TITLE
Support group overage indicator in Azure ad jwt token

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -214,6 +214,10 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-legacy-private</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftAzureClaims.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftAzureClaims.java
@@ -1,0 +1,19 @@
+package org.keycloak.social.microsoft;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicrosoftAzureClaims {
+    @JsonProperty("oid")
+    private String userId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(final String userId) {
+        this.userId = userId;
+    }
+}
+

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftAzureClient.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftAzureClient.java
@@ -1,0 +1,64 @@
+package org.keycloak.social.microsoft;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.logging.Logger;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.util.JsonSerialization;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class MicrosoftAzureClient {
+
+    private static final Logger logger = Logger.getLogger(MicrosoftAzureClaims.class);
+
+    private final String encodedAccessToken;
+
+    private final String tenantId;
+
+    public MicrosoftAzureClient(final String issuer, final String encodedAccessToken) {
+        this.encodedAccessToken = encodedAccessToken;
+
+        String[] parts = issuer.split("/");
+        tenantId = parts[parts.length-2];
+    }
+
+    public List<String> getUserGroups(String userId) {
+        final String graphApiUrl = String.format("https://graph.microsoft.com/v1.0/%s/users/%s/getMemberObjects", tenantId, userId);
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final HttpPost postRequest = new HttpPost(graphApiUrl);
+            postRequest.setHeader("Content-Type", "application/json");
+            postRequest.setHeader("Accept", "application/json");
+            postRequest.setHeader(HttpHeaders.AUTHORIZATION, "Bearer "+encodedAccessToken);
+
+            String body = "{\"securityEnabledOnly\": true}";
+            StringEntity requestEntity = new StringEntity(body, "UTF-8");
+            postRequest.setEntity(requestEntity);
+
+            final CloseableHttpResponse response = httpClient.execute(postRequest);
+
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                if (response.getStatusLine().getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                    logger.error("Failed to retrieve group memberships from AzureAD. Make sure the application has User.Read and GroupMember.Read.All permissions");
+                }
+                throw new RuntimeException();
+            }
+
+            HttpEntity responseEntity = response.getEntity();
+            String responseJson = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);
+
+            MicrosoftGraphGroups groups = JsonSerialization.readValue(responseJson, MicrosoftGraphGroups.class);
+            return groups.getValue();
+        } catch (Exception e) {
+            throw new IdentityBrokerException("unable to query microsoft graph api");
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftGraphGroups.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftGraphGroups.java
@@ -1,0 +1,21 @@
+package org.keycloak.social.microsoft;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicrosoftGraphGroups {
+    @JsonProperty("value")
+    private List<String> value;
+
+    public List<String> getValue() {
+        return value;
+    }
+
+    public void setValue(final List<String> value) {
+        this.value = value;
+    }
+}
+


### PR DESCRIPTION
Closes #26192

As stated in #16689 and #26192. If a user is in a lot of groups (including nested groups), Microsoft doesn't add the groups to the JWT Token, but instead just an "overage" indicator and a link to Microsofts Graph API. Now, the users don't get the groups added to their Keycloak account and in turn don't get any permissions in our downstream applications.

In our  case we use an additional [group claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims#configure-groups-optional-claims) and an [attribute mapper](https://www.keycloak.org/docs/latest/server_admin/#_mappers) to get the group memberships of Azure AD users and add them to the user object in Keycloak. Those group memberships are then used to grant permissions/rights in 'downstream' applications (clients that use Keycloak as IdP).

This PR makes Keycloak aware of the group overages indicator `_claim_names` send by Microsoft Azure AD. In case this
indicator pops up in the id token, Keycloak retrieves all groups of the given user and adds them to the token. 

Could someone please point me in the right direction regarding tests? I'm unsure if  this code is already covered by existing test or needs additional ones.

