### PR TITLE
Distinguish user registration action label from the security key registration action's one

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ar.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ar.properties
@@ -1,5 +1,6 @@
 doLogIn=تسجيل دخول
 doRegister=تسجيل جديد
+doRegisterSecurityKey=تسجيل جديد
 doCancel=إلغاء
 doSubmit=إرسال
 doBack=رجوع

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ca.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ca.properties
@@ -1,5 +1,6 @@
 doLogIn=Inicia la sessió
 doRegister=Registreu-vos
+doRegisterSecurityKey=Registreu-vos
 doCancel=Cancel·la
 doSubmit=Envia
 doBack=Enrere

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_cs.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_cs.properties
@@ -1,5 +1,6 @@
 doLogIn=Přihlásit se
 doRegister=Registrovat se
+doRegisterSecurityKey=Registrovat se
 doCancel=Zrušit
 doSubmit=Odeslat
 doBack=Zpět

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_da.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_da.properties
@@ -1,5 +1,6 @@
 doLogIn=Log ind
 doRegister=Registrer
+doRegisterSecurityKey=Registrer
 doCancel=Annuller
 doSubmit=Indsend
 doYes=Ja

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
@@ -1,5 +1,6 @@
 doLogIn=Anmelden
 doRegister=Registrieren
+doRegisterSecurityKey=Registrieren
 doCancel=Abbrechen
 doSubmit=Absenden
 doBack=Zurück

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_el.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_el.properties
@@ -1,5 +1,6 @@
 doLogIn=Είσοδος
 doRegister=Εγγραφή
+doRegisterSecurityKey=Εγγραφή
 doCancel=Ακύρωση
 doSubmit=Εφαρμογή
 doBack=Επιστροφή

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_es.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_es.properties
@@ -1,5 +1,6 @@
 doLogIn=Iniciar sesión
 doRegister=Regístrate
+doRegisterSecurityKey=Regístrate
 doCancel=Cancelar
 doSubmit=Enviar
 doYes=Sí

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_fa.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_fa.properties
@@ -1,5 +1,6 @@
 doLogIn=ورود
 doRegister=ثبت نام
+doRegisterSecurityKey=ثبت نام
 doCancel=لغو
 doSubmit=ارسال
 doBack=بازگشت

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_fi.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_fi.properties
@@ -1,5 +1,6 @@
 doLogIn=Kirjaudu
 doRegister=Rekisteröidy
+doRegisterSecurityKey=Rekisteröidy
 doCancel=Peruuta
 doSubmit=Lähetä
 doBack=Takaisin

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
@@ -1,5 +1,6 @@
 doLogIn=Connexion
 doRegister=Enregistrement
+doRegisterSecurityKey=Enregistrement
 doCancel=Annuler
 doSubmit=Soumettre
 doBack=Retour

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_hu.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_hu.properties
@@ -1,5 +1,6 @@
 doLogIn=Belépés
 doRegister=Regisztráció
+doRegisterSecurityKey=Regisztráció
 doCancel=Mégsem
 doSubmit=Elküld
 doBack=Vissza

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_it.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_it.properties
@@ -1,5 +1,6 @@
 doLogIn=Accedi
 doRegister=Registrati
+doRegisterSecurityKey=Registrati
 doCancel=Annulla
 doSubmit=Invia
 doBack=Indietro

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ja.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ja.properties
@@ -1,5 +1,6 @@
 doLogIn=ログイン
 doRegister=登録
+doRegisterSecurityKey=登録
 doCancel=キャンセル
 doSubmit=送信
 doBack=戻る

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_lt.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_lt.properties
@@ -1,5 +1,6 @@
 doLogIn=Prisijungti
 doRegister=Registruotis
+doRegisterSecurityKey=Registruotis
 doCancel=Atšaukti
 doSubmit=Patvirtinti
 doYes=Taip

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_lv.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_lv.properties
@@ -1,5 +1,6 @@
 doLogIn=Pieslēgties
 doRegister=Reģistrēties
