### PR TITLE
Add comment about MySQL invisible Primary key generation

### DIFF
--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -227,6 +227,12 @@ show server_encoding;
 create database keycloak with encoding 'UTF8';
 ----
 
+== Configuring MySQL server
+
+Beginning with MySQL 8.0.30, MySQL supports generated invisible primary keys for any InnoDB table that is created without an explicit primary key (more information https://dev.mysql.com/doc/refman/8.0/en/create-table-gipks.html[here]).
+If this feature is enabled, the database schema initialization and also migrations will fail with the error message `Multiple primary key defined (1068)`.
+You then need to disable it by setting the parameter `sql_generate_invisible_primary_key` to `OFF` in your MySQL server configuration before installing or upgrading Keycloak.
+
 == Changing database locking timeout in a cluster configuration
 
 Because cluster nodes can boot concurrently, they take extra time for database actions. For example, a booting server instance may perform some database migration, importing, or first time initializations. A database lock prevents start actions from conflicting with each other when cluster nodes boot up concurrently.


### PR DESCRIPTION
Closes #23268

If the MySQL server parameter `sql_generate_invisible_primary_key` is set to `ON`, MySQL migrations will fail during initial setup.

E.g. Microsoft Azure MySQL Server has this enabled by default.

This PR adds a comment in the documentation, to avoid trial & error when setting up Keycloak using MySQL.