### PR TITLE
docs(cpu and memory sizing): typo GB -> MB

### DIFF
--- a/docs/guides/high-availability/concepts-memory-and-cpu-sizing.adoc
+++ b/docs/guides/high-availability/concepts-memory-and-cpu-sizing.adoc
@@ -76,7 +76,7 @@ Limits calculated:
 +
 (1000 MB base memory plus 250 MB RAM for 50,000 active sessions)
 
-* Memory limit: 1360 GB
+* Memory limit: 1360 MB
 +
 (1250 MB expected memory usage minus 300 non-heap-usage, divided by 0.7)
 


### PR DESCRIPTION
Closes #27504

Found a typo, fixed it.

The deployment example should not be in GB for limits, MB instead.