### PR TITLE
fix: waiting more time for the log to appear

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -89,11 +89,8 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         k8sclient.resource(dbSecret).update();
 
         // dynamically check pod 0 to avoid race conditions
-        Awaitility.await().atMost(1, TimeUnit.MINUTES).ignoreExceptions()
-                .until(() -> k8sclient
-                        .raw(String.format("/api/v1/namespaces/%s/pods/%s/log?previous=true", namespace,
-                                kc.getMetadata().getName() + "-0"))
-                        .contains("password authentication failed for user \"" + username + "\""));
+        Awaitility.await().atMost(2, TimeUnit.MINUTES).ignoreExceptions().until(() ->
+                k8sclient.pods().withName(kc.getMetadata().getName() + "-0").getLog().contains("password authentication failed for user \"" + username + "\""));
     }
 
     private StatefulSet getStatefulSet(Keycloak kc) {


### PR DESCRIPTION
To recap:
- the initial commit addressed that we don't need to be creating loadbalancer services. This cleaned up the logging, but was not related to this issue
- the second commit was based upon my misreading of the log - it appeared that the current log was not available because of the crash looping and that we simply missed seeing the expected log. So I switched it to using the previous.
- however this reading of the test log was not correct - those probe failures were expected and based upon a subsequent test log the current log did not show the expected error. This is actually due to a difference in the local vs remote execution. For local we're changing the poll interval to 10 seconds, while leaving it as 1 minute for remote. So there simply wasn't enough time with remote execution to account for the polling delay.

We could also consider overriding the remote operator deployment to use a shorter polling interval.

closes: #26790

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
