### PR TITLE
Perform exact string match if redirect URI contains userinfo, encoded slashes or parent access

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Encode.java
+++ b/common/src/main/java/org/keycloak/common/util/Encode.java
@@ -46,6 +46,7 @@ public class Encode
    private static final String[] matrixParameterEncoding = new String[128];
    private static final String[] queryNameValueEncoding = new String[128];
    private static final String[] queryStringEncoding = new String[128];
+   private static final String[] userInfoStringEncoding = new String[128];
 
    static
    {
@@ -158,6 +159,44 @@ public class Encode
          }
          queryStringEncoding[i] = URLEncoder.encode(String.valueOf((char) i));
       }
+
+     /*
+      * userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
+      * unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+      * pct-encoded   = "%" HEXDIG HEXDIG
+      * sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+      *                   / "*" / "+" / "," / ";" / "="
+      */
+      for (int i = 0; i < 128; i++)
+      {
+         if (i >= 'a' && i <= 'z') continue;
+         if (i >= 'A' && i <= 'Z') continue;
+         if (i >= '0' && i <= '9') continue;
+         switch ((char) i)
+         {
+            case '-':
+            case '.':
+            case '_':
+            case '~':
+            case '!':
+            case '$':
+            case '&':
+            case '\'':
+            case '(':
+            case ')':
+            case '*':
+            case '+':
+            case ',':
+            case ';':
+            case '=':
+            case ':':
+               continue;
+            case ' ':
+               userInfoStringEncoding[i] = "%20";
+               continue;
+         }
+         userInfoStringEncoding[i] = URLEncoder.encode(String.valueOf((char) i));
+      }
    }
 
    /**
@@ -175,6 +214,24 @@ public class Encode
     */
    public static String encodeQueryStringNotTemplateParameters(String value) {
       return encodeNonCodes(encodeFromArray(value, queryStringEncoding, false));
+   }
+
+   /**
+    * Keep encoded values "%..." and template parameters intact.
+    * @param value The user-info value to encode
+    * @return The user-info encoded
+    */
+   public static String encodeUserInfo(String value) {
+      return encodeValue(value, userInfoStringEncoding);
+   }
+
+   /**
+    * Keep encoded values "%..." but not the template parameters.
+    * @param value The user-info to encode
+    * @return The user-info encoded
+    */
+   public static String encodeUserInfoNotTemplateParameters(String value) {
+      return encodeNonCodes(encodeFromArray(value, userInfoStringEncoding, false));
    }
 
    /**
@@ -420,6 +477,30 @@ public class Encode
    public static String encodeQueryParamSaveEncodings(String segment)
    {
       String result = encodeFromArray(segment, queryNameValueEncoding, false);
+      result = encodeNonCodes(result);
+      return result;
+   }
+
+   /**
+    * Encodes everything in user-info
+    *
+    * @param nameOrValue
+    * @return
+    */
+   public static String encodeUserInfoAsIs(String nameOrValue)
+   {
+      return encodeFromArray(nameOrValue, userInfoStringEncoding, true);
+   }
+
+   /**
+    * Keep any valid encodings from string i.e. keep "%2D" but don't keep "%p"
+    *
+    * @param segment
+    * @return
+    */
+   public static String encodeUserInfoSaveEncodings(String segment)
+   {
+      String result = encodeFromArray(segment, userInfoStringEncoding, false);
       result = encodeNonCodes(result);
       return result;
    }

