### PR TITLE
External Infinispan as cache - Part 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,46 @@ jobs:
           name: ${{ steps.aurora-init.outputs.name }}
           region: ${{ steps.aurora-init.outputs.region }}
 
+  external-infinispan-tests:
+    name: External Infinispan IT
+    needs: [ build, conditional ]
+    if: needs.conditional.outputs.ci-store == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    strategy:
+      matrix:
+        variant: [ "remote-cache,multi-site" ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+
+      - name: Run base tests without cache
+        run: |
+          TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh persistent-sessions`
+          echo "Tests: $TESTS"
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Pinfinispan-server -Dauth.server.feature=${{ matrix.variant }} -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+
+      - name: Upload JVM Heapdumps
+        if: always()
+        uses: ./.github/actions/upload-heapdumps
+
+      - uses: ./.github/actions/upload-flaky-tests
+        name: Upload flaky tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          job-name: Remote Infinispan IT
+
+      - name: Surefire reports
+        if: always()
+        uses: ./.github/actions/archive-surefire-reports
+        with:
+          job-id: remote-infinispan-integration-tests
+
   store-integration-tests:
     name: Store IT
     needs: [build, conditional]
@@ -827,6 +867,7 @@ jobs:
       - webauthn-integration-tests
       - sssd-unit-tests
       - migration-tests
+      - external-infinispan-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -346,9 +346,9 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         defineClusteredCache(cacheManager, OFFLINE_USER_SESSION_CACHE_NAME, clusteredConfiguration);
         defineClusteredCache(cacheManager, CLIENT_SESSION_CACHE_NAME, clusteredConfiguration);
         defineClusteredCache(cacheManager, OFFLINE_CLIENT_SESSION_CACHE_NAME, clusteredConfiguration);
-        defineClusteredCache(cacheManager, LOGIN_FAILURE_CACHE_NAME, clusteredConfiguration);
 
         if (InfinispanUtils.isEmbeddedInfinispan()) {
+            defineClusteredCache(cacheManager, LOGIN_FAILURE_CACHE_NAME, clusteredConfiguration);
             defineClusteredCache(cacheManager, AUTHENTICATION_SESSIONS_CACHE_NAME, clusteredConfiguration);
 
             var actionTokenBuilder = getActionTokenCacheConfig();

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/RemoteChangeLogTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/RemoteChangeLogTransaction.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.changes.remote;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.keycloak.models.AbstractKeycloakTransaction;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.Expiration;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.Updater;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.UpdaterFactory;
+
+/**
+ * A {@link org.keycloak.models.KeycloakTransaction} implementation that keeps track of changes made to entities stored
+ * in a Infinispan cache.
+ *
+ * @param <K> The type of the Infinispan cache key.
+ * @param <V> The type of the Infinispan cache value.
+ * @param <T> The type of the {@link Updater} implementation.
+ */
+public class RemoteChangeLogTransaction<K, V, T extends Updater<K, V>> extends AbstractKeycloakTransaction {
+
+
+    private final Map<K, T> entityChanges;
+    private final UpdaterFactory<K, V, T> factory;
+    private final RemoteCache<K, V> cache;
+    private final KeycloakSession session;
+    private Predicate<V> removePredicate;
+
+    public RemoteChangeLogTransaction(UpdaterFactory<K, V, T> factory, RemoteCache<K, V> cache, KeycloakSession session) {
+        this.factory = Objects.requireNonNull(factory);
+        this.cache = Objects.requireNonNull(cache);
+        this.session = Objects.requireNonNull(session);
+        entityChanges = new ConcurrentHashMap<>(8);
+    }
+
+    @Override
+    protected void commitImpl() {
+        var stage = CompletionStages.aggregateCompletionStage();
+        doCommit(stage);
+        CompletionStages.join(stage.freeze());
+        entityChanges.clear();
+        removePredicate = null;
+    }
+
+    @Override
+    protected void rollbackImpl() {
+        entityChanges.clear();
+        removePredicate = null;
+    }
+
+    private void doCommit(AggregateCompletionStage<Void> stage) {
+        if (removePredicate != null) {
+            // TODO [pruivo] [optimization] with protostream, use delete by query: DELETE FROM ...
+            var rmStage = Flowable.fromPublisher(cache.publishEntriesWithMetadata(null, 2048))
+                    .filter(e -> removePredicate.test(e.getValue().getValue()))
+                    .map(Map.Entry::getKey)
+                    .flatMapCompletable(this::removeKey)
+                    .toCompletionStage(null);
+            stage.dependsOn(rmStage);
+        }
+
+        for (var updater : entityChanges.values()) {
+            if (updater.isReadOnly() || (removePredicate != null && removePredicate.test(updater.getValue()))) {
+                continue;
+            }
+            if (updater.isDeleted()) {
+                stage.dependsOn(cache.removeAsync(updater.getKey()));
+                continue;
+            }
+
+            var expiration = updater.computeExpiration(session);
+
+            if (expiration.isExpired()) {
+                stage.dependsOn(cache.removeAsync(updater.getKey()));
+                continue;
+            }
+
+            if (updater.isCreated()) {
+                stage.dependsOn(putIfAbsent(updater, expiration));
+                continue;
+            }
+
+            stage.dependsOn(replace(updater, expiration));
+        }
+    }
+
+    /**
+     * @return The {@link RemoteCache} tracked by the transaction.
+     */
+    public RemoteCache<K, V> getCache() {
+        return cache;
+    }
+
+    /**
+     * Fetches the value associated to the {@code key}.
+     * <p>
+     * It fetches the value from the {@link RemoteCache} if a copy does not exist in the transaction.
+     *
+     * @param key The Infinispan cache key to fetch.
+     * @return The {@link Updater} to track further changes of the Infinispan cache value.
+     */
+    public T get(K key) {
+        var updater = entityChanges.get(key);
+        if (updater != null) {
+            return updater;
+        }
+        var entity = cache.getWithMetadata(key);
+        if (entity == null) {
+            return null;
+        }
+        updater = factory.wrapFromCache(key, entity);
+        entityChanges.put(key, updater);
+        return updater.isDeleted() ? null : updater;
+    }
+
+    /**
+     * Tracks a new value to be created in the Infinispan cache.
+     *
+     * @param key    The Infinispan cache key to be associated to the value.
+     * @param entity The Infinispan cache value.
+     * @return The {@link Updater} to track further changes of the Infinispan cache value.
+     */
+    public T create(K key, V entity) {
+        var updater = factory.create(key, entity);
+        entityChanges.put(key, updater);
+        return updater;
+    }
+
+    /**
+     * Removes the {@code key} from the {@link RemoteCache}.
+     *
+     * @param key The Infinispan cache key to remove.
+     */
+    public void remove(K key) {
+        var updater = entityChanges.get(key);
+        if (updater != null) {
+            updater.markDeleted();
+            return;
+        }
+        entityChanges.put(key, factory.deleted(key));
+    }
+
+    /**
+     * Removes all Infinispan cache values that satisfy the given predicate.
+     *
+     * @param predicate The {@link Predicate} which returns {@code true} for elements to be removed.
+     */
+    public void removeIf(Predicate<V> predicate) {
+        if (removePredicate == null) {
+            removePredicate = predicate;
+            return;
+        }
+        removePredicate = removePredicate.or(predicate);
+    }
+
+    private CompletionStage<V> putIfAbsent(Updater<K, V> updater, Expiration expiration) {
+        return cache.withFlags(Flag.FORCE_RETURN_VALUE)
+                .putIfAbsentAsync(updater.getKey(), updater.getValue(), expiration.lifespan(), TimeUnit.MILLISECONDS, expiration.maxIdle(), TimeUnit.MILLISECONDS)
+                .thenApply(Objects::isNull)
+                .thenCompose(completed -> handleResponse(completed, updater, expiration));
+    }
+
+    private CompletionStage<V> replace(Updater<K, V> updater, Expiration expiration) {
+        return cache.replaceWithVersionAsync(updater.getKey(), updater.getValue(), updater.getVersionRead(), expiration.lifespan(), TimeUnit.MILLISECONDS, expiration.maxIdle(), TimeUnit.MILLISECONDS)
+                .thenCompose(completed -> handleResponse(completed, updater, expiration));
+    }
+
+    private CompletionStage<V> handleResponse(boolean completed, Updater<K, V> updater, Expiration expiration) {
+        return completed ? CompletableFutures.completedNull() : merge(updater, expiration);
+    }
+
+    private CompletionStage<V> merge(Updater<K, V> updater, Expiration expiration) {
+        return cache.computeAsync(updater.getKey(), updater, expiration.lifespan(), TimeUnit.MILLISECONDS, expiration.maxIdle(), TimeUnit.MILLISECONDS);
+    }
+
+    private Completable removeKey(K key) {
+        return Completable.fromCompletionStage(cache.removeAsync(key));
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/BaseUpdater.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/BaseUpdater.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.changes.remote.updater;
+
+/**
+ * Base functionality of an {@link Updater} implementation.
+ * <p>
+ * It stores the Infinispan cache key, value, version, and it states. However, it does not keep track of the changed
+ * fields in the cache value, and it is the responsibility of the implementation to do that.
+ * <p>
+ * The method {@link #onFieldChanged()} must be invoked to track changes in the cache value.
+ *
+ * @param <K> The type of the Infinispan cache key.
+ * @param <V> The type of the Infinispan cache value.
+ */
+public abstract class BaseUpdater<K, V> implements Updater<K, V> {
+
+    private final K cacheKey;
+    private final V cacheValue;
+    private final long versionRead;
+    private UpdaterState state;
+
+    protected BaseUpdater(K cacheKey, V cacheValue, long versionRead, UpdaterState state) {
+        this.cacheKey = cacheKey;
+        this.cacheValue = cacheValue;
+        this.versionRead = versionRead;
+        this.state = state;
+    }
+
+    @Override
+    public final K getKey() {
+        return cacheKey;
+    }
+
+    @Override
+    public final V getValue() {
+        return cacheValue;
+    }
+
+    @Override
+    public final long getVersionRead() {
+        return versionRead;
+    }
+
+    @Override
+    public final boolean isDeleted() {
+        return state == UpdaterState.DELETED;
+    }
+
+    @Override
+    public final boolean isCreated() {
+        return state == UpdaterState.CREATED;
+    }
+
+    @Override
+    public final boolean isReadOnly() {
+        return state == UpdaterState.READ_ONLY;
+    }
+
+    @Override
+    public final void markDeleted() {
+        state = UpdaterState.DELETED;
+    }
+
+    /**
+     * Must be invoked when a field change to mark this updated and modified.
+     */
+    protected final void onFieldChanged() {
+        state = state.stateAfterChange();
+    }
+
+    protected enum UpdaterState {
+        /**
+         * The cache value is created. It implies {@link #MODIFIED}.
+         */
+        CREATED,
+        /**
+         * The cache value is deleted, and it will be removed from the Infinispan cache. It cannot be recreated.
+         */
+        DELETED,
+        /**
+         * The cache value was read the Infinispan cache and was not modified.
+         */
+        READ_ONLY {
+            @Override
+            UpdaterState stateAfterChange() {
+                return MODIFIED;
+            }
+        },
+        /**
+         * The cache value was read from the Infinispan cache and was modified. Changes will be merged into the current
+         * Infinispan cache value.
+         */
+        MODIFIED;
+
+        UpdaterState stateAfterChange() {
+            return this;
+        }
+
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/Expiration.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/Expiration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.changes.remote.updater;
+
+import org.keycloak.models.sessions.infinispan.util.SessionTimeouts;
+
+/**
+ * Expiration data for Infinispan storage, in milliseconds.
+ *
+ * @param maxIdle  The entity max-idle. The entity will be removed if not accessed during this time.
+ * @param lifespan The entity lifespan. The entity will be removed after this time.
+ */
+public record Expiration(long maxIdle, long lifespan) {
+
+    public boolean isExpired() {
+        return maxIdle == SessionTimeouts.ENTRY_EXPIRED_FLAG || lifespan == SessionTimeouts.ENTRY_EXPIRED_FLAG;
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/Updater.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/Updater.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.changes.remote.updater;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.sessions.infinispan.changes.remote.RemoteChangeLogTransaction;
+
+import java.util.function.BiFunction;
+
+/**
+ * An interface used by {@link RemoteChangeLogTransaction}.
+ * <p>
+ * It keeps track of the changes made in the entity and applies them to the entity stored in Infinispan cache.
+ *
+ * @param <K> The Infinispan key type.
+ * @param <V> The Infinispan value type.
+ */
+public interface Updater<K, V> extends BiFunction<K, V, V> {
+
+    /**
+     * @return The Infinispan cache key.
+     */
+    K getKey();
+
+    /**
+     * @return The up-to-date entity used by the transaction.
+     */
+    V getValue();
+
+    /**
+     * @return The entity version when reading for the first time from Infinispan.
+     */
+    long getVersionRead();
+
+    /**
+     * @return {@code true} if the entity was removed during the Keycloak transaction and it should be removed from
+     * Infinispan.
+     */
+    boolean isDeleted();
+
+    /**
+     * @return {@code true} if the entity was created during the Keycloak transaction. Allows some optimization like
+     * put-if-absent.
+     */
+    boolean isCreated();
+
+    /**
+     * @return {@code true} if the entity was not changed.
+     */
+    boolean isReadOnly();
+
+    /**
+     * Marks the entity as deleted.
+     */
+    void markDeleted();
+
+    /**
+     * Computes the expiration data for Infinispan cache.
+     *
+     * @param session The current Keycloak session.
+     * @return The {@link Expiration} data.
+     */
+    Expiration computeExpiration(KeycloakSession session);
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/UpdaterFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/UpdaterFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.changes.remote.updater;
+
+import org.infinispan.client.hotrod.MetadataValue;
+
+/**
+ * A factory interface that creates, wraps or deletes entities.
+ *
+ * @param <K> The Infinispan key type.
+ * @param <V> The Infinispan value type.
+ * @param <T> The {@link Updater} concrete type.
+ */
+public interface UpdaterFactory<K, V, T extends Updater<K, V>> {
+
+    /**
+     * Creates an {@link Updater} for an entity created by the current Keycloak transaction.
+     *
+     * @param key    The Infinispan key.
+     * @param entity The Infinispan value.
+     * @return The {@link Updater} to be used when updating the entity state.
+     */
+    T create(K key, V entity);
+
+    /**
+     * Wraps an entity read from the Infinispan cache.
+     *
+     * @param key    The Infinispan key.
+     * @param entity The Infinispan value.
+     * @return The {@link Updater} to be used when updating the entity state.
+     */
+    T wrapFromCache(K key, MetadataValue<V> entity);
+
+    /**
+     * Deletes a entity that was not previous read by the Keycloak transaction.
+     *
+     * @param key The Infinispan key.
+     * @return The {@link Updater} for a deleted entity.
+     */
+    T deleted(K key);
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/loginfailures/LoginFailuresUpdater.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/loginfailures/LoginFailuresUpdater.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.changes.remote.updater.loginfailures;
+
+import org.infinispan.client.hotrod.MetadataValue;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserLoginFailureModel;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.BaseUpdater;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.Expiration;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.Updater;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureKey;
+import org.keycloak.models.sessions.infinispan.util.SessionTimeouts;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Implementation of {@link Updater} and {@link UserLoginFailureModel}.
+ * <p>
+ * It keeps track of the changes made to the entity {@link LoginFailureEntity} and replays on commit.
+ */
+public class LoginFailuresUpdater extends BaseUpdater<LoginFailureKey, LoginFailureEntity> implements UserLoginFailureModel {
+
+    private final List<Consumer<LoginFailureEntity>> changes;
+
+    private LoginFailuresUpdater(LoginFailureKey key, LoginFailureEntity entity, long version, UpdaterState initialState) {
+        super(key, entity, version, initialState);
+        changes = new ArrayList<>(4);
+    }
+
+    public static LoginFailuresUpdater create(LoginFailureKey key, LoginFailureEntity entity) {
+        return new LoginFailuresUpdater(Objects.requireNonNull(key), Objects.requireNonNull(entity), -1, UpdaterState.CREATED);
+    }
+
+    public static LoginFailuresUpdater wrap(LoginFailureKey key, MetadataValue<LoginFailureEntity> entity) {
+        return new LoginFailuresUpdater(Objects.requireNonNull(key), Objects.requireNonNull(entity.getValue()), entity.getVersion(), UpdaterState.READ_ONLY);
+    }
+
+    public static LoginFailuresUpdater delete(LoginFailureKey key) {
+        return new LoginFailuresUpdater(Objects.requireNonNull(key), null, -1, UpdaterState.DELETED);
+    }
+
+    @Override
+    public Expiration computeExpiration(KeycloakSession session) {
+        var realm = session.realms().getRealm(getValue().getRealmId());
+        return new Expiration(
+                SessionTimeouts.getLoginFailuresMaxIdleMs(realm, null, getValue()),
+                SessionTimeouts.getLoginFailuresLifespanMs(realm, null, getValue()));
+    }
+
+    @Override
+    public LoginFailureEntity apply(LoginFailureKey ignored, LoginFailureEntity cachedEntity) {
+        assert !isDeleted();
+        assert !isReadOnly();
+        if (cachedEntity == null) {
+            //entity removed
+            return null;
+        }
+        changes.forEach(c -> c.accept(cachedEntity));
+        return cachedEntity;
+    }
+
+
+    @Override
+    public int getFailedLoginNotBefore() {
+        return getValue().getFailedLoginNotBefore();
+    }
+
+    @Override
+    public long getLastFailure() {
+        return getValue().getLastFailure();
+    }
+
+    @Override
+    public String getLastIPFailure() {
+        return getValue().getLastIPFailure();
+    }
+
+    @Override
+    public int getNumFailures() {
+        return getValue().getNumFailures();
+    }
+
+    @Override
+    public int getNumTemporaryLockouts() {
+        return getValue().getNumTemporaryLockouts();
+    }
+
+    @Override
+    public String getUserId() {
+        return getValue().getUserId();
+    }
+
+    @Override
+    public String getId() {
+        return getKey().toString();
+    }
+
+    @Override
+    public void clearFailures() {
+        addAndApplyChange(CLEAR);
+    }
+
+    @Override
+    public void setFailedLoginNotBefore(int notBefore) {
+        addAndApplyChange(e -> e.setFailedLoginNotBefore(notBefore));
+    }
+
+    @Override
+    public void incrementFailures() {
+        addAndApplyChange(INCREMENT_FAILURES);
+    }
+
+    @Override
+    public void incrementTemporaryLockouts() {
+        addAndApplyChange(INCREMENT_LOCK_OUTS);
+    }
+
+    @Override
+    public void setLastFailure(long lastFailure) {
+        addAndApplyChange(e -> e.setLastFailure(lastFailure));
+    }
+
+    @Override
+    public void setLastIPFailure(String ip) {
+        addAndApplyChange(e -> e.setLastIPFailure(ip));
+    }
+
+    private void addAndApplyChange(Consumer<LoginFailureEntity> change) {
+        if (change == CLEAR) {
+            changes.clear();
+            changes.add(CLEAR);
+        } else {
+            changes.add(change);
+        }
+        change.accept(getValue());
+        onFieldChanged();
+    }
+
+    private static final Consumer<LoginFailureEntity> CLEAR = LoginFailureEntity::clearFailures;
+    private static final Consumer<LoginFailureEntity> INCREMENT_FAILURES = e -> e.setNumFailures(e.getNumFailures() + 1);
+    private static final Consumer<LoginFailureEntity> INCREMENT_LOCK_OUTS = e -> e.setNumTemporaryLockouts(e.getNumTemporaryLockouts() + 1);
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/LoginFailureEntity.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/LoginFailureEntity.java
@@ -20,6 +20,8 @@ package org.keycloak.models.sessions.infinispan.entities;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
+
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.marshall.SerializeWith;
@@ -114,15 +116,9 @@ public class LoginFailureEntity extends SessionEntity {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof LoginFailureEntity)) return false;
-
-        LoginFailureEntity that = (LoginFailureEntity) o;
-
-        if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
-        if (getRealmId() != null ? !getRealmId().equals(that.getRealmId()) : that.getRealmId() != null) return false;
-
-
-        return true;
+        if (!(o instanceof LoginFailureEntity that)) return false;
+        return Objects.equals(userId, that.userId) &&
+                Objects.equals(getRealmId(), that.getRealmId());
     }
 
     @Override
@@ -156,12 +152,10 @@ public class LoginFailureEntity extends SessionEntity {
 
         @Override
         public LoginFailureEntity readObject(ObjectInput input) throws IOException {
-            switch (input.readByte()) {
-                case VERSION_1:
-                    return readObjectVersion1(input);
-                default:
-                    throw new IOException("Unknown version");
+            if (input.readByte() == VERSION_1) {
+                return readObjectVersion1(input);
             }
+            throw new IOException("Unknown version");
         }
 
         public LoginFailureEntity readObjectVersion1(ObjectInput input) throws IOException {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
@@ -1,5 +1,27 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.keycloak.models.sessions.infinispan.remote;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.util.concurrent.CompletionStages;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
@@ -15,10 +37,6 @@ import org.keycloak.models.utils.SessionExpiration;
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 public class RemoteInfinispanAuthenticationSessionProvider implements AuthenticationSessionProvider {
 
@@ -80,14 +98,16 @@ public class RemoteInfinispanAuthenticationSessionProvider implements Authentica
     public void onRealmRemoved(RealmModel realm) {
         // TODO [pruivo] [optimization] with protostream, use delete by query: DELETE FROM ...
         var cache = transaction.getCache();
+        var stage = CompletionStages.aggregateCompletionStage();
         try (var iterator = cache.retrieveEntries(null, 256)) {
             while (iterator.hasNext()) {
                 var entry = iterator.next();
                 if (realm.getId().equals(((RootAuthenticationSessionEntity) entry.getValue()).getRealmId())) {
-                    cache.removeAsync(entry.getKey());
+                    stage.dependsOn(cache.removeAsync(entry.getKey()));
                 }
             }
         }
+        CompletionStages.join(stage.freeze());
     }
 
     @Override
@@ -95,7 +115,6 @@ public class RemoteInfinispanAuthenticationSessionProvider implements Authentica
         // No update anything on clientRemove for now. AuthenticationSessions of removed client will be handled at runtime if needed.
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void updateNonlocalSessionAuthNotes(AuthenticationSessionCompoundId compoundId, Map<String, String> authNotesFragment) {
         if (compoundId == null) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserLoginFailureProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserLoginFailureProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.remote;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserLoginFailureModel;
+import org.keycloak.models.UserLoginFailureProvider;
+import org.keycloak.models.sessions.infinispan.changes.remote.RemoteChangeLogTransaction;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.loginfailures.LoginFailuresUpdater;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureKey;
+
+import static org.keycloak.common.util.StackUtil.getShortStackTrace;
+
+
+public class RemoteUserLoginFailureProvider implements UserLoginFailureProvider {
+
+    private static final Logger log = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final RemoteChangeLogTransaction<LoginFailureKey, LoginFailureEntity, LoginFailuresUpdater> transaction;
+
+    public RemoteUserLoginFailureProvider(RemoteChangeLogTransaction<LoginFailureKey, LoginFailureEntity, LoginFailuresUpdater> transaction) {
+        this.transaction = Objects.requireNonNull(transaction);
+    }
+
+
+    @Override
+    public UserLoginFailureModel getUserLoginFailure(RealmModel realm, String userId) {
+        if (log.isTraceEnabled()) {
+            log.tracef("getUserLoginFailure(%s, %s)%s", realm, userId, getShortStackTrace());
+        }
+        return transaction.get(new LoginFailureKey(realm.getId(), userId));
+    }
+
+    @Override
+    public UserLoginFailureModel addUserLoginFailure(RealmModel realm, String userId) {
+        if (log.isTraceEnabled()) {
+            log.tracef("addUserLoginFailure(%s, %s)%s", realm, userId, getShortStackTrace());
+        }
+
+        var key = new LoginFailureKey(realm.getId(), userId);
+        var entity = new LoginFailureEntity();
+        entity.setRealmId(realm.getId());
+        entity.setUserId(userId);
+
+        return transaction.create(key, entity);
+    }
+
+    @Override
+    public void removeUserLoginFailure(RealmModel realm, String userId) {
+        if (log.isTraceEnabled()) {
+            log.tracef("removeUserLoginFailure(%s, %s)%s", realm, userId, getShortStackTrace());
+        }
+        transaction.remove(new LoginFailureKey(realm.getId(), userId));
+    }
+
+    @Override
+    public void removeAllUserLoginFailures(RealmModel realm) {
+        if (log.isTraceEnabled()) {
+            log.tracef("removeAllUserLoginFailures(%s)%s", realm, getShortStackTrace());
+        }
+
+        transaction.removeIf(entity -> Objects.equals(entity.getRealmId(), realm.getId()));
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserLoginFailureProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserLoginFailureProviderFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.sessions.infinispan.remote;
+
+import org.infinispan.client.hotrod.MetadataValue;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.infinispan.util.InfinispanUtils;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.UserLoginFailureProvider;
+import org.keycloak.models.UserLoginFailureProviderFactory;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.sessions.infinispan.changes.remote.RemoteChangeLogTransaction;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.UpdaterFactory;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.loginfailures.LoginFailuresUpdater;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureKey;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+import java.lang.invoke.MethodHandles;
+
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.getRemoteCache;
+
+public class RemoteUserLoginFailureProviderFactory implements UserLoginFailureProviderFactory<RemoteUserLoginFailureProvider>, UpdaterFactory<LoginFailureKey, LoginFailureEntity, LoginFailuresUpdater>, EnvironmentDependentProviderFactory {
+
+    private static final Logger log = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private volatile RemoteCache<LoginFailureKey, LoginFailureEntity> cache;
+
+    @Override
+    public RemoteUserLoginFailureProvider create(KeycloakSession session) {
+        var tx = new RemoteChangeLogTransaction<>(this, cache, session);
+        session.getTransactionManager().enlistAfterCompletion(tx);
+        return new RemoteUserLoginFailureProvider(tx);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(final KeycloakSessionFactory factory) {
+        cache = getRemoteCache(factory, LOGIN_FAILURE_CACHE_NAME);
+        factory.register(event -> {
+            if (event instanceof UserModel.UserRemovedEvent userRemovedEvent) {
+                UserLoginFailureProvider provider = userRemovedEvent.getKeycloakSession().getProvider(UserLoginFailureProvider.class, getId());
+                provider.removeUserLoginFailure(userRemovedEvent.getRealm(), userRemovedEvent.getUser().getId());
+            }
+        });
+        log.debugf("Post Init. Cache=%s", cache.getName());
+    }
+
+    @Override
+    public void close() {
+        cache = null;
+    }
+
+    @Override
+    public String getId() {
+        return InfinispanUtils.REMOTE_PROVIDER_ID;
+    }
+
+    @Override
+    public int order() {
+        return InfinispanUtils.PROVIDER_ORDER;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return InfinispanUtils.isRemoteInfinispan();
+    }
+
+    @Override
+    public LoginFailuresUpdater create(LoginFailureKey key, LoginFailureEntity entity) {
+        return LoginFailuresUpdater.create(key, entity);
+    }
+
+    @Override
+    public LoginFailuresUpdater wrapFromCache(LoginFailureKey key, MetadataValue<LoginFailureEntity> entity) {
+        assert entity != null;
+        return LoginFailuresUpdater.wrap(key, entity);
+    }
+
+    @Override
+    public LoginFailuresUpdater deleted(LoginFailureKey key) {
+        return LoginFailuresUpdater.delete(key);
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/util/SessionTimeouts.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/util/SessionTimeouts.java
@@ -35,12 +35,9 @@ public class SessionTimeouts {
     /**
      * This indicates that entry is already expired and should be removed from the cache
      */
-    public static final long ENTRY_EXPIRED_FLAG = -2l;
+    public static final long ENTRY_EXPIRED_FLAG = -2;
 
-    /**
-     * This is used just if timeouts are not set on the realm (usually happens just during tests when realm is created manually with the model API)
-     */
-    public static final int MINIMAL_EXPIRATION_SEC = 300;
+    private static final long IMMORTAL_FLAG = -1;
 
     /**
      * Get the maximum lifespan, which this userSession can remain in the infinispan cache.
@@ -216,7 +213,7 @@ public class SessionTimeouts {
      * @return
      */
     public static long getLoginFailuresLifespanMs(RealmModel realm, ClientModel client, LoginFailureEntity loginFailureEntity) {
-        return -1l;
+        return IMMORTAL_FLAG;
     }
 
 
@@ -229,6 +226,6 @@ public class SessionTimeouts {
      * @return
      */
     public static long getLoginFailuresMaxIdleMs(RealmModel realm, ClientModel client, LoginFailureEntity loginFailureEntity) {
-        return -1l;
+        return IMMORTAL_FLAG;
     }
 }

--- a/model/infinispan/src/main/resources/META-INF/services/org.keycloak.models.UserLoginFailureProviderFactory
+++ b/model/infinispan/src/main/resources/META-INF/services/org.keycloak.models.UserLoginFailureProviderFactory
@@ -16,3 +16,4 @@
 #
 
 org.keycloak.models.sessions.infinispan.InfinispanUserLoginFailureProviderFactory
+org.keycloak.models.sessions.infinispan.remote.RemoteUserLoginFailureProviderFactory

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -68,6 +68,7 @@
         <migration.73.version>4.8.3.Final</migration.73.version>
 
         <!-- By default, skip docker-maven-plugin when running base tests-->
+        <docker.infinispan.skip>true</docker.infinispan.skip>
         <docker.database.skip>true</docker.database.skip>
         <docker.database.postStart>/bin/true</docker.database.postStart>
         <docker.database.wait-for-log-regex>NEVER-MATCHING-REGEX</docker.database.wait-for-log-regex>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -374,9 +374,6 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>${docker.maven.plugin.version}</version>
-                <configuration>
-                    <skip>${docker.database.skip}</skip>
-                </configuration>
                 <executions>
                     <execution>
                         <id>start-db-container</id>
@@ -385,6 +382,7 @@
                             <goal>start</goal>
                         </goals>
                         <configuration>
+                            <skip>${docker.database.skip}</skip>
                             <showLogs>true</showLogs>
                             <images>
                                 <image>
@@ -437,6 +435,9 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
+                        <configuration>
+                            <skip>${docker.database.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -1175,6 +1176,71 @@
                     <version>1.12.18</version>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>infinispan-server</id>
+            <properties>
+                <docker.infinispan.skip>false</docker.infinispan.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>${docker.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>start-ispn-container</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${docker.infinispan.skip}</skip>
+                                    <showLogs>true</showLogs>
+                                    <images>
+                                        <image>
+                                            <alias>infinispan</alias>
+                                            <name>quay.io/infinispan/server:${infinispan.version}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>11222:11222</port>
+                                                </ports>
+                                                <env>
+                                                    <USER>keycloak</USER>
+                                                    <PASS>Password1!</PASS>
+                                                </env>
+                                                <net>host</net>
+                                                <cmd>-b 127.0.0.1 -k 127.0.0.1</cmd>
+                                                <wait>
+                                                    <log>.*ISPN080001.*</log>
+                                                    <time>2000000</time>
+                                                    <kill>10000</kill>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-ispn-container</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${docker.infinispan.skip}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven-compiler-plugin.version}</version>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
     </profiles>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/KeycloakTestingClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/KeycloakTestingClient.java
@@ -22,6 +22,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
 import org.keycloak.common.Profile;
 import org.keycloak.testsuite.ProfileAssume;
 import org.keycloak.testsuite.client.resources.TestApplicationResource;
@@ -185,6 +186,8 @@ public class KeycloakTestingClient implements AutoCloseable {
 
                 if (t instanceof AssertionError) {
                     throw (AssertionError) t;
+                } else if (t instanceof AssumptionViolatedException) {
+                    throw (AssumptionViolatedException) t;
                 } else {
                     throw new RunOnServerException(t);
                 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/AuthenticationSessionProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/AuthenticationSessionProviderTest.java
@@ -17,12 +17,16 @@
 
 package org.keycloak.testsuite.model;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserManager;
@@ -37,15 +41,13 @@ import org.keycloak.sessions.CommonClientSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.arquillian.annotation.ModelTest;
+import org.keycloak.testsuite.util.InfinispanTestTimeServiceRule;
 
-import java.util.concurrent.atomic.AtomicReference;
-
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import org.keycloak.models.Constants;
-import org.keycloak.testsuite.util.InfinispanTestTimeServiceRule;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -212,10 +214,10 @@ public class AuthenticationSessionProviderTest extends AbstractTestRealmKeycloak
     @Test
     @ModelTest
     public void testExpiredAuthSessions(KeycloakSession session) {
+        assumeFalse(Profile.isFeatureEnabled(Profile.Feature.REMOTE_CACHE));
         AtomicReference<String> authSessionID = new AtomicReference<>();
 
-        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession sessionExpired) -> {
-            KeycloakSession mainSession = sessionExpired;
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), mainSession -> {
             try {
                 // AccessCodeLifespan = 10 ; AccessCodeLifespanUserAction = 10 ; AccessCodeLifespanLogin = 30
                 setAccessCodeLifespan(mainSession, 10, 10, 30);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionProviderTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.common.util.Time;
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -322,14 +323,20 @@ public class UserSessionProviderTest extends AbstractTestRealmKeycloakTest {
         RealmModel realm = session.realms().getRealmByName("test");
         createSessions(session);
 
-        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession kcSession) -> {
-            kcSession.sessions().removeUserSessions(realm);
-        });
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), kcSession -> kcSession.sessions().removeUserSessions(realm));
 
-        assertEquals(0, session.sessions().getUserSessionsStream(realm, session.users().getUserByUsername(realm, "user1"))
-                .count());
-        assertEquals(0, session.sessions().getUserSessionsStream(realm, session.users().getUserByUsername(realm, "user2"))
-                .count());
+        var user1 = session.users().getUserByUsername(realm, "user1");
+        var user2 = session.users().getUserByUsername(realm, "user2");
+
+        // TODO! [pruivo] to be removed when the session cache is remote only
+        // TODO! the Hot Rod events are async
+        if (InfinispanUtils.isRemoteInfinispan()) {
+            eventuallyEquals(null, 0L, () -> session.sessions().getUserSessionsStream(realm, user1).count());
+            eventuallyEquals(null, 0L, () -> session.sessions().getUserSessionsStream(realm, user2).count());
+        } else {
+            assertEquals(0, session.sessions().getUserSessionsStream(realm, user1).count());
+            assertEquals(0, session.sessions().getUserSessionsStream(realm, user2).count());
+        }
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -28,6 +28,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +38,7 @@ import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.common.Profile;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
@@ -44,6 +46,7 @@ import org.keycloak.crypto.ECDSAAlgorithm;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
@@ -69,6 +72,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.ActionURIUtils;
 import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.ProfileAssume;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.ClientBuilder;
@@ -110,6 +114,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.*;
 import static org.keycloak.testsuite.Assert.assertExpiration;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.admin.ApiUtil.findClientByClientId;
@@ -386,6 +391,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
     @Test
     public void accessTokenCodeExpired() {
+        ProfileAssume.assumeFeatureDisabled(Profile.Feature.REMOTE_CACHE);
         getTestingClient().testing().setTestingInfinispanTimeService();
         RealmManager.realm(adminClient.realm("test")).accessCodeLifeSpan(1);
         oauth.doLogin("test-user@localhost", "password");

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/FeatureEnabledTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/FeatureEnabledTest.java
@@ -22,6 +22,7 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.A
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHENTICATION_SESSIONS_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NAMES;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOCAL_CACHE_NAMES;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.WORK_CACHE_NAME;
 
 /**
@@ -51,12 +52,14 @@ public class FeatureEnabledTest extends KeycloakModelTest {
             assertEmbeddedCacheDoesNotExists(clusterProvider, WORK_CACHE_NAME);
             assertEmbeddedCacheDoesNotExists(clusterProvider, AUTHENTICATION_SESSIONS_CACHE_NAME);
             assertEmbeddedCacheDoesNotExists(clusterProvider, ACTION_TOKEN_CACHE);
+            assertEmbeddedCacheDoesNotExists(clusterProvider, LOGIN_FAILURE_CACHE_NAME);
 
             // TODO [pruivo] all caches eventually won't exists in embedded
             Arrays.stream(CLUSTERED_CACHE_NAMES)
                     .filter(Predicate.not(Predicate.isEqual(WORK_CACHE_NAME)))
                     .filter(Predicate.not(Predicate.isEqual(AUTHENTICATION_SESSIONS_CACHE_NAME)))
                     .filter(Predicate.not(Predicate.isEqual(ACTION_TOKEN_CACHE)))
+                    .filter(Predicate.not(Predicate.isEqual(LOGIN_FAILURE_CACHE_NAME)))
                     .forEach(s -> assertEmbeddedCacheExists(clusterProvider, s));
 
             Arrays.stream(CLUSTERED_CACHE_NAMES).forEach(s -> assertRemoteCacheExists(clusterProvider, s));

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/loginfailure/RemoteLoginFailureTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/loginfailure/RemoteLoginFailureTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.model.loginfailure;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.infinispan.util.InfinispanUtils;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.UserLoginFailureProvider;
+import org.keycloak.models.UserProvider;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
+import org.keycloak.models.sessions.infinispan.entities.LoginFailureKey;
+import org.keycloak.testsuite.model.KeycloakModelTest;
+import org.keycloak.testsuite.model.RequireProvider;
+
+@RequireProvider(UserLoginFailureProvider.class)
+@RequireProvider(UserProvider.class)
+@RequireProvider(RealmProvider.class)
+public class RemoteLoginFailureTest extends KeycloakModelTest {
+
+    private static final int NUM_USERS = 10;
+
+    private String realmId;
+    private List<String> userIds;
+
+    @Override
+    public void createEnvironment(KeycloakSession session) {
+        RealmModel realm = createRealm(session, "remote-login-failure-test");
+        realm.setDefaultRole(session.roles().addRealmRole(realm, Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + realm.getName()));
+        realmId = realm.getId();
+
+        userIds = IntStream.range(0, NUM_USERS)
+                .mapToObj(index -> "user-" + index)
+                .map(username -> {
+                    var user = session.users().addUser(realm, username);
+                    user.setEmail(username + "@localhost");
+                    return user.getId();
+                })
+                .collect(Collectors.toUnmodifiableList());
+
+    }
+
+    @Override
+    public void cleanEnvironment(KeycloakSession s) {
+        s.realms().removeRealm(realmId);
+    }
+
+    @Test
+    public void testLoginFailureCreation() {
+        Assume.assumeTrue(InfinispanUtils.isRemoteInfinispan());
+        var cache = getLoginFailureCache();
+
+        inComittedTransaction(session -> {
+            var realm = session.realms().getRealm(realmId);
+            var loginFailures = session.loginFailures().addUserLoginFailure(realm, userIds.get(0));
+            loginFailures.incrementFailures();
+        });
+
+        var entity = cache.get(new LoginFailureKey(realmId, userIds.get(0)));
+        assertEntity(entity, realmId, userIds.get(0), 0, null, 1, 0, 0);
+    }
+
+    @Test
+    public void testLoginFailureChangeLog() {
+        Assume.assumeTrue(InfinispanUtils.isRemoteInfinispan());
+        var cache = getLoginFailureCache();
+        var key = new LoginFailureKey(realmId, userIds.get(0));
+        var entity = new LoginFailureEntity();
+        entity.setRealmId(realmId);
+        entity.setUserId(userIds.get(0));
+        entity.setLastFailure(1000);
+        entity.setNumFailures(2);
+        entity.setNumTemporaryLockouts(10);
+        entity.setLastIPFailure("127.0.0.1");
+        entity.setFailedLoginNotBefore(2000);
+
+        cache.put(key, entity);
+
+        inComittedTransaction(session -> {
+            var realm = session.realms().getRealm(realmId);
+            var loginFailures = session.loginFailures().getUserLoginFailure(realm, userIds.get(0));
+
+            // update all fields
+            loginFailures.setLastFailure(10000);
+            loginFailures.incrementFailures();
+            loginFailures.incrementTemporaryLockouts();
+            loginFailures.setLastIPFailure("127.0.1.1");
+            loginFailures.setFailedLoginNotBefore(20000);
+        });
+
+        entity = cache.get(key);
+        assertEntity(entity, realmId, userIds.get(0), 10000, "127.0.1.1", 3, 20000, 11);
+    }
+
+    @Test
+    public void testLoginFailureChangeLogWithConcurrent() {
+        Assume.assumeTrue(InfinispanUtils.isRemoteInfinispan());
+        var cache = getLoginFailureCache();
+        var key = new LoginFailureKey(realmId, userIds.get(0));
+        var entity = new LoginFailureEntity();
+        entity.setRealmId(realmId);
+        entity.setUserId(userIds.get(0));
+        entity.setLastFailure(1000);
+        entity.setNumFailures(2);
+        entity.setNumTemporaryLockouts(10);
+        entity.setLastIPFailure("127.0.0.1");
+        entity.setFailedLoginNotBefore(2000);
+
+        cache.put(key, entity);
+
+        inComittedTransaction(session -> {
+            var realm = session.realms().getRealm(realmId);
+            var loginFailures = session.loginFailures().getUserLoginFailure(realm, userIds.get(0));
+
+            // update all fields
+            loginFailures.setLastFailure(10000);
+            loginFailures.incrementFailures();
+            loginFailures.incrementTemporaryLockouts();
+            loginFailures.setLastIPFailure("127.0.1.1");
+            loginFailures.setFailedLoginNotBefore(20000);
+
+            createRandomEntityInCache(cache, 20, 30, realmId, userIds.get(0));
+        });
+
+        entity = cache.get(key);
+        assertEntity(entity, realmId, userIds.get(0), 10000, "127.0.1.1", 21, 20000, 31);
+    }
+
+    @Test
+    public void testLoginFailureClear() {
+        Assume.assumeTrue(InfinispanUtils.isRemoteInfinispan());
+        var cache = getLoginFailureCache();
+        var key = new LoginFailureKey(realmId, userIds.get(0));
+        var entity = new LoginFailureEntity();
+        entity.setRealmId(realmId);
+        entity.setUserId(userIds.get(0));
+        entity.setLastFailure(1000);
+        entity.setNumFailures(2);
+        entity.setNumTemporaryLockouts(10);
+        entity.setLastIPFailure("127.0.0.1");
+        entity.setFailedLoginNotBefore(2000);
+
+        cache.put(key, entity);
+
+        inComittedTransaction(session -> {
+            var realm = session.realms().getRealm(realmId);
+            var loginFailures = session.loginFailures().getUserLoginFailure(realm, userIds.get(0));
+            loginFailures.incrementTemporaryLockouts();
+            loginFailures.clearFailures();
+
+            // create a conflict? should not make a difference
+            createRandomEntityInCache(cache, 1, 0, realmId, userIds.get(0));
+        });
+
+        entity = cache.get(key);
+        assertEntity(entity, realmId, userIds.get(0), 0, null, 0, 0, 0);
+    }
+
+    @Test
+    public void testLoginFailureRemove() {
+        Assume.assumeTrue(InfinispanUtils.isRemoteInfinispan());
+        var cache = getLoginFailureCache();
+        var key = new LoginFailureKey(realmId, userIds.get(0));
+        var entity = new LoginFailureEntity();
+
+        cache.put(key, entity);
+
+        inComittedTransaction(session -> {
+            var realm = session.realms().getRealm(realmId);
+            session.loginFailures().removeUserLoginFailure(realm, userIds.get(0));
+        });
+
+        entity = cache.get(key);
+        Assert.assertNull(entity);
+    }
+
+    @Test
+    public void testLoginFailureRemoveAll() {
+        Assume.assumeTrue(InfinispanUtils.isRemoteInfinispan());
+        var cache = getLoginFailureCache();
+
+        // clear garbage from previous tests
+        cache.clear();
+
+        for (var userId : userIds) {
+            var entity = new LoginFailureEntity();
+            entity.setRealmId(realmId);
+            entity.setUserId(userId);
+            cache.put(new LoginFailureKey(realmId, userId), entity);
+        }
+
+        Assert.assertEquals(10, cache.size());
+
+        inComittedTransaction(session -> {
+            var realm = session.realms().getRealm(realmId);
+            session.loginFailures().removeAllUserLoginFailures(realm);
+        });
+
+        Assert.assertEquals(0, cache.size());
+    }
+
+    private static void createRandomEntityInCache(RemoteCache<LoginFailureKey, LoginFailureEntity> cache, int failures, int temporaryLockouts, String realmId, String userId) {
+        var key = new LoginFailureKey(realmId, userId);
+        var entity = new LoginFailureEntity();
+        entity.setRealmId(realmId);
+        entity.setUserId(userId);
+        entity.setLastFailure(5000); // does not matter
+        entity.setNumFailures(failures);
+        entity.setNumTemporaryLockouts(temporaryLockouts);
+        entity.setLastIPFailure("127.0.0.1");
+        entity.setFailedLoginNotBefore(5000);
+
+        cache.put(key, entity);
+    }
+
+    private static void assertEntity(LoginFailureEntity entity, String realmId, String userId, long lastFailure, String lastIpFailure, int failures, int failedLoginNotBefore, int temporaryLockouts) {
+        Assert.assertNotNull(entity);
+        Assert.assertEquals(realmId, entity.getRealmId());
+        Assert.assertEquals(userId, entity.getUserId());
+        Assert.assertEquals(lastFailure, entity.getLastFailure());
+        Assert.assertEquals(lastIpFailure, entity.getLastIPFailure());
+        Assert.assertEquals(failures, entity.getNumFailures());
+        Assert.assertEquals(failedLoginNotBefore, entity.getFailedLoginNotBefore());
+        Assert.assertEquals(temporaryLockouts, entity.getNumTemporaryLockouts());
+    }
+
+    private RemoteCache<LoginFailureKey, LoginFailureEntity> getLoginFailureCache() {
+        return getInfinispanConnectionProvider().getRemoteCache(InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME);
+    }
+
+    private InfinispanConnectionProvider getInfinispanConnectionProvider() {
+        return inComittedTransaction(RemoteLoginFailureTest::getInfinispanConnectionProviderWithSession);
+    }
+
+    private static InfinispanConnectionProvider getInfinispanConnectionProviderWithSession(KeycloakSession session) {
+        return session.getProvider(InfinispanConnectionProvider.class);
+    }
+
+}

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/RemoteInfinispan.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/RemoteInfinispan.java
@@ -26,6 +26,7 @@ import org.keycloak.models.UserSessionSpi;
 import org.keycloak.models.sessions.infinispan.remote.RemoteInfinispanAuthenticationSessionProviderFactory;
 import org.keycloak.models.sessions.infinispan.remote.RemoteInfinispanSingleUseObjectProviderFactory;
 import org.keycloak.models.sessions.infinispan.remote.RemoteStickySessionEncoderProviderFactory;
+import org.keycloak.models.sessions.infinispan.remote.RemoteUserLoginFailureProviderFactory;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.testsuite.model.Config;
 import org.keycloak.testsuite.model.HotRodServerRule;
@@ -59,6 +60,7 @@ public class RemoteInfinispan extends KeycloakModelParameters {
             .add(RemoteInfinispanSingleUseObjectProviderFactory.class)
             .add(RemoteStickySessionEncoderProviderFactory.class)
             .add(RemoteLoadBalancerCheckProviderFactory.class)
+            .add(RemoteUserLoginFailureProviderFactory.class)
             .build();
 
     @Override


### PR DESCRIPTION
Implementation of UserLoginFailureProvider using remote caches only.

Closes #28754

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
