### PR TITLE
fix: adds service-ca.crt to the trust stores

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -444,4 +444,22 @@ public class PodTemplateTest {
         assertThat(volume.getConfigMap().getName()).isEqualTo("cm");
     }
 
+    @Test
+    public void testServiceCaCrt() {
+        this.deployment.setUseServiceCaCrt(true);
+        try {
+            // Arrange
+            PodTemplateSpec additionalPodTemplate = null;
+
+            // Act
+            var podTemplate = getDeployment(additionalPodTemplate, null, null).getSpec().getTemplate();
+
+            // Assert
+            var paths = podTemplate.getSpec().getContainers().get(0).getEnv().stream().filter(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRUSTSTORE_PATHS)).findFirst().orElseThrow();
+            assertThat(paths.getValue()).isEqualTo("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt");
+        } finally {
+            this.deployment.setUseServiceCaCrt(false);
+        }
+    }
+
 }


### PR DESCRIPTION
This was supported by the old operator, but wasn't initially identified as a requirement for the additional truststore support. This checks the operator's filesystem at startup to determine if the service-ca.crt is expected.

This has the same issue as #25671 - we aren't currently detecting / reacting to changes in the projected cert. I propose tacking that concern onto that issue, rather than addressing that here.

closes: #26910

cc @ahus1

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
