### PR TITLE
Align isEnabled in MSAD mappers to how other properties are processed…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -60,6 +60,7 @@ import org.keycloak.storage.ldap.mappers.LDAPMappersComparator;
 import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapperFactory;
+import org.keycloak.storage.ldap.mappers.msad.MSADUserAccountControlStorageMapper;
 import org.keycloak.storage.ldap.mappers.msad.MSADUserAccountControlStorageMapperFactory;
 import org.keycloak.storage.user.ImportSynchronization;
 import org.keycloak.storage.user.SynchronizationResult;
@@ -434,7 +435,8 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
 
         // MSAD specific mapper for account state propagation
         if (activeDirectory) {
-            mapperModel = KeycloakModelUtils.createComponentModel("MSAD account controls", model.getId(), MSADUserAccountControlStorageMapperFactory.PROVIDER_ID,LDAPStorageMapper.class.getName());
+            mapperModel = KeycloakModelUtils.createComponentModel("MSAD account controls", model.getId(), MSADUserAccountControlStorageMapperFactory.PROVIDER_ID,LDAPStorageMapper.class.getName(),
+                    MSADUserAccountControlStorageMapper.ALWAYS_READ_ENABLED_VALUE_FROM_LDAP, alwaysReadValueFromLDAP);
             realm.addComponentModel(mapperModel);
         }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/msadlds/MSADLDSUserAccountControlStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/msadlds/MSADLDSUserAccountControlStorageMapperFactory.java
@@ -21,9 +21,12 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.mappers.AbstractLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.AbstractLDAPStorageMapperFactory;
+import org.keycloak.storage.ldap.mappers.msad.MSADUserAccountControlStorageMapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +38,23 @@ import java.util.List;
 public class MSADLDSUserAccountControlStorageMapperFactory extends AbstractLDAPStorageMapperFactory {
 
     public static final String PROVIDER_ID = LDAPConstants.MSADLDS_USER_ACCOUNT_CONTROL_MAPPER;
-    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+    protected static final List<ProviderConfigProperty> configProperties;
 
     static {
+        configProperties = getConfigProps(null);
+    }
+
+    private static List<ProviderConfigProperty> getConfigProps(ComponentModel parentModel) {
+        UserStorageProviderModel parent = parentModel != null ? new UserStorageProviderModel(parentModel) : new UserStorageProviderModel();
+        if (parent.isImportEnabled()) {
+            ProviderConfigurationBuilder config = ProviderConfigurationBuilder.create()
+                    .property().name(MSADUserAccountControlStorageMapper.ALWAYS_READ_ENABLED_VALUE_FROM_LDAP).label("Always Read Enabled Value From LDAP")
+                    .helpText("If on, the user enabled/disabled state will always be read from MSAD LDS by checking the msDS-UserAccountDisabled attribute")
+                    .type(ProviderConfigProperty.BOOLEAN_TYPE).defaultValue("false").add();
+
+            return config.build();
+        }
+        return new ArrayList<>();
     }
 
     @Override
@@ -49,6 +66,11 @@ public class MSADLDSUserAccountControlStorageMapperFactory extends AbstractLDAPS
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         return configProperties;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties(RealmModel realm, ComponentModel parent) {
+        return getConfigProps(parent);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPMSADMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPMSADMapperTest.java
@@ -28,13 +28,18 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.component.ComponentModel;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.msad.MSADUserAccountControlStorageMapper;
+import org.keycloak.storage.ldap.mappers.msad.MSADUserAccountControlStorageMapperFactory;
 import org.keycloak.storage.ldap.mappers.msad.UserAccountControl;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.AppPage;
@@ -262,7 +267,7 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
         johnRep.setRequiredActions(Collections.singletonList(UserModel.RequiredAction.UPDATE_PASSWORD.name()));
         john.update(johnRep);
 
-        // Check in LDAP, that johnkeycloak has pwdLastSet set attribute set in MSAD to bigger value than 0. Previous update of requiredAction did not updated LDAP
+        // Check in LDAP, that johnkeycloak has pwdLastSet set attribute set in MSAD to bigger value than 0. Previous update of requiredAction did not update LDAP
         long pwdLastSetFromLDAP = getPwdLastSetOfJohn();
         assertThat(pwdLastSetFromLDAP, Matchers.greaterThan(0L));
 
@@ -384,6 +389,15 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
 
             ctx.getLdapModel().getConfig().putSingle(LDAPConstants.EDIT_MODE, UserStorageProvider.EditMode.UNSYNCED.toString());
             appRealm.updateComponent(ctx.getLdapModel());
+
+            // change MSAD mapper config "ALWAYS_READ_ENABLED_VALUE_FROM_LDAP" to false, so that local db has priority.
+            ComponentModel msadMapperComponent = appRealm.getComponentsStream(ctx.getLdapModel().getId(), LDAPStorageMapper.class.getName())
+                .filter(c -> MSADUserAccountControlStorageMapperFactory.PROVIDER_ID.equals(c.getProviderId()))
+                    .findFirst().orElse(null);
+            if (msadMapperComponent != null) {
+                msadMapperComponent.getConfig().putSingle(MSADUserAccountControlStorageMapper.ALWAYS_READ_ENABLED_VALUE_FROM_LDAP, "false");
+                appRealm.updateComponent(msadMapperComponent);
+            }
         });
 
         // Disable user johnkeycloak through Keycloak admin API. Due UNSYNCED mode, this should update Keycloak DB, but not MSAD
