### PR TITLE
fix: remove the env values from echos

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -72,7 +72,7 @@ goto READ-ARGS
 
 :MAIN
 if not "x%JAVA_OPTS%" == "x" (
-  echo "JAVA_OPTS already set in environment; overriding default settings with values: %JAVA_OPTS%"
+  echo "JAVA_OPTS already set in environment; overriding default settings"
 ) else (
   rem The defaults set up Keycloak with '-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90' which proved to provide a good throughput and efficiency in the total memory allocation and CPU overhead.
   rem If the memory is not used, it will be freed. See https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers for details.
@@ -93,13 +93,13 @@ if not "x%JAVA_OPTS%" == "x" (
 
     set "JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_KC_HEAP%"
   ) else (
-    echo "JAVA_OPTS_KC_HEAP already set in environment; overriding default settings with values: %JAVA_OPTS_KC_HEAP%"
+    echo "JAVA_OPTS_KC_HEAP already set in environment; overriding default settings"
   )
 )
 
 @REM See also https://github.com/wildfly/wildfly-core/blob/7e5624cf92ebe4b64a4793a8c0b2a340c0d6d363/core-feature-pack/common/src/main/resources/content/bin/common.sh#L57-L60
 if not "x%JAVA_ADD_OPENS%" == "x" (
-  echo "JAVA_ADD_OPENS already set in environment; overriding default settings with values: %JAVA_ADD_OPENS%"
+  echo "JAVA_ADD_OPENS already set in environment; overriding default settings"
 ) else (
   set "JAVA_ADD_OPENS=--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED"
 )
@@ -107,14 +107,14 @@ set "JAVA_OPTS=%JAVA_OPTS% %JAVA_ADD_OPENS%"
 
 @REM Set the default locale for the JVM to English to prevent locale-specific character variations
 if not "x%JAVA_LOCALE%" == "x" (
-  echo "JAVA_LOCALE already set in environment; overriding default settings with values: %JAVA_LOCALE%"
+  echo "JAVA_LOCALE already set in environment; overriding default settings"
 ) else (
   set "JAVA_LOCALE=-Duser.language=en -Duser.country=US"
 )
 set "JAVA_OPTS=%JAVA_OPTS% %JAVA_LOCALE%"
 
 if not "x%JAVA_OPTS_APPEND%" == "x" (
-  echo "Appending additional Java properties to JAVA_OPTS: %JAVA_OPTS_APPEND%"
+  echo "Appending additional Java properties to JAVA_OPTS"
   set JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_APPEND%
 )
 

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -109,20 +109,20 @@ if [ -z "$JAVA_OPTS" ]; then
          JAVA_OPTS_KC_HEAP="$JAVA_OPTS_KC_HEAP -Xms64m -Xmx512m"
       fi
    else
-      echo "JAVA_OPTS_KC_HEAP already set in environment; overriding default settings with values: $JAVA_OPTS_KC_HEAP"
+      echo "JAVA_OPTS_KC_HEAP already set in environment; overriding default settings"
    fi
 
    JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_KC_HEAP"
 
 else
-   echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
+   echo "JAVA_OPTS already set in environment; overriding default settings"
 fi
 
 # See also https://github.com/wildfly/wildfly-core/blob/7e5624cf92ebe4b64a4793a8c0b2a340c0d6d363/core-feature-pack/common/src/main/resources/content/bin/common.sh#L57-L60
 if [ -z "$JAVA_ADD_OPENS" ]; then
    JAVA_ADD_OPENS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED"
 else
-   echo "JAVA_ADD_OPENS already set in environment; overriding default settings with values: $JAVA_ADD_OPENS"
+   echo "JAVA_ADD_OPENS already set in environment; overriding default settings"
 fi
 JAVA_OPTS="$JAVA_OPTS $JAVA_ADD_OPENS"
 
@@ -130,12 +130,12 @@ JAVA_OPTS="$JAVA_OPTS $JAVA_ADD_OPENS"
 if [ -z "$JAVA_LOCALE" ]; then
    JAVA_LOCALE="-Duser.language=en -Duser.country=US"
 else
