### PR TITLE
fix: changes to XA transaction defaults

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -27,6 +27,11 @@ bin/kc.[sh|bat] --spi-connections-http-client-default-max-consumed-response-size
 
 The module `org.keycloak:keycloak-model-legacy` module was deprecated in a previous release and is removed in this release. Use the `org.keycloak:keycloak-model-storage` module instead.
 
+= XA Transaction Changes
+
+* The option `transaction-xa-enabled` will default to false, rather than true. If you want XA transaction support you will now need to explicitly set this option to true.
+* XA Transaction recovery support is enabled by default if `transaction-xa-enabled` is true. Transaction logs will be stored at KEYCLOAK_HOME/data/transaction-logs.
+
 = Removed offline session preloading
 
 The old behavior to preload offline sessions at startup is now removed after it has been deprecated in the previous release.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -268,12 +268,20 @@ The maximum timeout for this lock is 900 seconds. If a node waits on this lock f
 
 <@kc.start parameters="--spi-dblock-jpa-lock-wait-timeout 900"/>
 
-== Using Database Vendors without XA transaction support
-{project_name} uses XA transactions and the appropriate database drivers by default. Certain vendors, such as Azure SQL and MariaDB Galera, do not support or rely on the XA transaction mechanism. To use {project_name} without XA transaction support using the appropriate JDBC driver, enter the following command:
+== Using Database Vendors with XA transaction support
+{project_name} uses non-XA transactions and the appropriate database drivers by default. 
 
-<@kc.build parameters="--db=<vendor> --transaction-xa-enabled=false"/>
+If you wish to use the XA transaction support offered by your driver, enter the following command:
+
+<@kc.build parameters="--db=<vendor> --transaction-xa-enabled=true"/>
 
 {project_name} automatically chooses the appropriate JDBC driver for your vendor.
