### PR TITLE
Allow selecting attributes from user profile when managing token mappers

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/HardcodedAttributeMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/HardcodedAttributeMapperFactory.java
@@ -39,7 +39,7 @@ public class HardcodedAttributeMapperFactory extends AbstractLDAPStorageMapperFa
         ProviderConfigProperty attrName = createConfigProperty(HardcodedAttributeMapper.USER_MODEL_ATTRIBUTE,
                 "User Model Attribute Name",
                 "Name of the model attribute, which will be added when importing user from ldap",
-                ProviderConfigProperty.STRING_TYPE,
+                ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE,
                 null,
                 true);
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapperFactory.java
@@ -55,7 +55,7 @@ public class UserAttributeLDAPStorageMapperFactory extends AbstractLDAPStorageMa
                 .property().name(UserAttributeLDAPStorageMapper.USER_MODEL_ATTRIBUTE)
                 .label("User Model Attribute")
                 .helpText("Name of the UserModel property or attribute you want to map the LDAP attribute into. For example 'firstName', 'lastName, 'email', 'street' etc.")
-                .type(ProviderConfigProperty.STRING_TYPE)
+                .type(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE)
                 .required(true)
                 .add()
                 .property().name(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE).label("LDAP Attribute").helpText("Name of mapped attribute on LDAP object. For example 'cn', 'sn, 'mail', 'street' etc.")

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/client_scopes/client_scope_details/tabs/mappers/MapperDetailsPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/client_scopes/client_scope_details/tabs/mappers/MapperDetailsPage.ts
@@ -9,7 +9,7 @@ export enum ClaimJsonType {
 }
 
 export default class MapperDetailsPage extends CommonPage {
-  #userAttributeInput = '[id="user.attribute"]';
+  #userAttributeInput = '[data-testid="config.user🍺attribute"]';
   #tokenClaimNameInput = '[id="claim.name"]';
   #claimJsonType = '[id="jsonType.label"]';
 

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/AddMapperPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/AddMapperPage.ts
@@ -8,13 +8,13 @@ export default class AddMapperPage {
   #addMapperButton = "#add-mapper-button";
 
   #mapperNameInput = "#kc-name";
-  #attribute = "user.attribute";
+  #attribute = "config.user🍺attribute";
   #attributeName = "attribute.name";
   #attributeFriendlyName = "attribute.friendly.name";
   #claimInput = "claim";
   #socialProfileJSONfieldPath = "jsonField";
-  #userAttribute = "attribute";
-  #userAttributeName = "userAttribute";
+  #userAttribute = "config.attribute";
+  #userAttributeName = "config.userAttribute";
   #userAttributeValue = "attribute.value";
   #userSessionAttribute = "attribute";
   #userSessionAttributeValue = "attribute.value";

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/providers/ProviderPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/providers/ProviderPage.ts
@@ -63,9 +63,9 @@ export default class ProviderPage {
   #cachePolicyList = "#kc-cache-policy + ul";
 
   // Mapper input values
-  #userModelAttInput = "user.model.attribute";
+  #userModelAttInput = "config.user🍺model🍺attribute";
   #ldapAttInput = "ldap.attribute";
-  #userModelAttNameInput = "user.model.attribute";
+  #userModelAttNameInput = "config.user🍺model🍺attribute";
   #attValueInput = "attribute.value";
   #ldapFullNameAttInput = "ldap.full.name.attribute";
   #ldapAttNameInput = "ldap.attribute.name";
@@ -317,7 +317,7 @@ export default class ProviderPage {
   }
 
   createNewMapper(mapperType: string) {
-    const userModelAttValue = "firstName";
+    const userModelAttValue = "middleName";
     const ldapAttValue = "cn";
     const ldapDnValue = "ou=groups";
 

--- a/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
@@ -1,57 +1,33 @@
 import type { UserProfileConfig } from "@keycloak/keycloak-admin-client/lib/defs/userProfileMetadata";
 import { FormGroup } from "@patternfly/react-core";
 import { useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "ui-shared";
-import { convertToName } from "./DynamicComponents";
+
 import { adminClient } from "../../admin-client";
 import { useFetch } from "../../utils/useFetch";
+import { KeySelect } from "../key-value-form/KeySelect";
+import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
-import { KeySelect, FetchCallback } from "../key-value-form/KeySelect";
 
-type FetchCallbackWithValue = FetchCallback & {
-  fieldValue: string;
-};
 export const UserProfileAttributeListComponent = ({
   name,
   label,
   helpText,
-  defaultValue,
   required = false,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const {
-    control,
     formState: { errors },
   } = useFormContext();
 
   const [config, setConfig] = useState<UserProfileConfig>();
   const convertedName = convertToName(name!);
 
-  const [custom, setCustom] = useState(true);
-  const fetchCallback: FetchCallbackWithValue = {
-    fieldValue: "",
-    custom,
-    setCustom,
-  };
-  const updateFetchCallback: (
-    currentValue: string,
-  ) => FetchCallbackWithValue = (currentValue) => {
-    fetchCallback.fieldValue = currentValue;
-    return fetchCallback;
-  };
-
   useFetch(
     () => adminClient.users.getProfile(),
-    (cfg) => {
-      setConfig(cfg);
-
-      const fieldIncluded = cfg.attributes
-        ?.map((option) => option.name!)
-        .includes(fetchCallback.fieldValue);
-      setCustom(!fieldIncluded);
-    },
+    (cfg) => setConfig(cfg),
     [],
   );
 
@@ -64,6 +40,8 @@ export const UserProfileAttributeListComponent = ({
     }));
   };
 
+  if (!config) return null;
+
   return (
     <FormGroup
       label={t(label!)}
@@ -73,19 +51,10 @@ export const UserProfileAttributeListComponent = ({
       validated={errors[convertedName!] ? "error" : "default"}
       helperTextInvalid={t("required")}
     >
-      <Controller
-        name={convertedName!}
-        defaultValue={defaultValue || ""}
-        control={control}
+      <KeySelect
+        name={convertedName}
         rules={required ? { required: true } : {}}
-        render={({ field }) => (
-          <KeySelect
-            name={convertedName}
-            rules={required ? { required: true } : {}}
-            selectItems={convert(config)}
-            fetchCallback={updateFetchCallback(field.value)}
-          />
-        )}
+        selectItems={convert(config)}
       />
     </FormGroup>
   );

--- a/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
@@ -1,0 +1,92 @@
+import type { UserProfileConfig } from "@keycloak/keycloak-admin-client/lib/defs/userProfileMetadata";
+import { FormGroup } from "@patternfly/react-core";
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { HelpItem } from "ui-shared";
+import { convertToName } from "./DynamicComponents";
+import { adminClient } from "../../admin-client";
+import { useFetch } from "../../utils/useFetch";
+import type { ComponentProps } from "./components";
+import { KeySelect, FetchCallback } from "../key-value-form/KeySelect";
+
+type FetchCallbackWithValue = FetchCallback & {
+  fieldValue: string;
+};
+export const UserProfileAttributeListComponent = ({
+  name,
+  label,
+  helpText,
+  defaultValue,
+  required = false,
+}: ComponentProps) => {
+  const { t } = useTranslation();
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext();
+
+  const [config, setConfig] = useState<UserProfileConfig>();
+  const convertedName = convertToName(name!);
+
+  const [custom, setCustom] = useState(true);
+  const fetchCallback: FetchCallbackWithValue = {
+    fieldValue: "",
+    custom,
+    setCustom,
+  };
+  const updateFetchCallback: (
+    currentValue: string,
+  ) => FetchCallbackWithValue = (currentValue) => {
+    fetchCallback.fieldValue = currentValue;
+    return fetchCallback;
+  };
+
+  useFetch(
+    () => adminClient.users.getProfile(),
+    (cfg) => {
+      setConfig(cfg);
+
+      const fieldIncluded = cfg.attributes
+        ?.map((option) => option.name!)
+        .includes(fetchCallback.fieldValue);
+      setCustom(!fieldIncluded);
+    },
+    [],
+  );
+
+  const convert = (config?: UserProfileConfig) => {
+    if (!config?.attributes) return [];
+
+    return config.attributes.map((option) => ({
+      key: option.name!,
+      label: option.name!,
+    }));
+  };
+
+  return (
+    <FormGroup
+      label={t(label!)}
+      isRequired={required}
+      labelIcon={<HelpItem helpText={t(helpText!)} fieldLabelId={label!} />}
+      fieldId={convertedName!}
+      validated={errors[convertedName!] ? "error" : "default"}
+      helperTextInvalid={t("required")}
+    >
+      <Controller
+        name={convertedName!}
+        defaultValue={defaultValue || ""}
+        control={control}
+        rules={required ? { required: true } : {}}
+        render={({ field }) => (
+          <KeySelect
+            name={convertedName}
+            rules={required ? { required: true } : {}}
+            selectItems={convert(config)}
+            fetchCallback={updateFetchCallback(field.value)}
+          />
+        )}
+      />
+    </FormGroup>
+  );
+};

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -2,6 +2,7 @@ import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-clie
 
 import { BooleanComponent } from "./BooleanComponent";
 import { ClientSelectComponent } from "./ClientSelectComponent";
+import { UserProfileAttributeListComponent } from "./UserProfileAttributeListComponent";
 import { FileComponent } from "./FileComponent";
 import { GroupComponent } from "./GroupComponent";
 import { ListComponent } from "./ListComponent";
@@ -31,6 +32,7 @@ const ComponentTypes = [
   "Group",
   "MultivaluedList",
   "ClientList",
+  "UserProfileAttributeList",
   "MultivaluedString",
   "File",
   "Password",
@@ -50,6 +52,7 @@ export const COMPONENTS: {
   Map: MapComponent,
   Group: GroupComponent,
   ClientList: ClientSelectComponent,
+  UserProfileAttributeList: UserProfileAttributeListComponent,
   MultivaluedList: MultiValuedListComponent,
   MultivaluedString: MultiValuedStringComponent,
   File: FileComponent,

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -1,8 +1,8 @@
 import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
+import { FunctionComponent } from "react";
 
 import { BooleanComponent } from "./BooleanComponent";
 import { ClientSelectComponent } from "./ClientSelectComponent";
-import { UserProfileAttributeListComponent } from "./UserProfileAttributeListComponent";
 import { FileComponent } from "./FileComponent";
 import { GroupComponent } from "./GroupComponent";
 import { ListComponent } from "./ListComponent";
@@ -14,6 +14,7 @@ import { RoleComponent } from "./RoleComponent";
 import { ScriptComponent } from "./ScriptComponent";
 import { StringComponent } from "./StringComponent";
 import { TextComponent } from "./TextComponent";
+import { UserProfileAttributeListComponent } from "./UserProfileAttributeListComponent";
 
 export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
   isDisabled?: boolean;
@@ -41,7 +42,7 @@ const ComponentTypes = [
 export type Components = (typeof ComponentTypes)[number];
 
 export const COMPONENTS: {
-  [index in Components]: (props: ComponentProps) => JSX.Element;
+  [index in Components]: FunctionComponent<ComponentProps>;
 } = {
   String: StringComponent,
   Text: TextComponent,

--- a/js/apps/admin-ui/src/components/key-value-form/KeySelect.tsx
+++ b/js/apps/admin-ui/src/components/key-value-form/KeySelect.tsx
@@ -6,37 +6,18 @@ import { KeycloakTextInput } from "ui-shared";
 import useToggle from "../../utils/useToggle";
 import { DefaultValue } from "./KeyValueInput";
 
-/**
- * Used when the values passed to KeySelect in "selectItems" need to be fetched from the server dynamically. In this case, we might want to call "setCustom"
- * from parent component. The "fieldValue" sent to KeySelect is not supposed to be set by the calling component, as it will be set by KeySelect itself with the value of the field, so
- * it can be consumed from the callback function once the values are fetched from the server
- */
-export type FetchCallback = {
-  custom: boolean;
-  setCustom: any;
-};
-
 type KeySelectProp = UseControllerProps & {
   selectItems: DefaultValue[];
-  fetchCallback?: FetchCallback;
 };
 
-export const KeySelect = ({
-  selectItems,
-  fetchCallback,
-  ...rest
-}: KeySelectProp) => {
+export const KeySelect = ({ selectItems, ...rest }: KeySelectProp) => {
   const { t } = useTranslation();
   const [open, toggle] = useToggle();
   const { field } = useController(rest);
 
-  let [custom, setCustom] = useState(
+  const [custom, setCustom] = useState(
     !selectItems.map(({ key }) => key).includes(field.value),
   );
-
-  if (fetchCallback) {
-    [custom, setCustom] = [fetchCallback.custom, fetchCallback.setCustom];
-  }
 
   return (
     <Grid>

--- a/js/apps/admin-ui/src/components/key-value-form/KeySelect.tsx
+++ b/js/apps/admin-ui/src/components/key-value-form/KeySelect.tsx
@@ -6,17 +6,37 @@ import { KeycloakTextInput } from "ui-shared";
 import useToggle from "../../utils/useToggle";
 import { DefaultValue } from "./KeyValueInput";
 
-type KeySelectProp = UseControllerProps & {
-  selectItems: DefaultValue[];
+/**
+ * Used when the values passed to KeySelect in "selectItems" need to be fetched from the server dynamically. In this case, we might want to call "setCustom"
+ * from parent component. The "fieldValue" sent to KeySelect is not supposed to be set by the calling component, as it will be set by KeySelect itself with the value of the field, so
+ * it can be consumed from the callback function once the values are fetched from the server
+ */
+export type FetchCallback = {
+  custom: boolean;
+  setCustom: any;
 };
 
-export const KeySelect = ({ selectItems, ...rest }: KeySelectProp) => {
+type KeySelectProp = UseControllerProps & {
+  selectItems: DefaultValue[];
+  fetchCallback?: FetchCallback;
+};
+
+export const KeySelect = ({
+  selectItems,
+  fetchCallback,
+  ...rest
+}: KeySelectProp) => {
   const { t } = useTranslation();
   const [open, toggle] = useToggle();
   const { field } = useController(rest);
-  const [custom, setCustom] = useState(
+
+  let [custom, setCustom] = useState(
     !selectItems.map(({ key }) => key).includes(field.value),
   );
+
+  if (fetchCallback) {
+    [custom, setCustom] = [fetchCallback.custom, fetchCallback.setCustom];
+  }
 
   return (
     <Grid>

--- a/js/apps/admin-ui/src/components/key-value-form/KeySelect.tsx
+++ b/js/apps/admin-ui/src/components/key-value-form/KeySelect.tsx
@@ -14,7 +14,6 @@ export const KeySelect = ({ selectItems, ...rest }: KeySelectProp) => {
   const { t } = useTranslation();
   const [open, toggle] = useToggle();
   const { field } = useController(rest);
-
   const [custom, setCustom] = useState(
     !selectItems.map(({ key }) => key).includes(field.value),
   );

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -51,6 +51,11 @@ public class ProviderConfigProperty {
     public static final String MULTIVALUED_LIST_TYPE="MultivaluedList";
 
     public static final String CLIENT_LIST_TYPE="ClientList";
+
+    /**
+     * Possibility to select from user attributes defined in the user-profile, but also still have an option to configure custom value
+     */
+    public static final String USER_PROFILE_ATTRIBUTE_LIST_TYPE="UserProfileAttributeList";
     public static final String PASSWORD="Password";
 
     /**

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractJsonUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractJsonUserAttributeMapper.java
@@ -83,7 +83,7 @@ public abstract class AbstractJsonUserAttributeMapper extends AbstractIdentityPr
 		property.setName(CONF_USER_ATTRIBUTE);
 		property.setLabel("User Attribute Name");
 		property.setHelpText("User attribute name to store information into.");
-		property.setType(ProviderConfigProperty.STRING_TYPE);
+		property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
 		configProperties.add(property);
 	}
 

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/UserAttributeMapper.java
@@ -68,7 +68,7 @@ public class UserAttributeMapper extends AbstractClaimMapper {
         property.setName(USER_ATTRIBUTE);
         property.setLabel("User Attribute Name");
         property.setHelpText("User attribute name to store claim.  Use email, lastName, and firstName to map to those predefined user properties.");
-        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
     }
 

--- a/services/src/main/java/org/keycloak/broker/provider/HardcodedAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/provider/HardcodedAttributeMapper.java
@@ -46,7 +46,7 @@ public class HardcodedAttributeMapper extends AbstractIdentityProviderMapper {
         property.setName(ATTRIBUTE);
         property.setLabel("User Attribute");
         property.setHelpText("Name of user attribute you want to hardcode");
-        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
         property = new ProviderConfigProperty();
         property.setName(ATTRIBUTE_VALUE);

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/UserAttributeMapper.java
@@ -97,7 +97,7 @@ public class UserAttributeMapper extends AbstractIdentityProviderMapper implemen
         property.setName(USER_ATTRIBUTE);
         property.setLabel("User Attribute Name");
         property.setHelpText("User attribute name to store saml attribute.  Use email, lastName, and firstName to map to those predefined user properties.");
-        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
     }
 

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/XPathAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/XPathAttributeMapper.java
@@ -99,7 +99,7 @@ public class XPathAttributeMapper extends AbstractIdentityProviderMapper impleme
         property.setName(USER_ATTRIBUTE);
         property.setLabel("User Attribute Name");
         property.setHelpText("User attribute name to store XPath value. Use " + UserModel.EMAIL + ", " + UserModel.FIRST_NAME + ", and " + UserModel.LAST_NAME + " for e-mail, first and last name, respectively.");
-        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserAttributeMapper.java
@@ -47,7 +47,7 @@ public class UserAttributeMapper extends AbstractOIDCProtocolMapper implements O
         property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
         property.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
         property.setHelpText(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_HELP_TEXT);
-        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
         OIDCAttributeMapperHelper.addAttributeConfig(configProperties, UserAttributeMapper.class);
 

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
@@ -46,6 +46,7 @@ public class UserAttributeStatementMapper extends AbstractSAMLProtocolMapper imp
         property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
         property.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
         property.setHelpText(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_HELP_TEXT);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
         AttributeStatementHelper.setConfigProperties(configProperties);
 

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapper.java
@@ -44,6 +44,7 @@ public class UserPropertyAttributeStatementMapper extends AbstractSAMLProtocolMa
         property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
         property.setLabel(ProtocolMapperUtils.USER_MODEL_PROPERTY_LABEL);
         property.setHelpText(ProtocolMapperUtils.USER_MODEL_PROPERTY_HELP_TEXT);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
         AttributeStatementHelper.setConfigProperties(configProperties);
 


### PR DESCRIPTION
closes #24250

Sending the PR aligned with the approach here https://github.com/keycloak/keycloak/issues/24250#issuecomment-1886755220 .

So it allows administrator to pre-select from the attributes defined in user-profile, but at the same time, allows to use custom value (which is needed as lots of our OIDC built-in mappers use the claims from OIDC specification, which are not defined in user profile attributes). Some screenshot:

When one of the default attributes is selected:

![Screenshot from 2024-01-23 13-33-01](https://github.com/keycloak/keycloak/assets/1223965/113d810a-1da3-40af-a182-d2a516b2466c)

When custom attribute is used:
![Screenshot from 2024-01-23 13-33-25](https://github.com/keycloak/keycloak/assets/1223965/1eefdaf8-e284-4d36-a640-a169d3087989)

One of built-in OIDC mappers (pretty much same like previous as it uses custom value):
![Screenshot from 2024-01-23 13-34-04](https://github.com/keycloak/keycloak/assets/1223965/0e3f56ca-6cd5-40a2-a16e-508603d87dbe)