@@ -401,6 +415,7 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
         Assert.assertEquals("Account is disabled, contact your administrator.", loginPage.getError());
 
         // Enable johnkeycloak in admin REST API
+        johnRep = john.toRepresentation();
         johnRep.setEnabled(true);
         john.update(johnRep);
 
@@ -419,7 +434,101 @@ public class LDAPMSADMapperTest extends AbstractLDAPTest {
 
             ctx.getLdapModel().getConfig().putSingle(LDAPConstants.EDIT_MODE, UserStorageProvider.EditMode.WRITABLE.toString());
             appRealm.updateComponent(ctx.getLdapModel());
+
+            // reset MSAD mapper config "ALWAYS_READ_ENABLED_VALUE_FROM_LDAP" to true.
+            ComponentModel msadMapperComponent = appRealm.getComponentsStream(ctx.getLdapModel().getId(), LDAPStorageMapper.class.getName())
+                    .filter(c -> MSADUserAccountControlStorageMapperFactory.PROVIDER_ID.equals(c.getProviderId()))
+                    .findFirst().orElse(null);
+            if (msadMapperComponent != null) {
+                msadMapperComponent.getConfig().putSingle(MSADUserAccountControlStorageMapper.ALWAYS_READ_ENABLED_VALUE_FROM_LDAP, "true");
+                appRealm.updateComponent(msadMapperComponent);
+            }
+
         });
+    }
+
+    @Test
+    public void test09DisableUserImportDisabled() {
+        testingClient.server().run(session -> {
+            // set import enabled to false - in this case only attributes known to LDAP (via one of the mappers) are written
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ctx.getLdapModel().getConfig().putSingle(UserStorageProviderModel.IMPORT_ENABLED, "false");
+            appRealm.updateComponent(ctx.getLdapModel());
+        });
+
+        // check user is enabled both locally and on MSAD.
+        UserResource john = ApiUtil.findUserByUsernameId(adminClient.realm("test"), "johnkeycloak");
+        UserRepresentation johnRep = john.toRepresentation();
+        Assert.assertTrue(johnRep.isEnabled());
+        Assert.assertTrue(isJohnEnabledInMSAD());
+
+        // disable user johnkeycloak - it should disable both locally and on MSAD.
+        johnRep.setEnabled(false);
+        john.update(johnRep);
+
+        // Login as johnkeycloak and see the user is disabled.
+        loginPage.open();
+        loginPage.login("johnkeycloak", "Password1");
+        Assert.assertEquals("Account is disabled, contact your administrator.", loginPage.getError());
+
+        // check user is disabled in all places.
+        johnRep = john.toRepresentation();
+        Assert.assertFalse(johnRep.isEnabled());
+        Assert.assertFalse(isJohnEnabledInMSAD());
+
+        // restore john to enabled state.
+        johnRep.setEnabled(true);
+        john.update(johnRep);
+
+        // Login again. User should be enabled.
+        loginPage.open();
+        loginPage.login("johnkeycloak", "Password1");
+        Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
+
+        testingClient.server().run(session -> {
+            // restore import enabled mode in the storage provider.
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ctx.getLdapModel().getConfig().putSingle(UserStorageProviderModel.IMPORT_ENABLED, "true");
+            appRealm.updateComponent(ctx.getLdapModel());
+        });
+    }
+
+    @Test
+    public void test10DisabledUserSwitchedToEnabledOnMSAD() {
+        // disable user johnkeycloak via REST API - should be disabled in MSAD as well.
+        UserResource john = ApiUtil.findUserByUsernameId(adminClient.realm("test"), "johnkeycloak");
+        UserRepresentation johnRep = john.toRepresentation();
+        johnRep.setEnabled(false);
+        john.update(johnRep);
+
+        Assert.assertFalse(isJohnEnabledInMSAD());
+
+        // Login as johnkeycloak and see the user is disabled.
+        loginPage.open();
+        loginPage.login("johnkeycloak", "Password1");
+        Assert.assertEquals("Account is disabled, contact your administrator.", loginPage.getError());
+
+        // enable user johnkeycloak in MSAD only
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            LDAPObject ldapJohn = ctx.getLdapProvider().loadLDAPUserByUsername(appRealm, "johnkeycloak");
+            String userAccountControlStr = ldapJohn.getAttributeAsString(LDAPConstants.USER_ACCOUNT_CONTROL);
+            UserAccountControl control = new UserAccountControl(Long.parseLong(userAccountControlStr));
+            control.remove(UserAccountControl.ACCOUNTDISABLE);
+            ldapJohn.setSingleAttribute(LDAPConstants.USER_ACCOUNT_CONTROL, String.valueOf(control.getValue()));
+            ctx.getLdapProvider().getLdapIdentityStore().update(ldapJohn);
+        });
+
+        Assert.assertTrue(isJohnEnabledInMSAD());
+
+        // Login again. User should be enabled.
+        loginPage.open();
+        loginPage.login("johnkeycloak", "Password1");
+        Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
     }
 
     private long getPwdLastSetOfJohn() {


### PR DESCRIPTION
… in UserAttributeLDAPStorageMapper

- user model is updated by onImport with the enabled/disabled status of the LDAP user
- a config option always.read.enabled.value.from.ldap was introduced, in synch to what we have in UserAttributeLDAPStorageMapper
- isEnabled checks the flag to decide if it should always retrieve the value from LDAP, or return the local value.
- setEnabled first updates the LDAP tx, and then calls the delegate to avoid issue #24201

Closes #26695
Closed #24201

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
