### PR TITLE
keycloak-model-legacy is deprecated, not removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1220,6 +1220,11 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-model-legacy</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-model-storage</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -249,6 +249,16 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-legacy</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-storage-private</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Closes #27529

Signed-off-by: Stu Tomlinson <stu@nosnilmot.com>
Signed-off-by: Alexander Schwartz <aschwart@redhat.com>
Co-authored-by: Alexander Schwartz <aschwart@redhat.com>
(cherry picked from commit 662ab9811b05f31c35548fc1b36c6923138dd981)