### PR TITLE
Fix user-facing typos in Java code

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/PropertiesBasedRoleMapper.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/PropertiesBasedRoleMapper.java
@@ -60,7 +60,7 @@ import org.keycloak.adapters.saml.config.parsers.ResourceLoader;
  * The {@code properties} file can contain both roles and principals as keys, and a list of zero or more roles separated by comma
  * as values. When the {@code {@link #map(String, Set)}} method is called, the implementation iterates through the set of roles
  * that were extracted from the assertion and checks, for eache role, if a mapping exists. If the role maps to an empty role,
- * it is discarded. If it maps to a set of one ore more different roles, then these roles are set in the result set. If no
+ * it is discarded. If it maps to a set of one or more different roles, then these roles are set in the result set. If no
  * mapping is found for the role then it is included as is in the result set.
  *
  * Once the roles have been processed, the implementation checks if the principal extracted from the assertion contains an entry

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/SamlDeployment.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/SamlDeployment.java
@@ -94,19 +94,19 @@ public interface SamlDeployment {
         public interface SingleSignOnService {
             /**
              * Returns {@code true} if the requests to IdP need to be signed by SP key.
-             * @return see dscription
+             * @return see description
              */
             boolean signRequest();
             /**
              * Returns {@code true} if the complete response message from IdP should
              * be checked for valid signature.
-             * @return see dscription
+             * @return see description
              */
             boolean validateResponseSignature();
             /**
              * Returns {@code true} if individual assertions in response from IdP should
              * be checked for valid signature.
-             * @return see dscription
+             * @return see description
              */
             boolean validateAssertionSignature();
             Binding getRequestBinding();

--- a/common/src/main/java/org/keycloak/common/util/Base64.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64.java
@@ -1012,7 +1012,7 @@ public class Base64
      * anywhere along their length by specifying
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 4 for
+     * are large enough to accommodate <var>srcOffset</var> + 4 for
      * the <var>source</var> array or <var>destOffset</var> + 3 for
      * the <var>destination</var> array.
      * This method returns the actual number of bytes that

--- a/common/src/main/java/org/keycloak/common/util/Encode.java
+++ b/common/src/main/java/org/keycloak/common/util/Encode.java
@@ -405,7 +405,7 @@ public class Encode
    }
 
    /**
-    * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>.  PCHAR is allowed allong with '/'
+    * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>.  PCHAR is allowed along with '/'
     * <p/>
     * unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
     * sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
@@ -431,7 +431,7 @@ public class Encode
    }
 
    /**
-    * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>.  PCHAR is allowed allong with '/'
+    * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>.  PCHAR is allowed along with '/'
     * <p/>
     * unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
     * sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"

--- a/common/src/main/java/org/keycloak/common/util/NetworkUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/NetworkUtils.java
@@ -57,11 +57,11 @@ public class NetworkUtils {
     }
 
     /**
-     * <p>Convert IPv6 adress into RFC 5952 form.
+     * <p>Convert IPv6 address into RFC 5952 form.
      * E.g. 2001:db8:0:1:0:0:0:1 -> 2001:db8:0:1::1</p>
      *
      * <p>Method is null safe, and if IPv4 address or host name is passed to the
-     * method it is returned wihout any processing.</p>
+     * method it is returned without any processing.</p>
      *
      * <p>Method also supports IPv4 in IPv6 (e.g. 0:0:0:0:0:ffff:192.0.2.1 ->
      * ::ffff:192.0.2.1), and zone ID (e.g. fe80:0:0:0:f0f0:c0c0:1919:1234%4

--- a/common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -54,7 +54,7 @@ public final class StringPropertyReplacer
     private static final Properties systemEnvProperties = new SystemEnvProperties();
 
     /**
-     * Go through the input string and replace any occurance of ${p} with
+     * Go through the input string and replace any occurrence of ${p} with
      * the System.getProperty(p) value. If there is no such property p defined,
      * then the ${p} reference will remain unchanged.
      *
@@ -78,7 +78,7 @@ public final class StringPropertyReplacer
     }
 
     /**
-     * Go through the input string and replace any occurance of ${p} with
+     * Go through the input string and replace any occurrence of ${p} with
      * the props.getProperty(p) value. If there is no such property p defined,
      * then the ${p} reference will remain unchanged.
      *

--- a/common/src/main/java/org/keycloak/common/util/reflections/Reflections.java
+++ b/common/src/main/java/org/keycloak/common/util/reflections/Reflections.java
@@ -705,12 +705,12 @@ public class Reflections {
     }
 
     /**
-     * Check the assignability of one type to another, taking into account the actual type arguements
+     * Check the assignability of one type to another, taking into account the actual type arguments
      *
      * @param rawType1 the raw type of the class to check
-     * @param actualTypeArguments1 the actual type arguements to check, or an empty array if not a parameterized type
+     * @param actualTypeArguments1 the actual type arguments to check, or an empty array if not a parameterized type
      * @param rawType2 the raw type of the class to check
-     * @param actualTypeArguments2 the actual type arguements to check, or an empty array if not a parameterized type
+     * @param actualTypeArguments2 the actual type arguments to check, or an empty array if not a parameterized type
      *
      * @return
      */

--- a/core/src/main/java/org/keycloak/jose/jwk/JWKUtil.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKUtil.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 public class JWKUtil {
 
     /**
-     * Coverts {@code BigInteger} to 64-byte array removing the sign byte if
+     * Converts {@code BigInteger} to 64-byte array removing the sign byte if
      * necessary.
      *
      * @param bigInt {@code BigInteger} to be converted
@@ -34,7 +34,7 @@ public class JWKUtil {
     }
 
     /**
-     * Coverts {@code BigInteger} to 64-byte array but maintaining the length
+     * Converts {@code BigInteger} to 64-byte array but maintaining the length
      * to bitlen as specified in rfc7518 for certain fields (X and Y parameter
      * for EC keys).
      *

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwt.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwt.java
@@ -77,7 +77,7 @@ public class SdJwt {
     /**
      * Prepare to a nested payload to this SD-JWT.
      * <p>
-     * droping the algo claim.
+     * dropping the algo claim.
      *
      * @param nestedSdJwt
      * @return

--- a/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/TestCompareSdJwt.java
+++ b/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/TestCompareSdJwt.java
@@ -48,7 +48,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  * 
  * Warning: in orther to produce the same disclosure strings and hashes like in
  * the spect, i had to produce
- * the same print. This is by no way reliable enougth to be used to test
+ * the same print. This is by no way reliable enough to be used to test
  * conformity to the spec.
  * 
  * @author <a href="mailto:francis.pouatcha@adorsys.com">Francis Pouatcha</a>

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -953,7 +953,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
      *
      * @param realm realm
      * @param kerberosPrincipal kerberos principal of the authenticated user
-     * @return finded or newly created user
+     * @return found or newly created user
      */
     protected UserModel findOrCreateAuthenticatedUser(RealmModel realm, KerberosPrincipal kerberosPrincipal) {
         String kerberosPrincipalAttrName = kerberosConfig.getKerberosPrincipalAttribute();

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -62,7 +62,7 @@ public class LDAPUtils {
     private static final Logger log = Logger.getLogger(LDAPUtils.class);
 
     /**
-     * Method to crate a user in the LDAP. The user will be created when all
+     * Method to create a user in the LDAP. The user will be created when all
      * mandatory attributes specified by the mappers are set. The method
      * onRegisterUserToLDAP is first called in each mapper to set any default or
      * initial value.

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/connections/impl/BaseConnectionBuilder.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/connections/impl/BaseConnectionBuilder.java
@@ -160,8 +160,8 @@ public abstract class BaseConnectionBuilder<R extends BaseConnectionBuilder<R, C
     }
 
     /**
-     * Set the endianess for the connection
-     * Default is based on system endianess.
+     * Set the endianness for the connection
+     * Default is based on system endianness.
      *
      * @param _endianess {@link Endian#BIG} or {@value Endian#LITTLE}
      * @return this

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 /**
  * Handles a connection to DBus.
  * <p>
- * This is a Singleton class, only 1 connection to the SYSTEM or SESSION busses can be made. Repeated calls to
+ * This is a Singleton class, only 1 connection to the SYSTEM or SESSION buses can be made. Repeated calls to
  * getConnection will return the same reference.
  * </p>
  * <p>
@@ -469,7 +469,7 @@ public final class DBusConnection extends AbstractConnection {
      * Return a reference to a remote object. This method will always refer to the well known name (if given) rather
      * than resolving it to a unique bus name. In particular this means that if a process providing the well known name
      * disappears and is taken over by another process proxy objects gained by this method will make calls on the new
-     * proccess.
+     * process.
      *
      * This method will use bus introspection to determine the interfaces on a remote object and so <b>may block</b> and
      * <b>may fail</b>. The resulting proxy object will, however, be castable to any interface it implements. It will
@@ -551,7 +551,7 @@ public final class DBusConnection extends AbstractConnection {
      * Return a reference to a remote object. This method will always refer to the well known name (if given) rather
      * than resolving it to a unique bus name. In particular this means that if a process providing the well known name
      * disappears and is taken over by another process proxy objects gained by this method will make calls on the new
-     * proccess.
+     * process.
      *
      * @param <I>
      *            class extending {@link DBusInterface}
@@ -578,7 +578,7 @@ public final class DBusConnection extends AbstractConnection {
      * Return a reference to a remote object. This method will always refer to the well known name (if given) rather
      * than resolving it to a unique bus name. In particular this means that if a process providing the well known name
      * disappears and is taken over by another process proxy objects gained by this method will make calls on the new
-     * proccess.
+     * process.
      *
      * @param <I>
      *            class extending {@link DBusInterface}

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/interfaces/DBus.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/interfaces/DBus.java
@@ -107,7 +107,7 @@ public interface DBus extends DBusInterface {
     UInt32 GetConnectionUnixUser(String _connectionName);
 
     /**
-    * Returns the proccess ID associated with a connection.
+    * Returns the process ID associated with a connection.
     * @param _connectionName The name of the connection
     * @return The PID of the connection.
     */

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/messages/MethodCall.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/messages/MethodCall.java
@@ -74,7 +74,7 @@ public class MethodCall extends MethodBase {
     }
 
     /**
-    * Block (if neccessary) for a reply.
+    * Block (if necessary) for a reply.
     * @return The reply to this MethodCall, or null if a timeout happens.
     * @param _timeout The length of time to block before timing out (ms).
     */
@@ -93,7 +93,7 @@ public class MethodCall extends MethodBase {
     }
 
     /**
-    * Block (if neccessary) for a reply.
+    * Block (if necessary) for a reply.
     * Default timeout is 20s, or can be configured with setDefaultTimeout()
     * @return The reply to this MethodCall, or null if a timeout happens.
     */

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/utils/XmlUtil.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/utils/XmlUtil.java
@@ -66,7 +66,7 @@ public final class XmlUtil {
     }
 
     /**
-     * Applys a xpathExpression to a xml-Document and return a {@link NodeList} with the results.
+     * Applies a xpathExpression to a xml-Document and return a {@link NodeList} with the results.
      *
      * @param _xpathExpression xpath expression
      * @param _xmlDocumentOrNode document or node

--- a/federation/sssd/src/main/java/org/jvnet/libpam/PAM.java
+++ b/federation/sssd/src/main/java/org/jvnet/libpam/PAM.java
@@ -47,7 +47,7 @@ import static org.jvnet.libpam.impl.PAMLibrary.libpam;
  * PAM authenticator.
  * <p>
  * <p>
- * Instances are thread unsafe and non reentrant. An instace cannot be reused
+ * Instances are thread unsafe and non reentrant. An instance cannot be reused
  * to authenticate multiple users.
  * <p>
  * <p>

--- a/federation/sssd/src/main/java/org/jvnet/libpam/impl/PAMLibrary.java
+++ b/federation/sssd/src/main/java/org/jvnet/libpam/impl/PAMLibrary.java
@@ -74,7 +74,7 @@ public interface PAMLibrary extends Library {
     class pam_response extends Structure {
         /**
          * This is really a string, but this field needs to be malloc-ed by the conversation
-         * method, and to be freed by the caler, so I bind it to {@link Pointer} here.
+         * method, and to be freed by the caller, so I bind it to {@link Pointer} here.
          * <p>
          * The man page doesn't say that, but see
          * http://www.netbsd.org/docs/guide/en/chap-pam.html#pam-sample-conv

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -181,7 +181,7 @@ public interface UsersResource {
      *
      * @param search the value to search. It can be the username, email or any of the supported options to query based on user attributes
      * @param firstResult the position of the first result to retrieve
-     * @param maxResults the maximum number of results to retreive
+     * @param maxResults the maximum number of results to retrieve
      * @return a list of {@link UserRepresentation}
      */
     @GET
@@ -200,7 +200,7 @@ public interface UsersResource {
      *
      * @param search the value to search. It can be the username, email or any of the supported options to query based on user attributes
      * @param firstResult the position of the first result to retrieve
-     * @param maxResults the maximum number of results to retreive
+     * @param maxResults the maximum number of results to retrieve
      * @param briefRepresentation Only return basic information (only guaranteed to return id, username, created, first and last name,
      *      email, enabled state, email verification state, federation link, and access.
      *      Note that it means that namely user attributes, required actions, and not before are not returned.)

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -64,7 +64,7 @@ import java.util.stream.Stream;
  * ClientList caches:
  * - lists of clients are cached in a specific cache entry i.e. realm clients, find client by clientId
  * - realm client lists need to be invalidated and evited whenever a client is added or removed from a realm.  RealmProvider
- * now has addClient/removeClient at its top level.  All adapaters should use these methods so that the appropriate invalidations
+ * now has addClient/removeClient at its top level.  All adapters should use these methods so that the appropriate invalidations
  * can be registered.
  * - whenever a client is added/removed the realm of the client is added to a listInvalidations set
  * this set must be checked before sending back or caching a cached query.  This check is required to
@@ -83,7 +83,7 @@ import java.util.stream.Stream;
  * DBs with Repeatable Read:
  * - DBs like MySQL are Repeatable Read by default.  So, if you query a Client for instance, it will always return the same result in the same transaction even if the DB
  * was updated in between these queries.  This makes it possible to store stale cache entries.  To avoid this problem, this class stores the current local version counter
- * at the beginningof the transaction.  Whenever an entry is added to the cache, the current coutner is compared against the counter at the beginning of the tx.  If the current
+ * at the beginning of the transaction.  Whenever an entry is added to the cache, the current counter is compared against the counter at the beginning of the tx.  If the current
  * is greater, then don't cache.
  *
  * Groups and Roles:

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/AbstractExtendableRevisioned.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/AbstractExtendableRevisioned.java
@@ -30,7 +30,7 @@ public abstract class AbstractExtendableRevisioned extends AbstractRevisioned {
     }
 
     /**
-     * Cache things along with this cachable object
+     * Cache things along with this cacheable object
      *
      * @return
      */

--- a/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -234,7 +234,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */
@@ -244,7 +244,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */
@@ -255,7 +255,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */
@@ -265,7 +265,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */

--- a/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -241,7 +241,7 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */
@@ -251,7 +251,7 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */
@@ -261,7 +261,7 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */
@@ -271,7 +271,7 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * This method should not be overriden
+     * This method should not be overridden
      *
      * @return
      */

--- a/saml-core/src/main/java/org/keycloak/rotation/HardcodedKeyLocator.java
+++ b/saml-core/src/main/java/org/keycloak/rotation/HardcodedKeyLocator.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Key locator for a bunch of keys. It can be initializaed with or without
+ * Key locator for a bunch of keys. It can be initialized with or without
  * key names.
  *
  * @author <a href="mailto:hmlnarik@redhat.com">Hynek Mlnařík</a>

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/AssertionUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/AssertionUtil.java
@@ -363,7 +363,7 @@ public class AssertionUtil {
      * out of sync.
      *
      * @param assertion
-     * @param clockSkewInMilis in miliseconds
+     * @param clockSkewInMilis in milliseconds
      *
      * @return
      *
@@ -429,7 +429,7 @@ public class AssertionUtil {
      * out of sync.
      *
      * @param assertion
-     * @param clockSkewInMilis in miliseconds
+     * @param clockSkewInMilis in milliseconds
      *
      * @return
      *

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/XMLTimeUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/XMLTimeUtil.java
@@ -43,7 +43,7 @@ public class XMLTimeUtil {
     private static final PicketLinkLogger logger = PicketLinkLoggerFactory.getLogger();
 
     /**
-     * Add additional time in miliseconds
+     * Add additional time in milliseconds
      *
      * @param value calendar whose value needs to be updated
      * @param millis
@@ -68,10 +68,10 @@ public class XMLTimeUtil {
     }
 
     /**
-     * Subtract some miliseconds from the time value
+     * Subtract some milliseconds from the time value
      *
      * @param value
-     * @param millis miliseconds entered in a positive value
+     * @param millis milliseconds entered in a positive value
      *
      * @return
      */
@@ -128,7 +128,7 @@ public class XMLTimeUtil {
     }
 
     /**
-     * Convert the minutes into miliseconds
+     * Convert the minutes into milliseconds
      *
      * @param valueInMins
      *

--- a/server-spi-private/src/main/java/org/keycloak/authentication/AbstractAuthenticationFlowContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/AbstractAuthenticationFlowContext.java
@@ -184,7 +184,7 @@ public interface AbstractAuthenticationFlowContext {
     void challenge(Response challenge);
 
     /**
-     * Sends the challenge back to the HTTP client irregardless of the current executionr requirement
+     * Sends the challenge back to the HTTP client regardless of the current execution requirement
      *
      * @param challenge
      */

--- a/server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlowContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlowContext.java
@@ -113,7 +113,7 @@ public interface AuthenticationFlowContext extends AbstractAuthenticationFlowCon
     URI getRefreshUrl(boolean authSessionIdParam);
 
     /**
-     * End the flow and redirect browser based on protocol specific respones.  This should only be executed
+     * End the flow and redirect browser based on protocol specific response.  This should only be executed
      * in browser-based flows.
      *
      */

--- a/server-spi-private/src/main/java/org/keycloak/authentication/Authenticator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/Authenticator.java
@@ -37,7 +37,7 @@ public interface Authenticator extends Provider {
 
     /**
      * Initial call for the authenticator.  This method should check the current HTTP request to determine if the request
-     * satifies the Authenticator's requirements.  If it doesn't, it should send back a challenge response by calling
+     * satisfies the Authenticator's requirements.  If it doesn't, it should send back a challenge response by calling
      * the AuthenticationFlowContext.challenge(Response).  If this challenge is a authentication, the action URL
      * of the form must point to
      *

--- a/server-spi-private/src/main/java/org/keycloak/authentication/ConfigurableAuthenticatorFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/ConfigurableAuthenticatorFactory.java
@@ -41,7 +41,7 @@ public interface ConfigurableAuthenticatorFactory extends ConfiguredProvider {
     /**
      * General authenticator type, i.e. totp, password, cert.
      *
-     * @return null if not a referencable category
+     * @return null if not a referenceable category
      */
     String getReferenceCategory();
 

--- a/server-spi-private/src/main/java/org/keycloak/authentication/FlowStatus.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/FlowStatus.java
@@ -37,7 +37,7 @@ public enum FlowStatus {
     CHALLENGE,
 
     /**
-     * Irregardless of the execution's requirement, this challenge will be sent to the user.
+     * Regardless of the execution's requirement, this challenge will be sent to the user.
      *
      */
     FORCE_CHALLENGE,

--- a/server-spi-private/src/main/java/org/keycloak/authentication/RequiredActionContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/RequiredActionContext.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 
 /**
- * Interface that encapsulates current information about the current requred action
+ * Interface that encapsulates information about the current required action
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $

--- a/server-spi-private/src/main/java/org/keycloak/authentication/ValidationContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/ValidationContext.java
@@ -41,7 +41,7 @@ public interface ValidationContext extends FormContext {
     void error(String error);
 
     /**
-     * Mark this validation as sucessful
+     * Mark this validation as successful
      *
      */
     void success();

--- a/server-spi-private/src/main/java/org/keycloak/authorization/attribute/Attributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/attribute/Attributes.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * <p>Holds attributes, their values and provides utlity methods to manage them.
+ * <p>Holds attributes, their values and provides utility methods to manage them.
  *
  * <p>In the future, it may be useful to provide different implementations for this interface in order to plug or integrate with different
  * Policy Information Point (PIP).</p>

--- a/server-spi-private/src/main/java/org/keycloak/provider/ServerInfoAwareProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/provider/ServerInfoAwareProviderFactory.java
@@ -27,7 +27,7 @@ import java.util.Map;
 public interface ServerInfoAwareProviderFactory {
 
     /**
-     * Return actual info about the provider. This info contains informations about providers configuration and operational conditions (eg. errors in connection to remote systems etc) which is
+     * Return actual info about the provider. This info contains information about provider's configuration and operational conditions (eg. errors in connection to remote systems etc) which is
      * shown on "Server Info" page then.
      * 
      * @return Map with keys describing value and relevant values itself

--- a/server-spi-private/src/main/java/org/keycloak/storage/StoreMigrateRepresentationEvent.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/StoreMigrateRepresentationEvent.java
@@ -24,7 +24,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 /**
  * Event for notifying the store, so it can do migrations on the representation as needed.
  *
- * CAUTION: This event is exceptional as it performs any necessary modificaton of the representation.
+ * CAUTION: This event is exceptional as it performs any necessary modification of the representation.
  */
 public class StoreMigrateRepresentationEvent implements ProviderEvent {
 

--- a/server-spi-private/src/main/java/org/keycloak/utils/ProxyClassLoader.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ProxyClassLoader.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * 
  * The way it works:
  * - Get list of classloaders, which will be used as "delegates" when loaded classes or resources.
- *   - Can be retrived from provided classloaders or alternatively from the provided classes where the "delegate classloaders" will be determined from the classloaders of given classes
+ *   - Can be retrieved from provided classloaders or alternatively from the provided classes where the "delegate classloaders" will be determined from the classloaders of given classes
  * - For each class or resource that is 'requested':
  *   - First try all provided classloaders and if we have a match, return that
  *   - If no match was found: proceed with 'normal' classloading in 'current classpath' scope

--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
@@ -272,7 +272,7 @@ public class IdentityProviderModel implements Serializable {
     }
 
     /**
-     * Returns flag whether the users withing this IdP should be transient, ie. not stored in Keycloak database.
+     * Returns flag whether the users within this IdP should be transient, ie. not stored in Keycloak database.
      * Default value: {@code false}.
      * @return
      */

--- a/server-spi/src/main/java/org/keycloak/services/clientpolicy/ClientPolicyManager.java
+++ b/server-spi/src/main/java/org/keycloak/services/clientpolicy/ClientPolicyManager.java
@@ -50,7 +50,7 @@ public interface ClientPolicyManager extends Provider {
     /**
      * when importing a realm, or updating a realm, update model from the representation object
      *
-     * @param realm - the newly created realm to be overriden by imported realm's representation
+     * @param realm - the newly created realm to be overridden by imported realm's representation
      * @param rep - imported realm's representation
      */
     void updateRealmModelFromRepresentation(RealmModel realm, RealmRepresentation rep);
@@ -62,9 +62,9 @@ public interface ClientPolicyManager extends Provider {
      *
      * If the "clientProfiles" parameter contains the global client profiles, they won't be updated on the realm at all
      * 
-     * @param realm - the realm whose client profiles is to be overriden by the new client profiles
+     * @param realm - the realm whose client profiles is to be overridden by the new client profiles
      * @param clientProfiles - the json representation of the new client profiles that overrides the existing client profiles set on the realm. With
-     *                       the exception of global profiles, which are not overriden as mentioned above.
+     *                       the exception of global profiles, which are not overridden as mentioned above.
      * @throws {@link ClientPolicyException}
      */
     void updateClientProfiles(RealmModel realm, ClientProfilesRepresentation clientProfiles) throws ClientPolicyException;
@@ -83,7 +83,7 @@ public interface ClientPolicyManager extends Provider {
      * and overrides the existing client policies set on the realm with them.
      * if these operation fails, rolls them back to the existing client policies and throw an exception.
      *
-     * @param realm - the realm whose client policies is to be overriden by the new client policies
+     * @param realm - the realm whose client policies is to be overridden by the new client policies
      * @param clientPolicies - the json representation of the new client policies that overrides the existing client policies set on the realm
      * @throws {@link ClientPolicyException}
      */

--- a/server-spi/src/main/java/org/keycloak/sessions/CommonClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/sessions/CommonClientSessionModel.java
@@ -24,7 +24,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.util.EnumWithStableIndex;
 
 /**
- * Predecesor of AuthenticationSessionModel, ClientLoginSessionModel and ClientSessionModel (then action tickets). Maybe we will remove it later...
+ * Predecessor of AuthenticationSessionModel, ClientLoginSessionModel and ClientSessionModel (then action tickets). Maybe we will remove it later...
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */

--- a/server-spi/src/main/java/org/keycloak/storage/group/GroupLookupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/group/GroupLookupProvider.java
@@ -84,7 +84,7 @@ public interface GroupLookupProvider {
      *
      * @param realm Realm.
      * @param search Case sensitive searched string.
-     * @param exact Boolean which defines wheather search param should be matched exactly.
+     * @param exact Boolean which defines whether search param should be matched exactly.
      * @param firstResult First result to return. Ignored if negative or {@code null}.
      * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
      * @return Stream of root groups that have the given string in their name themself or a group in their child-collection has.

--- a/server-spi/src/main/java/org/keycloak/validate/ValidationError.java
+++ b/server-spi/src/main/java/org/keycloak/validate/ValidationError.java
@@ -118,7 +118,7 @@ public class ValidationError implements Serializable {
     }
 
     /**
-     * Returns an array where the first element is the {@link #inputHint} follwed by the {@link #messageParameters}.
+     * Returns an array where the first element is the {@link #inputHint} followed by the {@link #messageParameters}.
      *
      * @return
      */

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
@@ -54,7 +54,7 @@ import java.util.Map;
  * </ol>
  * </p>
  * <p>
- * Note that the {@code user} variable is only defined when the user was identified by a preceeding
+ * Note that the {@code user} variable is only defined when the user was identified by a preceding
  * authentication step, e.g. by the {@link UsernamePasswordForm} authenticator.
  * </p>
  * <p>

--- a/services/src/main/java/org/keycloak/authentication/authenticators/util/LoAUtil.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/util/LoAUtil.java
@@ -83,7 +83,7 @@ public class LoAUtil {
 
     /**
      * @param realm
-     * @return All LoA numbers configured in the conditions in the realm browser flow. Key is level, Vaue is maxAge for particular level
+     * @return All LoA numbers configured in the conditions in the realm browser flow. Key is level, Value is maxAge for particular level
      */
     public static Map<Integer, Integer> getLoaMaxAgesConfiguredInRealmBrowserFlow(RealmModel realm) {
         List<AuthenticationExecutionModel> loaConditions = AuthenticatorUtil.getExecutionsByType(realm, realm.getBrowserFlow().getId(), ConditionalLoaAuthenticatorFactory.PROVIDER_ID);

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/AbstractUserProfileBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/AbstractUserProfileBean.java
@@ -23,7 +23,7 @@ import org.keycloak.userprofile.UserProfile;
 import org.keycloak.userprofile.UserProfileProvider;
 
 /**
- * Abstract base for Freemarker context bean providing informations about user profile to render dynamic or crafted forms.  
+ * Abstract base for Freemarker context bean providing information about user profile to render dynamic or crafted forms.  
  * 
  * @author Vlastimil Elias <velias@redhat.com>
  */

--- a/services/src/main/java/org/keycloak/partialimport/IdentityProviderMappersPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/IdentityProviderMappersPartialImport.java
@@ -28,7 +28,7 @@ import org.keycloak.representations.idm.PartialImportRepresentation;
 import java.util.List;
 
 /**
- * PartialImport handler for Identitiy Provider Mappers.
+ * PartialImport handler for Identity Provider Mappers.
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */

--- a/services/src/main/java/org/keycloak/partialimport/IdentityProvidersPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/IdentityProvidersPartialImport.java
@@ -28,7 +28,7 @@ import org.keycloak.representations.idm.PartialImportRepresentation;
 import java.util.List;
 
 /**
- * PartialImport handler for Identitiy Providers.
+ * PartialImport handler for Identity Providers.
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/VCSigningServiceSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/VCSigningServiceSpi.java
@@ -22,7 +22,7 @@ import org.keycloak.provider.ProviderFactory;
 import org.keycloak.provider.Spi;
 
 /**
- * Spi implementation fo the creation of {@link  VerifiableCredentialsSigningService}
+ * Spi implementation of the creation of {@link  VerifiableCredentialsSigningService}
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserAttributeMapper.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * Mappings UserModel.attribute to an ID Token claim.  Token claim name can be a full qualified nested object name,
  * i.e. "address.country".  This will create a nested
- * json object within the toke claim.
+ * json object within the token claim.
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserPropertyMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserPropertyMapper.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * Mappings UserModel property (the property name of a getter method) to an ID Token claim.  Token claim name can be a full qualified nested object name,
  * i.e. "address.country".  This will create a nested
- * json object within the toke claim.
+ * json object within the token claim.
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/util/Soap.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/util/Soap.java
@@ -85,7 +85,7 @@ public final class Soap {
     }
 
     /**
-     * <p>Returns Docuemnt based on the given <code>inputStream</code> which must contain a valid SOAP message.
+     * <p>Returns Document based on the given <code>inputStream</code> which must contain a valid SOAP message.
      *
      * <p>The resulting string is based on the Body of the SOAP message, which should map to a valid SAML message.
      *
@@ -103,7 +103,7 @@ public final class Soap {
     }
 
     /**
-     * <p>Returns Docuemnt based on the given SOAP message.
+     * <p>Returns Document based on the given SOAP message.
      *
      * <p>The resulting string is based on the Body of the SOAP message, which should map to a valid SAML message.
      * @param soapMessage a SOAPMessage from which to extract the body
@@ -214,7 +214,7 @@ public final class Soap {
         }
 
         /**
-         * Build method for testing, generates an appache httpcomponents HttpPost
+         * Build method for testing, generates an apache httpcomponents HttpPost
          * @param uri the URI to which to POST the soap message
          * @return an HttpPost containing the SOAP message
          */

--- a/services/src/main/java/org/keycloak/services/resources/LoadBalancerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoadBalancerResource.java
@@ -50,7 +50,7 @@ public class LoadBalancerResource {
     KeycloakSession session;
 
     /**
-     * Return the status for a laod balancer in a multi-site setup if this Keycloak site should receive traffic.
+     * Return the status for a load balancer in a multi-site setup if this Keycloak site should receive traffic.
      * <p />
      * While a loadbalancer will usually check for the returned status code, the additional text <code>UP</code> or <code>DOWN</down>
      * is returned for humans to see the status in the browser.


### PR DESCRIPTION
This includes documentation and user-visible messages, but excludes log messages.

This is a follow-up to #28890. This is currently an incomplete draft, I want to make sure I have got "only user-facing content excluding log messages" right.