### PR TITLE
Client type service account default type

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
@@ -20,6 +20,9 @@ package org.keycloak.client.clienttype;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientTypeRepresentation;
+
+import java.util.Map;
 
 /**
  * TODO:client-types javadocs
@@ -40,6 +43,8 @@ public interface ClientType {
     // Return the value of particular option (if it can be provided by clientType) or return null if this option is not provided by client type
     <T> T getDefaultValue(String optionName, Class<T> optionType);
 
+
+    Map<String, ClientTypeRepresentation.PropertyConfig> getConfiguration();
 
     // Augment at the client type
     // Augment particular client on creation of client  (TODO:client-types Should it be clientModel or clientRepresentation? Or something else?)

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
@@ -19,7 +19,6 @@
 package org.keycloak.client.clienttype;
 
 import org.keycloak.models.ClientModel;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
 
 import java.util.Map;
@@ -47,9 +46,5 @@ public interface ClientType {
     Map<String, ClientTypeRepresentation.PropertyConfig> getConfiguration();
 
     // Augment at the client type
-    // Augment particular client on creation of client  (TODO:client-types Should it be clientModel or clientRepresentation? Or something else?)
-    void onCreate(ClientRepresentation newClient) throws ClientTypeException;
-
-    // Augment particular client on update of client (TODO:client-types Should it be clientModel or clientRepresentation? Or something else?)
-    void onUpdate(ClientModel currentClient, ClientRepresentation clientToUpdate) throws ClientTypeException;
+    ClientModel augment(ClientModel client);
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
@@ -23,7 +23,7 @@ import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
-import java.util.List;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicMarkableReference;

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -530,7 +530,7 @@ public class RepresentationToModel {
         if (rep.getAttributes() != null) {
             for (Map.Entry<String, String> entry : rep.getAttributes().entrySet()) {
                 clientPropertyUpdates.add(
-                    updatePropertyAction(val -> client.setAttribute(entry.getKey(), val), entry::getValue, () -> client.getAttribute(entry.getKey())));
+                    updatePropertyAction(val -> client.setAttribute(entry.getKey(), val), entry::getValue));
             }
         }
 
@@ -575,7 +575,7 @@ public class RepresentationToModel {
             return newSecret;
         }
         // Do not change current secret.
-        return null;
+        return currentSecret;
     }
 
     private static Set<String> defaultWebOrigins(ClientModel client) {
@@ -663,9 +663,7 @@ public class RepresentationToModel {
         return () -> {
             try {
                 T value = representationGetter.get();
-                if (value != null) {
-                        modelSetter.accept(value);
-                }
+                modelSetter.accept(value);
             } catch (ClientTypeException cte) {
                 return cte;
             }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -522,7 +522,7 @@ public class RepresentationToModel {
             // Client Secret
             add(updatePropertyAction(client::setSecret, () -> determineNewSecret(client, rep)));
             // Redirect uris / Web origins
-            add(updatePropertyAction(client::setRedirectUris, () -> collectionToSet(rep.getRedirectUris())));
+            add(updatePropertyAction(client::setRedirectUris, () -> collectionToSet(rep.getRedirectUris()), client::getRedirectUris));
             add(updatePropertyAction(client::setWebOrigins, () -> collectionToSet(rep.getWebOrigins()), () -> defaultWebOrigins(client)));
         }};
 
@@ -579,10 +579,16 @@ public class RepresentationToModel {
     }
 
     private static Set<String> defaultWebOrigins(ClientModel client) {
-        Optional<Set<String>> webOrigins = Optional.of(client.getWebOrigins()).filter(origins -> !origins.isEmpty());
-        if (webOrigins.isPresent()) {
-            return webOrigins.get();
+        Set<String> webOrigins = client.getWebOrigins();
+        if (webOrigins != null && !webOrigins.isEmpty()) {
+            return webOrigins;
         }
+
+        Set<String> redirectUris = client.getRedirectUris();
+        if (redirectUris == null || redirectUris.isEmpty()) {
+            return null;
+        }
+
         return client.getRedirectUris()
                 .stream()
                 .filter(uri -> uri.startsWith("http"))
@@ -1631,6 +1637,9 @@ public class RepresentationToModel {
     }
 
     private static <T> Set<T> collectionToSet(Collection<T> collection) {
-        return Optional.ofNullable(collection).map(HashSet::new).orElse(null);
+        return Optional.ofNullable(collection)
+                .filter(col -> !col.isEmpty())
+                .map(HashSet::new)
+                .orElse(null);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -1635,7 +1635,6 @@ public class RepresentationToModel {
 
     private static <T> Set<T> collectionToSet(Collection<T> collection) {
         return Optional.ofNullable(collection)
-                .filter(col -> !col.isEmpty())
                 .map(HashSet::new)
                 .orElse(null);
     }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -561,7 +561,6 @@ public class RepresentationToModel {
     private static String determineNewSecret(ClientModel client, ClientRepresentation rep) {
         if (Boolean.TRUE.equals(rep.isPublicClient()) || Boolean.TRUE.equals(rep.isBearerOnly())) {
             // Clear out the secret with null
-            client.setSecret(null);
             return null;
         }
 
@@ -586,7 +585,7 @@ public class RepresentationToModel {
 
         Set<String> redirectUris = client.getRedirectUris();
         if (redirectUris == null || redirectUris.isEmpty()) {
-            return null;
+            return new HashSet<>();
         }
 
         return client.getRedirectUris()

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -167,6 +167,30 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     }
 
     @Override
+    public Set<String> getWebOrigins() {
+        return TypedClientAttribute.WEB_ORIGINS
+                .getClientAttribute(clientType, super::getWebOrigins, Set.class);
+    }
+
+    @Override
+    public void setWebOrigins(Set<String> webOrigins) {
+        TypedClientAttribute.WEB_ORIGINS
+                .setClientAttribute(clientType, webOrigins, super::setWebOrigins, Set.class);
+    }
+
+    @Override
+    public void addWebOrigin(String webOrigin) {
+        TypedClientAttribute.WEB_ORIGINS
+                .setClientAttribute(clientType, webOrigin, super::addWebOrigin, String.class);
+    }
+
+    @Override
+    public void removeWebOrigin(String webOrigin) {
+        TypedClientAttribute.WEB_ORIGINS
+                .setClientAttribute(clientType, null, (val) -> super.removeWebOrigin(webOrigin), String.class);
+    }
+
+    @Override
     public Set<String> getRedirectUris() {
         return TypedClientAttribute.REDIRECT_URIS
                 .getClientAttribute(clientType, super::getRedirectUris, Set.class);
@@ -187,7 +211,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     @Override
     public void removeRedirectUri(String redirectUri) {
         TypedClientAttribute.REDIRECT_URIS
-            .setClientAttribute(clientType, null, (val) -> super.removeAttribute(redirectUri), String.class);
+            .setClientAttribute(clientType, null, (val) -> super.removeRedirectUri(redirectUri), String.class);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -18,14 +18,12 @@
 
 package org.keycloak.services.clienttype.client;
 
-import java.util.function.Consumer;
+import java.util.Map;
 import java.util.function.Supplier;
 
-import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.delegate.ClientModelLazyDelegate;
 import org.keycloak.client.clienttype.ClientType;
-import org.keycloak.client.clienttype.ClientTypeException;
 
 /**
  * Delegates to client-type and underlying delegate
@@ -47,45 +45,145 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isStandardFlowEnabled() {
-        return getBooleanProperty("standardFlowEnabled", super::isStandardFlowEnabled);
+        return TypedClientAttribute.STANDARD_FLOW_ENABLED
+                .getClientAttribute(clientType, super::isStandardFlowEnabled, Boolean.class);
     }
 
     @Override
     public void setStandardFlowEnabled(boolean standardFlowEnabled) {
-        setBooleanProperty("standardFlowEnabled", standardFlowEnabled, super::setStandardFlowEnabled);
+        TypedClientAttribute.STANDARD_FLOW_ENABLED
+                .setClientAttribute(clientType, standardFlowEnabled, super::setStandardFlowEnabled, Boolean.class);
     }
 
-
-    protected boolean getBooleanProperty(String propertyName, Supplier<Boolean> clientGetter) {
-        // Check if clientType supports the feature. If not, simply return false
-        if (!clientType.isApplicable(propertyName)) {
-            return false;
-        }
-
-        //  Check if this is read-only. If yes, then we just directly delegate to return stuff from the clientType rather than from client
-        if (clientType.isReadOnly(propertyName)) {
-            return clientType.getDefaultValue(propertyName, Boolean.class);
-        }
-
-        // Delegate to clientGetter
-        return clientGetter.get();
+    @Override
+    public boolean isBearerOnly() {
+        return TypedClientAttribute.BEARER_ONLY
+                .getClientAttribute(clientType, super::isBearerOnly, Boolean.class);
     }
 
-    protected void setBooleanProperty(String propertyName, Boolean newValue, Consumer<Boolean> clientSetter) {
-        // Check if clientType supports the feature. If not, return directly
-        if (!clientType.isApplicable(propertyName)) {
-            return;
-        }
+    @Override
+    public void setBearerOnly(boolean bearerOnly) {
+        TypedClientAttribute.BEARER_ONLY
+                .setClientAttribute(clientType, bearerOnly, super::setBearerOnly, Boolean.class);
+    }
 
-        // Check if this is read-only. If yes and there is an attempt to change some stuff, then throw an exception
-        if (clientType.isReadOnly(propertyName)) {
-            Boolean oldVal = clientType.getDefaultValue(propertyName, Boolean.class);
-            if (!ObjectUtil.isEqualOrBothNull(oldVal, newValue)) {
-                throw new ClientTypeException("Property " + propertyName + " of client " + getClientId() + " is read-only due to client type " + clientType.getName());
-            }
-        }
+    @Override
+    public boolean isConsentRequired() {
+        return TypedClientAttribute.CONSENT_REQUIRED
+                .getClientAttribute(clientType, super::isConsentRequired, Boolean.class);
+    }
 
-        // Call clientSetter
-        clientSetter.accept(newValue);
+    @Override
+    public void setConsentRequired(boolean consentRequired) {
+        TypedClientAttribute.CONSENT_REQUIRED
+                .setClientAttribute(clientType, consentRequired, super::setConsentRequired, Boolean.class);
+    }
+
+    @Override
+    public boolean isDirectAccessGrantsEnabled() {
+        return TypedClientAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+                .getClientAttribute(clientType, super::isDirectAccessGrantsEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setDirectAccessGrantsEnabled(boolean directAccessGrantsEnabled) {
+        TypedClientAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+                .setClientAttribute(clientType, directAccessGrantsEnabled, super::setDirectAccessGrantsEnabled, Boolean.class);
+    }
+
+    @Override
+    public boolean isAlwaysDisplayInConsole() {
+        return TypedClientAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+                .getClientAttribute(clientType, super::isAlwaysDisplayInConsole, Boolean.class);
+    }
+
+    @Override
+    public void setAlwaysDisplayInConsole(boolean alwaysDisplayInConsole) {
+        TypedClientAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+                .setClientAttribute(clientType, alwaysDisplayInConsole, super::setAlwaysDisplayInConsole, Boolean.class);
+    }
+
+    @Override
+    public boolean isFrontchannelLogout() {
+        return TypedClientAttribute.FRONTCHANNEL_LOGOUT
+                .getClientAttribute(clientType, super::isFrontchannelLogout, Boolean.class);
+    }
+
+    @Override
+    public void setFrontchannelLogout(boolean frontchannelLogout) {
+        TypedClientAttribute.FRONTCHANNEL_LOGOUT
+                .setClientAttribute(clientType, frontchannelLogout, super::setFrontchannelLogout, Boolean.class);
+    }
+
+    @Override
+    public boolean isImplicitFlowEnabled() {
+        return TypedClientAttribute.IMPLICIT_FLOW_ENABLED
+                .getClientAttribute(clientType, super::isImplicitFlowEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setImplicitFlowEnabled(boolean implicitFlowEnabled) {
+        TypedClientAttribute.IMPLICIT_FLOW_ENABLED
+                .setClientAttribute(clientType, implicitFlowEnabled, super::setImplicitFlowEnabled, Boolean.class);
+    }
+
+    @Override
+    public String getProtocol() {
+        return TypedClientAttribute.PROTOCOL
+                .getClientAttribute(clientType, super::getProtocol, String.class);
+    }
+
+    @Override
+    public void setProtocol(String protocol) {
+        TypedClientAttribute.PROTOCOL
+                .setClientAttribute(clientType, protocol, super::setProtocol, String.class);
+    }
+
+    @Override
+    public boolean isPublicClient() {
+        return TypedClientAttribute.PUBLIC_CLIENT
+                .getClientAttribute(clientType, super::isPublicClient, Boolean.class);
+    }
+
+    @Override
+    public void setPublicClient(boolean flag) {
+        TypedClientAttribute.PUBLIC_CLIENT
+                .setClientAttribute(clientType, flag, super::setPublicClient, Boolean.class);
+    }
+
+    @Override
+    public void setAttribute(String name, String value) {
+        TypedClientAttribute attribute = TypedClientAttribute.getAttributeByName(name);
+        if (attribute != null) {
+            attribute.setClientAttribute(clientType, value, (newValue) -> super.setAttribute(name, newValue), String.class);
+        } else {
+            super.setAttribute(name, value);
+        }
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        TypedClientAttribute attribute = TypedClientAttribute.getAttributeByName(name);
+        if (attribute != null) {
+            attribute.setClientAttribute(clientType, null, (val) -> super.removeAttribute(name), String.class);
+        } else {
+            super.removeAttribute(name);
+        }
+    }
+
+    @Override
+    public String getAttribute(String name) {
+        TypedClientAttribute attribute = TypedClientAttribute.getAttributeByName(name);
+        if (attribute != null) {
+            return attribute.getClientAttribute(clientType, () -> super.getAttribute(name), String.class);
+        } else {
+            return super.getAttribute(name);
+        }
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+        // TODO: Determine how to augment defined client type config attributes here.
+        return super.getAttributes();
     }
 }

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.delegate.ClientModelLazyDelegate;
 import org.keycloak.client.clienttype.ClientType;
-import org.keycloak.representations.idm.ClientTypeRepresentation;
 
 /**
  * Delegates to client-type and underlying delegate
@@ -129,6 +128,18 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     public void setImplicitFlowEnabled(boolean implicitFlowEnabled) {
         TypedClientAttribute.IMPLICIT_FLOW_ENABLED
                 .setClientAttribute(clientType, implicitFlowEnabled, super::setImplicitFlowEnabled, Boolean.class);
+    }
+
+    @Override
+    public boolean isServiceAccountsEnabled() {
+        return TypedClientAttribute.SERVICE_ACCOUNTS_ENABLED
+                .getClientAttribute(clientType, super::isServiceAccountsEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setServiceAccountsEnabled(boolean flag) {
+        TypedClientAttribute.SERVICE_ACCOUNTS_ENABLED
+                .setClientAttribute(clientType, flag, super::setServiceAccountsEnabled, Boolean.class);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -20,6 +20,7 @@ package org.keycloak.services.clienttype.client;
 
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.delegate.ClientModelLazyDelegate;
@@ -153,7 +154,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public void setAttribute(String name, String value) {
-        TypedClientAttribute attribute = TypedClientAttribute.getAttributeByName(name);
+        ExtendedTypedClientAttribute attribute = ExtendedTypedClientAttribute.getAttributesByName().get(name);
         if (attribute != null) {
             attribute.setClientAttribute(clientType, value, (newValue) -> super.setAttribute(name, newValue), String.class);
         } else {
@@ -163,7 +164,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public void removeAttribute(String name) {
-        TypedClientAttribute attribute = TypedClientAttribute.getAttributeByName(name);
+        ExtendedTypedClientAttribute attribute = ExtendedTypedClientAttribute.getAttributesByName().get(name);
         if (attribute != null) {
             attribute.setClientAttribute(clientType, null, (val) -> super.removeAttribute(name), String.class);
         } else {
@@ -173,7 +174,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public String getAttribute(String name) {
-        TypedClientAttribute attribute = TypedClientAttribute.getAttributeByName(name);
+        ExtendedTypedClientAttribute attribute = ExtendedTypedClientAttribute.getAttributesByName().get(name);
         if (attribute != null) {
             return attribute.getClientAttribute(clientType, () -> super.getAttribute(name), String.class);
         } else {
@@ -183,7 +184,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public Map<String, String> getAttributes() {
-        // TODO: Determine how to augment defined client type config attributes here.
-        return super.getAttributes();
+        return clientType.getConfiguration().entrySet().stream()
+                .filter(entry -> TypedClientAttribute.getAttributesByName().containsKey(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> getAttribute(entry.getKey())));
     }
 }

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -48,169 +48,169 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isStandardFlowEnabled() {
-        return TypedClientAttribute.STANDARD_FLOW_ENABLED
+        return TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
                 .getClientAttribute(clientType, super::isStandardFlowEnabled, Boolean.class);
     }
 
     @Override
     public void setStandardFlowEnabled(boolean standardFlowEnabled) {
-        TypedClientAttribute.STANDARD_FLOW_ENABLED
+        TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
                 .setClientAttribute(clientType, standardFlowEnabled, super::setStandardFlowEnabled, Boolean.class);
     }
 
     @Override
     public boolean isBearerOnly() {
-        return TypedClientAttribute.BEARER_ONLY
+        return TypedClientSimpleAttribute.BEARER_ONLY
                 .getClientAttribute(clientType, super::isBearerOnly, Boolean.class);
     }
 
     @Override
     public void setBearerOnly(boolean bearerOnly) {
-        TypedClientAttribute.BEARER_ONLY
+        TypedClientSimpleAttribute.BEARER_ONLY
                 .setClientAttribute(clientType, bearerOnly, super::setBearerOnly, Boolean.class);
     }
 
     @Override
     public boolean isConsentRequired() {
-        return TypedClientAttribute.CONSENT_REQUIRED
+        return TypedClientSimpleAttribute.CONSENT_REQUIRED
                 .getClientAttribute(clientType, super::isConsentRequired, Boolean.class);
     }
 
     @Override
     public void setConsentRequired(boolean consentRequired) {
-        TypedClientAttribute.CONSENT_REQUIRED
+        TypedClientSimpleAttribute.CONSENT_REQUIRED
                 .setClientAttribute(clientType, consentRequired, super::setConsentRequired, Boolean.class);
     }
 
     @Override
     public boolean isDirectAccessGrantsEnabled() {
-        return TypedClientAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+        return TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
                 .getClientAttribute(clientType, super::isDirectAccessGrantsEnabled, Boolean.class);
     }
 
     @Override
     public void setDirectAccessGrantsEnabled(boolean directAccessGrantsEnabled) {
-        TypedClientAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+        TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
                 .setClientAttribute(clientType, directAccessGrantsEnabled, super::setDirectAccessGrantsEnabled, Boolean.class);
     }
 
     @Override
     public boolean isAlwaysDisplayInConsole() {
-        return TypedClientAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+        return TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
                 .getClientAttribute(clientType, super::isAlwaysDisplayInConsole, Boolean.class);
     }
 
     @Override
     public void setAlwaysDisplayInConsole(boolean alwaysDisplayInConsole) {
-        TypedClientAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+        TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
                 .setClientAttribute(clientType, alwaysDisplayInConsole, super::setAlwaysDisplayInConsole, Boolean.class);
     }
 
     @Override
     public boolean isFrontchannelLogout() {
-        return TypedClientAttribute.FRONTCHANNEL_LOGOUT
+        return TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
                 .getClientAttribute(clientType, super::isFrontchannelLogout, Boolean.class);
     }
 
     @Override
     public void setFrontchannelLogout(boolean frontchannelLogout) {
-        TypedClientAttribute.FRONTCHANNEL_LOGOUT
+        TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
                 .setClientAttribute(clientType, frontchannelLogout, super::setFrontchannelLogout, Boolean.class);
     }
 
     @Override
     public boolean isImplicitFlowEnabled() {
-        return TypedClientAttribute.IMPLICIT_FLOW_ENABLED
+        return TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
                 .getClientAttribute(clientType, super::isImplicitFlowEnabled, Boolean.class);
     }
 
     @Override
     public void setImplicitFlowEnabled(boolean implicitFlowEnabled) {
-        TypedClientAttribute.IMPLICIT_FLOW_ENABLED
+        TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
                 .setClientAttribute(clientType, implicitFlowEnabled, super::setImplicitFlowEnabled, Boolean.class);
     }
 
     @Override
     public boolean isServiceAccountsEnabled() {
-        return TypedClientAttribute.SERVICE_ACCOUNTS_ENABLED
+        return TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
                 .getClientAttribute(clientType, super::isServiceAccountsEnabled, Boolean.class);
     }
 
     @Override
     public void setServiceAccountsEnabled(boolean flag) {
-        TypedClientAttribute.SERVICE_ACCOUNTS_ENABLED
+        TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
                 .setClientAttribute(clientType, flag, super::setServiceAccountsEnabled, Boolean.class);
     }
 
     @Override
     public String getProtocol() {
-        return TypedClientAttribute.PROTOCOL
+        return TypedClientSimpleAttribute.PROTOCOL
                 .getClientAttribute(clientType, super::getProtocol, String.class);
     }
 
     @Override
     public void setProtocol(String protocol) {
-        TypedClientAttribute.PROTOCOL
+        TypedClientSimpleAttribute.PROTOCOL
                 .setClientAttribute(clientType, protocol, super::setProtocol, String.class);
     }
 
     @Override
     public boolean isPublicClient() {
-        return TypedClientAttribute.PUBLIC_CLIENT
+        return TypedClientSimpleAttribute.PUBLIC_CLIENT
                 .getClientAttribute(clientType, super::isPublicClient, Boolean.class);
     }
 
     @Override
     public void setPublicClient(boolean flag) {
-        TypedClientAttribute.PUBLIC_CLIENT
+        TypedClientSimpleAttribute.PUBLIC_CLIENT
                 .setClientAttribute(clientType, flag, super::setPublicClient, Boolean.class);
     }
 
     @Override
     public Set<String> getWebOrigins() {
-        return TypedClientAttribute.WEB_ORIGINS
+        return TypedClientSimpleAttribute.WEB_ORIGINS
                 .getClientAttribute(clientType, super::getWebOrigins, Set.class);
     }
 
     @Override
     public void setWebOrigins(Set<String> webOrigins) {
-        TypedClientAttribute.WEB_ORIGINS
+        TypedClientSimpleAttribute.WEB_ORIGINS
                 .setClientAttribute(clientType, webOrigins, super::setWebOrigins, Set.class);
     }
 
     @Override
     public void addWebOrigin(String webOrigin) {
-        TypedClientAttribute.WEB_ORIGINS
+        TypedClientSimpleAttribute.WEB_ORIGINS
                 .setClientAttribute(clientType, webOrigin, super::addWebOrigin, String.class);
     }
 
     @Override
     public void removeWebOrigin(String webOrigin) {
-        TypedClientAttribute.WEB_ORIGINS
+        TypedClientSimpleAttribute.WEB_ORIGINS
                 .setClientAttribute(clientType, null, (val) -> super.removeWebOrigin(webOrigin), String.class);
     }
 
     @Override
     public Set<String> getRedirectUris() {
-        return TypedClientAttribute.REDIRECT_URIS
+        return TypedClientSimpleAttribute.REDIRECT_URIS
                 .getClientAttribute(clientType, super::getRedirectUris, Set.class);
     }
 
     @Override
     public void setRedirectUris(Set<String> redirectUris) {
-        TypedClientAttribute.REDIRECT_URIS
+        TypedClientSimpleAttribute.REDIRECT_URIS
                 .setClientAttribute(clientType, redirectUris, super::setRedirectUris, Set.class);
     }
 
     @Override
     public void addRedirectUri(String redirectUri) {
-        TypedClientAttribute.REDIRECT_URIS
+        TypedClientSimpleAttribute.REDIRECT_URIS
                 .setClientAttribute(clientType, redirectUri, super::addRedirectUri, String.class);
     }
 
     @Override
     public void removeRedirectUri(String redirectUri) {
-        TypedClientAttribute.REDIRECT_URIS
+        TypedClientSimpleAttribute.REDIRECT_URIS
             .setClientAttribute(clientType, null, (val) -> super.removeRedirectUri(redirectUri), String.class);
     }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -23,9 +24,9 @@ enum TypedClientAttribute implements TypedClientAttributeInterface {
     IMPLICIT_FLOW_ENABLED("implicitFlowEnabled", false),
     PROTOCOL("protocol", null),
     PUBLIC_CLIENT("publicClient", false),
-    REDIRECT_URIS("redirectUris", null),
+    REDIRECT_URIS("redirectUris", Set.of()),
     SERVICE_ACCOUNTS_ENABLED("serviceAccountsEnabled", false),
-    WEB_ORIGINS("webOrigins", null),
+    WEB_ORIGINS("webOrigins", Set.of()),
     ;
 
     private final String propertyName;

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -1,0 +1,90 @@
+package org.keycloak.services.clienttype.client;
+
+import org.keycloak.client.clienttype.ClientType;
+import org.keycloak.client.clienttype.ClientTypeException;
+import org.keycloak.common.util.ObjectUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+enum TypedClientAttribute {
+    STANDARD_FLOW_ENABLED("standardFlowEnabled", false),
+    BEARER_ONLY("bearerOnly", false),
+    CONSENT_REQUIRED("consentRequired", false),
+    DIRECT_ACCESS_GRANTS_ENABLED("directAccessGrantsEnabled", false),
+    ALWAYS_DISPLAY_IN_CONSOLE("alwaysDisplayInConsole", false),
+    AUTHORIZATION_SERVICES_ENABLED("authorizationServicesEnabled", false),
+    FRONTCHANNEL_LOGOUT("frontchannelLogout", false),
+    IMPLICIT_FLOW_ENABLED("implicitFlowEnabled", false),
+    LOGIN_THEME("login_theme", ""),
+    LOGO_URI("logoUri", null),
+    DEVICE_AUTHORIZATION_GRANT_ENABLED("oauth2.device.authorization.grant.enabled", "false"),
+    CIBA_GRANT_ENABLED("oidc.ciba.grant.enabled", "false"),
+    POLICY_URI("policyUri", null),
+    PROTOCOL("protocol", null),
+    PUBLIC_CLIENT("publicClient", false),
+    REDIRECT_URIS("redirectUris", false);
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    private final String propertyName;
+    private final Object nonApplicableValue;
+    private static final Map<String, TypedClientAttribute> attributeByName = new HashMap<>();
+
+    static {
+        Arrays.stream(TypedClientAttribute.values())
+                .forEach(attribute -> attributeByName.put(attribute.getPropertyName(), attribute));
+    }
+
+    TypedClientAttribute(String propertyName, Object nonApplicableValue) {
+        this.propertyName = propertyName;
+        this.nonApplicableValue = nonApplicableValue;
+    }
+
+    public <T> T getClientAttribute(ClientType clientType, Supplier<T> clientGetter, Class<T> tClass) {
+        // Check if clientType supports the feature.
+        if (!clientType.isApplicable(propertyName)) {
+            return tClass.cast(nonApplicableValue);
+        }
+
+        //  Check if this is read-only. If yes, then we just directly delegate to return stuff from the clientType rather than from client
+        if (clientType.isReadOnly(propertyName)) {
+            return clientType.getDefaultValue(propertyName, tClass);
+        }
+
+        // Delegate to clientGetter
+        return clientGetter.get();
+    }
+
+    public <T> void setClientAttribute(ClientType clientType, T newValue, Consumer<T> clientSetter, Class<T> tClass) {
+        // Check if clientType supports the feature. If not, return directly
+        if (!clientType.isApplicable(propertyName) && !Objects.equals(nonApplicableValue, newValue)) {
+            throw new ClientTypeException(
+                    "Property is not-applicable to client type " + clientType.getName()
+                    + " and can not be modified.", propertyName);
+        }
+
+        // Check if this is read-only. If yes and there is an attempt to change some stuff, then throw an exception
+        if (clientType.isReadOnly(propertyName)) {
+            T oldVal = clientType.getDefaultValue(propertyName, tClass);
+            if (!ObjectUtil.isEqualOrBothNull(oldVal, newValue)) {
+                throw new ClientTypeException(
+                        "Property " + propertyName + " is read-only due to client type " + clientType.getName(),
+                        propertyName);
+            }
+        }
+
+        // Delegate to clientSetter
+        clientSetter.accept(newValue);
+    }
+
+    public static TypedClientAttribute getAttributeByName(String name) {
+        return attributeByName.get(name);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -6,7 +6,6 @@ import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.common.util.ObjectUtil;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -15,7 +14,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 enum TypedClientAttribute implements TypedClientAttributeInterface {
-    // Client Type attributes shared by client model and representation.
+    // Top Level client attributes
     STANDARD_FLOW_ENABLED("standardFlowEnabled", false),
     BEARER_ONLY("bearerOnly", false),
     CONSENT_REQUIRED("consentRequired", false),
@@ -25,7 +24,9 @@ enum TypedClientAttribute implements TypedClientAttributeInterface {
     IMPLICIT_FLOW_ENABLED("implicitFlowEnabled", false),
     PROTOCOL("protocol", null),
     PUBLIC_CLIENT("publicClient", false),
-    REDIRECT_URIS("redirectUris", Set.of());
+    REDIRECT_URIS("redirectUris", Set.of()),
+    SERVICE_ACCOUNTS_ENABLED("serviceAccountsEnabled", false),
+    ;
 
     private final String propertyName;
     private final Object nonApplicableValue;

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -11,35 +11,89 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-enum TypedClientAttribute {
+
+enum ExtendedTypedClientAttribute implements TypedClientAttributeInterface {
+    // Extended Client Type attributes defined as client attribute entities.
+    DEVICE_AUTHORIZATION_GRANT_ENABLED("oauth2.device.authorization.grant.enabled", "false"),
+    CIBA_GRANT_ENABLED("oidc.ciba.grant.enabled", "false");
+
+    private static final Map<String, ExtendedTypedClientAttribute> attributesByName = new HashMap<>();
+
+    static {
+        Arrays.stream(ExtendedTypedClientAttribute.values())
+                .forEach(attribute -> attributesByName.put(attribute.getPropertyName(), attribute));
+    }
+
+    private final String propertyName;
+    private final Object nonApplicableValue;
+
+    ExtendedTypedClientAttribute(String propertyName, Object nonApplicableValue) {
+        this.propertyName = propertyName;
+        this.nonApplicableValue = nonApplicableValue;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public Object getNonApplicableValue() {
+        return nonApplicableValue;
+    }
+
+    public static Map<String, ExtendedTypedClientAttribute> getAttributesByName() {
+        return attributesByName;
+    }
+}
+
+enum TypedClientRepresentationAttribute implements TypedClientAttributeInterface {
+    // Client type attributes specific to client representations.
+    AUTHORIZATION_SERVICES_ENABLED("authorizationServicesEnabled", false),
+    LOGIN_THEME("login_theme", ""),
+    LOGO_URI("logoUri", null),
+    POLICY_URI("policyUri", null);
+
+    private final String propertyName;
+    private final Object nonApplicableValue;
+
+     TypedClientRepresentationAttribute(String propertyName, Object nonApplicableValue) {
+        this.propertyName = propertyName;
+        this.nonApplicableValue = nonApplicableValue;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public Object getNonApplicableValue() {
+        return nonApplicableValue;
+    }
+}
+
+enum TypedClientAttribute implements TypedClientAttributeInterface {
+    // Client Type attributes shared by client model and representation.
     STANDARD_FLOW_ENABLED("standardFlowEnabled", false),
     BEARER_ONLY("bearerOnly", false),
     CONSENT_REQUIRED("consentRequired", false),
     DIRECT_ACCESS_GRANTS_ENABLED("directAccessGrantsEnabled", false),
     ALWAYS_DISPLAY_IN_CONSOLE("alwaysDisplayInConsole", false),
-    AUTHORIZATION_SERVICES_ENABLED("authorizationServicesEnabled", false),
     FRONTCHANNEL_LOGOUT("frontchannelLogout", false),
     IMPLICIT_FLOW_ENABLED("implicitFlowEnabled", false),
-    LOGIN_THEME("login_theme", ""),
-    LOGO_URI("logoUri", null),
-    DEVICE_AUTHORIZATION_GRANT_ENABLED("oauth2.device.authorization.grant.enabled", "false"),
-    CIBA_GRANT_ENABLED("oidc.ciba.grant.enabled", "false"),
-    POLICY_URI("policyUri", null),
     PROTOCOL("protocol", null),
     PUBLIC_CLIENT("publicClient", false),
     REDIRECT_URIS("redirectUris", false);
 
-    public String getPropertyName() {
-        return propertyName;
-    }
-
     private final String propertyName;
     private final Object nonApplicableValue;
-    private static final Map<String, TypedClientAttribute> attributeByName = new HashMap<>();
+
+    private static final Map<String, TypedClientAttribute> attributesByName = new HashMap<>();
 
     static {
         Arrays.stream(TypedClientAttribute.values())
-                .forEach(attribute -> attributeByName.put(attribute.getPropertyName(), attribute));
+                .forEach(attribute -> attributesByName.put(attribute.getPropertyName(), attribute));
     }
 
     TypedClientAttribute(String propertyName, Object nonApplicableValue) {
@@ -47,7 +101,27 @@ enum TypedClientAttribute {
         this.nonApplicableValue = nonApplicableValue;
     }
 
-    public <T> T getClientAttribute(ClientType clientType, Supplier<T> clientGetter, Class<T> tClass) {
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public Object getNonApplicableValue() {
+        return nonApplicableValue;
+    }
+
+    public static Map<String, TypedClientAttribute> getAttributesByName() {
+        return attributesByName;
+    }
+}
+
+interface TypedClientAttributeInterface {
+
+    default <T> T getClientAttribute(ClientType clientType, Supplier<T> clientGetter, Class<T> tClass) {
+        String propertyName = getPropertyName();
+        Object nonApplicableValue = getNonApplicableValue();
+
         // Check if clientType supports the feature.
         if (!clientType.isApplicable(propertyName)) {
             return tClass.cast(nonApplicableValue);
@@ -62,12 +136,14 @@ enum TypedClientAttribute {
         return clientGetter.get();
     }
 
-    public <T> void setClientAttribute(ClientType clientType, T newValue, Consumer<T> clientSetter, Class<T> tClass) {
+    default <T> void setClientAttribute(ClientType clientType, T newValue, Consumer<T> clientSetter, Class<T> tClass) {
+        String propertyName = getPropertyName();
+        Object nonApplicableValue = getNonApplicableValue();
         // Check if clientType supports the feature. If not, return directly
         if (!clientType.isApplicable(propertyName) && !Objects.equals(nonApplicableValue, newValue)) {
             throw new ClientTypeException(
                     "Property is not-applicable to client type " + clientType.getName()
-                    + " and can not be modified.", propertyName);
+                            + " and can not be modified.", propertyName);
         }
 
         // Check if this is read-only. If yes and there is an attempt to change some stuff, then throw an exception
@@ -84,7 +160,6 @@ enum TypedClientAttribute {
         clientSetter.accept(newValue);
     }
 
-    public static TypedClientAttribute getAttributeByName(String name) {
-        return attributeByName.get(name);
-    }
+    String getPropertyName();
+    Object getNonApplicableValue();
 }

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -26,6 +26,7 @@ enum TypedClientAttribute implements TypedClientAttributeInterface {
     PUBLIC_CLIENT("publicClient", false),
     REDIRECT_URIS("redirectUris", Set.of()),
     SERVICE_ACCOUNTS_ENABLED("serviceAccountsEnabled", false),
+    WEB_ORIGINS("webOrigins", Set.of()),
     ;
 
     private final String propertyName;

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -24,9 +23,9 @@ enum TypedClientAttribute implements TypedClientAttributeInterface {
     IMPLICIT_FLOW_ENABLED("implicitFlowEnabled", false),
     PROTOCOL("protocol", null),
     PUBLIC_CLIENT("publicClient", false),
-    REDIRECT_URIS("redirectUris", Set.of()),
+    REDIRECT_URIS("redirectUris", null),
     SERVICE_ACCOUNTS_ENABLED("serviceAccountsEnabled", false),
-    WEB_ORIGINS("webOrigins", Set.of()),
+    WEB_ORIGINS("webOrigins", null),
     ;
 
     private final String propertyName;
@@ -52,7 +51,7 @@ enum TypedClientExtendedAttribute implements TypedClientAttributeInterface {
     // Extended Client Type attributes defined as client attribute entities.
     DEVICE_AUTHORIZATION_GRANT_ENABLED("oauth2.device.authorization.grant.enabled", "false"),
     CIBA_GRANT_ENABLED("oidc.ciba.grant.enabled", "false"),
-    LOGIN_THEME("login_theme", ""),
+    LOGIN_THEME("login_theme", null),
     LOGO_URI("logoUri", null),
     POLICY_URI("policyUri", null);
 

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -117,9 +117,8 @@ interface TypedClientAttributeInterface {
         Object nonApplicableValue = getNonApplicableValue();
         // Check if clientType supports the feature. If not, return directly
         if (!clientType.isApplicable(propertyName) && !Objects.equals(nonApplicableValue, newValue)) {
-            throw new ClientTypeException(
-                    "Property is not-applicable to client type " + clientType.getName()
-                            + " and can not be modified.", propertyName);
+            logger.warnf("Property %s is not-applicable to client type %s and can not be modified.", propertyName, clientType.getName());
+            return;
         }
 
         // Check if this is read-only. If yes and there is an attempt to change some stuff, then throw an exception

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientSimpleAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientSimpleAttribute.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-enum TypedClientAttribute implements TypedClientAttributeInterface {
+enum TypedClientSimpleAttribute implements TypedClientAttribute {
     // Top Level client attributes
     STANDARD_FLOW_ENABLED("standardFlowEnabled", false),
     BEARER_ONLY("bearerOnly", false),
@@ -32,7 +32,7 @@ enum TypedClientAttribute implements TypedClientAttributeInterface {
     private final String propertyName;
     private final Object nonApplicableValue;
 
-    TypedClientAttribute(String propertyName, Object nonApplicableValue) {
+    TypedClientSimpleAttribute(String propertyName, Object nonApplicableValue) {
         this.propertyName = propertyName;
         this.nonApplicableValue = nonApplicableValue;
     }
@@ -48,7 +48,7 @@ enum TypedClientAttribute implements TypedClientAttributeInterface {
     }
 }
 
-enum TypedClientExtendedAttribute implements TypedClientAttributeInterface {
+enum TypedClientExtendedAttribute implements TypedClientAttribute {
     // Extended Client Type attributes defined as client attribute entities.
     DEVICE_AUTHORIZATION_GRANT_ENABLED("oauth2.device.authorization.grant.enabled", "false"),
     CIBA_GRANT_ENABLED("oidc.ciba.grant.enabled", "false"),
@@ -86,8 +86,8 @@ enum TypedClientExtendedAttribute implements TypedClientAttributeInterface {
     }
 }
 
-interface TypedClientAttributeInterface {
-    Logger logger = Logger.getLogger(TypedClientAttributeInterface.class);
+interface TypedClientAttribute {
+    Logger logger = Logger.getLogger(TypedClientAttribute.class);
 
     default <T> T getClientAttribute(ClientType clientType, Supplier<T> clientGetter, Class<T> tClass) {
         String propertyName = getPropertyName();

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
@@ -18,7 +18,6 @@
 
 package org.keycloak.services.clienttype.impl;
 
-import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.keycloak.client.clienttype.ClientType;
 import org.keycloak.client.clienttype.ClientTypeException;
@@ -34,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -83,6 +81,11 @@ public class DefaultClientType implements ClientType {
     }
 
     @Override
+    public Map<String, ClientTypeRepresentation.PropertyConfig> getConfiguration() {
+        return clientType.getConfig();
+    }
+
+    @Override
     public void onCreate(ClientRepresentation createdClient) throws ClientTypeException {
         // Create empty client augmented with the applicable default client type values.
         ClientRepresentation defaultClientRep = augmentClient(new ClientRepresentation());
@@ -102,9 +105,9 @@ public class DefaultClientType implements ClientType {
         List<String> validationErrors = clientType.getConfig().entrySet().stream()
                 .filter(property -> clientPropertyHasInvalidChangeRequested(currentClient, newClient, property.getKey(), property.getValue()))
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .toList();
 
-        if (validationErrors.size() > 0) {
+        if (!validationErrors.isEmpty()) {
             throw new ClientTypeException(
                     "Cannot change property of client as it is not allowed by the specified client type.",
                     validationErrors.toArray());
@@ -112,8 +115,7 @@ public class DefaultClientType implements ClientType {
     }
 
     protected ClientRepresentation augmentClient(ClientRepresentation client) {
-        clientType.getConfig().entrySet()
-                .forEach(property -> setClientProperty(client, property.getKey(), property.getValue()));
+        clientType.getConfig().forEach((key, value) -> setClientProperty(client, key, value));
         return client;
     }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
@@ -18,38 +18,22 @@
 
 package org.keycloak.services.clienttype.impl;
 
-import org.jboss.logging.Logger;
 import org.keycloak.client.clienttype.ClientType;
-import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.utils.ModelToRepresentation;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
+import org.keycloak.services.clienttype.client.TypeAwareClientModelDelegate;
 
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public class DefaultClientType implements ClientType {
 
-    private static final Logger logger = Logger.getLogger(DefaultClientType.class);
-
-    private final KeycloakSession session;
     private final ClientTypeRepresentation clientType;
 
-    private final Map<String, PropertyDescriptor> clientRepresentationProperties;
-
-    public DefaultClientType(KeycloakSession session, ClientTypeRepresentation clientType, Map<String, PropertyDescriptor> clientRepresentationProperties) {
-        this.session = session;
+    public DefaultClientType(ClientTypeRepresentation clientType) {
         this.clientType = clientType;
-        this.clientRepresentationProperties = clientRepresentationProperties;
     }
 
     @Override
@@ -86,102 +70,7 @@ public class DefaultClientType implements ClientType {
     }
 
     @Override
-    public void onCreate(ClientRepresentation createdClient) throws ClientTypeException {
-        // Create empty client augmented with the applicable default client type values.
-        ClientRepresentation defaultClientRep = augmentClient(new ClientRepresentation());
-
-        validateClientRequest(createdClient, defaultClientRep);
-
-        augmentClient(createdClient);
-    }
-
-    @Override
-    public void onUpdate(ClientModel currentClient, ClientRepresentation newClient) throws ClientTypeException {
-        ClientRepresentation currentRep = ModelToRepresentation.toRepresentation(currentClient, session);
-        validateClientRequest(newClient, currentRep);
-    }
-
-    protected void validateClientRequest(ClientRepresentation newClient, ClientRepresentation currentClient) throws ClientTypeException {
-        List<String> validationErrors = clientType.getConfig().entrySet().stream()
-                .filter(property -> clientPropertyHasInvalidChangeRequested(currentClient, newClient, property.getKey(), property.getValue()))
-                .map(Map.Entry::getKey)
-                .toList();
-
-        if (!validationErrors.isEmpty()) {
-            throw new ClientTypeException(
-                    "Cannot change property of client as it is not allowed by the specified client type.",
-                    validationErrors.toArray());
-        }
-    }
-
-    protected ClientRepresentation augmentClient(ClientRepresentation client) {
-        clientType.getConfig().forEach((key, value) -> setClientProperty(client, key, value));
-        return client;
-    }
-
-    private boolean clientPropertyHasInvalidChangeRequested(
-            ClientRepresentation oldClient,
-            ClientRepresentation newClient,
-            String propertyName,
-            ClientTypeRepresentation.PropertyConfig propertyConfig) {
-        Object newClientProperty = getClientProperty(newClient, propertyName);
-        Object oldClientProperty = getClientProperty(oldClient, propertyName);
-
-        return (
-                    // Validate that non-applicable client properties were not changed.
-                    !propertyConfig.getApplicable() &&
-                    !Objects.isNull(newClientProperty) &&
-                    !Objects.equals(oldClientProperty, newClientProperty)
-                ) || (
-                    // Validate that applicable read-only client properties were not changed.
-                    propertyConfig.getApplicable() &&
-                    propertyConfig.getReadOnly() &&
-                    !Objects.isNull(newClientProperty) &&
-                    !Objects.equals(oldClientProperty, newClientProperty)
-                );
-    }
-
-    private void setClientProperty(ClientRepresentation client,
-                               String propertyName,
-                               ClientTypeRepresentation.PropertyConfig propertyConfig) {
-
-        if (!propertyConfig.getApplicable() || propertyConfig.getDefaultValue() == null) {
-            return;
-        }
-
-        if (clientRepresentationProperties.containsKey(propertyName)) {
-            // Java property on client representation
-            Method setter = clientRepresentationProperties.get(propertyName).getWriteMethod();
-            try {
-                setter.invoke(client, propertyConfig.getDefaultValue());
-            } catch (Exception e) {
-                logger.warnf("Cannot set property '%s' on client with value '%s'. Check configuration of the client type '%s'", propertyName, propertyConfig.getDefaultValue(), clientType.getName());
-                throw new ClientTypeException("Cannot set property on client", e);
-            }
-        } else {
-            // Client attribute
-            if (client.getAttributes() == null) {
-                client.setAttributes(new HashMap<>());
-            }
-            client.getAttributes().put(propertyName, propertyConfig.getDefaultValue().toString());
-        }
-    }
-
-    private Object getClientProperty(ClientRepresentation client, String propertyName) {
-        PropertyDescriptor propertyDescriptor = clientRepresentationProperties.get(propertyName);
-
-        if (propertyDescriptor != null) {
-            // Java property
-            Method getter = propertyDescriptor.getReadMethod();
-            try {
-                return getter.invoke(client);
-            } catch (Exception e) {
-                logger.warnf("Cannot read property '%s' on client '%s'. Client type is '%s'", propertyName, client.getClientId(), clientType.getName());
-                throw new ClientTypeException("Cannot read property of client", e);
-            }
-        } else {
-            // Attribute
-            return client.getAttributes() == null ? null : client.getAttributes().get(propertyName);
-        }
+    public ClientModel augment(ClientModel client) {
+        return new TypeAwareClientModelDelegate(this, () -> client);
     }
 }

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
@@ -18,11 +18,9 @@
 
 package org.keycloak.services.clienttype.impl;
 
-import java.beans.PropertyDescriptor;
 import java.util.Map;
 
 import org.jboss.logging.Logger;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
 import org.keycloak.client.clienttype.ClientType;
 import org.keycloak.client.clienttype.ClientTypeException;
@@ -35,17 +33,9 @@ public class DefaultClientTypeProvider implements ClientTypeProvider {
 
     private static final Logger logger = Logger.getLogger(DefaultClientTypeProvider.class);
 
-    private final KeycloakSession session;
-    private final Map<String, PropertyDescriptor> clientRepresentationProperties;
-
-    public DefaultClientTypeProvider(KeycloakSession session, Map<String, PropertyDescriptor> clientRepresentationProperties) {
-        this.session = session;
-        this.clientRepresentationProperties = clientRepresentationProperties;
-    }
-
     @Override
     public ClientType getClientType(ClientTypeRepresentation clientTypeRep) {
-        return new DefaultClientType(session, clientTypeRep, clientRepresentationProperties);
+        return new DefaultClientType(clientTypeRep);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProviderFactory.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProviderFactory.java
@@ -18,23 +18,11 @@
 
 package org.keycloak.services.clienttype.impl;
 
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.client.clienttype.ClientTypeProvider;
 import org.keycloak.client.clienttype.ClientTypeProviderFactory;
 
@@ -45,41 +33,13 @@ public class DefaultClientTypeProviderFactory implements ClientTypeProviderFacto
 
     public static final String PROVIDER_ID = "default";
 
-    private Map<String, PropertyDescriptor> clientRepresentationProperties;
-
     @Override
     public ClientTypeProvider create(KeycloakSession session) {
-        return new DefaultClientTypeProvider(session, clientRepresentationProperties);
+        return new DefaultClientTypeProvider();
     }
 
     @Override
-    public void init(Config.Scope config) {
-        Set<String> filtered = Arrays.stream(new String[] {"attributes", "type"}).collect(Collectors.toSet());
-
-        try {
-            BeanInfo bi = Introspector.getBeanInfo(ClientRepresentation.class);
-            PropertyDescriptor[] pd = bi.getPropertyDescriptors();
-            clientRepresentationProperties = Arrays.stream(pd)
-                    .filter(desc -> !filtered.contains(desc.getName()))
-                    .filter(desc -> desc.getWriteMethod() != null)
-                    .map(desc -> {
-                        // Take "is" methods into consideration
-                        if (desc.getReadMethod() == null && Boolean.class.equals(desc.getPropertyType())) {
-                            String methodName = "is" + desc.getName().substring(0, 1).toUpperCase() + desc.getName().substring(1);
-                            try {
-                                Method getter = ClientRepresentation.class.getDeclaredMethod(methodName);
-                                desc.setReadMethod(getter);
-                            } catch (Exception e) {
-                                throw new IllegalStateException("Getter method for property " + desc.getName() + " cannot be found");
-                            }
-                        }
-                        return desc;
-                    })
-                    .collect(Collectors.toMap(PropertyDescriptor::getName, Function.identity()));
-        } catch (IntrospectionException ie) {
-            throw new IllegalStateException("Introspection of Client representation failed", ie);
-        }
-    }
+    public void init(Config.Scope config) {}
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {

--- a/services/src/main/java/org/keycloak/services/managers/ClientManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ClientManager.java
@@ -42,8 +42,6 @@ import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.adapters.config.BaseRealmConfig;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.client.clienttype.ClientType;
-import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 
 import java.net.URI;
@@ -82,11 +80,6 @@ public class ClientManager {
      * @return
      */
     public static ClientModel createClient(KeycloakSession session, RealmModel realm, ClientRepresentation rep) {
-        if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && rep.getType() != null) {
-            ClientTypeManager mgr = session.getProvider(ClientTypeManager.class);
-            ClientType clientType = mgr.getClientType(realm, rep.getType());
-            clientType.onCreate(rep);
-        }
 
         ClientModel client = RepresentationToModel.createClient(session, realm, rep);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -152,17 +152,6 @@ public class ClientResource {
             session.setAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED,Boolean.FALSE);
             session.clientPolicy().triggerOnEvent(new AdminClientUpdateContext(rep, client, auth.adminAuth()));
 
