### PR TITLE
Do not rely on boot module loader for finding module dependencies

### DIFF
--- a/adapters/oidc/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/extension/KeycloakDependencyProcessor.java
+++ b/adapters/oidc/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/extension/KeycloakDependencyProcessor.java
@@ -61,7 +61,10 @@ public abstract class KeycloakDependencyProcessor implements DeploymentUnitProce
         }
 
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
-        final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+        ModuleLoader moduleLoader = Module.getCallerModuleLoader();
+        if (moduleLoader == null) {
+            moduleLoader = Module.getSystemModuleLoader();
+        }
         addCommonModules(moduleSpecification, moduleLoader);
         addPlatformSpecificModules(phaseContext, moduleSpecification, moduleLoader);
     }

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessor.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessor.java
@@ -63,7 +63,10 @@ public abstract class KeycloakDependencyProcessor implements DeploymentUnitProce
          // Next phase, need to detect if this is a Keycloak deployment.  If not, don't add the modules.
 
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
-        final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+        ModuleLoader moduleLoader = Module.getCallerModuleLoader();
+        if (moduleLoader == null) {
+            moduleLoader = Module.getSystemModuleLoader();
+        }
 
         addCoreModules(moduleSpecification, moduleLoader);
         addCommonModules(moduleSpecification, moduleLoader);


### PR DESCRIPTION
The `Module.getBootModuleLoader()` API may be deprecated at some point soon, so use a safer alternative.

The existing tests should cover this change.

Closes #28448.