### PR TITLE
Make sure empty configuration resolves to the system default configuration

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo23_0_0.java
+++ b/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo23_0_0.java
@@ -71,8 +71,11 @@ public class MigrateTo23_0_0 implements Migration {
             if (component.isPresent()) {
                 ComponentModel userProfileComponent = component.get();
                 int count = userProfileComponent.get(UP_PIECES_COUNT_COMPONENT_CONFIG_KEY, 0);
+                if (count < 1) {
+                    realm.removeComponent(userProfileComponent);
+                    return;
+                }
                 userProfileComponent.getConfig().remove(UP_PIECES_COUNT_COMPONENT_CONFIG_KEY);
-                if (count < 1) return; // default config
                 String configuration;
                 if (count == 1) {
                     configuration = userProfileComponent.get(UP_PIECE_COMPONENT_CONFIG_KEY_BASE + "0");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UserProfileTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_ADMIN;
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_USER;
+import static org.keycloak.userprofile.config.UPConfigUtils.parseSystemDefaultConfig;
 
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.Constants;
@@ -2243,5 +2245,20 @@ public class UserProfileTest extends AbstractUserProfileTest {
         provider.setConfiguration(upConfig);
         profile = provider.create(UserProfileContext.USER_API, attributes, user);
         profile.update();
+    }
+
+    @Test
+    public void testDefaultConfigWhenComponentConfigIsNotSet() {
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) UserProfileTest::testDefaultConfigWhenComponentConfigIsNotSet);
+    }
+
+    private static void testDefaultConfigWhenComponentConfigIsNotSet(KeycloakSession session) {
+        UserProfileProvider provider = getUserProfileProvider(session);
+        provider.setConfiguration(parseSystemDefaultConfig());
+        RealmModel realm = session.getContext().getRealm();
+        ComponentModel component = realm.getComponentsStream(realm.getId(), UserProfileProvider.class.getName()).findAny().get();
+        component.setConfig(new MultivaluedHashMap<>());
+        realm.updateComponent(component);
+        provider.create(UserProfileContext.USER_API, Map.of());
     }
 }


### PR DESCRIPTION
Closes #27611

* The refactoring is making more explicit the logic to check if the config is cached, parse the raw config or fallback to the system config (the actual fix for the issue), and finally cache the config.
* Also updating migration step for 23 to remove the component whenever the `config` is invalid

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
