### PR TITLE
Fix Husky setup

### DIFF
--- a/js/.husky/pre-commit
+++ b/js/.husky/pre-commit
@@ -7,5 +7,4 @@ if [ ! -f "$FILE" ]; then
   exit 0;
 fi
 
-cd js
-pnpm exec lint-staged
+ESLINT_USE_FLAT_CONFIG=true pnpm exec lint-staged

--- a/js/lint-staged.config.js
+++ b/js/lint-staged.config.js
@@ -1,0 +1,8 @@
+import path from "node:path";
+
+const CONFIG_PATH = path.resolve(import.meta.dirname, "eslint.config.js");
+
+export default {
+  "*.{js,jsx,mjs,ts,tsx}": (filenames) =>
+    `eslint --config ${CONFIG_PATH} --cache --fix ${filenames.join(" ")}`,
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "type": "module",
   "scripts": {
-    "prepare": "cd .. && husky js/.husky"
+    "prepare": "husky js/.husky"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.2",
@@ -24,8 +24,5 @@
     "typescript-eslint": "^7.6.0",
     "wireit": "^0.14.4"
   },
-  "packageManager": "pnpm@8.15.5",
-  "lint-staged": {
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix"
-  }
+  "packageManager": "pnpm@8.15.5"
 }


### PR DESCRIPTION
Fixes the Husky setup so it executes in the correct directory and explicitly adds the ESLint configuration to the command line. This is needed as ESLint v8 cannot find the flat config in some scenarios, an issue that will be resolved automatically when we upgrade to v9 in the future.