### PR TITLE
Fixes error returned when user is temporarily locked (#26293)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -84,7 +84,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
     }
 
     protected String disabledByBruteForceError() {
-        return Messages.INVALID_USER;
+        return Messages.ACCOUNT_TEMPORARILY_DISABLED;
     }
 
     protected String disabledByBruteForceFieldError(){


### PR DESCRIPTION
Currently, when a user gets temporarily disabled due to brute force security measures, his login attempts will return "Invalid username or password" as a message even if the credentials are correct.
This is not only misleading, but it could lead to further erroneous attempts.

The solution would be to return the correct message when a login attempt is performed for a temporarily disabled user: "Account is temporarily disabled; contact your administrator or retry later"