### PR TITLE
fix: do not re-neable AuthorizationService if it is already enabled

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/admin/AuthorizationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/AuthorizationService.java
@@ -64,7 +64,9 @@ public class AuthorizationService {
     }
 
     public void enable(boolean newClient) {
-        this.resourceServer = getResourceServerService().create(newClient);
+        if (!isEnabled()) {
+            this.resourceServer = getResourceServerService().create(newClient);
+        }
     }
 
     public void disable() {


### PR DESCRIPTION
The enable action needs the realm-wide "modify client" permission, which restricted admins with the fine-grained-authz feature do not have.

This causes a "forbidden" exception when try try to save a client with Authorization already enabled, even if the "enable" action does nothing since it was already enabled.

Fixes #22938

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
