### PR TITLE
doc: for the initial 24 release the duplicate name is required

### DIFF
--- a/docs/documentation/release_notes/topics/24_0_0.adoc
+++ b/docs/documentation/release_notes/topics/24_0_0.adoc
@@ -237,9 +237,11 @@ You may also take advantage of the new server-side handling of truststores by us
 spec:
   truststores:
     mystore:
+      name: mystore
       secret:
         name: mystore-secret
     myotherstore:
+      name: myotherstore
       secret:
         name: myotherstore-secret
 ----


### PR DESCRIPTION
relates to: #28012

This is to update the old release notes. If that doesn't happen automatically, then we'll probably just ignore this as #28012 will be backported and that syntax will then work.

cc @vmuzikar 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
