### PR TITLE
ClientBean filters allowed attributes

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/ClientBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/ClientBean.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.forms.login.freemarker.model;
 
+import com.google.common.collect.ImmutableMap;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.util.ResolveRelative;
@@ -29,12 +30,22 @@ import java.util.Map;
  */
 public class ClientBean {
 
+    protected static final String[] ATTRIBUTES_ALLOWED = { "logoUrl", "policyUri", "tosUri" };
+
     private KeycloakSession session;
     protected ClientModel client;
+    protected Map<String,String> attributes;
 
     public ClientBean(KeycloakSession session, ClientModel client) {
         this.session = session;
         this.client = client;
+        ImmutableMap.Builder<String,String> builder = new ImmutableMap.Builder<>();
+        if (client.getAttributes() != null) {
+          for (String key : ATTRIBUTES_ALLOWED) {
+            builder.put(key, client.getAttributes().get(key));
+          }
+        }
+        this.attributes = builder.build();
     }
 
     public String getClientId() {
@@ -54,10 +65,10 @@ public class ClientBean {
     }
 
     public Map<String,String> getAttributes(){
-        return client.getAttributes();
+        return attributes;
     }
 
     public String getAttribute(String key){
-        return client.getAttribute(key);
+        return attributes.get(key);
     }
 }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/ClientBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/ClientBean.java
@@ -42,7 +42,10 @@ public class ClientBean {
         ImmutableMap.Builder<String,String> builder = new ImmutableMap.Builder<>();
         if (client.getAttributes() != null) {
           for (String key : ATTRIBUTES_ALLOWED) {
-            builder.put(key, client.getAttributes().get(key));
+            String val = client.getAttributes().get(key);
+            if (val != null) {
+              builder.put(key, val);
+            }
           }
         }
         this.attributes = builder.build();


### PR DESCRIPTION
This prevents the unintentional leaking of secure/sensitive data by theme developers. It filters the attributes map to only appropriate and necessary data 

Fixes #28039