### PR TITLE
Show indicator for transient user in user sessions list in admin ui

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
@@ -33,6 +33,7 @@ public class UserSessionRepresentation {
     private long lastAccess;
     private boolean rememberMe;
     private Map<String, String> clients = new HashMap<>();
+    private boolean transientUser;
 
     public String getId() {
         return id;
@@ -96,5 +97,13 @@ public class UserSessionRepresentation {
 
     public void setClients(Map<String, String> clients) {
         this.clients = clients;
+    }
+
+    public boolean isTransientUser() {
+        return transientUser;
+    }
+
+    public void setTransientUser(boolean transientUser) {
+        this.transientUser = transientUser;
     }
 }

--- a/js/apps/admin-ui/src/sessions/SessionsTable.tsx
+++ b/js/apps/admin-ui/src/sessions/SessionsTable.tsx
@@ -1,12 +1,14 @@
 import type UserSessionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation";
 import {
   Button,
+  Label,
   List,
   ListItem,
   ListVariant,
   ToolbarItem,
+  Tooltip,
 } from "@patternfly/react-core";
-import { CubesIcon } from "@patternfly/react-icons";
+import { CubesIcon, InfoCircleIcon } from "@patternfly/react-icons";
 import { MouseEvent, ReactNode, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useMatch, useNavigate } from "react-router-dom";
@@ -50,9 +52,24 @@ export type SessionsTableProps = {
 
 const UsernameCell = (row: UserSessionRepresentation) => {
   const { realm } = useRealm();
+  const { t } = useTranslation();
   return (
     <Link to={toUser({ realm, id: row.userId!, tab: "sessions" })}>
       {row.username}
+      {row.transientUser && (
+        <>
+          {" "}
+          <Tooltip content={t("transientUserTooltip")}>
+            <Label
+              data-testid="user-details-label-transient-user"
+              icon={<InfoCircleIcon />}
+              isCompact
+            >
+              {t("transientUser")}
+            </Label>
+          </Tooltip>
+        </>
+      )}
     </Link>
   );
 };

--- a/js/libs/keycloak-admin-client/src/defs/userSessionRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/userSessionRepresentation.ts
@@ -6,4 +6,5 @@ export default interface UserSessionRepresentation {
   start?: number;
   userId?: string;
   username?: string;
+  transientUser?: boolean;
 }

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/SessionsResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/SessionsResource.java
@@ -14,6 +14,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 
 import jakarta.ws.rs.Consumes;
@@ -118,6 +119,7 @@ public class SessionsResource {
             ClientModel client = clientSession.getClient();
             rep.getClients().put(client.getId(), client.getClientId());
         }
+        rep.setTransientUser(LightweightUserAdapter.isLightweightUser(session.getUser().getId()));
         return rep;
     }
 }

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/SessionRepresentation.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/SessionRepresentation.java
@@ -13,6 +13,7 @@ public class SessionRepresentation {
     private String ipAddress;
     private long start;
     private long lastAccess;
+    private boolean transientUser;
 
     private SessionType type;
     private Map<String, String> clients = new HashMap<>();
@@ -79,6 +80,14 @@ public class SessionRepresentation {
 
     public void setClients(Map<String, String> clients) {
         this.clients = clients;
+    }
+
+    public boolean isTransientUser() {
+        return transientUser;
+    }
+
+    public void setTransientUser(boolean transientUser) {
+        this.transientUser = transientUser;
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -677,6 +677,7 @@ public class ModelToRepresentation {
             ClientModel client = clientSession.getClient();
             rep.getClients().put(client.getId(), client.getClientId());
         }
+        rep.setTransientUser(LightweightUserAdapter.isLightweightUser(session.getUser().getId()));
         return rep;
     }
 


### PR DESCRIPTION
This PR adds a transient user indicator to the user sessions listing.

- For transient users a `transient` label is now shown in the session list in the admin ui
- this adds a new boolean property `transientUser` to `org.keycloak.admin.ui.rest.model.SessionRepresentation`

Fixes #28879

With this PR applied the UI looks like this: 
![image](https://github.com/keycloak/keycloak/assets/314690/a00e2846-b7d0-405a-a22d-65aa0229c184)

Perhaps there could be a bit more spacing between the label and the username.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
