### PR TITLE
Revert changes to group concurrency test and fix stale cache records

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -1024,10 +1024,6 @@ public class RealmCacheSession implements CacheRealmProvider {
         boolean isInvalid = invalidations.contains(cacheKey) || listInvalidations.contains(cacheKey)
             || listInvalidations.contains(realm.getId());
 
-//        if (queryDB) {
-//            return getGroupDelegate().getTopLevelGroupsStream(realm);
-//        }
-
         GroupListQuery query = cache.get(cacheKey, GroupListQuery.class);
 
         if (Objects.nonNull(query)) {
@@ -1069,16 +1065,6 @@ public class RealmCacheSession implements CacheRealmProvider {
         if(max != null && max >= 0) {
             groups = groups.limit(max);
         }
-
-        // TODO this is an N+1 in the cache. We should invalidate on updates. A stale cache read is resolved by refreshing
-//        for (String id : query.getGroups()) {
-//            GroupModel group = session.groups().getGroupById(realm, id);
-//            if (Objects.isNull(group)) {
-//                invalidations.add(cacheKey);
-//                return getGroupDelegate().getTopLevelGroupsStream(realm);
-//            }
-//            list.add(group);
-//        }
 
         return groups;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrencyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrencyTest.java
@@ -234,18 +234,11 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
 
             c = realm.groups().group(id).toRepresentation();
             assertNotNull(c);
-
-            boolean retry = true;
-            int i = 0;
-            do {
-                List<String> groups = realm.groups().groups().stream()
-                    .map(GroupRepresentation::getName)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-                retry = !groups.contains(name);
-                i++;
-            } while(retry && i < 3);
-            assertFalse("Group " + name + " [" + id + "] " + " not found in group list", retry);
+            assertTrue("Group " + name + " [" + id + "] " + " not found in group list",
+                    realm.groups().groups().stream()
+                            .map(GroupRepresentation::getName)
+                            .filter(Objects::nonNull)
+                            .anyMatch(name::equals));
         }
     }
 


### PR DESCRIPTION
Fixes keycloak/keycloak#26983 
~~Notably this fails on local and potentially on GHA. Adding a thread sleep of one second between creation and read fixes the failure pointing to non-repeatable read issue of stale data~~

Cache was providing stale records. Cache has been updated to properly defer to the delegate db and load from cache where appropriate. Test now passes

