### PR TITLE
Avoid using wait() to wait for the redirect

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
@@ -60,6 +60,7 @@ import java.util.function.Consumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITHUB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITLAB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE;
@@ -565,10 +566,8 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
             WebElement aHref = driver.findElement(By.tagName("a"));
             driver.get(aHref.getAttribute("href"));
             // Waiting for account redirection from app page
-            driver.wait(1000);
+            waitForPage(driver, "Account Management", true);
             assertThat(driver.getTitle(), containsString("Account Management"));
-        } catch (Throwable t) {
-            t.printStackTrace();
         } finally {
             revertFlows("browser - alternative non-interactive executor");
         }


### PR DESCRIPTION
Usage of `driver.wait(1000)` was causing `java.lang.IllegalMonitorStateException: current thread is not owner`
Replaced with `BrokerTestTools.waitForPage()`.

Closes #22644