### PR TITLE
Make sure attribute metadata from user storage providers are added only for the provider associated with a federated user

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-24_0_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-24_0_3.adoc
@@ -1,0 +1,17 @@
+ifeval::[{project_community}==true]
+= Changes to the `org.keycloak.userprofile.UserProfileDecorator` interface
+
+To properly support multiple user storage providers within a realm, the `org.keycloak.userprofile.UserProfileDecorator`
+interface has changed.
+
+The `decorateUserProfile` method is no longer invoked when parsing the user profile configuration for the first time (and caching it),
+but everytime a user is being managed through the user profile provider. As a result, the method changed its contract to:
+
+```java
+List<AttributeMetadata> decorateUserProfile(String providerId, UserProfileMetadata metadata)
+```
+
+Differently than the previous contract and behavior, this method is only invoked for the user storage provider from where the user
+was loaded from.
+
+endif::[]

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -5,6 +5,10 @@
 
 include::changes-25_0_0.adoc[leveloffset=3]
 
+=== Migrating to 24.0.3
+
+include::changes-24_0_3.adoc[leveloffset=3]
+
 === Migrating to 24.0.2
 
 include::changes-24_0_2.adoc[leveloffset=3]

--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
@@ -42,16 +42,16 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.user.ImportedUserValidation;
 import org.keycloak.storage.user.UserLookupProvider;
-import org.keycloak.userprofile.AttributeContext;
 import org.keycloak.userprofile.AttributeGroupMetadata;
 import org.keycloak.userprofile.AttributeMetadata;
 import org.keycloak.userprofile.UserProfileDecorator;
 import org.keycloak.userprofile.UserProfileMetadata;
 import org.keycloak.userprofile.UserProfileUtil;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import javax.security.auth.login.LoginException;
@@ -302,22 +302,13 @@ public class KerberosFederationProvider implements UserStorageProvider,
     }
 
     @Override
-    public void decorateUserProfile(RealmModel realm, UserProfileMetadata metadata) {
-        Predicate<AttributeContext> kerberosUsersSelector = (attributeContext -> {
-            UserModel user = attributeContext.getUser();
-            if (user == null) {
-                return false;
-            }
-
-            return model.getId().equals(user.getFederationLink());
-        });
-
+    public List<AttributeMetadata> decorateUserProfile(String providerId, UserProfileMetadata metadata) {
         int guiOrder = (int) metadata.getAttributes().stream()
                 .map(AttributeMetadata::getName)
                 .distinct()
                 .count();
 
         AttributeGroupMetadata metadataGroup = UserProfileUtil.lookupUserMetadataGroup(session);
-        UserProfileUtil.addMetadataAttributeToUserProfile(KerberosConstants.KERBEROS_PRINCIPAL, metadata, metadataGroup, kerberosUsersSelector, guiOrder++, model.getName());
+        return Collections.singletonList(UserProfileUtil.createAttributeMetadata(KerberosConstants.KERBEROS_PRINCIPAL, metadata, metadataGroup, guiOrder++, model.getName()));
     }
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1121,47 +1120,27 @@ public class LDAPStorageProvider implements UserStorageProvider,
     }
 
     @Override
