### PR TITLE
Defer updates of last session updates and batch them

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
@@ -144,6 +144,9 @@ public class AuthenticatedClientSessionAdapter implements AuthenticatedClientSes
 
             @Override
             public void runUpdate(AuthenticatedClientSessionEntity entity) {
+                if (entity.getTimestamp() >= timestamp) {
+                    return;
+                }
                 entity.setTimestamp(timestamp);
             }
 
@@ -151,6 +154,11 @@ public class AuthenticatedClientSessionAdapter implements AuthenticatedClientSes
             public CrossDCMessageStatus getCrossDCMessageStatus(SessionEntityWrapper<AuthenticatedClientSessionEntity> sessionWrapper) {
                 return new CrossDCLastSessionRefreshChecker(provider.getLastSessionRefreshStore(), provider.getOfflineLastSessionRefreshStore())
                         .shouldSaveClientSessionToRemoteCache(kcSession, client.getRealm(), sessionWrapper, userSession, offline, timestamp);
+            }
+
+            @Override
+            public boolean isDeferrable() {
+                return true;
             }
 
             @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
@@ -238,6 +238,9 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
 
             @Override
             public void runUpdate(UserSessionEntity entity) {
+                if (entity.getLastSessionRefresh() >= lastSessionRefresh) {
+                    return;
+                }
                 entity.setLastSessionRefresh(lastSessionRefresh);
             }
 
@@ -245,6 +248,11 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
             public CrossDCMessageStatus getCrossDCMessageStatus(SessionEntityWrapper<UserSessionEntity> sessionWrapper) {
                 return new CrossDCLastSessionRefreshChecker(provider.getLastSessionRefreshStore(), provider.getOfflineLastSessionRefreshStore())
                         .shouldSaveUserSessionToRemoteCache(UserSessionAdapter.this.session, UserSessionAdapter.this.realm, sessionWrapper, offline, lastSessionRefresh);
+            }
+
+            @Override
+            public boolean isDeferrable() {
+                return true;
             }
 
             @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -36,6 +36,7 @@ import org.keycloak.models.sessions.infinispan.util.InfinispanKeyGenerator;
 import org.keycloak.models.sessions.infinispan.util.SessionTimeouts;
 
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ClientSessionPersistentChangelogBasedTransaction extends PersistentSessionsChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> {
@@ -44,8 +45,9 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
     private final InfinispanKeyGenerator keyGenerator;
     private final UserSessionPersistentChangelogBasedTransaction userSessionTx;
 
-    public ClientSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<AuthenticatedClientSessionEntity> lifespanMsLoader, SessionFunction<AuthenticatedClientSessionEntity> maxIdleTimeMsLoader, boolean offline, InfinispanKeyGenerator keyGenerator, UserSessionPersistentChangelogBasedTransaction userSessionTx, SerializeExecutionsByKey<UUID> serializer) {
-        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline, serializer);
+    public ClientSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<AuthenticatedClientSessionEntity> lifespanMsLoader, SessionFunction<AuthenticatedClientSessionEntity> maxIdleTimeMsLoader, boolean offline, InfinispanKeyGenerator keyGenerator,
+                                                            UserSessionPersistentChangelogBasedTransaction userSessionTx, SerializeExecutionsByKey<UUID> serializer, ArrayBlockingQueue<PersistentDeferredElement<UUID, AuthenticatedClientSessionEntity>> asyncQueue) {
+        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline, serializer, asyncQueue);
         this.keyGenerator = keyGenerator;
         this.userSessionTx = userSessionTx;
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
@@ -82,9 +82,11 @@ public class JpaChangesPerformer<K, V extends SessionEntity> implements SessionC
 
     @Override
     public void applyChanges() {
-        Retry.executeWithBackoff(iteration -> KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(),
-                        innerSession -> changes.forEach(c -> c.accept(innerSession))),
-                10, 10);
+        if (changes.size() > 0) {
+            Retry.executeWithBackoff(iteration -> KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(),
+                            innerSession -> changes.forEach(c -> c.accept(innerSession))),
+                    10, 10);
+        }
     }
 
     private void processClientSessionUpdate(KeycloakSession innerSession, Map.Entry<K, SessionUpdatesList<V>> entry, MergedUpdate<V> merged) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentDeferredElement.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentDeferredElement.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.changes;
