### PR TITLE
Enable Syslog log handler

### DIFF
--- a/docs/documentation/release_notes/topics/25_0_0.adoc
+++ b/docs/documentation/release_notes/topics/25_0_0.adoc
@@ -39,3 +39,11 @@ This fix will break code that relied on casting the List or its contents to `Lis
 
 When exporting the authorization settings for a client, the IDs for resources, scopes, and policies are no longer set. As a
 result, you can now import the settings from a client to another client.
+
+= Syslog for remote logging
+
+{project_name} now supports https://en.wikipedia.org/wiki/Syslog[Syslog] protocol for remote logging.
+It utilizes the protocol defined in https://datatracker.ietf.org/doc/html/rfc5424[RFC 5424].
+By default, the syslog handler is disabled, but when enabled, it sends all log events to a remote syslog server.
+
+For more information, see the https://www.keycloak.org/server/logging[Configuring logging] guide.

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -261,6 +261,7 @@ As you can see, the timestamp is present twice, so you can amend it correspondin
 
 == Centralized logging using GELF
 NOTE: The support for GELF log handler is deprecated and will be removed in a future {project_name} release.
+The recommended alternative is using the Syslog log handler described above.
 
 {project_name} can send logs to a centralized log management system such as the following:
 

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -13,6 +13,7 @@ includedOptions="log log-*">
 * root
 ** console (_default_)
 ** file
+** Syslog
 <@profile.ifCommunity>
 ** GELF
 </@profile.ifCommunity>
@@ -74,10 +75,10 @@ To enable log handlers, enter the following command:
 
 The available handlers are
 <@profile.ifCommunity>
-`console`, `file` and `gelf`.
+`console`, `file`, `syslog` and `gelf`.
 </@profile.ifCommunity>
 <@profile.ifProduct>
-`console` and `file`.
+`console`, `file` and `syslog`.
 </@profile.ifProduct>
 The more specific handler configuration mentioned below will only take effect when the handler is added to this comma-separated list.
 
@@ -188,6 +189,74 @@ To configure a different logging format for the file log handler, enter the foll
 
 See <<Configuring the console log format>> for more information and a table of the available pattern configuration.
 
+== Centralized logging using Syslog
+
+{project_name} provides the ability to send logs to a remote Syslog server.
+It utilizes the protocol defined in https://datatracker.ietf.org/doc/html/rfc5424[RFC 5424].
+
+=== Enable the Syslog handler
+To enable logging using Syslog, add it to the list of activated log handlers as follows:
+
+<@kc.start parameters="--log=\"console,syslog\""/>
+
+=== Configuring the Syslog endpoint
+
+To configure the endpoint(_host:port_) of your centralized logging system, enter the following command and substitute the values with your specific values:
+
+<@kc.start parameters="--log=\"console,syslog\" --log-syslog-endpoint=myhost:12345"/>
+
+When the Syslog handler is enabled, the host is using `localhost` as host value.
+The Default port is `514`.
+
+=== Configuring the Syslog protocol
+Syslog uses TCP as the default protocol for communication.
+To use UDP instead of TCP, add the `--log-syslog-protocol` option as follows:
+
+<@kc.start parameters="--log=\"console,syslog\" --log-syslog-protocol=udp"/>
+
+The available protocols are: `tpc`, `udp`, and `ssl-tcp`.
+
+=== Configuring the Syslog log format
+To set the logging format for a logged line, perform these steps:
+
+. Build your desired format template using the preceding table.
+. Enter the following command:
++
+<@kc.start parameters="--log-syslog-format=\"\'<format>\'\""/>
+
+Note that you need to escape characters when invoking commands containing special shell characters such as `;` using the CLI. Therefore, consider setting it in the configuration file instead.
+
+.Example: Abbreviate the fully qualified category name
+<@kc.start parameters="--log-syslog-format=\"\'%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n\'\""/>
+
+This example abbreviates the category name to three characters by setting `[%c{3.}]` in the template instead of the default `[%c]`.
+
+=== Configuring the Syslog structured output
+By default, the Syslog log handler sends plain unstructured data to the Syslog server.
+To use structured JSON log output instead, enter the following command:
+
+<@kc.start parameters="--log-syslog-output=json"/>
+
+.Example Log Message
+[source, bash]
+----
+2024-04-05T12:32:20.616+02:00 mabartos keycloak 2788276 io.quarkus - {"timestamp":"2024-04-05T12:32:20.616208533+02:00","sequence":9948,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus","level":"INFO","message":"Profile prod activated. ","threadName":"main","threadId":1,"mdc":{},"ndc":"","hostName":"host","processName":"QuarkusEntryPoint","processId":2788276}
+----
+
+When using JSON output, colors are disabled and the format settings set by `--log-syslog-format` will not apply.
+
+To use unstructured logging, enter the following command:
+
+<@kc.start parameters="--log-syslog-output=default"/>
+
+.Example Log Message
+[source, bash]
+----
+2024-04-05T12:31:38.473+02:00 mabartos keycloak 2787568 io.quarkus - 2024-04-05 12:31:38,473 INFO  [io.quarkus] (main) Profile prod activated.
+----
+
+As you can see, the timestamp is present twice, so you can amend it correspondingly via the `--log-syslog-format` property.
+
 <@profile.ifCommunity>
 
 == Centralized logging using GELF
@@ -210,6 +279,7 @@ To enable logging using GELF, add it to the list of activated log handlers.
 === Configuring the GELF handler
 
 To configure the Host and Port of your centralized logging system, enter the following command and substitute the values with your specific values:
+
 .Host and port of the GELF server:
 <@kc.start parameters="--log=\"console,gelf\" --log-gelf-host=myhost --log-gelf-port=12345"/>
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -12,6 +12,7 @@ public class LoggingOptions {
     public static final Handler DEFAULT_LOG_HANDLER = Handler.console;
     public static final Level DEFAULT_LOG_LEVEL = Level.INFO;
     public static final Output DEFAULT_CONSOLE_OUTPUT = Output.DEFAULT;
+    public static final Output DEFAULT_SYSLOG_OUTPUT = Output.DEFAULT;
     public static final String DEFAULT_LOG_FILENAME = "keycloak.log";
     public static final String DEFAULT_LOG_PATH = "data" + File.separator + "log" + File.separator + DEFAULT_LOG_FILENAME;
     public static final Boolean GELF_ACTIVATED = isGelfActivated();
@@ -19,6 +20,7 @@ public class LoggingOptions {
     public enum Handler {
         console,
         file,
+        syslog,
         gelf
     }
 
@@ -78,6 +80,8 @@ public class LoggingOptions {
             return super.toString().toLowerCase(Locale.ROOT);
         }
     }
+
+    // Console
     public static final Option<Output> LOG_CONSOLE_OUTPUT = new OptionBuilder<>("log-console-output", Output.class)
             .category(OptionCategory.LOGGING)
             .defaultValue(DEFAULT_CONSOLE_OUTPUT)
@@ -101,6 +105,7 @@ public class LoggingOptions {
             .hidden()
             .build();
 
+    // File
     public static final Option<Boolean> LOG_FILE_ENABLED = new OptionBuilder<>("log-file-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
             .hidden()
@@ -124,7 +129,45 @@ public class LoggingOptions {
             .description("Set the log output to JSON or default (plain) unstructured logging.")
             .build();
 
+    // Syslog
+    public static final Option<Boolean> LOG_SYSLOG_ENABLED = new OptionBuilder<>("log-syslog-enabled", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .hidden()
+            .build();
 
+    public static final Option<String> LOG_SYSLOG_ENDPOINT = new OptionBuilder<>("log-syslog-endpoint", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("The IP address and port of the syslog server.")
+            .defaultValue("localhost:514")
+            .build();
+
+    public static final Option<String> LOG_SYSLOG_APP_NAME = new OptionBuilder<>("log-syslog-app-name", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("The app name used when formatting the message in RFC5424 format.")
+            .defaultValue("keycloak")
+            .hidden()
+            .build();
+
+    public static final Option<String> LOG_SYSLOG_PROTOCOL = new OptionBuilder<>("log-syslog-protocol", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Sets the protocol used to connect to the syslog server.")
+            .defaultValue("tcp")
+            .expectedValues("tcp", "udp", "ssl-tcp")
+            .build();
+
+    public static final Option<String> LOG_SYSLOG_FORMAT = new OptionBuilder<>("log-syslog-format", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set a format specific to syslog entries.")
+            .defaultValue("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+            .build();
+
+    public static final Option<Output> LOG_SYSLOG_OUTPUT = new OptionBuilder<>("log-syslog-output", Output.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(DEFAULT_SYSLOG_OUTPUT)
+            .description("Set the syslog output to JSON or default (plain) unstructured logging.")
+            .build();
+
+    // GELF
     public static final Option<Boolean> LOG_GELF_ENABLED = new OptionBuilder<>("log-gelf-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
             .hidden()

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.quarkus.runtime.configuration.test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.quarkus.runtime.Environment.isWindows;
@@ -27,6 +30,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
@@ -45,6 +49,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.Config;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
@@ -510,25 +515,75 @@ public class ConfigurationTest {
         SmallRyeConfig config = createConfig();
         assertEquals("true", config.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("true", config.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config.getConfigValue("quarkus.log.syslog.enable").getValue());
         assertEquals("false", config.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
 
         ConfigArgsConfigSource.setCliArgs("--log=file");
         SmallRyeConfig config2 = createConfig();
         assertEquals("false", config2.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("true", config2.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config2.getConfigValue("quarkus.log.syslog.enable").getValue());
         assertEquals("false", config2.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
 
         ConfigArgsConfigSource.setCliArgs("--log=console");
         SmallRyeConfig config3 = createConfig();
         assertEquals("true", config3.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("false", config3.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config3.getConfigValue("quarkus.log.syslog.enable").getValue());
         assertEquals("false", config3.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
 
         ConfigArgsConfigSource.setCliArgs("--log=console,gelf");
         SmallRyeConfig config4 = createConfig();
         assertEquals("true", config4.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("false", config4.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config4.getConfigValue("quarkus.log.syslog.enable").getValue());
         assertEquals("true", config4.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
+
+        ConfigArgsConfigSource.setCliArgs("--log=console,syslog");
+        SmallRyeConfig config5 = createConfig();
+        assertEquals("true", config5.getConfigValue("quarkus.log.console.enable").getValue());
+        assertEquals("false", config5.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("true", config5.getConfigValue("quarkus.log.syslog.enable").getValue());
+        assertEquals("false", config5.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
+
+        ConfigArgsConfigSource.setCliArgs("--log=syslog");
+        SmallRyeConfig config6 = createConfig();
+        assertEquals("false", config6.getConfigValue("quarkus.log.console.enable").getValue());
+        assertEquals("false", config6.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("true", config6.getConfigValue("quarkus.log.syslog.enable").getValue());
+        assertEquals("false", config6.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
+    }
+
+    @Test
+    public void testSyslogProperties() {
+        putEnvVars(Map.of(
+                "KC_LOG", "syslog",
+                "KC_LOG_SYSLOG_ENDPOINT", "192.168.0.42:515",
+                "KC_LOG_SYSLOG_APP_NAME", "keycloak2",
+                "KC_LOG_SYSLOG_PROTOCOL", "udp",
+                "KC_LOG_SYSLOG_FORMAT", "some format",
+                "KC_LOG_SYSLOG_OUTPUT", "json"
+        ));
+
+        initConfig();
+
+        assertConfig(Map.of(
+                "log-syslog-enabled", "true",
+                "log-syslog-endpoint", "192.168.0.42:515",
+                "log-syslog-app-name", "keycloak2",
+                "log-syslog-protocol", "udp",
+                "log-syslog-format", "some format",
+                "log-syslog-output", "json"
+        ));
+
+        assertExternalConfig(Map.of(
+                "quarkus.log.syslog.enable", "true",
+                "quarkus.log.syslog.endpoint", "192.168.0.42:515",
+                "quarkus.log.syslog.app-name", "keycloak2",
+                "quarkus.log.syslog.protocol", "udp",
+                "quarkus.log.syslog.format", "some format",
+                "quarkus.log.syslog.json", "true"
+        ));
     }
 
     @Test
@@ -591,5 +646,28 @@ public class ConfigurationTest {
         resolver.registerConfig(config, Thread.currentThread().getContextClassLoader());
         ConfigProviderResolver.setInstance(resolver);
         return config;
+    }
+
+    protected void assertConfig(String key, String expectedValue, boolean isExternal) {
+        Function<String, ConfigValue> getConfig = isExternal ? Configuration::getConfigValue : Configuration::getKcConfigValue;
+        var value = getConfig.apply(key).getValue();
+        assertThat(String.format("Value is null for key '%s'", key), value, notNullValue());
+        assertThat(String.format("Different value for key '%s'", key), value, is(expectedValue));
+    }
+
+    protected void assertConfig(String key, String expectedValue) {
+        assertConfig(key, expectedValue, false);
+    }
+
+    protected void assertConfig(Map<String, String> expectedValues) {
+        expectedValues.forEach(this::assertConfig);
+    }
+
+    protected void assertExternalConfig(String key, String expectedValue) {
+        assertConfig(key, expectedValue, true);
+    }
+
+    protected void assertExternalConfig(Map<String, String> expectedValues) {
+        expectedValues.forEach(this::assertExternalConfig);
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ManagementConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ManagementConfigurationTest.java
@@ -17,13 +17,11 @@
 package org.keycloak.quarkus.runtime.configuration.test;
 
 import org.junit.Test;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.mappers.ManagementPropertyMappers;
 
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ManagementConfigurationTest extends ConfigurationTest {
@@ -263,15 +261,5 @@ public class ManagementConfigurationTest extends ConfigurationTest {
 
     private void assertManagementHttpsEnabled(boolean expected) {
         assertThat("Expected value for Management HTTPS is different", ManagementPropertyMappers.isManagementTlsEnabled(), is(expected));
-    }
-
-    private void assertConfig(String key, String expectedValue) {
-        var value = Configuration.getKcConfigValue(key).getValue();
-        assertThat(String.format("Value is null for key '%s'", key), value, notNullValue());
-        assertThat(String.format("Different value for key '%s'", key), value, is(expectedValue));
-    }
-
-    private void assertConfig(Map<String, String> expectedValues) {
-        expectedValues.forEach(this::assertConfig);
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -17,11 +17,13 @@
 
 package org.keycloak.it.cli.dist;
 
+import static org.awaitility.Awaitility.given;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_LONG_NAME;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -32,6 +34,8 @@ import org.keycloak.it.junit5.extension.RawDistOnly;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+
+import static io.restassured.RestAssured.when;
 
 import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawDistRootPath;
@@ -141,14 +145,14 @@ public class LoggingDistTest {
     void failUnknownHandlersInConfFile(KeycloakDistribution dist) {
         dist.copyOrReplaceFileFromClasspath("/logging/keycloak.conf", Paths.get("conf", "keycloak.conf"));
         CLIResult cliResult = dist.run("start-dev");
-        cliResult.assertError("Invalid value for option 'kc.log': foo. Expected values are: console, file, gelf.");
+        cliResult.assertError("Invalid value for option 'kc.log': foo. Expected values are: console, file, syslog, gelf.");
     }
 
     @Test
     void failEmptyLogErrorFromConfFileError(KeycloakDistribution dist) {
         dist.copyOrReplaceFileFromClasspath("/logging/emptylog.conf", Paths.get("conf", "emptylog.conf"));
         CLIResult cliResult = dist.run(CONFIG_FILE_LONG_NAME+"=../conf/emptylog.conf", "start-dev");
-        cliResult.assertError("Invalid value for option 'kc.log': . Expected values are: console, file, gelf.");
+        cliResult.assertError("Invalid value for option 'kc.log': . Expected values are: console, file, syslog, gelf.");
     }
 
     @Test
@@ -163,5 +167,14 @@ public class LoggingDistTest {
     void failEmptyLogValueInCliError(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertError("Invalid value for option '--log': .");
+    }
+
+    @Test
+    @Launch({"start-dev", "--log=syslog"})
+    void syslogHandler(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertNoMessage("org.keycloak");
+        cliResult.assertNoMessage("Listening on:");
+        cliResult.assertError("Error writing to TCP stream");
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -114,7 +114,7 @@ public class StartCommandDistTest {
     @Launch({ "start", "--optimized" })
     void testStartUsingOptimizedInvalidEnvOption(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertError("Invalid value for option 'kc.log': invalid. Expected values are: console, file, gelf. From ConfigSource KcEnvVarConfigSource");
+        cliResult.assertError("Invalid value for option 'kc.log': invalid. Expected values are: console, file, syslog, gelf. From ConfigSource KcEnvVarConfigSource");
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -108,7 +108,7 @@ Management:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -108,7 +108,7 @@ Management:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.
@@ -169,6 +169,22 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
+--log-syslog-endpoint <host:port>
+                     The IP address and port of the syslog server. Default: localhost:514.
+                       Available only when Syslog is activated.
+--log-syslog-format <format>
+                     Set a format specific to syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
+                       -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-output <output>
+                     Set the syslog output to JSON or default (plain) unstructured logging.
+                       Possible values are: default, json. Default: default. Available only when
+                       Syslog is activated.
+--log-syslog-protocol <protocol>
+                     Sets the protocol used to connect to the syslog server. Possible values are:
+                       tcp, udp, ssl-tcp. Default: tcp. Available only when Syslog is activated.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -108,7 +108,7 @@ Management:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -108,7 +108,7 @@ Management:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.
@@ -169,6 +169,22 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
+--log-syslog-endpoint <host:port>
+                     The IP address and port of the syslog server. Default: localhost:514.
+                       Available only when Syslog is activated.
+--log-syslog-format <format>
+                     Set a format specific to syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
+                       -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-output <output>
+                     Set the syslog output to JSON or default (plain) unstructured logging.
+                       Possible values are: default, json. Default: default. Available only when
+                       Syslog is activated.
+--log-syslog-protocol <protocol>
+                     Sets the protocol used to connect to the syslog server. Possible values are:
+                       tcp, udp, ssl-tcp. Default: tcp. Available only when Syslog is activated.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -272,7 +272,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -275,7 +275,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.
@@ -336,6 +336,22 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
+--log-syslog-endpoint <host:port>
+                     The IP address and port of the syslog server. Default: localhost:514.
+                       Available only when Syslog is activated.
+--log-syslog-format <format>
+                     Set a format specific to syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
+                       -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-output <output>
+                     Set the syslog output to JSON or default (plain) unstructured logging.
+                       Possible values are: default, json. Default: default. Available only when
+                       Syslog is activated.
+--log-syslog-protocol <protocol>
+                     Sets the protocol used to connect to the syslog server. Possible values are:
+                       tcp, udp, ssl-tcp. Default: tcp. Available only when Syslog is activated.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -273,7 +273,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -276,7 +276,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.
@@ -337,6 +337,22 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
+--log-syslog-endpoint <host:port>
+                     The IP address and port of the syslog server. Default: localhost:514.
+                       Available only when Syslog is activated.
+--log-syslog-format <format>
+                     Set a format specific to syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
+                       -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-output <output>
+                     Set the syslog output to JSON or default (plain) unstructured logging.
+                       Possible values are: default, json. Default: default. Available only when
+                       Syslog is activated.
+--log-syslog-protocol <protocol>
+                     Sets the protocol used to connect to the syslog server. Possible values are:
+                       tcp, udp, ssl-tcp. Default: tcp. Available only when Syslog is activated.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -212,7 +212,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -215,7 +215,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values
-                       are: console, file, gelf (deprecated). Default: console.
+                       are: console, file, syslog, gelf (deprecated). Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false. Available
                        only when Console log handler is activated.
@@ -276,6 +276,22 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
+--log-syslog-endpoint <host:port>
+                     The IP address and port of the syslog server. Default: localhost:514.
+                       Available only when Syslog is activated.
+--log-syslog-format <format>
+                     Set a format specific to syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
+                       -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-output <output>
+                     Set the syslog output to JSON or default (plain) unstructured logging.
+                       Possible values are: default, json. Default: default. Available only when
+                       Syslog is activated.
+--log-syslog-protocol <protocol>
+                     Sets the protocol used to connect to the syslog server. Possible values are:
+                       tcp, udp, ssl-tcp. Default: tcp. Available only when Syslog is activated.
 
 Truststore:
 


### PR DESCRIPTION
Closes #27544

Providing Syslog log handler was actually low-hanging fruit, as Quarkus supports it by default as one of the possible log handlers.