### PR TITLE
Run adapters in a separate job on GitHub Actions

### DIFF
--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -32,36 +32,12 @@ runs:
       name: Frontend Plugin Cache
       uses: ./.github/actions/frontend-plugin-cache
 
-    # Remove once https://github.com/keycloak/keycloak/issues/19299 is solved
-    ########################################################################################################
-    - id: check-adapter-changes
-      if: github.event_name == 'pull_request'
-      name: Check changes for WildFly adapters
-      shell: bash
-      # If there are no changes for WildFly adapters, we use adapters built in the latest nightly build
-      run: |
-        WF_ADAPTERS_REGEX="^adapters/oidc/wildfly|^adapters/saml/wildfly"
-        
-        git fetch origin --tags --force
-        
-        echo "GIT_WF_ADAPTERS_DIFF=$(git diff origin/main --name-only | egrep -ic -e "$WF_ADAPTERS_REGEX")" >> $GITHUB_ENV
-        echo "NIGHTLY_DIFF=$(git diff nightly --name-only | egrep -ic -e "$WF_ADAPTERS_REGEX")" >> $GITHUB_ENV
-
-    - id: set-maven-profile
-      if: ${{ github.event_name != 'pull_request' || env.GIT_WF_ADAPTERS_DIFF != 0 || env.NIGHTLY_DIFF != 0}}
-      name: Set profile for building distribution
-      shell: bash
-      run: |
-        echo "MVN_PROFILES=-Pdistribution" >> $GITHUB_ENV
-        echo "WildFly adapters will be built in our codebase"
-    ########################################################################################################
-
     - id: build-keycloak
       name: Build Keycloak
       shell: bash
       # By using "dependency:resolve", it will download all dependencies used in later stages for running the tests
       run: |
-        ./mvnw install dependency:resolve -V -e -DskipTests -DskipExamples ${{ env.MVN_PROFILES}}
+        ./mvnw install dependency:resolve -V -e -DskipTests -DskipExamples
 
     - id: compress-keycloak-maven-repository
       name: Compress Keycloak Maven artifacts

