### PR TITLE
fix http_tlsSecret example for operator

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
@@ -91,8 +91,8 @@ import io.quarkiverse.operatorsdk.annotations.SharedCSVMetadata;
             "    \"spec\": {\n" +
             "      \"instances\": 1,\n" +
             "      \"hostname\": \"example.org\",\n" +
-            "      \"http\":\n" +
-            "        \"tlsSecret\": \"my-tls-secret\"\n" +
+            "      \"http\":\n {" +
+            "        \"tlsSecret\": \"my-tls-secret\" } \n" +
             "    }\n" +
             "  },\n" +
             "  {\n" +

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
@@ -91,7 +91,8 @@ import io.quarkiverse.operatorsdk.annotations.SharedCSVMetadata;
             "    \"spec\": {\n" +
             "      \"instances\": 1,\n" +
             "      \"hostname\": \"example.org\",\n" +
-            "      \"tlsSecret\": \"my-tls-secret\"\n" +
+            "      \"http\":\n" +
+            "        \"tlsSecret\": \"my-tls-secret\"\n" +
             "    }\n" +
             "  },\n" +
             "  {\n" +


### PR DESCRIPTION
What: Update Keycloak Operator documentation as per issue #26281 

Why: To ensure new users to the Keycloak Operator have a good example to follow!

This is a pretty simple change, just ensuring the example [here](https://operatorhub.io/operator/keycloak-operator) is correct.