### PR TITLE
Document getGroupById() will not set subGroups in JavaDoc

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -121,6 +121,7 @@ public class GroupsResource {
      * @return
      */
     @Path("{group-id}")
+    @Operation( summary = "Get group details. Does not expand hierarchy.  Subgroups will not be set.")
     public GroupResource getGroupById(@PathParam("group-id") String id) {
         GroupModel group = realm.getGroupById(id);
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/27787

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
`GET /admin/realms/{realm}/groups/{group-id}` does not set `subGroups`. This was not clearly noted in the [API documentation](https://www.keycloak.org/docs-api/24.0.1/rest-api/#_groups).