### PR TITLE
Update Norwegian translation

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_no.properties
@@ -4,15 +4,40 @@ doLogOutAllSessions=Logg ut av alle sesjoner
 doRemove=Fjern
 doAdd=Legg til
 doSignOut=Logg ut
+doLogIn=Logg inn
+doLink=Tilknytt
+noAccessMessage=Ingen tilgang
+
+personalInfoSidebarTitle=Personlige data
+accountSecuritySidebarTitle=Kontosikkerhet
+signingInSidebarTitle=Innlogging
+deviceActivitySidebarTitle=Enhetsaktivitet
+linkedAccountsSidebarTitle=Tilknyttede kontoer
 
 editAccountHtmlTitle=Rediger konto
+personalInfoHtmlTitle=Personlige data
 federatedIdentitiesHtmlTitle=Federerte identiteter
 accountLogHtmlTitle=Kontologg
 changePasswordHtmlTitle=Endre passord
+deviceActivityHtmlTitle=Enhetsaktivitet
 sessionsHtmlTitle=Sesjoner
 accountManagementTitle=Keycloak kontoadministrasjon
-authenticatorTitle=Autentikator
+authenticatorTitle=Kodegenerator
 applicationsHtmlTitle=Applikasjoner
+linkedAccountsHtmlTitle=Tilknyttede kontoer
+
+accountManagementWelcomeMessage=Velkommen til Keycloak kontoadministrasjon
+personalInfoIntroMessage=Administrer dine personlige data
+accountSecurityTitle=Kontosikkerhet
+accountSecurityIntroMessage=Administrer ditt passord og kontotilganger
+applicationsIntroMessage=Følg og administrer applikasjoners tilgang til kontoen din
+resourceIntroMessage=Del ressursene dine med andre på teamet
+passwordLastUpdateMessage=Passordet ditt ble sist oppdatert
+updatePasswordTitle=Oppdater passord
+updatePasswordMessageTitle=Sørg for å velge et sterkt passord
+updatePasswordMessage=Et sterkt passord inneholder en blanding av tall, bokstaver og symboler. Det bør være vanskelig å gjette, ikke ligne på et ord, og kun brukes til denne kontoen.
+personalSubTitle=Dine personlige data
+personalSubMessage=Administrer dine personlige data.
 
 authenticatorCode=Engangskode
 email=E-post
@@ -22,17 +47,32 @@ fullName=Fullt navn
 lastName=Etternavn
 familyName=Etternavn
 password=Passord
-passwordConfirm=Bekreftelse
+currentPassword=Nåværende passord
+passwordConfirm=Bekreft passord
 passwordNew=Nytt passord
 username=Brukernavn
 address=Adresse
 street=Gate-/veinavn + husnummer
-locality=By
+locality=By eller sted
 region=Fylke
 postal_code=Postnummer
 country=Land
 emailVerified=E-post bekreftet
-gssDelegationCredential=GSS legitimasjonsdelegering
+website=Nettside
+phoneNumber=Telefonnummer
+phoneNumberVerified=Telefonnummer bekreftet
+gender=Kjønn
+birthday=Fødselsdato
+zoneinfo=Tidssone
+gssDelegationCredential=GSS-legitimasjonsdelegering
+
+profileScopeConsentText=Brukerprofil
+emailScopeConsentText=E-postadresse
+addressScopeConsentText=Adresse
+phoneScopeConsentText=Telefonnummer
+offlineAccessScopeConsentText=Frakoblet tilgang
+samlRoleListScopeConsentText=Mine roller
+rolesScopeConsentText=Brukerroller
 
 role_admin=Administrator
 role_realm-admin=Administrator for sikkerhetsdomene
@@ -40,9 +80,11 @@ role_create-realm=Opprette sikkerhetsdomene
 role_view-realm=Se sikkerhetsdomene
 role_view-users=Se brukere
 role_view-applications=Se applikasjoner
+role_view-groups=Se grupper
 role_view-clients=Se klienter
 role_view-events=Se hendelser
 role_view-identity-providers=Se identitetsleverandører
+role_view-consent=Se samtykker
 role_manage-realm=Administrere sikkerhetsdomene
 role_manage-users=Administrere brukere
 role_manage-applications=Administrere applikasjoner
@@ -51,10 +93,13 @@ role_manage-clients=Administrere klienter
 role_manage-events=Administrere hendelser
 role_view-profile=Se profil
 role_manage-account=Administrere konto
+role_manage-account-links=Administrere kontotilknytninger
+role_manage-consent=Administrere samtykker
 role_read-token=Lese token
 role_offline-access=Frakoblet tilgang
 role_uma_authorization=Skaffe tillatelser
 client_account=Konto
+client_account-console=Kontopanel
 client_security-admin-console=Sikkerhetsadministrasjonskonsoll
 client_admin-cli=Kommandolinje-grensesnitt for administrator
 client_realm-management=Sikkerhetsdomene-administrasjon
@@ -80,7 +125,8 @@ applications=Applikasjoner
 
 account=Konto
 federatedIdentity=Federert identitet
-authenticator=Autentikator
+authenticator=Kodegenerator
+device-activity=Enhetsaktivitet
 sessions=Sesjoner
 log=Logg
 
@@ -95,11 +141,37 @@ fullAccess=Full tilgang
 offlineToken=Offline token
 revoke=Opphev rettighet
 
-configureAuthenticators=Konfigurerte autentikatorer
+configureAuthenticators=Konfigurerte kodegeneratorer
 mobile=Mobiltelefon
-totpStep1=Installer ett av følgende programmer på  mobilen din.
-totpStep2=Åpne applikasjonen og skann strekkoden eller skriv inn koden.
-totpStep3=Skriv inn engangskoden gitt av applikasjonen og klikk Lagre for å fullføre.
+totpStep1=Installer en av følgende apper på mobilen din:
+totpStep2=Åpne appen og skann QR-koden, eller skriv inn koden:
+totpStep3=Skriv inn engangskoden gitt av appen og klikk Lagre for å fullføre.
+totpStep3DeviceName=Oppgi et enhetsnavn for å hjelpe deg å holde orden på kodegeneratorene dine.
+
+totpManualStep2=Åpne appen og skriv inn nøkkelen:
+totpManualStep3=Bruk følgende innstillinger hvis appen lar deg velge dem:
+totpUnableToScan=Får du ikke skannet?
+totpScanBarcode=Skann QR-kode?
+
+totp.totp=Tidsbasert
+totp.hotp=Tellerbasert
+
+totpType=Type
+totpAlgorithm=Algoritme
+totpDigits=Siffer
+totpInterval=Intervall
+totpCounter=Teller
+totpDeviceName=Enhetsnavn
+
+totpAppFreeOTPName=FreeOTP
+totpAppGoogleName=Google Authenticator
+totpAppMicrosoftAuthenticatorName=Microsoft Authenticator
+
+irreversibleAction=Denne handlingen er irreversibel
+deletingImplies=Sletting av kontoen din medfører følgende:
+errasingData=Alle dine data slettes
+loggingOutImmediately=Du blir logget ut umiddelbart
+accountUnusable=All videre bruk av applikasjonen vil være umulig med denne kontoen
 
 missingUsernameMessage=Vennligst oppgi brukernavn.
 missingFirstNameMessage=Vennligst oppgi fornavn.
@@ -108,8 +180,11 @@ missingLastNameMessage=Vennligst oppgi etternavn.
 missingEmailMessage=Vennligst oppgi e-postadresse.
 missingPasswordMessage=Vennligst oppgi passord.
 notMatchPasswordMessage=Passordene er ikke like.
+invalidUserMessage=Ugyldig bruker
+updateReadOnlyAttributesRejectedMessage=Endring av skrivebeskyttet attributt avvist
 
 missingTotpMessage=Vennligst oppgi engangskode.
+missingTotpDeviceNameMessage=Vennligst oppgi enhetsnavn.
 invalidPasswordExistingMessage=Ugyldig eksisterende passord.
 invalidPasswordConfirmMessage=Passordene er ikke like.
 invalidTotpMessage=Ugyldig engangskode.
@@ -118,10 +193,11 @@ usernameExistsMessage=Brukernavnet finnes allerede.
 emailExistsMessage=E-postadressen finnes allerede.
 
 readOnlyUserMessage=Du kan ikke oppdatere kontoen din ettersom den er skrivebeskyttet.
+readOnlyUsernameMessage=Du kan ikke oppdatere brukernavnet ditt ettersom det er skrivebeskyttet.
 readOnlyPasswordMessage=Du kan ikke oppdatere passordet ditt ettersom kontoen din er skrivebeskyttet.
 
-successTotpMessage=Autentikator for mobiltelefon er konfigurert.
-successTotpRemovedMessage=Autentikator for mobiltelefon er fjernet.
+successTotpMessage=Kodegenerator for mobiltelefon er konfigurert.
+successTotpRemovedMessage=Kodegenerator for mobiltelefon er fjernet.
 
 successGrantRevokedMessage=Vellykket oppheving av rettighet.
 
@@ -133,22 +209,174 @@ invalidFederatedIdentityActionMessage=Ugyldig eller manglende handling.
 identityProviderNotFoundMessage=Spesifisert identitetsleverandør ikke funnet.
 federatedIdentityLinkNotActiveMessage=Denne identiteten er ikke lenger aktiv.
 federatedIdentityRemovingLastProviderMessage=Du kan ikke fjerne siste federerte identitet ettersom du ikke har et passord.
