### PR TITLE
Clean up feature IDs in the docs

### DIFF
--- a/docs/documentation/authorization_services/topics/service-protection-policy-api.adoc
+++ b/docs/documentation/authorization_services/topics/service-protection-policy-api.adoc
@@ -77,10 +77,6 @@ curl -X POST \
 
 Or even using a custom policy using JavaScript:
 
-:tech_feature_name: Upload Scripts
-:tech_feature_setting: -Dkeycloak.profile.feature.upload_scripts=enabled
-include::./templates/deprecated.adoc[]
-
 [source,bash,subs="attributes+"]
 ----
 curl -X POST \

--- a/docs/documentation/securing_apps/topics/token-exchange/token-exchange.adoc
+++ b/docs/documentation/securing_apps/topics/token-exchange/token-exchange.adoc
@@ -4,7 +4,7 @@
 == Using token exchange
 
 :tech_feature_name: Token Exchange
-:tech_feature_setting: -Dkeycloak.profile.feature.token_exchange=enabled
+:tech_feature_id: token-exchange
 include::../templates/techpreview.adoc[]
 
 [NOTE]

--- a/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain.adoc
@@ -3,7 +3,6 @@
 === Fine grain admin permissions
 
 :tech_feature_name: Fine Grain Admin Permissions
-:tech_feature_setting: -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled
 :tech_feature_id: admin-fine-grained-authz
 include::../templates/techpreview.adoc[]
 

--- a/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
+++ b/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
@@ -4,18 +4,6 @@
 
 You can configure Recovery codes for two-factor authentication by adding 'Recovery Authentication Code Form' as a two-factor authenticator to your authentication flow. For an example of configuring this authenticator, see xref:webauthn_{context}[WebAuthn].
 
-ifeval::[{project_product}==true]
 :tech_feature_name: RecoveryCodes
-:tech_feature_setting: -Dkeycloak.profile.feature.recovery_codes=enabled
 :tech_feature_id: recovery-codes
 include::../templates/techpreview.adoc[]
-endif::[]
-
-ifeval::[{project_community}==true]
-
-[IMPORTANT]
-====
-Please note that Recovery Codes support is in development. Use this feature experimentally.
-====
-
-endif::[]

--- a/docs/documentation/server_admin/topics/clients/oidc/con-advanced-settings.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-advanced-settings.adoc
@@ -131,7 +131,6 @@ Currently, {project_name} client adapters do not support DPoP holder-of-key toke
 ====
 
 :tech_feature_name: DPoP
-:tech_feature_setting: -Dkeycloak.profile.feature.dpop=enabled
 :tech_feature_id: dpop
 include::../../templates/techpreview.adoc[]
 

--- a/docs/documentation/server_admin/topics/login-settings/update-email-workflow.adoc
+++ b/docs/documentation/server_admin/topics/login-settings/update-email-workflow.adoc
@@ -8,21 +8,9 @@ The action is associated with a single email input form. If the realm has email 
 
 Applications are able to send their users to the email update form by leveraging UPDATE_EMAIL as an AIA (Application Initiated Action).
 
-ifeval::[{project_product}==true]
 :tech_feature_name: UpdateEmail
-:tech_feature_setting: -Dkeycloak.profile.feature.update_email=enabled
 :tech_feature_id: update-email
 include::../templates/techpreview.adoc[]
-endif::[]
-
-ifeval::[{project_community}==true]
-
-[IMPORTANT]
-====
-Please note that Update Email Workflow support is in development. Use this feature experimentally.
-====
-
-endif::[]
 
 [NOTE]
 ====

--- a/docs/documentation/server_admin/topics/sessions/preloading.adoc
+++ b/docs/documentation/server_admin/topics/sessions/preloading.adoc
@@ -9,7 +9,10 @@ Therefore, the offline sessions are lazily fetched from the database by default.
 
 However, {project_name} can be configured to preload the offline sessions from the database into the Infinispan caches during the server startup.
 It can be achieved by setting `preloadOfflineSessionsFromDatabase` property in the `userSessions` SPI to `true`.
-This functionality is currently deprecated and will be removed in a future release.
+
+:tech_feature_name: Offline session preloading
+:tech_feature_id: offline-session-preloading
+include::../templates/deprecated.adoc[]
 
 The following example shows how to configure offline sessions preloading.
 

--- a/docs/documentation/server_development/topics/providers.adoc
+++ b/docs/documentation/server_development/topics/providers.adoc
@@ -235,6 +235,10 @@ bin/kc.[sh|bat] build --spi-user-cache-infinispan-enabled=false
 [[_script_providers]]
 === JavaScript providers
 
+:tech_feature_name: Scripts
+:tech_feature_id: scripts
+include::./templates/techpreview.adoc[]
+
 {project_name} has the ability to execute scripts during runtime in order to allow administrators to customize specific functionalities:
 
 * Authenticator
@@ -359,7 +363,8 @@ my-script-mapper.js
 
 The `META-INF/keycloak-scripts.json` is a file descriptor that provides metadata information about the scripts you want to deploy. It is a JSON file with the following structure:
 
-```json
+[source,json]
+----
 {
     "authenticators": [
         {
@@ -390,7 +395,7 @@ The `META-INF/keycloak-scripts.json` is a file descriptor that provides metadata
         }
     ]
 }
-```
+----
 
 This file should reference the different types of script providers that you want to deploy:
 
@@ -428,7 +433,6 @@ The name of the script file. This property is *mandatory* and should map to a fi
 ==== Deploy the script JAR
 
 Once you have a JAR file with a descriptor and the scripts you want to deploy, you just need to copy the JAR to the {project_name} `providers/` directory, then run `bin/kc.[sh|bat] build`.
-Note that you also need to enable the `scripts` feature.
 
 === Available SPIs
 

--- a/docs/documentation/topics/templates/deprecated.adoc
+++ b/docs/documentation/topics/templates/deprecated.adoc
@@ -3,10 +3,10 @@ ifeval::[{tech_feature_disabled}!=false]
 ====
 {tech_feature_name} is *Deprecated* and will be removed in future releases. This feature is disabled by default.
 
+ifdef::tech_feature_id[]
 To enable start the server with
-ifdef::tech_feature_setting[]
-`{tech_feature_setting}`
+`--features={tech_feature_id}`.
 endif::[]
-. For more details see the https://www.keycloak.org/server/features[Enabling and disabling features] {section}.
+For more details see the https://www.keycloak.org/server/features[Enabling and disabling features] {section}.
 ====
 endif::[]

--- a/docs/documentation/topics/templates/techpreview.adoc
+++ b/docs/documentation/topics/templates/techpreview.adoc
@@ -1,10 +1,17 @@
 ifeval::[{tech_feature_disabled}!=false]
 [NOTE]
 ====
-{tech_feature_name} is *Technology Preview* and is not fully supported. This feature is disabled by default.
+{tech_feature_name} is
+ifeval::[{project_product}==true]
+*Technology Preview*
+endif::[]
+ifeval::[{project_community}==true]
+*Preview*
+endif::[]
+and is not fully supported. This feature is disabled by default.
 
 To enable start the server with `--features=preview`
-ifdef::tech_feature_setting[]
+ifdef::tech_feature_id[]
 or `--features={tech_feature_id}`
 endif::[]
 


### PR DESCRIPTION
This removes the `tech_feature_setting` which is no longer used since we move to Quarkus. It also uses the term *Preview* instead of *Technology Preview* as this how it is used in the upstream docs.

Closes #27416

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
