### PR TITLE
Fix logic around what happens to client when client type is deleted

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeManager.java
@@ -41,7 +41,7 @@ public interface ClientTypeManager extends Provider {
     // Implementation is supposed also to validate clientTypes before persisting them
     void updateClientTypes(RealmModel realm, ClientTypesRepresentation clientTypes) throws ClientTypeException;
 
-    ClientType getClientType(RealmModel realm, String typeName)  throws ClientTypeException;
+    ClientType getClientType(RealmModel realm, ClientModel rep)  throws ClientTypeException;
 
     // Create client, which delegates to the particular client type
     ClientModel augmentClient(ClientModel client) throws ClientTypeException;

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -92,12 +92,13 @@ public class DefaultClientTypeManager implements ClientTypeManager {
 
 
     @Override
-    public ClientType getClientType(RealmModel realm, String typeName) throws ClientTypeException {
+    public ClientType getClientType(RealmModel realm, ClientModel rep) throws ClientTypeException {
         ClientTypesRepresentation clientTypes = getClientTypes(realm);
-        ClientTypeRepresentation clientType = getClientTypeByName(clientTypes, typeName);
+        ClientTypeRepresentation clientType = getClientTypeByName(clientTypes, rep.getType());
         if (clientType == null) {
-            logger.errorf("Referenced client type '%s' not found", typeName);
-            throw new ClientTypeException("Client type not found");
+            logger.errorf("Referenced client type '%s' not found", rep.getType());
+            rep.setType(null);
+            return null;
         }
 
         ClientTypeProvider provider = session.getProvider(ClientTypeProvider.class, clientType.getProvider());
@@ -110,7 +111,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
             return client;
         } else {
             try {
-                ClientType clientType = getClientType(client.getRealm(), client.getType());
+                ClientType clientType = getClientType(client.getRealm(), client);
                 return new TypeAwareClientModelDelegate(clientType, () -> client);
             } catch(ClientTypeException cte) {
                 logger.errorf("Could not augment client, %s, due to client type exception: %s",

--- a/services/src/main/java/org/keycloak/services/managers/ClientManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ClientManager.java
@@ -84,7 +84,7 @@ public class ClientManager {
     public static ClientModel createClient(KeycloakSession session, RealmModel realm, ClientRepresentation rep) {
         if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && rep.getType() != null) {
             ClientTypeManager mgr = session.getProvider(ClientTypeManager.class);
-            ClientType clientType = mgr.getClientType(realm, rep.getType());
+            ClientType clientType = mgr.getClientType(realm, (ClientModel) rep);
             clientType.onCreate(rep);
         }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -158,7 +158,7 @@ public class ClientResource {
                 }
                 if (rep.getType() != null) {
                     ClientTypeManager mgr = session.getProvider(ClientTypeManager.class);
-                    ClientType clientType = mgr.getClientType(realm, rep.getType());
+                    ClientType clientType = mgr.getClientType(realm, (ClientModel) rep);
                     clientType.onUpdate(client, rep);
                 }
             }


### PR DESCRIPTION
If you try to retrieve a client that has a client type that's been deleted, the client type gets set to null and the client is successfully retrieved.

closes #29061