### PR TITLE
Remove deprecated mode for saml encryption

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-24_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-24_0_0.adoc
@@ -220,3 +220,7 @@ PUT /admin/realms/{realm}/users/{id}/execute-actions-email
 
 ["VERIFY_EMAIL"]
 ----
+
+= Removal of the deprecated mode for SAML encryption
+
+The compatibility mode for SAML encryption introduced in version 21 is now removed. The system property `keycloak.saml.deprecated.encryption` is not managed anymore by the server. The clients which still used the old signing key for encryption should update it from the new IDP configuration metadata.

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -90,9 +90,7 @@ import jakarta.ws.rs.core.UriInfo;
 import javax.xml.namespace.QName;
 import java.io.IOException;
 import java.security.Key;
-import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -156,9 +154,6 @@ public class SAMLEndpoint {
     private final ClientConnection clientConnection;
 
     private final HttpHeaders headers;
-
-    public static final String ENCRYPTION_DEPRECATED_MODE_PROPERTY = "keycloak.saml.deprecated.encryption";
-    private final boolean DEPRECATED_ENCRYPTION = Boolean.getBoolean(ENCRYPTION_DEPRECATED_MODE_PROPERTY);
 
 
     public SAMLEndpoint(KeycloakSession session, SAMLIdentityProvider provider, SAMLIdentityProviderConfig config, IdentityProvider.AuthenticationCallback callback, DestinationValidator destinationValidator) {
@@ -460,17 +455,6 @@ public class SAMLEndpoint {
                 if (assertionIsEncrypted) {
                     try {
                         XMLEncryptionUtil.DecryptionKeyLocator decryptionKeyLocator = new SAMLDecryptionKeysLocator(session, realm, config.getEncryptionAlgorithm());
-                        /* This code is deprecated and will be removed in Keycloak 24 */
-                        if (DEPRECATED_ENCRYPTION) {
-                            KeyManager.ActiveRsaKey keys = session.keys().getActiveRsaKey(realm);
-                            final XMLEncryptionUtil.DecryptionKeyLocator tmp = decryptionKeyLocator;
-                            decryptionKeyLocator = data -> {
-                                List<PrivateKey> result = new ArrayList<>(tmp.getKeys(data));
-                                result.add(keys.getPrivateKey());
-                                return result;
-                            };
-                        }
-                        /* End of deprecated code */
                         assertionElement = AssertionUtil.decryptAssertion(responseType, decryptionKeyLocator);
                     } catch (ProcessingException ex) {
                         logger.warnf(ex, "Not possible to decrypt SAML assertion. Please check realm keys of usage ENC in the realm '%s' and make sure there is a key able to decrypt the assertion encrypted by identity provider '%s'", realm.getName(), config.getAlias());
@@ -518,17 +502,6 @@ public class SAMLEndpoint {
                 if (AssertionUtil.isIdEncrypted(responseType)) {
                     try {
                         XMLEncryptionUtil.DecryptionKeyLocator decryptionKeyLocator = new SAMLDecryptionKeysLocator(session, realm, config.getEncryptionAlgorithm());
-                        /* This code is deprecated and will be removed in Keycloak 24 */
-                        if (DEPRECATED_ENCRYPTION) {
-                            KeyManager.ActiveRsaKey keys = session.keys().getActiveRsaKey(realm);
-                            final XMLEncryptionUtil.DecryptionKeyLocator tmp = decryptionKeyLocator;
-                            decryptionKeyLocator = data -> {
-                                List<PrivateKey> result = new ArrayList<>(tmp.getKeys(data));
-                                result.add(keys.getPrivateKey());
-                                return result;
-                            };
-                        }
-                        /* End of deprecated code */
                         AssertionUtil.decryptId(responseType, decryptionKeyLocator);
                     } catch (ProcessingException ex) {
                         logger.warnf(ex, "Not possible to decrypt SAML encryptedId. Please check realm keys of usage ENC in the realm '%s' and make sure there is a key able to decrypt the encryptedId encrypted by identity provider '%s'", realm.getName(), config.getAlias());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractKcSamlEncryptedElementsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractKcSamlEncryptedElementsTest.java
@@ -48,7 +48,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.keycloak.broker.saml.SAMLEndpoint.ENCRYPTION_DEPRECATED_MODE_PROPERTY;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.SAML_CLIENT_ID_SALES_POST;
 import static org.keycloak.testsuite.util.Matchers.isSamlResponse;
@@ -84,24 +83,6 @@ public abstract class AbstractKcSamlEncryptedElementsTest extends AbstractBroker
             KeysMetadataRepresentation.KeyMetadataRepresentation activeSignatureKey = KeyUtils.findActiveSigningKey(adminClient.realm(bc.consumerRealmName()));
             assertThat(activeSignatureKey.getProviderId(), equalTo(sigProviderId));
             sendDocumentWithEncryptedElement(PemUtils.decodePublicKey(activeSignatureKey.getPublicKey()), XMLCipher.RSA_OAEP, null, null, false);
-        }
-
-        @Test
-        public void testEncryptedElementIsReadableInDeprecatedMode() throws ConfigurationException, ParsingException, ProcessingException {
-            try {
-                // Set flag that enabled deprecated mode for encryption
-                testingClient.server().run(session -> {
-                    System.setProperty(ENCRYPTION_DEPRECATED_MODE_PROPERTY, "true");
-                });
-                KeysMetadataRepresentation.KeyMetadataRepresentation activeSignatureKey = KeyUtils.findActiveSigningKey(adminClient.realm(bc.consumerRealmName()));
-                assertThat(activeSignatureKey.getProviderId(), equalTo(sigProviderId));
-                sendDocumentWithEncryptedElement(PemUtils.decodePublicKey(activeSignatureKey.getPublicKey()), XMLCipher.RSA_OAEP, null, null, true);
-            } finally {
-                // Clear flag
-                testingClient.server().run(session -> {
-                    System.clearProperty(ENCRYPTION_DEPRECATED_MODE_PROPERTY);
-                });
-            }
         }
 
         @Test


### PR DESCRIPTION
Closes #26291

Removing the deprecated encryption key mode (system prop `keycloak.saml.deprecated.encryption`). It was planned for 24 and it's causing issue #26291. Because of the jdk upgrade from 17.0.9 to 17.0.10 the BC-FIPS is not allowing to use the same key for both usages as the deprecated mode managed. This only affects FIPS mode, so people using the deprecated mode are save outside FIPS.
