### PR TITLE
fix: making the truststore name field optional

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/Truststore.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/Truststore.java
@@ -21,12 +21,13 @@ import io.fabric8.generator.annotation.Required;
 import io.sundr.builder.annotations.Buildable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class Truststore {
 
-    @Required
+    @JsonPropertyDescription("Not used. To be removed in later versions.")
     private String name;
     @Required
     private TruststoreSource secret;

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakTruststoresTests.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakTruststoresTests.java
@@ -39,7 +39,7 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
     public void testTruststoreMissing() {
         var kc = getTestKeycloakDeployment(true);
         var deploymentName = kc.getMetadata().getName();
-        kc.getSpec().getTruststores().put("xyz", new TruststoreBuilder().withName("xyz").withNewSecret().withName("xyz").endSecret().build());
+        kc.getSpec().getTruststores().put("xyz", new TruststoreBuilder().withNewSecret().withName("xyz").endSecret().build());
 
         deployKeycloak(k8sclient, kc, false);
         Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);
@@ -58,7 +58,7 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
         var deploymentName = kc.getMetadata().getName();
 
         K8sUtils.set(k8sclient, getResourceFromFile("example-truststore-secret.yaml", Secret.class));
-        kc.getSpec().getTruststores().put("example", new TruststoreBuilder().withName("example").withNewSecret().withName("example-truststore-secret").endSecret().build());
+        kc.getSpec().getTruststores().put("example", new TruststoreBuilder().withNewSecret().withName("example-truststore-secret").endSecret().build());
 
         deployKeycloak(k8sclient, kc, true);
         Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -65,6 +65,10 @@ spec:
       memory: "1500M"
   proxy:
     headers: forwarded
+  truststores:
+    x:
+      secret:
+        name: my-secret
   unsupported:
     podTemplate:
       metadata:


### PR DESCRIPTION
We unfortunately need to leave the field in the crd so this is not a breaking change. We can consider not storing a value in later version, and then completely removing in an even later version - or once we move to a different crd revision.

closes: #28012

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
