### PR TITLE
#24462 Refactor element identifiers from ID to class

### DIFF
--- a/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnAuthenticatorsList.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnAuthenticatorsList.java
@@ -37,17 +37,17 @@ import static org.keycloak.testsuite.util.UIUtils.getTextFromElementOrNull;
  */
 public class WebAuthnAuthenticatorsList {
 
-    @FindBy(id = "kc-webauthn-authenticator")
+    @FindBy(className = "kc-webauthn-authenticator")
     private List<WebElement> authenticators;
 
     public List<WebAuthnAuthenticatorItem> getItems() {
         try {
             List<WebAuthnAuthenticatorItem> items = new ArrayList<>();
             for (WebElement auth : authenticators) {
-                String name = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-label")));
-                String createdAt = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-created")));
-                String createdAtLabel = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-created-label")));
-                String transport = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-transport")));
+                String name = getTextFromElementOrNull(() -> auth.findElement(By.className("kc-webauthn-authenticator-label")));
+                String createdAt = getTextFromElementOrNull(() -> auth.findElement(By.className("kc-webauthn-authenticator-created")));
+                String createdAtLabel = getTextFromElementOrNull(() -> auth.findElement(By.className("kc-webauthn-authenticator-created-label")));
+                String transport = getTextFromElementOrNull(() -> auth.findElement(By.className("kc-webauthn-authenticator-transport")));
                 items.add(new WebAuthnAuthenticatorItem(name, createdAt, createdAtLabel, transport));
             }
             return items;

--- a/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnLoginPage.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnLoginPage.java
@@ -35,7 +35,7 @@ public class WebAuthnLoginPage extends LanguageComboboxAwarePage {
     @FindBy(id = "authenticateWebAuthnButton")
     private WebElement authenticateButton;
 
-    @FindBy(id = "kc-webauthn-authenticator-label")
+    @FindBy(className = "kc-webauthn-authenticator-label")
     private List<WebElement> authenticatorsLabels;
 
     @Page

--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -30,19 +30,19 @@
 
                         <div class="${properties.kcFormClass!}">
                             <#list authenticators.authenticators as authenticator>
-                                <div id="kc-webauthn-authenticator" class="${properties.kcSelectAuthListItemClass!}">
+                                <div class="kc-webauthn-authenticator ${properties.kcSelectAuthListItemClass!}">
                                     <div class="${properties.kcSelectAuthListItemIconClass!}">
                                         <i class="${(properties['${authenticator.transports.iconClass}'])!'${properties.kcWebAuthnDefaultIcon!}'} ${properties.kcSelectAuthListItemIconPropertyClass!}"></i>
                                     </div>
                                     <div class="${properties.kcSelectAuthListItemBodyClass!}">
-                                        <div id="kc-webauthn-authenticator-label"
-                                             class="${properties.kcSelectAuthListItemHeadingClass!}">
+                                        <div
+                                             class=" kc-webauthn-authenticator-label ${properties.kcSelectAuthListItemHeadingClass!}">
                                             ${kcSanitize(msg('${authenticator.label}'))?no_esc}
                                         </div>
 
                                         <#if authenticator.transports?? && authenticator.transports.displayNameProperties?has_content>
-                                            <div id="kc-webauthn-authenticator-transport"
-                                                 class="${properties.kcSelectAuthListItemDescriptionClass!}">
+                                            <div
+                                                 class="kc-webauthn-authenticator-transport ${properties.kcSelectAuthListItemDescriptionClass!}">
                                                 <#list authenticator.transports.displayNameProperties as nameProperty>
                                                     <span>${kcSanitize(msg('${nameProperty!}'))?no_esc}</span>
                                                     <#if nameProperty?has_next>
@@ -53,10 +53,10 @@
                                         </#if>
 
                                         <div class="${properties.kcSelectAuthListItemDescriptionClass!}">
-                                            <span id="kc-webauthn-authenticator-created-label">
+                                            <span class="kc-webauthn-authenticator-created-label">
                                                 ${kcSanitize(msg('webauthn-createdAt-label'))?no_esc}
                                             </span>
-                                            <span id="kc-webauthn-authenticator-created">
+                                            <span class="kc-webauthn-authenticator-created">
                                                 ${kcSanitize(authenticator.createdAt)?no_esc}
                                             </span>
                                         </div>


### PR DESCRIPTION
The commit replaces the usage of element ID identifiers with class identifiers in webauthn-authenticate.ftl. This applies to the test suite and login elements in the 'webauthn-authenticate.ftl' theme. closes #24462

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
