### PR TITLE
Fix Operator tests on ARM-based machines

### DIFF
--- a/operator/src/test/resources/example-postgres.yaml
+++ b/operator/src/test/resources/example-postgres.yaml
@@ -16,10 +16,7 @@ spec:
     spec:
       containers:
         - name: postgresql-db
-          # WARN: this image is not ARM64 native, consider using "postgres:latest" or "registry.redhat.io/rhel9/postgresql-15:latest" if you need that
-          # See also https://github.com/sclorg/postgresql-container/pull/527
-          # Using c8s instead of c9s as c9s requires additional arguments for emulation on ARM machines, while c8s works OOTB
-          image: quay.io/sclorg/postgresql-15-c8s:latest
+          image: quay.io/sclorg/postgresql-15-c9s:latest
           volumeMounts:
             - mountPath: /var/lib/pgsql/data
               name: cache-volume


### PR DESCRIPTION
postgres-15-c9s image now supports arm64

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