-identityProviderRedirectErrorMessage=Redirect til identitetsleverandør feilet.
+identityProviderRedirectErrorMessage=Omruting til identitetsleverandør feilet.
 identityProviderRemovedMessage=Fjerning av identitetsleverandør var vellykket.
 identityProviderAlreadyLinkedMessage=Federert identitet returnert av {0} er allerede koblet til en annen bruker.
 staleCodeAccountMessage=Siden har utløpt. Vennligst prøv en gang til.
 consentDenied=Samtykke avslått.
+access-denied-when-idp-auth=Tilgang ble avvist under innlogging med {0}
 
 accountDisabledMessage=Konto er deaktivert, kontakt administrator.
 
 accountTemporarilyDisabledMessage=Konto er midlertidig deaktivert, kontakt administrator eller prøv igjen senere.
-invalidPasswordMinLengthMessage=Ugyldig passord: minimum lengde {0}.
-invalidPasswordMinLowerCaseCharsMessage=Ugyldig passord: må inneholde minimum {0} små bokstaver.
-invalidPasswordMinDigitsMessage=Ugyldig passord: må inneholde minimum {0} sifre.
-invalidPasswordMinUpperCaseCharsMessage=Ugyldig passord: må inneholde minimum {0} store bokstaver.
-invalidPasswordMinSpecialCharsMessage=Ugyldig passord: må inneholde minimum {0} spesialtegn.
-invalidPasswordNotUsernameMessage=Ugyldig passord: kan ikke være likt brukernavn.
+invalidPasswordMinLengthMessage=Ugyldig passord: må bestå av minst {0} tegn.
+invalidPasswordMaxLengthMessage=Ugyldig passord: må bestå av maks {0} tegn.
+invalidPasswordMinLowerCaseCharsMessage=Ugyldig passord: må inneholde minst {0} små bokstaver.
+invalidPasswordMinDigitsMessage=Ugyldig passord: må inneholde minst {0} tall.
+invalidPasswordMinUpperCaseCharsMessage=Ugyldig passord: må inneholde minst {0} store bokstaver.
+invalidPasswordMinSpecialCharsMessage=Ugyldig passord: må inneholde minst {0} spesialtegn.
+invalidPasswordNotUsernameMessage=Ugyldig passord: kan ikke være likt brukernavnet.
+invalidPasswordNotEmailMessage=Ugyldig passord: kan ikke være likt e-postadressen.
 invalidPasswordRegexPatternMessage=Ugyldig passord: tilfredsstiller ikke kravene for passord-mønster.
 invalidPasswordHistoryMessage=Ugyldig passord: kan ikke være likt noen av de {0} foregående passordene.
+invalidPasswordBlacklistedMessage=Ugyldig passord: passordet er svartelistet.
+invalidPasswordGenericMessage=Ugyldig passord: nytt passord møter ikke passordkravene.
 
-locale_fa=فارسی
+# Authorization
+myResources=Mine ressurser
+myResourcesSub=Mine ressurser
+doDeny=Avslå
+doRevoke=Opphev
+doApprove=Godkjenn
+doRemoveSharing=Fjern deling
+doRemoveRequest=Fjern forespørsel
+peopleAccessResource=Folk med tilgang til denne ressursen
+resourceManagedPolicies=Tillatelser som gir tilgang til denne ressursen
+resourceNoPermissionsGrantingAccess=Ingen tillatelser gir tilgang til denne ressursen
+anyAction=Enhver handling
+description=Beskrivelse
+name=Navn
+scopes=Omfang
+resource=Ressurs
+user=Bruker
+peopleSharingThisResource=Folk som deler denne ressursen
+shareWithOthers=Del med andre
+needMyApproval=Trenger min godkjenning
+requestsWaitingApproval=Dine forespørsler som avventer godkjenning
+icon=Ikon
+requestor=Forespørrer
+owner=Eier
+resourcesSharedWithMe=Ressurser delt med meg
+permissionRequestion=Rettighetsforespørsel
+permission=Tillatelse
+shares=deling(er)
+notBeingShared=Denne ressursen deles ikke.
+notHaveAnyResource=Du har ingen ressurser
+noResourcesSharedWithYou=Ingen ressurser har blitt delt med deg
+havePermissionRequestsWaitingForApproval=Du har {0} forespørsler om tillatelser som venter på godkjenning.
+clickHereForDetails=Klikk her for detaljer.
+resourceIsNotBeingShared=Denne ressursen deles ikke
+
+# Applications
+applicationName=Navn
+applicationType=Applikasjonstype
+applicationInUse=Kun app i bruk
+clearAllFilter=Tøm alle filtre
+activeFilters=Aktive filtre
+filterByName=Filtrer etter navn ...
+allApps=Alle applikasjoner
+internalApps=Interne applikasjoner
+thirdpartyApps=Tredjepartsapplikasjoner
+appResults=Resultater
+clientNotFoundMessage=Klient ikke funnet.
+
+# Linked account
+authorizedProvider=Autorisert leverandør
+authorizedProviderMessage=Autoriserte leverandører tilknyttet din konto
+identityProvider=Identitetsleverandør
+identityProviderMessage=For å knytte kontoen din opp mot identitetsleverandører du har konfigurert
+socialLogin=Sosial innlogging
+userDefined=Brukerdefinert
+removeAccess=Fjern tilgang
+removeAccessMessage=Du må innvilge tilgang igjen dersom du ønsker å bruke denne appkontoen.
+
+#Authenticator
+authenticatorStatusMessage=Tofaktorautentisering er
+authenticatorFinishSetUpTitle=Din tofaktorautentisering
+authenticatorFinishSetUpMessage=Hver gang du logger inn på Keycloak-kontoen din, vil du bli bedt om å oppgi en engangskode.
+authenticatorSubTitle=Sett opp tofaktorautentisering
+authenticatorSubMessage=For å øke sikkerheten til kontoen din bør du aktivere minst én metode for tofaktorautentisering.
+authenticatorMobileTitle=Mobil kodegenerator
+authenticatorMobileMessage=Bruk en mobilapp til å generere engangskoder som tofaktormetode.
+authenticatorMobileFinishSetUpMessage=Kodegeneratoren har blitt bundet til telefonen din.
+authenticatorActionSetup=Sett opp
+authenticatorSMSTitle=SMS-kode
+authenticatorSMSMessage=Keycloak vil sende deg tekstmeldinger med engangskoder som tofaktormetode.
+authenticatorSMSFinishSetUpMessage=Tekstmeldinger vil bli sendt til
+authenticatorDefaultStatus=Standard
+authenticatorChangePhone=Endre telefonnummer
+
+#Authenticator - Mobile Authenticator setup
+authenticatorMobileSetupTitle=Oppsett av mobil kodegenerator
+smscodeIntroMessage=Skriv inn telefonnummeret ditt for å få tilsendt en bekreftelseskode på SMS.
+mobileSetupStep1=Installer en kodegenerator-app på telefonen din. Appene som er listet opp her støttes.
+mobileSetupStep2=Åpne appen og skann QR-koden:
+mobileSetupStep3=Skriv inn engangskoden gitt av appen og klikk Lagre for å fullføre.
+scanBarCode=Vil du skanne koden?
+enterBarCode=Oppgi engangskoden
+doCopy=Kopier
+doFinish=Fullfør
+
+#Authenticator - SMS Code setup
+authenticatorSMSCodeSetupTitle=SMS-kodeoppsett
+chooseYourCountry=Velg landet ditt
+enterYourPhoneNumber=Oppgi telefonnummeret ditt
+sendVerficationCode=Send bekreftelseskode
+enterYourVerficationCode=Oppgi bekreftelseskoden
+
+#Authenticator - backup Code setup
+authenticatorBackupCodesSetupTitle=Oppsett av backupkoder
+realmName=Sikkerhetsdomene
+doDownload=Last ned
+doPrint=Skriv ut
+generateNewBackupCodes=Generer nye backupkoder
+backtoAuthenticatorPage=TIlbake til kodegenerator-siden
+
+
+#Resources
+resources=Ressurser
+sharedwithMe=Delt med meg
+share=Del
+sharedwith=Delt med
+accessPermissions=Tilgangsrettigheter
+permissionRequests=Rettighetsforespørsler
+approve=Godkjenn
+approveAll=Godkjenn alle
+people=folk
+perPage=per side
+currentPage=Nåværende side
+sharetheResource=Del denne ressursen
+group=Gruppe
+selectPermission=Velg rettighet
+addPeople=Legg til folk du vil dele ressursen med
+addTeam=Legg til team du vil dele ressursen med
+myPermissions=Mine rettigheter
+waitingforApproval=Venter på godkjenning
+anyPermission=Enhver rettighet
+
+# Openshift messages
+openshift.scope.user_info=Brukerinformasjon
+openshift.scope.user_check-access=Brukertilgangsinformasjon
+openshift.scope.user_full=Full tilgang
+openshift.scope.list-projects=List ut prosjekter
+
+error-invalid-value=Ugyldig verdi.
+error-invalid-blank=Vennligst oppgi en verdi.
+error-empty=Vennligst oppgi en verdi.
+error-invalid-length=Attributten {0} må ha en lengde mellom {1} og {2}.
+error-invalid-length-too-short=Attributten {0} må ha minimum lengde {1}.
+error-invalid-length-too-long=Attributten {0} kan maksimalt ha lengde {2}.
+error-invalid-email=Ugyldig e-postadresse.
+error-invalid-number=Ugyldig tall.
+error-number-out-of-range=Attributten {0} må være et tall mellom {1} og {2}.
+error-number-out-of-range-too-small=Attributten {0} må ha en minsteverdi på {1}.
+error-number-out-of-range-too-big=Attributten {0} må ha en maksverdi på {2}.
+error-pattern-no-match=Ugyldig verdi.
+error-invalid-uri=Ugyldig URL.
+error-invalid-uri-scheme=Ugyldig URL-skjema.
+error-invalid-uri-fragment=Ugyldig URL-fragment.
+error-user-attribute-required=Vennligst oppgi attributten {0}.
+error-invalid-date=Ugyldig dato.
+error-user-attribute-read-only=Feltet {0} er skrivebeskyttet.
+error-username-invalid-character=Brukernavnet inneholder et ugyldig tegn.
+error-person-name-invalid-character=Navnet inneholder et ugyldig tegn.

