### PR TITLE
Remove effective roles filtering to avoid inconsistency

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/EffectiveRoleMappingResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/EffectiveRoleMappingResource.java
@@ -60,7 +60,7 @@ public class EffectiveRoleMappingResource extends RoleMappingResource {
         this.auth.clients().requireView(clientScope);
         return toSortedClientRoles(
                 addSubClientRoles(clientScope.getScopeMappingsStream())
-                .filter(auth.roles()::canMapClientScope));
+        );
     }
 
     @GET
@@ -90,7 +90,7 @@ public class EffectiveRoleMappingResource extends RoleMappingResource {
         auth.clients().requireView(client);
         return toSortedClientRoles(
                 addSubClientRoles(client.getScopeMappingsStream())
-                .filter(auth.roles()::canMapRole));
+        );
     }
 
     @GET
@@ -120,7 +120,7 @@ public class EffectiveRoleMappingResource extends RoleMappingResource {
         auth.groups().requireView(group);
         return toSortedClientRoles(
                 addSubClientRoles(addParents(group).flatMap(GroupModel::getRoleMappingsStream))
-                .filter(auth.roles()::canMapRole));
+        );
     }
 
     @GET
@@ -179,9 +179,7 @@ public class EffectiveRoleMappingResource extends RoleMappingResource {
         auth.roles().requireList(realm);
         final RoleModel defaultRole = this.realm.getDefaultRole();
         //this definitely does not return what the descriptions says
-        return toSortedClientRoles(
-                addSubClientRoles(Stream.of(defaultRole))
-                .filter(auth.roles()::canMapRole));
+        return toSortedClientRoles(addSubClientRoles(Stream.of(defaultRole)));
     }
 
     private Stream<RoleModel> addSubClientRoles(Stream<RoleModel> roles) {

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/EffectiveRoleMappingResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/EffectiveRoleMappingResource.java
@@ -154,7 +154,7 @@ public class EffectiveRoleMappingResource extends RoleMappingResource {
                 user.getGroupsStream()
                         .flatMap(g -> addParents(g))
                         .flatMap(GroupModel::getRoleMappingsStream)))
-                .filter(auth.roles()::canMapRole));
+        );
     }
 
     @GET


### PR DESCRIPTION
Fixes #29615.

I noticed a weird inconsistent behaviour at the users role-mapping tab. In following example there is a newly created user with additional client (master-realm) roles (view-realm, view-users).

When "Hide inherited roles" is ON it looks like this:
![original-hide-on](https://github.com/keycloak/keycloak/assets/69153350/783089ea-65c1-4537-bcf1-7de10ec2052b)

But when it is OFF the assigned client roles are nowhere to be seen:
![original-hide-off](https://github.com/keycloak/keycloak/assets/69153350/715d6a55-120b-4925-812e-2a5349e4dab4)

Following code is responsible for that:

```
        return toSortedClientRoles(
                addSubClientRoles(Stream.concat(
                user.getRoleMappingsStream(),
                user.getGroupsStream()
                        .flatMap(g -> addParents(g))
                        .flatMap(GroupModel::getRoleMappingsStream))) // Up until this point all assigned roles are being found, including the client-roles
                .filter(auth.roles()::canMapRole) // But this filter removes them.
        );
```

It looks like a user has to be able to assign roles just to be able to see them and I'm not really sure whether this is intended or not.

So I just removed the `.filter(...)`with my PR and this results in following.

![my-version-hide-off](https://github.com/keycloak/keycloak/assets/69153350/5f8e0fd0-1af2-4c14-a33a-d2670c77ad54)
![my-version-hide-on](https://github.com/keycloak/keycloak/assets/69153350/f5b55650-3e93-421b-9147-636b35da80f7)

With this changes, the endpoints `/admin/realms/master/ui-ext/effective-roles/users/{user-id}` and `/admin/realms/master/users/{user-id}/role-mappings` are consistent.

WDYT? 