### PR TITLE
Remove deprecated ConfigSourceInterceptor method

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -29,7 +29,6 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 import java.util.Iterator;
-import java.util.function.Function;
 
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 
@@ -60,14 +59,14 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
     public static void enable() {
         disable.remove();
     }
-    
-    <T> Iterator<T> filterRuntime(Iterator<T> iter, Function<T, String> nameFunc) {
+
+    static Iterator<String> filterRuntime(Iterator<String> iter) {
         if (!isRebuild() && !Environment.isRebuildCheck()) {
             return iter;
         }
-        return new FilterIterator<>(iter, item -> !isRuntime(nameFunc.apply(item)));
+        return new FilterIterator<>(iter, item -> !isRuntime(item));
     }
-    
+
     static boolean isRuntime(String name) {
         PropertyMapper<?> mapper = PropertyMappers.getMapper(name);
         return mapper != null && mapper.isRunTime();
@@ -75,12 +74,7 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
     @Override
     public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {
-        return filterRuntime(context.iterateNames(), Function.identity());
-    }
-
-    @Override
-    public Iterator<ConfigValue> iterateValues(ConfigSourceInterceptorContext context) {
-        return filterRuntime(context.iterateValues(), ConfigValue::getName);
+        return filterRuntime(context.iterateNames());
     }
 
     @Override


### PR DESCRIPTION
Closes: #28125

The `io.smallrye.config.ConfigSourceInterceptor#iterateValues` is marked as deprecated and for removal, so we should get rid of it. 

Also mentioned here: https://github.com/keycloak/keycloak/pull/25333#discussion_r1462182778

@shawkins Could you please take a look at this small PR as you were the author? Thanks