### PR TITLE
Upgrade to Quarkus 3.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.8.3</quarkus.version>
-        <quarkus.build.version>3.8.3</quarkus.build.version>
+        <quarkus.version>3.8.4</quarkus.version>
+        <quarkus.build.version>3.8.4</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -151,13 +151,7 @@ public final class LoggingPropertyMappers {
     }
 
     private static Optional<String> resolveFileLogLocation(Optional<String> value, ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        String location = value.get();
-
-        if (location.endsWith(File.separator)) {
-            return of(location + LoggingOptions.DEFAULT_LOG_FILENAME);
-        }
-
-        return value;
+        return value.map(location -> location.endsWith(File.separator) ? location + LoggingOptions.DEFAULT_LOG_FILENAME : location);
     }
 
     private static Level toLevel(String categoryLevel) throws IllegalArgumentException {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -104,7 +104,7 @@ public class PropertyMapper<T> {
         // try to obtain the value for the property we want to map first
         ConfigValue config = convertValue(context.proceed(from));
 
-        if (config == null) {
+        if (config == null || config.getValue() == null) {
             if (mapFrom != null) {
                 // if the property we want to map depends on another one, we use the value from the other property to call the mapper
                 String parentKey = MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + mapFrom;


### PR DESCRIPTION
Closes #28880

This includes also a backport of #28857 and #29030 that's required for Quarkus 3.8.4. (CC @Pepo48)

On hold until RHBQ 3.8.4 is available.