### PR TITLE
Automatically fill username when authenticating to through a broker

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
@@ -75,6 +75,10 @@ public class IdentityProviderAuthenticator implements Authenticator {
     }
 
     protected void redirect(AuthenticationFlowContext context, String providerId) {
+        redirect(context, providerId, null);
+    }
+
+    protected void redirect(AuthenticationFlowContext context, String providerId, String loginHint) {
         Optional<IdentityProviderModel> idp = context.getRealm().getIdentityProvidersStream()
                 .filter(IdentityProviderModel::isEnabled)
                 .filter(identityProvider -> Objects.equals(providerId, identityProvider.getAlias()))
@@ -84,7 +88,7 @@ public class IdentityProviderAuthenticator implements Authenticator {
             String clientId = context.getAuthenticationSession().getClient().getClientId();
             String tabId = context.getAuthenticationSession().getTabId();
             String clientData = AuthenticationProcessor.getClientData(context.getSession(), context.getAuthenticationSession());
-            URI location = Urls.identityProviderAuthnRequest(context.getUriInfo().getBaseUri(), providerId, context.getRealm().getName(), accessCode, clientId, tabId, clientData);
+            URI location = Urls.identityProviderAuthnRequest(context.getUriInfo().getBaseUri(), providerId, context.getRealm().getName(), accessCode, clientId, tabId, clientData, loginHint);
             Response response = Response.seeOther(location)
                     .build();
             // will forward the request to the IDP with prompt=none if the IDP accepts forwards with prompt=none.

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -59,6 +59,12 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         }
 
         String domain = getEmailDomain(username);
+
+        if (domain == null) {
+            context.attempted();
+            return;
+        }
+
         OrganizationProvider provider = getOrganizationProvider();
         OrganizationModel organization = provider.getByDomainName(domain);
 
@@ -74,7 +80,7 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             return;
         }
 
-        redirect(context, identityProvider.getAlias());
+        redirect(context, identityProvider.getAlias(), username);
     }
 
     private OrganizationProvider getOrganizationProvider() {

--- a/services/src/main/java/org/keycloak/services/Urls.java
+++ b/services/src/main/java/org/keycloak/services/Urls.java
@@ -52,7 +52,7 @@ public class Urls {
                 .build(realmName, providerAlias);
     }
 
-    public static URI identityProviderAuthnRequest(URI baseUri, String providerAlias, String realmName, String accessCode, String clientId, String tabId, String clientData) {
+    public static URI identityProviderAuthnRequest(URI baseUri, String providerAlias, String realmName, String accessCode, String clientId, String tabId, String clientData, String loginHint) {
         UriBuilder uriBuilder = realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
                 .path(IdentityBrokerService.class, "performLogin");
 
@@ -67,6 +67,9 @@ public class Urls {
         }
         if (clientData != null) {
             uriBuilder.replaceQueryParam(Constants.CLIENT_DATA, clientData);
+        }
+        if (loginHint != null) {
+            uriBuilder.replaceQueryParam(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
         }
 
         return uriBuilder.build(realmName, providerAlias);
@@ -87,7 +90,7 @@ public class Urls {
     }
 
     public static URI identityProviderAuthnRequest(URI baseURI, String providerAlias, String realmName) {
-        return identityProviderAuthnRequest(baseURI, providerAlias, realmName, null, null, null, null);
+        return identityProviderAuthnRequest(baseURI, providerAlias, realmName, null, null, null, null, null);
     }
 
     public static URI identityProviderAfterFirstBrokerLogin(URI baseUri, String realmName, String accessCode, String clientId, String tabId, String clientData) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationIdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationIdentityProviderTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.OrganizationIdentityProviderResource;
 import org.keycloak.admin.client.resource.OrganizationResource;
@@ -38,16 +39,19 @@ public class OrganizationIdentityProviderTest extends AbstractOrganizationTest {
     public void testUpdate() {
         OrganizationRepresentation organization = createOrganization();
         OrganizationIdentityProviderResource orgIdPResource = testRealm().organizations().get(organization.getId()).identityProvider();
-        IdentityProviderRepresentation idpRepresentation = orgIdPResource.toRepresentation();
-        assertThat(idpRepresentation.getAlias(), equalTo(bc.getIDPAlias()));
+        IdentityProviderRepresentation actual = orgIdPResource.toRepresentation();
+        IdentityProviderRepresentation expected = actual;
+        assertThat(expected.getAlias(), equalTo(bc.getIDPAlias()));
 
-        String displayName = "My Org Broker";
         //update
-        idpRepresentation.setDisplayName(displayName);
-        try (Response response = orgIdPResource.update(idpRepresentation)) {
+        expected.setDisplayName("My Org Broker");
+        expected.getConfig().put("test", "value");
+        try (Response response = orgIdPResource.update(expected)) {
             assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
         }
-        assertThat(orgIdPResource.toRepresentation().getDisplayName(), equalTo(displayName));
+        actual = orgIdPResource.toRepresentation();
+        assertThat(expected.getDisplayName(), equalTo(actual.getDisplayName()));
+        Assert.assertEquals(expected.getConfig().get("test"), actual.getConfig().get("test"));
     }
 
     @Test


### PR DESCRIPTION
Closes #28848

* Improves UX a bit when authenticating through a broker associated with an organization so that the username is sent as a `login_hint` to the identity provider to eventually fill the username automatically at login pages
* Administrators can choose to enable login hint to brokers

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
