### PR TITLE
Continue LDAP search if a duplicated user (ModelDuplicateException) is found

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSearchForUsersPaginationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSearchForUsersPaginationTest.java
@@ -36,10 +36,13 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.LDAPRule;
 import org.keycloak.testsuite.util.LDAPTestUtils;
+import org.keycloak.testsuite.util.UserBuilder;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class LDAPSearchForUsersPaginationTest extends AbstractLDAPTest {
@@ -178,6 +181,38 @@ public class LDAPSearchForUsersPaginationTest extends AbstractLDAPTest {
                 .stream().map(UserRepresentation::getUsername)
                 .collect(Collectors.toSet());
         Assert.assertEquals(Set.of("john"), usernames);
+    }
+
+    public void testDuplicateEmailInDatabase() {
+        setLDAPEnabled(false);
+        try {
+            // create a local db user with the same email than an a ldap user
+            String userId = ApiUtil.getCreatedId(testRealm().users().create(UserBuilder.create()
+                    .username("jdoe").firstName("John").lastName("Doe")
+                    .email("john14@email.org")
+                    .build()));
+            Assert.assertNotNull("User not created", userId);
+            getCleanup().addUserId(userId);
+        } finally {
+            setLDAPEnabled(true);
+        }
+
+        List<UserRepresentation> search = adminClient.realm(TEST_REALM_NAME).users()
+                .search("john14@email.org", null, null)
+                .stream().collect(Collectors.toList());
+        Assert.assertEquals("Incorrect users found", 1, search.size());
+        Assert.assertEquals("Incorrect User", "jdoe", search.get(0).getUsername());
+        Assert.assertTrue("Duplicated user created", adminClient.realm(TEST_REALM_NAME).users().search("john", true).isEmpty());
+    }
+
+    private void setLDAPEnabled(final boolean enabled) {
+        testingClient.server().run((KeycloakSession session) -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            ctx.getLdapModel().getConfig().putSingle("enabled", Boolean.toString(enabled));
+            appRealm.updateComponent(ctx.getLdapModel());
+        });
     }
 
     private void assertLDAPSearchMatchesLocalDB(String searchString) {


### PR DESCRIPTION
Closes #25778

The PR catches the `ModelDuplicateException` and return null if the `forcedImport` is not true. The idea is the search tries to continue when a duplicated user is found. Test added.

@pedroigor FYI
