### PR TITLE
Remove the preview note from Keycloak's HA guide

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -104,7 +104,7 @@ public class Profile {
 
         TRANSIENT_USERS("Transient users for brokering", Type.EXPERIMENTAL),
 
-        MULTI_SITE("Multi-site support", Type.PREVIEW),
+        MULTI_SITE("Multi-site support", Type.DISABLED_BY_DEFAULT),
 
         CLIENT_TYPES("Client Types", Type.EXPERIMENTAL),
 

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -96,7 +96,7 @@ public class ProfileTest {
             disabledFeatures.add(Profile.Feature.KERBEROS);
         }
         assertEquals(profile.getDisabledFeatures(), disabledFeatures);
-        assertEquals(profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.MULTI_SITE, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL, Profile.Feature.DPOP);
+        assertEquals(profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL, Profile.Feature.DPOP);
     }
 
     @Test

--- a/docs/guides/high-availability/bblocks-active-passive-sync.adoc
+++ b/docs/guides/high-availability/bblocks-active-passive-sync.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Building blocks active-passive deployments"
-summary="Overview of building blocks, alternatives and not considered options"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="Overview of building blocks, alternatives and not considered options" >
 
 The following building blocks are needed to set up an active-passive deployment with synchronous replication.
 

--- a/docs/guides/high-availability/concepts-active-passive-sync.adoc
+++ b/docs/guides/high-availability/concepts-active-passive-sync.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Concepts for active-passive deployments"
-summary="Understanding an active-passive deployment with synchronous replication"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="Understanding an active-passive deployment with synchronous replication" >
 
 This topic describes a highly available active/passive setup and the behavior to expect. It outlines the requirements of the high availability active/passive architecture and describes the benefits and tradeoffs.
 

--- a/docs/guides/high-availability/concepts-database-connections.adoc
+++ b/docs/guides/high-availability/concepts-database-connections.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Concepts for database connection pools"
 summary="Understand these concepts to avoid resource exhaustion and congestion"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 This section is intended when you want to understand considerations and best practices on how to configure database connection pools for {project_name}.

--- a/docs/guides/high-availability/concepts-infinispan-cli-batch.adoc
+++ b/docs/guides/high-availability/concepts-infinispan-cli-batch.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Concepts to automate {jdgserver_name} CLI commands"
 summary="{jdgserver_name} CLI commands can be automated by creating a `Batch` CR instance."
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 include::partials/infinispan/infinispan-attributes.adoc[]

--- a/docs/guides/high-availability/concepts-memory-and-cpu-sizing.adoc
+++ b/docs/guides/high-availability/concepts-memory-and-cpu-sizing.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Concepts for sizing CPU and memory resources"
 summary="Understand these concepts to avoid resource exhaustion and congestion"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 Use this as a starting point to size a product environment. 

--- a/docs/guides/high-availability/concepts-threads.adoc
+++ b/docs/guides/high-availability/concepts-threads.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Concepts for configuring thread pools"
 summary="Understand these concepts to avoid resource exhaustion and congestion"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 

--- a/docs/guides/high-availability/connect-keycloak-to-external-infinispan.adoc
+++ b/docs/guides/high-availability/connect-keycloak-to-external-infinispan.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Connect {project_name} with an external {jdgserver_name}"
 summary="Building block for an Infinispan deployment on Kubernetes"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 This topic describes advanced {jdgserver_name} configurations for {project_name} on Kubernetes.

--- a/docs/guides/high-availability/deploy-aurora-multi-az.adoc
+++ b/docs/guides/high-availability/deploy-aurora-multi-az.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Deploy AWS Aurora in multiple availability zones"
 summary="Building block for a database"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 This topic describes how to deploy an Aurora regional deployment of a PostgreSQL instance across multiple availability zones to tolerate one or more availability zone failures in a given AWS region.

--- a/docs/guides/high-availability/deploy-aws-route53-loadbalancer.adoc
+++ b/docs/guides/high-availability/deploy-aws-route53-loadbalancer.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Deploy an AWS Route 53 loadbalancer"
 summary="Building block for a loadbalancer"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 This topic describes the procedure required to configure DNS based failover for Multi-AZ {project_name} clusters using AWS Route53 for an active/passive setup. These instructions are intended for used with the setup described in the <@links.ha id="concepts-active-passive-sync"/> {section}.

