### PR TITLE
Fix MembershipType so that NPE is not thrown when an empty member is …

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
@@ -63,7 +63,7 @@ public enum MembershipType {
             Set<LDAPDn> result = new HashSet<>();
             for (String membership : allMemberships) {
                 LDAPDn childDn = LDAPDn.fromString(membership);
-                if (childDn.getFirstRdn().getAttrValue(rdnAttr) != null && childDn.isDescendantOf(requiredParentDn)) {
+                if (childDn.isDescendantOf(requiredParentDn) && childDn.getFirstRdn().getAttrValue(rdnAttr) != null) {
                     result.add(childDn);
                 }
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
@@ -513,7 +513,13 @@ public class LDAPGroupMapperTest extends AbstractLDAPTest {
             nonExistentLdapUser.setDn(nonExistentDn);
             LDAPUtils.addMember(ldapProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group2, nonExistentLdapUser);
 
-            // 4 - Check group members. Just existing user rob should be present
+            // 4 - Add an empty member to the same LDAP group
+            LDAPDn emptyDn = LDAPDn.fromString("");
+            LDAPObject emptyUser = new LDAPObject();
+            emptyUser.setDn(emptyDn);
+            LDAPUtils.addMember(ldapProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group2, emptyUser);
+
+            // 5 - Check group members. Just existing user rob should be present
             groupMapper.syncDataFromFederationProviderToKeycloak(appRealm);
             GroupModel kcGroup2 = KeycloakModelUtils.findGroupByPath(session, appRealm, "/group2");
             List<UserModel> groupUsers = session.users().getGroupMembersStream(appRealm, kcGroup2, 0, 5)


### PR DESCRIPTION
…found within a group

Closes #25883

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit d3ae075a33eebf91e171312a17a6edde13a2b5f3)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
