### PR TITLE
doc/token-exchange.adoc: issuer claim -> iss claim

### DIFF
--- a/docs/documentation/securing_apps/topics/token-exchange/token-exchange.adoc
+++ b/docs/documentation/securing_apps/topics/token-exchange/token-exchange.adoc
@@ -357,7 +357,7 @@ to do this is <<_client_to_client_permission, discussed earlier>> in this sectio
 The `subject_token_type` must either be `urn:ietf:params:oauth:token-type:access_token` or `urn:ietf:params:oauth:token-type:jwt`.
 If the type is `urn:ietf:params:oauth:token-type:access_token` you specify the `subject_issuer` parameter and it must be the
 alias of the configured identity provider.  If the type is `urn:ietf:params:oauth:token-type:jwt`, the provider will be matched via
-the `issuer` claim within the JWT which must be the alias of the provider, or a registered issuer within the providers configuration.
+the `iss` (issuer) claim within the JWT which must be the alias of the provider, or a registered issuer within the providers configuration.
 
 For validation, if the token is an access token, the provider's user info service will be invoked to validate the token.  A successful call
 will mean that the access token is valid.  If the subject token is a JWT and if the provider has signature validation enabled, that will be attempted,


### PR DESCRIPTION
Changes "`issuer` claim" to "`iss` (issuer) claim". 