--- a/themes/src/main/resources-community/theme/base/admin/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/admin/messages/messages_no.properties
@@ -1,14 +1,68 @@
-invalidPasswordMinLengthMessage=Ugyldig passord: minimum lengde {0}.
+invalidPasswordMinLengthMessage=Ugyldig passord: må bestå av minst {0} tegn.
+invalidPasswordMaxLengthMessage=Ugyldig passord: må bestå av maks {0} tegn.
 invalidPasswordMinLowerCaseCharsMessage=Ugyldig passord: må inneholde minst {0} små bokstaver.
-invalidPasswordMinDigitsMessage=Ugyldig passord: må inneholde minst {0} sifre.
+invalidPasswordMinDigitsMessage=Ugyldig passord: må inneholde minst {0} tall.
 invalidPasswordMinUpperCaseCharsMessage=Ugyldig passord: må inneholde minst {0} store bokstaver.
 invalidPasswordMinSpecialCharsMessage=Ugyldig passord: må inneholde minst {0} spesialtegn.
 invalidPasswordNotUsernameMessage=Ugyldig passord: kan ikke være likt brukernavn.
+invalidPasswordNotEmailMessage=Ugyldig passord: kan ikke være likt e-postadressen.
 invalidPasswordRegexPatternMessage=Ugyldig passord: tilfredsstiller ikke kravene for passord-mønster.
 invalidPasswordHistoryMessage=Ugyldig passord: kan ikke være likt noen av de {0} foregående passordene.
+invalidPasswordBlacklistedMessage=Ugyldig passord: passordet er svartelistet.
+invalidPasswordGenericMessage=Ugyldig passord: nytt passord møter ikke passordkravene.
 
+ldapErrorEditModeMandatory=Endringsmodus er påkrevd
 ldapErrorInvalidCustomFilter=Tilpasset konfigurasjon av LDAP-filter starter ikke med "(" eller slutter ikke med ")".
-ldapErrorMissingClientId=KlientID må være tilgjengelig i config når sikkerhetsdomenerollemapping ikke brukes.
-ldapErrorCantPreserveGroupInheritanceWithUIDMembershipType=Ikke mulig å bevare gruppearv og samtidig bruke UID medlemskapstype.
-ldapErrorCantWriteOnlyForReadOnlyLdap=Kan ikke sette write-only når LDAP leverandør-modus ikke er WRITABLE
+ldapErrorConnectionTimeoutNotNumber=Tidsavbrudd for tilkobling må være et tall
+ldapErrorReadTimeoutNotNumber=Tidsavbrudd for lesing må være et tall
+ldapErrorMissingClientId=Klient-ID må være oppgitt i konfigurasjonen når sikkerhetsdomenerollemapping ikke brukes.
+ldapErrorCantPreserveGroupInheritanceWithUIDMembershipType=Ikke mulig å bevare gruppearv og samtidig bruke UID-medlemskapstype.
+ldapErrorCantWriteOnlyForReadOnlyLdap=Kan ikke sette write-only når LDAP-leverandørmodus ikke er WRITABLE
 ldapErrorCantWriteOnlyAndReadOnly=Kan ikke sette både write-only og read-only
+ldapErrorCantEnableStartTlsAndConnectionPooling=Kan ikke aktivere både StartTLS og forbindelsespooling.
+ldapErrorCantEnableUnsyncedAndImportOff=Kan ikke deaktivere importering av brukere når LDAP-leverandørmodus er UNSYNCED
+ldapErrorMissingGroupsPathGroup=Gruppen på gruppebanen eksisterer ikke - vennligst opprett gruppen på oppgitt bane først
+ldapErrorValidatePasswordPolicyAvailableForWritableOnly=Passordkravvalidering gjelder bare med WRITABLE endringsmodus
+
+clientRedirectURIsFragmentError=Omdirigerings-URI kan ikke inneholde et URI-fragment
+clientRootURLFragmentError=Rot-URL kan ikke inneholde et URL-fragment
+clientRootURLIllegalSchemeError=Rot-URL bruker et ugyldig skjema
+clientBaseURLIllegalSchemeError=Base-URL bruker et ugyldig skjema
+backchannelLogoutUrlIllegalSchemeError=Bak-kanal utloggings-URL bruker et ugyldig skjema
+clientRedirectURIsIllegalSchemeError=En omdirigerings-URI bruker et ugyldig skjema
+clientBaseURLInvalid=Base-URL er ikke en gyldig URL
+clientRootURLInvalid=Rot-URL er ikke en gyldig URL
+clientRedirectURIsInvalid=En omdirigerings-URI er ikke en gyldig URI
+backchannelLogoutUrlIsInvalid=Bak-kanal utloggings-URL er ikke en gyldig URL
+
+
+pairwiseMalformedClientRedirectURI=Klienten inneholdt en ugyldig omdirigerings-URI.
+pairwiseClientRedirectURIsMissingHost=Klientens omdirigerings-URIer må inneholde en gyldig tjenerkomponent.
+pairwiseClientRedirectURIsMultipleHosts=Uten en konfigurert sektoridentifikator-URI kan ikke omdirigerings-URIer inneholde flere tjenerkomponenter.
+pairwiseMalformedSectorIdentifierURI=Misformet sektoridentifikator-URI.
+pairwiseFailedToGetRedirectURIs=Kunne ikke hente omdirigerings-URIer fra sektoridentifikator-URI.
+pairwiseRedirectURIsMismatch=Klientens omdirigerings-URIer stemmer ikke overens med omdirigerings-URIene hentet fra sektoridentifikator-URIen.
+
+duplicatedJwksSettings="Bruk JWKS"-bryteren og "Bruk JWKS-URL"-bryteren kan ikke begge være PÅ samtidig.
+
+error-invalid-value=Ugyldig verdi.
+error-invalid-blank=Vennligst oppgi en verdi.
+error-empty=Vennligst oppgi en verdi.
+error-invalid-length=Attributten {0} må ha en lengde mellom {1} og {2}.
+error-invalid-length-too-short=Attributten {0} må ha minimum lengde {1}.
+error-invalid-length-too-long=Attributten {0} kan maksimalt ha lengde {2}.
+error-invalid-email=Ugyldig e-postadresse.
+error-invalid-number=Ugyldig tall.
+error-number-out-of-range=Attributten {0} må være et tall mellom {1} og {2}.
+error-number-out-of-range-too-small=Attributten {0} må ha en minsteverdi på {1}.
+error-number-out-of-range-too-big=Attributten {0} må ha en maksverdi på {2}.
+error-pattern-no-match=Ugyldig verdi.
+error-invalid-uri=Ugyldig URL.
+error-invalid-uri-scheme=Ugyldig URL-skjema.
+error-invalid-uri-fragment=Ugyldig URL-fragment.
+error-user-attribute-required=Vennligst oppgi attributten {0}.
+error-invalid-date=Attributten {0} er en ugyldig dato.
+error-user-attribute-read-only=Attributten {0} er skrivebeskyttet.
+error-username-invalid-character=Brukernavnet inneholder et ugyldig tegn.
+error-person-name-invalid-character=Navnet inneholder et ugyldig tegn.
+error-invalid-multivalued-size=Attributten {0} må ha minst {1} og maks {2} verdi(er).

--- a/themes/src/main/resources-community/theme/base/email/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/email/messages/messages_no.properties
@@ -1,24 +1,50 @@
 emailVerificationSubject=Bekreft e-postadresse
