### PR TITLE
Always include offline_access scope when refreshing with offline token

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -414,7 +414,7 @@ public class TokenManager {
         //if scope parameter is not null, remove every scope that is not part of scope parameter
         if (scopeParameter != null && ! scopeParameter.isEmpty()) {
             Set<String> scopeParamScopes = Arrays.stream(scopeParameter.split(" ")).collect(Collectors.toSet());
-            oldTokenScope = Arrays.stream(oldTokenScope.split(" ")).filter(sc -> scopeParamScopes.contains(sc))
+            oldTokenScope = Arrays.stream(oldTokenScope.split(" ")).filter(sc -> scopeParamScopes.contains(sc) || sc.equals(OAuth2Constants.OFFLINE_ACCESS))
                     .collect(Collectors.joining(" "));
         }
 


### PR DESCRIPTION
This also causes the `offline_accecss` scope to always be present in the access token when it is present in the refresh token.

Before this, if you refresh the token including the scope claim but without `offline_access` (as in the issue but with the full scope allowed enabled), the `offline_access` scope is only present in the refresh token.

But if we want to keep the previous behavior we should only allow the refresh in `TokenManager.isOfflineTokenAllowed` without re-adding the `offline_access` scope for the grant.


Closes #27878
