### PR TITLE
Avoid re-creating required action comparator

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/RequiredActionProviderModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RequiredActionProviderModel.java
@@ -28,17 +28,11 @@ import java.util.Map;
 */
 public class RequiredActionProviderModel implements Serializable {
 
-    public static class RequiredActionComparator implements Comparator<RequiredActionProviderModel> {
-        public static final RequiredActionComparator SINGLETON = new RequiredActionComparator();
-
-        @Override
-        public int compare(RequiredActionProviderModel o1, RequiredActionProviderModel o2) {
-
-            return Comparator
-                    .comparingInt(RequiredActionProviderModel::getPriority)
-                    .thenComparing(RequiredActionProviderModel::getName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER))
-                    .compare(o1, o2);
-        }
+    public interface RequiredActionComparator extends Comparator<RequiredActionProviderModel> {
+        RequiredActionComparator SINGLETON = Comparator
+            .comparingInt(RequiredActionProviderModel::getPriority)
+            .thenComparing(RequiredActionProviderModel::getName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER))
+            ::compare;
     }
 
     private String id;


### PR DESCRIPTION
closes #29130

The current implementation of `org.keycloak.models.RequiredActionProviderModel.RequiredActionComparator` re-creates a delegate comparator on every invocaion of the `Comparator#compare` method.

This PR changes the implementation such that the same `Comparator` instance is re-used.