### PR TITLE
Fix NotContainsUsernamePasswordPolicyProvider: reversed check

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/NotContainsUsernamePasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/NotContainsUsernamePasswordPolicyProvider.java
@@ -36,7 +36,7 @@ public class NotContainsUsernamePasswordPolicyProvider implements PasswordPolicy
         if (username == null) {
             return null;
         }
-        return username.contains(password) ? new PolicyError(ERROR_MESSAGE) : null;
+        return password.contains(username) ? new PolicyError(ERROR_MESSAGE) : null;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -608,16 +608,19 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", "registerUserNotContainsUsername", "registerUserNotContainsUsername", "registerUserNotContainsUsername");
-
+            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", "Bob", "Bob123", "Bob123");
             assertTrue(registerPage.isCurrent());
             assertEquals("Invalid password: Can not contains the username.", registerPage.getInputPasswordErrors().getPasswordError());
 
-            try (Response response = adminClient.realm("test").users().create(UserBuilder.create().username("registerUserNotContainsUsername").build())) {
+            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", "Bob", "123Bob", "123Bob");
+            assertTrue(registerPage.isCurrent());
+            assertEquals("Invalid password: Can not contains the username.", registerPage.getInputPasswordErrors().getPasswordError());
+
+            try (Response response = adminClient.realm("test").users().create(UserBuilder.create().username("Bob").build())) {
                 assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
             }
 
-            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", "registerUserNotContainsUsername", "registerUserNotContainsUsername", "registerUserNotContainsUsername");
+            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", "Bob", "registerUserNotContainsUsername", "registerUserNotContainsUsername");
 
             assertTrue(registerPage.isCurrent());
             assertEquals("Username already exists.", registerPage.getInputAccountErrors().getUsernameError());


### PR DESCRIPTION
Fix the validation order
closes #28389

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
