### PR TITLE
Potentially Fixes keycloak/keycloak#25731 Fetch group count of subgroups at query time to avoid N+1 database queries when compiling response

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
@@ -38,6 +38,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
     private final String realm;
     private final String name;
     private final String parentId;
+    private final Long subGroupCount;
     private final LazyLoader<GroupModel, MultivaluedHashMap<String, String>> attributes;
     private final LazyLoader<GroupModel, Set<String>> roleMappings;
     private final LazyLoader<GroupModel, Set<String>> subGroups;
@@ -47,6 +48,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
         this.realm = realm.getId();
         this.name = group.getName();
         this.parentId = group.getParentId();
+        this.subGroupCount = group.getSubGroupsCount();
         this.attributes = new DefaultLazyLoader<>(source -> new MultivaluedHashMap<>(source.getAttributes()), MultivaluedHashMap::new);
         this.roleMappings = new DefaultLazyLoader<>(source -> source.getRoleMappingsStream().map(RoleModel::getId).collect(Collectors.toSet()), Collections::emptySet);
         this.subGroups = new DefaultLazyLoader<>(source -> source.getSubGroupsStream().map(GroupModel::getId).collect(Collectors.toSet()), Collections::emptySet);
@@ -74,6 +76,10 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
 
     public String getParentId() {
         return parentId;
+    }
+
+    public Long getSubGroupCount() {
+        return subGroupCount;
     }
 
     public Set<String> getSubGroups(Supplier<GroupModel> group) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -51,11 +51,18 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
     protected GroupEntity group;
     protected EntityManager em;
     protected RealmModel realm;
+    protected Long subGroupCount;
 
     public GroupAdapter(RealmModel realm, EntityManager em, GroupEntity group) {
         this.em = em;
         this.group = group;
         this.realm = realm;
+        this.subGroupCount = null;
+    }
+
+    public GroupAdapter(RealmModel realm, EntityManager em, GroupEntity group, Long subGroupCount) {
+        this(realm, em, group);
+        this.subGroupCount = subGroupCount;
     }
 
     public GroupEntity getEntity() {
@@ -148,10 +155,13 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
 
     @Override
     public Long getSubGroupsCount() {
-        return em.createNamedQuery("getGroupCountByParent", Long.class)
-                .setParameter("realm", realm.getId())
-                .setParameter("parent", group.getId())
-                .getSingleResult();
+        if (subGroupCount == null) {
+            subGroupCount = em.createNamedQuery("getGroupCountByParent", Long.class)
+                    .setParameter("realm", realm.getId())
+                    .setParameter("parent", group.getId())
+                    .getSingleResult();
+        }
+        return subGroupCount;
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -476,11 +476,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     @Override
     public GroupModel getGroupById(RealmModel realm, String id) {
         try {
-            // TODO this can be replaced with a named query, this is just a proof of concept
-            Tuple groupWithSubCount = em.createQuery(
-                            "SELECT g, COUNT(s.id) FROM GroupEntity g LEFT JOIN GroupEntity s ON g.id = s.parentId WHERE g.id = :id GROUP BY g.id", Tuple.class)
-                    .setParameter("id", id)
-                    .getSingleResult();
+            Tuple groupWithSubCount = em.createNamedQuery("getGroupsWithSubGroupCount", Tuple.class).setParameter("id", id).getSingleResult();
             GroupEntity groupEntity = groupWithSubCount.get(0, GroupEntity.class);
             if (groupEntity == null) return null;
             if (!groupEntity.getRealm().equals(realm.getId())) return null;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupEntity.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
  * @version $Revision: 1 $
  */
 @NamedQueries({
+        @NamedQuery(name="getGroupsWithSubGroupCount", query="SELECT g, COUNT(s.id) FROM GroupEntity g LEFT JOIN GroupEntity s ON g.id = s.parentId WHERE g.id = :id GROUP BY g.id, g.realm, g.name, g.parentId"),
         @NamedQuery(name="getGroupIdsByParent", query="select u.id from GroupEntity u where u.realm = :realm and u.parentId = :parent order by u.name ASC"),
         @NamedQuery(name="getGroupIdsByParentAndName", query="select u.id from GroupEntity u where u.realm = :realm and u.parentId = :parent and u.name = :search order by u.name ASC"),
         @NamedQuery(name="getGroupIdsByParentAndNameContaining", query="select u.id from GroupEntity u where u.realm = :realm and u.parentId = :parent and lower(u.name) like lower(concat('%',:search,'%')) order by u.name ASC"),

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.0.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- I'm not sure how these change set numbers are calculated -->
+    <changeSet author="keycloak" id="24.0.0-12062">
+        <createIndex tableName="KEYCLOAK_GROUP" indexName="IDX_GROUP_PARENT">
+            <column name="PARENT_GROUP"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -79,5 +79,6 @@
     <include file="META-INF/jpa-changelog-21.1.0.xml"/>
     <include file="META-INF/jpa-changelog-22.0.0.xml"/>
     <include file="META-INF/jpa-changelog-23.0.0.xml"/>
+    <include file="META-INF/jpa-changelog-24.0.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This doesn't resolve the double query of group ids but this does prevent N+1 queries back to the DB for the count value. Should at least reduce the impact of adding the count field. 

A more direct approach would be to add this count field to all relevant named queries and have those named queries return the entities directly rather than IDs. Cache would have to be modified to work correctly in this case
