### PR TITLE
Moving admin user creation to the Quarkus startup phase

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -39,17 +39,11 @@ import io.quarkus.runtime.ApplicationLifecycleManager;
 import io.quarkus.runtime.Quarkus;
 
 import org.jboss.logging.Logger;
-import org.keycloak.Config;
-import org.keycloak.models.KeycloakSessionFactory;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.common.Version;
 import org.keycloak.quarkus.runtime.cli.command.Start;
-import org.keycloak.services.ServicesLogger;
-import org.keycloak.services.managers.ApplianceBootstrap;
-import org.keycloak.services.resources.KeycloakApplication;
 
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
@@ -60,9 +54,6 @@ import io.quarkus.runtime.annotations.QuarkusMain;
 @QuarkusMain(name = "keycloak")
 @ApplicationScoped
 public class KeycloakMain implements QuarkusApplication {
-
-    private static final String KEYCLOAK_ADMIN_ENV_VAR = "KEYCLOAK_ADMIN";
-    private static final String KEYCLOAK_ADMIN_PASSWORD_ENV_VAR = "KEYCLOAK_ADMIN_PASSWORD";
 
     public static void main(String[] args) {
         System.setProperty("kc.version", Version.VERSION);
@@ -149,10 +140,6 @@ public class KeycloakMain implements QuarkusApplication {
      */
     @Override
     public int run(String... args) throws Exception {
-        if (!isImportExportMode()) {
-            createAdminUser();
-        }
-
         if (isDevProfile()) {
             Logger.getLogger(KeycloakMain.class).warnf("Running the server in development mode. DO NOT use this configuration in production.");
         }
@@ -170,23 +157,4 @@ public class KeycloakMain implements QuarkusApplication {
         return exitCode;
     }
 
-    private void createAdminUser() {
-        String adminUserName = System.getenv(KEYCLOAK_ADMIN_ENV_VAR);
-        String adminPassword = System.getenv(KEYCLOAK_ADMIN_PASSWORD_ENV_VAR);
-
-        if ((adminUserName == null || adminUserName.trim().length() == 0)
-                || (adminPassword == null || adminPassword.trim().length() == 0)) {
-            return;
-        }
-
-        KeycloakSessionFactory sessionFactory = KeycloakApplication.getSessionFactory();
-
-        try {
-            KeycloakModelUtils.runJobInTransaction(sessionFactory, session -> {
-                new ApplianceBootstrap(session).createMasterRealmUser(adminUserName, adminPassword);
-            });
-        } catch (Throwable t) {
-            ServicesLogger.LOGGER.addUserFailed(t, adminUserName, Config.getAdminRealm());
-        }
-    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -21,23 +21,35 @@ import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.common.annotation.Blocking;
 
+import org.keycloak.Config;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.platform.Platform;
 import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.integration.QuarkusPlatform;
+import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.ws.rs.ApplicationPath;
 
+import static org.keycloak.quarkus.runtime.Environment.isImportExportMode;
+
 @ApplicationPath("/")
 @Blocking
 public class QuarkusKeycloakApplication extends KeycloakApplication {
+
+    private static final String KEYCLOAK_ADMIN_ENV_VAR = "KEYCLOAK_ADMIN";
+    private static final String KEYCLOAK_ADMIN_PASSWORD_ENV_VAR = "KEYCLOAK_ADMIN_PASSWORD";
 
     void onStartupEvent(@Observes StartupEvent event) {
         QuarkusPlatform platform = (QuarkusPlatform) Platform.getPlatform();
         platform.started();
         startup();
+        if (!isImportExportMode()) {
+            createAdminUser();
+        }
     }
 
     void onShutdownEvent(@Observes ShutdownEvent event) {
@@ -54,6 +66,26 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
     @Override
     protected void loadConfig() {
         // no need to load config provider because we force quarkus impl
+    }
+
+    private void createAdminUser() {
+        String adminUserName = System.getenv(KEYCLOAK_ADMIN_ENV_VAR);
+        String adminPassword = System.getenv(KEYCLOAK_ADMIN_PASSWORD_ENV_VAR);
+
+        if ((adminUserName == null || adminUserName.trim().length() == 0)
+            || (adminPassword == null || adminPassword.trim().length() == 0)) {
+            return;
+        }
+
+        KeycloakSessionFactory sessionFactory = KeycloakApplication.getSessionFactory();
+
+        try {
+            KeycloakModelUtils.runJobInTransaction(sessionFactory, session -> {
+                new ApplianceBootstrap(session).createMasterRealmUser(adminUserName, adminPassword);
+            });
+        } catch (Throwable t) {
+            ServicesLogger.LOGGER.addUserFailed(t, adminUserName, Config.getAdminRealm());
+        }
     }
 
 }


### PR DESCRIPTION
With this change in place, the admin user is created before the HTTP port is opened. Therefore, it will be there before any HTTP request can arrive, including the startup probe.

No need to add another start-up probe!

Closes #29072

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