-   echo "JAVA_LOCALE already set in environment; overriding default settings with values: $JAVA_LOCALE"
+   echo "JAVA_LOCALE already set in environment; overriding default settings"
 fi
 JAVA_OPTS="$JAVA_OPTS $JAVA_LOCALE"
 
 if [ -n "$JAVA_OPTS_APPEND" ]; then
-  echo "Appending additional Java properties to JAVA_OPTS: $JAVA_OPTS_APPEND"
+  echo "Appending additional Java properties to JAVA_OPTS"
   JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_APPEND"
 fi
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
@@ -62,7 +62,8 @@ public class JavaOptsScriptTest {
         assertThat(output, matchesPattern("(?s).*Using JAVA_OPTS: " + DEFAULT_OPTS + ".*"));
         assertThat(output, not(containsString("-Xms64m -Xmx512m")));
         assertThat(output, not(containsString("-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50")));
-        assertThat(output, containsString("JAVA_OPTS_KC_HEAP already set in environment; overriding default settings with values: -Xms128m"));
+        assertThat(output, containsString("JAVA_OPTS_KC_HEAP already set in environment; overriding default settings"));
+        assertThat(output, containsString(" -Xms128m "));
     }
 
     @Test
@@ -70,10 +71,10 @@ public class JavaOptsScriptTest {
     @WithEnvVars({"JAVA_OPTS_KC_HEAP", "-Xms128m", "JAVA_OPTS", "-Xmx256m"})
     void testCustomJavaHeapContainerOptsWithCustomJavaOpts(LaunchResult result) {
         String output = result.getOutput();
-        assertThat(output, not(containsString("JAVA_OPTS_KC_HEAP already set in environment; overriding default settings with values:")));
+        assertThat(output, not(containsString("JAVA_OPTS_KC_HEAP already set in environment; overriding default settings with values")));
         assertThat(output, not(containsString("-Xms128m")));
 
-        assertThat(output, containsString("JAVA_OPTS already set in environment; overriding default settings with values: -Xmx256m"));
+        assertThat(output, containsString("JAVA_OPTS already set in environment; overriding default settings"));
         assertThat(output, containsString("Using JAVA_OPTS: -Xmx256m"));
     }
 
@@ -82,7 +83,7 @@ public class JavaOptsScriptTest {
     @WithEnvVars({ "JAVA_OPTS", "-Dfoo=bar"})
     void testJavaOpts(LaunchResult result) {
         String output = result.getOutput();
-        assertThat(output, containsString("JAVA_OPTS already set in environment; overriding default settings with values: -Dfoo=bar"));
+        assertThat(output, containsString("JAVA_OPTS already set in environment; overriding default settings"));
         assertThat(output, containsString("Using JAVA_OPTS: -Dfoo=bar"));
     }
 
@@ -91,7 +92,7 @@ public class JavaOptsScriptTest {
     @WithEnvVars({ "JAVA_OPTS_APPEND", "-Dfoo=bar"})
     void testJavaOptsAppend(LaunchResult result) {
         String output = result.getOutput();
-        assertThat(output, containsString("Appending additional Java properties to JAVA_OPTS: -Dfoo=bar"));
+        assertThat(output, containsString("Appending additional Java properties to JAVA_OPTS"));
         assertThat(output, matchesPattern("(?s).*Using JAVA_OPTS: " + DEFAULT_OPTS + " -Dfoo=bar\\n.*"));
     }
 
@@ -100,7 +101,7 @@ public class JavaOptsScriptTest {
     @WithEnvVars({ "JAVA_ADD_OPENS", "-Dfoo=bar"})
     void testJavaAddOpens(LaunchResult result) {
         String output = result.getOutput();
-        assertThat(output, containsString("JAVA_ADD_OPENS already set in environment; overriding default settings with values: -Dfoo=bar"));
+        assertThat(output, containsString("JAVA_ADD_OPENS already set in environment; overriding default settings"));
         assertThat(output, not(containsString("--add-opens")));
         assertThat(output, matchesPattern("(?s).*Using JAVA_OPTS: " + DEFAULT_OPTS + " -Dfoo=bar.*"));
     }


### PR DESCRIPTION
closes: #28090

It doesn't seem necessary in general to echo what is the env, the user can always inspect that on their own or use  PRINT_ENV

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
