### PR TITLE
Upgrading note to warn truststore changes affect webauthn registration

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-24_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-24_0_0.adoc
@@ -183,6 +183,10 @@ The `+spi-truststore-file-*+` options and the truststore related options `+https
 
 The `tls-hostname-verifier` property should be used instead of the `spi-truststore-file-hostname-verification-policy` property.
 
+A collateral effect of the changes is that now the truststore provider is always configured with some certificates (at least the default java trusted certificates are present). This new behavior can affect other parts of {project_name}.
+
+For example, *webauthn* registration can fail if *attestation conveyance* was configured to *Direct* validation. Previously, if the truststore provider was not configured the incoming certificate was not validated. But now this validation is always performed. The registration fails with `invalid cert path` error as the certificate chain sent by the dongle is not trusted by {project_name}. The Certificate Authorities of the authenticator need to be present in the truststore provider to correctly perform the attestation.
+
 = Deprecated `--proxy` option
 
 The `--proxy` option has been deprecated and will be removed in a future release. The following table explains how the deprecated option maps to supported options.


### PR DESCRIPTION
Closes #28113

Just a new paragraph to the 24.0.0 upgrading notes to warn trust-store changes are affecting attestation of webauthn (now the certificate of the authenticator is always validated and previously this validation can be skipped if the trust-store provider was not configured).