### PR TITLE
Removing duplicate claims in action tokens

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
@@ -44,6 +44,9 @@ public class DefaultActionToken extends DefaultActionTokenKey implements SingleU
     public static final String JSON_FIELD_AUTHENTICATION_SESSION_ID = "asid";
     public static final String JSON_FIELD_EMAIL = "eml";
 
+    @JsonProperty(value = JSON_FIELD_AUTHENTICATION_SESSION_ID)
+    private String compoundAuthenticationSessionId;
+
     @JsonProperty(value = JSON_FIELD_EMAIL)
     private String email;
 
@@ -85,14 +88,12 @@ public class DefaultActionToken extends DefaultActionTokenKey implements SingleU
         setCompoundAuthenticationSessionId(compoundAuthenticationSessionId);
     }
 
-    @JsonProperty(value = JSON_FIELD_AUTHENTICATION_SESSION_ID)
     public String getCompoundAuthenticationSessionId() {
-        return (String) getOtherClaims().get(JSON_FIELD_AUTHENTICATION_SESSION_ID);
+        return compoundAuthenticationSessionId;
     }
 
-    @JsonProperty(value = JSON_FIELD_AUTHENTICATION_SESSION_ID)
-    public final void setCompoundAuthenticationSessionId(String authenticationSessionId) {
-        setOtherClaims(JSON_FIELD_AUTHENTICATION_SESSION_ID, authenticationSessionId);
+    public void setCompoundAuthenticationSessionId(String compoundAuthenticationSessionId) {
+        this.compoundAuthenticationSessionId = compoundAuthenticationSessionId;
     }
 
     @JsonIgnore

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionToken.java
@@ -31,6 +31,12 @@ public class ExecuteActionsActionToken extends DefaultActionToken {
     private static final String JSON_FIELD_REQUIRED_ACTIONS = "rqac";
     private static final String JSON_FIELD_REDIRECT_URI = "reduri";
 
+    @JsonProperty(JSON_FIELD_REQUIRED_ACTIONS)
+    private List<String> requiredActions;
+
+    @JsonProperty(JSON_FIELD_REDIRECT_URI)
+    private String redirectUri;
+
     public ExecuteActionsActionToken(String userId, int absoluteExpirationInSecs, List<String> requiredActions, String redirectUri, String clientId) {
         super(userId, TOKEN_TYPE, absoluteExpirationInSecs, null);
         setRequiredActions(requiredActions == null ? new LinkedList<>() : new LinkedList<>(requiredActions));
@@ -46,31 +52,19 @@ public class ExecuteActionsActionToken extends DefaultActionToken {
     private ExecuteActionsActionToken() {
     }
 
-    @JsonProperty(value = JSON_FIELD_REQUIRED_ACTIONS)
     public List<String> getRequiredActions() {
-        return (List<String>) getOtherClaims().get(JSON_FIELD_REQUIRED_ACTIONS);
+        return requiredActions;
     }
 
-    @JsonProperty(value = JSON_FIELD_REQUIRED_ACTIONS)
-    public final void setRequiredActions(List<String> requiredActions) {
-        if (requiredActions == null) {
-            getOtherClaims().remove(JSON_FIELD_REQUIRED_ACTIONS);
-        } else {
-            setOtherClaims(JSON_FIELD_REQUIRED_ACTIONS, requiredActions);
-        }
+    public void setRequiredActions(List<String> requiredActions) {
+        this.requiredActions = requiredActions;
     }
 
-    @JsonProperty(value = JSON_FIELD_REDIRECT_URI)
     public String getRedirectUri() {
-        return (String) getOtherClaims().get(JSON_FIELD_REDIRECT_URI);
+        return redirectUri;
     }
 
-    @JsonProperty(value = JSON_FIELD_REDIRECT_URI)
-    public final void setRedirectUri(String redirectUri) {
-        if (redirectUri == null) {
-            getOtherClaims().remove(JSON_FIELD_REDIRECT_URI);
-        } else {
-            setOtherClaims(JSON_FIELD_REDIRECT_URI, redirectUri);
-        }
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/verifyemail/VerifyEmailActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/verifyemail/VerifyEmailActionToken.java
@@ -34,6 +34,9 @@ public class VerifyEmailActionToken extends DefaultActionToken {
     @JsonProperty(value = JSON_FIELD_ORIGINAL_AUTHENTICATION_SESSION_ID)
     private String originalAuthenticationSessionId;
 
+    @JsonProperty(JSON_FIELD_REDIRECT_URI)
+    private String redirectUri;
+
     public VerifyEmailActionToken(String userId, int absoluteExpirationInSecs, String compoundAuthenticationSessionId, String email, String clientId) {
         super(userId, TOKEN_TYPE, absoluteExpirationInSecs, null, compoundAuthenticationSessionId);
         setEmail(email);
@@ -51,17 +54,11 @@ public class VerifyEmailActionToken extends DefaultActionToken {
         this.originalAuthenticationSessionId = originalAuthenticationSessionId;
     }
 
-    @JsonProperty(value = JSON_FIELD_REDIRECT_URI)
     public String getRedirectUri() {
-        return (String) getOtherClaims().get(JSON_FIELD_REDIRECT_URI);
+        return redirectUri;
     }
 
-    @JsonProperty(value = JSON_FIELD_REDIRECT_URI)
-    public final void setRedirectUri(String redirectUri) {
-        if (redirectUri == null) {
-            getOtherClaims().remove(JSON_FIELD_REDIRECT_URI);
-        } else {
-            setOtherClaims(JSON_FIELD_REDIRECT_URI, redirectUri);
-        }
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
     }
 }


### PR DESCRIPTION
Using variables instead of otherClaims map for claims in action tokens to avoid duplicate claims in the JWT action token payload

Closes #24980
