### PR TITLE
Signed-off-by: Author Name satanshiro

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/authenticationManagement.ts
+++ b/js/libs/keycloak-admin-client/src/resources/authenticationManagement.ts
@@ -8,7 +8,7 @@ import type { AuthenticationProviderRepresentation } from "../defs/authenticator
 import type AuthenticatorConfigInfoRepresentation from "../defs/authenticatorConfigInfoRepresentation.js";
 import type RequiredActionProviderSimpleRepresentation from "../defs/requiredActionProviderSimpleRepresentation.js";
 
-export class AuthenticationManagement extends Resource {
+export class AuthenticationManagement extends Resource<{ realm?: string }> {
   /**
    * Authentication Management
    * https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_authentication_management_resource


### PR DESCRIPTION
I cannot send any request without specifying realm either in request or in the kc object. if your kc admin object is shared between requests you want to make sure the correct realm is sent in the request and not manipulate a possibly shared object like kcadmin. i cannot make requests to authentication management endpoints y specifying realm in the object i need to manipulate the kcadmin object that is shared between requests this should fix it

<img width="478" alt="image" src="https://github.com/keycloak/keycloak/assets/38865738/75cb7c29-d3e5-4505-b02d-bee2dc1d5d21">
