### PR TITLE
fix: add / clean labels on community images

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -19,3 +19,42 @@ USER 1000
 WORKDIR /opt/keycloak
 
 ENTRYPOINT [ "java", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "quarkus-run.jar" ]
+
+# common labels
+ARG KEYCLOAK_VERSION
+ARG KEYCLOAK_URL="https://www.keycloak.org/"
+ARG KEYCLOAK_TAGS="keycloak security identity"
+ARG KEYCLOAK_MAINTAINER=${KEYCLOAK_URL}
+ARG KEYCLOAK_VENDOR=${KEYCLOAK_MAINTAINER}
+
+LABEL maintainer=${KEYCLOAK_MAINTAINER} \
+      vendor=${KEYCLOAK_VENDOR} \
+      version=${KEYCLOAK_VERSION} \
+      url=${KEYCLOAK_URL} \
+      io.openshift.tags=${KEYCLOAK_TAGS} \
+      release="" \
+      vcs-ref="" \
+      com.redhat.build-host="" \
+      com.redhat.component="" \
+      com.redhat.license_terms=""
+
+# operator specific
+ARG KEYCLOAK_OPERATOR_DISPLAY_NAME="Keycloak Operator"
+ARG KEYCLOAK_OPERATOR_IMAGE_NAME="keycloak-operator"
+ARG KEYCLOAK_OPERATOR_DESCRIPTION="${KEYCLOAK_OPERATOR_DISPLAY_NAME} Image"
+
+LABEL name=${KEYCLOAK_OPERATOR_IMAGE_NAME} \
+      description=${KEYCLOAK_OPERATOR_DESCRIPTION} \
+      summary=${KEYCLOAK_OPERATOR_DESCRIPTION} \
+      io.k8s.display-name=${KEYCLOAK_OPERATOR_DISPLAY_NAME} \
+      io.k8s.description=${KEYCLOAK_OPERATOR_DESCRIPTION}
+
+# oci
+ARG KEYCLOAK_SOURCE="https://github.com/keycloak/keycloak"
+ARG KEYCLOAK_DOCS=${KEYCLOAK_URL}documentation
+
+LABEL org.opencontainers.image.title=${KEYCLOAK_OPERATOR_DISPLAY_NAME} \
+      org.opencontainers.image.url=${KEYCLOAK_URL} \
+      org.opencontainers.image.source=${KEYCLOAK_SOURCE} \
+      org.opencontainers.image.description=${KEYCLOAK_DESCRIPTION} \
+      org.opencontainers.image.documentation=${KEYCLOAK_DOCS}

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -23,6 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
+        <quarkus.docker.build-args.KEYCLOAK_VERSION>${project.version}</quarkus.docker.build-args.KEYCLOAK_VERSION>
     </properties>
 
     <dependencyManagement>

--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -38,3 +38,42 @@ EXPOSE 8443
 EXPOSE 9000
 
 ENTRYPOINT [ "/opt/keycloak/bin/kc.sh" ]
+
+# common labels
+ARG KEYCLOAK_VERSION
+ARG KEYCLOAK_URL="https://www.keycloak.org/"
+ARG KEYCLOAK_TAGS="keycloak security identity"
+ARG KEYCLOAK_MAINTAINER=${KEYCLOAK_URL}
+ARG KEYCLOAK_VENDOR=${KEYCLOAK_MAINTAINER}
+
+LABEL maintainer=${KEYCLOAK_MAINTAINER} \
+      vendor=${KEYCLOAK_VENDOR} \
+      version=${KEYCLOAK_VERSION} \
+      url=${KEYCLOAK_URL} \
+      io.openshift.tags=${KEYCLOAK_TAGS} \
+      release="" \
+      vcs-ref="" \
+      com.redhat.build-host="" \
+      com.redhat.component="" \
+      com.redhat.license_terms=""
+
+# server specific
+ARG KEYCLOAK_SERVER_DISPLAY_NAME="Keycloak Server"
+ARG KEYCLOAK_SERVER_IMAGE_NAME="keycloak"
+ARG KEYCLOAK_SERVER_DESCRIPTION="${KEYCLOAK_SERVER_DISPLAY_NAME} Image"
+
+LABEL name=${KEYCLOAK_SERVER_IMAGE_NAME} \
+      description=${KEYCLOAK_SERVER_DESCRIPTION} \
+      summary=${KEYCLOAK_SERVER_DESCRIPTION} \
+      io.k8s.display-name=${KEYCLOAK_SERVER_DISPLAY_NAME} \
+      io.k8s.description=${KEYCLOAK_SERVER_DESCRIPTION}
+
+# oci
+ARG KEYCLOAK_SOURCE="https://github.com/keycloak/keycloak"
+ARG KEYCLOAK_DOCS=${KEYCLOAK_URL}documentation
+
+LABEL org.opencontainers.image.title=${KEYCLOAK_SERVER_DISPLAY_NAME} \
+      org.opencontainers.image.url=${KEYCLOAK_URL} \
+      org.opencontainers.image.source=${KEYCLOAK_SOURCE} \
+      org.opencontainers.image.description=${KEYCLOAK_DESCRIPTION} \
+      org.opencontainers.image.documentation=${KEYCLOAK_DOCS}


### PR DESCRIPTION
closes: #24414

Aligns label handling of the operator and server images when built locally. A keycloak-rel pr will be added that will pass the KEYCLOAK_VERSION as a build arg to the server image build. At that point the community releases will be up-to-date. 

We can optionally update the product build to include a similar set of labels.

There are still a few more oci labels that could be included, but they are dependent upon build information - timestamp, commit sha, etc. so those were left off for now.

This mostly renders https://github.com/keycloak-rel/keycloak-rel/pull/103 obsolute - we just need to agree on how the description in particular should read. That pr has:

"Open Source Identity and Access Management For Modern Applications and Services"

@abstractj can you weigh in on what you want the maintainer set to?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
