### PR TITLE
A duplicate bean is already registered.

### DIFF
--- a/docs/documentation/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/docs/documentation/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -158,9 +158,6 @@ While Spring Security's XML namespace simplifies configuration, customizing the 
     <bean id="keycloakSecurityContextRequestFilter"
           class="org.keycloak.adapters.springsecurity.filter.KeycloakSecurityContextRequestFilter" />
 
-<bean id="keycloakSecurityContextRequestFilter"
-     class="org.keycloak.adapters.springsecurity.filter.KeycloakSecurityContextRequestFilter" />
-
     <bean id="keycloakLogoutHandler" class="org.keycloak.adapters.springsecurity.authentication.KeycloakLogoutHandler">
         <constructor-arg ref="adapterDeploymentContext" />
     </bean>


### PR DESCRIPTION
If execute the example registered in the document as it is, the following error. "Configuration problem: Bean name 'keycloakSecurityContextRequestFilter' is already used in this element"

close #27521

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