+
+import org.keycloak.models.sessions.infinispan.entities.SessionEntity;
+
+import java.util.Map;
+
+/**
+ * Capture information for a deferred update of the session stores.
+ *
+ * @author Alexander Schwartz
+ */
+public class PersistentDeferredElement<K, V extends SessionEntity> {
+    private final Map.Entry<K, SessionUpdatesList<V>> entry;
+    private final MergedUpdate<V> merged;
+
+    public PersistentDeferredElement(Map.Entry<K, SessionUpdatesList<V>> entry, MergedUpdate<V> merged) {
+        this.entry = entry;
+        this.merged = merged;
+    }
+
+    public Map.Entry<K, SessionUpdatesList<V>> getEntry() {
+        return entry;
+    }
+
+    public MergedUpdate<V> getMerged() {
+        return merged;
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
@@ -26,8 +26,11 @@ import org.keycloak.models.sessions.infinispan.SessionFunction;
 import org.keycloak.models.sessions.infinispan.entities.SessionEntity;
 import org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheInvoker;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
@@ -38,10 +41,13 @@ public class PersistentSessionsChangelogBasedTransaction<K, V extends SessionEnt
 
     private final List<SessionChangesPerformer<K, V>> changesPerformers;
     protected final boolean offline;
+    private final ArrayBlockingQueue<PersistentDeferredElement<K, V>> asyncQueue;
+    private Collection<PersistentDeferredElement<K, V>> batch;
 
-    public PersistentSessionsChangelogBasedTransaction(KeycloakSession session, Cache<K, SessionEntityWrapper<V>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<V> lifespanMsLoader, SessionFunction<V> maxIdleTimeMsLoader, boolean offline, SerializeExecutionsByKey<K> serializer) {
+    public PersistentSessionsChangelogBasedTransaction(KeycloakSession session, Cache<K, SessionEntityWrapper<V>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<V> lifespanMsLoader, SessionFunction<V> maxIdleTimeMsLoader, boolean offline, SerializeExecutionsByKey<K> serializer, ArrayBlockingQueue<PersistentDeferredElement<K, V>> asyncQueue) {
         super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, serializer);
         this.offline = offline;
+        this.asyncQueue = asyncQueue;
 
         if (!Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
             throw new IllegalStateException("Persistent user sessions are not enabled");
@@ -78,8 +84,18 @@ public class PersistentSessionsChangelogBasedTransaction<K, V extends SessionEnt
             MergedUpdate<V> merged = MergedUpdate.computeUpdate(sessionUpdates.getUpdateTasks(), sessionWrapper, lifespanMs, maxIdleTimeMs);
 
             if (merged != null) {
-                changesPerformers.forEach(p -> p.registerChange(entry, merged));
+                if (merged.isDeferrable()) {
+                    asyncQueue.add(new PersistentDeferredElement<>(entry, merged));
+                } else {
+                    changesPerformers.forEach(p -> p.registerChange(entry, merged));
+                }
             }
+        }
+
+        if (batch != null) {
+            batch.forEach(o -> {
+                changesPerformers.forEach(p -> p.registerChange(o.getEntry(), o.getMerged()));
+            });
         }
 
         changesPerformers.forEach(SessionChangesPerformer::applyChanges);
@@ -89,4 +105,12 @@ public class PersistentSessionsChangelogBasedTransaction<K, V extends SessionEnt
     protected void rollbackImpl() {
 
     }
+
+    public void applyDeferredBatch(Collection<PersistentDeferredElement<K, V>> batchToApply) {
+        if (this.batch == null) {
+            this.batch = new ArrayList<>(batchToApply.size());
+        }
+        batch.addAll(batchToApply);
+    }
+
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsWorker.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsWorker.java
@@ -104,9 +104,10 @@ public class PersistentSessionsWorker {
             Collection<PersistentDeferredElement<K, V>> batch = new ArrayList<>();
             PersistentDeferredElement<K, V> polled = queue.poll(100, TimeUnit.MILLISECONDS);
             if (polled != null) {
-                queue.add(polled);
+                batch.add(polled);
                 queue.drainTo(batch, 99);
                 try {
+                    LOG.debugf("Processing %d deferred session updates.", batch.size());
                     KeycloakModelUtils.runJobInTransaction(factory,
                             session -> adapter.run(((PersistentUserSessionProvider) session.getProvider(UserSessionProvider.class)), batch, offline));
                 } catch (RuntimeException ex) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsWorker.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsWorker.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.changes;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.sessions.infinispan.PersistentUserSessionProvider;
+import org.keycloak.models.sessions.infinispan.entities.AuthenticatedClientSessionEntity;
+import org.keycloak.models.sessions.infinispan.entities.SessionEntity;
+import org.keycloak.models.sessions.infinispan.entities.UserSessionEntity;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Run one thread per session type and drain the queues once there is an entry. Will batch entries if possible.
+ *
+ * @author Alexander Schwartz
+ */
+public class PersistentSessionsWorker {
+    private static final Logger LOG = Logger.getLogger(PersistentSessionsWorker.class);
+
+    private final KeycloakSessionFactory factory;
+    private final ArrayBlockingQueue<PersistentDeferredElement<String, UserSessionEntity>> asyncQueueUserSessions;
+    private final ArrayBlockingQueue<PersistentDeferredElement<String, UserSessionEntity>> asyncQueueUserOfflineSessions;
+    private final ArrayBlockingQueue<PersistentDeferredElement<UUID, AuthenticatedClientSessionEntity>> asyncQueueClientSessions;
+    private final ArrayBlockingQueue<PersistentDeferredElement<UUID, AuthenticatedClientSessionEntity>> asyncQueueClientOfflineSessions;
+    private final List<Thread> threads = new ArrayList<>();
+    private volatile boolean stop;
+
+    public PersistentSessionsWorker(KeycloakSessionFactory factory, ArrayBlockingQueue<PersistentDeferredElement<String, UserSessionEntity>> asyncQueueUserSessions, ArrayBlockingQueue<PersistentDeferredElement<String, UserSessionEntity>> asyncQueueUserOfflineSessions, ArrayBlockingQueue<PersistentDeferredElement<UUID, AuthenticatedClientSessionEntity>> asyncQueueClientSessions, ArrayBlockingQueue<PersistentDeferredElement<UUID, AuthenticatedClientSessionEntity>> asyncQueueClientOfflineSessions) {
+        this.factory = factory;
+        this.asyncQueueUserSessions = asyncQueueUserSessions;
+        this.asyncQueueUserOfflineSessions = asyncQueueUserOfflineSessions;
+        this.asyncQueueClientSessions = asyncQueueClientSessions;
+        this.asyncQueueClientOfflineSessions = asyncQueueClientOfflineSessions;
+    }
+
+    public void start() {
+        threads.add(new WorkerUserSession(asyncQueueUserSessions, false));
+        threads.add(new WorkerUserSession(asyncQueueUserOfflineSessions, true));
+        threads.add(new WorkerClientSession(asyncQueueClientSessions, false));
+        threads.add(new WorkerClientSession(asyncQueueClientOfflineSessions, true));
+        threads.forEach(Thread::start);
+    }
+
+    private class WorkerUserSession extends Worker<String, UserSessionEntity> {
+        public WorkerUserSession(ArrayBlockingQueue<PersistentDeferredElement<String, UserSessionEntity>> queue, boolean offline) {
+            super(queue, offline, PersistentUserSessionProvider::processDeferredUserSessionElements);
+        }
+    }
+
+    private class WorkerClientSession extends Worker<UUID, AuthenticatedClientSessionEntity> {
+        public WorkerClientSession(ArrayBlockingQueue<PersistentDeferredElement<UUID, AuthenticatedClientSessionEntity>> queue, boolean offline) {
+            super(queue, offline, PersistentUserSessionProvider::processDeferredClientSessionElements);
+        }
+    }
+
+    private class Worker<K, V extends SessionEntity> extends Thread {
+        private final ArrayBlockingQueue<PersistentDeferredElement<K, V>> queue;
+        private final boolean offline;
+        private final Adapter<K, V> adapter;
+
+        public Worker(ArrayBlockingQueue<PersistentDeferredElement<K, V>> queue, boolean offline, Adapter<K, V> adapter) {
+            this.queue = queue;
+            this.offline = offline;
+            this.adapter = adapter;
+        }
+
+        public void run() {
+            Thread.currentThread().setName(this.getClass().getName() + " for " + (offline ? "offline" : "online") + " sessions");
+            while (!stop) {
+                try {
+                    process(queue, offline);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+
+        private void process(ArrayBlockingQueue<PersistentDeferredElement<K, V>> queue, boolean offline) throws InterruptedException {
+            Collection<PersistentDeferredElement<K, V>> batch = new ArrayList<>();
+            PersistentDeferredElement<K, V> polled = queue.poll(100, TimeUnit.MILLISECONDS);
+            if (polled != null) {
+                queue.add(polled);
+                queue.drainTo(batch, 99);
+                try {
+                    KeycloakModelUtils.runJobInTransaction(factory,
+                            session -> adapter.run(((PersistentUserSessionProvider) session.getProvider(UserSessionProvider.class)), batch, offline));
+                } catch (RuntimeException ex) {
+                    LOG.warnf(ex, "Unable to write %d deferred session updates", queue.size());
+                }
+            }
+        }
+
+        interface Adapter<K, V extends SessionEntity> {
+            void run(PersistentUserSessionProvider sessionProvider, Collection<PersistentDeferredElement<K, V>> batch, boolean offline);
+        }
+    }
+
+    public void stop() {
+        stop = true;
+        threads.forEach(Thread::interrupt);
+        threads.forEach(t -> {
+            try {
+                t.join(TimeUnit.MINUTES.toMillis(1));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/SessionUpdateTask.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/SessionUpdateTask.java
@@ -30,6 +30,10 @@ public interface SessionUpdateTask<S extends SessionEntity> {
 
     CrossDCMessageStatus getCrossDCMessageStatus(SessionEntityWrapper<S> sessionWrapper);
 
+    default boolean isDeferrable() {
+        return false;
+    }
+
     enum CacheOperation {
 
         ADD,

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -31,8 +31,8 @@ import org.keycloak.models.sessions.infinispan.entities.SessionEntity;
 import org.keycloak.models.sessions.infinispan.entities.UserSessionEntity;
 import org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheInvoker;
 
-import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
 
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
@@ -42,8 +42,8 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.U
 public class UserSessionPersistentChangelogBasedTransaction extends PersistentSessionsChangelogBasedTransaction<String, UserSessionEntity> {
 
     private static final Logger LOG = Logger.getLogger(UserSessionPersistentChangelogBasedTransaction.class);
-    public UserSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<String, SessionEntityWrapper<UserSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<UserSessionEntity> lifespanMsLoader, SessionFunction<UserSessionEntity> maxIdleTimeMsLoader, boolean offline, SerializeExecutionsByKey<String> serializer) {
-        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline, serializer);
+    public UserSessionPersistentChangelogBasedTransaction(KeycloakSession session, Cache<String, SessionEntityWrapper<UserSessionEntity>> cache, RemoteCacheInvoker remoteCacheInvoker, SessionFunction<UserSessionEntity> lifespanMsLoader, SessionFunction<UserSessionEntity> maxIdleTimeMsLoader, boolean offline, SerializeExecutionsByKey<String> serializer, ArrayBlockingQueue<PersistentDeferredElement<String, UserSessionEntity>> asyncQueue) {
+        super(session, cache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offline, serializer, asyncQueue);
     }
 
     public SessionEntityWrapper<UserSessionEntity> get(RealmModel realm, String key) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -93,12 +93,7 @@ public class UserSessionPersistentChangelogBasedTransaction extends PersistentSe
             return null;
         }
 
-        SessionEntityWrapper<UserSessionEntity> userSessionEntitySessionEntityWrapper = importUserSession(persistentUserSession);
-        if (userSessionEntitySessionEntityWrapper == null) {
-            removeSessionEntityFromPersister(key);
-        }
-
-        return userSessionEntitySessionEntityWrapper;
+        return importUserSession(persistentUserSession);
     }
 
     private void removeSessionEntityFromPersister(String key) {


### PR DESCRIPTION
This should make persistent sessions a lot faster for refreshing tokens.

Closes #28501

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
