### PR TITLE
Do not require non-builtin attributes for service accounts

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountUserProfileTest.java
@@ -21,25 +21,33 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
+import jakarta.ws.rs.BadRequestException;
 import java.util.List;
 import java.util.Map;
-import org.junit.Rule;
+import java.util.Set;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributeRequired;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.testsuite.AbstractKeycloakTest;
-import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.util.ClientBuilder;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.userprofile.UserProfileConstants;
+import org.keycloak.validate.validators.EmailValidator;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -48,13 +56,6 @@ public class ServiceAccountUserProfileTest extends AbstractKeycloakTest {
 
     private static String userId;
     private static String userName;
-
-    @Rule
-    public AssertEvents events = new AssertEvents(this);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
 
     @Override
     public void addTestRealms(List<RealmRepresentation> testRealms) {
@@ -157,5 +158,33 @@ public class ServiceAccountUserProfileTest extends AbstractKeycloakTest {
         representation = serviceAccount.toRepresentation();
         assertFalse(representation.getAttributes().isEmpty());
         assertEquals("attr-1-value", representation.getAttributes().get("attr-1").get(0));
+    }
+
+    @Test
+    public void testEmailFormatIsEnforced() {
+        final RealmResource realm = adminClient.realm("test");
+        UserResource serviceAccount = realm.users().get(userId);
+        UserRepresentation rep = serviceAccount.toRepresentation();
+        rep.setEmail("invalidEmail");
+        BadRequestException e = assertThrows(BadRequestException.class, () -> serviceAccount.update(rep));
+        assertThat(e.getResponse().readEntity(String.class), containsString(EmailValidator.MESSAGE_INVALID_EMAIL));
+    }
+
+    @Test
+    public void testAttributesAreNotRequired() {
+        final RealmResource realm = adminClient.realm("test");
+        UPConfig config = realm.users().userProfile().getConfiguration();
+        UPAttribute lastName = config.getAttribute(UserModel.LAST_NAME);
+        assertNotNull("The attribute lastName is not defined in User Profile", lastName);
+        UPAttributeRequired upRequired = new UPAttributeRequired(Set.of(
+                UserProfileConstants.ROLE_ADMIN, UserProfileConstants.ROLE_USER), null);
+        lastName.setRequired(upRequired);
+        realm.users().userProfile().update(config);
+        getCleanup().addCleanup(() -> realm.users().userProfile().update(null));
+
+        UserResource serviceAccount = realm.users().get(userId);
+        UserRepresentation rep = serviceAccount.toRepresentation();
+        rep.setLastName(null);
+        serviceAccount.update(rep);
     }
 }


### PR DESCRIPTION
Closes #26716

The idea is non-builting attributes (all attrs except username) are not required for services accounts no matter the configuration in the UP. The rest of the validations (formats, length, email,...) are still executed for service accounts to avoid weird data in them. Tests added.

@patrickjennings This is the PR. take a look to see if it works for you.

