### PR TITLE
Make PropertyMapper to use Keycloak options' default values

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -115,7 +115,7 @@ public class PropertyMapper<T> {
         // try to obtain the value for the property we want to map first
         ConfigValue config = convertValue(context.proceed(from));
 
-        if (config == null) {
+        if (config == null || config.getValue() == null) {
             if (mapFrom != null) {
                 // if the property we want to map depends on another one, we use the value from the other property to call the mapper
                 String parentKey = MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + mapFrom;


### PR DESCRIPTION
* improved a condition in PropertyMapper.java

Co-authored-by: Steven Hawkins <shawkins@redhat.com>
Co-authored-by: Václav Muzikář <vmuzikar@redhat.com>

Related to: https://github.com/keycloak/keycloak/issues/28856


