### PR TITLE
Add information about token expiry to events

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -100,4 +100,6 @@ public interface Details {
 
     String LOGOUT_TRIGGERED_BY_ACTION_TOKEN = "logout_triggered_by_action_token";
     String LOGOUT_TRIGGERED_BY_REQUIRED_ACTION = "logout_triggered_by_required_action";
+    String ACCESS_TOKEN_EXPIRATION_TIME = "access_token_expiration_time";
+    String AGE_OF_REFRESH_TOKEN = "age_of_refresh_token";
 }


### PR DESCRIPTION
Closes #28311

What this PR adds: 

* Enrich the refresh event with additional information about the lifetime of the access token and when the refresh token was issued
* Monitor the refresh event and log a message like the following if the age of the refresh token is smaller than 25% of the lifetime of the access token:
   > In realm ... client .. requested a new access token when the refresh token was only ... seconds old which is ...% of the access token's lifetime. This indicates that that the previous access token was still valid for ... second.  Change the client to ask for new access tokens only when they are about to expire to reduce the load on Keycloak. Warnings are suppressed for this client for ... seconds.
* The warnings are logged only once per 60 seconds for a client to avoid logging too many messages

What a user can do: 

* Enable the event listener on selective realms and watch the event logs. 
* Write their own event listener to do different things with the information provided.
* Enable recording the events to the database, and analyze the events afterwards.

Documentation and tests are is still missing. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
