### PR TITLE
add EC support for the JavaKeystoreKeyProvider

### DIFF
--- a/common/src/main/java/org/keycloak/common/crypto/ECDSACryptoProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/ECDSACryptoProvider.java
@@ -1,13 +1,14 @@
 package org.keycloak.common.crypto;
 
 import java.io.IOException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 
 public interface ECDSACryptoProvider {
-
-
+    
     public byte[] concatenatedRSToASN1DER(final byte[] signature, int signLength) throws IOException;
 
     public byte[] asn1derToConcatenatedRS(final byte[] derEncodedSignatureValue, int signLength) throws IOException;
 
-    
+    public ECPublicKey getPublicFromPrivate(ECPrivateKey ecPrivateKey);
 }

--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCCertificateUtilsProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCCertificateUtilsProvider.java
@@ -67,7 +67,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * The Class CertificateUtils provides utility functions for generation of V1 and V3 {@link java.security.cert.X509Certificate}
+ * The Class CertificateUtils provides utility functions for generation of V1 and V3 {@link X509Certificate}
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @author <a href="mailto:giriraj.sharma27@gmail.com">Giriraj Sharma</a>
@@ -76,19 +76,17 @@ import java.util.List;
 public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
 
     /**
-     * Generates version 3 {@link java.security.cert.X509Certificate}.
+     * Generates version 3 {@link X509Certificate}.
      *
-     * @param keyPair the key pair
+     * @param keyPair      the key pair
      * @param caPrivateKey the CA private key
-     * @param caCert the CA certificate
-     * @param subject the subject name
-     * 
+     * @param caCert       the CA certificate
+     * @param subject      the subject name
      * @return the x509 certificate
-     * 
      * @throws Exception the exception
      */
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
-            String subject) throws Exception {
+                                                 String subject) throws Exception {
         try {
             X500Name subjectDN = new X500Name("CN=" + subject);
 
@@ -141,13 +139,11 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     }
 
     /**
-     * Generate version 1 self signed {@link java.security.cert.X509Certificate}..
+     * Generate version 1 self signed {@link X509Certificate}..
      *
      * @param caKeyPair the CA key pair
-     * @param subject the subject name
-     * 
+     * @param subject   the subject name
      * @return the x509 certificate
-     * 
      * @throws Exception the exception
      */
     public X509Certificate generateV1SelfSignedCertificate(KeyPair caKeyPair, String subject) {
@@ -174,16 +170,30 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     }
 
     /**
-     * Creates the content signer for generation of Version 1 {@link java.security.cert.X509Certificate}.
+     * Creates the content signer for generation of Version 1 {@link X509Certificate}.
      *
      * @param privateKey the private key
-     *
      * @return the content signer
      */
     private ContentSigner createSigner(PrivateKey privateKey) {
         try {
-            JcaContentSignerBuilder signerBuilder = new JcaContentSignerBuilder("SHA256WithRSAEncryption")
-                    .setProvider(BouncyIntegration.PROVIDER);
+            JcaContentSignerBuilder signerBuilder;
+            switch (privateKey.getAlgorithm()) {
+                case "RSA": {
+                    signerBuilder = new JcaContentSignerBuilder("SHA256WithRSAEncryption")
+                            .setProvider(BouncyIntegration.PROVIDER);
+                    break;
+                }
+                case "ECDSA": {
+                    signerBuilder = new JcaContentSignerBuilder("SHA256WithECDSA")
+                            .setProvider(BouncyIntegration.PROVIDER);
+                    break;
+
+                }
+                default: {
+                    throw new RuntimeException(String.format("Keytype %s is not supported.", privateKey.getAlgorithm()));
+                }
+            }
             return signerBuilder.build(privateKey);
         } catch (Exception e) {
             throw new RuntimeException("Could not create content signer.", e);
@@ -192,7 +202,7 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
 
     @Override
     public List<String> getCertificatePolicyList(X509Certificate cert) throws GeneralSecurityException {
-        
+
         Extensions certExtensions = new JcaX509CertificateHolder(cert).getExtensions();
         if (certExtensions == null)
             throw new GeneralSecurityException("Certificate Policy validation was expected, but no certificate extensions were found");
@@ -212,6 +222,7 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     /**
      * Retrieves a list of CRL distribution points from CRLDP v3 certificate extension
      * See <a href="www.nakov.com/blog/2009/12/01/x509-certificate-validation-in-java-build-and-verify-cchain-and-verify-clr-with-bouncy-castle/">CRL validation</a>
+     *
      * @param cert
      * @return
      * @throws IOException
@@ -225,7 +236,7 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
         List<String> distributionPointUrls = new LinkedList<>();
         DEROctetString octetString;
         try (ASN1InputStream crldpExtensionInputStream = new ASN1InputStream(new ByteArrayInputStream(data))) {
-            octetString = (DEROctetString)crldpExtensionInputStream.readObject();
+            octetString = (DEROctetString) crldpExtensionInputStream.readObject();
         }
         byte[] octets = octetString.getOctets();
 
@@ -251,28 +262,26 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     }
 
     public X509Certificate createServicesTestCertificate(String dn,
-                                             Date startDate,
-                                             Date expiryDate,
-                                             KeyPair keyPair,
-                                             String... certificatePolicyOid) {
+                                                         Date startDate,
+                                                         Date expiryDate,
+                                                         KeyPair keyPair,
+                                                         String... certificatePolicyOid) {
         // Cert data
         X500Name subjectDN = new X500Name(dn);
         X500Name issuerDN = new X500Name(dn);
 
         SubjectPublicKeyInfo subjPubKeyInfo = SubjectPublicKeyInfo.getInstance(
-            ASN1Sequence.getInstance(keyPair.getPublic().getEncoded()));
+                ASN1Sequence.getInstance(keyPair.getPublic().getEncoded()));
 
         BigInteger serialNumber = new BigInteger(130, new SecureRandom());
 
         // Build the certificate
         X509v3CertificateBuilder certGen = new X509v3CertificateBuilder(issuerDN, serialNumber, startDate, expiryDate,
-            subjectDN, subjPubKeyInfo);
+                subjectDN, subjPubKeyInfo);
 
-        if (certificatePolicyOid != null)
-        {
-            try
-            {
-                for (Extension certExtension: certPolicyExtensions(certificatePolicyOid))
+        if (certificatePolicyOid != null) {
+            try {
+                for (Extension certExtension : certPolicyExtensions(certificatePolicyOid))
                     certGen.addExtension(certExtension);
             } catch (CertIOException e) {
                 throw new IllegalStateException(e);
@@ -282,11 +291,11 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
         // Sign the cert with the private key
         try {
             ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256withRSA")
-                .setProvider(BouncyIntegration.PROVIDER)
-                .build(keyPair.getPrivate());
+                    .setProvider(BouncyIntegration.PROVIDER)
+                    .build(keyPair.getPrivate());
             X509Certificate x509Certificate = new JcaX509CertificateConverter()
-                .setProvider(BouncyIntegration.PROVIDER)
-                .getCertificate(certGen.build(contentSigner));
+                    .setProvider(BouncyIntegration.PROVIDER)
+                    .getCertificate(certGen.build(contentSigner));
 
             return x509Certificate;
         } catch (CertificateException | OperatorCreationException e) {
@@ -297,11 +306,9 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     private List<Extension> certPolicyExtensions(String... certificatePolicyOid) {
         List<Extension> certificatePolicies = new LinkedList<>();
 
-        if (certificatePolicyOid != null && certificatePolicyOid.length > 0)
-        {
+        if (certificatePolicyOid != null && certificatePolicyOid.length > 0) {
             List<PolicyInformation> policyInfoList = new LinkedList<>();
-            for (String oid: certificatePolicyOid)
-            {
+            for (String oid : certificatePolicyOid) {
                 policyInfoList.add(new PolicyInformation(new ASN1ObjectIdentifier(oid)));
             }
 

--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCECDSACryptoProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCECDSACryptoProvider.java
@@ -1,16 +1,28 @@
 package org.keycloak.crypto.def;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.math.BigInteger;
-
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequenceGenerator;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
+import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.math.ec.ECPoint;
 import org.keycloak.common.crypto.ECDSACryptoProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
 
 public class BCECDSACryptoProvider implements ECDSACryptoProvider {
 
@@ -60,5 +72,22 @@ public class BCECDSACryptoProvider implements ECDSACryptoProvider {
         return concatenatedSignatureValue;
     }
 
-    
+    @Override
+    public ECPublicKey getPublicFromPrivate(ECPrivateKey ecPrivateKey) {
+        try {
+            BCECPrivateKey bcecPrivateKey = new BCECPrivateKey(ecPrivateKey, BouncyCastleProvider.CONFIGURATION);
+
+            ECPoint q = bcecPrivateKey.getParameters().getG().multiply(bcecPrivateKey.getD());
+
+            ECPublicKeySpec publicKeySpec = new ECPublicKeySpec(q, bcecPrivateKey.getParameters());
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return (ECPublicKey) keyFactory.generatePublic(publicKeySpec);
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Key algorithm not supported.", e);
+        } catch (InvalidKeySpecException e) {
+            throw new RuntimeException("Received an invalid key spec.", e);
+        }
+    }
+
 }

--- a/crypto/default/src/test/java/org/keycloak/crypto/def/test/BCECDSACryptoProviderTest.java
+++ b/crypto/default/src/test/java/org/keycloak/crypto/def/test/BCECDSACryptoProviderTest.java
@@ -1,0 +1,65 @@
+package org.keycloak.crypto.def.test;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.crypto.def.BCECDSACryptoProvider;
+import org.keycloak.rule.CryptoInitRule;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class BCECDSACryptoProviderTest {
+
+
+    @ClassRule
+    public static CryptoInitRule cryptoInitRule = new CryptoInitRule();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"secp256r1"}, {"secp384r1"}, {"secp521r1"}
+        });
+    }
+
+    private String curve;
+
+    public BCECDSACryptoProviderTest(String curve) {
+        this.curve = curve;
+    }
+
+    @Test
+    public void getPublicFromPrivate() {
+        KeyPair testKey = generateECKey(curve);
+
+        BCECDSACryptoProvider bcecdsaCryptoProvider = new BCECDSACryptoProvider();
+        assertEquals("The derived key should be equal to the originally generated one.",
+                testKey.getPublic(),
+                bcecdsaCryptoProvider.getPublicFromPrivate((ECPrivateKey) testKey.getPrivate()));
+
+    }
+
+    public static KeyPair generateECKey(String curve) {
+
+        try {
+            KeyPairGenerator kpg = CryptoIntegration.getProvider().getKeyPairGen("ECDSA");
+            ECGenParameterSpec parameterSpec = new ECGenParameterSpec(curve);
+            kpg.initialize(parameterSpec);
+            return kpg.generateKeyPair();
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronECDSACryptoProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronECDSACryptoProvider.java
@@ -18,6 +18,8 @@ package org.keycloak.crypto.elytron;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.crypto.ECDSACryptoProvider;
@@ -51,7 +53,7 @@ public class ElytronECDSACryptoProvider implements ECDSACryptoProvider {
         seq.endSequence();
 
         return seq.getEncoded();
-        
+
     }
 
     @Override
@@ -60,8 +62,8 @@ public class ElytronECDSACryptoProvider implements ECDSACryptoProvider {
 
         DERDecoder der = new DERDecoder(derEncodedSignatureValue);
         der.startSequence();
-        byte[] r = convertToBytes(der.decodeInteger(),len);
-        byte[] s = convertToBytes(der.decodeInteger(),len);
+        byte[] r = convertToBytes(der.decodeInteger(), len);
+        byte[] s = convertToBytes(der.decodeInteger(), len);
         der.endSequence();
         byte[] concatenatedSignatureValue = new byte[signLength];
 
@@ -71,13 +73,18 @@ public class ElytronECDSACryptoProvider implements ECDSACryptoProvider {
         return concatenatedSignatureValue;
     }
 
+    @Override
+    public ECPublicKey getPublicFromPrivate(ECPrivateKey ecPrivateKey) {
+        throw new UnsupportedOperationException("Elytron Crypto Provider currently does not support extraction of EC Public Keys.");
+    }
+
     // If byte array length doesn't match expected length, copy to new
     // byte array of the expected length
     private byte[] convertToBytes(BigInteger decodeInteger, int len) {
 
         byte[] bytes = decodeInteger.toByteArray();
 
-        if(len < bytes.length) {
+        if (len < bytes.length) {
             log.debug("Decoded integer byte length greater than expected.");
             byte[] t = new byte[len];
             System.arraycopy(bytes, bytes.length - len, t, 0, len);

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSCertificateUtilsProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSCertificateUtilsProvider.java
@@ -67,7 +67,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * The Class CertificateUtils provides utility functions for generation of V1 and V3 {@link java.security.cert.X509Certificate}
+ * The Class CertificateUtils provides utility functions for generation of V1 and V3 {@link X509Certificate}
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @author <a href="mailto:giriraj.sharma27@gmail.com">Giriraj Sharma</a>
@@ -76,7 +76,7 @@ import java.util.List;
 public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
 
     /**
-     * Generates version 3 {@link java.security.cert.X509Certificate}.
+     * Generates version 3 {@link X509Certificate}.
      *
      * @param keyPair the key pair
      * @param caPrivateKey the CA private key
@@ -141,7 +141,7 @@ public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
     }
 
     /**
-     * Generate version 1 self signed {@link java.security.cert.X509Certificate}..
+     * Generate version 1 self signed {@link X509Certificate}..
      *
      * @param caKeyPair the CA key pair
      * @param subject the subject name
@@ -174,7 +174,7 @@ public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
     }
 
     /**
-     * Creates the content signer for generation of Version 1 {@link java.security.cert.X509Certificate}.
+     * Creates the content signer for generation of Version 1 {@link X509Certificate}.
      *
      * @param privateKey the private key
      *
@@ -182,8 +182,23 @@ public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
      */
     private ContentSigner createSigner(PrivateKey privateKey) {
         try {
-            JcaContentSignerBuilder signerBuilder = new JcaContentSignerBuilder("SHA256WithRSAEncryption")
-                    .setProvider(BouncyIntegration.PROVIDER);
+            JcaContentSignerBuilder signerBuilder;
+            switch (privateKey.getAlgorithm()) {
+                case "RSA": {
+                    signerBuilder = new JcaContentSignerBuilder("SHA256WithRSAEncryption")
+                            .setProvider(BouncyIntegration.PROVIDER);
+                    break;
+                }
+                case "EC": {
+                    signerBuilder = new JcaContentSignerBuilder("SHA256WithECDSA")
+                            .setProvider(BouncyIntegration.PROVIDER);
+                    break;
+
+                }
+                default: {
+                    throw new RuntimeException(String.format("Keytype %s is not supported.", privateKey.getAlgorithm()));
+                }
+            }
             return signerBuilder.build(privateKey);
         } catch (Exception e) {
             throw new RuntimeException("Could not create content signer.", e);

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSECDSACryptoProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSECDSACryptoProvider.java
@@ -3,13 +3,26 @@ package org.keycloak.crypto.fips;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
 
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequenceGenerator;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
+import org.bouncycastle.crypto.fips.FipsEC;
+import org.bouncycastle.jcajce.spec.ECDomainParameterSpec;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECMultiplier;
+import org.bouncycastle.math.ec.ECPoint;
 import org.keycloak.common.crypto.ECDSACryptoProvider;
 
 public class BCFIPSECDSACryptoProvider implements ECDSACryptoProvider {
@@ -60,5 +73,27 @@ public class BCFIPSECDSACryptoProvider implements ECDSACryptoProvider {
         return concatenatedSignatureValue;
     }
 
-    
+    @Override
+    public ECPublicKey getPublicFromPrivate(ECPrivateKey ecPrivateKey) {
+        try {
+            ECParameterSpec parameterSpec = ecPrivateKey.getParams();
+            ECDomainParameterSpec domainParameterSpec = new ECDomainParameterSpec(parameterSpec);
+
+            ECPoint q = domainParameterSpec.getDomainParameters().getG().multiply(ecPrivateKey.getS()).normalize();
+            ECPublicKeySpec ecPublicKeySpec = new ECPublicKeySpec(
+                    new java.security.spec.ECPoint(
+                            q.getAffineXCoord().toBigInteger(),
+                            q.getAffineYCoord().toBigInteger()),
+                    domainParameterSpec);
+
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return (ECPublicKey) keyFactory.generatePublic(ecPublicKeySpec);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Key algorithm not supported.", e);
+        } catch (InvalidKeySpecException e) {
+            throw new RuntimeException("Received an invalid key spec.", e);
+        }
+    }
+
+
 }

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/BCFIPSECDSACryptoProviderTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/BCFIPSECDSACryptoProviderTest.java
@@ -1,0 +1,70 @@
+package org.keycloak.crypto.fips.test;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.fips.BCFIPSECDSACryptoProvider;
+import org.keycloak.keys.AbstractEcdsaKeyProviderFactory;
+import org.keycloak.rule.CryptoInitRule;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class BCFIPSECDSACryptoProviderTest {
+
+    @ClassRule
+    public static CryptoInitRule cryptoInitRule = new CryptoInitRule();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {Algorithm.ES256}, {Algorithm.ES384}, {Algorithm.ES512}
+        });
+    }
+
+    private String algorithm;
+
+    public BCFIPSECDSACryptoProviderTest(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    @Test
+    public void getPublicFromPrivate() {
+        KeyPair testKey = generateECKey(algorithm);
+
+        BCFIPSECDSACryptoProvider bcfipsecdsaCryptoProvider = new BCFIPSECDSACryptoProvider();
+        ECPublicKey derivedKey = bcfipsecdsaCryptoProvider.getPublicFromPrivate((ECPrivateKey) testKey.getPrivate());
+        assertEquals("The derived key should be equal to the originally generated one.",
+                testKey.getPublic(),
+                derivedKey);
+    }
+
+    public static KeyPair generateECKey(String algorithm) {
+
+        try {
+            KeyPairGenerator kpg = CryptoIntegration.getProvider().getKeyPairGen("ECDSA");
+            String domainParamNistRep = AbstractEcdsaKeyProviderFactory.convertAlgorithmToECDomainParmNistRep(algorithm);
+            String curve = AbstractEcdsaKeyProviderFactory.convertECDomainParmNistRepToSecRep(domainParamNistRep);
+            ECGenParameterSpec parameterSpec = new ECGenParameterSpec(curve);
+            kpg.initialize(parameterSpec);
+            return kpg.generateKeyPair();
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
@@ -17,18 +17,25 @@
 
 package org.keycloak.keys;
 
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.KeystoreUtil;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyStatus;
+import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.models.RealmModel;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -43,6 +50,11 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.EllipticCurve;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -50,39 +62,49 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class JavaKeystoreKeyProvider extends AbstractRsaKeyProvider {
+public class JavaKeystoreKeyProvider implements KeyProvider {
+
+    private final KeyStatus status;
+
+    private final ComponentModel model;
+
+    private final KeyWrapper key;
+
+    private final String algorithm;
 
     public JavaKeystoreKeyProvider(RealmModel realm, ComponentModel model) {
-        super(realm, model);
+        this.model = model;
+        this.status = KeyStatus.from(model.get(Attributes.ACTIVE_KEY, true), model.get(Attributes.ENABLED_KEY, true));
+
+        String defaultAlgorithmKey = KeyUse.ENC.name().equals(model.get(Attributes.KEY_USE)) ? JWEConstants.RSA_OAEP : Algorithm.RS256;
+        this.algorithm = model.get(Attributes.ALGORITHM_KEY, defaultAlgorithmKey);
+
+        if (model.hasNote(KeyWrapper.class.getName())) {
+            key = model.getNote(KeyWrapper.class.getName());
+        } else {
+            key = loadKey(realm, model);
+            model.setNote(KeyWrapper.class.getName(), key);
+        }
     }
 
-    @Override
     protected KeyWrapper loadKey(RealmModel realm, ComponentModel model) {
         String keystorePath = model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_KEY);
         try (FileInputStream is = new FileInputStream(keystorePath)) {
-            // Use "JKS" as default type for backwards compatibility
-            String keystoreType = KeystoreUtil.getKeystoreType(model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_TYPE_KEY), keystorePath, "JKS");
-            KeyStore keyStore = KeyStore.getInstance(keystoreType);
-            keyStore.load(is, model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_PASSWORD_KEY).toCharArray());
-
+            KeyStore keyStore = loadKeyStore(is, keystorePath);
             String keyAlias = model.get(JavaKeystoreKeyProviderFactory.KEY_ALIAS_KEY);
-            PrivateKey privateKey = (PrivateKey) keyStore.getKey(keyAlias, model.get(JavaKeystoreKeyProviderFactory.KEY_PASSWORD_KEY).toCharArray());
-            PublicKey publicKey = KeyUtils.extractPublicKey(privateKey);
 
-            KeyPair keyPair = new KeyPair(publicKey, privateKey);
-
-            X509Certificate certificate = (X509Certificate) keyStore.getCertificate(keyAlias);
-            if (certificate == null) {
-                certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, realm.getName());
-            }
-
-            KeyUse keyUse = KeyUse.valueOf(model.get(Attributes.KEY_USE, KeyUse.SIG.getSpecName()).toUpperCase());
-
-            return createKeyWrapper(keyPair, certificate, loadCertificateChain(keyStore, keyAlias), keyUse);
+            return switch (algorithm) {
+                case Algorithm.HS256, Algorithm.HS384, Algorithm.HS512, Algorithm.RS256, Algorithm.RS384, Algorithm.RS512 ->
+                        loadRSAKey(realm, model, keyStore, keyAlias);
+                case Algorithm.ES256, Algorithm.ES384, Algorithm.ES512 -> loadECKey(realm, model, keyStore, keyAlias);
+                default ->
+                        throw new RuntimeException(String.format("Keys for algorithm %s are not supported.", algorithm));
+            };
         } catch (KeyStoreException kse) {
             throw new RuntimeException("KeyStore error on server. " + kse.getMessage(), kse);
         } catch (FileNotFoundException fnfe) {
@@ -100,6 +122,44 @@ public class JavaKeystoreKeyProvider extends AbstractRsaKeyProvider {
         }
     }
 
+    private KeyStore loadKeyStore(FileInputStream inputStream, String keystorePath) throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
+        // Use "JKS" as default type for backwards compatibility
+        String keystoreType = KeystoreUtil.getKeystoreType(model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_TYPE_KEY), keystorePath, "JKS");
+        KeyStore keyStore = KeyStore.getInstance(keystoreType);
+        keyStore.load(inputStream, model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_PASSWORD_KEY).toCharArray());
+        return keyStore;
+    }
+
+
+    private KeyWrapper loadECKey(RealmModel realm, ComponentModel model, KeyStore keyStore, String keyAlias) throws GeneralSecurityException {
+        ECPrivateKey privateKey = (ECPrivateKey) keyStore.getKey(keyAlias, model.get(JavaKeystoreKeyProviderFactory.KEY_PASSWORD_KEY).toCharArray());
+        String curve = AbstractEcdsaKeyProviderFactory.convertECDomainParmNistRepToSecRep(AbstractEcdsaKeyProviderFactory.convertAlgorithmToECDomainParmNistRep(algorithm));
+
+        PublicKey publicKey = CryptoIntegration.getProvider().getEcdsaCryptoProvider().getPublicFromPrivate(privateKey);
+
+        KeyPair keyPair = new KeyPair(publicKey, privateKey);
+
+        return createKeyWrapper(keyPair, getCertificate(keyStore, keyPair, keyAlias, realm.getName()), loadCertificateChain(keyStore, keyAlias), KeyType.EC);
+
+    }
+
+    private X509Certificate getCertificate(KeyStore keyStore, KeyPair keyPair, String keyAlias, String realmName) throws KeyStoreException {
+        X509Certificate certificate = (X509Certificate) keyStore.getCertificate(keyAlias);
+        if (certificate == null) {
+            certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, realmName);
+        }
+        return certificate;
+    }
+
+    private KeyWrapper loadRSAKey(RealmModel realm, ComponentModel model, KeyStore keyStore, String keyAlias) throws GeneralSecurityException {
+        PrivateKey privateKey = (PrivateKey) keyStore.getKey(keyAlias, model.get(JavaKeystoreKeyProviderFactory.KEY_PASSWORD_KEY).toCharArray());
+        PublicKey publicKey = KeyUtils.extractPublicKey(privateKey);
+
+        KeyPair keyPair = new KeyPair(publicKey, privateKey);
+
+        return createKeyWrapper(keyPair, getCertificate(keyStore, keyPair, keyAlias, realm.getName()), loadCertificateChain(keyStore, keyAlias), KeyType.RSA);
+    }
+
     private List<X509Certificate> loadCertificateChain(KeyStore keyStore, String keyAlias) throws GeneralSecurityException {
         List<X509Certificate> chain = Optional.ofNullable(keyStore.getCertificateChain(keyAlias))
                 .map(certificates -> Arrays.stream(certificates)
@@ -110,6 +170,34 @@ public class JavaKeystoreKeyProvider extends AbstractRsaKeyProvider {
         validateCertificateChain(chain);
 
         return chain;
+    }
+
+    private KeyWrapper createKeyWrapper(KeyPair keyPair, X509Certificate certificate, List<X509Certificate> certificateChain, String type) {
+        KeyUse keyUse = KeyUse.valueOf(model.get(Attributes.KEY_USE, KeyUse.SIG.getSpecName()).toUpperCase());
+
+        KeyWrapper key = new KeyWrapper();
+
+        key.setProviderId(model.getId());
+        key.setProviderPriority(model.get("priority", 0L));
+
+        key.setKid(model.get(Attributes.KID_KEY) != null ? model.get(Attributes.KID_KEY) : KeyUtils.createKeyId(keyPair.getPublic()));
+        key.setUse(keyUse);
+        key.setType(type);
+        key.setAlgorithm(algorithm);
+        key.setStatus(status);
+        key.setPrivateKey(keyPair.getPrivate());
+        key.setPublicKey(keyPair.getPublic());
+        key.setCertificate(certificate);
+
+        if (!certificateChain.isEmpty()) {
+            if (certificate != null && !certificate.equals(certificateChain.get(0))) {
+                // just in case the chain does not contain the end-user certificate
+                certificateChain.add(0, certificate);
+            }
+            key.setCertificateChain(certificateChain);
+        }
+
+        return key;
     }
 
     /**
@@ -139,5 +227,11 @@ public class JavaKeystoreKeyProvider extends AbstractRsaKeyProvider {
         CertPathValidator validator = CertPathValidator.getInstance(CertPathValidator.getDefaultType());
 
         validator.validate(certPath, params);
+    }
+
+
+    @Override
+    public Stream<KeyWrapper> getKeysStream() {
+        return Stream.of(key);
     }
 }

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
@@ -23,12 +23,15 @@ import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.KeystoreUtil;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.component.ComponentValidationException;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ConfigurationValidationHelper;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.keycloak.provider.ProviderConfigProperty.LIST_TYPE;
 import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
@@ -36,7 +39,7 @@ import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class JavaKeystoreKeyProviderFactory extends AbstractRsaKeyProviderFactory {
+public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
     private static final Logger logger = Logger.getLogger(JavaKeystoreKeyProviderFactory.class);
 
     public static final String ID = "java-keystore";
@@ -62,6 +65,7 @@ public class JavaKeystoreKeyProviderFactory extends AbstractRsaKeyProviderFactor
 
     private List<ProviderConfigProperty> configProperties;
 
+
     @Override
     public void init(Config.Scope config) {
         String[] supportedKeystoreTypes = CryptoIntegration.getProvider().getSupportedKeyStoreTypes()
@@ -71,7 +75,11 @@ public class JavaKeystoreKeyProviderFactory extends AbstractRsaKeyProviderFactor
                 "Keystore type. This parameter is not mandatory. If omitted, the type will be detected from keystore file or default keystore type will be used", LIST_TYPE,
                 supportedKeystoreTypes.length > 0 ? supportedKeystoreTypes[0] : null, supportedKeystoreTypes);
 
-        configProperties = AbstractRsaKeyProviderFactory.configurationBuilder()
+        configProperties = ProviderConfigurationBuilder.create()
+                .property(Attributes.PRIORITY_PROPERTY)
+                .property(Attributes.ENABLED_PROPERTY)
+                .property(Attributes.ACTIVE_PROPERTY)
+                .property(mergedAlgorithmProperties())
                 .property(KEYSTORE_PROPERTY)
                 .property(KEYSTORE_PASSWORD_PROPERTY)
                 .property(keystoreTypeProperty)
@@ -88,9 +96,11 @@ public class JavaKeystoreKeyProviderFactory extends AbstractRsaKeyProviderFactor
 
     @Override
     public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel model) throws ComponentValidationException {
-        super.validateConfiguration(session, realm, model);
 
         ConfigurationValidationHelper.check(model)
+                .checkLong(Attributes.PRIORITY_PROPERTY, false)
+                .checkBoolean(Attributes.ENABLED_PROPERTY, false)
+                .checkBoolean(Attributes.ACTIVE_PROPERTY, false)
                 .checkSingle(KEYSTORE_PROPERTY, true)
                 .checkSingle(KEYSTORE_PASSWORD_PROPERTY, true)
                 .checkSingle(keystoreTypeProperty, false)
@@ -103,6 +113,14 @@ public class JavaKeystoreKeyProviderFactory extends AbstractRsaKeyProviderFactor
             logger.error("Failed to load keys.", t);
             throw new ComponentValidationException("Failed to load keys. " + t.getMessage(), t);
         }
+    }
+
+    // merge the algorithms supported for RSA and EC keys and provide them as one configuration property
+    private static ProviderConfigProperty mergedAlgorithmProperties() {
+        List<String> ecAlgorithms = List.of(Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
+        List<String> algorithms = Stream.concat(Attributes.RS_ALGORITHM_PROPERTY.getOptions().stream(), ecAlgorithms.stream()).toList();
+        return new ProviderConfigProperty(Attributes.ALGORITHM_KEY, "Algorithm", "Intended algorithm for the key", LIST_TYPE, algorithms.toArray());
+
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/KeystoreUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/KeystoreUtils.java
@@ -63,16 +63,15 @@ public class KeystoreUtils {
                         .anyMatch(type -> type.equals(keystoreType.toString())));
     }
 
-    public static KeystoreInfo generateKeystore(TemporaryFolder folder, KeystoreUtil.KeystoreFormat keystoreType, String subject, String keystorePassword, String keyPassword) throws Exception {
-        String fileName = "keystore." + keystoreType.getPrimaryExtension();
+    public static KeystoreInfo generateKeystore(TemporaryFolder folder, KeystoreUtil.KeystoreFormat keystoreType, String subject, String keystorePassword, String keyPassword, KeyPair keyPair) throws Exception {
+        String fileName = "keystore." + keystoreType.getFileExtension();
 
-        KeyPair keyPair = KeyUtils.generateRsaKeyPair(2048);
         X509Certificate certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, subject);
 
         KeyStore keyStore = CryptoIntegration.getProvider().getKeyStore(keystoreType);
         keyStore.load(null, null);
 
-        Certificate[] chain =  {certificate};
+        Certificate[] chain = {certificate};
         keyStore.setKeyEntry(subject, keyPair.getPrivate(), keyPassword.trim().toCharArray(), chain);
 
         File file = folder.newFile(fileName);
@@ -83,6 +82,10 @@ public class KeystoreUtils {
         certRep.setPublicKey(PemUtils.encodeKey(keyPair.getPublic()));
         certRep.setCertificate(PemUtils.encodeCertificate(certificate));
         return new KeystoreInfo(certRep, file);
+    }
+
+    public static KeystoreInfo generateKeystore(TemporaryFolder folder, KeystoreUtil.KeystoreFormat keystoreType, String subject, String keystorePassword, String keyPassword) throws Exception {
+        return generateKeystore(folder, keystoreType, subject, keystorePassword, keyPassword, KeyUtils.generateRsaKeyPair(2048));
     }
 
     public static class KeystoreInfo {


### PR DESCRIPTION
Adds support for the import of EC Keys with the JavaKeystoreKeyProvider. 
closes #26936 