### PR TITLE
Changes the contract to make it simpler and rely on the realm available from the current session

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProviderFactory.java
@@ -57,8 +57,7 @@ public class JpaOrganizationProviderFactory implements OrganizationProviderFacto
         if (event instanceof RealmRemovedEvent) {
             KeycloakSession session = ((RealmRemovedEvent) event).getKeycloakSession();
             OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
-            RealmModel realm = ((RealmRemovedEvent) event).getRealm();
-            provider.removeOrganizations(realm);
+            provider.removeAll();
         }
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -37,8 +37,7 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
         return entity.getId();
     }
 
-    @Override
-    public RealmModel getRealm() {
+    RealmModel getRealm() {
         return realm;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -20,88 +20,81 @@ import java.util.stream.Stream;
 
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.OrganizationModel;
-import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.provider.Provider;
 
+/**
+ * A {@link Provider} that manages organization and its data within the scope of a realm.
+ */
 public interface OrganizationProvider extends Provider {
 
     /**
      * Creates a new organization with given {@code name} to the given realm.
      * The internal ID of the organization will be created automatically.
-     * @param realm Realm owning this organization.
      * @param name String name of the organization.
      * @throws ModelDuplicateException If there is already an organization with the given name
      * @return Model of the created organization.
      */
-    OrganizationModel createOrganization(RealmModel realm, String name);
+    OrganizationModel create(String name);
 
     /**
      * Returns a {@link OrganizationModel} by its {@code id};
      *
-     * @param realm the realm
      * @param id the id of an organization
      * @return the organization with the given {@code id}
      */
-    OrganizationModel getOrganizationById(RealmModel realm, String id);
+    OrganizationModel getById(String id);
 
     /**
      * Removes the given organization from the given realm.
      *
-     * @param realm Realm.
      * @param organization Organization to be removed.
      * @return true if the organization was removed, false if group doesn't exist or doesn't belong to the given realm
      */
-    boolean removeOrganization(RealmModel realm, OrganizationModel organization);
+    boolean remove(OrganizationModel organization);
 
     /**
      * Removes all organizations from the given realm.
-     * @param realm Realm.
      */
-    void removeOrganizations(RealmModel realm);
+    void removeAll();
 
     /**
      * Adds the give {@link UserModel} as a member of the given {@link OrganizationModel}.
      *
-     * @param realm the realm
      * @param organization the organization
      * @param user the user
      * @return {@code true} if the user was added as a member. Otherwise, returns {@code false}
      */
-    boolean addOrganizationMember(RealmModel realm, OrganizationModel organization, UserModel user);
+    boolean addMember(OrganizationModel organization, UserModel user);
 
     /**
      * Returns the organizations of the given realm as a stream.
-     * @param realm Realm.
      * @return Stream of the organizations. Never returns {@code null}.
      */
-    Stream<OrganizationModel> getOrganizationsStream(RealmModel realm);
+    Stream<OrganizationModel> getAllStream();
 
     /**
      * Returns the members of a given {@code organization}.
      *
-     * @param realm the realm
      * @param organization the organization
      * @return the organization with the given {@code id}
      */
-    Stream<UserModel> getMembersStream(RealmModel realm, OrganizationModel organization);
+    Stream<UserModel> getMembersStream(OrganizationModel organization);
 
     /**
      * Returns the member of an {@code organization} by its {@code id}.
      *
-     * @param realm the realm
      * @param organization the organization
      * @param id the member id
      * @return the organization with the given {@code id}
      */
-    UserModel getMemberById(RealmModel realm, OrganizationModel organization, String id);
+    UserModel getMemberById(OrganizationModel organization, String id);
 
     /**
      * Returns the {@link OrganizationModel} that a {@code member} belongs to.
      *
-     * @param realm the realm
      * @param member the member of a organization
      * @return the organization the {@code member} belongs to
      */
-    OrganizationModel getOrganizationByMember(RealmModel realm, UserModel member);
+    OrganizationModel getByMember(UserModel member);
 }

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -26,6 +26,4 @@ public interface OrganizationModel {
     void setName(String name);
 
     String getName();
-
-    RealmModel getRealm();
 }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -94,7 +94,7 @@ public class OrganizationMemberResource {
             OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
 
             try {
-                if (provider.addOrganizationMember(realm, organization, member)) {
+                if (provider.addMember(organization, member)) {
                     return Response.created(session.getContext().getUri().getAbsolutePathBuilder().path(member.getId()).build()).build();
                 }
             } catch (ModelException me) {
@@ -110,7 +110,7 @@ public class OrganizationMemberResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<UserRepresentation> getMembers() {
-        return provider.getMembersStream(realm, organization).map(this::toRepresentation);
+        return provider.getMembersStream(organization).map(this::toRepresentation);
     }
 
     @Path("{id}")
@@ -152,7 +152,7 @@ public class OrganizationMemberResource {
         }
 
         UserModel member = getMember(id);
-        OrganizationModel organization = provider.getOrganizationByMember(realm, member);
+        OrganizationModel organization = provider.getByMember(member);
         OrganizationRepresentation rep = new OrganizationRepresentation();
 
         rep.setId(organization.getId());
@@ -161,7 +161,7 @@ public class OrganizationMemberResource {
     }
 
     private UserModel getMember(String id) {
-        UserModel member = provider.getMemberById(realm, organization, id);
+        UserModel member = provider.getMemberById(organization, id);
 
         if (member == null) {
             throw new NotFoundException();

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OrganizationMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OrganizationMembershipMapper.java
@@ -28,7 +28,6 @@ import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.ProtocolMapperModel;
-import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.organization.OrganizationProvider;
@@ -70,11 +69,9 @@ public class OrganizationMembershipMapper extends AbstractOIDCProtocolMapper imp
 
     @Override
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
-
-        RealmModel realm = keycloakSession.getContext().getRealm();
         UserModel user = userSession.getUser();
         OrganizationProvider organizationProvider = keycloakSession.getProvider(OrganizationProvider.class);
-        OrganizationModel organization = organizationProvider.getOrganizationByMember(realm, user);
+        OrganizationModel organization = organizationProvider.getByMember(user);
 
         if (organization != null) {
             Map<String, Map<String, Object>> claim = new HashMap<>();


### PR DESCRIPTION
* Providers operating within the scope of a realm are always created based on a `KeycloakSession` from where the realm is already available so that there is no need to complicate APIs by having the `RealmModel` as a parameter to every single method.
*  This same pattern can be seem in different providers and provides a much cleaner contract for a `Provider` that only works within the scope of a realm

Closes #28403