### PR TITLE
Incorrect proxyMappings example in the guides

### DIFF
--- a/docs/guides/server/outgoinghttp.adoc
+++ b/docs/guides/server/outgoinghttp.adoc
@@ -85,7 +85,9 @@ For example, consider the following regex:
 
 You apply a regex-based hostname pattern by entering this command:
 
-<@kc.start parameters="--spi-connections-http-client-default-proxy-mappings=\"\'*\\\\\\.(google|googleapis)\\\\\\.com;http://www-proxy.acme.com:8080\'\""/>
+<@kc.start parameters="--spi-connections-http-client-default-proxy-mappings=\'.*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080\'"/>
+
+The backslash character `\` is escaped again because micro-profile config is used to parse the array of mappings.
 
 To determine the proxy for the outgoing HTTP request, the following occurs:
 


### PR DESCRIPTION
Closes #25514

Just a minor change in the documentation. After issue #22337 the double quoting is not needed. Besides I have checked that only the backslash should be escaped twice because of the microprofile config.
