### PR TITLE
Convert socketTimeout and establishConnectionTimeout to given time units in HttpClientBuilder

### DIFF
--- a/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
@@ -250,8 +250,8 @@ public class HttpClientBuilder {
             }
 
             RequestConfig requestConfig = RequestConfig.custom()
-                    .setConnectTimeout((int) establishConnectionTimeout)
-                    .setSocketTimeout((int) socketTimeout)
+                    .setConnectTimeout((int) TimeUnit.MILLISECONDS.convert(establishConnectionTimeout, establishConnectionTimeoutUnits))
+                    .setSocketTimeout((int) TimeUnit.MILLISECONDS.convert(socketTimeout, socketTimeoutUnits))
                     .setExpectContinueEnabled(expectContinueEnabled).build();
 
             org.apache.http.impl.client.HttpClientBuilder builder = HttpClients.custom()

--- a/services/src/test/java/org/keycloak/connections/httpclient/HttpClientBuilderTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/HttpClientBuilderTest.java
@@ -1,0 +1,56 @@
+package org.keycloak.connections.httpclient;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+public class HttpClientBuilderTest {
+
+    @Test
+    public void testDefaultBuilder() throws NoSuchFieldException, IllegalAccessException {
+        CloseableHttpClient httpClient = new HttpClientBuilder().build();
+
+        RequestConfig requestConfig = getRequestConfig(httpClient);
+
+        Assert.assertEquals("Default socket timeout is -1 and can be converted by TimeUnit", -1, requestConfig.getSocketTimeout());
+        Assert.assertEquals("Default connect timeout is -1 and can be converted by TimeUnit", -1, requestConfig.getConnectTimeout());
+    }
+
+    @Test
+    public void testTimeUnitSeconds() throws NoSuchFieldException, IllegalAccessException {
+        HttpClientBuilder httpClientBuilder = new HttpClientBuilder();
+        httpClientBuilder
+                .socketTimeout(2, TimeUnit.SECONDS)
+                .establishConnectionTimeout(1, TimeUnit.SECONDS);
+        CloseableHttpClient httpClient = httpClientBuilder.build();
+
+        RequestConfig requestConfig = getRequestConfig(httpClient);
+
+        Assert.assertEquals("Socket timeout is converted to milliseconds", 2000, requestConfig.getSocketTimeout());
+        Assert.assertEquals("Connect timeout is converted to milliseconds", 1000, requestConfig.getConnectTimeout());
+    }
+
+    @Test
+    public void testTimeUnitMilliSeconds() throws NoSuchFieldException, IllegalAccessException {
+        HttpClientBuilder httpClientBuilder = new HttpClientBuilder();
+        httpClientBuilder
+                .socketTimeout(2000, TimeUnit.MILLISECONDS)
+                .establishConnectionTimeout(1000, TimeUnit.MILLISECONDS);
+        CloseableHttpClient httpClient = httpClientBuilder.build();
+
+        RequestConfig requestConfig = getRequestConfig(httpClient);
+
+        Assert.assertEquals("Socket timeout is still in milliseconds", 2000, requestConfig.getSocketTimeout());
+        Assert.assertEquals("Connect timeout is still in milliseconds", 1000, requestConfig.getConnectTimeout());
+    }
+
+    private static RequestConfig getRequestConfig(CloseableHttpClient httpClient) throws NoSuchFieldException, IllegalAccessException {
+        Field defaultConfig = httpClient.getClass().getDeclaredField("defaultConfig");
+        defaultConfig.setAccessible(true);
+        return (RequestConfig) defaultConfig.get(httpClient);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Erwin Rohde <erwin@rohde.nu>

Convert socketTimeout and establishConnectionTimeout to given time units.
