### PR TITLE
Don't use no-arg version of GroupModel.getSubGroupsStream() when fetc…

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -144,7 +144,6 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
                 .map(realm::getGroupById)
                 // In concurrent tests, the group might be deleted in another thread, therefore, skip those null values.
                 .filter(Objects::nonNull)
-                .sorted(GroupModel.COMPARE_BY_NAME)
         );
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -164,10 +164,10 @@ public class GroupResource {
         @QueryParam("briefRepresentation") @DefaultValue("false") Boolean briefRepresentation) {
         this.auth.groups().requireView(group);
         boolean canViewGlobal = auth.groups().canView();
-        return paginatedStream(
-            group.getSubGroupsStream()
-            .filter(g -> canViewGlobal || auth.groups().canView(g)), first, max)
-            .map(g -> GroupUtils.populateSubGroupCount(g, GroupUtils.toRepresentation(auth.groups(), g, !briefRepresentation)));
+        return paginatedStream(group.getSubGroupsStream(-1, -1)
+                    .filter(g -> canViewGlobal || auth.groups().canView(g))
+                    .map(g -> GroupUtils.populateSubGroupCount(g, GroupUtils.toRepresentation(auth.groups(), g, !briefRepresentation)))
+                , first, max);
     }
 
     /**


### PR DESCRIPTION
…hing the subgroups from the GroupResource endpoint.

- prevents pre-loading all groups; instead use the stream from the JPA adapter to load subgroups one by one and then filter based on the user permissions.

Closes #28935

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
