### PR TITLE
Check if kerberos auth is enabled before creating the kerberos princi…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -569,7 +569,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
         if(getLdapIdentityStore().getConfig().isTrustEmail()){
             imported.setEmailVerified(true);
         }
-        if (kerberosConfig.getKerberosPrincipalAttribute() != null) {
+        if (kerberosConfig.isAllowKerberosAuthentication() && kerberosConfig.getKerberosPrincipalAttribute() != null) {
             String kerberosPrincipal = ldapUser.getAttributeAsString(kerberosConfig.getKerberosPrincipalAttribute());
             if (kerberosPrincipal == null) {
                 logger.warnf("Kerberos principal attribute not found on LDAP user [%s]. Configured kerberos principal attribute name is [%s]", ldapUser.getDn(), kerberosConfig.getKerberosPrincipalAttribute());


### PR DESCRIPTION
…pal in LDAPStorageProvider

- prevents misleading warn messages from being logged

Closes #25294

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit 143ccbfa152f02b3df3882adfb6ccff4ad29d1a7)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
