### PR TITLE
Authz-client: fix ClassCast Exception when getting resource permissions (#27483)

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/AuthorizationResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/AuthorizationResource.java
@@ -86,6 +86,7 @@ public class AuthorizationResource {
 
         if (request.getMetadata() == null) {
             metadata = new AuthorizationRequest.Metadata();
+            request.setMetadata(metadata);
         } else {
             metadata = request.getMetadata();
         }


### PR DESCRIPTION
Fixes #27483
Looks like a fairly obvious oversight in the initial implementation.  More details in the issue.