### PR TITLE
task: ensuring that keycloaksessions are closed

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/CreateSessionHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/CreateSessionHandler.java
@@ -22,6 +22,7 @@ import static org.keycloak.common.util.Resteasy.clearContextData;
 import jakarta.ws.rs.container.CompletionCallback;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+import org.keycloak.common.util.Resteasy;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.quarkus.runtime.transaction.TransactionalSessionHandler;
 
@@ -39,13 +40,20 @@ public final class CreateSessionHandler implements ServerRestHandler, Transactio
         if (currentSession == null) {
             // this handler might be invoked multiple times when resolving sub-resources
             // make sure the session is created once
-            routingContext.put(KeycloakSession.class.getName(), create());
+            KeycloakSession session = create();
+            routingContext.put(KeycloakSession.class.getName(), session);
             context.registerCompletionCallback(this);
+            Resteasy.pushContext(KeycloakSession.class, session);
         }
     }
 
     @Override
     public void onComplete(Throwable throwable) {
+        try {
+            close(Resteasy.getContextData(KeycloakSession.class));
+        } catch (Exception e) {
+
+        }
         clearContextData();
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -78,8 +78,7 @@ public class FipsDistTest {
             dist.copyOrReplaceFileFromClasspath("/server.keystore", Path.of("conf", "server.keystore"));
             CLIResult cliResult = dist.run("start", "--fips-mode=strict");
             dist.assertStopped();
-            // after https://issues.redhat.com/browse/JBTM-3830 reenable this check
-            //cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
+            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
         });
     }
 
@@ -127,8 +126,7 @@ public class FipsDistTest {
             dist.copyOrReplaceFileFromClasspath("/server.keystore.pkcs12", Path.of("conf", "server.keystore"));
             CLIResult cliResult = dist.run("start", "--fips-mode=strict", "--https-key-store-password=passwordpassword");
             dist.assertStopped();
-            // after https://issues.redhat.com/browse/JBTM-3830 reenable this check
-            //cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
+            cliResult.assertMessage("ERROR: java.lang.IllegalArgumentException: malformed sequence");
         });
     }
 


### PR DESCRIPTION
closes: #27681

In running repeated local tests I did see some test failures (in about 5% of runs) - however they were no longer related to the shutdown issue. Instead they were similar to #26042:

```
2024-03-07 15:43:52,573 WARN  [org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator] (JPA Startup Thread) HHH000342: Could not obtain connection to query metadata: java.lang.NullPointerException: Cannot invoke "org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(java.sql.SQLException, String)" because the return value of "org.hibernate.resource.transaction.backend.jta.internal.JtaIsolationDelegate.sqlExceptionHelper()" is null
```
Which shows:
```
2024-03-07 15:43:55,125 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) ERROR: Failed to obtain JDBC connection
```
In the start up errors rather than the expected fips error. 

So if we want this to wait until #26042 is invetigated more, that would be fine. This has conflicts with #27678 that should be straight-forward to resolve.

cc @vmuzikar @Pepo48 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
