### PR TITLE
Add protocol validation on creating client scope api

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -205,6 +205,9 @@ public class ClientScopeResource {
             }
         }
     }
+    public static void validateClientScopeProtocol(String protocol)throws ErrorResponseException{
+        if(protocol==null || (!protocol.equals("openid-connect") && !protocol.equals("saml"))) throw ErrorResponse.error("Unexpected protocol",Response.Status.BAD_REQUEST);
+    }
 
     public static void validateClientScopeName(String name) throws ErrorResponseException {
         if (!scopeNamePattern.matcher(name).matches()) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -102,6 +102,7 @@ public class ClientScopesResource {
     public Response createClientScope(ClientScopeRepresentation rep) {
         auth.clients().requireManageClientScopes();
         ClientScopeResource.validateClientScopeName(rep.getName());
+        ClientScopeResource.validateClientScopeProtocol(rep.getProtocol());
         ClientScopeResource.validateDynamicClientScope(rep);
         try {
             ClientScopeModel clientModel = RepresentationToModel.createClientScope(session, realm, rep);


### PR DESCRIPTION
Protocol now is mandatory during client scope creation.

closes #29027

