### PR TITLE
Add VS Code configuration for ESlint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.workingDirectories": ["js"]
+}


### PR DESCRIPTION
Adds configuration for VS Code so that it can properly find the ESLint configuration, see https://github.com/microsoft/vscode-eslint/issues/1826 for more information.