### PR TITLE
Don't fail reset credentials action upon first broker login without `EXISTING_USER_INFO`

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/resetcred/ResetCredentialsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/resetcred/ResetCredentialsActionTokenHandler.java
@@ -85,12 +85,19 @@ public class ResetCredentialsActionTokenHandler extends AbstractActionTokenHandl
             boolean firstBrokerLoginInProgress = (authenticationSession.getAuthNote(AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE) != null);
             if (firstBrokerLoginInProgress) {
 
-                UserModel linkingUser = AbstractIdpAuthenticator.getExistingUser(session, realm, authenticationSession);
                 SerializedBrokeredIdentityContext serializedCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authenticationSession, AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE);
                 authenticationSession.setAuthNote(AbstractIdpAuthenticator.FIRST_BROKER_LOGIN_SUCCESS, serializedCtx.getIdentityProviderId());
 
+                boolean hasExistingUserInfo = (authenticationSession.getAuthNote(AbstractIdpAuthenticator.EXISTING_USER_INFO) != null);
+                String username = "";
+
+                if (hasExistingUserInfo) {
+                    UserModel linkingUser = AbstractIdpAuthenticator.getExistingUser(session, realm, authenticationSession);
+                    username = linkingUser.getUsername();
+                }
+
                 logger.debugf("Forget-password flow finished when authenticated user '%s' after first broker login with identity provider '%s'.",
-                        linkingUser.getUsername(), serializedCtx.getIdentityProviderId());
+                        username, serializedCtx.getIdentityProviderId());
 
                 return LoginActionsService.redirectToAfterBrokerLoginEndpoint(session, realm, uriInfo, authenticationSession, true);
             } else {


### PR DESCRIPTION
Don't fail reset credentials action upon first broker login without `AbstractIdpAuthenticator.EXISTING_USER_INFO`.

The ResetCredentialsActionTokenHandler depends upon the `EXISTING_USER_INFO` through `AbstractIdpAuthenticator.getExistingUser` solely to log the username. However, if the first broker login flow does not include a `IdpCreateUserIfUniqueAuthenticator` or `IdpDetectExistingBrokerUserAuthenticator`, the `EXISTING_USER_INFO` is never set.

This commit does not attempt to fetch the existing user if we don't have this info set.

Closes #26323

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
