### PR TITLE
fix: adds a test and permissions for cache configmap

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -18,6 +18,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - secrets
       - services
     verbs:

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.events.v1.Event;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -169,6 +170,8 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
     K8sUtils.set(k8sclient, new FileInputStream(TARGET_KUBERNETES_GENERATED_YML_FOLDER + deploymentTarget + ".yml"), obj -> {
         if (obj instanceof ClusterRoleBinding) {
             ((ClusterRoleBinding)obj).getSubjects().forEach(s -> s.setNamespace(namespace));
+        } else if (obj instanceof RoleBinding && "keycloak-operator-view".equals(((RoleBinding)obj).getMetadata().getName())) {
+            return null; // exclude this role since it's not present in olm
         }
         return obj;
     });

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/CacheTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/CacheTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.quarkus.logging.Log;
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.CacheSpecBuilder;
+import org.keycloak.operator.testsuite.utils.CRAssert;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+
+@QuarkusTest
+public class CacheTest extends BaseOperatorTest {
+
+    private static final String CONFIGMAP_NAME = "my-config";
+
+    @AfterEach
+    public void cleanupConfigMap() {
+        k8sclient.configMaps().withName(CONFIGMAP_NAME).delete();
+    }
+
+    @Test
+    public void testCreateCacheConfigMapFileAfterDeployment() {
+        var kc = getTestKeycloakDeployment(true);
+        var deploymentName = kc.getMetadata().getName();
+        kc.getSpec().setCacheSpec(new CacheSpecBuilder().withNewConfigMapFile("file", CONFIGMAP_NAME, false).build());
+
+        deployKeycloak(k8sclient, kc, false);
+
+        // Check Operator has deployed Keycloak and the statefulset exists, this allows
+        // for the watched configmap to be picked up
+        Log.info("Checking Operator has deployed Keycloak deployment");
+        Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);
+        Resource<Keycloak> keycloakResource = k8sclient.resources(Keycloak.class).withName(deploymentName);
+        // expect no errors and not ready, which means we'll keep reconciling
+        Awaitility.await().ignoreExceptions().atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertThat(stsResource.get()).isNotNull();
+            Keycloak keycloak = keycloakResource.get();
+            CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.HAS_ERRORS, false);
+            CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.READY, false);
+        });
+
+        createCacheConfigMap();
+
+        K8sUtils.waitForKeycloakToBeReady(k8sclient, kc);
+    }
+
+    @Test
+    public void testCacheConfigMapFile() {
+        var kc = getTestKeycloakDeployment(true);
+        kc.getSpec().setCacheSpec(new CacheSpecBuilder().withNewConfigMapFile("file", CONFIGMAP_NAME, false).build());
+
+        createCacheConfigMap();
+        deployKeycloak(k8sclient, kc, true);
+    }
+
+    private void createCacheConfigMap() {
+        k8sclient.configMaps()
+                .resource(new ConfigMapBuilder().withNewMetadata().withName(CONFIGMAP_NAME).endMetadata()
+                        .addToData("file",
+                                """
+                                        <infinispan
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:schemaLocation="urn:infinispan:config:14.0 http://www.infinispan.org/schemas/infinispan-config-14.0.xsd"
+                                                xmlns="urn:infinispan:config:14.0">
+
+                                            <cache-container name="keycloak">
+                                                <local-cache name="default">
+                                                    <transaction transaction-manager-lookup="org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup"/>
+                                                </local-cache>
+                                            </cache-contianer>
+                                        </infinispan>""")
+                        .build())
+                .create();
+    }
+
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -68,7 +68,7 @@ public final class K8sUtils {
     }
 
     public static List<HasMetadata> set(KubernetesClient client, InputStream stream, Function<HasMetadata, HasMetadata> modifier) {
-        return client.load(stream).items().stream().map(modifier).map(i -> set(client, i)).collect(Collectors.toList());
+        return client.load(stream).items().stream().map(modifier).filter(Objects::nonNull).map(i -> set(client, i)).collect(Collectors.toList());
     }
 
     public static <T extends HasMetadata> T set(KubernetesClient client, T hasMetadata) {


### PR DESCRIPTION
closes: #28638

To match olm we need to remove the auto-generated view role from the remote tests. From there rbac on minikube is sufficient to catch this situation.

Added the permissions that will allow for using a watch/informer or polling.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
