### PR TITLE
EventsSection icons with color props should be wrapped in Icon

### DIFF
--- a/js/apps/admin-ui/src/events/EventsSection.tsx
+++ b/js/apps/admin-ui/src/events/EventsSection.tsx
@@ -78,7 +78,7 @@ const StatusRow = (event: EventRepresentation) =>
     <span>
       <Icon status="success">
         <CheckCircleIcon />
-      </Icon>{" "}
+      </Icon>
       {event.type}
     </span>
   ) : (
@@ -86,7 +86,7 @@ const StatusRow = (event: EventRepresentation) =>
       <span>
         <Icon status="warning">
           <WarningTriangleIcon />
-        </Icon>{" "}
+        </Icon>
         {event.type}
       </span>
     </Tooltip>

--- a/js/apps/admin-ui/src/events/EventsSection.tsx
+++ b/js/apps/admin-ui/src/events/EventsSection.tsx
@@ -15,6 +15,7 @@ import {
   FlexItem,
   Form,
   FormGroup,
+  Icon,
   PageSection,
   Tab,
   TabTitleText,
@@ -75,12 +76,18 @@ const defaultValues: UserEventSearchForm = {
 const StatusRow = (event: EventRepresentation) =>
   !event.error ? (
     <span>
-      <CheckCircleIcon color="green" /> {event.type}
+      <Icon status="success">
+        <CheckCircleIcon />
+      </Icon>{" "}
+      {event.type}
     </span>
   ) : (
     <Tooltip content={event.error}>
       <span>
-        <WarningTriangleIcon color="orange" /> {event.type}
+        <Icon status="warning">
+          <WarningTriangleIcon />
+        </Icon>{" "}
+        {event.type}
       </span>
     </Tooltip>
   );


### PR DESCRIPTION
PF codemods flagged these icons as issues... should wrap individual icons in <Icon> when using props like size and color.
