### PR TITLE
Authz-client: fix ClassCast Exception when getting resource permissions (#27483)

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/AuthorizationResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/AuthorizationResource.java
@@ -86,6 +86,7 @@ public class AuthorizationResource {
 
         if (request.getMetadata() == null) {
             metadata = new AuthorizationRequest.Metadata();
+            request.setMetadata(metadata);
         } else {
             metadata = request.getMetadata();
         }


### PR DESCRIPTION
Closes #27483

More details in the issue.

Looks like a fairly trivial oversight, where after a null guard, an new Metadata object is created and populated, but then never used.

Line 122 then expects this metadata to be populated.

Both have been added with the same commit and are seemingly intended to work in tandem.