### PR TITLE
fix TrustStoreFactory fetch using TrustStoreProvider.class

### DIFF
--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
@@ -80,7 +80,7 @@ public class NginxProxySslClientCertificateLookupFactory extends AbstractClientC
             }
             logger.debug(" Loading Keycloak truststore ...");
             KeycloakSessionFactory factory = kcSession.getKeycloakSessionFactory();
-            TruststoreProviderFactory truststoreFactory = (TruststoreProviderFactory) factory.getProviderFactory(TruststoreProvider.class, "file");
+            TruststoreProviderFactory truststoreFactory = (TruststoreProviderFactory) factory.getProviderFactory(TruststoreProvider.class);
             TruststoreProvider provider = truststoreFactory.create(kcSession);
 
             if (provider != null && provider.getTruststore() != null) {


### PR DESCRIPTION
Fix for: 

https://github.com/keycloak/keycloak/issues/26972

 NginxProxySslClientCertificateLookupFactory unable to work with custom trust stores #26972

This fix will enable to fetch a custom provider with different ID.