### PR TITLE
NoClassDefFoundError for Apache XML and EAP8

### DIFF
--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-adapter-core-jakarta/main/module.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-saml-adapter-core-jakarta/main/module.xml
@@ -38,6 +38,7 @@
         <module name="org.keycloak.keycloak-core"/>
         <module name="org.keycloak.keycloak-crypto-default" services="import"/>
         <module name="org.apache.httpcomponents"/>
+        <module name="org.apache.santuario.xmlsec"/>
     </dependencies>
 
 </module>


### PR DESCRIPTION
Fixes #24878

I was able to reproduce the issue, and after applying this change, everything works as expected.

@keycloak/core-shared-maintainers @pskopek Could you please take a look at it? Thanks