### PR TITLE
Supported option to specify maximum threads used to handle HTTP requests

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -124,4 +124,12 @@ public class HttpOptions {
                          "Use this to shed load in an overload situation. Excess requests will return a \"503 Server not Available\" response.")
             .build();
 
+    public static final Option<Integer> HTTP_POOL_MAX_THREADS = new OptionBuilder<>("http-pool-max-threads", Integer.class)
+            .category(OptionCategory.HTTP)
+            .description("The maximum number of threads. If this is not specified then it will be automatically sized " +
+                         "to the greatest of 8 * the number of available processors and 200. " +
+                         "For example if there are 4 processors the max threads will be 200. " +
+                         "If there are 48 processors it will be 384.")
+            .build();
+
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -110,6 +110,10 @@ final class HttpPropertyMappers {
                 fromOption(HttpOptions.HTTP_MAX_QUEUED_REQUESTS)
                         .to("quarkus.thread-pool.queue-size")
                         .paramLabel("requests")
+                        .build(),
+                fromOption(HttpOptions.HTTP_POOL_MAX_THREADS)
+                        .to("quarkus.thread-pool.max-threads")
+                        .paramLabel("threads")
                         .build()
         };
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -42,8 +42,7 @@ public class HttpDistTest {
     @Test
     @TestProvider(TestRealmResourceTestProvider.class)
     public void maxQueuedRequestsTest(KeycloakDistribution dist) {
-        dist.setQuarkusProperty("quarkus.thread-pool.max-threads", "1");
-        dist.run("start-dev", "--http-max-queued-requests=1");
+        dist.run("start-dev", "--http-max-queued-requests=1", "--http-pool-max-threads=1");
 
         // run requests async
         List<CompletableFuture<Integer>> statusCodesFuture = new ArrayList<>();

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
@@ -143,6 +143,11 @@ HTTP(S):
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.
+--http-pool-max-threads <threads>
+                     The maximum number of threads. If this is not specified then it will be
+                       automatically sized to the greatest of 8 * the number of available
+                       processors and 200. For example if there are 4 processors the max threads
+                       will be 200. If there are 48 processors it will be 384.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
@@ -143,6 +143,11 @@ HTTP(S):
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.
+--http-pool-max-threads <threads>
+                     The maximum number of threads. If this is not specified then it will be
+                       automatically sized to the greatest of 8 * the number of available
+                       processors and 200. For example if there are 4 processors the max threads
+                       will be 200. If there are 48 processors it will be 384.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
@@ -144,6 +144,11 @@ HTTP(S):
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.
+--http-pool-max-threads <threads>
+                     The maximum number of threads. If this is not specified then it will be
+                       automatically sized to the greatest of 8 * the number of available
+                       processors and 200. For example if there are 4 processors the max threads
+                       will be 200. If there are 48 processors it will be 384.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
@@ -144,6 +144,11 @@ HTTP(S):
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.
+--http-pool-max-threads <threads>
+                     The maximum number of threads. If this is not specified then it will be
+                       automatically sized to the greatest of 8 * the number of available
+                       processors and 200. For example if there are 4 processors the max threads
+                       will be 200. If there are 48 processors it will be 384.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
                      Set the path relative to '/' for serving resources. The path must start with a

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.unix.approved.txt
@@ -83,6 +83,11 @@ HTTP(S):
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.
+--http-pool-max-threads <threads>
+                     The maximum number of threads. If this is not specified then it will be
+                       automatically sized to the greatest of 8 * the number of available
+                       processors and 200. For example if there are 4 processors the max threads
+                       will be 200. If there are 48 processors it will be 384.
 --http-port <port>   The used HTTP port. Default: 8080.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.unix.approved.txt
@@ -83,6 +83,11 @@ HTTP(S):
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.
+--http-pool-max-threads <threads>
+                     The maximum number of threads. If this is not specified then it will be
+                       automatically sized to the greatest of 8 * the number of available
+                       processors and 200. For example if there are 4 processors the max threads
+                       will be 200. If there are 48 processors it will be 384.
 --http-port <port>   The used HTTP port. Default: 8080.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.


### PR DESCRIPTION
Closes #26455

* added a mapper for the thread-pool.max-threads raw quarkus option

Signed-off-by: Peter Zaoral <pzaoral@redhat.com>
