### PR TITLE
fix: completely removing problematic assertion

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -78,7 +78,8 @@ public class FipsDistTest {
             dist.copyOrReplaceFileFromClasspath("/server.keystore", Path.of("conf", "server.keystore"));
             CLIResult cliResult = dist.run("start", "--fips-mode=strict");
             dist.assertStopped();
-            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
+            // after https://issues.redhat.com/browse/JBTM-3830 reenable this check
+            //cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
         });
     }
 
@@ -126,7 +127,8 @@ public class FipsDistTest {
             dist.copyOrReplaceFileFromClasspath("/server.keystore.pkcs12", Path.of("conf", "server.keystore"));
             CLIResult cliResult = dist.run("start", "--fips-mode=strict", "--https-key-store-password=passwordpassword");
             dist.assertStopped();
-            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
+            // after https://issues.redhat.com/browse/JBTM-3830 reenable this check
+            //cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
         });
     }
 


### PR DESCRIPTION
closes: #26529

The only other possibility I can see would be to assert seeing the log "Disconnecting JGroups channel `ISPN`" - but since I'm not sure if that is guarenteed either, just removing the assertion entirely seems fine.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