--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -150,7 +150,7 @@ public class KeycloakUriBuilder {
             if (at > -1) {
                 String user = host.substring(0, at);
                 host = host.substring(at + 1);
-                this.userInfo = user;
+                replaceUserInfo(user, template);
             }
             Matcher hostPortMatch = hostPortPattern.matcher(host);
             if (hostPortMatch.matches()) {
@@ -459,7 +459,7 @@ public class KeycloakUriBuilder {
         } else if (userInfo != null || host != null || port != -1) {
             buffer.append("//");
             if (userInfo != null)
-                replaceParameter(paramMap, fromEncodedMap, isTemplate, userInfo, buffer, encodeSlash).append("@");
+                replaceUserInfoParameter(paramMap, fromEncodedMap, isTemplate, userInfo, buffer).append("@");
             if (host != null) {
                 if ("".equals(host)) throw new RuntimeException("empty host name");
                 replaceParameter(paramMap, fromEncodedMap, isTemplate, host, buffer, encodeSlash);
@@ -561,6 +561,33 @@ public class KeycloakUriBuilder {
                     value = Encode.encodeQueryParamAsIs(value);
                 } else {
                     value = Encode.encodeQueryParamSaveEncodings(value);
+                }
+                matcher.appendReplacement(buffer, value);
+            } else {
+                throw new IllegalArgumentException("path param " + param + " has not been provided by the parameter map");
+            }
+        }
+        matcher.appendTail(buffer);
+        return buffer;
+    }
+
+    protected StringBuffer replaceUserInfoParameter(Map<String, ?> paramMap, boolean fromEncodedMap, boolean isTemplate, String string, StringBuffer buffer) {
+        Matcher matcher = createUriParamMatcher(string);
+        while (matcher.find()) {
+            String param = matcher.group(1);
+            Object valObj = paramMap.get(param);
+            if (valObj == null && !isTemplate) {
+                throw new IllegalArgumentException("NULL value for template parameter: " + param);
+            } else if (valObj == null && isTemplate) {
+                matcher.appendReplacement(buffer, matcher.group());
+                continue;
+            }
+            String value = valObj.toString();
+            if (value != null) {
+                if (!fromEncodedMap) {
+                    value = Encode.encodeUserInfoAsIs(value);
+                } else {
+                    value = Encode.encodeUserInfoSaveEncodings(value);
                 }
                 matcher.appendReplacement(buffer, value);
             } else {
@@ -739,6 +766,15 @@ public class KeycloakUriBuilder {
             return this;
         }
         this.path = template? Encode.encodePath(path) : Encode.encodePathSaveEncodings(path);
+        return this;
+    }
+
+    public KeycloakUriBuilder replaceUserInfo(String userInfo, boolean template) {
+        if (userInfo == null) {
+            this.userInfo = null;
+            return this;
+        }
+        this.userInfo = template? Encode.encodeUserInfo(userInfo) : Encode.encodeUserInfoNotTemplateParameters(userInfo);
         return this;
     }
 

--- a/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
+++ b/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
@@ -80,4 +80,16 @@ public class KeycloakUriBuilderTest {
         Assert.assertEquals("https://localhost:8443/%7Bpath%7D?key=%7Bquery%7D#%7Bfragment%7D", KeycloakUriBuilder.fromUri(
                 "https://localhost:8443/{path}?key={query}#{fragment}", false).buildAsString());
     }
+
+    @Test
+    public void testUserInfo() {
+        Assert.assertEquals("https://user-info@localhost:8443/path?key=query#fragment", KeycloakUriBuilder.fromUri(
+                "https://{userinfo}@localhost:8443/{path}?key={query}#{fragment}").buildAsString("user-info", "path", "query", "fragment"));
+        Assert.assertEquals("https://user%20info%40%2F@localhost:8443/path?key=query#fragment", KeycloakUriBuilder.fromUri(
+                "https://{userinfo}@localhost:8443/{path}?key={query}#{fragment}").buildAsString("user info@/", "path", "query", "fragment"));
+        Assert.assertEquals("https://user-info%E2%82%AC@localhost:8443", KeycloakUriBuilder.fromUri(
+                "https://user-info%E2%82%AC@localhost:8443", false).buildAsString());
+        Assert.assertEquals("https://user-info%E2%82%AC@localhost:8443", KeycloakUriBuilder.fromUri(
+                "https://user-info€@localhost:8443", false).buildAsString());
+    }
 }

--- a/docs/documentation/server_admin/topics/clients/oidc/con-basic-settings.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-basic-settings.adoc
@@ -24,9 +24,13 @@ the name, set up a replacement string value. For example, a string value such as
 
 *Home URL*:: Provides the default URL for when the auth server needs to redirect or link back to the client.
 
-*Valid Redirect URIs*:: Required field.  Enter a URL pattern and click *+* to add and *-* to remove existing URLs and click *Save*. You can use wildcards at the end of the URL pattern. For example $$http://host.com/*$$
+*Valid Redirect URIs*:: Required field.  Enter a URL pattern and click *+* to add and *-* to remove existing URLs and click *Save*. Exact (case sensitive) string matching is used to compare valid redirect URIs.
 +
-Exclusive redirect URL patterns are typically more secure.  See xref:unspecific-redirect-uris_{context}[Unspecific Redirect URIs] for more information.
+You can use wildcards at the end of the URL pattern. For example `$$http://host.com/path/*$$`. To avoid security issues, if the passed redirect URI contains the *userinfo* part or its *path* manages access to parent directory (`/../`) no wildcard comparison is performed but the standard and secure exact string matching.
++
+The full wildcard `$$*$$` valid redirect URI can also be configured to allow any *http* or *https* redirect URI. Please do not use it in production environments.
++
+Exclusive redirect URI patterns are typically more secure. See xref:unspecific-redirect-uris_{context}[Unspecific Redirect URIs] for more information.
 
 Web Origins:: Enter a URL pattern and click + to add and - to remove existing URLs. Click Save.
 +

--- a/docs/documentation/upgrading/topics/changes/changes-24_0_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-24_0_3.adoc
@@ -15,3 +15,10 @@ Differently than the previous contract and behavior, this method is only invoked
 was loaded from.
 
 endif::[]
+= Changes in redirect URI verification when using wildcards
+
+Because of security concerns, the redirect URI verification now performs a exact string matching (no wildcard involved) if the passed redirect uri contains a `userinfo` part or its `path` accesses parent directory (`/../`).
+
+The full wildcard `*` can still be used as a valid redirect in development for http(s) URIs with those characteristics. In production environments a exact valid redirect URI without wildcard needs to be configured for any URI of that type.
+
+Please note that wildcard valid redirect URIs are not recommended for production and not covered by the OAuth 2.0 specification.

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
@@ -352,12 +352,12 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
         checkRedirectUri("http://example.com/foo/../", false);
         checkRedirectUri("http://example.com/foo/%2E%2E/", false); // url-encoded "http://example.com/foobar/../"
         checkRedirectUri("http://example.com/foo%2F%2E%2E%2F", false); // url-encoded "http://example.com/foobar/../"
-        checkRedirectUri("http://example.com/foo/%252E%252E/", false); // double-encoded "http://example.com/foobar/../"
-        checkRedirectUri("http://example.com/foo/%252E%252E/?some_query_param=some_value", false); // double-encoded "http://example.com/foobar/../?some_query_param=some_value"
-        checkRedirectUri("http://example.com/foo/%252E%252E/?encodeTest=a%3Cb", false); // double-encoded "http://example.com/foobar/../?encodeTest=a<b"
-        checkRedirectUri("http://example.com/foo/%252E%252E/#encodeTest=a%3Cb", false); // double-encoded "http://example.com/foobar/../?encodeTest=a<b"
-        checkRedirectUri("http://example.com/foo/%25252E%25252E/", false); // triple-encoded "http://example.com/foobar/../"
-        checkRedirectUri("http://example.com/foo/%2525252525252E%2525252525252E/", false); // seventh-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo/%252E%252E/", true); // double-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo/%252E%252E/?some_query_param=some_value", true); // double-encoded "http://example.com/foobar/../?some_query_param=some_value"
+        checkRedirectUri("http://example.com/foo/%252E%252E/?encodeTest=a%3Cb", true); // double-encoded "http://example.com/foobar/../?encodeTest=a<b"
+        checkRedirectUri("http://example.com/foo/%252E%252E/#encodeTest=a%3Cb", true); // double-encoded "http://example.com/foobar/../?encodeTest=a<b"
+        checkRedirectUri("http://example.com/foo/%25252E%25252E/", true); // triple-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo/%2525252525252E%2525252525252E/", true); // seventh-encoded "http://example.com/foobar/../"
 
         checkRedirectUri("http://example.com/foo?encodeTest=a%3Cb", true);
         checkRedirectUri("http://example.com/foo?encodeTest=a%3Cb#encode2=a%3Cb", true);


### PR DESCRIPTION
Closes keycloak/keycloak-private#113
Closes keycloak/keycloak-private#134

PR for main for RedirectUtils change from 24.0.3. Plain cherry-pick with minor tweaks in the documentation part.