### PR TITLE
Encode realm name in URL when fetching from `ui-ext`

### DIFF
--- a/js/apps/admin-ui/src/context/auth/admin-ui-endpoint.ts
+++ b/js/apps/admin-ui/src/context/auth/admin-ui-endpoint.ts
@@ -11,8 +11,12 @@ export async function fetchAdminUI<T>(
   const baseUrl = adminClient.baseUrl;
 
   const response = await fetchWithError(
-    joinPath(baseUrl, "admin/realms", adminClient.realmName, endpoint) +
-      (query ? "?" + new URLSearchParams(query) : ""),
+    joinPath(
+      baseUrl,
+      "admin/realms",
+      encodeURIComponent(adminClient.realmName),
+      endpoint,
+    ) + (query ? "?" + new URLSearchParams(query) : ""),
     {
       method: "GET",
       headers: getAuthorizationHeaders(accessToken),


### PR DESCRIPTION
closes #28702