-            if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES)) {
-                if (!ObjectUtil.isEqualOrBothNull(rep.getType(), client.getType())) {
-                    throw new ClientTypeException("Not supported to change client type");
-                }
-                if (rep.getType() != null) {
-                    ClientTypeManager mgr = session.getProvider(ClientTypeManager.class);
-                    ClientType clientType = mgr.getClientType(realm, rep.getType());
-                    clientType.onUpdate(client, rep);
-                }
-            }
-
             updateClientFromRep(rep, client, session);
 
             ValidationUtil.validateClient(session, client, false, r -> {

--- a/services/src/main/resources/keycloak-default-client-types.json
+++ b/services/src/main/resources/keycloak-default-client-types.json
@@ -6,8 +6,8 @@
       "config": {
         "standardFlowEnabled": {
           "applicable": true,
-          "read-only": true,
-          "default-value": true
+          "default-value": true,
+          "read-only": true
         }
       }
     },
@@ -18,56 +18,66 @@
         "alwaysDisplayInConsole": {
           "applicable": false
         },
+        "authorizationServicesEnabled": {
+          "applicable": false
+        },
+        "bearerOnly": {
+          "applicable": false
+        },
         "consentRequired": {
           "applicable": true,
-          "read-only": true,
-          "default-value": false
+          "default-value": false,
+          "read-only": true
+        },
+        "directAccessGrantsEnabled": {
+          "applicable": false
+        },
+        "frontchannelLogout": {
+          "applicable": false
+        },
+        "implicitFlowEnabled": {
+          "applicable": false
         },
         "login_theme": {
           "applicable": false
         },
-        "protocol": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": "openid-connect"
-        },
-        "publicClient": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": false
-        },
-        "bearerOnly": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": false
-        },
-        "standardFlowEnabled": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": false
-        },
-        "implicitFlowEnabled": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": false
-        },
-        "directAccessGrantsEnabled": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": false
-        },
-        "serviceAccountsEnabled": {
-          "applicable": true,
-          "read-only": true,
-          "default-value": true
-        },
         "logoUri": {
+          "applicable": false
+        },
+        "oauth2.device.authorization.grant.enabled": {
+          "applicable": false
+        },
+        "oidc.ciba.grant.enabled": {
           "applicable": false
         },
         "policyUri": {
           "applicable": false
         },
