### PR TITLE
PKCE should return error if code_verifier sent but no code_challenge in the authorization request

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/PkceUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/PkceUtils.java
@@ -84,6 +84,12 @@ public class PkceUtils {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verifier not specified", Response.Status.BAD_REQUEST);
         }
 
+        if (codeChallenge == null && codeVerifier != null) {
+            logger.warnf("PKCE code verifier specified but challenge not present in authorization, authUserId = %s, authUsername = %s", authUserId, authUsername);
+            event.error(Errors.INVALID_CODE_VERIFIER);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verifier specified but challenge not present in authorization", Response.Status.BAD_REQUEST);
+        }
+
         if (codeChallenge != null) {
             verifyCodeVerifier(codeVerifier, codeChallenge, codeChallengeMethod, authUserId, authUsername, event, cors);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractFAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractFAPITest.java
@@ -194,7 +194,9 @@ public abstract class AbstractFAPITest extends AbstractClientPoliciesTest {
             List<NameValuePair> parameters = new LinkedList<>();
             parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.AUTHORIZATION_CODE));
             parameters.add(new BasicNameValuePair(OAuth2Constants.CODE, code));
-            parameters.add(new BasicNameValuePair(OAuth2Constants.CODE_VERIFIER, codeVerifier));
+            if (codeVerifier != null) {
+                parameters.add(new BasicNameValuePair(OAuth2Constants.CODE_VERIFIER, codeVerifier));
+            }
             parameters.add(new BasicNameValuePair(OAuth2Constants.REDIRECT_URI, oauth.getRedirectUri()));
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ASSERTION_TYPE, OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT));
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ASSERTION, signedJwt));


### PR DESCRIPTION
Closes #26430

Implementing [the recommendations for the PKCE downgrade attack](https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-16.html#name-pkce-downgrade-attack). It says that:

> Beyond this, to prevent PKCE downgrade attacks, the AS MUST ensure that if there was no code_challenge in the authorization request, a request to the token endpoint containing a code_verifier is rejected.

Recommendation implemented when PKCE is not enforced in the client and test simulating the downgrade attack.
