### PR TITLE
Client Types - Client Update/Create Validations

### DIFF
--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -115,7 +115,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
             } catch(ClientTypeException cte) {
                 logger.errorf("Could not augment client, %s, due to client type exception: %s",
                         client, cte);
-                return client;
+                throw cte;
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -96,7 +96,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
         ClientTypesRepresentation clientTypes = getClientTypes(realm);
         ClientTypeRepresentation clientType = getClientTypeByName(clientTypes, typeName);
         if (clientType == null) {
-            logger.errorf("Referenced client type '%s' not found");
+            logger.errorf("Referenced client type '%s' not found", typeName);
             throw new ClientTypeException("Client type not found");
         }
 
@@ -109,8 +109,14 @@ public class DefaultClientTypeManager implements ClientTypeManager {
         if (client.getType() == null) {
             return client;
         } else {
-            ClientType clientType = getClientType(client.getRealm(), client.getType());
-            return new TypeAwareClientModelDelegate(clientType, () -> client);
+            try {
+                ClientType clientType = getClientType(client.getRealm(), client.getType());
+                return new TypeAwareClientModelDelegate(clientType, () -> client);
+            } catch(ClientTypeException cte) {
+                logger.errorf("Could not augment client, %s, due to client type exception: %s",
+                        client, cte);
+                return client;
+            }
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
@@ -18,29 +18,23 @@
 
 package org.keycloak.services.clienttype.impl;
 
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.ObjectUtil;
+import org.keycloak.client.clienttype.ClientType;
+import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
-import org.keycloak.client.clienttype.ClientType;
-import org.keycloak.client.clienttype.ClientTypeException;
-import org.keycloak.representations.idm.ErrorRepresentation;
-import org.keycloak.services.ErrorResponse;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -104,17 +98,16 @@ public class DefaultClientType implements ClientType {
         validateClientRequest(newClient, currentRep);
     }
 
-    protected void validateClientRequest(ClientRepresentation newClient, ClientRepresentation currentClient) {
+    protected void validateClientRequest(ClientRepresentation newClient, ClientRepresentation currentClient) throws ClientTypeException {
         List<String> validationErrors = clientType.getConfig().entrySet().stream()
                 .filter(property -> clientPropertyHasInvalidChangeRequested(currentClient, newClient, property.getKey(), property.getValue()))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
 
         if (validationErrors.size() > 0) {
-            throw ErrorResponse.error(
+            throw new ClientTypeException(
                     "Cannot change property of client as it is not allowed by the specified client type.",
-                    validationErrors.toArray(),
-                    Response.Status.BAD_REQUEST);
+                    validationErrors.toArray());
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
@@ -122,11 +122,21 @@ public class DefaultClientType implements ClientType {
             ClientRepresentation newClient,
             String propertyName,
             ClientTypeRepresentation.PropertyConfig propertyConfig) {
-        // Validate that read-only client properties were not changed.
-        return propertyConfig.getApplicable() &&
-                propertyConfig.getReadOnly() &&
-                !Objects.isNull(getClientProperty(newClient, propertyName)) &&
-                !Objects.equals(getClientProperty(oldClient, propertyName), getClientProperty(newClient, propertyName));
+        Object newClientProperty = getClientProperty(newClient, propertyName);
+        Object oldClientProperty = getClientProperty(oldClient, propertyName);
+
+        return (
+                    // Validate that non-applicable client properties were not changed.
+                    !propertyConfig.getApplicable() &&
+                    !Objects.isNull(newClientProperty) &&
+                    !Objects.equals(oldClientProperty, newClientProperty)
+                ) || (
+                    // Validate that applicable read-only client properties were not changed.
+                    propertyConfig.getApplicable() &&
+                    propertyConfig.getReadOnly() &&
+                    !Objects.isNull(newClientProperty) &&
+                    !Objects.equals(oldClientProperty, newClientProperty)
+                );
     }
 
     private void setClientProperty(ClientRepresentation client,

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -186,7 +186,7 @@ public class ClientResource {
         } catch (ModelDuplicateException e) {
             throw ErrorResponse.exists("Client already exists");
         } catch (ClientTypeException cte) {
-            throw ErrorResponse.error(cte.getMessage(), Response.Status.BAD_REQUEST);
+            throw ErrorResponse.error(cte.getMessage(), cte.getParameters(), Response.Status.BAD_REQUEST);
         } catch (ClientPolicyException cpe) {
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.authorization.admin.AuthorizationService;
+import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Errors;
 import org.keycloak.events.admin.OperationType;
@@ -226,6 +227,9 @@ public class ClientsResource {
             throw ErrorResponse.exists("Client " + rep.getClientId() + " already exists");
         } catch (ClientPolicyException cpe) {
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+        }
+        catch (ClientTypeException cte) {
+            throw ErrorResponse.error(cte.getMessage(), Response.Status.BAD_REQUEST);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -229,7 +229,7 @@ public class ClientsResource {
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
         }
         catch (ClientTypeException cte) {
-            throw ErrorResponse.error(cte.getMessage(), Response.Status.BAD_REQUEST);
+            throw ErrorResponse.error(cte.getMessage(), cte.getParameters(), Response.Status.BAD_REQUEST);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
@@ -18,24 +18,17 @@
 
 package org.keycloak.testsuite.client;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
-
 import org.junit.Test;
+import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.models.ClientModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
-
 import org.keycloak.representations.idm.ClientTypesRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.services.clienttype.impl.DefaultClientTypeProviderFactory;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.Assert;
@@ -45,7 +38,13 @@ import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.testsuite.util.ClientBuilder;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.keycloak.common.Profile.Feature.CLIENT_TYPES;
 
@@ -75,9 +74,9 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testCreateClientWithClientType() {
         ClientRepresentation clientRep = createClientWithType("foo", ClientTypeManager.SERVICE_ACCOUNT);
-        Assert.assertEquals("foo", clientRep.getClientId());
-        Assert.assertEquals(ClientTypeManager.SERVICE_ACCOUNT, clientRep.getType());
-        Assert.assertEquals(OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep.getProtocol());
+        assertEquals("foo", clientRep.getClientId());
+        assertEquals(ClientTypeManager.SERVICE_ACCOUNT, clientRep.getType());
+        assertEquals(OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep.getProtocol());
         Assert.assertFalse(clientRep.isStandardFlowEnabled());
         Assert.assertFalse(clientRep.isImplicitFlowEnabled());
         Assert.assertFalse(clientRep.isDirectAccessGrantsEnabled());
@@ -87,6 +86,17 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
 
         // Check type not included as client attribute
         Assert.assertFalse(clientRep.getAttributes().containsKey(ClientModel.TYPE));
+    }
+
+    @Test
+    public void testThatCreateClientWithWrongClientTypeFails() {
+        ClientRepresentation clientRep = ClientBuilder.create()
+                .clientId("client-type-does-not-exist-request")
+                .type("DNE")
+                .build();
+
+        Response response = testRealm().clients().create(clientRep);
+        assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
     }
 
     @Test
@@ -133,7 +143,7 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
     public void testClientTypesAdminRestAPI_globalTypes() {
         ClientTypesRepresentation clientTypes = testRealm().clientTypes().getClientTypes();
 
-        Assert.assertEquals(0, clientTypes.getRealmClientTypes().size());
+        assertEquals(0, clientTypes.getRealmClientTypes().size());
 
         List<String> globalClientTypeNames = clientTypes.getGlobalClientTypes().stream()
                 .map(ClientTypeRepresentation::getName)
@@ -144,7 +154,7 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
                 .filter(clientType -> "service-account".equals(clientType.getName()))
                 .findFirst()
                 .get();
-        Assert.assertEquals("default", serviceAccountType.getProvider());
+        assertEquals("default", serviceAccountType.getProvider());
 
         ClientTypeRepresentation.PropertyConfig cfg = serviceAccountType.getConfig().get("standardFlowEnabled");
         assertPropertyConfig("standardFlowEnabled", cfg, true, true, false);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
@@ -122,15 +122,11 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
             // Expected
         }
 
-        // Adding non-applicable attribute should fail
+
         clientRep.setServiceAccountsEnabled(true);
+
+        // Adding non-applicable attribute should not fail
         clientRep.getAttributes().put(ClientModel.LOGO_URI, "https://foo");
-        try {
-            testRealm().clients().get(clientRep.getId()).update(clientRep);
-            Assert.fail("Not expected to update client");
-        } catch (BadRequestException bre) {
-            // Expected
-        }
 
         // Update of supported attribute should be successful
         clientRep.getAttributes().remove(ClientModel.LOGO_URI);


### PR DESCRIPTION
Closes #28528.

Improves validation of client creation and update requests, by returning the full list of fields that failed due to being non-applicable or read-only and a value being specified by the request.

Respond with 400 bad request response and all failures are provided in the params response field.