-    public void decorateUserProfile(RealmModel realm, UserProfileMetadata metadata) {
-        Predicate<AttributeContext> ldapUsersSelector = (attributeContext -> {
-            UserModel user = attributeContext.getUser();
-            if (user == null) {
-                return false;
-            }
-
-            if (model.isImportEnabled()) {
-                return getModel().getId().equals(user.getFederationLink());
-            } else {
-                return getModel().getId().equals(new StorageId(user.getId()).getProviderId());
-            }
-        });
-
-        Predicate<AttributeContext> onlyAdminCondition = context -> metadata.getContext().isAdminContext();
-
+    public List<AttributeMetadata> decorateUserProfile(String providerId, UserProfileMetadata metadata) {
         int guiOrder = (int) metadata.getAttributes().stream()
                 .map(AttributeMetadata::getName)
                 .distinct()
                 .count();
-
+        RealmModel realm = session.getContext().getRealm();
         // 1 - get configured attributes from LDAP mappers and add them to the user profile (if they not already present)
-        Set<String> attributes = new LinkedHashSet<>();
-        realm.getComponentsStream(model.getId(), LDAPStorageMapper.class.getName())
+        List<String> attributes = realm.getComponentsStream(model.getId(), LDAPStorageMapper.class.getName())
                 .sorted(ldapMappersComparator.sortAsc())
-                .forEachOrdered(mapperModel -> {
+                .flatMap(mapperModel -> {
                     LDAPStorageMapper ldapMapper = mapperManager.getMapper(mapperModel);
-                    attributes.addAll(ldapMapper.getUserAttributes());
-                });
+                    return ldapMapper.getUserAttributes().stream();
+                }).toList();
+
+        List<AttributeMetadata> metadatas = new ArrayList<>();
+
         for (String attrName : attributes) {
-            // In case that attributes from LDAP mappers are explicitly defined on user profile, we can prefer defined configuration
-            if (!metadata.getAttribute(attrName).isEmpty()) {
-                logger.debugf("Ignore adding attribute '%s' to user profile by LDAP provider '%s' as attribute is already defined on user profile.", attrName, getModel().getName());
-            } else {
-                logger.debugf("Adding attribute '%s' to user profile by LDAP provider '%s' for user profile context '%s'.", attrName, getModel().getName(), metadata.getContext().toString());
-                // Writable and readable only by administrators by default. Applied only for LDAP users
-                AttributeMetadata attributeMetadata = metadata.addAttribute(attrName, guiOrder++, Collections.emptyList())
-                        .addWriteCondition(onlyAdminCondition)
-                        .addReadCondition(onlyAdminCondition)
-                        .setRequired(AttributeMetadata.ALWAYS_FALSE);
-                attributeMetadata.setSelector(ldapUsersSelector);
+            AttributeMetadata attributeMetadata = UserProfileUtil.createAttributeMetadata(attrName, metadata, guiOrder++, getModel().getName());
+
+            if (attributeMetadata != null) {
+                metadatas.add(attributeMetadata);
             }
         }
 
@@ -1174,17 +1153,20 @@ public class LDAPStorageProvider implements UserStorageProvider,
         AttributeGroupMetadata metadataGroup = UserProfileUtil.lookupUserMetadataGroup(session);
 
         for (String attrName : metadataAttributes) {
-            boolean attributeAdded = UserProfileUtil.addMetadataAttributeToUserProfile(attrName, metadata, metadataGroup, ldapUsersSelector, guiOrder++, getModel().getName());
-            if (!attributeAdded) {
+            AttributeMetadata attributeAdded = UserProfileUtil.createAttributeMetadata(attrName, metadata, metadataGroup, guiOrder++, getModel().getName());
+            if (attributeAdded == null) {
                 guiOrder--;
+            } else {
+                metadatas.add(attributeAdded);
             }
         }
 
         // 3 - make all attributes read-only for LDAP users in case that LDAP itself is read-only
         if (getEditMode() == EditMode.READ_ONLY) {
-            for (AttributeMetadata attrMetadata : metadata.getAttributes()) {
-                attrMetadata.addWriteCondition(ldapUsersSelector.negate());
-            }
+            Stream.concat(metadata.getAttributes().stream(), metadatas.stream())
+                    .forEach(attrMetadata -> attrMetadata.addWriteCondition(AttributeMetadata.ALWAYS_FALSE));
         }
+
+        return metadatas;
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -63,6 +63,7 @@ import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.client.ClientStorageProvider;
+import org.keycloak.userprofile.AttributeMetadata;
 import org.keycloak.userprofile.UserProfileDecorator;
 import org.keycloak.userprofile.UserProfileMetadata;
 
@@ -950,9 +951,10 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     @Override
-    public void decorateUserProfile(RealmModel realm, UserProfileMetadata metadata) {
+    public List<AttributeMetadata> decorateUserProfile(String providerId, UserProfileMetadata metadata) {
         if (getDelegate() instanceof UserProfileDecorator) {
-            ((UserProfileDecorator) getDelegate()).decorateUserProfile(realm, metadata);
+            return ((UserProfileDecorator) getDelegate()).decorateUserProfile(providerId, metadata);
         }
+        return List.of();
     }
 }

--- a/server-spi/src/main/java/org/keycloak/userprofile/UserProfileDecorator.java
+++ b/server-spi/src/main/java/org/keycloak/userprofile/UserProfileDecorator.java
@@ -19,18 +19,27 @@
 
 package org.keycloak.userprofile;
 
+import java.util.List;
+
 import org.keycloak.models.RealmModel;
 
 /**
+ * <p>This interface allows user storage providers to customize the user profile configuration and its attributes for realm
+ * on a per-user storage provider basis.
+ *
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public interface UserProfileDecorator {
 
     /**
-     * Decorates user profile with additional metadata. For instance, metadata attributes, which are available just for your user-storage
-     * provider can be added there, so they are available just for the users coming from your provider
+     * <p>Decorates user profile with additional metadata. For instance, metadata attributes, which are available just for your user-storage
+     * provider can be added there, so they are available just for the users coming from your provider.
      *
-     * @param metadata to decorate
+     * <p>This method is invoked every time a user is being managed through a user profile provider.
+     *
+     * @param providerId the id of the user storage provider to which the user is associated with
+     * @param metadata the current {@link UserProfileMetadata} for the current realm
+     * @return a list of attribute metadata.The {@link AttributeMetadata} returned from this method overrides any other metadata already set in {@code metadata} for a given attribute.
      */
-    void decorateUserProfile(RealmModel realm, UserProfileMetadata metadata);
+    List<AttributeMetadata> decorateUserProfile(String providerId, UserProfileMetadata metadata);
 }

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -176,13 +176,9 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
     protected UserProfileMetadata configureUserProfile(UserProfileMetadata metadata, KeycloakSession session) {
         UserProfileContext context = metadata.getContext();
         UserProfileMetadata decoratedMetadata = metadata.clone();
-        RealmModel realm = session.getContext().getRealm();
-
         ComponentModel component = getComponentModel().orElse(null);
 
         if (component == null) {
-            // makes sure user providers can override metadata for any attribute
-            decorateUserProfileMetadataWithUserStorage(realm, decoratedMetadata);
             return decoratedMetadata;
         }
 
@@ -411,21 +407,8 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
             }
         }
 
-        if (session != null) {
-            // makes sure user providers can override metadata for any attribute
-            decorateUserProfileMetadataWithUserStorage(session.getContext().getRealm(), decoratedMetadata);
-        }
-
         return decoratedMetadata;
 
-    }
-
-    private void decorateUserProfileMetadataWithUserStorage(RealmModel realm, UserProfileMetadata userProfileMetadata) {
-        // makes sure user providers can override metadata for any attribute
-        UserProvider users = session.users();
-        if (users instanceof UserProfileDecorator) {
-            ((UserProfileDecorator) users).decorateUserProfile(realm, userProfileMetadata);
-        }
     }
 
     private Map<String, UPGroup> asHashMap(List<UPGroup> groups) {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/LDAPTestUtils.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/LDAPTestUtils.java
@@ -187,6 +187,14 @@ public class LDAPTestUtils {
                 .orElse(null);
     }
 
+    public static ComponentModel getLdapProviderModel(RealmModel realm, String providerName) {
+        return realm.getComponentsStream(realm.getId(), UserStorageProvider.class.getName())
+                .filter(component -> Objects.equals(component.getProviderId(), LDAPStorageProviderFactory.PROVIDER_NAME))
+                .filter(component -> providerName == null || component.getName().equals(providerName))
+                .findFirst()
+                .orElse(null);
+    }
+
     public static LDAPStorageProvider getLdapProvider(KeycloakSession keycloakSession, ComponentModel ldapFedModel) {
         return (LDAPStorageProvider)keycloakSession.getProvider(UserStorageProvider.class, ldapFedModel);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
@@ -124,6 +124,11 @@ public class LDAPAccountRestApiTest extends AbstractLDAPTest {
         List<String> origLdapEntryDn = adminRestUserRep.getAttributes().get(LDAPConstants.LDAP_ENTRY_DN);
         Assert.assertNotNull(origLdapId.get(0));
         Assert.assertNotNull(origLdapEntryDn.get(0));
+        adminRestUserRep = testRealm().users().get(adminRestUserRep.getId()).toRepresentation();
+        origLdapId = adminRestUserRep.getAttributes().get(LDAPConstants.LDAP_ID);
+        origLdapEntryDn = adminRestUserRep.getAttributes().get(LDAPConstants.LDAP_ENTRY_DN);
+        Assert.assertNotNull(origLdapId.get(0));
+        Assert.assertNotNull(origLdapEntryDn.get(0));
 
         // Trying to add KERBEROS_PRINCIPAL (Adding attribute, which was not yet present). Request does not fail, but attribute is not updated
         user.setFirstName("JohnUpdated");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPTestContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPTestContext.java
@@ -34,8 +34,12 @@ public class LDAPTestContext {
     private final LDAPStorageProvider ldapProvider;
 
     public static LDAPTestContext init(KeycloakSession session) {
+        return init(session, null);
+    }
+
+    public static LDAPTestContext init(KeycloakSession session, String providerName) {
         RealmModel testRealm = session.realms().getRealmByName(AbstractLDAPTest.TEST_REALM_NAME);
-        ComponentModel ldapCompModel = LDAPTestUtils.getLdapProviderModel(testRealm);
+        ComponentModel ldapCompModel = LDAPTestUtils.getLdapProviderModel(testRealm, providerName);
         UserStorageProviderModel ldapModel = new UserStorageProviderModel(ldapCompModel);
         LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
         return new LDAPTestContext(testRealm, ldapModel, ldapProvider);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/ldap/users.ldif
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/ldap/users.ldif
@@ -23,3 +23,8 @@ dn: ou=Groups,dc=keycloak,dc=org
 objectclass: top
 objectclass: organizationalUnit
 ou: Groups
+
+dn: ou=OtherPeople,dc=keycloak,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: People

--- a/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDUserProfileTest.java
@@ -184,7 +184,8 @@ public class SSSDUserProfileTest extends AbstractBaseSSSDTest {
             String sssdId = getSssdProviderId();
             UserResource userResource = ApiUtil.findUserByUsernameId(testRealm(), username);
             UserRepresentation user = userResource.toRepresentation(true);
-            assertUser(user, username, getEmail(username), getFirstName(username), getLastName(username), sssdId);
+            // first and last names are removed from the UP config (unmanaged) and are not available from the representation
+            assertUser(user, username, getEmail(username), null, null, sssdId);
             assertProfileAttributes(user, null, true, UserModel.USERNAME, UserModel.EMAIL, UserModel.FIRST_NAME, UserModel.LAST_NAME);
             assertProfileAttributes(user, null, false, "postal_code");
 


### PR DESCRIPTION
Closes #28248

* Avoid conflicts when a realm is configured with multiple user storage providers (e.g: LDAP) so that additional attribute metadata from these providers are not cached and added every time a `UserProfile` instance is created
* Also added test coverage for multiple LDAP providers as we were missing

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
