### PR TITLE
Fix flaky ManagementDistTest

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
@@ -27,7 +27,7 @@ import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.DistributionType;
 import org.keycloak.it.utils.KeycloakDistribution;
 
-import java.net.SocketException;
+import java.io.IOException;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.is;
@@ -56,8 +56,8 @@ public class ManagementDistTest {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertNoMessage("Management interface listening on");
 
-        assertThrows(SocketException.class, () -> when().get("/"), "Connection refused must be thrown");
-        assertThrows(SocketException.class, () -> when().get("/health"), "Connection refused must be thrown");
+        assertThrows(IOException.class, () -> when().get("/"), "Connection refused must be thrown");
+        assertThrows(IOException.class, () -> when().get("/health"), "Connection refused must be thrown");
 
         distribution.setRequestPort(8080);
 


### PR DESCRIPTION
Fixes #28509

The Apache HTTP client used for the execution of the HTTP calls uses a retry mechanism when accessing these endpoints is not successful. For the container runtime, the `SocketException` is thrown in the first retries as expected, but it seems the last retries are trying to make a request to a server, which might already be in a terminated state and not accepting requests. 

I think this is a reasonable fix, as it's only test-related and correctly verifies the management interface is not accessible.

@keycloak/cloud-native PTAL, once you have a chance, thanks!