### PR TITLE
Expose display name and locales when user has ANY admin role

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -380,6 +380,10 @@ public class RealmAdminResource {
 
             RealmRepresentation rep = new RealmRepresentation();
             rep.setRealm(realm.getName());
+            rep.setDefaultLocale(realm.getDefaultLocale());
+            rep.setDisplayName(realm.getDisplayName());
+            rep.setDisplayNameHtml(realm.getDisplayNameHtml());
+            rep.setSupportedLocales(realm.getSupportedLocales());
 
             if (auth.users().canView()) {
                 rep.setRegistrationEmailAsUsername(realm.isRegistrationEmailAsUsername());

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -383,7 +383,7 @@ public class RealmAdminResource {
             rep.setDefaultLocale(realm.getDefaultLocale());
             rep.setDisplayName(realm.getDisplayName());
             rep.setDisplayNameHtml(realm.getDisplayNameHtml());
-            rep.setSupportedLocales(realm.getSupportedLocales());
+            rep.setSupportedLocales(realm.getSupportedLocalesStream().collect(Collectors.toSet()));
 
             if (auth.users().canView()) {
                 rep.setRegistrationEmailAsUsername(realm.isRegistrationEmailAsUsername());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -2057,7 +2057,8 @@ public class PermissionsTest extends AbstractKeycloakTest {
     }
 
     private void assertGettersEmpty(RealmRepresentation rep) {
-        assertGettersEmpty(rep, "getRealm", "getAttributesOrEmpty");
+        assertGettersEmpty(rep, "getRealm", "getAttributesOrEmpty", "getRealmName", "getDisplayNameHtml", 
+            "getDisplayName", "getDefaultLocale", "getSupportedLocales");
     }
 
     private void assertGettersEmpty(ClientRepresentation rep) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -2057,7 +2057,7 @@ public class PermissionsTest extends AbstractKeycloakTest {
     }
 
     private void assertGettersEmpty(RealmRepresentation rep) {
-        assertGettersEmpty(rep, "getRealm", "getAttributesOrEmpty", "getRealmName", "getDisplayNameHtml", 
+        assertGettersEmpty(rep, "getRealm", "getAttributesOrEmpty", "getDisplayNameHtml", 
             "getDisplayName", "getDefaultLocale", "getSupportedLocales");
     }
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Closes #26584

I've exposed the `displayName`, `displayNameHtml`, `supportedLocales` and `defaultLocale` fields when the user has ANY admin role (instead of the view-realm role). The `supportedLocales` and `defaultLocale` are necessary to let a user that can create users (but not change the realm-settings) select a locale. Currently only the `realm-name` field is exposed which is not sufficient. The `displayName` and `displayNameHtml` are added because the check is called `canViewRealmNameList`, and these both field seem logical to expose too.

Just for clarification: because of https://github.com/keycloak/keycloak/pull/27160/files#diff-5876d8ba07cbea7e2dd84d5b21a125cd15bb1ef227ad93826a68a3c647df688bR379, this is not globally exposed but only when the user has any admin role.