-emailVerificationBody=Noen har opprettet en {2} konto med denne e-postadressen. Hvis dette var deg, klikk på lenken nedenfor for å bekrefte e-postadressen din\n\n{0}\n\nDenne lenken vil utløpe om {1} minutter.\n\nHvis du ikke opprettet denne kontoen, vennligst ignorer denne meldingen.
-emailVerificationBodyHtml=<p>Noen har opprettet en {2} konto med denne e-postadressen. Hvis dette var deg, klikk på lenken nedenfor for å bekrefte e-postadressen din</p><p><a href="{0}">Lenke for å bekrefte e-postadresse</a></p><p>Denne lenken vil utløpe om {1} minutter.</p><p>Hvis du ikke opprettet denne kontoen, vennligst ignorer denne meldingen.</p>
+emailVerificationBody=Noen har opprettet en {2}-konto med denne e-postadressen. Hvis dette var deg, klikk på lenken nedenfor for å bekrefte e-postadressen din\n\n{0}\n\nDenne lenken vil utløpe om {3}.\n\nHvis du ikke opprettet denne kontoen, kan du se bort ifra denne meldingen.
+emailVerificationBodyHtml=<p>Noen har opprettet en {2}-konto med denne e-postadressen. Hvis dette var deg, klikk på lenken nedenfor for å bekrefte e-postadressen din</p><p><a href="{0}">Lenke for å bekrefte e-postadresse</a></p><p>Denne lenken vil utløpe om {3}.</p><p>Hvis du ikke opprettet denne kontoen, kan du se bort ifra denne meldingen.</p>
+emailUpdateConfirmationSubject=Bekreft ny e-postadresse
+emailUpdateConfirmationBody=For å oppdatere {2}-kontoen med e-postadressen {1}, klikk på lenken nedenfor\n\n{0}\n\nDenne lenken vil utløpe om {3}.\n\nHvis du ikke ønsker å gå videre med denne endringen, kan du se bort ifra denne meldingen.
+emailUpdateConfirmationBodyHtml=<p>For å oppdatere {2}-kontoen med e-postadressen {1}, klikk på lenken nedenfor</p><p><a href="{0}">{0}</a></p><p>Denne lenken vil utløpe om {3}.</p><p>Hvis du ikke ønsker å gå videre med denne endringen, kan du se bort ifra denne meldingen.</p>
+emailTestSubject=[KEYCLOAK] - SMTP-testmelding
+emailTestBody=Dette er en testmelding
+emailTestBodyHtml=<p>Dette er en testmelding</p>
 identityProviderLinkSubject=Lenke {0}
-identityProviderLinkBody=Noen vil koble din <b>{1}</b> konto med <b>{0}</b> konto til bruker {2}. Hvis dette var deg, klikk på lenken nedenfor for å koble kontoene\n\n{3}\n\nDenne lenken vil utløpe om {4} minutter\n\nHvis du ikke vil koble kontoene, vennligst ignorer denne meldingen. Hvis du kobler kontoene sammen vil du kunne logge inn til {1} gjennom {0}.
-identityProviderLinkBodyHtml=<p>Noen vil koble din <b>{1}</b> konto med <b>{0}</b> konto til bruker {2}. Hvis dette var deg, klikk på lenken nedenfor for å koble kontoene.</p><p><a href="{3}">Lenke for å koble konto</a></p><p>Denne lenken vil utløpe om {4} minutter.</p><p>Hvis du ikke vil koble kontoene, vennligst ignorer denne meldingen. Hvis du kobler kontoene sammen vil du kunne logge inn til {1} gjennom {0}.</p>
+identityProviderLinkBody=Noen vil koble din "{1}"-konto med "{0}"-kontoen til bruker {2}. Hvis dette var deg, klikk på lenken nedenfor for å sammenkoble kontoene\n\n{3}\n\nDenne lenken vil utløpe om {5}\n\nHvis du ikke vil koble sammen kontoene, kan du se bort ifra denne meldingen. Hvis du kobler kontoene sammen vil du kunne logge inn på {1} gjennom {0}.
+identityProviderLinkBodyHtml=<p>Noen vil koble din <b>{1}</b>-konto med <b>{0}</b>-kontoen til bruker {2}. Hvis dette var deg, klikk på lenken nedenfor for å sammenkoble kontoene.</p><p><a href="{3}">Lenke for å sammenkoble konto</a></p><p>Denne lenken vil utløpe om {5}.</p><p>Hvis du ikke vil koble sammen kontoene, kan du se bort ifra denne meldingen. Hvis du kobler kontoene sammen vil du kunne logge inn på {1} gjennom {0}.</p>
 passwordResetSubject=Tilbakestill passord
-passwordResetBody=Noen har bedt om å endre innloggingsdetaljene til din konto {2}. Hvis dette var deg, klikk på lenken nedenfor for å tilbakestille dem.\n\n{0}\n\nDenne lenken vil utløpe om {1} minutter.\n\nHvis du ikke vil tilbakestille din innloggingsdata, vennligst ignorer denne meldingen og ingenting vil bli endret.
-passwordResetBodyHtml=<p>Noen har bedt om å endre innloggingsdetaljene til din konto {2}. Hvis dette var deg, klikk på lenken nedenfor for å tilbakestille dem.</p><p><a href="{0}">Lenke for å tillbakestille innloggingsdetaljene</a></p><p>Denne lenken vil utløpe om {1} minutter.</p><p>Hvis du ikke vil tilbakestille din innloggingsdata, vennligst ignorer denne meldingen og ingenting vil bli endret.</p>
+passwordResetBody=Noen har bedt om å endre innloggingsdetaljene til {2}-kontoen din. Hvis dette var deg, klikk på lenken nedenfor for å tilbakestille dem.\n\n{0}\n\nDenne lenken vil utløpe om {3}.\n\nHvis du ikke vil tilbakestille innloggingsdetaljene dine, kan du se bort ifra denne meldingen og ingenting vil bli endret.
+passwordResetBodyHtml=<p>Noen har bedt om å endre innloggingsdetaljene til {2}-kontoen din. Hvis dette var deg, klikk på lenken nedenfor for å tilbakestille dem.</p><p><a href="{0}">Lenke for å tillbakestille innloggingsdetaljene</a></p><p>Denne lenken vil utløpe om {3}.</p><p>Hvis du ikke vil tilbakestille innloggingsdetaljene dine, kan du se bort ifra denne meldingen og ingenting vil bli endret.</p>
 executeActionsSubject=Oppdater kontoen din
