### PR TITLE
Clarify format of keys in `additionalOptions` field in the Keycloak CR (#27435)

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -98,6 +98,8 @@ spec:
     - name: spi-email-template-mycustomprovider-enabled
       value: true # plain text value
 ----
+NOTE:  The name format of options defined in this way is identical to the key format of options specified in the configuration file.
+       For details on various configuration formats, see <@links.server id="configuration"/>.
 
 === Secret References
 


### PR DESCRIPTION
Closes #27433

Signed-off-by: Václav Muzikář <vmuzikar@redhat.com>
(cherry picked from commit 43727aa10f469b78716e1e16a4e1f29a8530ebd6)