### PR TITLE
Drop `base64-js` dependency from Keycloak JS

### DIFF
--- a/js/libs/keycloak-js/package.json
+++ b/js/libs/keycloak-js/package.json
@@ -75,7 +75,6 @@
     "shx": "^0.3.4"
   },
   "dependencies": {
-    "base64-js": "^1.5.1",
     "js-sha256": "^0.10.1",
     "jwt-decode": "^4.0.0"
   }

--- a/js/libs/keycloak-js/rollup.config.ts
+++ b/js/libs/keycloak-js/rollup.config.ts
@@ -39,7 +39,7 @@ function defineOptions({
           file: path.join(targetDir, `${file}.mjs`),
         },
       ],
-      external: ["base64-js", "js-sha256", "jwt-decode"],
+      external: ["js-sha256", "jwt-decode"],
     },
     // Legacy Universal Module Definition, or “UMD”, with inlined dependencies.
     {

--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import base64 from 'base64-js';
 import sha256 from 'js-sha256';
 import { jwtDecode } from 'jwt-decode';
 
@@ -380,7 +379,7 @@ function Keycloak (config) {
             case "S256":
                 // hash codeVerifier, then encode as url-safe base64 without padding
                 var hashBytes = new Uint8Array(sha256.arrayBuffer(codeVerifier));
-                var encodedHash = base64.fromByteArray(hashBytes)
+                var encodedHash = bytesToBase64(hashBytes)
                     .replace(/\+/g, '-')
                     .replace(/\//g, '_')
                     .replace(/\=/g, '');
@@ -1756,3 +1755,9 @@ function Keycloak (config) {
 }
 
 export default Keycloak;
+
+// See: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+function bytesToBase64(bytes) {
+    const binString = String.fromCodePoint(...bytes);
+    return btoa(binString);
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -350,9 +350,6 @@ importers:
 
   libs/keycloak-js:
     dependencies:
-      base64-js:
-        specifier: ^1.5.1
-        version: 1.5.1
       js-sha256:
         specifier: ^0.10.1
         version: 0.10.1
@@ -2733,6 +2730,7 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
 
   /bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}


### PR DESCRIPTION
Closes #26264

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
