### PR TITLE
Fix the client's authorization setting import error

### DIFF
--- a/docs/documentation/release_notes/topics/25_0_0.adoc
+++ b/docs/documentation/release_notes/topics/25_0_0.adoc
@@ -34,3 +34,8 @@ For users of the `keycloak-authz-client` library, calling `AuthorizationResource
 Previously, it would return a `List<Map>` at runtime, even though the method declaration advertised `List<Permission>`.
 
 This fix will break code that relied on casting the List or its contents to `List<Map>`. If you have used this method in any capacity, you are likely to have done this and be affected.
+
+= IDs are no longer set when exporting authorization settings for a client
+
+When exporting the authorization settings for a client, the IDs for resources, scopes, and policies are no longer set. As a
+result, you can now import the settings from a client to another client.

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -1119,6 +1119,8 @@ public class ModelToRepresentation {
                 .stream().map(resource -> {
                     ResourceRepresentation rep = toRepresentation(resource, settingsModel, authorization);
 
+                    rep.setId(null);
+
                     if (rep.getOwner().getId().equals(settingsModel.getClientId())) {
                         rep.setOwner((ResourceOwnerRepresentation) null);
                     } else {
@@ -1139,16 +1141,25 @@ public class ModelToRepresentation {
 
         policies.addAll(policyStore.findByResourceServer(settingsModel)
                 .stream().filter(policy -> !policy.getType().equals("resource") && !policy.getType().equals("scope") && policy.getOwner() == null)
-                .map(policy -> toRepresentation(authorization, policy)).collect(Collectors.toList()));
+                .map(policy -> {
+                    PolicyRepresentation rep = toRepresentation(authorization, policy);
+                    rep.setId(null);
+                    return rep;
+                }).collect(Collectors.toList()));
         policies.addAll(policyStore.findByResourceServer(settingsModel)
                 .stream().filter(policy -> (policy.getType().equals("resource") || policy.getType().equals("scope") && policy.getOwner() == null))
-                .map(policy -> toRepresentation(authorization, policy)).collect(Collectors.toList()));
+                .map(policy -> {
+                    PolicyRepresentation rep = toRepresentation(authorization, policy);
+                    rep.setId(null);
+                    return rep;
+                }).collect(Collectors.toList()));
 
         representation.setPolicies(policies);
 
         List<ScopeRepresentation> scopes = storeFactory.getScopeStore().findByResourceServer(settingsModel).stream().map(scope -> {
             ScopeRepresentation rep = toRepresentation(scope);
 
+            rep.setId(null);
             rep.setPolicies(null);
             rep.setResources(null);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/client-with-authz-settings.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/client-with-authz-settings.json
@@ -447,202 +447,127 @@
                 "name": "Resource 1 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 2 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 3 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 4 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 5 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 6 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 7 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 8 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 9 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 10 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 11 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 12 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 13 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 14 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 15 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 16 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 17 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 18 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 19 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 20 Policy",
                 "type": "role",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "roles": "[{\"id\":\"authz-client/uma_protection\",\"required\":false}]"
-                }
-            },
-            {
-                "name": "Default Permission",
-                "description": "A permission that applies to the default resource type",
-                "type": "resource",
-                "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "defaultResourceType": "urn:authz-client:resources:default",
-                    "applyPolicies": "[\"Default Policy\"]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 1 Permission",
                 "type": "resource",
                 "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "config": {
-                    "resources": "[\"Resource 1\"]",
-                    "applyPolicies": "[\"Resource 1 Policy\"]"
-                }
+                "decisionStrategy": "UNANIMOUS"
             },
             {
                 "name": "Resource 2 Permission",


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/25975

This commit is about the issue "Failing to import client's authorisation settings through UI"

I added namedQuery to `ResourceEntity`, `PolicyEntity` and `ScopeEntity` for each store to use the resourceServerId for the query parameter.
I also changed `importSettings` method of `ResourceServerService`  to avoid conflict related to id when importing the authorization setting

I finished the functional test with building Keycloak distribution from source code and confirmed the client's authorization setting import was working well.

<img width="1208" alt="client-auth-import-test-screenshot" src="https://github.com/keycloak/keycloak/assets/79843980/2d474c48-8da4-40c7-a096-2e3efa0aecca">

