### PR TITLE
Do not print executed commands in loop when checking deployments

### DIFF
--- a/.github/actions/conditional/conditions
+++ b/.github/actions/conditional/conditions
@@ -22,6 +22,7 @@ pom.xml                                     ci ci-store operator
 federation/sssd/                            ci ci-sssd
 
 model/                                      ci-store
+operator/                                   operator
 
 docs/guides/                                guides
 docs/documentation/                         documentation

--- a/operator/scripts/check-crds-installed.sh
+++ b/operator/scripts/check-crds-installed.sh
@@ -1,11 +1,11 @@
 #! /bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 max_retries=240
 c=0
 while ! kubectl get keycloaks
 do
-  echo "waiting for Keycloak CRD"
+  echo "$(date +"%T") Waiting for Keycloak CRD"
   ((c++)) && ((c==max_retries)) && exit -1
   sleep 1
 done
@@ -13,7 +13,7 @@ done
 c=0
 while ! kubectl get keycloakrealmimports
 do
-  echo "waiting for Keycloak Realm Import CRD"
+  echo "$(date +"%T") Waiting for Keycloak Realm Import CRD"
   ((c++)) && ((c==max_retries)) && exit -1
   sleep 1
 done

--- a/operator/scripts/check-examples-installed.sh
+++ b/operator/scripts/check-examples-installed.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 NAMESPACE=${1:-default}
 
@@ -7,7 +7,7 @@ max_retries=500
 c=0
 while [[ $(kubectl -n $NAMESPACE get keycloaks/example-kc -o jsonpath="{.status.conditions[?(@.type == 'Ready')].status}") != "True" ]]
 do
-  echo "waiting for Keycloak example-kc status"
+  echo "$(date +"%T") Waiting for Keycloak example-kc status"
   ((c++)) && ((c==max_retries)) && exit -1
   sleep 1
 done
@@ -15,7 +15,7 @@ done
 c=0
 while [[ $(kubectl -n $NAMESPACE get keycloakrealmimports/example-count0-kc -o jsonpath="{.status.conditions[?(@.type == 'Done')].status}") != "True" ]]
 do
-  echo "waiting for Keycloak Realm Import example-count0-kc status"
+  echo "$(date +"%T") Waiting for Keycloak Realm Import example-count0-kc status"
   ((c++)) && ((c==max_retries)) &&  exit -1
   sleep 1
 done

--- a/operator/scripts/install-keycloak-operator.sh
+++ b/operator/scripts/install-keycloak-operator.sh
@@ -1,11 +1,11 @@
 #! /bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 INSTALL_NAMESPACE=${1:-default}
 
-# Delete the default catalog if it exists
+echo "$(date +"%T") Delete the default catalog if it exists"
 sh -c "kubectl delete catalogsources operatorhubio-catalog -n olm | true"
 
 kubectl apply -f $SCRIPT_DIR/../olm/testing-resources/catalog.yaml
@@ -15,10 +15,11 @@ max_retries=200
 c=0
 while [[ $(kubectl get catalogsources test-catalog -o jsonpath="{.status.connectionState.lastObservedState}") != "READY" ]]
 do
-  echo "waiting for the test-catalog to be ready"
+  echo "$(date +"%T") Waiting for the test-catalog to be ready"
   ((c++)) && ((c==max_retries)) && exit -1
   sleep 1
 done
 
+echo "$(date +"%T") The test-catalog is ready"
 kubectl apply -f $SCRIPT_DIR/../olm/testing-resources/operatorgroup.yaml -n $INSTALL_NAMESPACE
 kubectl apply -f $SCRIPT_DIR/../olm/testing-resources/subscription.yaml -n $INSTALL_NAMESPACE


### PR DESCRIPTION
We will prevent comprehensive logs when checking the Operator and related deployments. Sometimes, the important logs are hidden somewhere in the polluted logs :) 

@shawkins WDYT?

New logging would look like this:

```
error: the server doesn't have a resource type "keycloaks"
16:55:42 Waiting for Keycloak CRD
error: the server doesn't have a resource type "keycloaks"
16:55:43 Waiting for Keycloak CRD
error: the server doesn't have a resource type "keycloaks"
16:55:44 Waiting for Keycloak CRD
error: the server doesn't have a resource type "keycloaks"
16:55:45 Waiting for Keycloak CRD
error: the server doesn't have a resource type "keycloaks"
16:55:46 Waiting for Keycloak CRD
error: the server doesn't have a resource type "keycloaks"
16:55:47 Waiting for Keycloak CRD
error: the server doesn't have a resource type "keycloaks"
16:55:48 Waiting for Keycloak CRD
```

Instead of this:

```
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
waiting for Keycloak CRD
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
waiting for Keycloak CRD
+ echo 'waiting for Keycloak CRD'
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
waiting for Keycloak CRD
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
+ (( c++ ))
+ (( c==max_retries ))
waiting for Keycloak CRD
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
+ (( c++ ))
+ (( c==max_retries ))
waiting for Keycloak CRD
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
+ kubectl get keycloaks
error: the server doesn't have a resource type "keycloaks"
+ echo 'waiting for Keycloak CRD'
waiting for Keycloak CRD
+ (( c++ ))
+ (( c==max_retries ))
+ sleep 1
```