### PR TITLE
OpenJDK 21 support

### DIFF
--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -9,7 +9,7 @@ inputs:
   jdk-version:
     description: JDK version
     required: false
-    default: "17"
+    default: "21"
 
 runs:
   using: composite

--- a/.github/actions/java-setup/action.yml
+++ b/.github/actions/java-setup/action.yml
@@ -9,7 +9,7 @@ inputs:
   java-version:
     description: The Java version that is going to be set up.
     required: false
-    default: "17"
+    default: "21"
 
 runs:
   using: composite

--- a/.github/scripts/ansible/roles/keycloak_ec2_installer/README.md
+++ b/.github/scripts/ansible/roles/keycloak_ec2_installer/README.md
@@ -15,7 +15,7 @@ See `defaults/main.yml` for default values.
 ### Other
 - `update_system_packages`: Whether to update the system packages. Defaults to `no`.
 - `install_java`: Whether to install OpenJDK on the system. Defaults to `yes`.
-- `java_version`: Version of OpenJDK to be installed. Defaults to `17`.
+- `java_version`: Version of OpenJDK to be installed. Defaults to `21`.
 
 
 ## Example Playbook

--- a/.github/scripts/ansible/roles/keycloak_ec2_installer/defaults/main.yml
+++ b/.github/scripts/ansible/roles/keycloak_ec2_installer/defaults/main.yml
@@ -4,4 +4,4 @@ ansible_ssh_user: ec2-user
 kc_home: /opt/keycloak
 update_system_packages: no
 install_java: yes
-java_version: 17
+java_version: 21

--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-dnf install -y java-17-openjdk-devel
+dnf install -y java-21-openjdk-devel
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --is-enabled
 if [ $? -ne 0 ]; then