+doRegisterSecurityKey=Reģistrēties
 doCancel=Atcelt
 doSubmit=Iesniegt
 doBack=Atpakaļ

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -1,5 +1,6 @@
 doLogIn=Inloggen
 doRegister=Registreer
+doRegisterSecurityKey=Registreer
 doCancel=Annuleer
 doSubmit=Verzenden
 doBack=Terug

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_no.properties
@@ -1,5 +1,6 @@
 doLogIn=Logg inn
 doRegister=Registrer deg
+doRegisterSecurityKey=Registrer deg
 doCancel=Avbryt
 doSubmit=Send inn
 doYes=Ja

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
@@ -1,5 +1,6 @@
 doLogIn=Logowanie
 doRegister=Rejestracja
+doRegisterSecurityKey=Rejestracja
 doCancel=Anuluj
 doSubmit=Zatwierdź
 doBack=Cofnij

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pt_BR.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pt_BR.properties
@@ -1,5 +1,6 @@
 doLogIn=Entrar
 doRegister=Cadastre-se
+doRegisterSecurityKey=Cadastre-se
 doCancel=Cancelar
 doSubmit=Ok
 doBack=Voltar

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ru.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ru.properties
@@ -1,5 +1,6 @@
 doLogIn=Вход
 doRegister=Регистрация
+doRegisterSecurityKey=Регистрация
 doCancel=Отмена
 doSubmit=Подтвердить
 doYes=Да

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
@@ -1,5 +1,6 @@
 doLogIn=Prihlásenie
 doRegister=Registrácia
+doRegisterSecurityKey=Registrácia
 doCancel=Zrušiť
 doSubmit=Odoslať
 doBack=Späť

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_sv.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_sv.properties
@@ -1,5 +1,6 @@
 doLogIn=Logga in
 doRegister=Registrera
+doRegisterSecurityKey=Registrera
 doCancel=Avbryt
 doSubmit=Skicka
 doYes=Ja

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_th.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_th.properties
@@ -1,5 +1,6 @@
 doLogIn=เข้าสู่ระบบ
 doRegister=ลงทะเบียน
+doRegisterSecurityKey=ลงทะเบียน
 doCancel=ยกเลิก
 doSubmit=ส่ง
 doBack=ย้อนกลับ

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_tr.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_tr.properties
@@ -1,5 +1,6 @@
 doLogIn=Oturum aç
 doRegister=Kayıt ol
+doRegisterSecurityKey=Kayıt ol
 doCancel=İptal et
 doSubmit=Gönder
 doYes=Evet

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_uk.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_uk.properties
@@ -1,5 +1,6 @@
 doLogIn=Увійти
 doRegister=Зареєструватися
+doRegisterSecurityKey=Зареєструватися
 doCancel=Скасувати
 doSubmit=Надіслати
 doBack=Назад

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_zh_CN.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_zh_CN.properties
@@ -1,5 +1,6 @@
 doLogIn=登录
 doRegister=注册
+doRegisterSecurityKey=注册
 doCancel=取消
 doSubmit=提交
 doBack=返回

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -1,5 +1,6 @@
 doLogIn=Sign In
 doRegister=Register
+doRegisterSecurityKey=Register
 doCancel=Cancel
 doSubmit=Submit
 doBack=Back

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -178,7 +178,7 @@
 
         <input type="submit"
                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
-               id="registerWebAuthn" value="${msg("doRegister")}" onclick="registerSecurityKey()"/>
+               id="registerWebAuthn" value="${msg("doRegisterSecurityKey")}" onclick="registerSecurityKey()"/>
 
         <#if !isSetRetry?has_content && isAppInitiatedAction?has_content>
             <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-webauthn-settings-form"


### PR DESCRIPTION
This should allow theme creators to customize the user registration action label without impacting the security key registration label.

closes #27143