### PR TITLE
Fix parsing of multivalued list type in client mappers

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ConfigPropertyRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ConfigPropertyRepresentation.java
@@ -32,6 +32,7 @@ public class ConfigPropertyRepresentation {
     protected List<String> options;
     protected boolean secret;
     protected boolean required;
+    protected boolean stringify;
     private boolean readOnly;
 
     public String getName() {
@@ -104,5 +105,13 @@ public class ConfigPropertyRepresentation {
 
     public boolean isReadOnly() {
         return readOnly;
+    }
+
+    public boolean isStringify() {
+        return stringify;
+    }
+
+    public void setStringify(boolean stringify) {
+        this.stringify = stringify;
     }
 }

--- a/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
@@ -218,7 +218,10 @@ export default function MappingDetails() {
               rules={{ required: { value: true, message: t("required") } }}
             />
             <DynamicComponents
-              properties={mapping?.properties || []}
+                properties={(mapping?.properties || []).map((obj: any) => ({
+                  ...obj,
+                  stringify: true,
+                }))}
               isNew={!isUpdating}
             />
             <ActionGroup>

--- a/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
@@ -218,11 +218,8 @@ export default function MappingDetails() {
               rules={{ required: { value: true, message: t("required") } }}
             />
             <DynamicComponents
-                properties={(mapping?.properties || []).map((obj: any) => ({
-                  ...obj,
-                  stringify: true,
-                }))}
-              isNew={!isUpdating}
+                properties={mapping?.properties || []}
+                isNew={!isUpdating}
             />
             <ActionGroup>
               <Button variant="primary" type="submit">

--- a/js/libs/keycloak-admin-client/src/defs/configPropertyRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/configPropertyRepresentation.ts
@@ -10,4 +10,5 @@ export interface ConfigPropertyRepresentation {
   options?: string[];
   secret?: boolean;
   required?: boolean;
+  stringify?: boolean;
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -933,6 +933,7 @@ public class ModelToRepresentation {
         propRep.setHelpText(prop.getHelpText());
         propRep.setSecret(prop.isSecret());
         propRep.setRequired(prop.isRequired());
+        propRep.setStringify(prop.isStringify());
         return propRep;
     }
 

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -76,6 +76,7 @@ public class ProviderConfigProperty {
     protected List<String> options;
     protected boolean secret;
     protected boolean required;
+    protected boolean stringify;
     private boolean readOnly;
 
     public ProviderConfigProperty() {
@@ -106,6 +107,10 @@ public class ProviderConfigProperty {
     public ProviderConfigProperty(String name, String label, String helpText, String type, Object defaultValue, boolean secret, boolean required) {
         this(name, label, helpText, type, defaultValue, secret);
         this.required = required;
+    }
+    public ProviderConfigProperty(String name, String label, String helpText, String type, Object defaultValue, boolean secret, boolean required, boolean stringify) {
+        this(name, label, helpText, type, defaultValue, secret, required);
+        this.stringify = stringify;
     }
 
     /**
@@ -218,5 +223,13 @@ public class ProviderConfigProperty {
 
     public boolean isReadOnly() {
         return readOnly;
+    }
+
+    public boolean isStringify() {
+        return stringify;
+    }
+
+    public void setStringify(boolean stringify) {
+        this.stringify = stringify;
     }
 }


### PR DESCRIPTION
Enable stringify by default, backend expects only a string and currently errors on parsing

Closes #26794

a list was sent instead of a string:
![image](https://github.com/keycloak/keycloak/assets/74083411/7269d2fd-f192-4261-806b-e6377f83723a)
![image](https://github.com/keycloak/keycloak/assets/74083411/4f801ca6-000a-4a83-95be-8b1ba93d6d9a)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
