### PR TITLE
Possibility to email being not required

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
@@ -243,6 +243,10 @@ export const AttributeGeneralSettings = () => {
               />
             </FormGroup>
           )}
+        </>
+      )}
+      {attributeName !== "username" && (
+        <>
           <Divider />
           <FormGroup
             label={t("required")}

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -358,21 +358,22 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
                 }
 
                 if (UserModel.EMAIL.equals(attributeName)) {
-                    if (context.isAdminContext()) {
-                        required = new Predicate<AttributeContext>() {
-                            @Override
-                            public boolean test(AttributeContext context) {
-                                UserModel user = context.getUser();
+                    Predicate<AttributeContext> requiredFromConfig = required;
+                    required = new Predicate<AttributeContext>() {
+                        @Override
+                        public boolean test(AttributeContext context) {
+                            UserModel user = context.getUser();
 
-                                if (user != null && user.getServiceAccountClientLink() != null) {
-                                    return false;
-                                }
-
-                                RealmModel realm = context.getSession().getContext().getRealm();
-                                return realm.isRegistrationEmailAsUsername();
+                            if (user != null && user.getServiceAccountClientLink() != null) {
+                                return false;
                             }
-                        };
-                    }
+
+                            if (requiredFromConfig.test(context)) return true;
+
+                            RealmModel realm = context.getSession().getContext().getRealm();
+                            return realm.isRegistrationEmailAsUsername();
+                        }
+                    };
                 }
 
                 List<AttributeMetadata> existingMetadata = decoratedMetadata.getAttribute(attributeName);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/ModelTestExecutor.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/ModelTestExecutor.java
@@ -53,7 +53,8 @@ public class ModelTestExecutor extends LocalTestExecuter {
                 // Model test - wrap the call inside the
                 TestContext ctx = testContext.get();
                 KeycloakTestingClient testingClient = ctx.getTestingClient();
-                testingClient.server().runModelTest(testMethod.getDeclaringClass().getName(), testMethod.getName());
+                String realmName = annotation.realmName();
+                testingClient.server(realmName).runModelTest(testMethod.getDeclaringClass().getName(), testMethod.getName());
 
                 result.setStatus(TestResult.Status.PASSED);
             } catch (Throwable e) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/annotation/ModelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/annotation/ModelTest.java
@@ -33,4 +33,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({ElementType.METHOD}) // TODO: Maybe ElementClass.TYPE too? That way it will be possible to add the annotation on the the test class and not need to add on all the test methods inside the class
 public @interface ModelTest {
+
+    /**
+     * Name of the realm to be set on the KeycloakContext when the test is executed. Defaults to "master" for backwards compatibility
+     */
+    String realmName() default "master";
 }


### PR DESCRIPTION
closes #26552

- It is possible to configure if "email" attribute is required or not
- In case that realm settings `registrationEmailAsUsername` is enabled, then the email is always required for both admins and users (Same behaviour like before).

