### PR TITLE
Fix for "Role mapping" tab visibility for users with "view-users" role (closes #25054 and closes #20125)

### DIFF
--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -294,7 +294,7 @@ export default function EditUser() {
               </Tab>
               <Tab
                 data-testid="role-mapping-tab"
-                isHidden={!user.access?.mapRoles}
+                isHidden={!user.access?.view}
                 title={<TabTitleText>{t("roleMapping")}</TabTitleText>}
                 {...roleMappingTab}
               >


### PR DESCRIPTION
Users in the master realm with "view-users" role (and NO "manage-users" role) of a sub-realm should now be able to see the "Role mapping" tab of the users of that sub-realm and its content without being able to edit.

This PR closes https://github.com/keycloak/keycloak/issues/25054 and closes https://github.com/keycloak/keycloak/issues/20125