### PR TITLE
Avoid changing the config value for the useTruststoreSpi property

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -66,11 +66,7 @@ public class LDAPConfig {
 
     public String getUseTruststoreSpi() {
         String value = config.getFirst(LDAPConstants.USE_TRUSTSTORE_SPI);
-        if (LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY.equals(value)) {
-            value = LDAPConstants.USE_TRUSTSTORE_ALWAYS;
-            config.putSingle(LDAPConstants.USE_TRUSTSTORE_SPI, value);
-        }
-        return value;
+        return LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY.equals(value) ? LDAPConstants.USE_TRUSTSTORE_ALWAYS : value;
     }
 
     public String getUsersDn() {


### PR DESCRIPTION
- prevents cached LDAPConfig entry from changing when retrieving this value

Closes #25912

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit eac43822c342802512e226f9692c91aa12ae4fef)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
