### PR TITLE
"Allowed Protocol Mapper Types" prevents clients from self-updating via client registration api

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
@@ -74,13 +74,15 @@ public class ProtocolMappersClientRegistrationPolicy implements ClientRegistrati
 			}
 			String mapperRepresentationId = mapperRepresentation.getId();
 			if (mapperRepresentationId == null) {
-				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
-				return;
+				String message = "Missing id for mapper named '%s'".formatted(mapperRepresentation.getName());
+				ServicesLogger.LOGGER.warn(message);
+				throw new ClientRegistrationPolicyException(message);
 			}
 			ProtocolMapperModel mapperModel = clientModel.getProtocolMapperById(mapperRepresentationId);
 			if (mapperModel == null) {
-				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
-				return;
+				String message = "No existing mapper model found for id '%s'".formatted(mapperRepresentationId);
+				ServicesLogger.LOGGER.warn(message);
+				throw new ClientRegistrationPolicyException(message);
 			}
 			Map<String, String> modelConfig = mapperModel.getConfig();
 			Map<String, String> representationConfig = mapperRepresentation.getConfig();

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
@@ -18,12 +18,15 @@
 package org.keycloak.services.clientregistration.policy.impl;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.clientregistration.ClientRegistrationContext;
@@ -48,10 +51,10 @@ public class ProtocolMappersClientRegistrationPolicy implements ClientRegistrati
 
     @Override
     public void beforeRegister(ClientRegistrationContext context) throws ClientRegistrationPolicyException {
-        testMappers(context);
+        testMappers(context, null);
     }
 
-    protected void testMappers(ClientRegistrationContext context) throws ClientRegistrationPolicyException {
+    protected void testMappers(ClientRegistrationContext context, ClientModel clientModel) throws ClientRegistrationPolicyException {
         List<ProtocolMapperRepresentation> protocolMappers = context.getClient().getProtocolMappers();
         if (protocolMappers == null) {
             return;
@@ -59,15 +62,39 @@ public class ProtocolMappersClientRegistrationPolicy implements ClientRegistrati
 
         List<String> allowedMapperProviders = getAllowedMapperProviders();
 
-        for (ProtocolMapperRepresentation mapper : protocolMappers) {
-            String mapperType = mapper.getProtocolMapper();
+        for (ProtocolMapperRepresentation mapperRepresentation : protocolMappers) {
+            String mapperType = mapperRepresentation.getProtocolMapper();
 
-            if (!allowedMapperProviders.contains(mapperType)) {
-                ServicesLogger.LOGGER.clientRegistrationMapperNotAllowed(mapper.getName(), mapperType);
-                throw new ClientRegistrationPolicyException("ProtocolMapper type not allowed");
-            }
-        }
+			if (allowedMapperProviders.contains(mapperType)) {
+				continue;
+			}
+			if (clientModel == null) {
+				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
+				return;
+			}
+			String mapperRepresentationId = mapperRepresentation.getId();
+			if (mapperRepresentationId == null) {
+				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
+				return;
+			}
+			ProtocolMapperModel mapperModel = clientModel.getProtocolMapperById(mapperRepresentationId);
+			if (mapperModel == null) {
+				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
+				return;
+			}
+			Map<String, String> modelConfig = mapperModel.getConfig();
+			Map<String, String> representationConfig = mapperRepresentation.getConfig();
+			if (!Objects.equals(representationConfig, modelConfig)) {
+				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
+				return;
+			}
+		}
     }
+
+	protected void failWithProtocolMapperTypeNotAllowedError(ProtocolMapperRepresentation mapper) {
+		ServicesLogger.LOGGER.clientRegistrationMapperNotAllowed(mapper.getName(), mapper.getProtocolMapper());
+		throw new ClientRegistrationPolicyException("ProtocolMapper type not allowed");
+	}
 
     // Remove builtin mappers of unsupported types too
     @Override
@@ -82,10 +109,9 @@ public class ProtocolMappersClientRegistrationPolicy implements ClientRegistrati
                 .forEach(clientModel::removeProtocolMapper);
     }
 
-    // We don't take already existing protocolMappers into consideration for now
     @Override
     public void beforeUpdate(ClientRegistrationContext context, ClientModel clientModel) throws ClientRegistrationPolicyException {
-        testMappers(context);
+        testMappers(context, clientModel);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationPoliciesTest.java
@@ -573,7 +573,7 @@ public class ClientRegistrationPoliciesTest extends AbstractClientRegistrationTe
         registeredClient.getProtocolMappers().add(createHardcodedMapperRep());
 
         // Check I can't update client because of protocolMapper
-        assertFail(ClientRegOp.UPDATE, registeredClient, 403, "ProtocolMapper type not allowed");
+        assertFail(ClientRegOp.UPDATE, registeredClient, 403, "Missing id for mapper named 'Hardcoded foo role'");
 
         // Remove "bad" protocolMapper
         registeredClient.getProtocolMappers().removeIf((ProtocolMapperRepresentation mapper) -> {
@@ -625,7 +625,7 @@ public class ClientRegistrationPoliciesTest extends AbstractClientRegistrationTe
 
         ClientRepresentation representation = clientResource.toRepresentation();
         representation.getProtocolMappers().add(createHardcodedMapperRep());
-        assertFail(ClientRegOp.UPDATE, representation, 403, "ProtocolMapper type not allowed");
+        assertFail(ClientRegOp.UPDATE, representation, 403, "Missing id for mapper named 'Hardcoded foo role'");
 
         // Revert client
         ApiUtil.findClientResourceByClientId(realmResource(), "test-app").remove();
@@ -668,10 +668,9 @@ public class ClientRegistrationPoliciesTest extends AbstractClientRegistrationTe
         ClientResource clientResource = realmResource().clients().get(clientTechnicalId);
 
         reg.auth(Auth.token(clientResource.regenerateRegistrationAccessToken()));
-        // Check the client can be updated with a representation keeping the disallowed protocolMapper
         ClientRepresentation representation = clientResource.toRepresentation();
         representation.getProtocolMappers().forEach(mapper -> mapper.setId(UUID.randomUUID().toString()));
-        assertFail(ClientRegOp.UPDATE, representation, 403, "ProtocolMapper type not allowed");
+        assertFail(ClientRegOp.UPDATE, representation, 403, "No existing mapper model found for id");
 
         // Revert client
         ApiUtil.findClientResourceByClientId(realmResource(), "test-app").remove();


### PR DESCRIPTION
Fix #27558