### PR TITLE
Fix authz/resource-server/policy/... endpoints

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/admin/BasePolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/BasePolicyService.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.admin;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.jboss.resteasy.reactive.NoCache;
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
+import org.keycloak.authorization.policy.provider.PolicyProviderAdminService;
+import org.keycloak.authorization.policy.provider.PolicyProviderFactory;
+import org.keycloak.authorization.store.PolicyStore;
+import org.keycloak.authorization.store.ResourceStore;
+import org.keycloak.authorization.store.ScopeStore;
+import org.keycloak.authorization.store.StoreFactory;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyProviderRepresentation;
+import org.keycloak.services.ErrorResponseException;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+public abstract class BasePolicyService {
+
+    protected final ResourceServer resourceServer;
+    protected final AuthorizationProvider authorization;
+    protected final AdminPermissionEvaluator auth;
+    protected final AdminEventBuilder adminEvent;
+
+    public BasePolicyService(ResourceServer resourceServer, AuthorizationProvider authorization, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.resourceServer = resourceServer;
+        this.authorization = authorization;
+        this.auth = auth;
+        this.adminEvent = adminEvent.resource(ResourceType.AUTHORIZATION_POLICY);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @APIResponse(responseCode = "201", description = "Created")
+    public Response create(String payload) {
+        if (auth != null) {
+            this.auth.realm().requireManageAuthorization();
+        }
+
+        AbstractPolicyRepresentation representation = doCreateRepresentation(payload);
+        Policy policy = create(representation);
+
+        representation.setId(policy.getId());
+
+        audit(representation, representation.getId(), OperationType.CREATE, authorization.getKeycloakSession());
+
+        return Response.status(Status.CREATED).entity(representation).build();
+    }
+
+    protected abstract AbstractPolicyRepresentation doCreateRepresentation(String payload);
+
+    public Policy create(AbstractPolicyRepresentation representation) {
+        PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
+        Policy existing = policyStore.findByName(resourceServer, representation.getName());
+
+        if (existing != null) {
+            throw new ErrorResponseException("Policy with name [" + representation.getName() + "] already exists", "Conflicting policy", Status.CONFLICT);
+        }
+
+        return policyStore.create(resourceServer, representation);
+    }
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @APIResponses(value = {
+        @APIResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = AbstractPolicyRepresentation.class))
+        ),
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request")
+    })
+    public Response findByName(@QueryParam("name") String name, @QueryParam("fields") String fields) {
+        if (auth != null) {
+            this.auth.realm().requireViewAuthorization();
+        }
+
+        StoreFactory storeFactory = authorization.getStoreFactory();
+
+        if (name == null) {
+            return Response.status(Status.BAD_REQUEST).build();
+        }
+
+        Policy model = storeFactory.getPolicyStore().findByName(this.resourceServer, name);
+
+        if (model == null) {
+            return Response.noContent().build();
+        }
+
+        return Response.ok(toRepresentation(model, fields, authorization)).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @APIResponses(value = {
+        @APIResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = AbstractPolicyRepresentation.class, type = SchemaType.ARRAY))
+        ),
+        @APIResponse(responseCode = "204", description = "No Content")
+    })
+    public Response findAll(@QueryParam("policyId") String id,
+                            @QueryParam("name") String name,
+                            @QueryParam("type") String type,
+                            @QueryParam("resource") String resource,
+                            @QueryParam("scope") String scope,
+                            @QueryParam("permission") Boolean permission,
+                            @QueryParam("owner") String owner,
+                            @QueryParam("fields") String fields,
+                            @QueryParam("first") Integer firstResult,
+                            @QueryParam("max") Integer maxResult) {
+        if (auth != null) {
+            this.auth.realm().requireViewAuthorization();
+        }
+
+        Map<Policy.FilterOption, String[]> search = new EnumMap<>(Policy.FilterOption.class);
+
+        if (id != null && !"".equals(id.trim())) {
+            search.put(Policy.FilterOption.ID, new String[] {id});
+        }
+
+        if (name != null && !"".equals(name.trim())) {
+            search.put(Policy.FilterOption.NAME, new String[] {name});
+        }
+
+        if (type != null && !"".equals(type.trim())) {
+            search.put(Policy.FilterOption.TYPE, new String[] {type});
+        }
+
+        if (owner != null && !"".equals(owner.trim())) {
+            search.put(Policy.FilterOption.OWNER, new String[] {owner});
+        }
+
+        StoreFactory storeFactory = authorization.getStoreFactory();
+
+        if (resource != null && !"".equals(resource.trim())) {
+            ResourceStore resourceStore = storeFactory.getResourceStore();
+            Resource resourceModel = resourceStore.findById(resourceServer, resource);
+
+            if (resourceModel == null) {
+                Map<Resource.FilterOption, String[]> resourceFilters = new EnumMap<>(Resource.FilterOption.class);
+
+                resourceFilters.put(Resource.FilterOption.NAME, new String[]{resource});
+
+                if (owner != null) {
+                    resourceFilters.put(Resource.FilterOption.OWNER, new String[]{owner});
+                }
+
+                Set<String> resources = resourceStore.find(resourceServer, resourceFilters, -1, 1).stream().map(Resource::getId).collect(Collectors.toSet());
+
+                if (resources.isEmpty()) {
+                    return Response.noContent().build();
+                }
+
+                search.put(Policy.FilterOption.RESOURCE_ID, resources.toArray(new String[resources.size()]));
+            } else {
+                search.put(Policy.FilterOption.RESOURCE_ID, new String[] {resourceModel.getId()});
+            }
+        }
+
+        if (scope != null && !"".equals(scope.trim())) {
+            ScopeStore scopeStore = storeFactory.getScopeStore();
+            Scope scopeModel = scopeStore.findById(resourceServer, scope);
+
+            if (scopeModel == null) {
+                Map<Scope.FilterOption, String[]> scopeFilters = new EnumMap<>(Scope.FilterOption.class);
+
+                scopeFilters.put(Scope.FilterOption.NAME, new String[]{scope});
+
+                Set<String> scopes = scopeStore.findByResourceServer(resourceServer, scopeFilters, -1, 1).stream().map(Scope::getId).collect(Collectors.toSet());
+
+                if (scopes.isEmpty()) {
+                    return Response.noContent().build();
+                }
+
+                search.put(Policy.FilterOption.SCOPE_ID, scopes.toArray(new String[scopes.size()]));
+            } else {
+                search.put(Policy.FilterOption.SCOPE_ID, new String[] {scopeModel.getId()});
+            }
+        }
+
+        if (permission != null) {
+            search.put(Policy.FilterOption.PERMISSION, new String[] {permission.toString()});
+        }
+
+        return Response.ok(
+                doSearch(firstResult, maxResult, fields, search))
+                .build();
+    }
+
+    protected AbstractPolicyRepresentation toRepresentation(Policy model, String fields, AuthorizationProvider authorization) {
+        return ModelToRepresentation.toRepresentation(model, authorization, true, false, fields != null && fields.equals("*"));
+    }
+
+    protected List<Object> doSearch(Integer firstResult, Integer maxResult, String fields, Map<Policy.FilterOption, String[]> filters) {
+        PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
+        return policyStore.find(resourceServer, filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
+                .map(policy -> toRepresentation(policy, fields, authorization))
+                .collect(Collectors.toList());
+    }
+
+    @Path("providers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @APIResponse(
+        responseCode = "200",
+        content = @Content(schema = @Schema(implementation = PolicyProviderRepresentation.class, type = SchemaType.ARRAY))
+    )
+    public Response findPolicyProviders() {
+        if (auth != null) {
+            this.auth.realm().requireViewAuthorization();
+        }
+
+        return Response.ok(
+                authorization.getProviderFactoriesStream()
+                        .filter(((Predicate<PolicyProviderFactory>) PolicyProviderFactory::isInternal).negate())
+                        .map(factory -> {
+                            PolicyProviderRepresentation representation = new PolicyProviderRepresentation();
+
+                            representation.setName(factory.getName());
+                            representation.setGroup(factory.getGroup());
+                            representation.setType(factory.getId());
+
+                            return representation;
+                        })
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    @Path("evaluate")
+    public PolicyEvaluationService getPolicyEvaluateResource() {
+        if (auth != null) {
+            this.auth.realm().requireViewAuthorization();
+        }
+
+        return new PolicyEvaluationService(this.resourceServer, this.authorization, this.auth);
+    }
+
+    protected PolicyProviderAdminService getPolicyProviderAdminResource(String policyType) {
+        return getPolicyProviderFactory(policyType).getAdminResource(resourceServer, authorization);
+    }
+
+    protected PolicyProviderFactory getPolicyProviderFactory(String policyType) {
+        return authorization.getProviderFactory(policyType);
+    }
+
+    private void audit(AbstractPolicyRepresentation resource, String id, OperationType operation, KeycloakSession session) {
+        if (id != null) {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
+        } else {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
@@ -27,9 +27,16 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.Policy;
@@ -45,13 +52,15 @@ import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentati
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
-import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.util.JsonSerialization;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
 public class PolicyResourceService {
 
     private final Policy policy;
@@ -69,9 +78,10 @@ public class PolicyResourceService {
     }
 
     @PUT
-    @Consumes("application/json")
-    @Produces("application/json")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
+    @APIResponse(responseCode = "201", description = "Created")
     public Response update(String payload) {
         if (auth != null) {
             this.auth.realm().requireManageAuthorization();
@@ -94,6 +104,7 @@ public class PolicyResourceService {
     }
 
     @DELETE
+    @APIResponse(responseCode = "204", description = "No Content")
     public Response delete() {
         if (auth != null) {
             this.auth.realm().requireManageAuthorization();
@@ -122,8 +133,12 @@ public class PolicyResourceService {
     }
 
     @GET
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PolicyRepresentation.class))),
+        @APIResponse(responseCode = "404", description = "Not Found")
+    })
     public Response findById(@QueryParam("fields") String fields) {
         if (auth != null) {
             this.auth.realm().requireViewAuthorization();
@@ -146,8 +161,9 @@ public class PolicyResourceService {
 
     @Path("/dependentPolicies")
     @GET
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PolicyRepresentation.class, type = SchemaType.ARRAY)))
     public Response getDependentPolicies() {
         if (auth != null) {
             this.auth.realm().requireViewAuthorization();
@@ -172,8 +188,9 @@ public class PolicyResourceService {
 
     @Path("/scopes")
     @GET
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ScopeRepresentation.class, type = SchemaType.ARRAY)))
     public Response getScopes() {
         if (auth != null) {
             this.auth.realm().requireViewAuthorization();
@@ -195,8 +212,9 @@ public class PolicyResourceService {
 
     @Path("/resources")
     @GET
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ResourceRepresentation.class, type = SchemaType.ARRAY)))
     public Response getResources() {
         if (auth != null) {
             this.auth.realm().requireViewAuthorization();
@@ -218,8 +236,9 @@ public class PolicyResourceService {
 
     @Path("/associatedPolicies")
     @GET
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     @NoCache
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PolicyRepresentation.class, type = SchemaType.ARRAY)))
     public Response getAssociatedPolicies() {
         if (auth != null) {
             this.auth.realm().requireViewAuthorization();

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -17,52 +17,18 @@
 package org.keycloak.authorization.admin;
 
 import java.io.IOException;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
-import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.Policy;
-import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
-import org.keycloak.authorization.model.Scope;
-import org.keycloak.authorization.policy.provider.PolicyProviderAdminService;
 import org.keycloak.authorization.policy.provider.PolicyProviderFactory;
-import org.keycloak.authorization.store.PolicyStore;
-import org.keycloak.authorization.store.ResourceStore;
-import org.keycloak.authorization.store.ScopeStore;
-import org.keycloak.authorization.store.StoreFactory;
-import org.keycloak.events.admin.OperationType;
-import org.keycloak.events.admin.ResourceType;
-import org.keycloak.models.Constants;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentation;
-import org.keycloak.representations.idm.authorization.PolicyProviderRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.services.ErrorResponseException;
-import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.util.JsonSerialization;
@@ -70,60 +36,35 @@ import org.keycloak.util.JsonSerialization;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
-public class PolicyService {
-
-    protected final ResourceServer resourceServer;
-    protected final AuthorizationProvider authorization;
-    protected final AdminPermissionEvaluator auth;
-    protected final AdminEventBuilder adminEvent;
-
+public class PolicyService extends BasePolicyService {
     public PolicyService(ResourceServer resourceServer, AuthorizationProvider authorization, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
-        this.resourceServer = resourceServer;
-        this.authorization = authorization;
-        this.auth = auth;
-        this.adminEvent = adminEvent.resource(ResourceType.AUTHORIZATION_POLICY);
+        super(resourceServer, authorization, auth, adminEvent);
     }
 
     @Path("{type}")
-    public Object getResource(@PathParam("type") String type) {
+    public Object getResourceServiceOrTypeService(@PathParam("type") String type) {
+        try {
+            return getTypeService(type);
+        } catch (ErrorResponseException ex) {
+            return getResourceService(type);
+        }
+    }
+
+    @Path("/by-type/{policy-type}")
+    public PolicyTypeService getTypeService(@PathParam("policy-type") String type) {
         PolicyProviderFactory providerFactory = getPolicyProviderFactory(type);
 
         if (providerFactory != null) {
-            return doCreatePolicyTypeResource(type);
+            return new PolicyTypeService(type, resourceServer, authorization, auth, adminEvent);
         }
-
-        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(resourceServer, type);
-
-        return doCreatePolicyResource(policy);
+        throw new ErrorResponseException("No policy provider found for this type.", "Invalid type", Status.NOT_FOUND);
     }
 
-    protected PolicyTypeService doCreatePolicyTypeResource(String type) {
-        return new PolicyTypeService(type, resourceServer, authorization, auth, adminEvent);
-    }
+    @Path("/by-id/{policy-id}")
+    public PolicyResourceService getResourceService(@PathParam("policy-id") String policyId) {
+        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(resourceServer, policyId);
 
-    protected Object doCreatePolicyResource(Policy policy) {
         return new PolicyResourceService(policy, resourceServer, authorization, auth, adminEvent);
-    }
-
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    @APIResponse(responseCode = "201", description = "Created")
-    public Response create(String payload) {
-        if (auth != null) {
-            this.auth.realm().requireManageAuthorization();
-        }
-
-        AbstractPolicyRepresentation representation = doCreateRepresentation(payload);
-        Policy policy = create(representation);
-
-        representation.setId(policy.getId());
-
-        audit(representation, representation.getId(), OperationType.CREATE, authorization.getKeycloakSession());
-
-        return Response.status(Status.CREATED).entity(representation).build();
     }
 
     protected AbstractPolicyRepresentation doCreateRepresentation(String payload) {
@@ -136,212 +77,5 @@ public class PolicyService {
         }
 
         return representation;
-    }
-
-    public Policy create(AbstractPolicyRepresentation representation) {
-        PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
-        Policy existing = policyStore.findByName(resourceServer, representation.getName());
-
-        if (existing != null) {
-            throw new ErrorResponseException("Policy with name [" + representation.getName() + "] already exists", "Conflicting policy", Status.CONFLICT);
-        }
-
-        return policyStore.create(resourceServer, representation);
-    }
-
-    @Path("/search")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    @APIResponses(value = {
-        @APIResponse(
-            responseCode = "200",
-            content = @Content(schema = @Schema(implementation = AbstractPolicyRepresentation.class))
-        ),
-        @APIResponse(responseCode = "204", description = "No Content"),
-        @APIResponse(responseCode = "400", description = "Bad Request")
-    })
-    public Response findByName(@QueryParam("name") String name, @QueryParam("fields") String fields) {
-        if (auth != null) {
-            this.auth.realm().requireViewAuthorization();
-        }
-
-        StoreFactory storeFactory = authorization.getStoreFactory();
-
-        if (name == null) {
-            return Response.status(Status.BAD_REQUEST).build();
-        }
-
-        Policy model = storeFactory.getPolicyStore().findByName(this.resourceServer, name);
-
-        if (model == null) {
-            return Response.noContent().build();
-        }
-
-        return Response.ok(toRepresentation(model, fields, authorization)).build();
-    }
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    @APIResponses(value = {
-        @APIResponse(
-            responseCode = "200",
-            content = @Content(schema = @Schema(implementation = AbstractPolicyRepresentation.class, type = SchemaType.ARRAY))
-        ),
-        @APIResponse(responseCode = "204", description = "No Content")
-    })
-    public Response findAll(@QueryParam("policyId") String id,
-                            @QueryParam("name") String name,
-                            @QueryParam("type") String type,
-                            @QueryParam("resource") String resource,
-                            @QueryParam("scope") String scope,
-                            @QueryParam("permission") Boolean permission,
-                            @QueryParam("owner") String owner,
-                            @QueryParam("fields") String fields,
-                            @QueryParam("first") Integer firstResult,
-                            @QueryParam("max") Integer maxResult) {
-        if (auth != null) {
-            this.auth.realm().requireViewAuthorization();
-        }
-
-        Map<Policy.FilterOption, String[]> search = new EnumMap<>(Policy.FilterOption.class);
-
-        if (id != null && !"".equals(id.trim())) {
-            search.put(Policy.FilterOption.ID, new String[] {id});
-        }
-
-        if (name != null && !"".equals(name.trim())) {
-            search.put(Policy.FilterOption.NAME, new String[] {name});
-        }
-
-        if (type != null && !"".equals(type.trim())) {
-            search.put(Policy.FilterOption.TYPE, new String[] {type});
-        }
-
-        if (owner != null && !"".equals(owner.trim())) {
-            search.put(Policy.FilterOption.OWNER, new String[] {owner});
-        }
-
-        StoreFactory storeFactory = authorization.getStoreFactory();
-
-        if (resource != null && !"".equals(resource.trim())) {
-            ResourceStore resourceStore = storeFactory.getResourceStore();
-            Resource resourceModel = resourceStore.findById(resourceServer, resource);
-
-            if (resourceModel == null) {
-                Map<Resource.FilterOption, String[]> resourceFilters = new EnumMap<>(Resource.FilterOption.class);
-
-                resourceFilters.put(Resource.FilterOption.NAME, new String[]{resource});
-
-                if (owner != null) {
-                    resourceFilters.put(Resource.FilterOption.OWNER, new String[]{owner});
-                }
-
-                Set<String> resources = resourceStore.find(resourceServer, resourceFilters, -1, 1).stream().map(Resource::getId).collect(Collectors.toSet());
-
-                if (resources.isEmpty()) {
-                    return Response.noContent().build();
-                }
-
-                search.put(Policy.FilterOption.RESOURCE_ID, resources.toArray(new String[resources.size()]));
-            } else {
-                search.put(Policy.FilterOption.RESOURCE_ID, new String[] {resourceModel.getId()});
-            }
-        }
-
-        if (scope != null && !"".equals(scope.trim())) {
-            ScopeStore scopeStore = storeFactory.getScopeStore();
-            Scope scopeModel = scopeStore.findById(resourceServer, scope);
-
-            if (scopeModel == null) {
-                Map<Scope.FilterOption, String[]> scopeFilters = new EnumMap<>(Scope.FilterOption.class);
-
-                scopeFilters.put(Scope.FilterOption.NAME, new String[]{scope});
-
-                Set<String> scopes = scopeStore.findByResourceServer(resourceServer, scopeFilters, -1, 1).stream().map(Scope::getId).collect(Collectors.toSet());
-
-                if (scopes.isEmpty()) {
-                    return Response.noContent().build();
-                }
-
-                search.put(Policy.FilterOption.SCOPE_ID, scopes.toArray(new String[scopes.size()]));
-            } else {
-                search.put(Policy.FilterOption.SCOPE_ID, new String[] {scopeModel.getId()});
-            }
-        }
-
-        if (permission != null) {
-            search.put(Policy.FilterOption.PERMISSION, new String[] {permission.toString()});
-        }
-
-        return Response.ok(
-                doSearch(firstResult, maxResult, fields, search))
-                .build();
-    }
-
-    protected AbstractPolicyRepresentation toRepresentation(Policy model, String fields, AuthorizationProvider authorization) {
-        return ModelToRepresentation.toRepresentation(model, authorization, true, false, fields != null && fields.equals("*"));
-    }
-
-    protected List<Object> doSearch(Integer firstResult, Integer maxResult, String fields, Map<Policy.FilterOption, String[]> filters) {
-        PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
-        return policyStore.find(resourceServer, filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
-                .map(policy -> toRepresentation(policy, fields, authorization))
-                .collect(Collectors.toList());
-    }
-
-    @Path("providers")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    @APIResponse(
-        responseCode = "200",
-        content = @Content(schema = @Schema(implementation = PolicyProviderRepresentation.class, type = SchemaType.ARRAY))
-    )
-    public Response findPolicyProviders() {
-        if (auth != null) {
-            this.auth.realm().requireViewAuthorization();
-        }
-
-        return Response.ok(
-                authorization.getProviderFactoriesStream()
-                        .filter(((Predicate<PolicyProviderFactory>) PolicyProviderFactory::isInternal).negate())
-                        .map(factory -> {
-                            PolicyProviderRepresentation representation = new PolicyProviderRepresentation();
-
-                            representation.setName(factory.getName());
-                            representation.setGroup(factory.getGroup());
-                            representation.setType(factory.getId());
-
-                            return representation;
-                        })
-                        .collect(Collectors.toList()))
-                .build();
-    }
-
-    @Path("evaluate")
-    public PolicyEvaluationService getPolicyEvaluateResource() {
-        if (auth != null) {
-            this.auth.realm().requireViewAuthorization();
-        }
-
-        return new PolicyEvaluationService(this.resourceServer, this.authorization, this.auth);
-    }
-
-    protected PolicyProviderAdminService getPolicyProviderAdminResource(String policyType) {
-        return getPolicyProviderFactory(policyType).getAdminResource(resourceServer, authorization);
-    }
-
-    protected PolicyProviderFactory getPolicyProviderFactory(String policyType) {
-        return authorization.getProviderFactory(policyType);
-    }
-
-    private void audit(AbstractPolicyRepresentation resource, String id, OperationType operation, KeycloakSession session) {
-        if (id != null) {
-            adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
-        } else {
-            adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
-        }
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyTypeService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyTypeService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.Policy;
@@ -36,7 +37,7 @@ import org.keycloak.util.JsonSerialization;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class PolicyTypeService extends PolicyService {
+public class PolicyTypeService extends BasePolicyService {
 
     private final String type;
 
@@ -45,8 +46,15 @@ public class PolicyTypeService extends PolicyService {
         this.type = type;
     }
 
+    @Path("{policy-id}")
+    public PolicyTypeResourceService getResourceService(@PathParam("policy-id") String policyId) {
+        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(resourceServer, policyId);
+
+        return new PolicyTypeResourceService(policy, resourceServer,authorization, auth, adminEvent);
+    }
+
     @Path("/provider")
-    public Object getPolicyAdminResourceProvider() {
+    public PolicyProviderAdminService getPolicyAdminResourceProvider() {
         PolicyProviderAdminService resource = getPolicyProviderAdminResource(type);
 
         if (resource == null) {
@@ -56,12 +64,6 @@ public class PolicyTypeService extends PolicyService {
         return resource;
     }
 
-    @Override
-    protected Object doCreatePolicyResource(Policy policy) {
-        return new PolicyTypeResourceService(policy, resourceServer,authorization, auth, adminEvent);
-    }
-
-    @Override
     protected AbstractPolicyRepresentation doCreateRepresentation(String payload) {
         PolicyProviderFactory provider = getPolicyProviderFactory(type);
         Class<? extends AbstractPolicyRepresentation> representationType = provider.getRepresentationType();

--- a/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
@@ -97,14 +97,14 @@ public class UserManagedPermissionService {
 
         checkRequest(getAssociatedResourceId(policyId), representation);
 
-        return PolicyTypeResourceService.class.cast(delegate.getResource(policyId)).update(payload);
+        return PolicyTypeResourceService.class.cast(delegate.getResourceService(policyId)).update(payload);
     }
 
     @Path("{policyId}")
     @DELETE
     public Response delete(@PathParam("policyId") String policyId) {
         checkRequest(getAssociatedResourceId(policyId), null);
-        PolicyTypeResourceService.class.cast(delegate.getResource(policyId)).delete();
+        PolicyTypeResourceService.class.cast(delegate.getResourceService(policyId)).delete();
         return Response.noContent().build();
     }
 
@@ -113,7 +113,7 @@ public class UserManagedPermissionService {
     @Produces("application/json")
     public Response findById(@PathParam("policyId") String policyId) {
         checkRequest(getAssociatedResourceId(policyId), null);
-        return PolicyTypeResourceService.class.cast(delegate.getResource(policyId)).findById(null);
+        return PolicyTypeResourceService.class.cast(delegate.getResourceService(policyId)).findById(null);
     }
 
     @GET


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Closes: #26851

This PR changes the `admin/realms/{realm}/clients/{client-uuid}/authz/resource-server/policy/` endpoints by splitting the `.../policy/{type}/` endpoint (which could return two different sub services depending on whether a policy type or policy uuid was given as `{type}`) into two separate endpoints `.../policy/by-type/{type}/` and `.../policy/by-id/{policy-id}/`. This allows us
1. to correctly document those endpoints in the OpenAPI spec as the generator previously couldn't descend into the sub services as the method just returned `Object` instead of concrete services and
2. to prevent the infinite recursion for the `PolicyTypeService` which inherited the old endpoint from the `PolicyService` thus allowing API calls like `.../policy/{type}/{type}/{type}/{type}/...` to actually work.

This is a backend-only change and keeps the current dual-use endpoint working to prevent introducing breaking API changes (except for disallowing the infinite recursion which hopefully no one is actually using). This endpoint is still undocumented in the OpenAPI spec though as different sub services and thus different endpoints can be returned depending on the `{type}`-argument.

For this change, I've extracted the common code of `PolicyService` and `PolicyTypeService` into a new abstract base class `BasePolicyService` and changed `PolicyTypeService` to extend that instead of the `PolicyService` to make sure the dual-use endpoint is only available for the `PolicyService` and not for the `PolicyTypeService`. An easier change would've been to override the method in `PolicyTypeService` to throw an exception or something but this sadly is impossible to communicate to the OpenAPI spec generator thus documenting the endpoint twice.
The new `.../policy/by-type/{type}/` and `.../policy/by-id/{policy-id}/` endpoints are added to the `PolicyService` only and also would've been documented for the `PolicyTypeService` if it still extended that instead of the common base class.