### PR TITLE
Revert "Update disabled feature status code in social login tests"

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -625,7 +625,7 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         Assert.assertEquals(1, users.size());
 
         String username = users.get(0).getUsername();
-        checkFeature(400, username);
+        checkFeature(501, username);
 
         testingClient.enableFeature(Profile.Feature.TOKEN_EXCHANGE);
 
@@ -712,7 +712,7 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         } finally {
             httpClient.close();
             testingClient.disableFeature(Profile.Feature.TOKEN_EXCHANGE);
-            checkFeature(400, username);
+            checkFeature(501, username);
         }
     }
 }


### PR DESCRIPTION
This commit shouldn't've been backported to KC 22