-executeActionsBody=Administrator har anmodet at du oppdaterer din {2} konto. Klikk på lenken nedenfor for å starte denne prosessen\n\n{0}\n\nDenne lenken vil utløpe om {1} minutter.\n\nHvis du ikke var klar over at administrator har bedt om dette, vennligst ignorer denne meldingen og ingenting vil bli endret.
-executeActionsBodyHtml=<p>Administrator har anmodet at du oppdaterer din {2} konto. Klikk på linken nedenfor for å starte denne prosessen.</p><p><a href="{0}">Lenke for å oppdatere din konto</a></p><p>Denne lenken vil utløpe om {1} minutter.</p><p>Hvis du ikke var klar over at administrator har bedt om dette, ignorer denne meldingen og ingenting vil bli endret. </p>
-eventLoginErrorSubject=Innlogging feilet
-eventLoginErrorBody=Et mislykket innloggingsforsøk ble oppdaget på din konto på {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
-eventLoginErrorBodyHtml=<p>Et mislykket innloggingsforsøk ble oppdaget på din konto på {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.</p>
-eventRemoveTotpSubject=Fjern engangskode
-eventRemoveTotpBody=Engangskode ble fjernet fra kontoen din på {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
-eventRemoveTotpBodyHtml=<p>Engangskode ble fjernet fra kontoen din på {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.</p>
+executeActionsBody=Administrator har bedt om at du oppdaterer {2}-kontoen din ved å utføre følgende handling(er): {3}. Klikk på lenken nedenfor for å starte denne prosessen\n\n{0}\n\nDenne lenken vil utløpe om {4}.\n\nHvis du ikke var klar over at administrator har bedt om dette, kan du se bort ifra denne meldingen og ingenting vil bli endret.
+executeActionsBodyHtml=<p>Administrator har bedt om at du oppdaterer {2}-kontoen din ved å utføre følgende handling(er): {3}. Klikk på lenken nedenfor for å starte denne prosessen.</p><p><a href="{0}">Lenke for å oppdatere kontoen din</a></p><p>Denne lenken vil utløpe om {4}.</p><p>Hvis du ikke var klar over at administrator har bedt om dette, kan du se bort ifra denne meldingen og ingenting vil bli endret.</p>
+eventLoginErrorSubject=Innlogging mislyktes
+eventLoginErrorBody=Et mislykket innloggingsforsøk ble oppdaget på kontoen din hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
+eventLoginErrorBodyHtml=<p>Et mislykket innloggingsforsøk ble oppdaget på kontoen din hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.</p>
+eventRemoveTotpSubject=Fjern kodegenerator
+eventRemoveTotpBody=En kodegenerator ble fjernet fra kontoen din hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
+eventRemoveTotpBodyHtml=<p>En kodegenerator ble fjernet fra kontoen din hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.</p>
 eventUpdatePasswordSubject=Oppdater passord
-eventUpdatePasswordBody=Ditt passord ble endret i {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
-eventUpdatePasswordBodyHtml=<p>Ditt passord ble endret i {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator. </p>
-eventUpdateTotpSubject=Oppdater engangskode
-eventUpdateTotpBody=Engangskode ble oppdatert for kontoen din på {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
-eventUpdateTotpBodyHtml=<p>Engangskode ble oppdatert for kontoen din på {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator. </p>
+eventUpdatePasswordBody=Ditt passord ble endret hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
+eventUpdatePasswordBodyHtml=<p>Ditt passord ble endret hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.</p>
+eventUpdateTotpSubject=Oppdater kodegenerator
+eventUpdateTotpBody=En kodegenerator ble oppdatert for kontoen din hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.
+eventUpdateTotpBodyHtml=<p>En kodegenerator ble oppdatert for kontoen din hos {0} fra {1}. Hvis dette ikke var deg, vennligst kontakt administrator.</p>
+
+requiredAction.CONFIGURE_TOTP=Sett opp tofaktor-kodegenerator
+requiredAction.TERMS_AND_CONDITIONS=Vilkår og betingelser
+requiredAction.UPDATE_PASSWORD=Endre passord
+requiredAction.UPDATE_PROFILE=Oppdater profil
+requiredAction.VERIFY_EMAIL=Bekreft e-postadresse
+requiredAction.CONFIGURE_RECOVERY_AUTHN_CODES=Generer backupkoder
+
+# units for link expiration timeout formatting
+# for languages which have more unit plural forms depending on the value (eg. Czech and other Slavic langs) you can override unit text for some other values like described in the Java choice format which is documented here. For Czech, it would be '{0,choice,0#minut|1#minuta|2#minuty|2<minut}'
+# https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/text/MessageFormat.html
+# https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/text/ChoiceFormat.html
+linkExpirationFormatter.timePeriodUnit.seconds={0,choice,0#sekunder|1#sekund|1<sekunder}
+linkExpirationFormatter.timePeriodUnit.minutes={0,choice,0#minutter|1#minutt|1<minutter}
+linkExpirationFormatter.timePeriodUnit.hours={0,choice,0#timer|1#time|1<timer}
+linkExpirationFormatter.timePeriodUnit.days={0,choice,0#dager|1#dag|1<dager}
+
+emailVerificationBodyCode=Vennligst bekreft e-postadressen din ved å skrive inn følgende kode.\n\n{0}\n\n.
+emailVerificationBodyCodeHtml=<p>Vennligst bekreft e-postadressen din ved å skrive inn følgende kode.</p><p><b>{0}</b></p>
+

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_no.properties
@@ -3,45 +3,77 @@ doRegister=Registrer deg
 doRegisterSecurityKey=Registrer deg
 doCancel=Avbryt
 doSubmit=Send inn
+doBack=Tilbake
 doYes=Ja
 doNo=Nei
 doContinue=Fortsett
+doIgnore=Ignorer
 doAccept=Aksepter
 doDecline=Avslå
 doForgotPassword=Glemt passord?
 doClickHere=Klikk her
-doImpersonate=Utgi deg for å være en annen bruker
+doImpersonate=Utgi deg som bruker
+doTryAgain=Prøv igjen
+doTryAnotherWay=Prøv på annen måte
+doConfirmDelete=Bekreft sletting
+errorDeletingAccount=Feil oppstod under sletting av konto
+deletingAccountForbidden=Du har ikke tilganger nok til å slette kontoen din, kontakt administrator.
 kerberosNotConfigured=Kerberos er ikke konfigurert
 kerberosNotConfiguredTitle=Kerberos er ikke konfigurert
 bypassKerberosDetail=Enten er du ikke logget inn via Kerberos eller så støtter ikke nettleseren innlogging med Kerberos. Vennligst klikk Fortsett for å logge inn på andre måter
 kerberosNotSetUp=Kerberos er ikke konfigurert. Du kan ikke logge inn.
-registerWithTitle=Registrer deg med {0}
-registerWithTitleHtml={0}
+registerTitle=Registrer deg
+loginAccountTitle=Logg inn på kontoen din
 loginTitle=Logg inn på {0}
 loginTitleHtml={0}
-impersonateTitle={0} Gi deg ut for å være en annen bruker
-impersonateTitleHtml=<strong>{0}</strong> Gi deg ut for å være en annen bruker
+impersonateTitle={0} Utgi deg som bruker
+impersonateTitleHtml=<strong>{0}</strong> Utgi deg som bruker
 realmChoice=Sikkerhetsdomene
 unknownUser=Ukjent bruker
-loginTotpTitle=Konfigurer autentifikator for mobil
-loginProfileTitle=Oppdater konto
+loginTotpTitle=Konfigurer mobil autentikator
+loginProfileTitle=Oppdater kontoinformasjon
+loginIdpReviewProfileTitle=Oppdater kontoinformasjon
 loginTimeout=Du brukte for lang tid på å logge inn. Vennligst prøv igjen.
-oauthGrantTitle=Gi tilgang
+reauthenticate=Vennligst reautentiser for å fortsette
+oauthGrantTitle=Gi tilgang til {0}
 oauthGrantTitleHtml={0}
+oauthGrantInformation=Sørg for at du stoler på {0} ved å lære hvordan {0} håndterer dataen din.
+oauthGrantReview=Du kan gjennomgå
+oauthGrantTos=tjenestevilkårene.
+oauthGrantPolicy=personvernerklæringen.
 errorTitle=Vi beklager...
 errorTitleHtml=Vi <strong>beklager</strong> ...
 emailVerifyTitle=E-postbekreftelse
 emailForgotTitle=Glemt passord?
+updateEmailTitle=Oppdater e-postadresse
+emailUpdateConfirmationSentTitle=E-postbekreftelse sendt
+emailUpdateConfirmationSent=En bekreftelsese-post har blitt sendt til {0}. Følg instruksjonene i e-posten for å bekrefte oppdateringen av e-postadresse.
+emailUpdatedTitle=E-postadresse oppdatert
+emailUpdated=E-postadressen til kontoen din har blitt endret til {0}.
 updatePasswordTitle=Oppdater passord
 codeSuccessTitle=Suksesskode
 codeErrorTitle=Feilkode\: {0}
+displayUnsupported=Forespurt visningstype støttes ikke
+browserRequired=Nettleser kreves for å logge inn
+browserContinue=Nettleser kreves for å fullføre innlogging
+browserContinuePrompt=Åpne nettleser for å fortsette innlogging? [j/n]:
+browserContinueAnswer=j
+
+# Transports
+usb=USB
+nfc=NFC
+bluetooth=Bluetooth
+internal=Intern
+unknown=Ukjent
 
 termsTitle=Vilkår og betingelser
-termsTitleHtml=Vilkår og betingelser
 termsText=<p>Vilkår og betingelser kommer</p>
+termsPlainText=Vilkår og betingelser kommer.
+termsAcceptanceRequired=Du må godta vilkårene og betingelsene våre.
+acceptTerms=Jeg godtar vilkårene og betingelsene
 
-recaptchaFailed=Ugyldig Bildebekreftelse
-recaptchaNotConfigured=Bildebekreftelse er påkrevet, men er ikke konfigurert
+recaptchaFailed=Ugyldig Recaptcha
+recaptchaNotConfigured=Recaptcha kreves, men er ikke konfigurert
 consentDenied=Samtykke avslått.
 
 noAccount=Ny bruker?
@@ -49,48 +81,108 @@ username=Brukernavn
 usernameOrEmail=Brukernavn eller e-postadresse
 firstName=Fornavn
 givenName=Fornavn
-fullName=Fullstendig navn
+fullName=Fullt navn
 lastName=Etternavn
 familyName=Etternavn
 email=E-postadresse
 password=Passord
 passwordConfirm=Bekreft passord
 passwordNew=Nytt passord
-passwordNewConfirm=Bekreft nytt Passord
+passwordNewConfirm=Bekreft nytt passord
+hidePassword=Skjul password
+showPassword=Vis password
 rememberMe=Husk meg
 authenticatorCode=Engangskode
 address=Adresse
 street=Gate-/veinavn + husnummer
-locality=By
+locality=By eller sted
 region=Fylke
 postal_code=Postnummer
 country=Land
-emailVerified=E-postadresse bekreftet
-gssDelegationCredential=GSS legitimasjons-delegering
+emailVerified=E-post bekreftet
+website=Nettside
+phoneNumber=Telefonnummer
+phoneNumberVerified=Telefonnummer bekreftet
+gender=Kjønn
+birthday=Fødselsdato
+zoneinfo=Tidssone
+gssDelegationCredential=GSS-legitimasjonsdelegering
+logoutOtherSessions=Logg ut fra andre enheter
 
-loginTotpStep1=Installer <a href="https://freeotp.github.io/" target="_blank">FreeOTP</a> eller Google Authenticator på din mobiltelefon. Begge applikasjoner er tilgjengelige på <a href="https://play.google.com">Google Play</a> og Apple App Store.
-loginTotpStep2=Åpne applikasjonen og skann strekkoden eller skriv inn koden
-loginTotpStep3=Skriv inn engangskoden fra applikasjonen og klikk send inn for å fullføre
+profileScopeConsentText=Brukerprofil
+emailScopeConsentText=E-postadresse
+addressScopeConsentText=Adresse
+phoneScopeConsentText=Telefonnummer
+offlineAccessScopeConsentText=Frakoblet tilgang
+samlRoleListScopeConsentText=Mine roller
+rolesScopeConsentText=Brukerroller
+
+restartLoginTooltip=Start innlogging på nytt
+
+loginTotpIntro=Du må sette opp en engangskodegenerator for å få tilgang til denen kontoen
+loginTotpStep1=Installer en av følgende apper på mobilen din:
+loginTotpStep2=Åpne appen og skann QR-koden:
+loginTotpStep3=Skriv inn engangskoden gitt av appen og klikk Send inn for å fullføre.
+loginTotpStep3DeviceName=Oppgi et enhetsnavn for å hjelpe deg å holde orden på kodegeneratorene dine.
+loginTotpManualStep2=Åpne appen og skriv inn nøkkelen:
+loginTotpManualStep3=Bruk følgende innstillinger hvis appen lar deg velge dem:
+loginTotpUnableToScan=Får du ikke skannet?
+loginTotpScanBarcode=Skann QR-kode?
+loginCredential=Legitimasjon
 loginOtpOneTime=Engangskode
+loginTotpType=Type
+loginTotpAlgorithm=Algoritme
+loginTotpDigits=Siffer
+loginTotpInterval=Intervall
+loginTotpCounter=Teller
+loginTotpDeviceName=Enhetsnavn
+
+loginTotp.totp=Tidsbasert
+loginTotp.hotp=Tellerbasert
+
+totpAppFreeOTPName=FreeOTP
+totpAppGoogleName=Google Authenticator
+totpAppMicrosoftAuthenticatorName=Microsoft Authenticator
+
+loginChooseAuthenticator=Velg innloggingsmetode
 
 oauthGrantRequest=Vil du gi disse tilgangsrettighetene?
 inResource=i
 
-emailVerifyInstruction1=En e-post med instruksjoner for å bekrefte din e-postadresse har blitt sendt til deg.
-emailVerifyInstruction2=Ikke mottatt en bekreftelseskode i e-posten vi sendte til deg?
-emailVerifyInstruction3=for å sende e-post på nytt.
+oauth2DeviceVerificationTitle=Enhetsinnlogging
+verifyOAuth2DeviceUserCode=Oppgi koden fra enheten din og klikk Send inn
+oauth2DeviceInvalidUserCodeMessage=Ugyldig kode, vennligst prøv igjen.
+oauth2DeviceExpiredUserCodeMessage=Koden har utløpt. Vennligst gå tilbake til enheten din og prøv å koble til igjen.
+oauth2DeviceVerificationCompleteHeader=Enhetsinnlogging vellykket
+oauth2DeviceVerificationCompleteMessage=Du kan nå lukke dette vinduet og gå tilbake til enheten din.
+oauth2DeviceVerificationFailedHeader=Enhetsinnlogging mislyktes
+oauth2DeviceVerificationFailedMessage=Du kan nå lukke dette vinduet og gå tilbake til enheten din for å prøve å koble til igjen.
+oauth2DeviceConsentDeniedMessage=Samtykke avslått for tilkobling av enheten.
+oauth2DeviceAuthorizationGrantDisabledMessage=Klienten har ikke lov til å initiere OAuth 2.0 Device Authorization Grant. Denne flyten er deaktivert for klienten.
 
-emailLinkIdpTitle=Lenke {0}
-emailLinkIdp1=En e-post med instruksjoner for å koble {0} konto med din {2} konto har blitt sendt til deg.
+emailVerifyInstruction1=En e-post med instruksjoner for å bekrefte e-postadressen din har blitt sendt til deg på {0}.
+emailVerifyInstruction2=Ikke mottatt en bekreftelseskode i e-posten vi sendte til deg?
+emailVerifyInstruction3=for å sende e-posten på nytt.
+
+emailLinkIdpTitle=Tilknytt {0}
+emailLinkIdp1=En e-post med instruksjoner for å knytte {0}-kontoen {1} til {2}-kontoen din har blitt sendt til deg.
 emailLinkIdp2=Ikke mottatt en bekreftelseskode i e-posten vi sendte til deg?
 emailLinkIdp3=for å sende e-post på nytt.
+emailLinkIdp4=Hvis du allerede bekreftet e-posten i en annen nettleser
+emailLinkIdp5=for å fortsette.
 
 backToLogin=&laquo; Tilbake til innlogging
-emailInstruction=Skriv inn e-postadressen din og vi vil sende deg instruksjoner for hvordan du oppretter et nytt passord.
+
+emailInstruction=Skriv inn brukernavnet eller e-postadressen din, så sender vi deg instruksjoner for hvordan du lager et nytt passord.
+emailInstructionUsername=Skriv inn brukernavnet ditt, så sender vi deg instruksjoner for hvordan du lager et nytt passord.
 
 copyCodeInstruction=Vennligst kopier denne koden og lim den inn i applikasjonen din:
 
-personalInfo=Personlig informasjon:
+pageExpiredTitle=Siden har utløpt
+pageExpiredMsg1=For å starte innloggingen på nytt
+pageExpiredMsg2=For å fortsette innloggingen
+
+personalInfo=Personlige data:
 role_admin=Administrator
 role_realm-admin=Administrator for sikkerhetsdomene
 role_create-realm=Opprette sikkerhetsdomene
@@ -109,81 +201,132 @@ role_manage-clients=Administrere klienter
 role_manage-events=Administrere hendelser
 role_view-profile=Se profil
 role_manage-account=Administrere konto
+role_manage-account-links=Administrere kontotilknytninger
 role_read-token=Lese token
 role_offline-access=Frakoblet tilgang
-role_uma_authorization=Skaffe tillatelser
 client_account=Konto
+client_account-console=Kontopanel
 client_security-admin-console=Sikkerthetsadministrasjonskonsoll
+client_admin-cli=Kommandolinje-grensesnitt for administrator
 client_realm-management=Sikkerhetsdomene-administrasjon
 client_broker=Broker
 
+requiredFields=Obligatoriske felt
+
 invalidUserMessage=Ugyldig brukernavn eller passord.
+invalidUsernameMessage=Ugyldig brukernavn.
+invalidUsernameOrEmailMessage=Ugyldig brukernavn eller e-postadresse.
+invalidPasswordMessage=Ugyldig passord.
 invalidEmailMessage=Ugyldig e-postadresse.
 accountDisabledMessage=Konto er deaktivert, kontakt administrator.
-accountTemporarilyDisabledMessage=Konto er midlertidig deaktivert, kontakt administrator eller prøv på nytt senere.
-expiredCodeMessage=Login ble tidsavbrutt. Vennligst logg inn på nytt.
+accountTemporarilyDisabledMessage=Konto er midlertidig deaktivert, kontakt administrator eller prøv igjen senere.
+expiredCodeMessage=Innloggingen ble tidsavbrutt. Vennligst logg inn på nytt.
+expiredActionMessage=Handlingen har utløpt. Vennligst fortsett med innlogging nå.
+expiredActionTokenNoSessionMessage=Handlingen har utløpt.
+expiredActionTokenSessionExistsMessage=Handlingen har utløpt. Vennligst start på nytt.
+sessionLimitExceeded=Det er for mange sesjoner
+identityProviderLogoutFailure=SAML IdP-utloggingsfeil
 
 missingFirstNameMessage=Vennligst oppgi fornavn.
 missingLastNameMessage=Vennligst oppgi etternavn.
 missingEmailMessage=Vennligst oppgi e-postadresse.
 missingUsernameMessage=Vennligst oppgi brukernavn.
 missingPasswordMessage=Vennligst oppgi passord.
-missingTotpMessage=Vennligst oppgi autentiseringskode.
+missingTotpMessage=Vennligst oppgi engangskode.
+missingTotpDeviceNameMessage=Vennligst oppgi enhetsnavn.
 notMatchPasswordMessage=Passordene er ikke like.
 
+error-invalid-value=Ugyldig verdi.
+error-invalid-blank=Vennligst oppgi en verdi.
+error-empty=Vennligst oppgi en verdi.
+error-invalid-length=Lengden må være mellom {1} og {2}.
+error-invalid-length-too-short=Minimum lengde er {1}.
+error-invalid-length-too-long=Maksimum lengde er {2}.
+error-invalid-email=Ugyldig e-postadresse.
+error-invalid-number=Ugyldig tall.
+error-number-out-of-range=Tallet må være mellom {1} og {2}.
+error-number-out-of-range-too-small=Nummeret må ha en minsteverdi på {1}.
+error-number-out-of-range-too-big=Nummeret må ha en maksverdi på {2}.
+error-pattern-no-match=Ugyldig verdi.
+error-invalid-uri=Ugyldig URL.
+error-invalid-uri-scheme=Ugyldig URL-skjema.
+error-invalid-uri-fragment=Ugyldig URL-fragment.
+error-user-attribute-required=Vennligst oppgi dette feltet.
+error-invalid-date=Ugyldig dato.
+error-user-attribute-read-only=Dette feltet er skrivebeskyttet.
+error-username-invalid-character=Verdien inneholder et ugyldig tegn.
+error-person-name-invalid-character=Verdien inneholder et ugyldig tegn.
+error-reset-otp-missing-id=Vennligst velg en kodegenerator-konfigurasjon.
+
 invalidPasswordExistingMessage=Ugyldig eksisterende passord.
-invalidPasswordConfirmMessage=Passord er ikke like.
+invalidPasswordBlacklistedMessage=Ugyldig passord: passordet er svartelistet.
+invalidPasswordConfirmMessage=Passordene er ikke like.
 invalidTotpMessage=Ugyldig engangskode.
 
 usernameExistsMessage=Brukernavnet finnes allerede.
-emailExistsMessage=E-post finnes allerede.
+emailExistsMessage=E-postadressen finnes allerede.
 
 federatedIdentityExistsMessage=Bruker med {0} {1} finnes allerede. Vennligst logg inn på kontoadministratsjon for å koble sammen kontoene.
+federatedIdentityUnavailableMessage=Bruker {0} autentisert med identitetsleverandøren {1} finnes ikke. Kontakt administrator.
+federatedIdentityUnmatchedEssentialClaimMessage=ID-tokenet utstedt av identitetsleverandøren stemmer ikke overens med det konfigurerte grunnleggende kravet. Kontakt administrator.
 
 confirmLinkIdpTitle=Kontoen finnes allerede
 federatedIdentityConfirmLinkMessage=Bruker med {0} {1} finnes allerede. Hvordan vil du fortsette?
-#federatedIdentityConfirmReauthenticateMessage=Bekreft at du er {0} for å koble din konto med {1}
+federatedIdentityConfirmReauthenticateMessage=Autentiser for å knytte kontoen din til {0}
+nestedFirstBrokerFlowMessage={0}-brukeren {1} er ikke knyttet til noen kjent bruker.
 confirmLinkIdpReviewProfile=Se over og bekreft profil
-confirmLinkIdpContinue=Legg til eksisterende konto
+confirmLinkIdpContinue=Legg til i eksisterende konto
 
-configureTotpMessage=Du må sette opp en engangskode-generator for å aktivere konto.
-updateProfileMessage=Du må oppdatere brukerprofilen din for å aktivere konto.
-updatePasswordMessage=Du må skifte passord for å aktivere kontoen din.
-verifyEmailMessage=Du må bekrefte e-postadressen din for å aktivere konto.
-linkIdpMessage=You need to verify your email address to link your account with {0}.
+configureTotpMessage=Du må sette opp en engangskodegenerator for å aktivere kontoen din.
+configureBackupCodesMessage=Du må sette opp backupkoder for å aktivere kontoen din.
+updateProfileMessage=Du må oppdatere brukerprofilen din for å aktivere kontoen.
+updatePasswordMessage=Du må bytte passord for å aktivere kontoen din.
+updateEmailMessage=Du må oppdatere e-postadressen din for å aktivere kontoen.
+resetPasswordMessage=Du må bytte passordet ditt.
+verifyEmailMessage=Du må bekrefte e-postadressen din for å aktivere kontoen.
+linkIdpMessage=Du må bekrefte e-postadressen din for å koble kontoen din til {0}.
 
-emailSentMessage=Du vil straks motta en e-post med ytterlige instruksjoner.
-emailSendErrorMessage=Mislyktes å sende e-post, vennligst prøv igjen senere.
+emailSentMessage=Du vil straks motta en e-post med videre instruksjoner.
+emailSendErrorMessage=Klarte ikke å sende e-post, vennligst prøv igjen senere.
 
-accountUpdatedMessage=Din konto har blitt oppdatert.
-accountPasswordUpdatedMessage=Ditt passord har blitt oppdatert.
+accountUpdatedMessage=Kontoen din har blitt oppdatert.
+accountPasswordUpdatedMessage=Passordet ditt har blitt endret.
+
+delegationCompleteHeader=Innlogging vellykket
+delegationCompleteMessage=Du kan nå lukke dette vinduet og gå tilbake til konsollapplikasjonen din.
+delegationFailedHeader=Innlogging mislyktes
+delegationFailedMessage=Du kan nå lukke dette vinduet og gå tilbake til konsollapplikasjonen for å prøve å logge inn på nytt.
 
 noAccessMessage=Ingen tilgang
 
-invalidPasswordMinLengthMessage=Ugyldig passord: minimum lengde {0}.
-invalidPasswordMinDigitsMessage=Ugyldig passord: må inneholde minimum {0} sifre.
-invalidPasswordMinLowerCaseCharsMessage=Ugyldig passord: må inneholde minimum {0} små bokstaver.
-invalidPasswordMinUpperCaseCharsMessage=Ugyldig passord: må inneholde minimum {0} store bokstaver.
-invalidPasswordMinSpecialCharsMessage=Ugyldig passord: må inneholde minimum {0} spesialtegn.
-invalidPasswordNotUsernameMessage=Ugyldig passord: kan ikke være likt brukernavn.
+invalidPasswordMinLengthMessage=Ugyldig passord: må bestå av minst {0} tegn.
+invalidPasswordMaxLengthMessage=Ugyldig passord: må bestå av maks {0} tegn.
+invalidPasswordMinDigitsMessage=Ugyldig passord: må inneholde minst {0} tall.
+invalidPasswordMinLowerCaseCharsMessage=Ugyldig passord: må inneholde minst {0} små bokstaver.
+invalidPasswordMinUpperCaseCharsMessage=Ugyldig passord: må inneholde minst {0} store bokstaver.
+invalidPasswordMinSpecialCharsMessage=Ugyldig passord: må inneholde minst {0} spesialtegn.
+invalidPasswordNotUsernameMessage=Ugyldig passord: kan ikke være likt brukernavnet.
+invalidPasswordNotEmailMessage=Ugyldig passord: kan ikke være likt e-postadressen.
 invalidPasswordRegexPatternMessage=Ugyldig passord: tilfredsstiller ikke kravene for passord-mønster.
 invalidPasswordHistoryMessage=Ugyldig passord: kan ikke være likt noen av de {0} foregående passordene.
+invalidPasswordGenericMessage=Ugyldig passord: nytt passord møter ikke passordkravene.
 
 failedToProcessResponseMessage=Kunne ikke behandle svar
 httpsRequiredMessage=HTTPS påkrevd
-realmNotEnabledMessage=Sikkerhetsdomene er ikke aktivert
+realmNotEnabledMessage=Sikkerhetsdomenet er ikke aktivert
 invalidRequestMessage=Ugyldig forespørsel
+successLogout=Du er logget ut
 failedLogout=Utlogging feilet
 unknownLoginRequesterMessage=Ukjent anmoder for innlogging
 loginRequesterNotEnabledMessage=Anmoder for innlogging er ikke aktivert
-bearerOnlyMessage=Bearer-only applikasjoner har ikke lov til å initiere innlogging via nettleser
+bearerOnlyMessage=Bearer-only-applikasjoner har ikke lov til å initiere innlogging via nettleser
 standardFlowDisabledMessage=Klienten har ikke lov til å initiere innlogging via nettleser med gitt response_type. Standard flow er deaktivert for denne klienten.
 implicitFlowDisabledMessage=Klienten har ikke lov til å initiere innlogging via nettleser med gitt response_type. Implicit flow er deaktivert for denne klienten.
 invalidRedirectUriMessage=Ugyldig redirect uri
-unsupportedNameIdFormatMessage=NameIDFormat er ikke støttet
-invalidRequesterMessage=Ugyldig sender av forespørsel
+unsupportedNameIdFormatMessage=NameIDFormatet støttes ikke
+invalidRequesterMessage=Ugyldig anmoder
 registrationNotAllowedMessage=Registrering er ikke lov
-resetCredentialNotAllowedMessage=Tilbakestilling av innloggingsdata er ikke lov
+resetCredentialNotAllowedMessage=Tilbakestilling av innloggingsdetaljer er ikke lov
 
 permissionNotApprovedMessage=Tillatelse ikke godkjent.
 noRelayStateInResponseMessage=Ingen relay state i svar fra identitetsleverandør.
@@ -197,19 +340,163 @@ couldNotSendAuthenticationRequestMessage=Kunne ikke sende autentiseringsforespø
 unexpectedErrorHandlingRequestMessage=Uventet feil ved håndtering av autentiseringsforespørsel til identitetsleverandør.
 invalidAccessCodeMessage=Ugyldig tilgangskode.
 sessionNotActiveMessage=Sesjonen er ikke aktiv.
-invalidCodeMessage=En feil oppstod, vennligst logg inn på nytt i din applikasjon.
+invalidCodeMessage=En feil oppstod, vennligst logg inn på nytt i applikasjonen din.
+cookieNotFoundMessage=Fant ikke informasjonskapsel. Sjekk at informasjonskapsler er aktivert i nettleseren din.
+insufficientLevelOfAuthentication=Det forespørte autentiseringsnivået har ikke blitt tilfredsstilt.
 identityProviderUnexpectedErrorMessage=Uventet feil ved autentisering med identitetsleverandør
+identityProviderMissingStateMessage=State-parameter mangler i svaret fra identitetsleverandøren.
+identityProviderMissingCodeOrErrorMessage=Kode- eller feilparameter mangler i svaret fra identitetsleverandøren.
+identityProviderInvalidResponseMessage=Ugyldig svar fra identitetsleverandøren.
+identityProviderInvalidSignatureMessage=Ugyldig signatur i svaret fra identitetsleverandøren.
 identityProviderNotFoundMessage=Kunne ikke finne en identitetsleverandør med identifikatoren.
-identityProviderLinkSuccess=Din konto ble suksessfullt koblet med {0} konto {1}.
-staleCodeMessage=Denne siden er ikke lenger gyldig. Vennligst gå tilbake til applikasjonen din og logg inn på nytt.
-realmSupportsNoCredentialsMessage=Sikkerhetsdomene støtter ingen legitimasjonstyper.
-identityProviderNotUniqueMessage=Sikkerhetsdomene støtter flere identitetsleverandører. Kunne ikke avgjøre hvilken identitetsleverandør som burde brukes for autentisering.
-emailVerifiedMessage=Din e-postadresse har blitt verifisert.
-staleEmailVerificationLink=Lenken du klikket er utgått og er ikke lenger gyldig. Har du kanskje allerede bekreftet e-postadressen din?
+identityProviderLinkSuccess=Bekreftelse av e-postadresse var vellykket. Gå tilbake til den opprinnelige nettleseren og fortsett med innloggingen der.
+staleCodeMessage=Denne siden er ikke lenger gyldig. Vennligst gå tilbake til applikasjonen din og logg inn på nytt
+realmSupportsNoCredentialsMessage=Sikkerhetsdomenet støtter ingen legitimasjonstyper.
+credentialSetupRequired=Kan ikke logge inn, legitimasjonsoppsett kreves.
+identityProviderNotUniqueMessage=Sikkerhetsdomenet støtter flere identitetsleverandører. Kunne ikke avgjøre hvilken identitetsleverandør som burde brukes for autentisering.
+emailVerifiedMessage=E-postadressen din har blitt bekreftet.
+emailVerifiedAlreadyMessage=E-postadressen din har allerede blitt bekreftet.
+staleEmailVerificationLink=Lenken du klikket har utløpt og er ikke lenger gyldig. Har du kanskje allerede bekreftet e-postadressen din?
+identityProviderAlreadyLinkedMessage=Den federerte identiteten returnert av {0} er allerede knyttet opp mot en annen bruker.
+confirmAccountLinking=Bekreft tilknytting av kontoen {0} hos identitetsleverandøren {1} til kontoen din.
+confirmEmailAddressVerification=Bekreft gyldigheten av e-postadressen {0}.
+confirmExecutionOfActions=Utfør følgende handling(er)
 
 backToApplication=&laquo; Tilbake til applikasjonen
-missingParameterMessage=Manglende parameter\: {0}
+missingParameterMessage=Manglende parametre\: {0}
 clientNotFoundMessage=Klient ikke funnet.
 clientDisabledMessage=Klient deaktivert.
 invalidParameterMessage=Ugyldig parameter\: {0}
 alreadyLoggedIn=Du er allerede innlogget.
+differentUserAuthenticated=Du er allerede autentisert som en annen bruker ''{0}'' i denne sesjonen. Vennligst logg ut først.
+brokerLinkingSessionExpired=Brokerkontotilknytning ble forespurt, men inneværende sesjon er ikke lenger gyldig.
+proceedWithAction=&raquo; Klikk her for å fortsette
+acrNotFulfilled=Autentiseringskrav ikke oppfylt
+
+requiredAction.CONFIGURE_TOTP=Sett opp tofaktor-kodegenerator
+requiredAction.TERMS_AND_CONDITIONS=Vilkår og betingelser
+requiredAction.UPDATE_PASSWORD=Endre passord
+requiredAction.UPDATE_PROFILE=Oppdater profil
+requiredAction.VERIFY_EMAIL=Bekreft e-postadresse
+requiredAction.CONFIGURE_RECOVERY_AUTHN_CODES=Generer backupkoder
+requiredAction.webauthn-register-passwordless=Registrer med passordløs WebAuthn
+
+invalidTokenRequiredActions=Handlingene som er inkludert i lenken er ugyldige
+
+doX509Login=Du vil bli logget inn som\:
+clientCertificate=X509-klientsertifikat\:
+noCertificate=[Ingen sertifikat]
+
+
+pageNotFound=Side ikke funnet
+internalServerError=En intern serverfeil har oppstått
+
+console-username=Brukernavn:
+console-password=Passord:
+console-otp=Engangskode:
+console-new-password=Nytt passord:
+console-confirm-password=Bekreft passord:
+console-update-password=Endring av passord kreves.
+console-verify-email=Du må bekrefte e-postadressen din. Vi har sendt en e-post til {0} med en bekreftelseskode. Skriv inn denne koden under.
+console-email-code=E-postkode:
+console-accept-terms=Godta vilkår? [j/n]:
+console-accept=j
+
+# Openshift messages
+openshift.scope.user_info=Brukerinformasjon
+openshift.scope.user_check-access=Brukertilgangsinformasjon
+openshift.scope.user_full=Full tilgang
+openshift.scope.list-projects=List ut prosjekter
+
+# SAML authentication
+saml.post-form.title=Omdirigering for autentisering
+saml.post-form.message=Omdirigerer, vennligst vent.
+saml.post-form.js-disabled=JavaScript er skrudd av. Vi anbefaler sterkt at det skrus på. Klikk på knappen under for å fortsette.
+saml.artifactResolutionServiceInvalidResponse=Kunne ikke løse artifakt.
+
+#authenticators
+otp-display-name=Autentikatorprogram
+otp-help-text=Skriv inn en engangskode fra kodegeneratoren.
+otp-reset-description=Hvilket kodegeneratoroppsett skal fjernes?
+password-display-name=Passord
+password-help-text=Logg inn ved å skrive inn passordet ditt.
+auth-username-form-display-name=Brukernavn
+auth-username-form-help-text=Start innloggingen ved å skrive inn brukernavnet ditt
+auth-username-password-form-display-name=Brukernavn og passord
+auth-username-password-form-help-text=Logg inn ved å skrive inn brukernavnet og passordet ditt.
+
+# Recovery Codes
+auth-recovery-authn-code-form-display-name=Backupkoder
+auth-recovery-authn-code-form-help-text=Skriv inn en backupkode fra en tidligere generert listen.
+auth-recovery-code-info-message=Skriv inn den spesifiserte backupkoden.
+auth-recovery-code-prompt=Backupkode #{0}
+auth-recovery-code-header=Logg inn med en backupkode
+recovery-codes-error-invalid=Ugyldig backupkode
+recovery-code-config-header=Backupkoder
+recovery-code-config-warning-title=Disse backupkodene vil ikke vises igjen etter at du forlater denne siden
+recovery-code-config-warning-message=Sørg for at du skriver ut, laster ned eller kopierer dem til et passordhvelv og holder dem trygt lagret. Hvis du avbryter dette oppsettet, fjernes disse backupkodene fra kontoen din.
+recovery-codes-print=Skriv ut
+recovery-codes-download=Last ned
+recovery-codes-copy=Kopier
+recovery-codes-copied=Kopiert
+recovery-codes-confirmation-message=Jeg har lagret kodene på et trygt sted
+recovery-codes-action-complete=Fullfør oppsett
+recovery-codes-action-cancel=Avbryt oppsett
+recovery-codes-download-file-header=Lagre disse kodene på et trygt sted.
+recovery-codes-download-file-description=Backupkoder er engangskoder som lar deg logge inn på kontoen din selv om du ikke har tilgang til kodegeneratoren din.
+recovery-codes-download-file-date=Disse kodene ble generert den
+recovery-codes-label-default=Backupkoder
+
+# WebAuthn
+webauthn-display-name=WebAuthn-nøkkel
+webauthn-help-text=Bruk en nøkkel for å logge inn.
+webauthn-passwordless-display-name=WebAuthn-nøkkel
+webauthn-passwordless-help-text=Bruk en nøkkel for å logge inn uten passord.
+webauthn-login-title=WebAuthn-nøkkelinnlogging
+webauthn-registration-title=WebAuthn-nøkkelregistrering
+webauthn-available-authenticators=Tilgjengelige nøkler
+webauthn-unsupported-browser-text=WebAuthn støttes ikke i denne nettleseren. Prøv en annen nettleser, eller kontakt administrator.
+webauthn-doAuthenticate=Logg inn med nøkkel
+webauthn-createdAt-label=Opprettet
+webauthn-registration-init-label=WebAuthn-nøkkel (Standard merkelapp)
+webauthn-registration-init-label-prompt=Vennligst skriv inn merkelappen til den registrerte nøkkelen
+
+
+# WebAuthn Error
+webauthn-error-title=WebAuthn-nøkkelfeil
+webauthn-error-registration=Kunne ikke registrere nøkkelen din.<br/> {0}
+webauthn-error-api-get=Kunne ikke autentisere ved hjelp av nøkkelen.<br/> {0}
+webauthn-error-different-user=Første autentiserte bruker er ikke den som er autentisert av nøkkelen.
+webauthn-error-auth-verification=Resultatet av nøkkelautentiseringen er ugyldig.<br/> {0}
+webauthn-error-register-verification=Resultatet av nøkkelregistreringen er ugyldig.<br/> {0}
+webauthn-error-user-not-found=Ukjent bruker autentisert av nøkkelen.
+
+# Identity provider
+identity-provider-redirector=Koble til med en annen identitetsleverandør
+identity-provider-login-label=Eller logg inn med
+idp-email-verification-display-name=E-postbekreftelse
+idp-email-verification-help-text=Tilknytt kontoen ved å bekrefte e-postadressen din.
+idp-username-password-form-display-name=Brukernavn og passord
+idp-username-password-form-help-text=Tilknytt kontoen ved å logge inn.
+
+finalDeletionConfirmation=Hvis du sletter kontoen din, kan den ikke gjenopprettes. For å beholde kontoen likevel, klikk Avbryt.
+irreversibleAction=Denne handlingen er irreversibel
+deleteAccountConfirm=Bekreft sletting av konto
+
+deletingImplies=Sletting av kontoen din medfører følgende:
+errasingData=Alle dine data slettes
+loggingOutImmediately=Du blir logget ut umiddelbart
+accountUnusable=All videre bruk av applikasjonen vil være umulig med denne kontoen
+userDeletedSuccessfully=Brukeren ble slettet
+
+access-denied=Tilgang avvist
+access-denied-when-idp-auth=Tilgang ble avvist under innlogging med {0}
+
+frontchannel-logout.title=Logger ut
+frontchannel-logout.message=Du logger ut fra følgende applikasjoner
+logoutConfirmTitle=Logger ut
+logoutConfirmHeader=Vil du logge ut?
+doLogout=Logg ut
+
+readOnlyUsernameMessage=Du kan ikke oppdatere brukernavnet ditt ettersom det er skrivebeskyttet.
+error-invalid-multivalued-size=Attributten {0} må ha minst {1} og maks {2} verdi(er).


### PR DESCRIPTION
This PR updates the Norwegian translation of Keycloak to cover most strings that are currently missing from this localization. It also cleans up the translation a bit and fixes some issues (e.g. `identityProviderLinkBody` no longer contains HTML tags, email link expiry templates are updated from `{1} minutes` to `{4}` in line with source string changes, new standardized translation of some terms like "OTP device", some rephrasing to make sentences flow a bit better for end users, etc.)