### PR TITLE
fix documentation for resetting OTP in "reset credentials" flow (#26834)

### DIFF
--- a/docs/documentation/server_admin/topics/login-settings/forgot-password.adoc
+++ b/docs/documentation/server_admin/topics/login-settings/forgot-password.adoc
@@ -38,7 +38,7 @@ To change this behavior, perform these steps:
 .Reset credentials flow
 image:images/reset-credentials-flow.png[Reset Credentials Flow]
 +
-If you do not want to reset the OTP, set the `Reset OTP` requirement to *Disabled*.
+If you do not want to reset the OTP, set the `Reset - Conditional OTP` sub-flow requirement to *Disabled*.
 . Click *Authentication* in the menu.
 . Click the *Required actions* tab.
 . Ensure *Update Password* is enabled.


### PR DESCRIPTION
The former version stated that the "Reset OTP" step had to be disabled in the "reset credentials" authentication flow in order to keep the OTP unchanged. This leads to an error. More precisely, the "Reset - Conditional OTP" sub-flow has to be disabled.

Fixes #26834
