### PR TITLE
Add missing q query parameter to user and client queries on js admin client

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/js/libs/keycloak-admin-client/src/resources/clients.ts
@@ -29,6 +29,7 @@ export interface ClientQuery extends PaginatedQuery {
   clientId?: string;
   viewableOnly?: boolean;
   search?: boolean;
+  q?: string;
 }
 
 export interface ResourceQuery extends PaginatedQuery {

--- a/js/libs/keycloak-admin-client/src/resources/users.ts
+++ b/js/libs/keycloak-admin-client/src/resources/users.ts
@@ -29,6 +29,7 @@ interface UserBaseQuery {
   firstName?: string;
   lastName?: string;
   username?: string;
+  q?: string;
 }
 
 export interface UserQuery extends PaginationQuery, SearchQuery, UserBaseQuery {


### PR DESCRIPTION
With the JS Keycloak Admin Client, I tried to count users by using the `q` query parameter (this endpoint https://www.keycloak.org/docs-api/23.0.7/rest-api/#_get_adminrealmsrealmuserscount):

```ts
const keycloakClient = new KcAdminClient({ baseUrl: "http://localhost:8080" });

// ...

const usersCount = await keycloakClient.users.count({ q: `organizationId:${organizationId}` });
```

This causes the following TypeScript error:
```
Argument of type '{ q: string; }' is not assignable to parameter of type 'UserBaseQuery & SearchQuery & { realm?: string | undefined; }'.
  Object literal may only specify known properties, and 'q' does not exist in type 'UserBaseQuery & SearchQuery & { realm?: string | undefined; }'.ts(2345)
```

I have updated the TypeScript interfaces for the user query parameters and for the client query parameters, as they were also missing there.


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

fixes #29190
