### PR TITLE
Fix the limitation of working only with TrustStoreProvider with id "file"

### DIFF
--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
@@ -87,7 +87,7 @@ public class NginxProxySslClientCertificateLookupFactory extends AbstractClientC
             }
             logger.debug(" Loading Keycloak truststore ...");
             KeycloakSessionFactory factory = kcSession.getKeycloakSessionFactory();
-            TruststoreProviderFactory truststoreFactory = (TruststoreProviderFactory) factory.getProviderFactory(TruststoreProvider.class, "file");
+            TruststoreProviderFactory truststoreFactory = (TruststoreProviderFactory) factory.getProviderFactory(TruststoreProvider.class);
             TruststoreProvider provider = truststoreFactory.create(kcSession);
 
             if (provider != null && provider.getTruststore() != null) {


### PR DESCRIPTION
This fix the limitation of working only with TrustStoreProvider with ID "file" and enables to work with custom trust store provider via custom SPI.

Closes #26972

