### PR TITLE
Disable issuer verification of Initial Access Token and Registration Access Token

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
@@ -753,4 +753,24 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
             }
         }
     }
+
+    @Test
+    public void registerClientInMasterRealmViaAlternativeDomain() throws Exception {
+        String alternativeContextRoot = "http://keycloak.127.0.0.1.nip.io:" + System.getProperty("auth.server.http.port");
+        ClientRegistration alternativeReg = ClientRegistration.create().url(alternativeContextRoot + "/auth", "master").build();
+
+        String token = oauth.doGrantAccessTokenRequest("master", "admin", "admin", null, Constants.ADMIN_CLI_CLIENT_ID, null).getAccessToken();
+        alternativeReg.auth(Auth.token(token));
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(CLIENT_ID);
+        client.setSecret(CLIENT_SECRET);
+
+        try {
+            alternativeReg.create(client);
+            fail("Expected 401");
+        } catch (ClientRegistrationException e) {
+            assertEquals(401, ((HttpErrorException) e.getCause()).getStatusLine().getStatusCode());
+        }
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/InitialAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/InitialAccessTokenTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.ClientInitialAccessResource;
 import org.keycloak.client.registration.Auth;
+import org.keycloak.client.registration.ClientRegistration;
 import org.keycloak.client.registration.ClientRegistrationException;
 import org.keycloak.client.registration.HttpErrorException;
 import org.keycloak.crypto.Algorithm;
@@ -148,6 +149,22 @@ public class InitialAccessTokenTest extends AbstractClientRegistrationTest {
         } catch (ClientRegistrationException e) {
             assertEquals(401, ((HttpErrorException) e.getCause()).getStatusLine().getStatusCode());
         }
+    }
+
+    @Test
+    public void createViaAlternativeDomain() throws ClientRegistrationException {
+        String alternativeContextRoot = "http://keycloak.127.0.0.1.nip.io:" + System.getProperty("auth.server.http.port");
+        ClientRegistration alternativeReg = ClientRegistration.create().url(alternativeContextRoot + "/auth", "test").build();
+
+        ClientInitialAccessPresentation response = resource.create(new ClientInitialAccessCreatePresentation());
+        alternativeReg.auth(Auth.token(response));
+
+        ClientRepresentation rep = new ClientRepresentation();
+
+        setTimeOffset(10);
+
+        ClientRepresentation created = alternativeReg.create(rep);
+        Assert.assertNotNull(created);
     }
 
 }


### PR DESCRIPTION
Fix #28045

As stated in https://github.com/keycloak/keycloak/issues/28045#issue-2194641401, issuer verification of long term client side persisted tokens such as `Initial Access Token` and `Registration Access Token` highly complicates Keycloak issuer modification.

Since those tokens are already `statefully verified` via their `jti` claim in addition to standard stateless verifications (signature verification, expiration date verification, ...) the `issuer` verification seems superfluous.

This change disables the `issuer` verification for the following token types:
- Initial Access Token
- Registration Access Token