### PR TITLE
Ensure that the CNCF Code of Conduct are explicitly referenced at the project's README on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To write tests, refer to the [writing tests](docs/tests-development.md) guide.
 
 ## Contributing
 
-Before contributing to Keycloak, please read our [contributing guidelines](CONTRIBUTING.md).
+Before contributing to Keycloak, please read our [contributing guidelines](CONTRIBUTING.md). Participation in the Keycloak project is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 
 ## Other Keycloak Projects


### PR DESCRIPTION
Closes #26268

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
