### PR TITLE
Adding different strategies to avoid conflicts when updating sessions in Infinispan

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheManager.java
@@ -31,6 +31,7 @@ import org.keycloak.models.cache.infinispan.stream.InRealmPredicate;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 
 /**
@@ -40,7 +41,7 @@ public class RealmCacheManager extends CacheManager {
 
     private static final Logger logger = Logger.getLogger(RealmCacheManager.class);
 
-    private final ConcurrentHashMap<String, String> cacheInteractions = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ReentrantLock> cacheInteractions = new ConcurrentHashMap<>();
 
     @Override
     protected Logger getLogger() {
@@ -136,15 +137,19 @@ public class RealmCacheManager extends CacheManager {
     public <T> T computeSerialized(KeycloakSession session, String id, BiFunction<String, KeycloakSession, T> compute) {
         // this locking is only to ensure that if there is a computation for the same id in the "synchronized" block below,
         // it will have the same object instance to lock the current execution until the other is finished.
-        String lock = cacheInteractions.computeIfAbsent(id, s -> id);
+        ReentrantLock lock = cacheInteractions.computeIfAbsent(id, s -> new ReentrantLock());
         try {
-            synchronized (lock) {
-                // in case the previous thread has removed the entry in the finally block
-                cacheInteractions.putIfAbsent(id, lock);
-                return compute.apply(id, session);
+            lock.lock();
+            // in case the previous thread has removed the entry in the finally block
+            ReentrantLock existingLock = cacheInteractions.putIfAbsent(id, lock);
+            if (existingLock != lock) {
+                logger.debugf("Concurrent execution detected for realm '%s'.", id);
             }
+
+            return compute.apply(id, session);
         } finally {
-            cacheInteractions.remove(lock);
+            lock.unlock();
+            cacheInteractions.remove(id, lock);
         }
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
@@ -136,6 +136,10 @@ public class AuthenticatedClientSessionAdapter implements AuthenticatedClientSes
 
     @Override
     public void setTimestamp(int timestamp) {
+        if (timestamp <= getTimestamp()) {
+            return;
+        }
+
         ClientSessionUpdateTask task = new ClientSessionUpdateTask() {
 
             @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserLoginFailureProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserLoginFailureProvider.java
@@ -25,6 +25,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction;
+import org.keycloak.models.sessions.infinispan.changes.SerializeExecutionsByKey;
 import org.keycloak.models.sessions.infinispan.changes.SessionEntityWrapper;
 import org.keycloak.models.sessions.infinispan.changes.SessionUpdateTask;
 import org.keycloak.models.sessions.infinispan.changes.Tasks;
@@ -59,10 +60,11 @@ public class InfinispanUserLoginFailureProvider implements UserLoginFailureProvi
 
     public InfinispanUserLoginFailureProvider(KeycloakSession session,
                                               RemoteCacheInvoker remoteCacheInvoker,
-                                              Cache<LoginFailureKey, SessionEntityWrapper<LoginFailureEntity>> loginFailureCache) {
+                                              Cache<LoginFailureKey, SessionEntityWrapper<LoginFailureEntity>> loginFailureCache,
+                                              SerializeExecutionsByKey<LoginFailureKey> serializer) {
         this.session = session;
         this.loginFailureCache = loginFailureCache;
-        this.loginFailuresTx = new InfinispanChangelogBasedTransaction<>(session, loginFailureCache, remoteCacheInvoker, SessionTimeouts::getLoginFailuresLifespanMs, SessionTimeouts::getLoginFailuresMaxIdleMs);
+        this.loginFailuresTx = new InfinispanChangelogBasedTransaction<>(session, loginFailureCache, remoteCacheInvoker, SessionTimeouts::getLoginFailuresLifespanMs, SessionTimeouts::getLoginFailuresMaxIdleMs, serializer);
         this.clusterEventsSenderTx = new SessionEventsSenderTransaction(session);
 
         session.getTransactionManager().enlistAfterCompletion(clusterEventsSenderTx);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserLoginFailureProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserLoginFailureProviderFactory.java
@@ -24,7 +24,6 @@ import org.keycloak.Config;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
-import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.KeycloakSessionTask;
@@ -32,6 +31,7 @@ import org.keycloak.models.UserLoginFailureProvider;
 import org.keycloak.models.UserLoginFailureProviderFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.sessions.infinispan.changes.SerializeExecutionsByKey;
 import org.keycloak.models.sessions.infinispan.changes.SessionEntityWrapper;
 import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
 import org.keycloak.models.sessions.infinispan.entities.LoginFailureKey;
@@ -50,6 +50,7 @@ import org.keycloak.models.utils.PostMigrationEvent;
 
 import java.io.Serializable;
 import java.util.Set;
+
 import static org.keycloak.models.sessions.infinispan.InfinispanAuthenticationSessionProviderFactory.PROVIDER_PRIORITY;
 
 /**
@@ -68,13 +69,14 @@ public class InfinispanUserLoginFailureProviderFactory implements UserLoginFailu
     private Config.Scope config;
 
     private RemoteCacheInvoker remoteCacheInvoker;
+    SerializeExecutionsByKey<LoginFailureKey> serializer = new SerializeExecutionsByKey<>();
 
     @Override
     public UserLoginFailureProvider create(KeycloakSession session) {
         InfinispanConnectionProvider connections = session.getProvider(InfinispanConnectionProvider.class);
         Cache<LoginFailureKey, SessionEntityWrapper<LoginFailureEntity>> loginFailures = connections.getCache(InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME);
 
-        return new InfinispanUserLoginFailureProvider(session, remoteCacheInvoker, loginFailures);
+        return new InfinispanUserLoginFailureProvider(session, remoteCacheInvoker, loginFailures, serializer);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -35,6 +35,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.UserSessionProviderFactory;
+import org.keycloak.models.sessions.infinispan.changes.SerializeExecutionsByKey;
 import org.keycloak.models.sessions.infinispan.changes.sessions.CrossDCLastSessionRefreshStore;
 import org.keycloak.models.sessions.infinispan.changes.sessions.CrossDCLastSessionRefreshStoreFactory;
 import org.keycloak.models.sessions.infinispan.changes.sessions.PersisterLastSessionRefreshStore;
@@ -93,6 +94,10 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
     private CrossDCLastSessionRefreshStore offlineLastSessionRefreshStore;
     private PersisterLastSessionRefreshStore persisterLastSessionRefreshStore;
     private InfinispanKeyGenerator keyGenerator;
+    SerializeExecutionsByKey<String> serializerSession = new SerializeExecutionsByKey<>();
+    SerializeExecutionsByKey<String> serializerOfflineSession = new SerializeExecutionsByKey<>();
+    SerializeExecutionsByKey<UUID> serializerClientSession = new SerializeExecutionsByKey<>();
+    SerializeExecutionsByKey<UUID> serializerOfflineClientSession = new SerializeExecutionsByKey<>();
 
     @Override
     public UserSessionProvider create(KeycloakSession session) {
@@ -115,7 +120,11 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
                     clientSessionCache,
                     offlineClientSessionsCache,
                     this::deriveOfflineSessionCacheEntryLifespanMs,
-                    this::deriveOfflineClientSessionCacheEntryLifespanOverrideMs
+                    this::deriveOfflineClientSessionCacheEntryLifespanOverrideMs,
+                    serializerSession,
+                    serializerOfflineSession,
+                    serializerClientSession,
+                    serializerOfflineClientSession
             );
         }
         return new InfinispanUserSessionProvider(
@@ -130,7 +139,11 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
                 clientSessionCache,
                 offlineClientSessionsCache,
                 this::deriveOfflineSessionCacheEntryLifespanMs,
-                this::deriveOfflineClientSessionCacheEntryLifespanOverrideMs
+                this::deriveOfflineClientSessionCacheEntryLifespanOverrideMs,
+                serializerSession,
+                serializerOfflineSession,
+                serializerClientSession,
+                serializerOfflineClientSession
         );
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
@@ -158,6 +158,7 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
         clientSessionUuids.forEach(clientSessionId -> this.clientSessionUpdateTx.addTask(clientSessionId, Tasks.removeSync()));
     }
 
+    @Override
     public String getId() {
         return entity.getId();
     }
@@ -177,6 +178,7 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
         return entity.getBrokerUserId();
     }
 
+    @Override
     public UserModel getUser() {
         return this.user;
     }
@@ -192,6 +194,7 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
         }
     }
 
+    @Override
     public String getIpAddress() {
         return entity.getIpAddress();
     }
@@ -206,15 +209,22 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
         return entity.isRememberMe();
     }
 
+    @Override
     public int getStarted() {
         return entity.getStarted();
     }
 
+    @Override
     public int getLastSessionRefresh() {
         return entity.getLastSessionRefresh();
     }
 
+    @Override
     public void setLastSessionRefresh(int lastSessionRefresh) {
+        if (lastSessionRefresh <= entity.getLastSessionRefresh()) {
+            return;
+        }
+
         if (offline) {
             // Received the message from the other DC that we should update the lastSessionRefresh in local cluster. Don't update DB in that case.
             // The other DC already did.

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -44,8 +44,8 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
     private final InfinispanKeyGenerator keyGenerator;
     private final UserSessionPersistentChangelogBasedTransaction userSessionTx;
 
-    public ClientSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<AuthenticatedClientSessionEntity> lifespanMsLoader, SessionFunction<AuthenticatedClientSessionEntity> maxIdleTimeMsLoader, boolean offline, InfinispanKeyGenerator keyGenerator, UserSessionPersistentChangelogBasedTransaction userSessionTx) {
-        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline);
+    public ClientSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<AuthenticatedClientSessionEntity> lifespanMsLoader, SessionFunction<AuthenticatedClientSessionEntity> maxIdleTimeMsLoader, boolean offline, InfinispanKeyGenerator keyGenerator, UserSessionPersistentChangelogBasedTransaction userSessionTx, SerializeExecutionsByKey<UUID> serializer) {
+        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline, serializer);
         this.keyGenerator = keyGenerator;
         this.userSessionTx = userSessionTx;
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/EmbeddedCachesChangesPerformer.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/EmbeddedCachesChangesPerformer.java
@@ -88,45 +88,58 @@ public class EmbeddedCachesChangesPerformer<K, V extends SessionEntity> implemen
     private void replace(K key, MergedUpdate<V> task, SessionEntityWrapper<V> oldVersionEntity, long lifespanMs, long maxIdleTimeMs) {
         serializer.runSerialized(key, () -> {
             SessionEntityWrapper<V> oldVersion = oldVersionEntity;
-        boolean replaced = false;
-        int iteration = 0;
+            boolean replaced = false;
+            int iteration = 0;
             V session = oldVersion.getEntity();
 
-        while (!replaced && iteration < InfinispanUtil.MAXIMUM_REPLACE_RETRIES) {
-            iteration++;
+            while (!replaced && iteration < InfinispanUtil.MAXIMUM_REPLACE_RETRIES) {
+                iteration++;
 
                 SessionEntityWrapper<V> newVersionEntity = generateNewVersionAndWrapEntity(session, oldVersion.getLocalMetadata());
 
-            // Atomic cluster-aware replace
+                // Atomic cluster-aware replace
                 replaced = CacheDecorators.skipCacheStoreIfRemoteCacheIsEnabled(cache).replace(key, oldVersion, newVersionEntity, lifespanMs, TimeUnit.MILLISECONDS, maxIdleTimeMs, TimeUnit.MILLISECONDS);
 
-            // Replace fail. Need to load latest entity from cache, apply updates again and try to replace in cache again
-            if (!replaced) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debugf("Replace failed for entity: %s, old version %s, new version %s. Will try again", key, oldVersion.getVersion(), newVersionEntity.getVersion());
-                }
+                // Replace fail. Need to load latest entity from cache, apply updates again and try to replace in cache again
+                if (!replaced) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debugf("Replace failed for entity: %s, old version %s, new version %s. Will try again", key, oldVersion.getVersion(), newVersionEntity.getVersion());
+                    }
+                    backoff(iteration);
 
                     oldVersion = cache.get(key);
 
                     if (oldVersion == null) {
-                    LOG.debugf("Entity %s not found. Maybe removed in the meantime. Replace task will be ignored", key);
-                    return;
-                }
+                        LOG.debugf("Entity %s not found. Maybe removed in the meantime. Replace task will be ignored", key);
+                        return;
+                    }
 
                     session = oldVersion.getEntity();
 
-                task.runUpdate(session);
-            } else {
-                if (LOG.isTraceEnabled()) {
+                    task.runUpdate(session);
+                } else {
+                    if (LOG.isTraceEnabled()) {
                         LOG.tracef("Replace SUCCESS for entity: %s . old version: %s, new version: %s, Lifespan: %d ms, MaxIdle: %d ms", key, oldVersion.getVersion(), newVersionEntity.getVersion(), task.getLifespanMs(), task.getMaxIdleTimeMs());
+                    }
                 }
             }
-        }
 
-        if (!replaced) {
-            LOG.warnf("Failed to replace entity '%s' in cache '%s'", key, cache.getName());
-        }
+            if (!replaced) {
+                LOG.warnf("Failed to replace entity '%s' in cache '%s'", key, cache.getName());
+            }
         });
+    }
+
+    /**
+     * Wait a random amount of time to avoid a conflict with other concurrent actors on the next attempt.
+     */
+    private static void backoff(int iteration) {
+        try {
+            Thread.sleep(new Random().nextInt(iteration));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     private SessionEntityWrapper<V> generateNewVersionAndWrapEntity(V entity, Map<String, String> localMetadata) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
@@ -37,8 +37,8 @@ public class PersistentSessionsChangelogBasedTransaction<K, V extends SessionEnt
     private final List<SessionChangesPerformer<K, V>> changesPerformers;
     protected final boolean offline;
 
-    public PersistentSessionsChangelogBasedTransaction(KeycloakSession session, Cache<K, SessionEntityWrapper<V>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<V> lifespanMsLoader, SessionFunction<V> maxIdleTimeMsLoader, boolean offline) {
-        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader);
+    public PersistentSessionsChangelogBasedTransaction(KeycloakSession session, Cache<K, SessionEntityWrapper<V>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<V> lifespanMsLoader, SessionFunction<V> maxIdleTimeMsLoader, boolean offline, SerializeExecutionsByKey<K> serializer) {
+        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, serializer);
         this.offline = offline;
 
         if (!Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
@@ -52,7 +52,7 @@ public class PersistentSessionsChangelogBasedTransaction<K, V extends SessionEnt
         } else {
             changesPerformers = List.of(
                     new JpaChangesPerformer<>(session, cache.getName(), offline),
-                    new EmbeddedCachesChangesPerformer<>(cache),
+                    new EmbeddedCachesChangesPerformer<>(cache, serializer),
                     new RemoteCachesChangesPerformer<>(session, cache, remoteCacheInvoker)
             );
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/SerializeExecutionsByKey.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/SerializeExecutionsByKey.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.changes;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Adding an in-JVM lock to prevent a best-effort concurrent executions for the same ID.
+ * This should prevent a burst of requests by letting only the first request pass, and then the others will follow one-by-one.
+ * Use this when the code wrapped by runSerialized is known to produce conflicts when run concurrently with the same ID.
+ *
+ * @author Alexander Schwartz
+ */
+public class SerializeExecutionsByKey<K> {
+    private final ConcurrentHashMap<K, K> cacheInteractions = new ConcurrentHashMap<>();
+
+    public void runSerialized(K key, Runnable task) {
+        // this locking is only to ensure that if there is a computation for the same id in the "synchronized" block below,
+        // it will have the same object instance to lock the current execution until the other is finished.
+        K lock = cacheInteractions.computeIfAbsent(key, s -> key);
+        try {
+            synchronized (lock) {
+                // in case the previous thread has removed the entry in the finally block
+                cacheInteractions.putIfAbsent(key, lock);
+                task.run();
+            }
+        } finally {
+            cacheInteractions.remove(lock);
+        }
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -40,8 +40,8 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.U
 public class UserSessionPersistentChangelogBasedTransaction extends PersistentSessionsChangelogBasedTransaction<String, UserSessionEntity> {
 
     private static final Logger LOG = Logger.getLogger(UserSessionPersistentChangelogBasedTransaction.class);
-    public UserSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<String, SessionEntityWrapper<UserSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<UserSessionEntity> lifespanMsLoader, SessionFunction<UserSessionEntity> maxIdleTimeMsLoader, boolean offline) {
-        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline);
+    public UserSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<String, SessionEntityWrapper<UserSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<UserSessionEntity> lifespanMsLoader, SessionFunction<UserSessionEntity> maxIdleTimeMsLoader, boolean offline, SerializeExecutionsByKey<String> serializer) {
+        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline, serializer);
     }
 
     public SessionEntityWrapper<UserSessionEntity> get(RealmModel realm, String key) {

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -182,6 +182,9 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
 
     @Override
     public void setTimestamp(int timestamp) {
+        if (timestamp <= model.getTimestamp()) {
+            return;
+        }
         model.setTimestamp(timestamp);
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
@@ -250,6 +250,9 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
 
     @Override
     public void setLastSessionRefresh(int seconds) {
+        if (seconds <= getLastSessionRefresh()) {
+            return;
+        }
         model.setLastSessionRefresh(seconds);
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -49,6 +49,11 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     }
 
     int getTimestamp();
+
+    /**
+     * Set the timestamp for the client session.
+     * If the timestamp is smaller or equal than the current timestamp, the operation is ignored.
+     */
     void setTimestamp(int timestamp);
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/UserSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserSessionModel.java
@@ -58,6 +58,10 @@ public interface UserSessionModel {
 
     int getLastSessionRefresh();
 
+    /**
+     * Set the last session refresh timestamp for the user session.
+     * If the timestamp is smaller or equal than the current timestamp, the operation is ignored.
+     */
     void setLastSessionRefresh(int seconds);
 
     boolean isOffline();


### PR DESCRIPTION
This applies three strategies: 

* Avoid unnecessary updates to the sessions during refreshes of tokens
* Avoid conflicts when writing to the session store by checking for concurrent requests within the JVM
* Add a back-off period when replacing cache entries fails

Closes #28388

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
