### PR TITLE
fix: accounting for the possibility of null flows from existing realms

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/AuthenticationMapper.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/AuthenticationMapper.java
@@ -43,7 +43,7 @@ public class AuthenticationMapper {
 
         final List<String> useAsDefault = Stream.of(realm.getBrowserFlow(), realm.getRegistrationFlow(), realm.getDirectGrantFlow(),
                         realm.getResetCredentialsFlow(), realm.getClientAuthenticationFlow(), realm.getDockerAuthenticationFlow(), realm.getFirstBrokerLoginFlow())
-                .filter(f -> flow.getAlias().equals(f.getAlias())).map(AuthenticationFlowModel::getAlias).collect(Collectors.toList());
+                .filter(f -> f != null && flow.getAlias().equals(f.getAlias())).map(AuthenticationFlowModel::getAlias).collect(Collectors.toList());
 
         if (!useAsDefault.isEmpty()) {
             authentication.setUsedBy(new UsedBy(UsedBy.UsedByType.DEFAULT, useAsDefault));

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -605,13 +605,15 @@ public class DefaultAuthenticationFlows {
             if (browserFlow == null) {
                 browserFlow = realm.getFlowByAlias(DefaultAuthenticationFlows.BROWSER_FLOW);
             }
-            List<AuthenticationExecutionModel> browserExecutions = new LinkedList<>();
-            KeycloakModelUtils.deepFindAuthenticationExecutions(realm, browserFlow, browserExecutions);
-            for (AuthenticationExecutionModel browserExecution : browserExecutions) {
-                if (browserExecution.isAuthenticatorFlow()){
-                    if (realm.getAuthenticationExecutionsStream(browserExecution.getFlowId())
-                            .anyMatch(e -> e.getAuthenticator().equals("auth-otp-form"))){
-                        execution.setRequirement(browserExecution.getRequirement());
+            if (browserFlow != null) {
+                List<AuthenticationExecutionModel> browserExecutions = new LinkedList<>();
+                KeycloakModelUtils.deepFindAuthenticationExecutions(realm, browserFlow, browserExecutions);
+                for (AuthenticationExecutionModel browserExecution : browserExecutions) {
+                    if (browserExecution.isAuthenticatorFlow()){
+                        if (realm.getAuthenticationExecutionsStream(browserExecution.getFlowId())
+                                .anyMatch(e -> e.getAuthenticator().equals("auth-otp-form"))){
+                            execution.setRequirement(browserExecution.getRequirement());
+                        }
                     }
                 }
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -258,6 +258,13 @@ public class ExportImportTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void testImportFromRealmWithPartialAuthenticationFlows() {
+        // import a realm with no built-in authentication flows
+        importRealmFromFile("/import/partial-authentication-flows-import.json");
+        Assert.assertTrue("Imported realm hasn't been found!", isRealmPresent("partial-authentication-flows-import"));
+    }
+
+    @Test
     public void testImportWithNullAuthenticatorConfigAndNoDefaultBrowserFlow() {
         importRealmFromFile("/import/testrealm-authenticator-config-null.json");
         Assert.assertTrue("Imported realm hasn't been found!", isRealmPresent("cez"));

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/import/partial-authentication-flows-import.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/import/partial-authentication-flows-import.json
@@ -1,0 +1,23 @@
+{
+  "enabled": true,
+  "realm": "partial-authentication-flows-import",
+  "authenticationFlows": [
+    {
+      "alias": "X.509 browser",
+      "description": "Browser-based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
closes: #23980

@vmuzikar @keycloak/core-maintainers this is a proposed fix for #23980. The underlying issue for the user who logged the issue was that importing a realm with just a single authentication flow errored out with an NPE. Adding another authentication flow caused a different NPE. Both of these are now guarded against with these changes.

However as far as I can tell the underlying issue is that when performing an import we will create all of the 7 built-in authentication flows - but only if the existing list is empty. So having a single flow populated prevented this from happening. The proposal instead is that we should always perform the migration of authentication flows on import even if the list is populated.

The reason to leave in the NPE fixes in addition to this import change is that other users on that issue reported the AuthenticationMapper exception on an existing realm. So it seems like we'll still have to guard against one of the 7 built-in authentication flows from being null - unless there is some other change that would force the migration if needed.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
