### PR TITLE
changed repository url to make finding the source easier

### DIFF
--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -59,7 +59,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/keycloak/keycloak.git"
+    "url": "https://github.com/keycloak/keycloak.git",
+    "directory": "js/libs/keycloak-admin-client"
   },
   "homepage": "https://www.keycloak.org/"
 }


### PR DESCRIPTION
right now the repository url just points to the main repo.
this PR changes it to the actual location, making it easier.

related to issue: #27008

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
