### PR TITLE
keycloak-model-legacy is deprecated, not removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1220,6 +1220,11 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-model-legacy</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-model-storage</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -249,6 +249,16 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-legacy</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-storage-private</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Closes #27529

`keycloak-model-legacy` is supposedly only deprecated and not yet removed, but without it being a dependency of keycloak the class `LegacyUserCredentialManager` is not available at runtime.

```
2024-03-04 22:06:59,850 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-7) Uncaught server error: java.lang.NoClassDefFoundError: org/keycloak/credential/LegacyUserCredentialManager
```
