### PR TITLE
Set client in the context for docker protocol. Fix to execute again the docker test

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
@@ -61,6 +61,7 @@ public class DockerEndpoint extends AuthorizationEndpointBase {
             logger.errorv("Failed to lookup client given by service={0} parameter for realm: {1}.", service, realm.getName());
             throw new ErrorResponseException("invalid_client", "Client specified by 'service' parameter does not exist", Response.Status.BAD_REQUEST);
         }
+        session.getContext().setClient(client);
         scope = params.getFirst(DockerAuthV2Protocol.SCOPE_PARAM);
 
         checkSsl();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
@@ -5,10 +5,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.KeyStatus;
+import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.KeysMetadataRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
-import org.keycloak.testsuite.ProfileAssume;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
@@ -26,9 +28,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assume.assumeTrue;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
-
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;
 import static org.keycloak.testsuite.util.WaitUtils.pause;
 
+@EnableFeature(Profile.Feature.DOCKER)
 public class DockerClientTest extends AbstractKeycloakTest {
     public static final String REALM_ID = "docker-test-realm";
     public static final String CLIENT_ID = "docker-test-client";
@@ -43,12 +46,9 @@ public class DockerClientTest extends AbstractKeycloakTest {
     private GenericContainer dockerClientContainer = null;
 
     private static String hostIp;
-    private static String authServerPort;
 
     @BeforeClass
     public static void verifyEnvironment() {
-        ProfileAssume.assumeFeatureEnabled(Profile.Feature.DOCKER);
-
         final Optional<DockerVersion> dockerVersion = new DockerHostVersionSupplier().get();
         assumeTrue("Could not determine docker version for host machine.  It either is not present or accessible to the JVM running the test harness.", dockerVersion.isPresent());
         assumeTrue("Docker client on host machine is not a supported version.  Please upgrade and try again.", DockerVersion.COMPARATOR.compare(dockerVersion.get(), DockerVersion.parseVersionString(MINIMUM_DOCKER_VERSION)) >= 0);
@@ -62,8 +62,6 @@ public class DockerClientTest extends AbstractKeycloakTest {
             }
         }
         Assert.assertNotNull("Could not resolve host machine's IP address for docker adapter, and 'host.ip' system poperty not set. Client will not be able to authenticate against the keycloak server!", hostIp);
-
-        authServerPort = AUTH_SERVER_PORT;
     }
 
     @Override
@@ -83,7 +81,10 @@ public class DockerClientTest extends AbstractKeycloakTest {
         String realmCert = null;
         List<KeysMetadataRepresentation.KeyMetadataRepresentation> realmKeys = adminClient.realm(REALM_ID).keys().getKeyMetadata().getKeys();
         for (KeysMetadataRepresentation.KeyMetadataRepresentation key : realmKeys) {
-            if (key.getType().equals("RSA")) {
+            if (Constants.DEFAULT_SIGNATURE_ALGORITHM.equals(key.getAlgorithm()) && KeyStatus.ACTIVE.name().equals(key.getStatus())) {
+                if (realmCert != null) {
+                     throw new IllegalStateException("More than one public realm cert enabled");
+                }
                 realmCert = key.getCertificate();
             }
         }
@@ -102,9 +103,9 @@ public class DockerClientTest extends AbstractKeycloakTest {
 
         final Map<String, String> environment = new HashMap<>();
         environment.put("REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY", "/tmp");
-        environment.put("REGISTRY_AUTH_TOKEN_REALM", "http://" + hostIp + ":" + authServerPort + "/auth/realms/" + REALM_ID + "/protocol/docker-v2/auth");
+        environment.put("REGISTRY_AUTH_TOKEN_REALM", AUTH_SERVER_SCHEME + "://" + hostIp + ":" + AUTH_SERVER_PORT + "/auth/realms/" + REALM_ID + "/protocol/docker-v2/auth");
         environment.put("REGISTRY_AUTH_TOKEN_SERVICE", CLIENT_ID);
-        environment.put("REGISTRY_AUTH_TOKEN_ISSUER", "http://" + hostIp + ":" + authServerPort + "/auth/realms/" + REALM_ID);
+        environment.put("REGISTRY_AUTH_TOKEN_ISSUER", AUTH_SERVER_SCHEME + "://" + hostIp + ":" + AUTH_SERVER_PORT + "/auth/realms/" + REALM_ID);
         environment.put("REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE", "/opt/kc-certs/" + tmpCertFile.getCanonicalFile().getName());
         environment.put("INSECURE_REGISTRY", "--insecure-registry " + REGISTRY_HOSTNAME + ":" + REGISTRY_PORT);
 


### PR DESCRIPTION
Closes #28649

There was a NPE in docker when the DYNAMIC_SCOPES was also enabled. Besides I detected the test for docker was not executed (it was always skipped because the profile was not set), so I modified it to use the `@EnableFeature` and make it work OK. I considered that this doesn't need a backport as it should be in combination with DYNAMIC_SCOPES, but if you think that it's needed just let me know.