### PR TITLE
Add `proxy-headers` option to the Keycloak CR

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-24_0_0.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-24_0_0.adoc
@@ -174,6 +174,25 @@ The `--proxy` option has been deprecated and will be removed in a future release
 NOTE: For hardened security, the `--proxy-headers` option does not allow selecting both `forwarded` and `xforwarded` values at the same time (as it was
 the case before for `--proxy edge` and `--proxy reencrypt`).
 
+WARNING: When using the proxy headers option, make sure your reverse proxy properly sets and overwrites the `Forwarded` or `X-Forwarded-*` headers respectively.
+To set these headers, consult the documentation for your reverse proxy. Misconfiguration will leave {project_name} exposed to security vulnerabilities.
+
+You can also set the proxy headers when using the Operator:
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  ...
+  proxy:
+    headers: forwarded|xforwarded
+----
+NOTE: If the `proxy.headers` field is not specified, the Operator falls back to the previous behaviour by implicitly setting
+`proxy=passthrough` by default. This results in deprecation warnings in the server log. This fallback will be removed
+in a future release.
+
 = Changes to the user representation in both Admin API and Account contexts
 
 Both `org.keycloak.representations.idm.UserRepresentation` and `org.keycloak.representations.account.UserRepresentation` representation classes have changed

--- a/docs/guides/operator/basic-deployment.adoc
+++ b/docs/guides/operator/basic-deployment.adoc
@@ -152,6 +152,8 @@ spec:
     tlsSecret: example-tls-secret
   hostname:
     hostname: test.keycloak.org
+  proxy:
+    headers: xforwarded # double check your reverse proxy sets and overwrites the X-Forwarded-* headers
 ----
 
 Apply the changes:
@@ -232,6 +234,34 @@ For debugging and development purposes, consider directly connecting to the {pro
 ----
 kubectl port-forward service/example-kc-service 8443:8443
 ----
+
+==== Configuring the reverse proxy settings matching your Ingress Controller
+
+The Operator supports configuring which of the reverse proxy headers should be accepted by server, which includes
+`Forwarded` and `X-Forwarded-*` headers.
+
+If you Ingress implementation sets and overwrites either `Forwarded` or `X-Forwarded-*` headers, you can reflect that
+in the Keycloak CR as follows:
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  ...
+  proxy:
+    headers: forwarded|xforwarded
+----
+NOTE: If the `proxy.headers` field is not specified, the Operator falls back to legacy behaviour by implicitly setting
+`proxy=passthrough` by default. This results in deprecation warnings in the server log. This fallback will be removed
+in a future release.
+
+WARNING: When using the `proxy.headers` field, make sure your Ingress properly sets and overwrites the `Forwarded` or `X-Forwarded-*` headers respectively. To set these headers, consult the documentation for your Ingress Controller. Consider configuring it for
+either reencrypt or edge TLS termination as passthrough TLS doesn't allow the Ingress to modify the requests headers.
+Misconfiguration will leave {project_name} exposed to security vulnerabilities.
+
+For more details refer to the <@links.server id="reverseproxy"/> guide.
 
 === Accessing the Admin Console
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -32,6 +32,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.DatabaseSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.ProxySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TransactionsSpec;
 
 import java.util.ArrayList;
@@ -68,6 +69,7 @@ public class KeycloakDistConfigurator {
         configureHttp();
         configureDatabase();
         configureCache();
+        configureProxy();
     }
 
     /**
@@ -128,6 +130,11 @@ public class KeycloakDistConfigurator {
                 .mapOption("db-pool-initial-size", DatabaseSpec::getPoolInitialSize)
                 .mapOption("db-pool-min-size", DatabaseSpec::getPoolMinSize)
                 .mapOption("db-pool-max-size", DatabaseSpec::getPoolMaxSize);
+    }
+
+    void configureProxy() {
+        optionMapper(keycloakCR -> keycloakCR.getSpec().getProxySpec())
+                .mapOption("proxy-headers", ProxySpec::getHeaders);
     }
 
     /* ---------- END of configuration of first-class citizen fields ---------- */

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -26,6 +26,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.ProxySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TransactionsSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.Truststore;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.UnsupportedSpec;
@@ -99,6 +100,10 @@ public class KeycloakSpec {
     @JsonProperty("resources")
     @JsonPropertyDescription("Compute Resources required by Keycloak container")
     private ResourceRequirements resourceRequirements;
+
+    @JsonProperty("proxy")
+    @JsonPropertyDescription("In this section you can configure Keycloak's reverse proxy setting")
+    private ProxySpec proxySpec;
 
     public HttpSpec getHttpSpec() {
         return httpSpec;
@@ -226,4 +231,11 @@ public class KeycloakSpec {
         this.resourceRequirements = resourceRequirements;
     }
 
+    public ProxySpec getProxySpec() {
+        return proxySpec;
+    }
+
+    public void setProxySpec(ProxySpec proxySpec) {
+        this.proxySpec = proxySpec;
+    }
 }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/ProxySpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/ProxySpec.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.crds.v2alpha1.deployment.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class ProxySpec {
+    @JsonPropertyDescription("The proxy headers that should be accepted by the server. Misconfiguration might leave the server exposed to security vulnerabilities.")
+    private String headers;
+
+    public String getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(String headers) {
+        this.headers = headers;
+    }
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -158,20 +158,13 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
         var defaultKCDeploy = getTestKeycloakDeployment(true);
 
         var valueSecretHealthProp = new ValueOrSecret("health-enabled", "false");
-        var valueSecretProxyProp = new ValueOrSecret("proxy", "reencrypt");
 
         var healthEnvVar = new EnvVarBuilder()
                 .withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(valueSecretHealthProp.getName()))
                 .withValue(valueSecretHealthProp.getValue())
                 .build();
 
-        var proxyEnvVar = new EnvVarBuilder()
-                .withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(valueSecretProxyProp.getName()))
-                .withValue(valueSecretProxyProp.getValue())
-                .build();
-
         defaultKCDeploy.getSpec().getAdditionalOptions().add(valueSecretHealthProp);
-        defaultKCDeploy.getSpec().getAdditionalOptions().add(valueSecretProxyProp);
 
         deployKeycloak(k8sclient, defaultKCDeploy, false);
 
@@ -182,14 +175,6 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                                                   .get()
                                                   .getValue()
         ).isEqualTo("true"); // just a sanity check default values did not change
