### PR TITLE
authz/client: Fix getPermissions returning wrong type (#16520)

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/AuthorizationResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/AuthorizationResource.java
@@ -71,7 +71,7 @@ public class AuthorizationResource {
      * @throws AuthorizationDeniedException in case the request was denied by the server
      */
     public AuthorizationResponse authorize(final AuthorizationRequest request) throws AuthorizationDeniedException {
-        return invoke(request);
+        return invoke(request, new TypeReference<AuthorizationResponse>(){});
     }
 
     /**
@@ -93,10 +93,10 @@ public class AuthorizationResource {
 
         metadata.setResponseMode("permissions");
 
-        return invoke(request);
+        return (List<Permission>) invoke(request, new TypeReference<List<Permission>>(){});
     }
 
-    private <T> T invoke(AuthorizationRequest request) {
+    private <T> T invoke(AuthorizationRequest request, TypeReference<T> responseType) {
         if (request == null) {
             throw new IllegalArgumentException("Authorization request must not be null");
         }
@@ -117,13 +117,8 @@ public class AuthorizationResource {
                 HttpMethodResponse<T> response = method
                         .authentication()
                         .uma(request)
-                        .response();
-
-                if (request.getMetadata() != null && "permissions".equals(request.getMetadata().getResponseMode())) {
-                    response = response.json(new TypeReference<T>(){});
-                } else {
-                    response = response.json((Class<T>) AuthorizationResponse.class);
-                }
+                        .response()
+                        .json(responseType);
 
                 return response.execute();
             }

--- a/docs/documentation/release_notes/topics/25_0_0.adoc
+++ b/docs/documentation/release_notes/topics/25_0_0.adoc
@@ -26,3 +26,11 @@ Keycloak supports a new password policy that allows you to deny user passwords w
 = Searching by user attribute no longer case insensitive
 
 When searching for users by user attribute, {project_name} no longer searches for user attribute names forcing lower case comparisons. The goal of this change was to speed up searches by using {project_name}'s native index on the user attribute table. If your database collation is case-insensitive, your search results will stay the same. If your database collation is case-sensitive, you might see less search results than before.
+
+= Breaking fix in authorization client library
+
+For users of the `keycloak-authz-client` library, calling `AuthorizationResource.getPermissions(...)` now correctly returns a `List<Permission>`.
+
+Previously, it would return a `List<Map>` at runtime, even though the method declaration advertised `List<Permission>`.
+
+This fix will break code that relied on casting the List or its contents to `List<Map>`. If you have used this method in any capacity, you are likely to have done this and be affected.

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationAPITest.java
@@ -204,6 +204,7 @@ public class AuthorizationAPITest extends AbstractAuthzTest {
 
         List<Permission> permissions = authzClient.authorization("marta", "password").getPermissions(request);
         assertFalse(permissions.isEmpty());
+        assertTrue(permissions.get(0) instanceof Permission);
     }
 
     public void testResourceServerAsAudience(String clientId, String resourceServerClientId, String authzConfigFile) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RegexPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RegexPolicyTest.java
@@ -290,11 +290,8 @@ private void createRegexPolicyExtended(String name, String targetClaim, String p
         theRequest.setMetadata(metadata);
         List<Permission> permissions = authzClient.authorization("admin", "password").getPermissions(theRequest);
         assertNotNull(permissions);
-       Assert.assertTrue(((Map)permissions.get(0)).get("rsname").equals("service"));
-       Assert.assertTrue(((List)(((Map)permissions.get(0)).get("scopes"))).get(0).equals("read"));
-
-
-
+        Assert.assertTrue(permissions.get(0).getResourceName().equals("service"));
+        Assert.assertTrue(permissions.get(0).getScopes().contains("read"));
     }
 
 


### PR DESCRIPTION
Fixed an issue with getPermissions() ALWAYS returning the wrong Type `List<LinkedHashMap>` instead of `List<Permission>` at runtime, differing from the compile time type.

Due to the nature of this problem, this fix will probably break most code that used this method before and not give any compiler errors. 

Closes #16520