### PR TITLE
Escape slashes in full group path representation

### DIFF
--- a/docs/documentation/server_admin/topics/roles-groups/proc-managing-groups.adoc
+++ b/docs/documentation/server_admin/topics/roles-groups/proc-managing-groups.adoc
@@ -12,6 +12,15 @@ Groups are hierarchical. A group can have multiple subgroups but a group can hav
 
 If you have a parent group and a child group, and a user that belongs only to the child group, the user in the child group inherits the attributes and role mappings of both the parent group and the child group.
 
+The hierarchy of a group is sometimes represented using the group path. The path is the complete list of names that represents the hierarchy of a specific group, from top to bottom and separated by slashes `/` (similar to files in a File System). For example a path can be `/top/level1/level2` which means that `top` is a top level group and is parent of `level1`, which in turn is parent of `level2`. This path represents unambiguously the hierarchy for the group `level2`.
+
+Because of historical reasons {project_name}, does not escape slashes in the group name itself. Therefore a group named `level1/group` under `top` uses the path `/top/level1/group`, which is misleading. {project_name} can be started with the option `--spi-group-jpa-escape-slashes-in-group-path` to `true` and then the slashes in the name are escaped with the character `~`. The escape char marks that the slash is part of the name and has no hierarchical meaning. The previous path example would be `/top/level1~/group` when escaped.
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --spi-group-jpa-escape-slashes-in-group-path=true
+----
+
 The following example includes a top-level *Sales* group and a child *North America* subgroup.  
 
 To add a group:

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -107,3 +107,16 @@ The management interface uses a different HTTP server than the default {project_
 Beware, if no values are supplied for the management interface properties, they are inherited from the default {project_name} HTTP server.
 
 For more details, see https://www.keycloak.org/server/management-interface[Configuring the Management Interface].
+
+= Escaping slashes in group paths
+
+{project_name} has never escaped slashes in the group paths. Because of that, a group named `group/slash` child of `top` uses the full path `/top/group/slash`, which is clearly misleading. Starting with this version, the server can be started to perform escaping of those slashes in the name:
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --spi-group-jpa-escape-slashes-in-group-path=true
+----
+
+The escape char is the tilde character `~`. The previous example results in the path `/top/group~/slash`. The escape marks the last slash is part of the name and not a hierarchy separator.
+
+The escaping is currently disabled by default because it represents a change in behavior. Nevertheless enabling escaping is recommended and it can be the default in future versions.

--- a/js/apps/admin-ui/src/user/UserGroups.tsx
+++ b/js/apps/admin-ui/src/user/UserGroups.tsx
@@ -74,7 +74,10 @@ export const UserGroups = ({ user }: UserGroupsProps) => {
     const indirect: GroupRepresentation[] = [];
     if (!isDirectMembership)
       joinedUserGroups.forEach((g) => {
-        const paths = g.path?.substring(1).split("/").slice(0, -1) || [];
+        const paths = (
+          g.path?.substring(1).match(/((~\/)|[^/])+/g) || []
+        ).slice(0, -1);
+
         indirect.push(
           ...paths.map((p) => ({
             name: p,

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
@@ -23,6 +23,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.cache.infinispan.entities.CachedGroup;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 
 import java.util.HashSet;
@@ -283,5 +284,10 @@ public class GroupAdapter implements GroupModel {
 
     private GroupModel getGroupModel() {
         return cacheSession.getGroupDelegate().getGroupById(realm, cached.getId());
+    }
+
+    @Override
+    public boolean escapeSlashesInGroupPath() {
+        return KeycloakModelUtils.escapeSlashesInGroupPath(keycloakSession);
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -48,11 +48,13 @@ import static org.keycloak.utils.StreamsUtil.closing;
  */
 public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
 
+    protected final KeycloakSession session;
     protected GroupEntity group;
     protected EntityManager em;
     protected RealmModel realm;
 
-    public GroupAdapter(RealmModel realm, EntityManager em, GroupEntity group) {
+    public GroupAdapter(KeycloakSession session, RealmModel realm, EntityManager em, GroupEntity group) {
+        this.session = session;
         this.em = em;
         this.group = group;
         this.realm = realm;
@@ -313,6 +315,8 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
         return getId().hashCode();
     }
 
-
-
+    @Override
+    public boolean escapeSlashesInGroupPath() {
+        return KeycloakModelUtils.escapeSlashesInGroupPath(session);
+    }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaGroupProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaGroupProviderFactory.java
@@ -23,22 +23,27 @@ import org.keycloak.models.GroupProvider;
 import org.keycloak.models.GroupProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
 
 import jakarta.persistence.EntityManager;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.keycloak.models.jpa.JpaRealmProviderFactory.PROVIDER_ID;
 import static org.keycloak.models.jpa.JpaRealmProviderFactory.PROVIDER_PRIORITY;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 public class JpaGroupProviderFactory implements GroupProviderFactory {
 
     private Set<String> groupSearchableAttributes = null;
+    private boolean escapeSlashesInGroupPath;
 
     @Override
     public void init(Config.Scope config) {
+        escapeSlashesInGroupPath = config.getBoolean("escapeSlashesInGroupPath", GroupProvider.DEFAULT_ESCAPE_SLASHES);
         String[] searchableAttrsArr = config.getArray("searchableAttributes");
         if (searchableAttrsArr == null) {
             String s = System.getProperty("keycloak.group.searchableAttributes");
@@ -77,4 +82,25 @@ public class JpaGroupProviderFactory implements GroupProviderFactory {
         return PROVIDER_PRIORITY;
     }
 
+    @Override
+    public boolean escapeSlashesInGroupPath() {
+        return escapeSlashesInGroupPath;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name("escapeSlashesInGroupPath")
+                .helpText("If true slashes `/` in group names are escaped with the character `~` when converted to paths.")
+                .type("boolean")
+                .defaultValue(false)
+                .add()
+                .property()
+                .name("searchableAttributes")
+                .helpText("The list of attributes separated by comma that are allowed in client attribute searches.")
+                .type("string")
+                .add()
+                .build();
+    }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -483,7 +483,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         GroupEntity groupEntity = em.find(GroupEntity.class, id);
         if (groupEntity == null) return null;
         if (!groupEntity.getRealm().equals(realm.getId())) return null;
-        GroupAdapter adapter =  new GroupAdapter(realm, em, groupEntity);
+        GroupAdapter adapter =  new GroupAdapter(session, realm, em, groupEntity);
         return adapter;
     }
 
@@ -650,7 +650,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         Stream<GroupEntity> results = paginateQuery(query, firstResult, maxResults).getResultStream();
 
         return closing(results
-        		.map(g -> (GroupModel) new GroupAdapter(realm, em, g))
+                .map(g -> (GroupModel) new GroupAdapter(session, realm, em, g))
                 .sorted(GroupModel.COMPARE_BY_NAME));
     }
 
@@ -733,7 +733,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         em.persist(groupEntity);
         em.flush();
 
-        return new GroupAdapter(realm, em, groupEntity);
+        return new GroupAdapter(session, realm, em, groupEntity);
     }
 
     @Override
@@ -1169,7 +1169,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
         TypedQuery<GroupEntity> query = em.createQuery(queryBuilder);
         return closing(paginateQuery(query, firstResult, maxResults).getResultStream())
-                .map(g -> new GroupAdapter(realm, em, g));
+                .map(g -> new GroupAdapter(session, realm, em, g));
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/GroupProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/GroupProviderFactory.java
@@ -20,4 +20,8 @@ package org.keycloak.models;
 import org.keycloak.provider.ProviderFactory;
 
 public interface GroupProviderFactory<T extends GroupProvider> extends ProviderFactory<T> {
+
+    default boolean escapeSlashesInGroupPath() {
+        return GroupProvider.DEFAULT_ESCAPE_SLASHES;
+    }
 }

--- a/server-spi/src/main/java/org/keycloak/models/GroupModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/GroupModel.java
@@ -173,4 +173,8 @@ public interface GroupModel extends RoleMapperModel {
      * @param subGroup
      */
     void removeChild(GroupModel subGroup);
+
+    default boolean escapeSlashesInGroupPath() {
+        return GroupProvider.DEFAULT_ESCAPE_SLASHES;
+    }
 }

--- a/server-spi/src/main/java/org/keycloak/models/GroupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/GroupProvider.java
@@ -30,6 +30,8 @@ import java.util.stream.Stream;
  */
 public interface GroupProvider extends Provider, GroupLookupProvider {
 
+    static boolean DEFAULT_ESCAPE_SLASHES = false;
+
     /**
      * Returns groups for the given realm.
      *

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -1084,8 +1084,7 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
     @Operation()
-    public GroupRepresentation getGroupByPath(@PathParam("path") List<PathSegment> pathSegments) {
-        String[] path = pathSegments.stream().map(PathSegment::getPath).toArray(String[]::new);
+    public GroupRepresentation getGroupByPath(@PathParam("path") String path) {
         GroupModel found = KeycloakModelUtils.findGroupByPath(session, realm, path);
         if (found == null) {
             throw new NotFoundException("Group path does not exist");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
@@ -17,11 +17,16 @@
 
 package org.keycloak.testsuite.admin.group;
 
+import jakarta.ws.rs.core.Response;
+import java.util.*;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.ProtocolMappersResource;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.models.GroupProvider;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.mappers.GroupMembershipMapper;
@@ -30,11 +35,12 @@ import org.keycloak.protocol.oidc.mappers.UserAttributeMapper;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-
-import java.util.*;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.util.ProtocolMapperUtil;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -128,6 +134,43 @@ public class GroupMappersTest extends AbstractGroupTest {
             MatcherAssert.assertThat(groups.get("groups"), Matchers.contains("level2group"));
             Assert.assertEquals("true", token.getOtherClaims().get("topAttribute"));
             Assert.assertEquals("true", token.getOtherClaims().get("level2Attribute"));
+        }
+    }
+
+    @Test
+    public void testGroupMappersWithSlash() throws Exception {
+        RealmResource realm = adminClient.realms().realm("test");
+        GroupRepresentation topGroup = realm.getGroupByPath("/topGroup");
+        Assert.assertNotNull(topGroup);
+        GroupRepresentation childSlash = new GroupRepresentation();
+        childSlash.setName("child/slash");
+        try (Response response = realm.groups().group(topGroup.getId()).subGroup(childSlash)) {
+            Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            childSlash.setId(ApiUtil.getCreatedId(response));
+        }
+        List<UserRepresentation> users = realm.users().search("level2GroupUser", true);
+        Assert.assertEquals(1, users.size());
+        UserRepresentation user = users.iterator().next();
+        realm.users().get(user.getId()).joinGroup(childSlash.getId());
+
+        ProtocolMappersResource protocolMappers = ApiUtil.findClientResourceByClientId(realm, "test-app").getProtocolMappers();
+        ProtocolMapperRepresentation groupsMapper = ProtocolMapperUtil.getMapperByNameAndProtocol(
+                protocolMappers, OIDCLoginProtocol.LOGIN_PROTOCOL, "groups");
+        groupsMapper.getConfig().put("full.path", Boolean.TRUE.toString());
+        protocolMappers.update(groupsMapper.getId(), groupsMapper);
+
+        try {
+            AccessToken token = login(user.getUsername(), "test-app", "password", user.getId());
+            Assert.assertNotNull(token.getOtherClaims().get("groups"));
+            Map<String, Collection<String>> groups = (Map<String, Collection<String>>) token.getOtherClaims().get("groups");
+            MatcherAssert.assertThat(groups.get("groups"), Matchers.containsInAnyOrder(
+                    KeycloakModelUtils.buildGroupPath(GroupProvider.DEFAULT_ESCAPE_SLASHES, "topGroup", "level2group"),
+                    KeycloakModelUtils.buildGroupPath(GroupProvider.DEFAULT_ESCAPE_SLASHES, "topGroup", "child/slash")));
+        } finally {
+            realm.users().get(user.getId()).leaveGroup(childSlash.getId());
+            realm.groups().group(childSlash.getId()).remove();
+            groupsMapper.getConfig().remove("full.path");
+            protocolMappers.update(groupsMapper.getId(), groupsMapper);
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -31,6 +31,7 @@ import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.Constants;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
@@ -87,6 +88,7 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.keycloak.models.GroupProvider;
 import static org.keycloak.testsuite.Assert.assertNames;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
@@ -1370,14 +1372,13 @@ public class GroupTest extends AbstractGroupTest {
         assertTrue(searchResultGroups.isEmpty());
     }
 
-    @Test
-    public void testGroupsWithSpaces() {
+    public void testParentAndChildGroup(String parentName, String childName) {
         RealmResource realm = adminClient.realms().realm("test");
         GroupRepresentation parentGroup = new GroupRepresentation();
-        parentGroup.setName("parent space");
+        parentGroup.setName(parentName);
         parentGroup = createGroup(realm, parentGroup);
         GroupRepresentation childGroup = new GroupRepresentation();
-        childGroup.setName("child space");
+        childGroup.setName(childName);
         try (Response response = realm.groups().group(parentGroup.getId()).subGroup(childGroup)) {
             assertEquals(201, response.getStatus()); // created status
             childGroup.setId(ApiUtil.getCreatedId(response));
@@ -1385,20 +1386,28 @@ public class GroupTest extends AbstractGroupTest {
         assertAdminEvents.assertEvent(testRealmId, OperationType.CREATE,
                 AdminEventPaths.groupSubgroupsPath(parentGroup.getId()), childGroup, ResourceType.GROUP);
 
-        List<GroupRepresentation> groupsFound = realm.groups().groups("parent space", true, 0, 1, true);
+        List<GroupRepresentation> groupsFound = realm.groups().groups(parentGroup.getName(), true, 0, 1, true);
         Assert.assertEquals(1, groupsFound.size());
         Assert.assertEquals(parentGroup.getId(), groupsFound.iterator().next().getId());
         Assert.assertEquals(0, groupsFound.iterator().next().getSubGroups().size());
-        groupsFound = realm.groups().groups("child space", true, 0, 1, true);
+        parentGroup = groupsFound.iterator().next();
+        Assert.assertEquals(KeycloakModelUtils.buildGroupPath(GroupProvider.DEFAULT_ESCAPE_SLASHES, parentName),
+                parentGroup.getPath());
+
+        groupsFound = realm.groups().groups(childGroup.getName(), true, 0, 1, true);
         Assert.assertEquals(1, groupsFound.size());
         Assert.assertEquals(parentGroup.getId(), groupsFound.iterator().next().getId());
         Assert.assertEquals(1, groupsFound.iterator().next().getSubGroups().size());
         Assert.assertEquals(childGroup.getId(), groupsFound.iterator().next().getSubGroups().iterator().next().getId());
+        childGroup = groupsFound.iterator().next().getSubGroups().iterator().next();
+        Assert.assertEquals(KeycloakModelUtils.normalizeGroupPath(
+                KeycloakModelUtils.buildGroupPath(GroupProvider.DEFAULT_ESCAPE_SLASHES, parentName, childName)),
+                childGroup.getPath());
 
-        GroupRepresentation groupFound = realm.getGroupByPath(parentGroup.getName());
+        GroupRepresentation groupFound = realm.getGroupByPath(parentGroup.getPath());
         Assert.assertNotNull(groupFound);
         Assert.assertEquals(parentGroup.getId(), groupFound.getId());
-        groupFound = realm.getGroupByPath("/" + parentGroup.getName() + "/" + childGroup.getName());
+        groupFound = realm.getGroupByPath(childGroup.getPath());
         Assert.assertNotNull(groupFound);
         Assert.assertEquals(childGroup.getId(), groupFound.getId());
 
@@ -1406,6 +1415,16 @@ public class GroupTest extends AbstractGroupTest {
         assertAdminEvents.assertEvent(testRealmId, OperationType.DELETE, AdminEventPaths.groupPath(childGroup.getId()), ResourceType.GROUP);
         realm.groups().group(parentGroup.getId()).remove();
         assertAdminEvents.assertEvent(testRealmId, OperationType.DELETE, AdminEventPaths.groupPath(parentGroup.getId()), ResourceType.GROUP);
+    }
+
+    @Test
+    public void testGroupsWithSpaces() {
+         testParentAndChildGroup("parent space", "child space");
+    }
+
+    @Test
+    public void testGroupsWithSlashes() {
+         testParentAndChildGroup("parent/slash", "child/slash");
     }
 
     /**


### PR DESCRIPTION
Closes #23900

This PR escapes slashes in group full path representations. The idea is if a top group is called `parent/slash` the full path will be `/parent\/slash` (if the name is `parent\/slash`, it will be `parent\\/slash`, so it's just ading a back-slash before any slash). So the slash inside the name is escaped to mark is not a real hierarchy separation. It's a draft because I have two doubts:

1. It's a change than can break things because now full paths are different. I was thinking about adding some compatibility option to revert to previous (wrong) behavior. I thought about adding a config option in a provider factory but, because of how the methods are done, it's complicated (it requires a lot of refactoring for methods to pass the session or a boolean parameter, and I don't like it). So I just see the option of adding a system property (something like `-Dorg.keycloak.models.groups.doNotEscapeSlashInFullPath=true`). Is it OK?
2. I needed to change again `RealmAdminResource` which was modified in https://github.com/keycloak/keycloak/issues/25111. I saw my PR in quarkus is also merged in 3.2 branch so I expect it will be in quarkus 3.2.10 when released. With the original code no change is needed here as we were getting the full path directly.

@mposolda @pedroigor WDYT? Do you see ok adding a system property for point 1? For the second question I'll just wait to quarkus 3.2.10 and will modify the PR once the upgrade is merged in keycloak, I this PR can wait as it's not urgent.