### PR TITLE
Add sub via protocol mapper to access token

### DIFF
--- a/core/src/main/java/org/keycloak/TokenVerifier.java
+++ b/core/src/main/java/org/keycloak/TokenVerifier.java
@@ -256,7 +256,6 @@ public class TokenVerifier<T extends JsonWebToken> {
     public TokenVerifier<T> withDefaultChecks()  {
         return withChecks(
           RealmUrlCheck.NULL_INSTANCE,
-          SUBJECT_EXISTS_CHECK,
           TokenTypeCheck.INSTANCE_DEFAULT_TOKEN_TYPE,
           IS_ACTIVE
         );

--- a/docs/documentation/server_admin/topics/clients/con-protocol-mappers.adoc
+++ b/docs/documentation/server_admin/topics/clients/con-protocol-mappers.adoc
@@ -67,6 +67,12 @@ Use the *Script Mapper* to map claims to tokens by running user-defined JavaScri
 
 When scripts deploy, you should be able to select the deployed scripts from the list of available mappers.
 
+== Pairwise subject identifier mapper
+
+Subject claim _sub_ is mapped by default by *Subject (sub)* protocol mapper in the default client scope *basic*.
+
+To use a pairwise subject identifier by using a protocol mapper such as *Pairwise subject identifier*, remove the *Subject (sub)* protocol mapper from the *basic* client scope.
+
 [[_using_lightweight_access_token]]
 == Using lightweight access token
 The access token in {project_name} contains sensitive information, including Personal Identifiable Information (PII).
@@ -75,7 +81,7 @@ Further, when the resource server acquires the PII removed from the access token
 
 Information that cannot be removed from a lightweight access token::
   Protocol mappers can controls which information is put onto an access token and the lightweight access token use the protocol mappers. Therefore, the following information cannot be removed from the lightweight access. +
-  `exp`, `iat`, `jti`, `iss`, `sub`, `typ`, `azp`, `nonce`, `sid`, `scope`, `cnf`
+  `exp`, `iat`, `jti`, `iss`, `typ`, `azp`, `sid`, `scope`, `cnf`
 
 Using a lightweight access token in {project_name}::
   By applying `use-lightweight-access-token` executor of <<_client_policies, client policies>> to a client, the client can receive a lightweight access token instead of an access token. The lightweight access token contains a claim controlled by a protocol mapper where its setting `Add to lightweight access token`(default OFF) is turned ON. Also, by turning ON its setting `Add to token introspection` of the protocol mapper, the client can obtain the claim by sending the access token to {project_name}'s token introspection endpoint.

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -89,7 +89,19 @@ Note that the `setSessionState()` method is also removed from the `IDToken` clas
 
 A new `Session State (session_state)` mapper is also included and can be assigned to client scopes (for instance `basic` client scope) to revert to the old behavior.
 
-If an old version of the JS adapter is used, the `Session State (session_state)` mapper should also be used via client scopes as described above.
+If an old version of the JS adapter is used, the `Session State (session_state)` mapper should also be used by using client scopes as described above.
+
+= `sub` claim is added to access token via protocol mapper
+
+The `sub` claim, which was always added to the access token, is now added by default but using a new `Subject (sub)` protocol mapper.
+
+The `Subject (sub)` mapper is configured by default in the `basic` client scope. Therefore, no extra configuration is required after upgrading to this version.
+
+Only in the case you are using `Pairwise subject identifier` mapper to map `sub` claim for access token you should disable or remove `Subject (sub)` mapper.
+
+You can use the `Subject (sub)` mapper to configure the `sub` claim only for access token, lightweight access token, and introspection response. IDToken and Userinfo always contain `sub` claim.
+
+The mapper has no effects for service accounts, because no user session exists, and the`sub` claim is always added to the access token.
 
 = Default `http-pool-max-threads` reduced
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -45,6 +45,7 @@ import org.keycloak.protocol.oidc.mappers.UserClientRoleMappingMapper;
 import org.keycloak.protocol.oidc.mappers.UserPropertyMapper;
 import org.keycloak.protocol.oidc.mappers.UserRealmRoleMappingMapper;
 import org.keycloak.protocol.oidc.mappers.UserSessionNoteMapper;
+import org.keycloak.protocol.oidc.mappers.SubMapper;
 import org.keycloak.representations.IDToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.ServicesLogger;
@@ -226,7 +227,10 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         model = UserSessionNoteMapper.createClaimMapper(IDToken.AUTH_TIME, AuthenticationManager.AUTH_TIME,
                 IDToken.AUTH_TIME, "long",
                 true, true, false, true);
-        builtins.put(BASIC_SCOPE, model);
+        builtins.put(IDToken.AUTH_TIME, model);
+
+        model = SubMapper.create(IDToken.SUBJECT,true, true);
+        builtins.put(IDToken.SUBJECT, model);
     }
 
     private void createUserAttributeMapper(String name, String attrName, String claimName, String type) {
@@ -420,7 +424,8 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             basicScope.setDisplayOnConsentScreen(false);
             basicScope.setIncludeInTokenScope(false);
             basicScope.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-            basicScope.addProtocolMapper(builtins.get(BASIC_SCOPE));
+            basicScope.addProtocolMapper(builtins.get(IDToken.AUTH_TIME));
+            basicScope.addProtocolMapper(builtins.get(IDToken.SUBJECT));
 
             newRealm.addDefaultClientScope(basicScope, true);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -387,7 +387,7 @@ public class TokenManager {
      */
     public static UserModel lookupUserFromStatelessToken(KeycloakSession session, RealmModel realm, AccessToken token) {
         // Try to lookup user based on "sub" claim. It should work for most cases with some rare exceptions (EG. OIDC "pairwise" subjects)
-        UserModel user = session.users().getUserById(realm, token.getSubject());
+        UserModel user = token.getSubject() == null ? null : session.users().getUserById(realm, token.getSubject());
         if (user != null) {
             return user;
         }
@@ -976,7 +976,9 @@ public class TokenManager {
         AccessToken token = new AccessToken();
         token.id(KeycloakModelUtils.generateId());
         token.type(TokenUtil.TOKEN_TYPE_BEARER);
-        token.subject(user.getId());
+        if (UserSessionModel.SessionPersistenceState.TRANSIENT.equals(session.getPersistenceState())) {
+            token.subject(user.getId());
+        }
         token.issuedNow();
         token.issuedFor(client.getClientId());
 
@@ -1184,7 +1186,7 @@ public class TokenManager {
             idToken = new IDToken();
             idToken.id(KeycloakModelUtils.generateId());
             idToken.type(TokenUtil.TOKEN_TYPE_ID);
-            idToken.subject(accessToken.getSubject());
+            idToken.subject(userSession.getUser().getId());
             idToken.audience(client.getClientId());
             idToken.issuedNow();
             idToken.issuedFor(accessToken.getIssuedFor());

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -49,3 +49,4 @@ org.keycloak.protocol.saml.mappers.UserAttributeNameIdMapper
 org.keycloak.protocol.oidc.mappers.ClaimsParameterWithValueIdTokenMapper
 org.keycloak.protocol.oidc.mappers.NonceBackwardsCompatibleMapper
 org.keycloak.protocol.oidc.mappers.SessionStateMapper
+org.keycloak.protocol.oidc.mappers.SubMapper

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/HardcodedClientStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/HardcodedClientStorageProvider.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jboss.logging.Logger;
@@ -107,8 +108,10 @@ public class HardcodedClientStorageProvider implements ClientStorageProvider, Cl
         if (defaultScope) {
                 ClientScopeModel rolesScope = KeycloakModelUtils.getClientScopeByName(realm, OIDCLoginProtocolFactory.ROLES_SCOPE);
                 ClientScopeModel webOriginsScope = KeycloakModelUtils.getClientScopeByName(realm, OIDCLoginProtocolFactory.WEB_ORIGINS_SCOPE);
-                return Arrays.asList(rolesScope, webOriginsScope)
+                ClientScopeModel basicScope = KeycloakModelUtils.getClientScopeByName(realm, OIDCLoginProtocolFactory.BASIC_SCOPE);
+                return Arrays.asList(rolesScope, webOriginsScope, basicScope)
                         .stream()
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toMap(ClientScopeModel::getName, clientScope -> clientScope));
 
             } else {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
@@ -28,6 +28,7 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.client.registration.Auth;
 import org.keycloak.client.registration.ClientRegistrationException;
 import org.keycloak.client.registration.HttpErrorException;
+import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.protocol.oidc.mappers.SHA256PairwiseSubMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
@@ -90,6 +91,7 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
         OIDCClientRepresentation clientRep = createRep();
         clientRep.setSubjectType("pairwise");
         OIDCClientRepresentation pairwiseClient = reg.oidc().create(clientRep);
+        removeDefaultBasicClientScope(pairwiseClient.getClientId());
         return pairwiseClient;
     }
 
@@ -327,11 +329,8 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
         Assert.assertEquals(user.getId(), tokenUserId);
 
         // Create pairwise client
-        OIDCClientRepresentation clientRep = createRep();
-        clientRep.setSubjectType("pairwise");
-        OIDCClientRepresentation pairwiseClient = reg.oidc().create(clientRep);
+        OIDCClientRepresentation pairwiseClient = createPairwise();
         Assert.assertEquals("pairwise", pairwiseClient.getSubjectType());
-
         // Login to pairwise client
         oauth.clientId(pairwiseClient.getClientId());
         oauth.openLoginForm();
@@ -371,7 +370,6 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
     public void refreshPairwiseToken() throws Exception {
         // Create pairwise client
         OIDCClientRepresentation pairwiseClient = createPairwise();
-
         // Login to pairwise client
         OAuthClient.AccessTokenResponse accessTokenResponse = login(pairwiseClient, "test-user@localhost", "password");
 
@@ -486,5 +484,25 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
     private String getPayload(String token) {
         String payloadBase64 = token.split("\\.")[1];
         return new String(Base64.getDecoder().decode(payloadBase64));
+    }
+
+    public void addDefaultBasicClientScope(String clientId) {
+        realmsResouce().realm(REALM_NAME).getDefaultDefaultClientScopes()
+                .stream()
+                .filter(scope-> scope.getName().equals(OIDCLoginProtocolFactory.BASIC_SCOPE))
+                .findFirst()
+                .ifPresent(scope-> {
+                    ApiUtil.findClientResourceByClientId(adminClient.realm(REALM_NAME), clientId).addDefaultClientScope(scope.getId());
+                });
+    }
+
+    public void removeDefaultBasicClientScope(String clientId) {
+        realmsResouce().realm(REALM_NAME).getDefaultDefaultClientScopes()
+                .stream()
+                .filter(scope-> scope.getName().equals(OIDCLoginProtocolFactory.BASIC_SCOPE))
+                .findFirst()
+                .ifPresent(scope-> {
+                    ApiUtil.findClientResourceByClientId(adminClient.realm(REALM_NAME), clientId).removeDefaultClientScope(scope.getId());
+                });
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
@@ -378,7 +378,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
 
         // create a user attr mapping for some claims that exist as properties in the tokens
         ClientResource app = findClientResourceByClientId(adminClient.realm("test"), "test-app");
-        app.getProtocolMappers().createMapper(createClaimMapper("userid-as-sub", "userid", "sub", "String", true, true, true,false)).close();
+        app.getProtocolMappers().createMapper(createClaimMapper("userid-as-sub", "userid", "sub", "String", false, true, true,false)).close();
         app.getProtocolMappers().createMapper(createClaimMapper("useraud", "useraud", "aud", "String", true, true, true, true)).close();
         app.getProtocolMappers().createMapper(createHardcodedClaim("website-hardcoded", "website", "http://localhost", "String", true, true, true)).close();
         app.getProtocolMappers().createMapper(createHardcodedClaim("iat-hardcoded", "iat", "123", "long", true, false, true)).close();
@@ -394,7 +394,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
         assertThat(Arrays.asList(idToken.getAudience()), hasItems("test-app", "other"));
 
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
-        assertEquals(user.firstAttribute("userid"), accessToken.getSubject());
+        assertNotEquals(user.firstAttribute("userid"), accessToken.getSubject());
         assertEquals("http://localhost", accessToken.getWebsite());
         assertNotNull(accessToken.getAudience());
         assertThat(Arrays.asList(accessToken.getAudience()), hasItems("test-app", "other"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -349,7 +349,6 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
             assertTrue(rep.isActive());
             assertEquals("test-user@localhost", rep.getUserName());
             assertEquals("no-scope", rep.getClientId());
-            assertEquals(loginEvent.getUserId(), rep.getSubject());
             assertNull(rep.getScope());
         } finally {
             testRealm.setClientScopes(preExistingClientScopes);


### PR DESCRIPTION
With this PR `sub` claim is removed from lightweight access token and you can also remove it from the access token as well.

`sub` claim, which was always added to access token, is now added by default using a new `SubMapper` protocol mapper.

This mapper is configured by default in the `basic` client scope so no extra configuration is required after upgrading to this version.

The Sub (sub) mapper allows you to configure the sub claim only for access token, lightweight access token and introspection response, instead [IDToken](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) and [Userinfo](https://openid.net/specs/openid-connect-core-1_0.html#IDToken:~:text=The%20sub%20(subject)%20Claim%20MUST%20always%20be%20returned%20in%20the%20UserInfo%20Response) always contain sub claim as specification.

The `sub` claim is always added to access token in case of transient user session because using `sub` is the only way to get the user when session id is missing.

Closes #21185