-
-        assertThat(
-                Constants.DEFAULT_DIST_CONFIG_LIST.stream()
-                                                  .filter(oneValueOrSecret -> oneValueOrSecret.getName().equalsIgnoreCase(valueSecretProxyProp.getName()))
-                                                  .findFirst()
-                                                  .get()
-                                                  .getValue()
-        ).isEqualTo("passthrough"); // just a sanity check default values did not change
 
         Awaitility.await()
                 .ignoreExceptions()
@@ -212,10 +197,6 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                     assertThat(firstKCContainer.getEnv().stream()
                             .filter(oneEnvVar -> oneEnvVar.getName().equalsIgnoreCase(healthEnvVar.getName())))
                             .containsExactly(healthEnvVar);
-
-                    assertThat(firstKCContainer.getEnv().stream()
-                            .filter(oneEnvVar -> oneEnvVar.getName().equalsIgnoreCase(proxyEnvVar.getName())))
-                            .containsExactly(proxyEnvVar);
 
                 });
     }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -135,6 +135,15 @@ public class KeycloakDistConfiguratorTest {
         assertEnvVarNotPresent(envVars, "KC_HOSTNAME_STRICT_BACKCHANNEL");
     }
 
+    @Test
+    public void proxy() {
+        final Map<String, String> expectedValues = Map.of(
+                "proxy-headers", "forwarded"
+        );
+
+        testFirstClassCitizen(expectedValues);
+    }
+
     /* UTILS */
 
     private void testFirstClassCitizen(Map<String, String> expectedValues) {

--- a/operator/src/test/resources/example-keycloak.yaml
+++ b/operator/src/test/resources/example-keycloak.yaml
@@ -17,3 +17,5 @@ spec:
     tlsSecret: example-tls-secret
   hostname:
     hostname: example.com
+  proxy:
+    headers: xforwarded # default nginx ingress sets x-forwarded

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -63,6 +63,8 @@ spec:
     limits:
       cpu: "2"
       memory: "1500M"
+  proxy:
+    headers: forwarded
   unsupported:
     podTemplate:
       metadata:

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/ConstantsDebugHostname.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/ConstantsDebugHostname.java
@@ -37,6 +37,7 @@ public class ConstantsDebugHostname {
             "hostname-path",
             "hostname-port",
             "proxy",
+            "proxy-headers",
             "http-enabled",
             "http-relative-path",
             "http-port",


### PR DESCRIPTION
Closes #25179

I considered setting some default value for the `proxy-headers` option but I decided not to do that in the end. There are too many moving parts to safely assume if the Ingress really overwrites the proxy headers and which of them. Initially, I [implemented the defaults](https://github.com/vmuzikar/keycloak/commit/5a7982eca60c989a48cd87cb1664d3244c4a12e5) at least for OpenShift's default ingressClass but turned out we could only use that if TLS is not configured (i.e. the edge termination), and we don't currently reflect reencrypt termination in the Operator. It did not make sense to me to implement the logic for just this one use case as it seemed inconsistent to me. But let me know if you think otherwise.