### PR TITLE
fix(CVE): Fix postgres jdbc CVE-2024-1597

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <postgresql.version>15</postgresql.version>
         <aurora-postgresql.version>15.3</aurora-postgresql.version>
         <aws-jdbc-wrapper.version>2.3.3</aws-jdbc-wrapper.version>
-        <postgresql-jdbc.version>42.7.1</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.2</postgresql-jdbc.version>
         <mariadb.version>10.11</mariadb.version>
         <mariadb-jdbc.version>3.3.2</mariadb-jdbc.version>
         <mssql.version>2022-latest</mssql.version>


### PR DESCRIPTION
Fix postgres jdbc [CVE-2024-1597](https://www.postgresql.org/about/news/postgresql-jdbc-4272-4261-4255-4244-4239-42228-and-42228jre7-security-update-for-cve-2024-1597-2812/) SQL injection 

- There is no evidence that Keycloak is impacted

Close : #27204, #27183


