### PR TITLE
Re-index CLIENT_ATTRIBUTES using name and value

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.0.xml
@@ -50,4 +50,40 @@
         <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.FederatedUserAttributeTextColumnMigration" />
     </changeSet>
 
+    <changeSet author="keycloak" id="24.0.0-26618-drop-index-if-present">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <and>
+                <indexExists tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE" />
+                <or>
+                    <dbms type="mysql"/>
+                    <dbms type="mariadb"/>
+                    <dbms type="postgresql"/>
+                    <dbms type="oracle"/>
+                </or>
+            </and>
+        </preConditions>
+        <dropIndex tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE"/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="24.0.0-26618-reindex">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <or>
+                <dbms type="mysql"/>
+                <dbms type="mariadb"/>
+                <dbms type="postgresql"/>
+                <dbms type="oracle"/>
+            </or>
+        </preConditions>
+        <createIndex tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE">
+            <column name="NAME" type="VARCHAR(255)"/>
+            <column name="VALUE(255)" valueComputed="VALUE(255)" />
+        </createIndex>
+        <modifySql dbms="postgresql">
+            <replace replace="VALUE(255)" with="substr(VALUE,1,255)" />
+        </modifySql>
+        <modifySql dbms="oracle">
+            <replace replace="VALUE(255)" with="dbms_lob.substr(VALUE,255,1)" />
+        </modifySql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
@@ -82,6 +82,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -409,6 +410,7 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
             testUnmanagedAttributePolicySet(migrationRealm2, null);
             testHS512KeyCreated(migrationRealm);
             testHS512KeyCreated(migrationRealm2);
+            testClientAttributes(migrationRealm);
         }
         if (testLdapUseTruststoreSpiMigration) {
             testLdapUseTruststoreSpiMigration(migrationRealm2);
@@ -1253,5 +1255,21 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
         KeysMetadataRepresentation keysMetadata = realm.keys().getKeyMetadata();
         Assert.assertNotNull("Old HS256 key does not exist", keysMetadata.getActive().get(Algorithm.HS256));
         Assert.assertNotNull("New HS256 key does not exist", keysMetadata.getActive().get(Algorithm.HS512));
+    }
+
+    private void testClientAttributes(RealmResource realm) {
+        List<ClientRepresentation> clients = realm.clients().findByClientId("migration-saml-client");
+        Assert.assertEquals(1, clients.size());
+        ClientRepresentation client = clients.get(0);
+        Assert.assertNotNull(client.getAttributes().get("saml.artifact.binding.identifier"));
+        Assert.assertNotNull(client.getAttributes().get("saml_idp_initiated_sso_url_name"));
+        List<String> clientIds = realm.clients().query("saml.artifact.binding.identifier:\"" + client.getAttributes().get("saml.artifact.binding.identifier") + "\"")
+                .stream().map(ClientRepresentation::getClientId)
+                .collect(Collectors.toList());
+        Assert.assertEquals(Collections.singletonList(client.getClientId()), clientIds);
+        clientIds = realm.clients().query("saml_idp_initiated_sso_url_name:\"" + client.getAttributes().get("saml_idp_initiated_sso_url_name") + "\"")
+                .stream().map(ClientRepresentation::getClientId)
+                .collect(Collectors.toList());
+        Assert.assertEquals(Collections.singletonList(client.getClientId()), clientIds);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-19.0.3.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-19.0.3.json
@@ -600,7 +600,7 @@
       "saml.encrypt" : "false",
       "saml_assertion_consumer_url_post" : "http://localhost:8080/sales-post/saml",
       "saml.server.signature" : "true",
-      "saml_idp_initiated_sso_url_name" : "sales-post",
+      "saml_idp_initiated_sso_url_name" : "sales-post-very-long-name-greater-than-255-characters-0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",
       "exclude.session.state.from.auth.response" : "false",
       "saml.artifact.binding.identifier" : "ZDisLXkadz6IlDoL8l343V44KP0=",
       "saml.artifact.binding" : "false",


### PR DESCRIPTION
Closes #26618

Re-adding the indexes for the databases that allows indexing substring. It was detected that the index was not used for postgresql and oracle so there is a minimal change for those engines to do a search using the index. Tests ran OK in my branch.

@ahus1 @vramik FYI
