### PR TITLE
Fix return type of clients.findRole() in @keycloak/keycloak-admin-client

### DIFF
--- a/js/apps/admin-ui/src/clients/roles/CreateClientRole.tsx
+++ b/js/apps/admin-ui/src/clients/roles/CreateClientRole.tsx
@@ -34,10 +34,10 @@ export default function CreateClientRole() {
         ...role,
       });
 
-      const createdRole = await adminClient.clients.findRole({
+      const createdRole = (await adminClient.clients.findRole({
         id: clientId!,
         roleName: role.name!,
-      });
+      }))!;
 
       addAlert(t("roleCreated"), AlertVariant.success);
       navigate(

--- a/js/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/js/libs/keycloak-admin-client/src/resources/clients.ts
@@ -113,7 +113,7 @@ export class Clients extends Resource<{ realm?: string }> {
 
   public findRole = this.makeRequest<
     { id: string; roleName: string },
-    RoleRepresentation
+    RoleRepresentation | null
   >({
     method: "GET",
     path: "/{id}/roles/{roleName}",


### PR DESCRIPTION
If no role by that name is found `null` is returned

Closes: #27444


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