@@ -13,7 +13,7 @@ fi
 echo "STRICT_OPTIONS: $STRICT_OPTIONS"
 TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh fips`
 echo "Tests: $TESTS"
-export JAVA_HOME=/etc/alternatives/java_sdk_17
+export JAVA_HOME=/etc/alternatives/java_sdk_21
 set -o pipefail
 
 # Profile app-server-wildfly needs to be explicitly set for FIPS tests

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-dnf install -y java-17-openjdk-devel crypto-policies-scripts
+dnf install -y java-21-openjdk-devel crypto-policies-scripts
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --is-enabled
 if [ $? -ne 0 ]; then
   exit 1
 fi
-echo "fips.provider.7=XMLDSig" >>/etc/alternatives/java_sdk_17/conf/security/java.security
-export JAVA_HOME=/etc/alternatives/java_sdk_17
+echo "fips.provider.7=XMLDSig" >>/etc/alternatives/java_sdk_21/conf/security/java.security
+export JAVA_HOME=/etc/alternatives/java_sdk_21
 
 # Build all dependent modules
 ./mvnw install -nsu -B -am -pl crypto/default,crypto/fips1402 -DskipTests

--- a/.github/scripts/run-ipa-tests.sh
+++ b/.github/scripts/run-ipa-tests.sh
@@ -39,9 +39,9 @@ EOF
   kdestroy
 fi
 
-echo "Installing jdk-17 in the container"
-dnf install -y java-17-openjdk-devel
-export JAVA_HOME=/etc/alternatives/java_sdk_17
+echo "Installing jdk-21 in the container"
+dnf install -y java-21-openjdk-devel
+export JAVA_HOME=/etc/alternatives/java_sdk_21
 
 echo "Building quarkus keyclok server with SSSD integration"
 ./mvnw install -nsu -B -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         dist: [temurin]
-        version: [19]
+        version: [17]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -604,7 +604,7 @@ jobs:
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
         with:
-          jdk-version: 17
+          jdk-version: 21
 
       - name: Build adapter distributions
         run: ./mvnw install -DskipTests -f distribution/pom.xml

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           check-latest: true
           cache: maven
 
@@ -183,7 +183,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Start Keycloak server
         run: |
@@ -277,7 +277,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Start Keycloak server
         run: |

--- a/adapters/saml/core-jakarta/pom.xml
+++ b/adapters/saml/core-jakarta/pom.xml
@@ -94,7 +94,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}" />
@@ -110,18 +110,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/adapters/saml/wildfly-elytron-jakarta/pom.xml
+++ b/adapters/saml/wildfly-elytron-jakarta/pom.xml
@@ -104,7 +104,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>transform</id>
@@ -115,7 +115,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}" />
@@ -131,18 +131,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
@@ -44,7 +44,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>transform</id>
@@ -55,7 +55,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}" />
@@ -71,18 +71,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCUserIdentityExtractorProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCUserIdentityExtractorProvider.java
@@ -149,34 +149,41 @@ public class BCUserIdentityExtractorProvider  extends UserIdentityExtractorProvi
                                 return obj;
                             }
 
-                            byte[] otherNameBytes = (byte[]) obj;
+                            // From Java 21, the 3rd entry can be present with the type-id as String and 4th entry with the value (either in String or byte format).
+                            // See javadoc of X509Certificate.getSubjectAlternativeNames in Java 21. For the sake of simplicity, we just ignore those additional String entries and
+                            // always parse it from byte (2nd entry) as we still need to support Java 17 and it is not reliable anyway that entries are present in Java 21.
+                            if (obj instanceof byte[]) {
+                                byte[] otherNameBytes = (byte[]) obj;
 
-                            try {
-                                ASN1InputStream asn1Stream = new ASN1InputStream(new ByteArrayInputStream(otherNameBytes));
-                                ASN1Encodable asn1otherName = asn1Stream.readObject();
-                                asn1otherName = unwrap(asn1otherName);
+                                try {
+                                    ASN1InputStream asn1Stream = new ASN1InputStream(new ByteArrayInputStream(otherNameBytes));
+                                    ASN1Encodable asn1otherName = asn1Stream.readObject();
+                                    asn1otherName = unwrap(asn1otherName);
 
-                                ASN1Sequence asn1Sequence = ASN1Sequence.getInstance(asn1otherName);
+                                    ASN1Sequence asn1Sequence = ASN1Sequence.getInstance(asn1otherName);
 
-                                if (asn1Sequence != null) {
-                                    ASN1Encodable encodedOid = asn1Sequence.getObjectAt(0);
-                                    ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(unwrap(encodedOid));
-                                    tempOid = oid.getId();
+                                    if (asn1Sequence != null) {
+                                        ASN1Encodable encodedOid = asn1Sequence.getObjectAt(0);
+                                        ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(unwrap(encodedOid));
+                                        tempOid = oid.getId();
 
-                                    ASN1Encodable principalNameEncoded = asn1Sequence.getObjectAt(1);
-                                    ASN1UTF8String principalName = DERUTF8String.getInstance(unwrap(principalNameEncoded));
+                                        ASN1Encodable principalNameEncoded = asn1Sequence.getObjectAt(1);
+                                        ASN1UTF8String principalName = DERUTF8String.getInstance(unwrap(principalNameEncoded));
 
-                                    tempOtherName = principalName.getString();
+                                        tempOtherName = principalName.getString();
 
-                                    // We found UPN among the 'otherName' principal. We don't need to look other
-                                    if (UPN_OID.equals(tempOid)) {
-                                        foundUpn = true;
-                                        break;
+                                        // We found UPN among the 'otherName' principal. We don't need to look other
+                                        if (UPN_OID.equals(tempOid)) {
+                                            foundUpn = true;
+                                            break;
+                                        }
                                     }
-                                }
 
-                            } catch (Exception e) {
-                                logger.error("Failed to parse subjectAltName", e);
+                                } catch (Exception e) {
+                                    logger.error("Failed to parse subjectAltName", e);
+                                }
+                            } else {
+                                logger.tracef("Ignoring the Subject alternative name entry. Entry number: %d, value: %s", i + 1, obj);
                             }
                         }
 

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSUserIdentityExtractorProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSUserIdentityExtractorProvider.java
@@ -58,7 +58,7 @@ public class BCFIPSUserIdentityExtractorProvider  extends UserIdentityExtractorP
 
         private ASN1ObjectIdentifier x500NameStyle;
         Function<X509Certificate[],Principal> x500Name;
-        
+
         public X500NameRDNExtractorBCProvider(String attrName, Function<X509Certificate[], Principal> x500Name) {
             this.x500NameStyle = BCStyle.INSTANCE.attrNameToOID(attrName);
             this.x500Name = x500Name;
@@ -147,34 +147,41 @@ public class BCFIPSUserIdentityExtractorProvider  extends UserIdentityExtractorP
                                 return obj;
                             }
 
-                            byte[] otherNameBytes = (byte[]) obj;
+                            // From Java 21, the 3rd entry can be present with the type-id as String and 4th entry with the value (either in String or byte format).
+                            // See javadoc of X509Certificate.getSubjectAlternativeNames in Java 21. For the sake of simplicity, we just ignore those additional String entries and
+                            // always parse it from byte (2nd entry) as we still need to support Java 17 and it is not reliable anyway that entries are present in Java 21.
+                            if (obj instanceof byte[]) {
+                                byte[] otherNameBytes = (byte[]) obj;
 
-                            try {
-                                ASN1InputStream asn1Stream = new ASN1InputStream(new ByteArrayInputStream(otherNameBytes));
-                                ASN1Encodable asn1otherName = asn1Stream.readObject();
-                                asn1otherName = unwrap(asn1otherName);
+                                try {
+                                    ASN1InputStream asn1Stream = new ASN1InputStream(new ByteArrayInputStream(otherNameBytes));
+                                    ASN1Encodable asn1otherName = asn1Stream.readObject();
+                                    asn1otherName = unwrap(asn1otherName);
 
-                                ASN1Sequence asn1Sequence = ASN1Sequence.getInstance(asn1otherName);
+                                    ASN1Sequence asn1Sequence = ASN1Sequence.getInstance(asn1otherName);
 
-                                if (asn1Sequence != null) {
-                                    ASN1Encodable encodedOid = asn1Sequence.getObjectAt(0);
-                                    ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(unwrap(encodedOid));
-                                    tempOid = oid.getId();
+                                    if (asn1Sequence != null) {
+                                        ASN1Encodable encodedOid = asn1Sequence.getObjectAt(0);
+                                        ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(unwrap(encodedOid));
+                                        tempOid = oid.getId();
 
-                                    ASN1Encodable principalNameEncoded = asn1Sequence.getObjectAt(1);
-                                    DERUTF8String principalName = DERUTF8String.getInstance(unwrap(principalNameEncoded));
+                                        ASN1Encodable principalNameEncoded = asn1Sequence.getObjectAt(1);
+                                        DERUTF8String principalName = DERUTF8String.getInstance(unwrap(principalNameEncoded));
 
-                                    tempOtherName = principalName.getString();
+                                        tempOtherName = principalName.getString();
 
-                                    // We found UPN among the 'otherName' principal. We don't need to look other
-                                    if (UPN_OID.equals(tempOid)) {
-                                        foundUpn = true;
-                                        break;
+                                        // We found UPN among the 'otherName' principal. We don't need to look other
+                                        if (UPN_OID.equals(tempOid)) {
+                                            foundUpn = true;
+                                            break;
+                                        }
                                     }
-                                }
 
-                            } catch (Exception e) {
-                                logger.error("Failed to parse subjectAltName", e);
+                                } catch (Exception e) {
+                                    logger.error("Failed to parse subjectAltName", e);
+                                }
+                            } else {
+                                logger.tracef("Ignoring the Subject alternative name entry. Entry number: %d, value: %s", i + 1, obj);
                             }
                         }
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,6 +1,6 @@
 ## Building from source
 
-Ensure you have JDK 17 (or newer) and Git installed
+Ensure you have JDK 21 (or newer) and Git installed
 
     java -version
     git --version

--- a/docs/documentation/release_notes/topics/25_0_0.adoc
+++ b/docs/documentation/release_notes/topics/25_0_0.adoc
@@ -2,6 +2,14 @@
 
 The Account Console v2 theme has been removed from {project_name}. This theme was deprecated in {project_name} 24 and replaced by the Account Console v3 theme. If you are still using this theme, you should migrate to the Account Console v3 theme.
 
+= Java 21 support
+
+{project_name} now supports OpenJDK 21, as we want to stick to the latest LTS OpenJDK versions.
+
+= Java 17 support is deprecated
+
+OpenJDK 17 support is deprecated in {project_name}, and will be removed in a following release in favor of OpenJDK 21.
+
 = Most of Java adapters removed
 
 As stated in the release notes of previous {project_name} version, the most of Java adapters are now removed from the {project_name} codebase and downloads pages.

--- a/docs/documentation/server_admin/topics/user-federation/sssd.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/sssd.adoc
@@ -31,7 +31,7 @@ The https://quay.io/repository/freeipa/freeipa-server?tab=tags/[FreeIPA Containe
  -v /var/lib/ipa-data:/data:Z freeipa/freeipa-server
 ----
 +
-The parameter `-h` with `server.freeipa.local` represents the FreeIPA/IdM server hostname. 
+The parameter `-h` with `server.freeipa.local` represents the FreeIPA/IdM server hostname.
 Change `YOUR_PASSWORD` to a password of your own.
 
 . After the container starts, change the `/etc/hosts` file to include:
@@ -156,7 +156,7 @@ ipaapi:x:992:988:IPA Framework User:/:/sbin/nologin
 
 {project_name} uses https://github.com/hypfvieh/dbus-java[DBus-Java] project to communicate at a low level with D-Bus and https://github.com/java-native-access/jna[JNA] to authenticate via Operating System Pluggable Authentication Modules (PAM).
 
-Although now {project_name} contains all the needed libraries to run the `SSSD` provider, JDK version 17 is needed. Therefore the `SSSD` provider will only be displayed when the host configuration is correct and JDK 17 is used to run {project_name}.
+Although now {project_name} contains all the needed libraries to run the `SSSD` provider, JDK version 21 is needed. Therefore the `SSSD` provider will only be displayed when the host configuration is correct and JDK 21 is used to run {project_name}.
 
 ==== Configuring a federated SSSD store
 

--- a/docs/guides/getting-started/getting-started-zip.adoc
+++ b/docs/guides/getting-started/getting-started-zip.adoc
@@ -13,7 +13,7 @@ summary="Get started with {project_name} on bare metal">
 
 include::templates/hw-requirements.adoc[]
 
-Make sure you have https://openjdk.java.net/[OpenJDK 17] installed. 
+Make sure you have https://openjdk.java.net/[OpenJDK 21] installed.
 
 == Download {project_name}
 

--- a/docs/guides/server/fips.adoc
+++ b/docs/guides/server/fips.adoc
@@ -52,7 +52,7 @@ You can create either `pkcs12` or `bcfks` keystore to be used for the {project_n
 
 The `p12` (or `pkcs12`) keystore (and/or truststore) works well in BCFIPS non-approved mode.
 
-PKCS12 keystore can be generated with OpenJDK 17 Java on RHEL 9 in the standard way. For instance,  the following command can be used to generate the keystore:
+PKCS12 keystore can be generated with OpenJDK 21 Java on RHEL 9 in the standard way. For instance, the following command can be used to generate the keystore:
 
 [source,bash]
 ----
@@ -180,7 +180,7 @@ available. Details are in the https://bugzilla.redhat.com/show_bug.cgi?id=205162
 
 == Run the CLI on the FIPS host
 
-If you want to run Client Registration CLI (`kcreg.sh|bat` script) or Admin CLI (`kcadm.sh|bat` script), 
+If you want to run Client Registration CLI (`kcreg.sh|bat` script) or Admin CLI (`kcadm.sh|bat` script),
  the CLI must also use the BouncyCastle FIPS dependencies instead of plain BouncyCastle dependencies. To achieve this, you may copy the
 jars to the CLI library folder and that is enough. CLI tool will automatically use BCFIPS dependencies instead of plain BC when
 it detects that corresponding BCFIPS jars are present (see above for the versions used). For example, use command such as the following before running the CLI:
@@ -268,8 +268,8 @@ earlier. If you prefer to avoid this option, you can for instance ask all your u
 the non-RHEL compatible platform or on the non-FIPS enabled platform, the FIPS compliance cannot be strictly guaranteed and cannot be officially supported.
 
 If you are still restricted to running {project_name} on such a system, you can at least update your security providers configured in `java.security` file. This update does not amount to FIPS compliance, but
-at least the setup is closer to it. It can be done by providing a custom security file with only an overridden list of security providers as described earlier. For a list of recommended providers, 
-see the https://access.redhat.com/documentation/en-us/openjdk/17/html/configuring_openjdk_17_on_rhel_with_fips/openjdk-default-fips-configuration[OpenJDK 17 documentation].
+at least the setup is closer to it. It can be done by providing a custom security file with only an overridden list of security providers as described earlier. For a list of recommended providers,
+see the https://access.redhat.com/documentation/en-us/red_hat_build_of_openjdk/21/html/configuring_red_hat_build_of_openjdk_21_on_rhel_with_fips[OpenJDK 21 documentation].
 
 You can check the {project_name} server log at startup to see if the correct security providers are used. TRACE logging should be enabled for crypto-related {project_name} packages as described in the Keycloak startup command earlier.
 

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -31,8 +31,6 @@
     <description/>
 
     <properties>
-        <ant.jvm.args>-Dnone</ant.jvm.args>
-
         <jakarta-transformer-sources>${project.basedir}/../admin-client-jee/src</jakarta-transformer-sources>
         <jakarta-transformer-target>${project.basedir}/src</jakarta-transformer-target>
     </properties>
@@ -95,8 +93,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath"/>
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
-                                    <jvmarg value="${ant.jvm.args}"/>
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o"/>
                                     <arg value="${jakarta-transformer-sources}"/>
                                     <arg value="${jakarta-transformer-target}"/>
@@ -122,18 +119,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -153,18 +144,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>jdk17+</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <!--For more information, see https://github.com/apache/ant/pull/200-->
-                <ant.jvm.args>-Djava.security.manager=allow</ant.jvm.args>
-            </properties>
-        </profile>
-    </profiles>
 
 </project>

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 
 ADD target/ubi-null.sh /tmp/
-RUN bash /tmp/ubi-null.sh java-17-openjdk-headless glibc-langpack-en
+RUN bash /tmp/ubi-null.sh java-21-openjdk-headless glibc-langpack-en
 
 FROM registry.access.redhat.com/ubi9-micro
 ENV LANG en_US.UTF-8

--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -17,7 +17,7 @@ RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 RUN chmod -R g+rwX /opt/keycloak
 
 ADD ubi-null.sh /tmp/
-RUN bash /tmp/ubi-null.sh java-17-openjdk-headless glibc-langpack-en findutils
+RUN bash /tmp/ubi-null.sh java-21-openjdk-headless glibc-langpack-en findutils
 
 FROM registry.access.redhat.com/ubi9-micro
 ENV LANG en_US.UTF-8

--- a/services/src/test/java/org/keycloak/test/broker/saml/XPathAttributeMapperTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/saml/XPathAttributeMapperTest.java
@@ -50,7 +50,9 @@ public class XPathAttributeMapperTest {
                 assertThrows(RuntimeException.class, () -> testMapping("<Open>Foo</Close>", "//*"));
         assertThat(actualException.getCause(), instanceOf(ParsingException.class));
 
-        assertThrows(RuntimeException.class, () -> testMapping(XML_WITH_NAMESPACE, "//*[local-name()=$street]"));
+        // it seems additional validation is added as 'TransformerException: Prefix must resolve to a namespace: unknownPrefix'
+        // is thrown before the XPath function resolver
+        assertNull(testMapping(XML_WITH_NAMESPACE, "//*[local-name()=$street]"));
         assertNull(testMapping(XML_WITH_NAMESPACE, "//*[local-name()=myPrefix:add(1,2)]"));
     }
 

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -786,7 +786,7 @@ mvn clean install -f crypto/fips1402 -Dorg.bouncycastle.fips.approved_only=true
 
 ### Integration tests
 
-On the FIPS enabled platform with FIPS enabled OpenJDK 17, you can run this to test against a Keycloak server on Quarkus
+On the FIPS enabled platform with FIPS enabled OpenJDK 21, you can run this to test against a Keycloak server on Quarkus
 with FIPS 140-2 integration enabled
 
 ```

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -57,6 +57,7 @@
         <jakarta.persistence-legacy.version>2.2.3</jakarta.persistence-legacy.version>
         <smallrye.jandex.version>3.0.5</smallrye.jandex.version>
         <commons.validator.version>1.8.0</commons.validator.version>