+        "protocol": {
+          "applicable": true,
+          "default-value": "openid-connect",
+          "read-only": true
+        },
+        "publicClient": {
+          "applicable": true,
+          "default-value": false,
+          "read-only": true
+        },
+        "redirectUris": {
+          "applicable": false
+        },
+        "serviceAccountsEnabled": {
+          "applicable": true,
+          "default-value": true,
+          "read-only": true
+        },
+        "standardFlowEnabled": {
+          "applicable": false
+        },
         "tosUri": {
+          "applicable": false
+        },
+        "webOrigins": {
           "applicable": false
         }
       }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
@@ -126,14 +126,10 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
 
         clientRep.setServiceAccountsEnabled(true);
 
-        // Adding non-applicable attribute should not fail
+        // Adding non-applicable attribute should not fail but not update client attribute
         clientRep.getAttributes().put(ClientModel.LOGO_URI, "https://foo");
-        try {
-            testRealm().clients().get(clientRep.getId()).update(clientRep);
-            Assert.fail("Not expected to update client");
-        } catch (BadRequestException bre) {
-            assertErrorResponseContainsParams(bre.getResponse(), "logoUri");
-        }
+        testRealm().clients().get(clientRep.getId()).update(clientRep);
+        assertEquals(testRealm().clients().get(clientRep.getId()).toRepresentation().getAttributes().get(ClientModel.LOGO_URI), null);
 
         // Update of supported attribute should be successful
         clientRep.getAttributes().remove(ClientModel.LOGO_URI);
