### PR TITLE
Add new ProviderConfigProperty type to expose URLs in admin-v2

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/UrlComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/UrlComponent.tsx
@@ -1,0 +1,30 @@
+import { FormGroup } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+import { HelpItem } from "ui-shared";
+import { useFormContext, useWatch } from "react-hook-form";
+import type { ComponentProps } from "./components";
+import { FormattedLink } from "../external-link/FormattedLink";
+
+import "./url-component.css";
+
+export const UrlComponent = ({ name, label, helpText }: ComponentProps) => {
+  const { t } = useTranslation();
+  const { control } = useFormContext();
+  const { value } = useWatch({
+    control,
+    name: name!,
+    defaultValue: "",
+  });
+
+  return (
+    <FormGroup
+      label={t(label!)}
+      fieldId={name!}
+      labelIcon={<HelpItem helpText={t(helpText!)} fieldLabelId={`${label}`} />}
+      className="keycloak__identity-providers__url_component"
+    >
+      <FormattedLink title={t(helpText!)} href={value} isInline />
+    </FormGroup>
+  );
+};

--- a/js/apps/admin-ui/src/components/dynamic/UrlComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/UrlComponent.tsx
@@ -1,7 +1,7 @@
 import { FormGroup } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 
-import { HelpItem } from "ui-shared";
+import { HelpItem } from "@keycloak/keycloak-ui-shared";
 import { useFormContext, useWatch } from "react-hook-form";
 import type { ComponentProps } from "./components";
 import { FormattedLink } from "../external-link/FormattedLink";

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -14,6 +14,7 @@ import { RoleComponent } from "./RoleComponent";
 import { ScriptComponent } from "./ScriptComponent";
 import { StringComponent } from "./StringComponent";
 import { TextComponent } from "./TextComponent";
+import { UrlComponent } from "./UrlComponent";
 import { UserProfileAttributeListComponent } from "./UserProfileAttributeListComponent";
 
 export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
@@ -37,6 +38,7 @@ const ComponentTypes = [
   "MultivaluedString",
   "File",
   "Password",
+  "Url",
 ] as const;
 
 export type Components = (typeof ComponentTypes)[number];
@@ -58,6 +60,7 @@ export const COMPONENTS: {
   MultivaluedString: MultiValuedStringComponent,
   File: FileComponent,
   Password: PasswordComponent,
+  Url: UrlComponent,
 } as const;
 
 export const isValidComponentType = (value: string): value is Components =>

--- a/js/apps/admin-ui/src/components/dynamic/url-component.css
+++ b/js/apps/admin-ui/src/components/dynamic/url-component.css
@@ -1,3 +1,3 @@
-.keycloak__identity-providers__url_component > .pf-c-form__group-control {
-    padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
+.keycloak__identity-providers__url_component > .pf-v5-c-form__group-control {
+  padding-top: var(--pf-v5-c-form--m-horizontal__group-label--md--PaddingTop);
 }

--- a/js/apps/admin-ui/src/components/dynamic/url-component.css
+++ b/js/apps/admin-ui/src/components/dynamic/url-component.css
@@ -1,0 +1,3 @@
+.keycloak__identity-providers__url_component > .pf-c-form__group-control {
+    padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
+}

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -68,6 +68,11 @@ public class ProviderConfigProperty {
      */
     public static final String MAP_TYPE ="Map";
 
+    /**
+     * URL field
+     */
+    public static final String URL_TYPE ="Url";
+
     protected String name;
     protected String label;
     protected String helpText;


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/27673

## Approach 2 (wider)
Given after `admin-v2` migration custom IdPs can already leverage `ConfiguredProvider` to show new fields, it's possible to extend this structure with a new type `Url` to be used to show any given URL, therefore adding any number of read-only URLs in the admin UI.

Example output from custom SAML IdP configured with

        return ProviderConfigurationBuilder.create()
        .property()
        .name(METADATA_URL)
        .type(ProviderConfigProperty.URL_TYPE)
        .defaultValue("/realms/<realm>/example-metadata-url")
        .label("identity-provider.saml.url.metadata")
        .helpText("identity-provider.saml.url.metadata.tooltip")
        .add()

<img width="1437" alt="image" src="https://github.com/keycloak/keycloak/assets/2743637/d3508b8a-0982-48e0-a8c6-f9dd2081c41a">
