### PR TITLE
Use the response_permissions_limit value, if provided, to set the maximum number of results when retrieving resources by URI

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -810,7 +810,7 @@ public class AuthorizationTokenService {
             return clientConnection;
         }
 
-        public void addPermissions(List<String> permissionList, String permissionResourceFormat, boolean matchingUri) {
+        public void addPermissions(List<String> permissionList, String permissionResourceFormat, boolean matchingUri, Integer maxResults) {
             if (permissionResourceFormat == null) {
                 permissionResourceFormat = "id";
             }
@@ -820,7 +820,7 @@ public class AuthorizationTokenService {
                     addPermissionsById(permissionList);
                     break;
                 case "uri":
-                    addPermissionsByUri(permissionList, matchingUri);
+                    addPermissionsByUri(permissionList, matchingUri, maxResults);
                     break;
             }
 
@@ -840,7 +840,7 @@ public class AuthorizationTokenService {
             }
         }
 
-        private void addPermissionsByUri(List<String> permissionList, boolean matchingUri) {
+        private void addPermissionsByUri(List<String> permissionList, boolean matchingUri, Integer maxResults) {
             StoreFactory storeFactory = authorization.getStoreFactory();
 
             for (String permission : permissionList) {
@@ -856,7 +856,7 @@ public class AuthorizationTokenService {
                         throw invalidResourceException;
                     }
 
-                    List<Resource> resources = getResourceListByUri(uri, storeFactory, matchingUri);
+                    List<Resource> resources = getResourceListByUri(uri, storeFactory, matchingUri, maxResults);
 
                     if (resources == null || resources.isEmpty()) {
                         CorsErrorResponseException invalidResourceException = new CorsErrorResponseException(getCors(),
@@ -876,7 +876,7 @@ public class AuthorizationTokenService {
                         return;
                     }
 
-                    List<Resource> resources = getResourceListByUri(uri, storeFactory, matchingUri);
+                    List<Resource> resources = getResourceListByUri(uri, storeFactory, matchingUri, maxResults);
 
                     if (resources == null || resources.isEmpty()) {
                         CorsErrorResponseException invalidResourceException = new CorsErrorResponseException(getCors(),
@@ -890,13 +890,13 @@ public class AuthorizationTokenService {
             }
         }
 
-        private List<Resource> getResourceListByUri(String uri, StoreFactory storeFactory, boolean matchingUri) {
+        private List<Resource> getResourceListByUri(String uri, StoreFactory storeFactory, boolean matchingUri, Integer maxResults) {
             Map<Resource.FilterOption, String[]> search = new EnumMap<>(Resource.FilterOption.class);
             search.put(Resource.FilterOption.URI, new String[] { uri });
             ResourceServer resourceServer = storeFactory.getResourceServerStore()
                 .findByClient(getRealm().getClientByClientId(getAudience()));
-            List<Resource> resources = storeFactory.getResourceStore().find(resourceServer, search, -1,
-                Constants.DEFAULT_MAX_RESULTS);
+
+            List<Resource> resources = storeFactory.getResourceStore().find(resourceServer, search, -1, maxResults);
 
             if (!matchingUri || !resources.isEmpty()) {
                 return resources;

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java
@@ -158,12 +158,14 @@ public class PermissionGrantType extends OAuth2GrantTypeBase {
 
         // permissions have a format like RESOURCE#SCOPE1,SCOPE2
         List<String> permissions = formParams.get("permission");
+        String responsePermissionsLimit = formParams.getFirst("response_permissions_limit");
+        Integer maxResults = responsePermissionsLimit != null ? Integer.parseInt(responsePermissionsLimit) : null;
 
         if (permissions != null) {
             event.detail(Details.PERMISSION, String.join("|", permissions));
             String permissionResourceFormat = formParams.getFirst("permission_resource_format");
             boolean permissionResourceMatchingUri = Boolean.parseBoolean(formParams.getFirst("permission_resource_matching_uri"));
-            authorizationRequest.addPermissions(permissions, permissionResourceFormat, permissionResourceMatchingUri);
+            authorizationRequest.addPermissions(permissions, permissionResourceFormat, permissionResourceMatchingUri, maxResults);
         }
 
         AuthorizationRequest.Metadata metadata = new AuthorizationRequest.Metadata();
@@ -174,10 +176,8 @@ public class PermissionGrantType extends OAuth2GrantTypeBase {
             metadata.setIncludeResourceName(Boolean.parseBoolean(responseIncludeResourceName));
         }
 
-        String responsePermissionsLimit = formParams.getFirst("response_permissions_limit");
-
         if (responsePermissionsLimit != null) {
-            metadata.setLimit(Integer.parseInt(responsePermissionsLimit));
+            metadata.setLimit(maxResults);
         }
 
         metadata.setResponseMode(formParams.getFirst("response_mode"));


### PR DESCRIPTION
This pull request introduces a new feature to limit the number of permissions returned in authorization requests. The changes primarily involve adding a `maxResults` parameter to various methods to support this functionality.

### Enhancements to Authorization Token Service:

* [`services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java`](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL813-R813): Added `maxResults` parameter to `addPermissions`, `addPermissionsByUri`, and `getResourceListByUri` methods to limit the number of permissions returned. [[1]](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL813-R813) [[2]](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL823-R823) [[3]](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL843-R843) [[4]](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL859-R859) [[5]](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL879-R879) [[6]](diffhunk://#diff-d290a97561bd75bb55542258200bcf040eeb91d8f670aad3a7fd95cbb1788c7eL893-R899)

### Modifications to Permission Grant Type:

* [`services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java`](diffhunk://#diff-746d95e3cc7ebca7ca7a93f29dbdca2f84fc3e2c5102792abda39d350731c2edR161-R168): Introduced handling of `response_permissions_limit` form parameter to set the `maxResults` for permissions in the authorization request. [[1]](diffhunk://#diff-746d95e3cc7ebca7ca7a93f29dbdca2f84fc3e2c5102792abda39d350731c2edR161-R168) [[2]](diffhunk://#diff-746d95e3cc7ebca7ca7a93f29dbdca2f84fc3e2c5102792abda39d350731c2edL177-R180)

- Closes #26780
- Discussion #27119
