### PR TITLE
Fix OCSP nonce handling

### DIFF
--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCOCSPProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCOCSPProvider.java
@@ -53,17 +53,16 @@ import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.keycloak.jose.jwe.JWEUtils;
 import org.keycloak.common.util.BouncyIntegration;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.utils.OCSPProvider;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.SecureRandom;
 import java.security.cert.CRLReason;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidatorException;
@@ -120,26 +119,24 @@ public class BCOCSPProvider extends OCSPProvider {
 
             JcaCertificateID certificateID = new JcaCertificateID(digCalc, issuerCertificate, cert.getSerialNumber());
 
-            // Create a nounce extension to protect against replay attacks
-            SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
-            BigInteger nounce = BigInteger.valueOf(Math.abs(random.nextInt()));
-
-            DEROctetString derString = new DEROctetString(nounce.toByteArray());
-            Extension nounceExtension = new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false, derString);
-            Extensions extensions = new Extensions(nounceExtension);
-
-            OCSPReq ocspReq = new OCSPReqBuilder().addRequest(certificateID, extensions).build();
-
             URI responderURI = responderURIs.get(0);
-            logger.log(Level.INFO, "OCSP Responder {0}", responderURI);
 
             try {
+                // Create a nonce extension to protect against replay attacks
+                DEROctetString requestNonce = new DEROctetString(new DEROctetString(JWEUtils.generateSecret(16)));
+                Extension nonceExtension = new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false, requestNonce);
+                Extensions extensions = new Extensions(nonceExtension);
+
+                OCSPReq ocspReq = new OCSPReqBuilder().addRequest(certificateID).setRequestExtensions(extensions).build();
+
+                logger.log(Level.INFO, "OCSP Responder {0}", responderURI);
+
                 OCSPResp resp = getResponse(session, ocspReq, responderURI);
                 logger.log(Level.FINE, "Received a response from OCSP responder {0}, the response status is {1}", new Object[]{responderURI, resp.getStatus()});
                 switch (resp.getStatus()) {
                     case OCSPResp.SUCCESSFUL:
                         if (resp.getResponseObject() instanceof BasicOCSPResp) {
-                            return processBasicOCSPResponse(issuerCertificate, responderCert, date, certificateID, nounce, (BasicOCSPResp)resp.getResponseObject());
+                            return processBasicOCSPResponse(issuerCertificate, responderCert, date, certificateID, requestNonce, (BasicOCSPResp)resp.getResponseObject());
                         } else {
                             throw new CertPathValidatorException("OCSP responder returned an invalid or unknown OCSP response.");
                         }
@@ -172,7 +169,7 @@ public class BCOCSPProvider extends OCSPProvider {
         }
     }
 
-    private OCSPRevocationStatus processBasicOCSPResponse(X509Certificate issuerCertificate, X509Certificate responderCertificate, Date date, JcaCertificateID certificateID, BigInteger nounce, BasicOCSPResp basicOcspResponse)
+    private OCSPRevocationStatus processBasicOCSPResponse(X509Certificate issuerCertificate, X509Certificate responderCertificate, Date date, JcaCertificateID certificateID, DEROctetString requestNonce, BasicOCSPResp basicOcspResponse)
             throws OCSPException, NoSuchProviderException, NoSuchAlgorithmException, CertificateNotYetValidException, CertificateExpiredException, CertPathValidatorException {
         SingleResp expectedResponse = null;
         for (SingleResp singleResponse : basicOcspResponse.getResponses()) {
@@ -183,7 +180,7 @@ public class BCOCSPProvider extends OCSPProvider {
         }
 
         if (expectedResponse != null) {
-            verifyResponse(basicOcspResponse, issuerCertificate, responderCertificate, nounce.toByteArray(), date);
+            verifyResponse(basicOcspResponse, issuerCertificate, responderCertificate, requestNonce, date);
             return singleResponseToRevocationStatus(expectedResponse);
         } else {
             throw new CertPathValidatorException("OCSP response does not include a response for a certificate supplied in the OCSP request");
@@ -201,7 +198,7 @@ public class BCOCSPProvider extends OCSPProvider {
                 idLeft.getSerialNumber().equals(idRight.getSerialNumber());
     }
 
-    private void verifyResponse(BasicOCSPResp basicOcspResponse, X509Certificate issuerCertificate, X509Certificate responderCertificate, byte[] requestNonce, Date date) throws NoSuchProviderException, NoSuchAlgorithmException, CertificateNotYetValidException, CertificateExpiredException, CertPathValidatorException {
+    private void verifyResponse(BasicOCSPResp basicOcspResponse, X509Certificate issuerCertificate, X509Certificate responderCertificate, DEROctetString requestNonce, Date date) throws NoSuchProviderException, NoSuchAlgorithmException, CertificateNotYetValidException, CertificateExpiredException, CertPathValidatorException {
 
         List<X509CertificateHolder> certs = new ArrayList<>(Arrays.asList(basicOcspResponse.getCerts()));
         X509Certificate signingCert = null;
@@ -332,7 +329,10 @@ public class BCOCSPProvider extends OCSPProvider {
                 throw new CertPathValidatorException("Error verifying OCSP Response\'s signature");
             } else {
                 Extension responseNonce = basicOcspResponse.getExtension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce);
-                if (responseNonce != null && requestNonce != null && !Arrays.equals(requestNonce, responseNonce.getExtnValue().getOctets())) {
+                if (responseNonce == null && requestNonce != null) {
+                    logger.log(Level.FINE, "No OCSP nonce in response");
+                }
+                if (responseNonce != null && requestNonce != null && !requestNonce.equals(responseNonce.getExtnValue())) {
                     throw new CertPathValidatorException("Nonces do not match.");
                 } else {
                     // See Sun's OCSP implementation.


### PR DESCRIPTION
Closes #26439

This fixes the issue with the OCSP nonce as setting with `setRequestExtensions` sets it properly in `requestExtensions` while setting it as the second parameter to `addRequest` actually sets it in `singleRequestExtensions`.

For testing the `OcspHandler` was modified to require that the nonce is present otherwise it will return a `malformedRequest`.

Debug logs were added if no OCSP nonce is found in the response.