### PR TITLE
OAuth 2.1 default profile lacks oauth-2-1-compliant setting for SecureRedirectUrisEnforcerExecutor

### DIFF
--- a/services/src/main/resources/keycloak-default-client-profiles.json
+++ b/services/src/main/resources/keycloak-default-client-profiles.json
@@ -308,7 +308,8 @@
           "configuration": {
             "allow-ipv4-loopback-address": "true",
             "allow-ipv6-loopback-address": "true",
-            "allow-private-use-uri-scheme": "true"
+            "allow-private-use-uri-scheme": "true",
+            "oauth-2-1-compliant": "true"
           }
         },
         {
@@ -346,7 +347,8 @@
           "configuration": {
             "allow-ipv4-loopback-address": "true",
             "allow-ipv6-loopback-address": "true",
-            "allow-private-use-uri-scheme": "true"
+            "allow-private-use-uri-scheme": "true",
+            "oauth-2-1-compliant": "true"
           }
         },
         {


### PR DESCRIPTION
closes #27412

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
