### PR TITLE
MTLS Cache options should be runtime options, not build time options

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/CachingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/CachingOptions.java
@@ -60,20 +60,17 @@ public class CachingOptions {
             .category(OptionCategory.CACHE)
             .description("Encrypts the network communication between Keycloak servers.")
             .defaultValue(Boolean.FALSE)
-            .buildTime(true)
             .build();
 
     public static final Option<String> CACHE_EMBEDDED_MTLS_KEYSTORE = new OptionBuilder<>(CACHE_EMBEDDED_MTLS_KEYSTORE_FILE_PROPERTY, String.class)
             .category(OptionCategory.CACHE)
             .description("The Keystore file path. The Keystore must contain the certificate to use by the TLS protocol. " +
                     "By default, it lookup 'cache-mtls-keystore.p12' under conf/ directory.")
-            .buildTime(true)
             .build();
 
     public static final Option<String> CACHE_EMBEDDED_MTLS_KEYSTORE_PASSWORD = new OptionBuilder<>(CACHE_EMBEDDED_MTLS_KEYSTORE_PASSWORD_PROPERTY, String.class)
             .category(OptionCategory.CACHE)
             .description("The password to access the Keystore.")
-            .buildTime(true)
             .build();
 
     public static final Option<String> CACHE_EMBEDDED_MTLS_TRUSTSTORE = new OptionBuilder<>(CACHE_EMBEDDED_MTLS_TRUSTSTORE_FILE_PROPERTY, String.class)
@@ -81,13 +78,11 @@ public class CachingOptions {
             .description("The Truststore file path. " +
                     "It should contain the trusted certificates or the Certificate Authority that signed the certificates. " +
                     "By default, it lookup 'cache-mtls-truststore.p12' under conf/ directory.")
-            .buildTime(true)
             .build();
 
     public static final Option<String> CACHE_EMBEDDED_MTLS_TRUSTSTORE_PASSWORD = new OptionBuilder<>(CACHE_EMBEDDED_MTLS_TRUSTSTORE_PASSWORD_PROPERTY, String.class)
             .category(OptionCategory.CACHE)
             .description("The password to access the Truststore.")
-            .buildTime(true)
             .build();
 
     public static final Option<String> CACHE_REMOTE_HOST = new OptionBuilder<>(CACHE_REMOTE_HOST_PROPERTY, String.class)

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
@@ -27,20 +27,6 @@ Cache:
 --cache-config-file <file>
                      Defines the file from which cache configuration should be loaded from. The
                        configuration file is relative to the 'conf/' directory.
---cache-embedded-mtls-enabled <true|false>
-                     Encrypts the network communication between Keycloak servers. Default: false.
---cache-embedded-mtls-key-store-file <file>
-                     The Keystore file path. The Keystore must contain the certificate to use by
-                       the TLS protocol. By default, it lookup 'cache-mtls-keystore.p12' under
-                       conf/ directory.
---cache-embedded-mtls-key-store-password <password>
-                     The password to access the Keystore.
---cache-embedded-mtls-trust-store-file <file>
-                     The Truststore file path. It should contain the trusted certificates or the
-                       Certificate Authority that signed the certificates. By default, it lookup
-                       'cache-mtls-truststore.p12' under conf/ directory.
---cache-embedded-mtls-trust-store-password <password>
-                     The password to access the Truststore.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.unix.approved.txt
@@ -18,6 +18,20 @@ Options:
 
 Cache:
 
+--cache-embedded-mtls-enabled <true|false>
+                     Encrypts the network communication between Keycloak servers. Default: false.
+--cache-embedded-mtls-key-store-file <file>
+                     The Keystore file path. The Keystore must contain the certificate to use by
+                       the TLS protocol. By default, it lookup 'cache-mtls-keystore.p12' under
+                       conf/ directory.
+--cache-embedded-mtls-key-store-password <password>
+                     The password to access the Keystore.
+--cache-embedded-mtls-trust-store-file <file>
+                     The Truststore file path. It should contain the trusted certificates or the
+                       Certificate Authority that signed the certificates. By default, it lookup
+                       'cache-mtls-truststore.p12' under conf/ directory.
+--cache-embedded-mtls-trust-store-password <password>
+                     The password to access the Truststore.
 --cache-remote-host <hostname>
                      The hostname of the remote server for the remote store configuration. It
                        replaces the 'host' attribute of 'remote-server' tag of the configuration

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.unix.approved.txt
@@ -18,6 +18,20 @@ Options:
 
 Cache:
 
+--cache-embedded-mtls-enabled <true|false>
+                     Encrypts the network communication between Keycloak servers. Default: false.
+--cache-embedded-mtls-key-store-file <file>
+                     The Keystore file path. The Keystore must contain the certificate to use by
+                       the TLS protocol. By default, it lookup 'cache-mtls-keystore.p12' under
+                       conf/ directory.
+--cache-embedded-mtls-key-store-password <password>
+                     The password to access the Keystore.
+--cache-embedded-mtls-trust-store-file <file>
+                     The Truststore file path. It should contain the trusted certificates or the
+                       Certificate Authority that signed the certificates. By default, it lookup
+                       'cache-mtls-truststore.p12' under conf/ directory.
+--cache-embedded-mtls-trust-store-password <password>
+                     The password to access the Truststore.
 --cache-remote-host <hostname>
                      The hostname of the remote server for the remote store configuration. It
                        replaces the 'host' attribute of 'remote-server' tag of the configuration


### PR DESCRIPTION
Closes #27701

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
