### PR TITLE
ORA-01450 error for index IDX_CLIENT_ATT_BY_NAME_VALUE in oracle when MAX_STRING_SIZE is EXTENDED

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -865,12 +865,13 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
             Predicate attrNamePredicate = builder.equal(attributeJoin.get("name"), key);
 
             if (dbProductName.equals("Oracle")) {
-                // Use the dbms_lob.substr index and the full comparison in oracle
-                Predicate attrValuePredicate1 = builder.equal(
-                        builder.function("dbms_lob.substr", Integer.class, attributeJoin.get("value"), builder.literal(255), builder.literal(1)),
-                        builder.function("substr", Integer.class, builder.literal(value), builder.literal(1), builder.literal(255)));
-                Predicate attrValuePredicate2 = builder.equal(builder.function("dbms_lob.compare", Integer.class, attributeJoin.get("value"), builder.literal(value)), 0);
-                predicates.add(builder.and(attrNamePredicate, attrValuePredicate1, attrValuePredicate2));
+                // SELECT * FROM client_attributes WHERE ... DBMS_LOB.COMPARE(value, '0') = 0 ...;
+                // Oracle is not able to compare a CLOB with a VARCHAR unless it being converted with TO_CHAR
+                // But for this all values in the table need to be smaller than 4K, otherwise the cast will fail with
+                // "ORA-22835: Buffer too small for CLOB to CHAR" (even if it is in another row).
+                // This leaves DBMS_LOB.COMPARE as the option to compare the CLOB with the value.
+                Predicate attrValuePredicate = builder.equal(builder.function("DBMS_LOB.COMPARE", Integer.class, attributeJoin.get("value"), builder.literal(value)), 0);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate));
             } else if (dbProductName.equals("PostgreSQL")) {
                 // use the substr comparison and the full comparison in postgresql
                 Predicate attrValuePredicate1 = builder.equal(

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.0.xml
@@ -66,12 +66,12 @@
     </changeSet>
 
     <changeSet author="keycloak" id="24.0.0-26618-reindex">
+        <validCheckSum>9:bd2bd0fc7768cf0845ac96a8786fa735</validCheckSum>
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <or>
                 <dbms type="mysql"/>
                 <dbms type="mariadb"/>
                 <dbms type="postgresql"/>
-                <dbms type="oracle"/>
             </or>
         </preConditions>
         <createIndex tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE">
@@ -80,9 +80,6 @@
         </createIndex>
         <modifySql dbms="postgresql">
             <replace replace="VALUE(255)" with="substr(VALUE,1,255)" />
-        </modifySql>
-        <modifySql dbms="oracle">
-            <replace replace="VALUE(255)" with="dbms_lob.substr(VALUE,255,1)" />
         </modifySql>
     </changeSet>
 

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.2.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.2.xml
@@ -21,4 +21,23 @@
         <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate24_0_2_FederatedTermsAndConditionsRequiredAction"/>
     </changeSet>
 
+    <changeSet author="keycloak" id="24.0.2-27967-drop-index-if-present">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <and>
+                <dbms type="oracle"/>
+                <indexExists tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE" />
+            </and>
+        </preConditions>
+        <dropIndex tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE"/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="24.0.2-27967-reindex">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <dbms type="oracle"/>
+        </preConditions>
+        <createIndex tableName="CLIENT_ATTRIBUTES" indexName="IDX_CLIENT_ATT_BY_NAME_VALUE">
+            <column name="NAME" type="VARCHAR(255)"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Closes #27967

The re-index done in issue #26618 generates and error in Oracle (ORA-01450) when the pfile parameter MAX_STRING_SIZE is changed to EXTENDED. Using the default value DEFAULT the function index creates a NVARCHAR(2000) which is OK, but when using EXTENDED the size is 32767 and makes the index fail. It is explained in [Oracle documentation](https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/MAX_STRING_SIZE.html), it explicitly says that function based indexes will fail.

To correctly use the index queries need to use CAST and that function cannot be used with the `CriteriaBuilder` we are using to search clients. This PR just puts oracle with mssql and H2 and just indexes NAME and not the VALUE. I set the fix for 24.0.2, if there is no time I'll just change to the next release.

@pedroigor FYI