### PR TITLE
Display the webauthn sig-alg in computer language in the template

### DIFF
--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -29,7 +29,7 @@
                     challenge : '${challenge}',
                     userid : '${userid}',
                     username : '${username}',
-                    signatureAlgorithms : [<#list signatureAlgorithms as sigAlg>${sigAlg},</#list>],
+                    signatureAlgorithms : [<#list signatureAlgorithms as sigAlg>${sigAlg?c},</#list>],
                     rpEntityName : '${rpEntityName}',
                     rpId : '${rpId}',
                     attestationConveyancePreference : '${attestationConveyancePreference}',


### PR DESCRIPTION
Closes #27824

Just format the COSE algorithm identifier using computer format (if not the long is displayed with commas and other locale features that can potentially break the JS code). I have added no test as this is just a minimal change (`${sigAlg}` to `${sigAlg?c}`). 