+
+NOTE: Certain vendors, such as Azure SQL and MariaDB Galera, do not support or rely on the XA transaction mechanism.
+
+XA recovery defaults to enabled and will use the file system location `KEYCLOAK_HOME/data/transaction-logs` to store transaction logs. 
+
+NOTE: Enabling XA transactions in a containerized envionment does not fully support XA recovery unless stable storage is available at that path.
 
 == Setting JPA provider configuration option for migrationStrategy
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
@@ -4,8 +4,8 @@ public class TransactionOptions {
 
     public static final Option<Boolean> TRANSACTION_XA_ENABLED = new OptionBuilder<>("transaction-xa-enabled", Boolean.class)
             .category(OptionCategory.TRANSACTION)
-            .description("If set to false, Keycloak uses a non-XA datasource in case the database does not support XA transactions.")
+            .description("If set to true, XA datasources will be used.")
             .buildTime(true)
-            .defaultValue(Boolean.TRUE)
+            .defaultValue(Boolean.FALSE)
             .build();
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -99,7 +99,7 @@ final class DatabasePropertyMappers {
 
     private static Optional<String> getXaOrNonXaDriver(Optional<String> value, ConfigSourceInterceptorContext context) {
         ConfigValue xaEnabledConfigValue = context.proceed("kc.transaction-xa-enabled");
-        boolean isXaEnabled = xaEnabledConfigValue == null || Boolean.parseBoolean(xaEnabledConfigValue.getValue());
+        boolean isXaEnabled = xaEnabledConfigValue != null && Boolean.parseBoolean(xaEnabledConfigValue.getValue());
 
         Optional<String> driver = Database.getDriver(value.get(), isXaEnabled);
 

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -40,6 +40,7 @@ quarkus.log.category."io.quarkus.arc.processor.IndexClassLookupUtils".level=off
 quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
 quarkus.log.category."io.quarkus.deployment.steps.ReflectiveHierarchyStep".level=error
 
+quarkus.transaction-manager.enable-recovery=true
 # Set default directory name for the location of the transaction logs
 quarkus.transaction-manager.object-store.directory=${kc.home.dir:default}${file.separator}data${file.separator}transaction-logs
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -38,6 +38,7 @@ import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.h2.Driver;
 import org.hibernate.dialect.MariaDBDialect;
 import org.junit.After;
 import org.junit.Assert;
@@ -274,6 +275,7 @@ public class ConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db=dev-file");
         SmallRyeConfig config = createConfig();
         assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals(Driver.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
 
         // JDBC location treated as file:// URI
         final String userHomeUri = Path.of(System.getProperty("user.home"))
@@ -360,6 +362,7 @@ public class ConfigurationTest {
     public void testDatabaseProperties() {
         System.setProperty("kc.db-url-properties", ";;test=test;test1=test1");
         System.setProperty("kc.db-url-path", "test-dir");
+        System.setProperty("kc.transaction-xa-enabled", "true");
         ConfigArgsConfigSource.setCliArgs("--db=dev-file");
         SmallRyeConfig config = createConfig();
         assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
@@ -42,8 +42,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
@@ -27,20 +27,6 @@ Cache:
 --cache-config-file <file>
                      Defines the file from which cache configuration should be loaded from. The
                        configuration file is relative to the 'conf/' directory.
---cache-embedded-mtls-enabled <true|false>
-                     Encrypts the network communication between Keycloak servers. Default: false.
---cache-embedded-mtls-key-store-file <file>
-                     The Keystore file path. The Keystore must contain the certificate to use by
-                       the TLS protocol. By default, it lookup 'cache-mtls-keystore.p12' under
-                       conf/ directory.
---cache-embedded-mtls-key-store-password <password>
-                     The password to access the Keystore.
---cache-embedded-mtls-trust-store-file <file>
-                     The Truststore file path. It should contain the trusted certificates or the
-                       Certificate Authority that signed the certificates. By default, it lookup
-                       'cache-mtls-truststore.p12' under conf/ directory.
---cache-embedded-mtls-trust-store-password <password>
-                     The password to access the Truststore.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
@@ -56,8 +42,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.unix.approved.txt
@@ -51,8 +51,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.unix.approved.txt
@@ -51,8 +51,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.unix.approved.txt
@@ -51,8 +51,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.unix.approved.txt
@@ -51,8 +51,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
@@ -103,8 +103,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
@@ -103,8 +103,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 
@@ -238,47 +237,16 @@ Logging:
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
                        are: console, file, gelf (deprecated). Default: console.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false.
+                     Enable or disable colors when logging to console. Default: false. Available
+                       only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
-                       -5p [%c] (%t) %s%e%n.
+                       -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
---log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
---log-file-format <format>
-                     Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
-                       SSS} %-5p [%c] (%t) %s%e%n.
---log-file-output <output>
-                     Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
---log-gelf-facility <name>
-                     DEPRECATED. The facility (name of the process) that sends the message.
-                       Default: keycloak.
---log-gelf-host <hostname>
-                     DEPRECATED. Hostname of the Logstash or Graylog Host. By default UDP is used,
-                       prefix the host with 'tcp:' to switch to TCP. Example: 'tcp:localhost'
-                       Default: localhost.
---log-gelf-include-location <true|false>
-                     DEPRECATED. Include source code location. Default: true.
---log-gelf-include-message-parameters <true|false>
-                     DEPRECATED. Include message parameters from the log event. Default: true.
---log-gelf-include-stack-trace <true|false>
-                     DEPRECATED. If set to true, occuring stack traces are included in the
-                       'StackTrace' field in the GELF output. Default: true.
---log-gelf-level <level>
-                     DEPRECATED. The log level specifying which message levels will be logged by
-                       the GELF logger. Message levels lower than this value will be discarded.
-                       Default: INFO.
---log-gelf-max-message-size <size>
-                     DEPRECATED. Maximum message size (in bytes). If the message size is exceeded,
-                       GELF will submit the message in multiple chunks. Default: 8192.
---log-gelf-port <port>
-                     DEPRECATED. The port the Logstash or Graylog Host is called on. Default: 12201.
---log-gelf-timestamp-format <pattern>
-                     DEPRECATED. Set the format for the GELF timestamp field. Uses Java
-                       SimpleDateFormat pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
+                       values are: default, json. Default: default. Available only when Console log
+                       handler is activated.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
@@ -106,8 +106,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
@@ -39,6 +39,9 @@ Cache:
                        'cache-mtls-truststore.p12' under conf/ directory.
 --cache-embedded-mtls-trust-store-password <password>
                      The password to access the Truststore.
+--cache-metrics-histograms-enabled <true|false>
+                     Enable histograms for metrics for the embedded caches. Default: false.
+                       Available only when metrics are enabled.
 --cache-remote-host <hostname>
                      The hostname of the remote server for the remote store configuration. It
                        replaces the 'host' attribute of 'remote-server' tag of the configuration
@@ -103,8 +106,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 
@@ -238,47 +240,61 @@ Logging:
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
                        are: console, file, gelf (deprecated). Default: console.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false.
+                     Enable or disable colors when logging to console. Default: false. Available
+                       only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
-                       -5p [%c] (%t) %s%e%n.
+                       -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
---log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
+                       values are: default, json. Default: default. Available only when Console log
+                       handler is activated.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log. Available
+                       only when File log handler is activated.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
-                       SSS} %-5p [%c] (%t) %s%e%n.
+                       SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
+                       activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
+                       values are: default, json. Default: default. Available only when File log
+                       handler is activated.
 --log-gelf-facility <name>
                      DEPRECATED. The facility (name of the process) that sends the message.
-                       Default: keycloak.
+                       Default: keycloak. Available only when GELF is activated.
 --log-gelf-host <hostname>
                      DEPRECATED. Hostname of the Logstash or Graylog Host. By default UDP is used,
                        prefix the host with 'tcp:' to switch to TCP. Example: 'tcp:localhost'
-                       Default: localhost.
+                       Default: localhost. Available only when GELF is activated.
 --log-gelf-include-location <true|false>
-                     DEPRECATED. Include source code location. Default: true.
+                     DEPRECATED. Include source code location. Default: true. Available only when
+                       GELF is activated.
 --log-gelf-include-message-parameters <true|false>
                      DEPRECATED. Include message parameters from the log event. Default: true.
+                       Available only when GELF is activated.
 --log-gelf-include-stack-trace <true|false>
                      DEPRECATED. If set to true, occuring stack traces are included in the
-                       'StackTrace' field in the GELF output. Default: true.
+                       'StackTrace' field in the GELF output. Default: true. Available only when
+                       GELF is activated.
 --log-gelf-level <level>
                      DEPRECATED. The log level specifying which message levels will be logged by
                        the GELF logger. Message levels lower than this value will be discarded.
-                       Default: INFO.
+                       Default: INFO. Available only when GELF is activated.
 --log-gelf-max-message-size <size>
                      DEPRECATED. Maximum message size (in bytes). If the message size is exceeded,
-                       GELF will submit the message in multiple chunks. Default: 8192.
+                       GELF will submit the message in multiple chunks. Default: 8192. Available
+                       only when GELF is activated.
 --log-gelf-port <port>
-                     DEPRECATED. The port the Logstash or Graylog Host is called on. Default: 12201.
+                     DEPRECATED. The port the Logstash or Graylog Host is called on. Default:
+                       12201. Available only when GELF is activated.
 --log-gelf-timestamp-format <pattern>
                      DEPRECATED. Set the format for the GELF timestamp field. Uses Java
-                       SimpleDateFormat pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
+                       SimpleDateFormat pattern. Default: yyyy-MM-dd HH:mm:ss,SSS. Available only
+                       when GELF is activated.
+--log-gelf-version <version>
+                     The GELF version to be used. Possible values are: 1.0, 1.1. Default: 1.1.
+                       Available only when GELF is activated.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
@@ -104,8 +104,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
@@ -104,8 +104,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 
@@ -239,47 +238,16 @@ Logging:
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
                        are: console, file, gelf (deprecated). Default: console.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false.
+                     Enable or disable colors when logging to console. Default: false. Available
+                       only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
-                       -5p [%c] (%t) %s%e%n.
+                       -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
---log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
---log-file-format <format>
-                     Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
-                       SSS} %-5p [%c] (%t) %s%e%n.
---log-file-output <output>
-                     Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
---log-gelf-facility <name>
-                     DEPRECATED. The facility (name of the process) that sends the message.
-                       Default: keycloak.
---log-gelf-host <hostname>
-                     DEPRECATED. Hostname of the Logstash or Graylog Host. By default UDP is used,
-                       prefix the host with 'tcp:' to switch to TCP. Example: 'tcp:localhost'
-                       Default: localhost.
---log-gelf-include-location <true|false>
-                     DEPRECATED. Include source code location. Default: true.
---log-gelf-include-message-parameters <true|false>
-                     DEPRECATED. Include message parameters from the log event. Default: true.
---log-gelf-include-stack-trace <true|false>
-                     DEPRECATED. If set to true, occuring stack traces are included in the
-                       'StackTrace' field in the GELF output. Default: true.
---log-gelf-level <level>
-                     DEPRECATED. The log level specifying which message levels will be logged by
-                       the GELF logger. Message levels lower than this value will be discarded.
-                       Default: INFO.
---log-gelf-max-message-size <size>
-                     DEPRECATED. Maximum message size (in bytes). If the message size is exceeded,
-                       GELF will submit the message in multiple chunks. Default: 8192.
---log-gelf-port <port>
-                     DEPRECATED. The port the Logstash or Graylog Host is called on. Default: 12201.
---log-gelf-timestamp-format <pattern>
-                     DEPRECATED. Set the format for the GELF timestamp field. Uses Java
-                       SimpleDateFormat pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
+                       values are: default, json. Default: default. Available only when Console log
+                       handler is activated.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
@@ -107,8 +107,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
@@ -40,6 +40,9 @@ Cache:
                        'cache-mtls-truststore.p12' under conf/ directory.
 --cache-embedded-mtls-trust-store-password <password>
                      The password to access the Truststore.
+--cache-metrics-histograms-enabled <true|false>
+                     Enable histograms for metrics for the embedded caches. Default: false.
+                       Available only when metrics are enabled.
 --cache-remote-host <hostname>
                      The hostname of the remote server for the remote store configuration. It
                        replaces the 'host' attribute of 'remote-server' tag of the configuration
@@ -104,8 +107,7 @@ Database:
 Transaction:
 
 --transaction-xa-enabled <true|false>
-                     If set to false, Keycloak uses a non-XA datasource in case the database does
-                       not support XA transactions. Default: true.
+                     If set to true, XA datasources will be used. Default: false.
 
 Feature:
 
@@ -239,47 +241,61 @@ Logging:
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
                        are: console, file, gelf (deprecated). Default: console.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false.
+                     Enable or disable colors when logging to console. Default: false. Available
+                       only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
-                       -5p [%c] (%t) %s%e%n.
+                       -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
---log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
+                       values are: default, json. Default: default. Available only when Console log
+                       handler is activated.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log. Available
+                       only when File log handler is activated.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
-                       SSS} %-5p [%c] (%t) %s%e%n.
+                       SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
+                       activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
-                       values are: default, json. Default: default.
+                       values are: default, json. Default: default. Available only when File log
+                       handler is activated.
 --log-gelf-facility <name>
                      DEPRECATED. The facility (name of the process) that sends the message.
-                       Default: keycloak.
+                       Default: keycloak. Available only when GELF is activated.
 --log-gelf-host <hostname>
                      DEPRECATED. Hostname of the Logstash or Graylog Host. By default UDP is used,
                        prefix the host with 'tcp:' to switch to TCP. Example: 'tcp:localhost'
-                       Default: localhost.
+                       Default: localhost. Available only when GELF is activated.
 --log-gelf-include-location <true|false>
-                     DEPRECATED. Include source code location. Default: true.
+                     DEPRECATED. Include source code location. Default: true. Available only when
+                       GELF is activated.
 --log-gelf-include-message-parameters <true|false>
                      DEPRECATED. Include message parameters from the log event. Default: true.
+                       Available only when GELF is activated.
 --log-gelf-include-stack-trace <true|false>
                      DEPRECATED. If set to true, occuring stack traces are included in the
-                       'StackTrace' field in the GELF output. Default: true.
+                       'StackTrace' field in the GELF output. Default: true. Available only when
+                       GELF is activated.
 --log-gelf-level <level>
                      DEPRECATED. The log level specifying which message levels will be logged by
                        the GELF logger. Message levels lower than this value will be discarded.
-                       Default: INFO.
+                       Default: INFO. Available only when GELF is activated.
 --log-gelf-max-message-size <size>
                      DEPRECATED. Maximum message size (in bytes). If the message size is exceeded,
-                       GELF will submit the message in multiple chunks. Default: 8192.
+                       GELF will submit the message in multiple chunks. Default: 8192. Available
+                       only when GELF is activated.
 --log-gelf-port <port>
-                     DEPRECATED. The port the Logstash or Graylog Host is called on. Default: 12201.
+                     DEPRECATED. The port the Logstash or Graylog Host is called on. Default:
+                       12201. Available only when GELF is activated.
 --log-gelf-timestamp-format <pattern>
                      DEPRECATED. Set the format for the GELF timestamp field. Uses Java
-                       SimpleDateFormat pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
+                       SimpleDateFormat pattern. Default: yyyy-MM-dd HH:mm:ss,SSS. Available only
+                       when GELF is activated.
+--log-gelf-version <version>
+                     The GELF version to be used. Possible values are: 1.0, 1.1. Default: 1.1.
+                       Available only when GELF is activated.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to


### PR DESCRIPTION
closes: #27308

As per the discussion on the issue:
xa is not enabled by default
recovery is enabled by default

A separate issue was capatured for the global state warning
Another issue will be needed for making recovery work out-of-box for the operator.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
