### PR TITLE
Disable test retries to find flaky tests

### DIFF
--- a/js/apps/admin-ui/cypress.config.js
+++ b/js/apps/admin-ui/cypress.config.js
@@ -13,11 +13,6 @@ export default defineConfig({
   defaultCommandTimeout: 30000,
   numTestsKeptInMemory: 30,
   experimentalMemoryManagement: true,
-
-  retries: {
-    runMode: 3,
-  },
-
   e2e: {
     baseUrl: "http://localhost:8080",
     slowTestThreshold: 30000,


### PR DESCRIPTION
This PR is not intended to be merged, but simply used as an indicator of tests that are not as robust as they should be.