### PR TITLE
Fixing UriValidator

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -6,6 +6,10 @@ import { HelpItem } from "ui-shared";
 import { MultiLineInput } from "../multi-line-input/MultiLineInput";
 import { convertToName } from "./DynamicComponents";
 
+function convertDefaultValue(formValue?: any): string[] {
+  return formValue && Array.isArray(formValue) ? formValue : [formValue];
+}
+
 export const MultiValuedStringComponent = ({
   name,
   label,
@@ -29,7 +33,7 @@ export const MultiValuedStringComponent = ({
         aria-label={t(label!)}
         name={fieldName}
         isDisabled={isDisabled}
-        defaultValue={[defaultValue]}
+        defaultValue={convertDefaultValue(defaultValue)}
         addButtonLabel={t("addMultivaluedLabel", {
           fieldLabel: t(label!).toLowerCase(),
         })}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/validation/BuiltinValidatorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/validation/BuiltinValidatorsTest.java
@@ -22,6 +22,7 @@ package org.keycloak.testsuite.validation;
 import static org.keycloak.validate.ValidatorConfig.configFromMap;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -500,10 +501,18 @@ public class BuiltinValidatorsTest extends AbstractKeycloakTest {
         Assert.assertTrue(validator.validate("http://localhost:3000/", "baseUrl").isValid());
         Assert.assertTrue(validator.validate("https://localhost:3000/", "baseUrl").isValid());
         Assert.assertTrue(validator.validate("https://localhost:3000/#someFragment", "baseUrl").isValid());
+        Assert.assertTrue(validator.validate(new URL("https://localhost:3000/#someFragment"), "baseUrl").isValid());
+
+        // Collections
+        Assert.assertTrue(validator.validate(Arrays.asList("https://localhost:3000/#someFragment", "https://localhost:3000"), "baseUrl").isValid());
+        Assert.assertTrue(validator.validate(Arrays.asList("https://localhost:3000/#someFragment"), "baseUrl").isValid());
+        Assert.assertTrue(validator.validate(Arrays.asList(new URL("https://localhost:3000/#someFragment")), "baseUrl").isValid());
+        Assert.assertTrue(validator.validate(Arrays.asList(""), "baseUrl").isValid());
 
         Assert.assertFalse(validator.validate(" ", "baseUrl").isValid());
         Assert.assertFalse(validator.validate("file:///somefile.txt", "baseUrl").isValid());
         Assert.assertFalse(validator.validate("invalidUrl++@23", "invalidUri").isValid());
+        Assert.assertFalse(validator.validate(Arrays.asList("https://localhost:3000/#someFragment", "file:///somefile.txt"), "baseUrl").isValid());
 
         ValidatorConfig config = configFromMap(ImmutableMap.of(UriValidator.KEY_ALLOW_FRAGMENT, false));
         Assert.assertFalse(validator.validate("https://localhost:3000/#someFragment", "baseUrl", config).isValid());


### PR DESCRIPTION
closes #26792

Some details regarding the change in `MultivaluedStringComponent.tsx` : We have some providers with the property of type `ProviderConfigProperty.MULTIVALUED_STRING_TYPE` . Some of those configuration properties use simple String as the default value. For example https://github.com/keycloak/keycloak/blob/23.0.6/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java#L143 . However this is multivalued string and hence also the "default value" might support array with multiple values rather than single string.

I've updated to allow default value as array, simple string or null. This is how it looked before my change (the array was incorrectly shown as the string "http,https" instead of the 2 separate values): 


![Screenshot from 2024-02-12 17-59-53](https://github.com/keycloak/keycloak/assets/1223965/74cc7bf1-e1e9-421f-a98d-b2bb2abce1a3)

This is how it looks now:

![Screenshot from 2024-02-12 17-59-16](https://github.com/keycloak/keycloak/assets/1223965/a33bf891-9087-4ad0-a506-c787cfe02577)

