### PR TITLE
Upgrade arquilliam bom to match org.apache.maven dependency versions from Quarkus

### DIFF
--- a/quarkus/CONTRIBUTING.md
+++ b/quarkus/CONTRIBUTING.md
@@ -237,6 +237,10 @@ It is also possible to change to a snapshot version by running:
 ./set-quarkus-version.sh
 ```
 
+After setting the version, please verify that:
+
+* `org.apache.maven` dependencies used by the test suite (and arquillian) are the same from the new Quarkus version 
+
 ### Run a local build
 
 After changing the dependency versions, you can run a local build to make sure the server extension is not broken by API changes and if

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -41,9 +41,9 @@
         <cache.server.java.home>${java.home}</cache.server.java.home>
 
         <!--component versions-->
-        <arquillian-core.version>1.7.1.Final</arquillian-core.version>
+        <arquillian-core.version>1.8.0.Final</arquillian-core.version>
         <!--the version of shrinkwrap_resolver should align with the version in arquillian-bom-->
-        <shrinkwrap-resolver.version>3.1.4</shrinkwrap-resolver.version>
+        <shrinkwrap-resolver.version>3.2.1</shrinkwrap-resolver.version>
         <selenium.version>3.14.0</selenium.version>
         <arquillian-drone.version>2.5.5</arquillian-drone.version>
         <arquillian-graphene.version>3.0.0-alpha.3</arquillian-graphene.version>


### PR DESCRIPTION
* After the latest Quarkus upgrade the `auth-server-quarkus-embedded` is not working because there is a mismatch between the `org.apache.maven` (groupId) dependencies from Quarkus and Arquillian in our test suite.
* This PR makes sure our test suite is using the same Maven version by bumping the Arquillian BOM to `1.8.0`.
* Run a few tests and upgrading Arquillian seems to not break compilation and runtime of the testsuite