### PR TITLE
Only run Husky scripts when installed

### DIFF
--- a/js/.husky/pre-commit
+++ b/js/.husky/pre-commit
@@ -1,2 +1,11 @@
+# Get the path the the Husky script.
+DIRNAME="$(dirname "$0")"
+FILE="$DIRNAME/_/husky.sh"
+
+# Exit if Husky is not installed.
+if [ ! -f "$FILE" ]; then
+  exit 0;
+fi
+
 cd js
 pnpm exec lint-staged


### PR DESCRIPTION
Only runs the Husky pre-commits hooks when it is actually installed.