### PR TITLE
SAMLIdentityProvider not honoring SamlAuthenticationPreprocessor (keycloak/keycloak#27875)

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -204,9 +204,9 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
             request.getAuthenticationSession().setClientNote(SamlProtocol.SAML_REQUEST_ID_BROKER, authnRequest.getID());
 
             if (postBinding) {
-                return binding.postBinding(authnRequestBuilder.toDocument()).request(destinationUrl);
+                return binding.postBinding(SAML2Request.convert(authnRequest)).request(destinationUrl);
             } else {
-                return binding.redirectBinding(authnRequestBuilder.toDocument()).request(destinationUrl);
+                return binding.redirectBinding(SAML2Request.convert(authnRequest)).request(destinationUrl);
             }
         } catch (Exception e) {
             throw new IdentityBrokerException("Could not create authentication request.", e);


### PR DESCRIPTION
Fixes https://github.com/keycloak/keycloak/issues/27875

In [`SAMLIdentityProvider.performLogin`](https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java) 

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L125

when an `AuthnRequestType` is created 

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L194

and possibly customized with available `SamlAuthenticationPreprocessor.beforeSendingLoginRequest`

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L195

such `authnRequest` instance is discarded and a new one is created with `authnRequestBuilder.toDocument()`

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L207

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L207

It's fixed by this PR using the created `SAML2Request.convert(authnRequest)` in place a brand-new one as it's correctly already done in `keycloakInitiatedBrowserLogout`

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L312

https://github.com/keycloak/keycloak/blob/9ad447390a9b46d208ad7ea391afe83fd9c8e95b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java#L314