### PR TITLE
Ensure correct treatment of auth and transient users

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AdminExtResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AdminExtResource.java
@@ -57,6 +57,6 @@ public final class AdminExtResource {
 
     @Path("/users")
     public UsersResource users() {
-        return new UsersResource(session);
+        return new UsersResource(session, auth);
     }
 }

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UsersResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UsersResource.java
@@ -6,21 +6,38 @@ import jakarta.ws.rs.PathParam;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+import jakarta.ws.rs.ForbiddenException;
 
 public class UsersResource {
     private final KeycloakSession session;
 
-    public UsersResource(KeycloakSession session) {
+    private final AdminPermissionEvaluator auth;
+
+    public UsersResource(KeycloakSession session, AdminPermissionEvaluator auth) {
         this.session = session;
+        this.auth = auth;
     }
 
     @Path("{id}")
     public UserResource getUser(@PathParam("id") String id) {
         RealmModel realm = session.getContext().getRealm();
-        UserModel user = session.users().getUserById(realm, id);
+        UserModel user = null;
+        if (LightweightUserAdapter.isLightweightUser(id)) {
+            UserSessionModel userSession = session.sessions().getUserSession(realm, LightweightUserAdapter.getLightweightUserId(id));
+            if (userSession != null) {
+                user = userSession.getUser();
+            }
+        } else {
+            user = session.users().getUserById(realm, id);
+        }
 
         if (user == null) {
-            throw new NotFoundException();
+            // we do this to make sure somebody can't phish ids
+            if (auth.users().canQuery()) throw new NotFoundException("User not found");
+            else throw new ForbiddenException();
         }
 
         return new UserResource(session, user);


### PR DESCRIPTION
This commit establishes consistency in retrieval of users and responses between `org.keycloak.admin.ui.rest.UsersResource.getUser(String)` and [`org.keycloak.services.resources.admin.UsersResource.user(String)`](https://github.com/keycloak/keycloak/blob/61b1eec50432a3c2d4917c663be70dd72abefb7f/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java#L198-L216)

Fixes: #28666

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
