### PR TITLE
Ignore a false positive in internal code scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,3 +8,7 @@
   paths = [
     '''saml-core/src/test/java/org/keycloak/saml/processing/core/saml/v2/util/AssertionUtilTest.java'''
   ]
+  
+  regexes = [
+    '''H0JaTc7VBu3HJR26vrzMxgidfJmgI5Dw'''
+  ]


### PR DESCRIPTION
Found in:
- https://github.com/hmlnarik/keycloak/blob/004805e21d1b5cb20afc4307fd1c55942c3f19c7/js/apps/account-ui/test/account-security/linked-accounts.spec.ts?plain=1#L40
- https://github.com/hmlnarik/keycloak/blob/004805e21d1b5cb20afc4307fd1c55942c3f19c7/js/apps/account-ui/test/realms/groups-idp.json?plain=1#L8
- https://github.com/hmlnarik/keycloak/blob/004805e21d1b5cb20afc4307fd1c55942c3f19c7/js/apps/account-ui/test/realms/groups-realm.json?plain=1#L171

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