@@ -180,7 +176,7 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertEquals("default", serviceAccountType.getProvider());
 
         ClientTypeRepresentation.PropertyConfig cfg = serviceAccountType.getConfig().get("standardFlowEnabled");
-        assertPropertyConfig("standardFlowEnabled", cfg, true, true, false);
+        assertPropertyConfig("standardFlowEnabled", cfg, false, null, null);
 
         cfg = serviceAccountType.getConfig().get("serviceAccountsEnabled");
         assertPropertyConfig("serviceAccountsEnabled", cfg, true, true, true);


### PR DESCRIPTION
Changes requested as part of https://github.com/keycloak/keycloak/issues/29198.

Removing reflection used in augmentation of the client representation during create and update. This is replaced by utilizing the `TypeAwareClientModelDelegate` to catch any ClientTypeExceptions that might be thrown on fields that are non-applicable or read-only.

Static methods `updateClient` and `createClient` of `RepresentationToModel` will handle updating the model from the client representation and consolidating validations error to report all failures of client type fields. Removed duplicate code used to update the properties in these two methods.

Created enums for well known client type attributes, in `TypedClientAttribute` and `TypedClientExtendedAttribute`. These also define non-applicable default values for each of the properties.

With this, you can create a service account with all relevant fields by only specifying the type:
```
curl --location 'http://localhost:8080/admin/realms/master/clients' \
--data '{
    "type": "service-account"
}'
```