--- a/.github/actions/upload-heapdumps/action.yml
+++ b/.github/actions/upload-heapdumps/action.yml
@@ -11,5 +11,7 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: jvm-heap-dumps
-        path: '**/java_pid*.hprof'
+        path: |
+          '**/java_pid*.hprof'
+          !distribution/**
         if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,47 @@ jobs:
         with:
           job-id: base-integration-tests-${{ matrix.group }}
 
+  adapter-integration-tests:
+    name: Adapter IT
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 100
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+
+      - name: Build adapter distributions
+        run: ./mvnw install -DskipTests -f distribution/pom.xml
+
+      - name: Build app servers
+        run: ./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
+
+      - name: Run adapter tests
+        run: |
+          TESTS="org.keycloak.testsuite.adapter.**"
+          echo "Tests: $TESTS"
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Papp-server-wildfly "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+
+      - name: Upload JVM Heapdumps
+        if: always()
+        uses: ./.github/actions/upload-heapdumps
+
+      - uses: ./.github/actions/upload-flaky-tests
+        name: Upload flaky tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          job-name: Base IT
+
+      - name: Surefire reports
+        if: always()
+        uses: ./.github/actions/archive-surefire-reports
+        with:
+          job-id: adapter-integration-tests
+
   quarkus-unit-tests:
     name: Quarkus UT
     needs: build
@@ -416,6 +457,13 @@ jobs:
         with:
           jdk-version: 17
 
+      - name: Build adapter distributions
+        run: ./mvnw install -DskipTests -f distribution/pom.xml
+
+      - name: Build app servers
+        run: ./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
+
+
       - name: Prepare Quarkus distribution with BCFIPS
         run: ./mvnw install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
 
@@ -649,6 +697,7 @@ jobs:
       - build
       - unit-tests
       - base-integration-tests
+      - adapter-integration-tests
       - quarkus-unit-tests
       - quarkus-integration-tests
       - jdk-integration-tests

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -37,7 +37,7 @@
         <containers.home>${project.build.directory}/containers</containers.home>
         <auth.server.java.home>${java.home}</auth.server.java.home>
         <app.server.java.home>${java.home}</app.server.java.home>
-        <app.server>wildfly</app.server>
+        <app.server>disabled</app.server>
         <cache.server.java.home>${java.home}</cache.server.java.home>
 
         <!--component versions-->
@@ -638,20 +638,5 @@
             </build>
         </profile>
     </profiles>
-
-    <repositories>
-        <repository>
-            <id>sonatype-snapshots</id>
-            <name>Sonatype Snapshots</name>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
 
 </project>

--- a/testsuite/integration-arquillian/servers/app-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/pom.xml
@@ -37,11 +37,19 @@
 
     <modules>
         <module>app-server-spi</module>
-        <module>jboss</module>
-        <module>karaf</module>
-        <module>tomcat</module>
-        <module>undertow</module>
-        <module>jetty</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>build-app-servers</id>
+            <modules>
+                <module>jboss</module>
+                <module>karaf</module>
+                <module>tomcat</module>
+                <module>undertow</module>
+                <module>jetty</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -513,7 +513,6 @@
         <profile>
             <id>app-server-wildfly</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>app.server</name>
                     <value>wildfly</value>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
@@ -73,7 +73,7 @@ public class AppServerTestEnricher {
 
     private static final Logger log = Logger.getLogger(AppServerTestEnricher.class);
 
-    public static final String CURRENT_APP_SERVER = System.getProperty("app.server", "wildfly");
+    public static final String CURRENT_APP_SERVER = System.getProperty("app.server", "disabled");
     public static final boolean APP_SERVER_SSL_REQUIRED = Boolean.parseBoolean(System.getProperty("app.server.ssl.required", "false"));
 
     @Inject private Instance<ContainerController> containerConrollerInstance;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/AbstractBaseServletAuthzAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/AbstractBaseServletAuthzAdapterTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.graphene.page.Page;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/AbstractServletAuthzAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/AbstractServletAuthzAdapterTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/AbstractServletPolicyEnforcerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/AbstractServletPolicyEnforcerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/DefaultAuthzConfigAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/DefaultAuthzConfigAdapterTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/PermissiveModeAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/PermissiveModeAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
+
+import java.io.File;
+import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
+import org.keycloak.testsuite.arquillian.AppServerTestEnricher;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -35,24 +42,30 @@ import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
 @AppServerContainer(ContainerConstants.APP_SERVER_EAP71)
 @AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT8)
 @AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT9)
-public class ServletAuthzLazyLoadPathsAdapterTest extends AbstractServletAuthzAdapterTest {
+public class PermissiveModeAdapterTest extends AbstractBaseServletAuthzAdapterTest {
 
     @Deployment(name = RESOURCE_SERVER_ID, managed = false)
     public static WebArchive deployment() throws IOException {
         return exampleDeployment(RESOURCE_SERVER_ID)
-                .addAsWebInfResource(new File(TEST_APPS_HOME_DIR + "/servlet-authz-app/keycloak-lazy-load-authz-service.json"), "keycloak.json");
+                .addAsWebInfResource(new File(TEST_APPS_HOME_DIR + "/servlet-authz-app/servlet-authz-realm.json"), "keycloak-permissive-authz-service.json");
     }
 
     @Test
-    public void testPathPEPDisabled() {
+    public void testCanAccessWhenPermissive() throws Exception {
         performTests(() -> {
-            login("alice", "alice");
-            assertWasNotDenied();
+            login("jdoe", "jdoe");
+            driver.navigate().to(getResourceServerUrl() + "/enforcing/resource");
 
-            navigateTo();
-            getLink("PEP Disabled").click();
+            if (AppServerTestEnricher.isEAP6AppServer() || AppServerTestEnricher.isTomcatAppServer()) {
+                assertThat(driver.getPageSource(), containsString("HTTP Status 404"));
+            } else {
+                assertThat(driver.getTitle(), is(equalTo("Error")));
+                assertThat(driver.getPageSource(), containsString("Not Found"));
+            }
 
-            hasText("Policy enforcement is disabled. Access granted: true");
+            driver.navigate().to(getResourceServerUrl() + "/protected/admin");
+            assertWasDenied();
         });
     }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletAuthzCIPAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletAuthzCIPAdapterTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletAuthzLazyLoadPathsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletAuthzLazyLoadPathsAdapterTest.java
@@ -14,12 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
-
-import java.io.IOException;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
 
@@ -33,11 +35,24 @@ import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
 @AppServerContainer(ContainerConstants.APP_SERVER_EAP71)
 @AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT8)
 @AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT9)
-public class ServletAuthzNoLazyLoadPathsAdapterTest extends AbstractServletAuthzAdapterTest {
+public class ServletAuthzLazyLoadPathsAdapterTest extends AbstractServletAuthzAdapterTest {
 
     @Deployment(name = RESOURCE_SERVER_ID, managed = false)
     public static WebArchive deployment() throws IOException {
-        return exampleDeployment(RESOURCE_SERVER_ID);
+        return exampleDeployment(RESOURCE_SERVER_ID)
+                .addAsWebInfResource(new File(TEST_APPS_HOME_DIR + "/servlet-authz-app/keycloak-lazy-load-authz-service.json"), "keycloak.json");
     }
 
+    @Test
+    public void testPathPEPDisabled() {
+        performTests(() -> {
+            login("alice", "alice");
+            assertWasNotDenied();
+
+            navigateTo();
+            getLink("PEP Disabled").click();
+
+            hasText("Policy enforcement is disabled. Access granted: true");
+        });
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletAuthzNoLazyLoadPathsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletAuthzNoLazyLoadPathsAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.keycloak.testsuite.arquillian.AppServerTestEnricher;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -42,30 +33,11 @@ import static org.hamcrest.Matchers.is;
 @AppServerContainer(ContainerConstants.APP_SERVER_EAP71)
 @AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT8)
 @AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT9)
-public class PermissiveModeAdapterTest extends AbstractBaseServletAuthzAdapterTest {
+public class ServletAuthzNoLazyLoadPathsAdapterTest extends AbstractServletAuthzAdapterTest {
 
     @Deployment(name = RESOURCE_SERVER_ID, managed = false)
     public static WebArchive deployment() throws IOException {
-        return exampleDeployment(RESOURCE_SERVER_ID)
-                .addAsWebInfResource(new File(TEST_APPS_HOME_DIR + "/servlet-authz-app/servlet-authz-realm.json"), "keycloak-permissive-authz-service.json");
-    }
-
-    @Test
-    public void testCanAccessWhenPermissive() throws Exception {
-        performTests(() -> {
-            login("jdoe", "jdoe");
-            driver.navigate().to(getResourceServerUrl() + "/enforcing/resource");
-
-            if (AppServerTestEnricher.isEAP6AppServer() || AppServerTestEnricher.isTomcatAppServer()) {
-                assertThat(driver.getPageSource(), containsString("HTTP Status 404"));
-            } else {
-                assertThat(driver.getTitle(), is(equalTo("Error")));
-                assertThat(driver.getPageSource(), containsString("Not Found"));
-            }
-
-            driver.navigate().to(getResourceServerUrl() + "/protected/admin");
-            assertWasDenied();
-        });
+        return exampleDeployment(RESOURCE_SERVER_ID);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletPolicyEnforcerLifespanTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletPolicyEnforcerLifespanTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import java.io.File;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletPolicyEnforcerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/authz/example/ServletPolicyEnforcerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.testsuite.authz.adapter.example;
+package org.keycloak.testsuite.adapter.authz.example;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SamlXMLAttacksTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SamlXMLAttacksTest.java
@@ -1,4 +1,4 @@
-package org.keycloak.testsuite.saml;
+package org.keycloak.testsuite.adapter.servlet;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -12,6 +12,7 @@ import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.saml.processing.web.util.PostBindingUtil;
 
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
+import org.keycloak.testsuite.saml.AbstractSamlTest;
 import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/testsuite/integration-arquillian/tests/base/testsuites/base-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/base-suite
@@ -1,6 +1,6 @@
 account,4
 actions,1
-adapter,2
+adapter,IGNORED
 admin,1
 authz,3
 broker,2

--- a/testsuite/integration-arquillian/tests/other/adapters/karaf/fuse61/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/karaf/fuse61/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests-adapters-karaf</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-adapters-fuse61</artifactId>

--- a/testsuite/integration-arquillian/tests/other/adapters/karaf/fuse62/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/karaf/fuse62/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests-adapters-karaf</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-adapters-fuse62</artifactId>

--- a/testsuite/integration-arquillian/tests/other/adapters/karaf/karaf3/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/karaf/karaf3/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests-adapters-karaf</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-adapters-karaf3</artifactId>

--- a/testsuite/integration-arquillian/tests/other/adapters/karaf/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/karaf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests-adapters</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-adapters-karaf</artifactId>


### PR DESCRIPTION
Removes the need to have the snapshot repository in the testsuite by introducing a profile to build app-servers in the testsuite.

Moved all adapter tests to org.keycloak.testsuite.adapter to make it easier to separate adapter tests from the rest.

Adapter tests are removed from the base testsuite and moved to a separate adapter job, which builds the distribution (adapter dists) and the testsuite with the app-servers enabled.

Final thing that needed updating is FIPS IT tests that for some reason rely on adapters.