### PR TITLE
fix: increases another timeout to accomodate for the transaction timeout

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -77,8 +77,8 @@ public class FipsDistTest {
         runOnFipsEnabledDistribution(dist, () -> {
             dist.copyOrReplaceFileFromClasspath("/server.keystore", Path.of("conf", "server.keystore"));
             CLIResult cliResult = dist.run("start", "--fips-mode=strict");
-            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
             dist.assertStopped();
+            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
         });
     }
 
@@ -125,8 +125,8 @@ public class FipsDistTest {
         runOnFipsEnabledDistribution(dist, () -> {
             dist.copyOrReplaceFileFromClasspath("/server.keystore.pkcs12", Path.of("conf", "server.keystore"));
             CLIResult cliResult = dist.run("start", "--fips-mode=strict", "--https-key-store-password=passwordpassword");
-            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
             dist.assertStopped();
+            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
         });
     }
 


### PR DESCRIPTION
closes: #26529

So there were 3 ways (so far) in which the hung shutdown was affecting the tests:
- by making the instance fail the readiness check - resolved with the first issue
- by making the instance fail to stop - resolved with the second issue
- by making the expected output never appear - resolved here

I haven't determined why, but on the first one was highly reproducible. I've also reached out again on the associated quarkus and narayna issues so that this can get properly fixed.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
