### PR TITLE
Throw meaningful error message for invalid session codes

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1072,9 +1072,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
      */
     private AuthenticationSessionModel parseSessionCode(String code, String clientId, String tabId) {
         if (code == null || clientId == null || tabId == null) {
-            logger.debugf("Invalid request. Authorization code, clientId or tabId was null. Code=%s, clientId=%s, tabID=%s", code, clientId, tabId);
-            Response staleCodeError = redirectToErrorPage(Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);
-            throw new WebApplicationException(staleCodeError);
+            String error = String.format("Invalid request. Authorization code, clientId or tabId was null. Code=%s, clientId=%s, tabID=%s", code, clientId, tabId);
+            throw new WebApplicationException(error);
         }
 
         SessionCodeChecks checks = new SessionCodeChecks(realmModel, session.getContext().getUri(), request, clientConnection, session, event, null, code, null, clientId, tabId, LoginActionsService.AUTHENTICATE_PATH);


### PR DESCRIPTION
Our keycloak instance regularly logs error messages like the following:
```
"message":{"message":"unexpectedErrorHandlingRequestMessage"},
"error":{"type":"javax.ws.rs.WebApplicationException","message":"HTTP 200 OK","stack_trace":"javax.ws.rs.WebApplicationException: HTTP 200 OK\n\tat org.keycloak.services.resources.IdentityBrokerService.parseSessionCode(IdentityBrokerService.java:1083)\n\tat org.keycloak.services.resources.IdentityBrokerService.performLogin(IdentityBrokerService.java:375)...
```

These messages are a bit confusing as the error details describe a 200: OK response which typically means success.  I believe this was a simple miss on a previous refactor of this code that used to redirect to an error screen, but now throws an exception to be handled later.  See this [PR](https://github.com/keycloak/keycloak/commit/41dc94fead4c20560e0dd96c3efbd7bd10a484b6#diff-e44efb607cb8cb833e99677c01e7fc10d67afc6ee54ce4faf06a01f5acaf50e7L1074) for when I believe this issue was introduced.

This PR simply changes the content of the exception that is thrown to contain a somewhat more meaningful error message.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
