### PR TITLE
Show Realm Display Name in Realm Dropdown

### DIFF
--- a/js/apps/admin-ui/src/App.tsx
+++ b/js/apps/admin-ui/src/App.tsx
@@ -25,9 +25,9 @@ import { AuthWall } from "./root/AuthWall";
 const AppContexts = ({ children }: PropsWithChildren) => (
   <ErrorBoundaryProvider>
     <ServerInfoProvider>
-      <RealmsProvider>
-        <RealmContextProvider>
-          <WhoAmIContextProvider>
+      <RealmContextProvider>
+        <WhoAmIContextProvider>
+          <RealmsProvider>
             <RecentRealmsProvider>
               <AccessContextProvider>
                 <Help>
@@ -37,9 +37,9 @@ const AppContexts = ({ children }: PropsWithChildren) => (
                 </Help>
               </AccessContextProvider>
             </RecentRealmsProvider>
-          </WhoAmIContextProvider>
-        </RealmContextProvider>
-      </RealmsProvider>
+          </RealmsProvider>
+        </WhoAmIContextProvider>
+      </RealmContextProvider>
     </ServerInfoProvider>
   </ErrorBoundaryProvider>
 );

--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -60,7 +60,7 @@ const RealmText = ({ name, displayName }: RealmTextProps) => {
     <Split className="keycloak__realm_selector__list-item-split">
       <SplitItem isFilled>
         <Stack>
-          <StackItem className="pf-u-font-weight-bold">{displayName}</StackItem>
+          <StackItem className="pf-u-font-weight-bold" isFilled>{displayName}</StackItem>
           <StackItem isFilled>{name}</StackItem>
         </Stack>
       </SplitItem>

--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -52,9 +52,10 @@ const AddRealm = ({ onClick }: AddRealmProps) => {
 type RealmTextProps = {
   name: string;
   displayName?: string;
+  showIsRecent?: boolean;
 };
 
-const RealmText = ({ name, displayName }: RealmTextProps) => {
+const RealmText = ({ name, displayName, showIsRecent }: RealmTextProps) => {
   const { realm } = useRealm();
   const { t } = useTranslation();
 
@@ -64,13 +65,18 @@ const RealmText = ({ name, displayName }: RealmTextProps) => {
         <Stack>
           {displayName ? (
             <StackItem className="pf-u-font-weight-bold" isFilled>
-              {label(t, displayName, displayName)}
+              {label(t, displayName)}
             </StackItem>
           ) : null}
           <StackItem isFilled>{name}</StackItem>
         </Stack>
       </SplitItem>
       <SplitItem>{name === realm && <CheckIcon />}</SplitItem>
+      {showIsRecent ? (
+        <SplitItem>
+          <Label>{t("recent")}</Label>
+        </SplitItem>
+      ) : null}
     </Split>
   );
 };
@@ -94,7 +100,7 @@ const ContextSelectorItemLink = ({
 
 export const RealmSelector = () => {
   const { realm } = useRealm();
-  const { realms, refresh } = useRealms();
+  const { realms } = useRealms();
   const { whoAmI } = useWhoAmI();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -130,7 +136,7 @@ export const RealmSelector = () => {
       : all.filter(
           (r) =>
             r.realm.name.toLowerCase().includes(normalizedSearch) ||
-            label(t, r.realm.displayName, undefined)
+            label(t, r.realm.displayName)
               ?.toLowerCase()
               .includes(normalizedSearch),
         );
@@ -140,10 +146,6 @@ export const RealmSelector = () => {
     () => realms.find((r) => r.name === realm)?.displayName,
     [realm, realms],
   );
-
-  if (realms.length === 0) {
-    refresh();
-  }
 
   return realms.length > 5 ? (
     <ContextSelector
@@ -169,8 +171,7 @@ export const RealmSelector = () => {
           to={toDashboard({ realm: item.realm.name })}
           onClick={() => setOpen(false)}
         >
-          <RealmText {...item.realm} />{" "}
-          {item.used && <Label>{t("recent")}</Label>}
+          <RealmText {...item.realm} showIsRecent={item.used} />{" "}
         </ContextSelectorItemLink>
       ))}
     </ContextSelector>

--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -60,7 +60,9 @@ const RealmText = ({ name, displayName }: RealmTextProps) => {
     <Split className="keycloak__realm_selector__list-item-split">
       <SplitItem isFilled>
         <Stack>
-          <StackItem className="pf-u-font-weight-bold" isFilled>{displayName}</StackItem>
+          <StackItem className="pf-u-font-weight-bold" isFilled>
+            {displayName}
+          </StackItem>
           <StackItem isFilled>{name}</StackItem>
         </Stack>
       </SplitItem>

--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -18,6 +18,7 @@ import { CheckIcon } from "@patternfly/react-icons";
 import { Fragment, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, To, useHref } from "react-router-dom";
+import { label } from "ui-shared";
 
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useRealms } from "../../context/RealmsContext";
@@ -50,19 +51,22 @@ const AddRealm = ({ onClick }: AddRealmProps) => {
 
 type RealmTextProps = {
   name: string;
-  displayName: string | undefined;
+  displayName?: string;
 };
 
 const RealmText = ({ name, displayName }: RealmTextProps) => {
   const { realm } = useRealm();
+  const { t } = useTranslation();
 
   return (
     <Split className="keycloak__realm_selector__list-item-split">
       <SplitItem isFilled>
         <Stack>
-          <StackItem className="pf-u-font-weight-bold" isFilled>
-            {displayName}
-          </StackItem>
+          {displayName ? (
+            <StackItem className="pf-u-font-weight-bold" isFilled>
+              {label(t, displayName, displayName)}
+            </StackItem>
+          ) : null}
           <StackItem isFilled>{name}</StackItem>
         </Stack>
       </SplitItem>
@@ -91,40 +95,50 @@ const ContextSelectorItemLink = ({
 export const RealmSelector = () => {
   const { realm } = useRealm();
   const { realms, refresh } = useRealms();
-  const [realmDisplayName, setRealmDisplayName] = useState("");
   const { whoAmI } = useWhoAmI();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const { t } = useTranslation();
   const recentRealms = useRecentRealms();
 
-  const all = useMemo(() => {
-    const displayName = realms.find((r) => r.name === realm)?.displayName;
-    setRealmDisplayName(displayName ? displayName : "");
-    return realms
-      .filter((r) => r.name !== realm)
-      .map((realm) => {
-        const used = recentRealms.some((name) => name === realm.name);
-        return { realm, used };
-      })
-      .sort((r1, r2) => {
-        if (r1.used == r2.used) return 0;
-        if (r1.used) return -1;
-        if (r2.used) return 1;
-        return 0;
-      });
-  }, [recentRealms, realm, realms]);
-
-  const filteredItems = useMemo(
+  const all = useMemo(
     () =>
-      search.trim() === ""
-        ? all
-        : all.filter(
-            (r) =>
-              r.realm.name.toLowerCase().includes(search.toLowerCase()) ||
-              r.realm.displayName?.toLowerCase().includes(search.toLowerCase()),
-          ),
-    [search, all],
+      realms
+        .filter((r) => r.name !== realm)
+        .map((realm) => {
+          const used = recentRealms.some((name) => name === realm.name);
+          return { realm, used };
+        })
+        .sort((r1, r2) => {
+          if (r1.used == r2.used) return 0;
+          if (r1.used) return -1;
+          if (r2.used) return 1;
+          return 0;
+        }),
+    [recentRealms, realm, realms],
+  );
+
+  const filteredItems = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+
+    if (normalizedSearch.length === 0) {
+      return all;
+    }
+
+    return search.trim() === ""
+      ? all
+      : all.filter(
+          (r) =>
+            r.realm.name.toLowerCase().includes(normalizedSearch) ||
+            label(t, r.realm.displayName, undefined)
+              ?.toLowerCase()
+              .includes(normalizedSearch),
+        );
+  }, [search, all]);
+
+  const realmDisplayName = useMemo(
+    () => realms.find((r) => r.name === realm)?.displayName,
+    [realm, realms],
   );
 
   if (realms.length === 0) {
@@ -134,9 +148,9 @@ export const RealmSelector = () => {
   return realms.length > 5 ? (
     <ContextSelector
       data-testid="realmSelector"
-      toggleText={realmDisplayName ? realmDisplayName : realm}
+      toggleText={label(t, realmDisplayName, realm)}
       isOpen={open}
-      screenReaderLabel={realmDisplayName ? realmDisplayName : realm}
+      screenReaderLabel={label(t, realmDisplayName, realm)}
       onToggle={() => setOpen(!open)}
       searchInputValue={search}
       onSearchInputChange={(value) => setSearch(value)}
@@ -174,7 +188,7 @@ export const RealmSelector = () => {
           }}
           className="keycloak__realm_selector_dropdown__toggle"
         >
-          {realmDisplayName ? realmDisplayName : realm}
+          {label(t, realmDisplayName, realm)}
         </DropdownToggle>
       }
       dropdownItems={(realms.length !== 0

--- a/js/apps/admin-ui/src/context/RealmsContext.tsx
+++ b/js/apps/admin-ui/src/context/RealmsContext.tsx
@@ -37,11 +37,6 @@ export const RealmsProvider = ({ children }: PropsWithChildren) => {
 
   useFetch(
     async () => {
-      // We don't want to fetch until the user has requested it, so let's ignore the initial mount.
-      if (refreshCount === 0) {
-        return [];
-      }
-
       try {
         return await fetchAdminUI<RealmNameRepresentation[]>(
           "ui-ext/realms/names",

--- a/js/apps/admin-ui/src/context/RealmsContext.tsx
+++ b/js/apps/admin-ui/src/context/RealmsContext.tsx
@@ -1,11 +1,12 @@
 import { NetworkError } from "@keycloak/keycloak-admin-client";
 import { PropsWithChildren, useCallback, useMemo, useState } from "react";
-import { createNamedContext, useRequiredContext } from "ui-shared";
+import { createNamedContext, useRequiredContext, label } from "ui-shared";
 
 import { keycloak } from "../keycloak";
 import { useFetch } from "../utils/useFetch";
 import { fetchAdminUI } from "./auth/admin-ui-endpoint";
-import { sortBy } from "lodash-es";
+import useLocaleSort from "../utils/useLocaleSort";
+import { useTranslation } from "react-i18next";
 
 type RealmsContextProps = {
   /** A list of all the realms. */
@@ -16,7 +17,7 @@ type RealmsContextProps = {
 
 export interface RealmNameRepresentation {
   name: string;
-  displayName: string | undefined;
+  displayName?: string;
 }
 
 export const RealmsContext = createNamedContext<RealmsContextProps | undefined>(
@@ -27,9 +28,11 @@ export const RealmsContext = createNamedContext<RealmsContextProps | undefined>(
 export const RealmsProvider = ({ children }: PropsWithChildren) => {
   const [realms, setRealms] = useState<RealmNameRepresentation[]>([]);
   const [refreshCount, setRefreshCount] = useState(0);
+  const localeSort = useLocaleSort();
+  const { t } = useTranslation();
 
   function updateRealms(realms: RealmNameRepresentation[]) {
-    setRealms(sortBy(realms, "displayName", "name"));
+    setRealms(localeSort(realms, (r) => label(t, r.displayName, r.name)));
   }
 
   useFetch(

--- a/js/apps/admin-ui/src/context/RealmsContext.tsx
+++ b/js/apps/admin-ui/src/context/RealmsContext.tsx
@@ -5,13 +5,19 @@ import { createNamedContext, useRequiredContext } from "ui-shared";
 import { keycloak } from "../keycloak";
 import { useFetch } from "../utils/useFetch";
 import { fetchAdminUI } from "./auth/admin-ui-endpoint";
+import { sortBy } from "lodash-es";
 
 type RealmsContextProps = {
   /** A list of all the realms. */
-  realms: string[];
+  realms: RealmNameRepresentation[];
   /** Refreshes the realms with the latest information. */
   refresh: () => Promise<void>;
 };
+
+export interface RealmNameRepresentation {
+  name: string;
+  displayName: string | undefined;
+}
 
 export const RealmsContext = createNamedContext<RealmsContextProps | undefined>(
   "RealmsContext",
@@ -19,11 +25,11 @@ export const RealmsContext = createNamedContext<RealmsContextProps | undefined>(
 );
 
 export const RealmsProvider = ({ children }: PropsWithChildren) => {
-  const [realms, setRealms] = useState<string[]>([]);
+  const [realms, setRealms] = useState<RealmNameRepresentation[]>([]);
   const [refreshCount, setRefreshCount] = useState(0);
 
-  function updateRealms(realms: string[]) {
-    setRealms(realms.sort());
+  function updateRealms(realms: RealmNameRepresentation[]) {
+    setRealms(sortBy(realms, "displayName", "name"));
   }
 
   useFetch(
@@ -34,7 +40,10 @@ export const RealmsProvider = ({ children }: PropsWithChildren) => {
       }
 
       try {
-        return await fetchAdminUI<string[]>("ui-ext/realms/names", {});
+        return await fetchAdminUI<RealmNameRepresentation[]>(
+          "ui-ext/realms/names",
+          {},
+        );
       } catch (error) {
         if (error instanceof NetworkError && error.response.status < 500) {
           return [];

--- a/js/apps/admin-ui/src/context/RecentRealms.tsx
+++ b/js/apps/admin-ui/src/context/RecentRealms.tsx
@@ -6,7 +6,7 @@ import {
   useStoredState,
 } from "ui-shared";
 import { useRealm } from "./realm-context/RealmContext";
-import { useRealms } from "./RealmsContext";
+import { RealmNameRepresentation, useRealms } from "./RealmsContext";
 
 const MAX_REALMS = 4;
 
@@ -43,12 +43,17 @@ export const RecentRealmsProvider = ({ children }: PropsWithChildren) => {
 
 export const useRecentRealms = () => useRequiredContext(RecentRealmsContext);
 
-function filterRealmNames(realms: string[], storedRealms: string[]) {
+function filterRealmNames(
+  realms: RealmNameRepresentation[],
+  storedRealms: string[],
+) {
   // If no realms have been set yet we can't filter out any non-existent realm names.
   if (realms.length === 0) {
     return storedRealms;
   }
 
   // Only keep realm names that actually still exist.
-  return storedRealms.filter((realm) => realms.includes(realm));
+  return storedRealms.filter((realm) => {
+    return realms.some((r) => r.name === realm);
+  });
 }

--- a/js/apps/admin-ui/src/dashboard/Dashboard.tsx
+++ b/js/apps/admin-ui/src/dashboard/Dashboard.tsx
@@ -34,7 +34,7 @@ import FeatureRepresentation, {
 } from "@keycloak/keycloak-admin-client/lib/defs/featureRepresentation";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
-import { HelpItem } from "ui-shared";
+import { HelpItem, label } from "ui-shared";
 import environment from "../environment";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import useLocaleSort, { mapByKey } from "../utils/useLocaleSort";
@@ -57,7 +57,7 @@ const EmptyDashboard = () => {
   const [realmInfo, setRealmInfo] = useState<RealmRepresentation>();
   const brandImage = environment.logo ? environment.logo : "/icon.svg";
   useFetch(() => adminClient.realms.findOne({ realm }), setRealmInfo, []);
-  const realmDisplayInfo = realmInfo?.displayName || realm;
+  const realmDisplayInfo = label(t, realmInfo?.displayName, realm);
 
   return (
     <PageSection variant="light">
@@ -133,7 +133,7 @@ const Dashboard = () => {
 
   useFetch(() => adminClient.realms.findOne({ realm }), setRealmInfo, []);
 
-  const realmDisplayInfo = realmInfo?.displayName || realm;
+  const realmDisplayInfo = label(t, realmInfo?.displayName, realm);
 
   const welcomeTab = useTab("welcome");
   const infoTab = useTab("info");

--- a/js/apps/admin-ui/src/page-nav.css
+++ b/js/apps/admin-ui/src/page-nav.css
@@ -1,4 +1,5 @@
 
 .keycloak__page_nav__nav {
-  --pf-c-page__sidebar--Transition: all 50ms cubic-bezier(.42, 0, .58, 1)
+  --pf-c-page__sidebar--Transition: all 50ms cubic-bezier(.42, 0, .58, 1);
+  overflow: inherit;
 }

--- a/js/libs/ui-shared/src/user-profile/utils.ts
+++ b/js/libs/ui-shared/src/user-profile/utils.ts
@@ -30,7 +30,7 @@ export const unWrap = (key: string) => key.substring(2, key.length - 1);
 export const label = (
   t: TFunction,
   text: string | undefined,
-  fallback: string | undefined,
+  fallback?: string,
 ) => (isBundleKey(text) ? t(unWrap(text!)) : text) || fallback;
 
 export const labelAttribute = (

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/RealmNameRepresentation.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/RealmNameRepresentation.java
@@ -1,0 +1,22 @@
+package org.keycloak.admin.ui.rest.model;
+
+public class RealmNameRepresentation {
+    private String name;
+    private String displayName;
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDisplayName() {
+        return this.displayName;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}


### PR DESCRIPTION
Closes #17735 

![image](https://github.com/keycloak/keycloak/assets/1793007/0eb2cb91-6af5-4afd-88b2-161dc72d3404)

Maybe two things that can be improved:

1. To show the display name of the currently selected realm before ever opening the dropdown, I had to trigger the gathering of the realm list on component creation. See line 128 in js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
2. When updating the realm display name in the realm settings the dropdown and the realm display names shown there are not automatically refreshed. Same goes with changing the localization value (if the displayname is localized). A page reload would be required atm.