### PR TITLE
Encode realm name in console URIs

### DIFF
--- a/js/apps/account-ui/src/routes.tsx
+++ b/js/apps/account-ui/src/routes.tsx
@@ -59,7 +59,7 @@ export const PersonalInfoRoute: IndexRouteObject = {
 };
 
 export const RootRoute: RouteObject = {
-  path: new URL(environment.baseUrl).pathname,
+  path: decodeURIComponent(new URL(environment.baseUrl).pathname),
   element: <Root />,
   errorElement: <ErrorPage />,
   children: [

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -16,10 +16,10 @@
  */
 package org.keycloak.services.managers;
 
-import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.common.enums.SslRequired;
+import org.keycloak.common.util.Encode;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AdminRoles;
@@ -180,7 +180,7 @@ public class RealmManager {
 
         adminConsole.setRootUrl(Constants.AUTH_ADMIN_URL_PROP);
 
-        String baseUrl = UriBuilder.fromPath( "/admin/{realmName}/console/").build(realm.getName()).toString();
+        String baseUrl = "/admin/" + Encode.encodePathAsIs(realm.getName()) + "/console/";
         adminConsole.setBaseUrl(baseUrl);
         adminConsole.addRedirectUri(baseUrl + "*");
         adminConsole.setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, "+");
@@ -427,7 +427,7 @@ public class RealmManager {
 
             accountClient.setRootUrl(Constants.AUTH_BASE_URL_PROP);
 
-            String baseUrl = UriBuilder.fromPath( "/realms/{realmName}/account/").build(realm.getName()).toString();
+            String baseUrl = "/realms/" + Encode.encodePathAsIs(realm.getName()) + "/account/";
             accountClient.setBaseUrl(baseUrl);
             accountClient.addRedirectUri(baseUrl + "*");
             accountClient.setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, "+");
@@ -532,6 +532,7 @@ public class RealmManager {
         try {
             session.getContext().setRealm(realm);
             ReservedCharValidator.validate(rep.getRealm());
+            ReservedCharValidator.validateLocales(rep.getSupportedLocales());
             realm.setName(rep.getRealm());
 
             // setup defaults

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.services.managers;
 
+import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.common.enums.SslRequired;
@@ -178,7 +179,8 @@ public class RealmManager {
         adminConsole.setName("${client_" + Constants.ADMIN_CONSOLE_CLIENT_ID + "}");
 
         adminConsole.setRootUrl(Constants.AUTH_ADMIN_URL_PROP);
-        String baseUrl = "/admin/" + realm.getName() + "/console/";
+
+        String baseUrl = UriBuilder.fromPath( "/admin/{realmName}/console/").build(realm.getName()).toString();
         adminConsole.setBaseUrl(baseUrl);
         adminConsole.addRedirectUri(baseUrl + "*");
         adminConsole.setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, "+");
@@ -424,7 +426,8 @@ public class RealmManager {
             accountClient.setFullScopeAllowed(false);
 
             accountClient.setRootUrl(Constants.AUTH_BASE_URL_PROP);
-            String baseUrl = "/realms/" + realm.getName() + "/account/";
+
+            String baseUrl = UriBuilder.fromPath( "/realms/{realmName}/account/").build(realm.getName()).toString();
             accountClient.setBaseUrl(baseUrl);
             accountClient.addRedirectUri(baseUrl + "*");
             accountClient.setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, "+");

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -23,6 +23,7 @@ import org.keycloak.http.HttpResponse;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.NotAuthorizedException;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.Encode;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.KeycloakSession;
@@ -170,7 +171,7 @@ public class AdminRoot {
         } catch (JWSInputException e) {
             throw new NotAuthorizedException("Bearer token format error");
         }
-        String realmName = token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+        String realmName = Encode.decodePath(token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1));
         RealmManager realmManager = new RealmManager(session);
         RealmModel realm = realmManager.getRealmByName(realmName);
         if (realm == null) {


### PR DESCRIPTION
Closes #25807

This probably also closes #26108. I'll take a look but I think that with this the realm is properly checked in name and id.

The PR encodes the URLs generated when a realm is created. It also decodes the issuer to obtain the realm that was previously encoded. Tests added.

Maybe there are more issues about spaces in realms but the idea is managing them one by one. With this PR at least the realm is created and it's functional with the admin console. I'm going to file a new bug for the account console. The v2 one worked OK but v3 is failing.
