### PR TITLE
25731 admin realms realm groups endpoint is slow backport to kc23

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
@@ -258,7 +258,7 @@ public class GroupAdapter implements GroupModel {
     @Override
     public Long getSubGroupsCount() {
         if (isUpdated()) return updated.getSubGroupsCount();
-        return modelSupplier.get().getSubGroupsCount();
+        return cached.getSubGroupsCount(modelSupplier);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
@@ -41,6 +41,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
     private final LazyLoader<GroupModel, MultivaluedHashMap<String, String>> attributes;
     private final LazyLoader<GroupModel, Set<String>> roleMappings;
     private final LazyLoader<GroupModel, Set<String>> subGroups;
+    private final LazyLoader<GroupModel, Long> subGroupsCount;
 
     public CachedGroup(Long revision, RealmModel realm, GroupModel group) {
         super(revision, group.getId());
@@ -50,6 +51,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
         this.attributes = new DefaultLazyLoader<>(source -> new MultivaluedHashMap<>(source.getAttributes()), MultivaluedHashMap::new);
         this.roleMappings = new DefaultLazyLoader<>(source -> source.getRoleMappingsStream().map(RoleModel::getId).collect(Collectors.toSet()), Collections::emptySet);
         this.subGroups = new DefaultLazyLoader<>(source -> source.getSubGroupsStream().map(GroupModel::getId).collect(Collectors.toSet()), Collections::emptySet);
+        this.subGroupsCount = new DefaultLazyLoader<>(GroupModel::getSubGroupsCount, () -> 0L);
     }
 
     public String getRealm() {
@@ -78,5 +80,9 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
 
     public Set<String> getSubGroups(Supplier<GroupModel> group) {
         return subGroups.get(group);
+    }
+
+    public Long getSubGroupsCount(Supplier<GroupModel> group) {
+        return subGroupsCount.get(group);
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -100,13 +100,11 @@ public class GroupsResource {
             stream = ModelToRepresentation.searchGroupModelsByAttributes(session, realm, attributes, firstResult, maxResults);
         } else if (Objects.nonNull(search)) {
             stream = session.groups().searchForGroupByNameStream(realm, search.trim(), exact, firstResult, maxResults);
-        } else if(Objects.nonNull(firstResult) && Objects.nonNull(maxResults)) {
-            stream = session.groups().getTopLevelGroupsStream(realm, firstResult, maxResults);
         } else {
-            stream = session.groups().getTopLevelGroupsStream(realm);
+            stream = session.groups().getTopLevelGroupsStream(realm, firstResult, maxResults);
         }
 
-        if(populateHierarchy) {
+        if (populateHierarchy) {
             return GroupUtils.populateGroupHierarchyFromSubGroups(session, realm, stream, !briefRepresentation, groupsEvaluator);
         }
         boolean canViewGlobal = groupsEvaluator.canView();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -1146,8 +1146,20 @@ public class GroupTest extends AbstractGroupTest {
         List<GroupRepresentation> allGroups = realm.groups().groups();
         assertEquals(20, allGroups.size());
 
-        List<GroupRepresentation> slice = realm.groups().groups(5, 7);
+        List<GroupRepresentation> slice = realm.groups().groups(0, 7);
         assertEquals(7, slice.size());
+
+        slice = realm.groups().groups(null, 7);
+        assertEquals(7, slice.size());
+
+        slice = realm.groups().groups(10, null);
+        assertEquals(10, slice.size());
+
+        slice = realm.groups().groups(5, 7);
+        assertEquals(7, slice.size());
+
+        slice = realm.groups().groups(15, 7);
+        assertEquals(5, slice.size());
 
         List<GroupRepresentation> search = realm.groups().groups("group1",0,20);
         assertEquals(11, search.size());


### PR DESCRIPTION
Closes #25731 

Backport to KC23 of https://github.com/keycloak/keycloak/pull/26904

Cherrypick of https://github.com/keycloak/keycloak/commit/e55ba5dcdc254b281ec97551aaafa39e55b1cdf9 and https://github.com/keycloak/keycloak/commit/f7f7f1bd1027614d6119b38f3d63819f9559a38f
