### PR TITLE
Allow adding realm users as an organization member

### DIFF
--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -17,10 +17,8 @@
 
 package org.keycloak.admin.client.resource;
 
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -31,10 +29,6 @@ public interface OrganizationMemberResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     UserRepresentation toRepresentation();
-
-    @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    Response update(UserRepresentation organization);
 
     @DELETE
     Response delete();

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -34,7 +34,7 @@ public interface OrganizationMembersResource {
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    Response addMember(UserRepresentation member);
+    Response addMember(String userId);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationsResource.java
@@ -67,4 +67,14 @@ public interface OrganizationsResource {
             @QueryParam("first") Integer first,
             @QueryParam("max") Integer max
     );
+
+    /**
+     * Return all organizations that match the specified filter.
+     *
+     * @param search a {@code String} representing either an organization name or domain.
+     * @return a list containing the matched organizations.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> search(@QueryParam("search") String search);
 }

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -17,10 +17,11 @@
 
 package org.keycloak.organization.jpa;
 
-import static org.keycloak.models.OrganizationModel.USER_ORGANIZATION_ATTRIBUTE;
+import static org.keycloak.models.OrganizationModel.ORGANIZATION_ATTRIBUTE;
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +30,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.TypedQuery;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.GroupProvider;
 import org.keycloak.models.IdentityProviderModel;
@@ -94,7 +96,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         GroupModel group = getOrganizationGroup(organization);
 
         //TODO: won't scale, requires a better mechanism for bulk deleting users
-        userProvider.getGroupMembersStream(realm, group).forEach(userModel -> userProvider.removeUser(realm, userModel));
+        userProvider.getGroupMembersStream(realm, group).forEach(userModel -> removeMember(organization, userModel));
         groupProvider.removeGroup(realm, group);
 
         realm.removeIdentityProviderByAlias(entity.getIdpAlias());
@@ -122,12 +124,12 @@ public class JpaOrganizationProvider implements OrganizationProvider {
             return false;
         }
 
-        if (user.getFirstAttribute(USER_ORGANIZATION_ATTRIBUTE) != null) {
+        if (user.getFirstAttribute(ORGANIZATION_ATTRIBUTE) != null) {
             throw new ModelException("User [" + user.getId() + "] is a member of a different organization");
         }
 
         user.joinGroup(group);
-        user.setSingleAttribute(USER_ORGANIZATION_ATTRIBUTE, entity.getId());
+        user.setSingleAttribute(ORGANIZATION_ATTRIBUTE, entity.getId());
 
         return true;
     }
@@ -185,7 +187,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
             return null;
         }
 
-        String orgId = user.getFirstAttribute(USER_ORGANIZATION_ATTRIBUTE);
+        String orgId = user.getFirstAttribute(ORGANIZATION_ATTRIBUTE);
 
         if (organization.getId().equals(orgId)) {
             return user;
@@ -198,7 +200,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
     public OrganizationModel getByMember(UserModel member) {
         throwExceptionIfObjectIsNull(member, "User");
 
-        String orgId = member.getFirstAttribute(USER_ORGANIZATION_ATTRIBUTE);
+        String orgId = member.getFirstAttribute(ORGANIZATION_ATTRIBUTE);
 
         if (orgId == null) {
             return null;
@@ -214,6 +216,9 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
         OrganizationEntity organizationEntity = getEntity(organization.getId());
         organizationEntity.setIdpAlias(identityProvider.getAlias());
+        identityProvider.getConfig().put(ORGANIZATION_ATTRIBUTE, organization.getId());
+        realm.updateIdentityProvider(identityProvider);
+
         return true;
     }
 
@@ -233,6 +238,48 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
         OrganizationEntity organizationEntity = getEntity(organization.getId());
         organizationEntity.setIdpAlias(null);
+        return true;
+    }
+
+    @Override
+    public boolean isManagedMember(OrganizationModel organization, UserModel member) {
+        throwExceptionIfObjectIsNull(organization, "organization");
+
+        if (member == null) {
+            return false;
+        }
+
+        IdentityProviderModel identityProvider = organization.getIdentityProvider();
+
+        if (identityProvider == null) {
+            return false;
+        }
+
+        FederatedIdentityModel federatedIdentity = userProvider.getFederatedIdentity(realm, member, identityProvider.getAlias());
+
+        return federatedIdentity != null;
+    }
+
+    @Override
+    public boolean removeMember(OrganizationModel organization, UserModel member) {
+        throwExceptionIfObjectIsNull(organization, "organization");
+        throwExceptionIfObjectIsNull(member, "member");
+
+        OrganizationModel userOrg = getByMember(member);
+
+        if (userOrg == null || !userOrg.equals(organization)) {
+            return false;
+        }
+
+        if (isManagedMember(organization, member)) {
+            userProvider.removeUser(realm, member);
+        } else {
+            List<String> organizations = member.getAttributes().get(ORGANIZATION_ATTRIBUTE);
+            organizations.remove(organization.getId());
+            member.setAttribute(ORGANIZATION_ATTRIBUTE, organizations);
+            member.leaveGroup(getOrganizationGroup(organization));
+        }
+
         return true;
     }
 

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -32,6 +32,7 @@ import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.OrganizationDomainModel;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.jpa.JpaModel;
 import org.keycloak.models.jpa.entities.OrganizationDomainEntity;
 import org.keycloak.models.jpa.entities.OrganizationEntity;
@@ -134,6 +135,11 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
     }
 
     @Override
+    public boolean isManaged(UserModel user) {
+        return provider.isManagedMember(this, user);
+    }
+
+    @Override
     public OrganizationEntity getEntity() {
         return entity;
     }
@@ -152,6 +158,20 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
                 .append(",")
                 .append("groupId=")
                 .append(getGroupId()).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OrganizationModel)) return false;
+
+        OrganizationModel that = (OrganizationModel) o;
+        return that.getId().equals(getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
     }
 
     private OrganizationDomainModel toModel(OrganizationDomainEntity entity) {

--- a/server-spi-private/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -156,4 +156,35 @@ public interface OrganizationProvider extends Provider {
      * @return {@code true} if organization is supported. Otherwise, returns {@code false}
      */
     boolean isEnabled();
+
+    /**
+     * <p>Indicates if the given {@code member} is managed by the organization.
+     *
+     * <p>A member is managed by the organization whenever the member cannot exist without the organization they belong
+     * to so that their lifecycle is bound to the organization lifecycle. For instance, when a member is federated from
+     * the identity provider associated with an organization, there is a strong relationship between the member identity
+     * and the organization.
+     *
+     * <p>On the other hand, existing realm users whose identities are not intrinsically linked to an organization but
+     * are eventually joining an organization are not managed by the organization. They have a lifecycle that does not
+     * depend on the organization they are linked to.
+     *
+     * @param organization the organization
+     * @param member the member
+     * @return {@code true} if the {@code member} is managed by the given {@code organization}. Otherwise, returns {@code false}
+     */
+    boolean isManagedMember(OrganizationModel organization, UserModel member);
+
+    /**
+     * <p>Removes a member from the organization.
+     *
+     * <p>This method can either remove the given {@code member} entirely from the realm (and the organization) or only
+     * remove the link to the {@code organization} so that the user still exists but is no longer a member of the organization.
+     * The decision to remove the user entirely or only the link depends on whether the user is managed by the organization or not, respectively.
+     *
+     * @param organization the organization
+     * @param member the member
+     * @return {@code true} if the given {@code member} is a member and was successfully removed from the organization. Otherwise, returns {@code false}
+     */
+    boolean removeMember(OrganizationModel organization, UserModel member);
 }

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 public interface OrganizationModel {
 
-    String USER_ORGANIZATION_ATTRIBUTE = "kc.org";
+    String ORGANIZATION_ATTRIBUTE = "kc.org";
 
     String getId();
 
@@ -41,4 +41,6 @@ public interface OrganizationModel {
     void setDomains(Set<OrganizationDomainModel> domains);
 
     IdentityProviderModel getIdentityProvider();
+
+    boolean isManaged(UserModel user);
 }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -45,6 +45,10 @@ public class IdentityProviderBean {
     private RealmModel realm;
     private final KeycloakSession session;
 
+    public IdentityProviderBean() {
+        this.session = null;
+    }
+
     public IdentityProviderBean(RealmModel realm, KeycloakSession session, List<IdentityProviderModel> identityProviders, URI baseURI) {
         this.realm = realm;
         this.session = session;

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAwareIdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAwareIdentityProviderBean.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.organization.authentication.authenticators.browser;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+
+public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean {
+
+    private final IdentityProviderBean delegate;
+    private final KeycloakSession session;
+
+    public OrganizationAwareIdentityProviderBean(IdentityProviderBean delegate, KeycloakSession session) {
+        this.delegate = delegate;
+        this.session = session;
+    }
+
+    @Override
+    public List<IdentityProvider> getProviders() {
+        return Optional.ofNullable(delegate.getProviders()).orElse(List.of()).stream()
+                .filter(this::filterOrganizationalIdentityProvider)
+                .toList();
+    }
+
+    @Override
+    public boolean isDisplayInfo() {
+        return delegate.isDisplayInfo();
+    }
+
+    private boolean filterOrganizationalIdentityProvider(IdentityProvider idp) {
+        RealmModel realm = session.getContext().getRealm();
+        IdentityProviderModel model = realm.getIdentityProviderByAlias(idp.getAlias());
+        Map<String, String> config = model.getConfig();
+        return !config.containsKey(OrganizationModel.ORGANIZATION_ATTRIBUTE);
+    }
+}

--- a/services/src/main/java/org/keycloak/organization/validator/OrganizationMemberValidator.java
+++ b/services/src/main/java/org/keycloak/organization/validator/OrganizationMemberValidator.java
@@ -70,13 +70,21 @@ public class OrganizationMemberValidator extends AbstractSimpleValidator impleme
     }
 
     private void validateEmailDomain(String email, String inputHint, ValidationContext context, OrganizationModel organization) {
-        if (UserModel.USERNAME.equals(inputHint) || UserModel.EMAIL.equals(inputHint)) {
+        if (UserModel.EMAIL.equals(inputHint)) {
             if (StringUtil.isBlank(email)) {
                 context.addError(new ValidationError(ID, inputHint, "Email not set"));
                 return;
             }
 
             if (!emailValidator().validate(email, inputHint, context).isValid()) {
+                return;
+            }
+
+            UserProfileAttributeValidationContext upContext = (UserProfileAttributeValidationContext) context;
+            AttributeContext attributeContext = upContext.getAttributeContext();
+            UserModel user = attributeContext.getUser();
+
+            if (!organization.isManaged(user)) {
                 return;
             }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import org.jboss.arquillian.graphene.page.Page;
 import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
@@ -34,6 +35,10 @@ import org.keycloak.testsuite.admin.AbstractAdminTest;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.admin.Users;
 import org.keycloak.testsuite.broker.KcOidcBrokerConfiguration;
+import org.keycloak.testsuite.pages.AppPage;
+import org.keycloak.testsuite.pages.IdpConfirmLinkPage;
+import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.pages.UpdateAccountInformationPage;
 import org.keycloak.testsuite.util.UserBuilder;
 
 /**
@@ -76,6 +81,18 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
             return name + "-identity-provider";
         }
     };
+
+    @Page
+    protected LoginPage loginPage;
+
+    @Page
+    protected IdpConfirmLinkPage idpConfirmLinkPage;
+
+    @Page
+    protected UpdateAccountInformationPage updateAccountInformationPage;
+
+    @Page
+    protected AppPage appPage;
 
     protected KcOidcBrokerConfiguration bc = brokerConfigFunction.apply(organizationName);
 
@@ -141,13 +158,20 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
         expected.setEnabled(true);
         Users.setPasswordFor(expected, memberPassword);
 
-        try (Response response = organization.members().addMember(expected)) {
+        try (Response response = testRealm().users().create(expected)) {
+            expected.setId(ApiUtil.getCreatedId(response));
+        }
+
+        getCleanup().addCleanup(() -> testRealm().users().get(expected.getId()).remove());
+
+        String userId = expected.getId();
+
+        try (Response response = organization.members().addMember(userId)) {
             assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
-            String id = ApiUtil.getCreatedId(response);
-            UserRepresentation actual = organization.members().member(id).toRepresentation();
+            UserRepresentation actual = organization.members().member(userId).toRepresentation();
 
             assertNotNull(expected);
-            assertEquals(id, actual.getId());
+            assertEquals(userId, actual.getId());
             assertEquals(expected.getUsername(), actual.getUsername());
             assertEquals(expected.getEmail(), actual.getEmail());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationAdminPermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationAdminPermissionsTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.organization.admin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.fail;
+
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.Constants;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.util.AdminClientUtil;
+import org.keycloak.testsuite.util.UserBuilder;
+
+@EnableFeature(Feature.ORGANIZATION)
+public class OrganizationAdminPermissionsTest extends AbstractOrganizationTest {
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+        testRealm.getUsers().add(UserBuilder.create().username("realmAdmin").password("password")
+                .role(Constants.REALM_MANAGEMENT_CLIENT_ID, AdminRoles.MANAGE_REALM)
+                .role(Constants.REALM_MANAGEMENT_CLIENT_ID, AdminRoles.MANAGE_IDENTITY_PROVIDERS)
+                .role(Constants.REALM_MANAGEMENT_CLIENT_ID, AdminRoles.MANAGE_USERS)
+                .build());
+    }
+
+    @Test
+    public void testManageRealmRole() throws Exception {
+        try (
+                Keycloak manageRealmAdminClient = AdminClientUtil.createAdminClient(suiteContext.isAdapterCompatTesting(),
+                        TEST_REALM_NAME, "realmAdmin", "password", Constants.ADMIN_CLI_CLIENT_ID, null);
+                Keycloak userAdminClient = AdminClientUtil.createAdminClient(suiteContext.isAdapterCompatTesting(),
+                        TEST_REALM_NAME, "test-user@localhost", "password", Constants.ADMIN_CLI_CLIENT_ID, null)
+        ) {
+            RealmResource realmAdminResource = manageRealmAdminClient.realm(TEST_REALM_NAME);
+            RealmResource realmUserResource = userAdminClient.realm(TEST_REALM_NAME);
+
+            /* Org */
+            //create org
+            OrganizationRepresentation orgRep = createRepresentation("testOrg", "testOrg.org");
+            String orgId;
+            try (
+                    Response userResponse = realmUserResource.organizations().create(orgRep);
+                    Response adminResponse = realmAdminResource.organizations().create(orgRep)
+            ) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+                assertThat(adminResponse.getStatus(), equalTo(Status.CREATED.getStatusCode()));
+                orgId = ApiUtil.getCreatedId(adminResponse);
+                getCleanup().addCleanup(() -> testRealm().organizations().get(orgId).delete().close());
+            }
+
+            //search for org
+            try {
+                realmUserResource.organizations().search("testOrg.org");
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            assertThat(realmAdminResource.organizations().search("testOrg.org"), Matchers.notNullValue());
+
+            //get org
+            try {
+                realmUserResource.organizations().get(orgId).toRepresentation();
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            assertThat(realmAdminResource.organizations().get(orgId).toRepresentation(), Matchers.notNullValue());
+
+            //update org
+            try (Response userResponse = realmUserResource.organizations().get(orgId).update(orgRep)) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+            }
+
+            //delete org
+            try (Response userResponse = realmUserResource.organizations().get(orgId).delete()) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+            }
+
+            /* IdP */
+            IdentityProviderRepresentation idpRep = new IdentityProviderRepresentation();
+            idpRep.setAlias("dummy");
+            idpRep.setProviderId("oidc");
+            //create IdP
+            try (
+                    Response userResponse = realmUserResource.organizations().get(orgId).identityProvider().create(idpRep);
+                    Response adminResponse = realmAdminResource.organizations().get(orgId).identityProvider().create(idpRep)
+            ) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+                assertThat(adminResponse.getStatus(), equalTo(Status.CREATED.getStatusCode()));
+                getCleanup().addCleanup(() -> testRealm().organizations().get(orgId).identityProvider().delete().close());
+            }
+
+            //get IdP
+            try {
+                //we should get 403, not 400 or 404 etc.
+                realmUserResource.organizations().get("non-existing").identityProvider().toRepresentation();
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            try {
+                realmUserResource.organizations().get(orgId).identityProvider().toRepresentation();
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            assertThat(realmAdminResource.organizations().get(orgId).identityProvider().toRepresentation(), Matchers.notNullValue());
+
+            //update IdP
+            try (Response userResponse = realmUserResource.organizations().get(orgId).identityProvider().update(idpRep)) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+            }
+
+            //delete IdP
+            try (Response userResponse = realmUserResource.organizations().get(orgId).identityProvider().delete()) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+            }
+
+            /* Members */
+            UserRepresentation userRep = UserBuilder.create()
+                    .username("user@testOrg.org")
+                    .email("user@testOrg.org")
+                    .build();
+
+            try (Response response = realmAdminResource.users().create(userRep)) {
+                userRep.setId(ApiUtil.getCreatedId(response));
+            }
+
+            String userId;
+
+            //create member
+            try (
+                    Response userResponse = realmUserResource.organizations().get(orgId).members().addMember(userRep.getId());
+                    Response adminResponse = realmAdminResource.organizations().get(orgId).members().addMember(userRep.getId())
+            ) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+                assertThat(adminResponse.getStatus(), equalTo(Status.CREATED.getStatusCode()));
+                userId = ApiUtil.getCreatedId(adminResponse);
+                assertThat(userId, Matchers.notNullValue());
+                getCleanup().addCleanup(() -> testRealm().organizations().get(orgId).members().member(userId).delete().close());
+            }
+
+            //get members
+            try {
+                //we should get 403, not 400 or 404 etc.
+                realmUserResource.organizations().get("non-existing").members().getAll();
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            try {
+                realmUserResource.organizations().get(orgId).members().getAll();
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            assertThat(realmAdminResource.organizations().get(orgId).members().getAll(), Matchers.notNullValue());
+
+            //get member
+            try {
+                realmUserResource.organizations().get(orgId).members().member(userId).toRepresentation();
+                fail("Expected ForbiddenException");
+            } catch (ForbiddenException expected) {}
+            assertThat(realmAdminResource.organizations().get(orgId).members().member(userId).toRepresentation(), Matchers.notNullValue());
+
+            //delete member
+            try (Response userResponse = realmUserResource.organizations().get(orgId).members().member(userId).delete()) {
+                assertThat(userResponse.getStatus(), equalTo(Status.FORBIDDEN.getStatusCode()));
+            }
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationMemberAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationMemberAuthenticationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.organization.admin;
+
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+
+@EnableFeature(Feature.ORGANIZATION)
+public class OrganizationMemberAuthenticationTest extends AbstractOrganizationTest {
+
+    @Test
+    public void testAuthenticateUnmanagedMember() {
+        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        UserRepresentation member = addMember(organization, "contractor@contractor.org");
+
+        // first try to log in using only the email
+        oauth.clientId("broker-app");
+        loginPage.open(bc.consumerRealmName());
+        Assert.assertFalse(loginPage.isPasswordInputPresent());
+        Assert.assertFalse(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
+        loginPage.loginUsername(member.getEmail());
+
+        // the email does not match an organization so redirect to the realm's default authentication mechanism
+        waitForPage(driver, "sign in to", true);
+        Assert.assertTrue("Driver should be on the provider realm page right now",
+                driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/"));
+        Assert.assertTrue(loginPage.isPasswordInputPresent());
+        Assert.assertEquals(member.getEmail(), loginPage.getUsername());
+        // no idp should be shown because there is only a single idp that is bound to an organization
+        Assert.assertFalse(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
+
+        // the member should be able to log in using the credentials
+        loginPage.login(member.getEmail(), memberPassword);
+        appPage.assertCurrent();
+    }
+
+    @Test
+    public void testTryLoginWithUsernameNotAnEmail() {
+        testRealm().organizations().get(createOrganization().getId());
+        oauth.clientId("broker-app");
+
+        // login with email only
+        loginPage.open(bc.consumerRealmName());
+        log.debug("Logging in");
+        Assert.assertFalse(loginPage.isPasswordInputPresent());
+        loginPage.loginUsername("user");
+
+        // check if the login page is shown
+        Assert.assertTrue(loginPage.isUsernameInputPresent());
+        Assert.assertTrue(loginPage.isPasswordInputPresent());
+    }
+
+    @Test
+    public void testDefaultAuthenticationMechanismIfNotOrganizationMember() {
+        testRealm().organizations().get(createOrganization().getId());
+        oauth.clientId("broker-app");
+
+        // login with email only
+        loginPage.open(bc.consumerRealmName());
+        log.debug("Logging in");
+        Assert.assertFalse(loginPage.isPasswordInputPresent());
+        loginPage.loginUsername("user@noorg.org");
+
+        // check if the login page is shown
+        Assert.assertTrue(loginPage.isUsernameInputPresent());
+        Assert.assertTrue(loginPage.isPasswordInputPresent());
+    }
+}


### PR DESCRIPTION
Closes #29023

* Enables use cases where existing realm users should be added as members of an organization
* Introduces the concept of managed/unmanaged organization members so that we can manage member accounts according to the relationship between their identities and the organizations they belong to. For instance, existing realm users and their identities are not bound to a specific organization but the realm. On the other hand, members federated from the identity provider associated with an organization have their identities, and their lifecycle, strongly coupled with the organization.
* Make sure the `kc.org` attribute set to users can not change if not managed through the Organization API
* It is now possible to have a username other than the email where validations related to the organization (e.g.: email domain matching the organization domain) only happens when validating the email attribute.
* Members not managed by the organization can use any email domain and authenticate using their credentials as per the realm's policies.
* The Organization API no longer creates or updates users as we are now introducing the possibility of linking existing users to an organization.
* Removing organization members now takes into account whether they are managed or not by the organization they are associated with so that managed members have their account completely removed from the realm. On the other hand, users whose identities do not depend on the organization are not removed from the realm but only their link to the organization.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
