### PR TITLE
fix: increasing the default max-form-attribute-size

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -44,7 +44,7 @@ quarkus.log.category."io.quarkus.deployment.steps.ReflectiveHierarchyStep".level
 quarkus.transaction-manager.object-store.directory=${kc.home.dir:default}${file.separator}data${file.separator}transaction-logs
 
 # Sets the minimum size for a form attribute
-quarkus.http.limits.max-form-attribute-size=32768
+quarkus.http.limits.max-form-attribute-size=131072
 
 # Configure the content-types that should be recognized as file parts when processing multipart form requests
 quarkus.http.body.multipart.file-content-types=application/octet-stream


### PR DESCRIPTION
Follows the resolution proposed in https://github.com/keycloak/keycloak/issues/26330#issuecomment-1907943118

Noone proposed making this a first class configuration value, so this seems sufficient.

closes: #26330

cc @pedroigor @rmartinc @sschu 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
