### PR TITLE
fix: provide a better error message when option parsing fails

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/aesh/AeshConsoleCallbackImpl.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/aesh/AeshConsoleCallbackImpl.java
@@ -70,8 +70,9 @@ class AeshConsoleCallbackImpl extends AeshConsoleCallback {
             } catch (Exception e) {
                 console.stop();
 
-                if (e instanceof OptionParserException) {
-                    System.err.println("Unknown command: " + aeshLine.getWords().get(0));
+                if (e instanceof OptionParserException && "Option: - must be followed by a valid operator".equals(e.getMessage())) {
+                    System.err.println("Please double check your command options, one or more of them are not specified correctly. "
+                            + "It is possible to have unintentional overlap with other options. e.g. using --clientid will get mistaken for --client, however --cclientid is needed.");
                 } else {
                     System.err.println(e.getMessage());
                 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmTest.java
@@ -227,6 +227,15 @@ public class KcAdmTest extends AbstractAdmCliTest {
     }
 
     @Test
+    public void testBadOverlappingOption() {
+        KcAdmExec exe = KcAdmExec.execute("config credentials --server http://localhost:8080 --realm master --username admin --password admin");
+
+        assertExitCodeAndStreamSizes(exe, 1, 0, 1);
+        Assert.assertEquals("stderr first line", "Please double check your command options, one or more of them are not specified correctly. "
+                + "It is possible to have unintentional overlap with other options. e.g. using --clientid will get mistaken for --client, however --cclientid is needed.", exe.stderrLines().get(0));
+    }
+
+    @Test
     public void testCredentialsServerAndRealmWithDefaultConfig() {
         /*
          *  Test without --server specified


### PR DESCRIPTION
closes: #16260 

This is caused by some odd parsing logic in aesh which allow it to get confused and produce a non-meaningful exception. This is the easiest fix - just provide a suggestion. Other option exceptions appear to provide meaningful messages, so we'll use those instead.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
