### PR TITLE
Retry the login in the SAML adapter if response is authentication_expired

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/AbstractInitiateLogin.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/AbstractInitiateLogin.java
@@ -40,10 +40,16 @@ public abstract class AbstractInitiateLogin implements AuthChallenge {
 
     protected SamlDeployment deployment;
     protected SamlSessionStore sessionStore;
+    protected boolean saveRequestUri;
 
     public AbstractInitiateLogin(SamlDeployment deployment, SamlSessionStore sessionStore) {
+        this(deployment, sessionStore, true);
+    }
+
+    public AbstractInitiateLogin(SamlDeployment deployment, SamlSessionStore sessionStore, boolean saveRequestUri) {
         this.deployment = deployment;
         this.sessionStore = sessionStore;
+        this.saveRequestUri = saveRequestUri;
     }
 
     @Override
@@ -56,7 +62,9 @@ public abstract class AbstractInitiateLogin implements AuthChallenge {
         try {
             SAML2AuthnRequestBuilder authnRequestBuilder = buildSaml2AuthnRequestBuilder(deployment);
             BaseSAML2BindingBuilder binding = createSaml2Binding(deployment);
-            sessionStore.saveRequest();
+            if (saveRequestUri) {
+                sessionStore.saveRequest();
+            }
 
             sendAuthnRequest(httpFacade, authnRequestBuilder, binding);
             sessionStore.setCurrentAction(SamlSessionStore.CurrentAction.LOGGING_IN);

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/AdapterConstants.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/AdapterConstants.java
@@ -25,4 +25,5 @@ public class AdapterConstants {
     public static final String AUTH_DATA_PARAM_NAME="org.keycloak.saml.xml.adapterConfig";
     public static final String REPLICATION_CONFIG_CONTAINER_PARAM_NAME = "org.keycloak.saml.replication.container";
     public static final String REPLICATION_CONFIG_SSO_CACHE_PARAM_NAME = "org.keycloak.saml.replication.cache.sso";
+    public static final String AUTHENTICATION_EXPIRED_MESSAGE = "authentication_expired";
 }

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/ecp/EcpAuthenticationHandler.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/ecp/EcpAuthenticationHandler.java
@@ -105,8 +105,8 @@ public class EcpAuthenticationHandler extends AbstractSamlAuthenticationHandler 
     }
 
     @Override
-    protected AbstractInitiateLogin createChallenge() {
-        return new AbstractInitiateLogin(deployment, sessionStore) {
+    protected AbstractInitiateLogin createChallenge(boolean saveChallenge) {
+        return new AbstractInitiateLogin(deployment, sessionStore, saveChallenge) {
             @Override
             protected void sendAuthnRequest(HttpFacade httpFacade, SAML2AuthnRequestBuilder authnRequestBuilder, BaseSAML2BindingBuilder binding) {
                 try {


### PR DESCRIPTION
Closes #28412

Now the SAML adapter checks the result and if it's `authentication_expired` the login is re-initiated/re-tried. The only difference with a normal login is that the current URI is not saved as the one to redirect back when logged-in. The current URL is for sure `/saml` which is internal and a 404 for the app (so it uses the previous saved URI or default if it doesn't exist, timed-out or whatever). Added two methods to test normal and expired re-try when login happened in another tab.