### PR TITLE
UPDATED_PASSWORD required-action triggered only when login using password

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import static org.keycloak.services.managers.AuthenticationManager.FORCED_REAUTHENTICATION;
 import static org.keycloak.services.managers.AuthenticationManager.SSO_AUTH;
+import static org.keycloak.services.managers.AuthenticationManager.PASSWORD_VALIDATED;
 
 public class AuthenticatorUtil {
 
@@ -56,6 +57,10 @@ public class AuthenticatorUtil {
 
     public static boolean isForcedReauthentication(AuthenticationSessionModel authSession) {
         return "true".equals(authSession.getAuthNote(FORCED_REAUTHENTICATION));
+    }
+
+    public static boolean isPasswordValidated(AuthenticationSessionModel authSession) {
+        return "true".equals(authSession.getAuthNote(PASSWORD_VALIDATED));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -228,6 +228,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         if (isDisabledByBruteForce(context, user)) return false;
 
         if (password != null && !password.isEmpty() && user.credentialManager().isValid(UserCredentialModel.password(password))) {
+            context.getAuthenticationSession().setAuthNote(AuthenticationManager.PASSWORD_VALIDATED, "true");
             return true;
         } else {
             return badPasswordHandler(context, user, clearUser,false);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java
@@ -30,6 +30,8 @@ import org.keycloak.representations.idm.CredentialRepresentation;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import org.keycloak.services.managers.AuthenticationManager;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -52,7 +54,7 @@ public class ValidatePassword extends AbstractDirectGrantAuthenticator {
             context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return;
         }
-
+        context.getAuthenticationSession().setAuthNote(AuthenticationManager.PASSWORD_VALIDATED, "true");
         context.success();
     }
 

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
@@ -71,6 +71,9 @@ public class UpdatePassword implements RequiredActionProvider, RequiredActionFac
     
     @Override
     public void evaluateTriggers(RequiredActionContext context) {
+        if(!AuthenticatorUtil.isPasswordValidated(context.getAuthenticationSession())) {
+            return;
+        }
         int daysToExpirePassword = context.getRealm().getPasswordPolicy().getDaysToExpirePassword();
         if(daysToExpirePassword != -1) {
             PasswordCredentialProvider passwordProvider = (PasswordCredentialProvider)context.getSession().getProvider(CredentialProvider.class, PasswordCredentialProviderFactory.PROVIDER_ID);

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -148,6 +148,9 @@ public class AuthenticationManager {
     // authSession note with flag that is true if user is forced to re-authenticate by client (EG. in case of OIDC client by sending "prompt=login")
     public static final String FORCED_REAUTHENTICATION = "FORCED_REAUTHENTICATION";
 
+    // authSession note with flag that is true if the user's password has been correctly validated
+    public static final String PASSWORD_VALIDATED = "PASSWORD_VALIDATED";
+
     protected static final Logger logger = Logger.getLogger(AuthenticationManager.class);
 
     public static final String FORM_USERNAME = "username";


### PR DESCRIPTION
`UpdatePassword.evaluateTriggers` adds the required-action to the user by evaluating the expiration password policy. Added a check that skips the evaluation if no password used during auth flow. This check uses the value of an auth note set in the `validatePassword` method of the `AbstractUsernameFormAuthenticator`. 
Manually adding UPDATED_PASSWORD required-action to the user continues to trigger the action regardless of the authentication method.

Closes #17155
