### PR TITLE
doc: Quarkus launch rebuild optimization

### DIFF
--- a/docs/documentation/server_development/topics/providers.adoc
+++ b/docs/documentation/server_development/topics/providers.adoc
@@ -241,7 +241,7 @@ If you find that your server will not start due to a `NoSuchFileException` error
 
 [source,bash]
 ----
-./kc.sh -Dquarkus.launch.rebuild=true
+./kc.sh -Dquarkus.launch.rebuild=true --help
 ----
 
 This will force Quarkus to rebuild the classloading related index files. From there you should be able to perform a non-optimized start or build without an exception.


### PR DESCRIPTION
Closes #28336

The command suggested by the documentation as a fix to `NoSuchFileException` during Keycloak build performs the desired action of updating the classloading indexes twice. This is because the Keycloak startup script [kc.sh](https://github.com/keycloak/keycloak/blob/e9ad9d05643e9492f800deeefb98201a1f2b7d67/quarkus/dist/src/main/content/bin/kc.sh) actually executes the Quarkus application twice:
* first time [at line 169](https://github.com/keycloak/keycloak/blob/e9ad9d05643e9492f800deeefb98201a1f2b7d67/quarkus/dist/src/main/content/bin/kc.sh#L169)
* second time [at line 173](https://github.com/keycloak/keycloak/blob/e9ad9d05643e9492f800deeefb98201a1f2b7d67/quarkus/dist/src/main/content/bin/kc.sh#L173)

Passing the extra `--help` parameter - as proposed in this patch - makes the script skip the first execution.

While probably insignificant in most scenarios, we do benefit from a similar change when building Docker images for the arm64 architecture on amd64 hardware using QEMU emulation - there it shaves minutes from our build times.