### PR TITLE
Support for searching users based on search filter, enabled attribute, first, max

### DIFF
--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -213,6 +213,27 @@ public interface UsersResource {
                                     @QueryParam("max") Integer maxResults,
                                     @QueryParam("briefRepresentation") Boolean briefRepresentation);
 
+    /**
+     * Search for users whose username, first or last name or email matches the value provided by {@code search}. The {@code search}
+     * argument also allows finding users by specific attributes as follows:
+     *
+     * <ul>
+     *     <li><i>id:</i> - Find users by identifier. For instance, <i>id:aa497859-bbf5-44ac-bf1a-74dbffcaf197</i></li>
+     * </ul>
+     *
+     * @param search the value to search. It can be the username, email or any of the supported options to query based on user attributes
+     * @param enabled if true, only users that are enabled are returned
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("search") String search,
+      @QueryParam("enabled") Boolean enabled,
+      @QueryParam("first") Integer firstResult,
+      @QueryParam("max") Integer maxResults);
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> list(@QueryParam("first") Integer firstResult,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -1099,6 +1099,31 @@ public class UserTest extends AbstractAdminTest {
     }
 
     @Test
+    public void searchWithFilterAndEnabledAttribute() {
+        createUser();
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("user3");
+        user.setFirstName("user3First");
+        user.setLastName("user3Last");
+        user.setEmail("user3@localhost");
+        user.setRequiredActions(Collections.emptyList());
+        user.setEnabled(false);
+        createUser(user);
+
+        List<UserRepresentation> searchFilterUserNameAndDisabled = realm.users().search("user3", false, 0, 5);
+        assertEquals(1, searchFilterUserNameAndDisabled.size());
+        assertEquals(user.getUsername(), searchFilterUserNameAndDisabled.get(0).getUsername());
+
+        List<UserRepresentation> searchFilterMailAndDisabled = realm.users().search("user3@localhost", false, 0, 5);
+        assertEquals(1, searchFilterMailAndDisabled.size());
+        assertEquals(user.getUsername(), searchFilterMailAndDisabled.get(0).getUsername());
+
+        List<UserRepresentation> searchFilterLastNameAndEnabled = realm.users().search("user3Last", true, 0, 5);
+        assertEquals(0, searchFilterLastNameAndEnabled.size());
+    }
+
+    @Test
     public void searchByIdp() {
         // Add user without IDP
         createUser();


### PR DESCRIPTION
This enhancement includes searching users based on search filter, enabled attribute, first, max including a unit test. 

Closes [#27241](https://github.com/keycloak/keycloak/issues/27210)