### PR TITLE
rename 'realm name' field to 'realm ID' on create-realm page

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/GeneralTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/GeneralTab.tsx
@@ -153,7 +153,7 @@ function RealmSettingsGeneralTabForm({
           className="pf-u-mt-lg"
           onSubmit={onSubmit}
         >
-          <FormGroup label={t("realmId")} fieldId="kc-realm-id" isRequired>
+          <FormGroup label={t("realmName")} fieldId="kc-realm-id" isRequired>
             <Controller
               name="realm"
               control={control}


### PR DESCRIPTION
closes #23496
