### PR TITLE
Change supported criteria for Google Authenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/otp/GoogleAuthenticatorProvider.java
+++ b/services/src/main/java/org/keycloak/authentication/otp/GoogleAuthenticatorProvider.java
@@ -22,15 +22,10 @@ public class GoogleAuthenticatorProvider implements OTPApplicationProviderFactor
 
     @Override
     public boolean supports(OTPPolicy policy) {
-        if (policy.getDigits() != 6) {
-            return false;
+        if (policy.getType().equals("totp")) {
+            return policy.getPeriod() == 30;
         }
-
-        if (!policy.getAlgorithm().equals("HmacSHA1")) {
-            return false;
-        }
-
-        return policy.getType().equals("totp") && policy.getPeriod() == 30;
+        return true;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
@@ -105,7 +105,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         String userId = events.expectRegister("setupTotp", "email@mail.com").assertEvent().getUserId();
 
         doAIA();
-        
+
         totpPage.assertCurrent();
 
         totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));
@@ -115,10 +115,10 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
                 .getDetails().get(Details.CODE_ID);
 
         assertKcActionStatus(SUCCESS);
-        
+
         events.expectLogin().user(userId).session(authSessionId).detail(Details.USERNAME, "setuptotp").assertEvent();
     }
-    
+
     @Test
     public void cancelSetupTotp() throws Exception {
         try {
@@ -187,9 +187,9 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         loginPage.open();
         loginPage.clickRegister();
         registerPage.register("firstName", "lastName", "checkQrCode@mail.com", "checkQrCode", "password", "password");
-        
+
         doAIA();
-        
+
         String pageSource = driver.getPageSource();
 
         assertTrue(pageSource.contains("Install one of the following applications on your mobile"));
@@ -246,7 +246,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         registerPage.register("firstName", "lastName", "setupTotpRegisterManualModeSwitchesOnBadSubmit@mail.com", "setupTotpRegisterManualModeSwitchesOnBadSubmit", "password", "password");
 
         doAIA();
-        
+
         String pageSource = driver.getPageSource();
 
         assertTrue(pageSource.contains("Unable to scan?"));
@@ -277,7 +277,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         registerPage.register("firstName", "lastName", "setupTotpRegisterBarcodeModeSwitchesOnBadSubmit@mail.com", "setupTotpRegisterBarcodeModeSwitchesOnBadSubmit", "password", "password");
 
         doAIA();
-        
+
         String pageSource = driver.getPageSource();
 
         assertTrue(pageSource.contains("Unable to scan?"));
@@ -314,11 +314,11 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
             registerPage.register("firstName", "lastName", "setupTotpModifiedPolicy@mail.com", "setupTotpModifiedPolicy", "password", "password");
 
             doAIA();
-            
+
             String pageSource = driver.getPageSource();
 
             assertTrue(pageSource.contains("FreeOTP"));
-            assertFalse(pageSource.contains("Google Authenticator"));
+            assertTrue(pageSource.contains("Google Authenticator"));
 
             totpPage.clickManual();
 
@@ -337,9 +337,9 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
     @Test
     public void setupTotpExisting() {
         doAIA();
-        
+
         loginPage.login("test-user@localhost", "password");
-        
+
         totpPage.assertCurrent();
 
         String totpSecret = totpPage.getTotpSecret();
@@ -378,7 +378,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         String userId = events.expectRegister("setupTotp2", "email2@mail.com").assertEvent().getUserId();
 
         doAIA();
-        
+
         // Configure totp
         totpPage.assertCurrent();
 
@@ -438,7 +438,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
 
 
         doAIA();
-        
+
         loginPage.login("test-user@localhost", "password");
 
         totpPage.assertCurrent();
@@ -505,7 +505,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
 
         String sessionId = events.expectRequiredAction(EventType.UPDATE_TOTP).assertEvent()
             .getDetails().get(Details.CODE_ID);
-        
+
         //RequestType reqType = appPage.getRequestType();
         assertKcActionStatus(SUCCESS);
         EventRepresentation loginEvent = events.expectLogin().session(sessionId).assertEvent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
@@ -338,7 +338,7 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
             String pageSource = driver.getPageSource();
 
             assertTrue(pageSource.contains("FreeOTP"));
-            assertFalse(pageSource.contains("Google Authenticator"));
+            assertTrue(pageSource.contains("Google Authenticator"));
             assertFalse(pageSource.contains("Microsoft Authenticator"));
 
             totpPage.clickManual();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
@@ -569,7 +569,7 @@ public class RealmTest extends AbstractAdminTest {
         rep.setRealm("");
         assertThrows(BadRequestException.class, () -> realm.update(rep));
     }
-    
+
     @Test
     public void updateRealm() {
         // first change
@@ -1027,8 +1027,17 @@ public class RealmTest extends AbstractAdminTest {
         rep = realm.toRepresentation();
 
         supportedApplications = rep.getOtpSupportedApplications();
-        assertThat(supportedApplications, hasSize(1));
-        assertThat(supportedApplications, containsInAnyOrder("totpAppFreeOTPName"));
+        assertThat(supportedApplications, hasSize(2));
+        assertThat(supportedApplications, containsInAnyOrder("totpAppFreeOTPName", "totpAppGoogleName"));
+
+        rep.setOtpPolicyType("hotp");
+        realm.update(rep);
+
+        rep = realm.toRepresentation();
+
+        supportedApplications = rep.getOtpSupportedApplications();
+        assertThat(supportedApplications, hasSize(2));
+        assertThat(supportedApplications, containsInAnyOrder("totpAppFreeOTPName", "totpAppGoogleName"));
     }
 
     private void setupTestAppAndUser() {


### PR DESCRIPTION
This change adds Google Authenticator to the list of supported authenticator apps, also when OTP policy sets any combination of:

- hash algorithm: SHA256 or SHA512
- number of digits:  8
- OTP type: HOTP 

The list of supported authenticators is visible in admin console in OTP policy page, and in account console when user adds authenticator. Before this PR, Google Authenticator was not listed as supported, even though the latest version of the app works under these OTP parameters.

Fixes #27349

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