+        <byte-buddy.version>1.14.13</byte-buddy.version>
 
         <!--migration properties-->
         <migration.70.version>1.9.8.Final</migration.70.version>

--- a/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-saml-jakarta/pom.xml
+++ b/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-saml-jakarta/pom.xml
@@ -81,6 +81,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>transform</id>
@@ -91,8 +92,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
-                                    <jvmarg value="${ant.jvm.args}"/>
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}/tmp" />
@@ -115,18 +115,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-spi-jakarta/pom.xml
+++ b/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-spi-jakarta/pom.xml
@@ -42,6 +42,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>transform</id>
@@ -52,8 +53,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
-                                    <jvmarg value="${ant.jvm.args}"/>
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}/tmp" />
@@ -76,18 +76,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/testsuite/integration-arquillian/test-apps/servlets-jakarta/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/servlets-jakarta/pom.xml
@@ -96,7 +96,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath"/>
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <arg value="-o"/>
                                     <arg value="${jakarta-transformer-sources}"/>
                                     <arg value="${jakarta-transformer-target}/tmp"/>
@@ -119,18 +119,12 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -797,7 +797,7 @@
                 <dependency>
                     <groupId>net.bytebuddy</groupId>
                     <artifactId>byte-buddy</artifactId>
-                    <version>1.12.18</version>
+                    <version>{byte-buddy.version}</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/OAuthGrantPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/OAuthGrantPage.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.pages;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -64,7 +65,7 @@ public class OAuthGrantPage extends LanguageComboboxAwarePage {
     }
 
     public List<String> getDisplayedGrants() {
-        List<String> table = new LinkedList<>();
+        List<String> table = new ArrayList<>();
         WebElement divKcOauth = driver.findElement(By.id("kc-oauth"));
         for (WebElement li : divKcOauth.findElements(By.tagName("li"))) {
             WebElement span = li.findElement(By.tagName("span"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginSubjectAltNameTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginSubjectAltNameTest.java
@@ -18,10 +18,8 @@
 package org.keycloak.testsuite.x509;
 
 import org.jboss.arquillian.drone.api.annotation.Drone;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.keycloak.testsuite.util.HtmlUnitBrowser;
 import org.openqa.selenium.WebDriver;
@@ -55,8 +53,6 @@ public class X509BrowserLoginSubjectAltNameTest extends AbstractX509Authenticati
 
     @Test
     public void loginAsUserFromCertSANUpn() {
-        Assume.assumeTrue("Does not work with JDK 21. See https://github.com/keycloak/keycloak/issues/29968", Runtime.version().feature() < 21);
-
         x509BrowserLogin(createLoginSubjectAltNameOtherName2UserAttributeConfig(), userId, "test-user@localhost", "test_upn_name@localhost");
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginSubjectAltNameTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginSubjectAltNameTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.testsuite.x509;
 
 import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -54,6 +55,8 @@ public class X509BrowserLoginSubjectAltNameTest extends AbstractX509Authenticati
 
     @Test
     public void loginAsUserFromCertSANUpn() {
+        Assume.assumeTrue("Does not work with JDK 21. See https://github.com/keycloak/keycloak/issues/29968", Runtime.version().feature() < 21);
+
         x509BrowserLogin(createLoginSubjectAltNameOtherName2UserAttributeConfig(), userId, "test-user@localhost", "test_upn_name@localhost");
     }
 }

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1608,7 +1608,7 @@
                 <dependency>
                     <groupId>net.bytebuddy</groupId>
                     <artifactId>byte-buddy</artifactId>
-                    <version>1.12.18</version>
+                    <version>${byte-buddy.version}</version>
                 </dependency>
 
                 <dependency>


### PR DESCRIPTION
Closes #28517
Closes #29968

# Discussion

We need to assess the lifecycle of the currently supported OpenJDK 17 with the OpenJDK 21.
We may face some obstacles, which need a discussion. 

## Some considerations

- We'd like to stick to the latest LTS OpenJDK versions
- If we support OpenJDK 17 and OpenJDK 21 simultaneously, testing would need to be doubled = **NOK**
- Or we can test OpenJDK 17 only during nightly builds
- We can deprecate OpenJDK 17 and claim the testing of it will be limited
- If deprecated for Keycloak 25 and removed in **Keycloak 26**, it'd be a bad move for RHBK 26 (support for JDK 17 should be set - AFAIK) = **NOK**
- If deprecated for Keycloak 25 and removed in **Keycloak 27**, the OpenJDK 17 would be deprecated for RHBK 26 and removed in RHBK ~28 (potentially) = **OK**
- Java Distribution IT tests check OpenJDK 17 ~~and the latest JDK (OpenJDK 22)~~ [Invalid CEN header (invalid zip64 extra data field size](https://bugs.openjdk.org/browse/JDK-8313765) is thrown due to the additional ZIP64 validation)

## Summary
I'd suggest the following:

- OpenJDK 21 is the default (users can still use JDK17 and JDK17-based extensions)
- Deprecate OpenJDK 17 for Keycloak 25
- Remove OpenJDK 17 in Keycloak ~27
- Test OpenJDK 17 only as part of Java Distribution IT tests

---------------

@stianst @vmuzikar @ahus1 @miquelsi 
What are the requirements for the JDK support, and what are your thoughts on this? 