### PR TITLE
Explicitly specify React version for ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,11 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    settings: {
+      react: {
+        version: "18",
+      },
+    },
     rules: {
       // ## Rules overwriting config, disabled for now, but will have to be evaluated. ##
       "no-undef": "off",
@@ -143,5 +148,5 @@ export default tseslint.config(
       "mocha/no-mocha-arrows": "off",
       "mocha/no-setup-in-describe": "off",
     },
-  }
+  },
 );


### PR DESCRIPTION
Specifies the React version explicitly in the ESLint configuration, this prevents warnings when the React version cannot be automatically detected.