### PR TITLE
Update federation-sssd-setup.sh to add ifp section

### DIFF
--- a/quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
+++ b/quarkus/dist/src/main/content/bin/federation-sssd-setup.sh
@@ -14,6 +14,10 @@ then
     sed -i '/^services/ s/$/, ifp/' $SSSD_FILE
   fi
 
+  if ! grep -q ^\[ifp\] $SSSD_FILE; then
+    sed -i $'$a\\\n\\\n\[ifp\]' $SSSD_FILE
+  fi
+
   if ! grep -q ^allowed_uids $SSSD_FILE; then
     sed -i '/^\[ifp\]/a allowed_uids = root' $SSSD_FILE
   fi


### PR DESCRIPTION
Closes #42726

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
The federation-sssd-setup.sh script adds `ifp` to the `[services]` section, then tries to add parameters to the `[ifp]` service section without checking if it exists. 

This PR updates the script to add an `[ifp]` section at the bottom of `sssd.conf` when not already present, so that the following commands can also succeed.