--- a/docs/guides/high-availability/deploy-infinispan-kubernetes-crossdc.adoc
+++ b/docs/guides/high-availability/deploy-infinispan-kubernetes-crossdc.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Deploy {jdgserver_name} for HA with the {jdgserver_name} Operator"
 summary="Building block for an {jdgserver_name} deployment on Kubernetes"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 include::partials/infinispan/infinispan-attributes.adoc[]

--- a/docs/guides/high-availability/deploy-keycloak-kubernetes.adoc
+++ b/docs/guides/high-availability/deploy-keycloak-kubernetes.adoc
@@ -4,8 +4,6 @@
 <@tmpl.guide
 title="Deploy {project_name} for HA with the {project_name} Operator"
 summary="Building block for a {project_name} deployment"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269"
 tileVisible="false" >
 
 This guide describes advanced {project_name} configurations for Kubernetes which are load tested and will recover from single Pod failures.

--- a/docs/guides/high-availability/introduction.adoc
+++ b/docs/guides/high-availability/introduction.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Multi-site deployments"
-summary="Connect multiple {project_name} deployments in different sites to increase the overall availability"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="Connect multiple {project_name} deployments in different sites to increase the overall availability" >
 
 {project_name} supports deployments that consist of multiple {project_name} instances that connect to each other using its embedded Infinispan; load balancers can distribute the load evenly across those instances.
 Those setups are intended for a transparent network on a single site.

--- a/docs/guides/high-availability/operate-failover.adoc
+++ b/docs/guides/high-availability/operate-failover.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Fail over to the secondary site"
-summary="This describes the automatic and operational procedures necessary"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="This describes the automatic and operational procedures necessary" >
 
 This {section} describes the steps to fail over from primary site to secondary site in a setup as outlined in <@links.ha id="concepts-active-passive-sync" /> together with the blueprints outlined in <@links.ha id="bblocks-active-passive-sync" />.
 

--- a/docs/guides/high-availability/operate-network-partition-recovery.adoc
+++ b/docs/guides/high-availability/operate-network-partition-recovery.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Recover from an out-of-sync passive site"
-summary="This describes the automatic and operational procedures necessary"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="This describes the automatic and operational procedures necessary" >
 
 This {section} describes the procedures required to synchronize the secondary site with the primary site in a setup as outlined in <@links.ha id="concepts-active-passive-sync" /> together with the blueprints outlined in <@links.ha id="bblocks-active-passive-sync" />.
 

--- a/docs/guides/high-availability/operate-switch-back.adoc
+++ b/docs/guides/high-availability/operate-switch-back.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Switch back to the primary site"
-summary="This describes the operational procedures necessary"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="This describes the operational procedures necessary" >
 
 These procedures switch back to the primary site back after a failover or switchover to the secondary site.
 In a setup as outlined in <@links.ha id="concepts-active-passive-sync" /> together with the blueprints outlined in <@links.ha id="bblocks-active-passive-sync" />.

--- a/docs/guides/high-availability/operate-switch-over.adoc
+++ b/docs/guides/high-availability/operate-switch-over.adoc
@@ -3,9 +3,7 @@
 
 <@tmpl.guide
 title="Switch over to the secondary site"
-summary="This topic describes the operational procedures necessary"
-preview="true"
-previewDiscussionLink="https://github.com/keycloak/keycloak/discussions/25269" >
+summary="This topic describes the operational procedures necessary" >
 
 This procedure switches from the primary site to the secondary site when using a setup as outlined in <@links.ha id="concepts-active-passive-sync" /> together with the blueprints outlined in <@links.ha id="bblocks-active-passive-sync" />.
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -26,7 +26,7 @@ import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTI
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class FeaturesDistTest {
 
-    private static final String PREVIEW_FEATURES_EXPECTED_LOG = "Preview features enabled: admin-fine-grained-authz:v1, client-secret-rotation:v1, dpop:v1, multi-site:v1, recovery-codes:v1, scripts:v1, token-exchange:v1, update-email:v1";
+    private static final String PREVIEW_FEATURES_EXPECTED_LOG = "Preview features enabled: admin-fine-grained-authz:v1, client-secret-rotation:v1, dpop:v1, recovery-codes:v1, scripts:v1, token-exchange:v1, update-email:v1";
 
     @Test
     public void testEnableOnBuild(KeycloakDistribution dist) {


### PR DESCRIPTION
Closes #27084 

Hold until the following epics are done: 
* #26491
* #26496

Make the multi-site feature non-preview, but also not enabled by default

Update: Epics are done for the functionality, to this is now ready to be merged.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
