### PR TITLE
#26826 fix for Freemarker erroneously escapes/sanitizes URL in template.ftl (&amp;)

### DIFF
--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -41,7 +41,7 @@
             checkCookiesAndSetTimer(
               "${authenticationSession.authSessionId}",
               "${authenticationSession.tabId}",
-              "${url.ssoLoginInOtherTabsUrl}"
+              "${url.ssoLoginInOtherTabsUrl?no_esc}"
             );
         </script>
     </#if>


### PR DESCRIPTION
closes #26826 

Fix for https://github.com/keycloak/keycloak/issues/26826 as suggested in https://github.com/keycloak/keycloak/issues/26826#issuecomment-1930229774