### PR TITLE
quarkus-next: java.util.NoSuchElementException: No value present caus…

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -208,13 +208,7 @@ public final class LoggingPropertyMappers {
     }
 
     private static Optional<String> resolveFileLogLocation(Optional<String> value, ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        String location = value.get();
-
-        if (location.endsWith(File.separator)) {
-            return of(location + LoggingOptions.DEFAULT_LOG_FILENAME);
-        }
-
-        return value;
+        return value.map(location -> location.endsWith(File.separator) ? location + LoggingOptions.DEFAULT_LOG_FILENAME : location);
     }
 
     private static Level toLevel(String categoryLevel) throws IllegalArgumentException {


### PR DESCRIPTION
…es quarkus-server build failure

* resolveFileLogLocation transformer method now checks the location value presence

Closes: #28856
