### PR TITLE
Force anonymous binding if testing ldap authentication with none bind type

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
@@ -71,9 +71,9 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
         response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhost:10389", "uid=admin,ou=system", "${vault.ldap_bindCredential}", "false", null));
         assertStatus(response, 204);
 
-        // Authentication success anonymous bind
+        // Authentication error for anonymous bind (default ldap rule does not allow anonymous binings)
         response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhost:10389", null, null, "false", null, "false", LDAPConstants.AUTH_TYPE_NONE));
-        assertStatus(response, 204);
+        assertStatus(response, 400);
 
         response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhost:10389", "uid=admin,ou=system", "${vault.ldap_bindCredential}", "false", null));
         assertStatus(response, 204);
@@ -103,7 +103,7 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
         assertStatus(response, 204);
 
         response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldaps://localhost:10636", null, null, "false", null, "false", LDAPConstants.AUTH_TYPE_NONE));
-        assertStatus(response, 204);
+        assertStatus(response, 400);
 
         // Authentication success with bindCredential from Vault
         response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldaps://localhost:10636", "uid=admin,ou=system", "${vault.ldap_bindCredential}", "true", null));


### PR DESCRIPTION
Closes #26464

The ldap test authentication performs no ldap bind when configured to none (anonymous binding). Java performs it like this, because if there is no bind, it's an anonymous connection by LDAPv3 spec. The problem is that, if no bind is done, the `test authentication` is exactly the same as the `test connection` and it can return a success when it should return an error (port open but no ldap server, server configured to not allow anonymous binding,...). The PR performs a reconnect to force the bind when none.

The tests were also testing this but incorrectly. Because the default ldap rule does not allow [anonymous connections](https://github.com/keycloak/keycloak/blob/23.0.5/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java#L99). As we were not really doing a bind before, the test authentication was OK although it should be KO. I didn't add a correct anonymous test because it needs a restart of the ldap and I didn't want to do that.

@keycloak/store No hurries for this, I added the issue to 25 but if it's merged before please move it to 24.