### PR TITLE
Bump postgresql-jdbc 42.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <postgresql.version>15</postgresql.version>
         <aurora-postgresql.version>15.3</aurora-postgresql.version>
         <aws-jdbc-wrapper.version>2.3.1</aws-jdbc-wrapper.version>
-        <postgresql-jdbc.version>42.7.1</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.2</postgresql-jdbc.version>
         <mariadb.version>10.11</mariadb.version>
         <mariadb-jdbc.version>3.3.2</mariadb-jdbc.version>
         <mssql.version>2022-latest</mssql.version>


### PR DESCRIPTION
Even if it is not 100% clear whether we are affected by CVE-2024-1597, the new lib should be used to calm down the CVE scans (e.g. Trivy)