### PR TITLE
Update teams and areas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -33,8 +33,8 @@ body:
         - admin/cli
         - admin/fine-grained-permissions
         - admin/ui
-        - admin/client/node
-        - admin/client/java
+        - admin/client-java
+        - admin/client-js
         - authentication
         - authentication/webauthn
         - authorization-services
@@ -42,7 +42,6 @@ body:
         - core
         - dependencies
         - dist/quarkus
-        - dist/wildfly
         - docs
         - identity-brokering
         - import-export
@@ -50,6 +49,7 @@ body:
         - ldap
         - login/ui
         - oidc
+        - oid4vc
         - operator
         - saml
         - storage
@@ -57,6 +57,7 @@ body:
         - token-exchange
         - translations
         - user-profile
+        - welcome/ui
     validations:
       required: true
   - type: textarea

--- a/.github/check-area-labels.sh
+++ b/.github/check-area-labels.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+TEAMS="teams.yml"
+BUG="ISSUE_TEMPLATE/bug.yml"
+
+GH_AREAS=( $(gh label list --search 'area/' --limit 100 --json name | jq -r .[].name | sort) )
+LOCAL_AREAS=( $(cat teams.yml | grep 'area/' | sed 's/.*- //') )
+BUG_TEMPLATE_AREAS=( $(yq '.body.[] | select(.id | test("area")) | .attributes.options.[]' ISSUE_TEMPLATE/bug.yml | grep -v '^$') )
+
+TEAMS_VALID=true
+BUG_VALID=true
+
+echo "Checking: $TEAMS"
+for AREA in "${GH_AREAS[@]}"; do
+    if ! ( echo "${LOCAL_AREAS[@]}" | grep -q -F -w "$AREA" ); then
+        echo "[$AREA] missing in $TEAMS"
+        TEAMS_VALID=false
+    fi
+done
+
+for AREA in "${LOCAL_AREAS[@]}"; do
+    if ! ( echo "${GH_AREAS[@]}" | grep -q -F -w "$AREA" ); then
+        echo "[$AREA] missing in GitHub"
+        TEAMS_VALID=false
+    fi
+done
+
+if [ "$TEAMS_VALID" = true ]; then
+    echo "[OK]"
+fi
+
+echo ""
+
+echo "Checking: $BUG"
+for AREA in "${GH_AREAS[@]}"; do
+    AREA_SHORT=$(echo $AREA | sed 's|area/||g')
+    if ! ( echo "${BUG_TEMPLATE_AREAS[@]}" | grep -q -F -w "$AREA_SHORT" ); then
+        echo "[$AREA] missing in $BUG"
+        BUG_VALID=false
+    fi
+done
+
+for AREA in "${BUG_TEMPLATE_AREAS[@]}"; do
+    AREA_LONG="area/$AREA"
+    if ! ( echo "${GH_AREAS[@]}" | grep -q -F -w "$AREA_LONG" ); then
+        echo "[$AREA_LONG] missing in GitHub"
+        BUG_VALID=false
+    fi
+done
+
+if [ "$BUG_VALID" = true ]; then
+    echo "[OK]"
+fi
+
+if [ "$TEAMS_VALID" != true ] || [ "$BUG_VALID" != true ]; then
+    exit 1
+fi

--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,6 +1,5 @@
 team/cloud-native:
   - area/admin/cli
-  - area/dependencies
   - area/dist/quarkus
   - area/operator
 
@@ -8,40 +7,49 @@ team/continuous-testing:
   - area/ci
   - area/testsuite
 
-team/core:
-  - area/admin/api
-  - area/admin/fine-grained-permissions
-  - area/authentication
-  - area/authentication/webauthn
-  - area/authorization-services
-  - area/core
-  - area/identity-brokering
-  - area/oidc
-  - area/saml
-  - area/token-exchange
-  - area/user-profile
-
-team/store:
-  - area/import-export
-  - area/infinispan
-  - area/ldap
-  - area/storage
-
-team/ui:
-  - area/account/ui
-  - area/adapter/javascript
-  - area/admin/client/node
-  - area/admin/ui
-
-team/other:
-  - area/account/api
+team/core-clients:
   - area/adapter/fuse
   - area/adapter/java-cli
   - area/adapter/jee
   - area/adapter/jee-saml
   - area/adapter/spring
-  - area/dist/wildfly
-  - area/docs
+  - area/authentication
+  - area/authentication/webauthn
+  - area/login/ui
+  - area/oidc
+  - area/oid4vc
+  - area/saml
+
+team/core-iam:
+  - area/admin/fine-grained-permissions
+  - area/authorization-services
+  - area/identity-brokering
+  - area/user-profile
+
+team/core-shared:
+  - area/account/api
+  - area/admin/api
+  - area/admin/client-java
+  - area/core
+  - area/import-export
+  - area/infinispan
+  - area/ldap
+  - area/storage
+  - area/token-exchange
+
+team/ui:
+  - area/account/ui
+  - area/adapter/javascript
+  - area/admin/client-js
+  - area/admin/ui
+  - area/welcome/ui
 
 team/community:
   - area/translations
+
+team/core:
+team/store:
+
+no-team:
+  - area/docs
+  - area/dependencies


### PR DESCRIPTION
This is just the first step for re-organising teams and associated areas. 

Quite a few things end up in `core-shared`, and we will need to manually review/move those to either `core-clients` or `core-iam`.

To further improve on this we should:

1. Review areas, and introduce some more, especially for `core-iam` stuff
2. Figure out a plan on how to handle the shared stuff

For 2. I have two ideas:

a. Round-robin - basically have the bot add `core-shared` as well as round robin add `core-clients` or `core-iam`
b. Add all, and manually remove - bot adds both `core-clients` and `core-iam` and a team can manually remove themselves if it shouldn't be handled by that team

I'm thinking a could be a way to go at least initially.