### PR TITLE
Set the default locale for the JVM to English to prevent locale-speci…

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -105,6 +105,14 @@ if not "x%JAVA_ADD_OPENS%" == "x" (
 )
 set "JAVA_OPTS=%JAVA_OPTS% %JAVA_ADD_OPENS%"
 
+@REM Set the default locale for the JVM to English to prevent locale-specific character variations
+if not "x%JAVA_LOCALE%" == "x" (
+  echo "JAVA_LOCALE already set in environment; overriding default settings with values: %JAVA_LOCALE%"
+) else (
+  set "JAVA_LOCALE=-Duser.language=en -Duser.country=US"
+)
+set "JAVA_OPTS=%JAVA_OPTS% %JAVA_LOCALE%"
+
 if not "x%JAVA_OPTS_APPEND%" == "x" (
   echo "Appending additional Java properties to JAVA_OPTS: %JAVA_OPTS_APPEND%"
   set JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_APPEND%

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -126,6 +126,14 @@ else
 fi
 JAVA_OPTS="$JAVA_OPTS $JAVA_ADD_OPENS"
 
+# Set the default locale for the JVM to English to prevent locale-specific character variations
+if [ -z "$JAVA_LOCALE" ]; then
+   JAVA_LOCALE="-Duser.language=en -Duser.country=US"
+else
+   echo "JAVA_LOCALE already set in environment; overriding default settings with values: $JAVA_LOCALE"
+fi
+JAVA_OPTS="$JAVA_OPTS $JAVA_LOCALE"
+
 if [ -n "$JAVA_OPTS_APPEND" ]; then
   echo "Appending additional Java properties to JAVA_OPTS: $JAVA_OPTS_APPEND"
   JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_APPEND"


### PR DESCRIPTION
…fic character variations

* introduced the JAVA_LOCALE variable within kc.sh|bat in order to control JVM locale

Closes #26438

@vmuzikar I decided to preserve the way we handle the other java options in our scripts and I added a little bit of logic around appending the java language options, too.

Here I demonstrate the new default behaviour on a Turkish system compared to the latest release behaviour:
![image](https://github.com/keycloak/keycloak/assets/12138171/c88271aa-49ea-42a4-b2e2-3102e78b014b)

And this happens when a user decides to override the new default behaviour (as they are allowed to do so):
![image](https://github.com/keycloak/keycloak/assets/12138171/3fb86ccb-8b84-4abb-9341-eebdbcc27e23)

Previously I ran the tests [here](https://github.com/Pepo48/keycloak/actions/runs/8255969714) - every workflow was green.

Let me know your opinion about this approach and we can eventually ask someone from the core team about their opinion as well.
Thanks.