### PR TITLE
[backport] - Only remove attributes with empty values when updating user profile

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -196,14 +196,22 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public void removeAttribute(String name) {
-        List<UserAttributeEntity> toRemove = new ArrayList<>();
+        List<UserAttributeEntity> customAttributesToRemove = new ArrayList<>();
         for (UserAttributeEntity attr : user.getAttributes()) {
             if (attr.getName().equals(name)) {
-                toRemove.add(attr);
+                customAttributesToRemove.add(attr);
             }
         }
 
-        if (toRemove.isEmpty()) {
+        if (customAttributesToRemove.isEmpty()) {
+            // make sure root user attributes are set to null
+            if (UserModel.FIRST_NAME.equals(name)) {
+                setFirstName(null);
+            } else if (UserModel.LAST_NAME.equals(name)) {
+                setLastName(null);
+            } else if (UserModel.EMAIL.equals(name)) {
+                setEmail(null);
+            }
             return;
         }
 
@@ -213,7 +221,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         query.setParameter("userId", user.getId());
         query.executeUpdate();
         // KEYCLOAK-3494 : Also remove attributes from local user entity
-        user.getAttributes().removeAll(toRemove);
+        user.getAttributes().removeAll(customAttributesToRemove);
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultUserProfile.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultUserProfile.java
@@ -119,8 +119,7 @@ public final class DefaultUserProfile implements UserProfile {
                 String name = attribute.getKey();
                 List<String> currentValue = user.getAttributeStream(name)
                         .filter(Objects::nonNull).collect(Collectors.toList());
-                List<String> updatedValue = attribute.getValue().stream()
-                        .filter(StringUtil::isNotBlank).collect(Collectors.toList());
+                List<String> updatedValue = attribute.getValue();
 
                 if (CollectionUtil.collectionEquals(currentValue, updatedValue)) {
                     continue;
@@ -132,7 +131,11 @@ public final class DefaultUserProfile implements UserProfile {
                     continue;
                 }
 
-                user.setAttribute(name, updatedValue);
+                if (updatedValue.stream().allMatch(StringUtil::isBlank)) {
+                    user.removeAttribute(name);
+                } else {
+                    user.setAttribute(name, updatedValue.stream().filter(StringUtil::isNotBlank).collect(Collectors.toList()));
+                }
 
                 if (UserModel.EMAIL.equals(name) && metadata.getContext().isResetEmailVerified()) {
                     user.setEmailVerified(false);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
@@ -59,6 +59,7 @@ import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.LoginUpdateProfileEditUsernameAllowedPage;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.utils.StringUtil;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 /**
@@ -512,6 +513,10 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
                 }
                 for (String value : values) {
                     updateProfilePage.clickRemoveAttributeValue(attribute + "-0");
+                }
+                // make sure the last attribute is set with a value
+                if (StringUtil.isBlank(updateProfilePage.getAttribute(attribute + "-0"))) {
+                    updateProfilePage.setAttribute(attribute + "-0", values.get(values.size() - 1));
                 }
                 updateProfilePage.update("f", "l", "e@keycloak.org");
                 userRep = ActionUtil.findUserWithAdminClient(adminClient, "john-doh@localhost");


### PR DESCRIPTION
Closes #27797

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
