### PR TITLE
use inputOptionLabels in select-radiobuttons input elements

### DIFF
--- a/js/libs/ui-shared/src/user-profile/OptionsComponent.tsx
+++ b/js/libs/ui-shared/src/user-profile/OptionsComponent.tsx
@@ -2,15 +2,22 @@ import { Checkbox, Radio } from "@patternfly/react-core";
 import { Controller } from "react-hook-form";
 import { Options, UserProfileFieldProps } from "./UserProfileFields";
 import { UserProfileGroup } from "./UserProfileGroup";
-import { fieldName, isRequiredAttribute } from "./utils";
+import { fieldName, isRequiredAttribute, unWrap } from "./utils";
 
+type OptionLabel = Record<string, string> | undefined;
 export const OptionComponent = (props: UserProfileFieldProps) => {
-  const { form, inputType, attribute } = props;
+  const { t, form, inputType, attribute } = props;
   const isRequired = isRequiredAttribute(attribute);
   const isMultiSelect = inputType.startsWith("multiselect");
   const Component = isMultiSelect ? Checkbox : Radio;
   const options =
     (attribute.validators?.options as Options | undefined)?.options || [];
+
+  const optionLabel = attribute.annotations?.[
+    "inputOptionLabels"
+  ] as OptionLabel;
+  const label = (label: string) =>
+    optionLabel ? t(unWrap(optionLabel[label])) : label;
 
   return (
     <UserProfileGroup {...props}>
@@ -25,7 +32,7 @@ export const OptionComponent = (props: UserProfileFieldProps) => {
                 key={option}
                 id={option}
                 data-testid={option}
-                label={option}
+                label={label(option)}
                 value={option}
                 isChecked={field.value.includes(option)}
                 onChange={() => {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

If available,  `select-radiobuttons` input elements will use `inputOptionLabels` annotation to provide labels for individual options.
This feature is already documented here https://www.keycloak.org/docs/latest/server_admin/index.html#_managing_options_for_select_fields, but it only works with `select` input element (not `select-radiobuttons`).