### PR TITLE
Add note to documentation about using groups with transient-users

### DIFF
--- a/docs/transient-users.md
+++ b/docs/transient-users.md
@@ -38,6 +38,11 @@ When using transient users, you should be aware of the following:
   which is added to regular users automatically, but has to be assigned
   to transient users also through a mapper (e.g. the `Hardcoded Role` mapper type).
 
+  An alternative to the Hardcoded Role mapper approach is to use groups which allows for more flexible role mappings.
+  To do so, create a group like `transient-users` and assign the `default-roles-{realm}` realm role to it.
+  Then add a Hardcoded Group mapper to the identity-provider and select the `transient-users` group.
+  This will ensure that all roles associated with the `transient-users` group are automatically assigned to the brokered users.
+
 - Since every transient user is created afresh, mappers always
   work in the `Import` sync mode.
 


### PR DESCRIPTION
Document an additional approach for managing user-roles for transient-users via groups.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
