### PR TITLE
Upgrade artifact actions to latest version

### DIFF
--- a/.github/actions/archive-surefire-reports/action.yml
+++ b/.github/actions/archive-surefire-reports/action.yml
@@ -37,7 +37,7 @@ runs:
     - id: upload-surefire-linux
       name: Upload Surefire reports
       if: (!cancelled() && contains(fromJSON(inputs.release-branches), github.ref) && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name))
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: surefire-${{ inputs.job-id }}
         path: |

--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -51,7 +51,7 @@ runs:
     - id: upload-keycloak-maven-repository
       name: Upload Keycloak Maven artifacts
       if: inputs.upload-m2-repo == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: m2-keycloak.tzts
         path: m2-keycloak.tzts
@@ -60,7 +60,7 @@ runs:
     - id: upload-keycloak-dist
       name: Upload Keycloak dist
       if: inputs.upload-dist == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: keycloak-dist
         path: quarkus/dist/target/keycloak*.tar.gz

--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - id: download-keycloak
       name: Download Keycloak Maven artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: m2-keycloak.tzts
 

--- a/.github/actions/upload-flaky-tests/action.yml
+++ b/.github/actions/upload-flaky-tests/action.yml
@@ -47,7 +47,7 @@ runs:
           echo "EOF" >> $GITHUB_OUTPUT
         fi
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ steps.flaky-tests.outputs.flakes }}
       with:
         name: flaky-tests-${{ github.job }}-${{ join(matrix.*, '-') }}

--- a/.github/actions/upload-heapdumps/action.yml
+++ b/.github/actions/upload-heapdumps/action.yml
@@ -8,7 +8,7 @@ runs:
       name: Upload JVM Heapdumps
       # Windows runners are running into https://github.com/actions/upload-artifact/issues/240
       if: runner.os != 'Windows'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jvm-heap-dumps
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
 
       - name: EC2 Maven Logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: store-it-mvn-logs
           path: .github/scripts/ansible/files
@@ -463,7 +463,7 @@ jobs:
 
       - name: EC2 Maven Logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: store-it-mvn-logs
           path: .github/scripts/ansible/files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,7 +60,7 @@ jobs:
 
       - id: upload-keycloak-documentation
         name: Upload Keycloak documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: keycloak-documentation
           path: docs/documentation/dist/target/*.zip

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -57,7 +57,7 @@ jobs:
           mv ./quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz ./keycloak-999.0.0-SNAPSHOT.tar.gz
 
       - name: Upload Keycloak dist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: keycloak
           path: keycloak-999.0.0-SNAPSHOT.tar.gz
@@ -175,7 +175,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup
 
       - name: Download Keycloak server
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: keycloak
 
@@ -201,7 +201,7 @@ jobs:
         env:
           KEYCLOAK_SERVER: http://localhost:8080
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: account-ui-playwright-report
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload server logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: account-ui-server-log
           path: ~/server.log
@@ -253,7 +253,7 @@ jobs:
         run: pnpm --filter @keycloak/keycloak-admin-client build
 
       - name: Download Keycloak server
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: keycloak
 
@@ -289,13 +289,13 @@ jobs:
 
       - name: Upload server logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: admin-ui-server-log-${{ matrix.container }}-${{ matrix.browser }}
           path: ~/server.log
 
       - name: Upload Cypress videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && github.repository != 'keycloak/keycloak-private'
         with:
           name: cypress-videos-${{ matrix.container }}-${{ matrix.browser }}

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Download keycloak distribution
         id: download-keycloak-dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: keycloak-dist
           path: quarkus/container
@@ -121,7 +121,7 @@ jobs:
 
       - name: Download keycloak distribution
         id: download-keycloak-dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: keycloak-dist
           path: quarkus/container
@@ -177,7 +177,7 @@ jobs:
 
       - name: Download keycloak distribution
         id: download-keycloak-dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: keycloak-dist
           path: quarkus/container


### PR DESCRIPTION
Upgrades the artifact actions to the latest version now that the reliability issues [have been fixed](https://github.com/actions/download-artifact/issues/249#issuecomment-2040750798).