### PR TITLE
Change fake_fips for linux 6.4 changes

### DIFF
--- a/.github/fake_fips/fake_fips.c
+++ b/.github/fake_fips/fake_fips.c
@@ -22,6 +22,7 @@
 
 #include <linux/module.h>
 #include <linux/sysctl.h>
+#include <linux/version.h>
 
 int fips_enabled = 1;
 
@@ -39,7 +40,9 @@ static struct ctl_table crypto_dir_table[] = {
 	{
 		.procname       = "crypto",
 		.mode           = 0555,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
 		.child          = crypto_sysctl_table
+#endif
 	},
 	{}
 };
@@ -48,7 +51,11 @@ static struct ctl_table_header *crypto_sysctls;
 
 static void crypto_proc_fips_init(void)
 {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
 	crypto_sysctls = register_sysctl_table(crypto_dir_table);
+#else
+	crypto_sysctls = register_sysctl(crypto_dir_table->procname, crypto_sysctl_table);
+#endif
 }
 
 static void crypto_proc_fips_exit(void)


### PR DESCRIPTION
Closes #27345

Just updating the fake fips module for 6.4 kernel module. Now it checks the version and uses the new or the old api.
