### PR TITLE
Adds a new MERGE_EXISTING option to the realm import so that users won't be lost.

### DIFF
--- a/model/storage-services/src/main/java/org/keycloak/exportimport/util/ImportUtils.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/util/ImportUtils.java
@@ -96,19 +96,24 @@ public class ImportUtils {
             if (strategy == Strategy.IGNORE_EXISTING) {
                 logger.infof("Realm '%s' already exists. Import skipped", realmName);
                 return false;
+            } else if (strategy == Strategy.MERGE_EXISTING) {
+                logger.infof("Realm '%s' already exists. Merging existing realm with new import", realmName);
+                RealmManager realmManager = new RealmManager(session);
+                realmManager.mergeRealm(rep, skipUserDependent);
             } else {
                 logger.infof("Realm '%s' already exists. Removing it before import", realmName);
                 if (Config.getAdminRealm().equals(realm.getId())) {
                     // Delete all masterAdmin apps due to foreign key constraints
                    model.getRealmsStream().forEach(r -> r.setMasterAdminClient(null));
                 }
-                // TODO: For migration between versions, it should be possible to delete just realm but keep it's users
                 model.removeRealm(realm.getId());
+                RealmManager realmManager = new RealmManager(session);
+                realmManager.importRealm(rep, skipUserDependent);
             }
+        } else {
+            RealmManager realmManager = new RealmManager(session);
+            realmManager.importRealm(rep, skipUserDependent);
         }
-
-        RealmManager realmManager = new RealmManager(session);
-        realmManager.importRealm(rep, skipUserDependent);
 
         if (System.getProperty(ExportImportConfig.ACTION) != null) {
             logger.infof("Realm '%s' imported", realmName);

--- a/server-spi-private/src/main/java/org/keycloak/exportimport/Strategy.java
+++ b/server-spi-private/src/main/java/org/keycloak/exportimport/Strategy.java
@@ -22,6 +22,7 @@ package org.keycloak.exportimport;
  */
 public enum Strategy {
 
-    IGNORE_EXISTING,         // Ignore existing user entries
-    OVERWRITE_EXISTING       // Overwrite existing user entries
+    IGNORE_EXISTING,         // Ignore existing realm
+    OVERWRITE_EXISTING,      // Overwrite existing realm
+    MERGE_EXISTING           // Merge existing realm (preserves users)
 }


### PR DESCRIPTION
Updating the Keycloak resource in a k8s environment will cause realms to be re-imported. The current options either ignore the import entirely or remove all of the users. Closes #25326

