### PR TITLE
Snyk workflow failure

### DIFF
--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Upload Quarkus scanner results to GitHub
         uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
         with:
           sarif_file: quarkus-report.sarif
           category: snyk-quarkus-report


### PR DESCRIPTION
Closes #27761

As mentioned in the issue at [https://github.com/github/codeql-action/issues/2187](https://github.com/github/codeql-action/issues/2187), a problem has emerged due to Snyk, leading to  a SARIF file where the security severity remains undefined. The straightforward solution is to ignore these failures, at least for now.

Exploring other options would require new post-processing rules, which could consume additional resources and extend the time needed for implementation.

Evidence of a working solution: https://github.com/keycloak-poc/keycloak/actions/runs/8264533839.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
