### PR TITLE
Change oidcScopeMissing from WARN to DEBUG

### DIFF
--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -401,7 +401,7 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=90, value="Failed to close ProviderSession")
     void failedToCloseProviderSession(@Cause Throwable t);
 
-    @LogMessage(level = WARN)
+    @LogMessage(level = DEBUG)
     @Message(id=91, value="Request is missing scope 'openid' so it's not treated as OIDC, but just pure OAuth2 request.")
     @Once
     void oidcScopeMissing();


### PR DESCRIPTION
Closes #27391

Just changing the `oidcScopeMissing` mssage from WARN to DEBUG to not display it by default.

@mposolda Let me know if this is enough or something more is needed.
