### PR TITLE
Present effective sync mode value

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -773,6 +773,11 @@ public class ModelToRepresentation {
         providerRep.setConfig(config);
         providerRep.setAddReadTokenRoleOnCreate(identityProviderModel.isAddReadTokenRoleOnCreate());
 
+        String syncMode = config.get(IdentityProviderModel.SYNC_MODE);
+        if (syncMode == null) {
+            config.put(IdentityProviderModel.SYNC_MODE, "LEGACY");
+        }
+
         String firstBrokerLoginFlowId = identityProviderModel.getFirstBrokerLoginFlowId();
         if (firstBrokerLoginFlowId != null) {
             AuthenticationFlowModel flow = realm.getAuthenticationFlowById(firstBrokerLoginFlowId);

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
@@ -124,7 +124,12 @@ public class IdentityProvidersResource {
         String providerId = formDataMap.getFirst("providerId").asString();
         String config = StreamUtil.readString(formDataMap.getFirst("file").asInputStream());
         IdentityProviderFactory<?> providerFactory = getProviderFactoryById(providerId);
-        return providerFactory.parseConfig(session, config);
+        final Map<String, String> parsedConfig = providerFactory.parseConfig(session, config);
+        String syncMode = parsedConfig.get(IdentityProviderModel.SYNC_MODE);
+        if (syncMode == null) {
+            parsedConfig.put(IdentityProviderModel.SYNC_MODE, "LEGACY");
+        }
+        return parsedConfig;
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -1032,6 +1032,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
         // check that saml-idp-metadata.xml was properly converted into key value pairs
         //System.out.println(config);
         assertThat(config.keySet(), containsInAnyOrder(
+          "syncMode",
           "validateSignature",
           "singleLogoutServiceUrl",
           "postBindingLogout",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmCreateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmCreateTest.java
@@ -54,8 +54,8 @@ public class KcAdmCreateTest extends AbstractAdmCliTest {
             assertExitCodeAndStdErrSize(exe, 0, 1);
         }
 
-        // If the sync mode is not present on creating the idp, it will never be added automatically. However, the model will always assume "LEGACY", so no errors should occur.
-        Assert.assertNull(realmResource.identityProviders().get("idpAlias").toRepresentation().getConfig().get(IdentityProviderModel.SYNC_MODE));
+        // If the sync mode is not present on creating the idp, it will never be stored automatically. However, the model will always report behaviour as "LEGACY", so no errors should occur.
+        Assert.assertEquals("LEGACY", realmResource.identityProviders().get("idpAlias").toRepresentation().getConfig().get(IdentityProviderModel.SYNC_MODE));
     }
 
     @Test


### PR DESCRIPTION
When sync mode value is missing in the config of newly created identity provider, the provider does not store any. When no value is found, the identity provider behaves as if `LEGACY` was used (#6705).

This PR ensures the correct sync mode is returned from the REST endpoint, regardless of whether it has been stored in the database or not.

Fixes: #26019

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
