### PR TITLE
Fix GitHub Action Trivy Analysis warnings #27264

### DIFF
--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -22,15 +22,14 @@ jobs:
         uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55
         with:
           image-ref: quay.io/keycloak/${{ matrix.container}}:nightly
-          format: template
-          template: '@/contrib/sarif.tpl'
+          format: sarif
           output: trivy-results.sarif
           severity: MEDIUM,CRITICAL,HIGH
           ignore-unfixed: true
-          security-checks: vuln
           timeout: 15m
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
+          category: ${{ matrix.container}}


### PR DESCRIPTION
Fix GitHub Action Trivy Analysis warnings

- Warning: Unexpected input(s) '[security-checks](https://github.com/aquasecurity/trivy/discussions/3519)'
- BREAKING CHANGE: [deprecated](https://github.com/aquasecurity/trivy/discussions/1571) sarif.tpl 

Change tested on my repo https://github.com/yyvess/keycloak/actions/runs/8030060139
Security scan report https://github.com/yyvess/keycloak/security/code-scanning/1

Close https://github.com/keycloak/keycloak/issues/27264