### PR TITLE
Update Keycloak operator example with correct hostname syntax

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
@@ -77,6 +77,7 @@ import io.quarkiverse.operatorsdk.annotations.SharedCSVMetadata;
         capabilities = "Deep Insights",
         categories = "Security",
         certified = false,
+        // language=JSON
         almExamples =
             "[\n" +
             "  {\n" +
@@ -90,10 +91,12 @@ import io.quarkiverse.operatorsdk.annotations.SharedCSVMetadata;
             "    },\n" +
             "    \"spec\": {\n" +
             "      \"instances\": 1,\n" +
-            "      \"hostname\": \n {" +
-            "        \"hostname\": \"example.org\" } \n" +
-            "      \"http\":\n {" +
-            "        \"tlsSecret\": \"my-tls-secret\" } \n" +
+            "      \"hostname\": {\n" +
+            "        \"hostname\": \"example.org\"\n" +
+            "      },\n" +
+            "      \"http\": {\n" +
+            "        \"tlsSecret\": \"my-tls-secret\"\n" +
+            "      }\n" +
             "    }\n" +
             "  },\n" +
             "  {\n" +

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
@@ -90,7 +90,8 @@ import io.quarkiverse.operatorsdk.annotations.SharedCSVMetadata;
             "    },\n" +
             "    \"spec\": {\n" +
             "      \"instances\": 1,\n" +
-            "      \"hostname\": \"example.org\",\n" +
+            "      \"hostname\": \n {" +
+            "        \"hostname\": \"example.org\" } \n" +
             "      \"http\":\n {" +
             "        \"tlsSecret\": \"my-tls-secret\" } \n" +
             "    }\n" +


### PR DESCRIPTION
Closes #26818

What: _Another_ Update for the Keycloak Operator documentation as per issue https://github.com/keycloak/keycloak/issues/26281

Why: To ensure new users to the Keycloak Operator have a good example to follow!

I just realized that the hostname stanza was also incorrect, so submitting a new PR (correctly DCO'd!) to fix that too. Let me know if you'd rather me create a new issue for this.

This is a pretty simple change, just ensuring the example [here](https://operatorhub.io/operator/keycloak-operator) is correct.