### PR TITLE
Make sure refresh token expiration is based on the current time when the token is issued

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -430,10 +430,6 @@ public class TokenManager {
 
         validateTokenReuseForRefresh(session, realm, refreshToken, validation);
 
-        int currentTime = Time.currentTime();
-        clientSession.setTimestamp(currentTime);
-        validation.userSession.setLastSessionRefresh(currentTime);
-
         if (refreshToken.getAuthorization() != null) {
             validation.newToken.setAuthorization(refreshToken.getAuthorization());
         }
@@ -1142,24 +1138,29 @@ public class TokenManager {
         }
 
         private void generateRefreshToken(boolean offlineTokenRequested) {
+            refreshToken = new RefreshToken(accessToken);
+            refreshToken.id(KeycloakModelUtils.generateId());
+            refreshToken.issuedNow();
+            int currentTime = Time.currentTime();
+            AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
+            clientSession.setTimestamp(currentTime);
+            UserSessionModel userSession = clientSession.getUserSession();
+            userSession.setLastSessionRefresh(currentTime);
+
             if (offlineTokenRequested) {
                 UserSessionManager sessionManager = new UserSessionManager(session);
                 if (!sessionManager.isOfflineTokenAllowed(clientSessionCtx)) {
                     event.error(Errors.NOT_ALLOWED);
                     throw new ErrorResponseException("not_allowed", "Offline tokens not allowed for the user or client", Response.Status.BAD_REQUEST);
                 }
-
-                refreshToken = new RefreshToken(accessToken);
                 refreshToken.type(TokenUtil.TOKEN_TYPE_OFFLINE);
-                if (realm.isOfflineSessionMaxLifespanEnabled())
+                if (realm.isOfflineSessionMaxLifespanEnabled()) {
                     refreshToken.expiration(getExpiration(true));
+                }
                 sessionManager.createOrUpdateOfflineSession(clientSessionCtx.getClientSession(), userSession);
             } else {
-                refreshToken = new RefreshToken(accessToken);
                 refreshToken.expiration(getExpiration(false));
             }
-            refreshToken.id(KeycloakModelUtils.generateId());
-            refreshToken.issuedNow();
         }
 
         private int getExpiration(boolean offline) {


### PR DESCRIPTION
Closes #27180 
Needs #27574

* When issuing tokens, the expiration time for refresh tokens should be based on when the token is being issued and not from the last time the client session was refreshed.

The problem being fixed here is more evident when using the permission grant type because for this grant type we are not creating new user/client sessions on every token request like when doing client credentials (where a new user session is created all the time).

I'm not 100% sure if the fix here is the best because the time stamp from the client session should not be used to set the expiration time for refresh tokens but the time the token response is being created. For this reason, marking it as a draft for now.