### PR TITLE
Handle possible special characters in a path to kc.bat

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -14,7 +14,7 @@ if "%OS%" == "Windows_NT" (
 )
 
 if "%OS%" == "Windows_NT" (
-  set DIRNAME=%~dp0%
+  set "DIRNAME=%~dp0"
 ) else (
   set DIRNAME=.\
 )


### PR DESCRIPTION
* enclose the DIRNAME variable in double quotes

Closes #19294
