### PR TITLE
Fix oid4vc tests

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakContainerFeaturesController.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakContainerFeaturesController.java
@@ -10,8 +10,10 @@ import org.jboss.arquillian.test.spi.event.suite.After;
 import org.jboss.arquillian.test.spi.event.suite.AfterClass;
 import org.jboss.arquillian.test.spi.event.suite.Before;
 import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+import org.jboss.logging.Logger;
 import org.keycloak.common.Profile;
 import org.keycloak.testsuite.ProfileAssume;
+import org.keycloak.testsuite.arquillian.DeploymentArchiveProcessor;
 import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.arquillian.TestContext;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
@@ -20,6 +22,7 @@ import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeatures;
 import org.keycloak.testsuite.arquillian.annotation.SetDefaultProvider;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
+import org.keycloak.testsuite.util.FeatureDeployerUtil;
 import org.keycloak.testsuite.util.SpiProvidersSwitchingUtils;
 
 import java.lang.reflect.AnnotatedElement;
@@ -94,7 +97,7 @@ public class KeycloakContainerFeaturesController {
         private void assertPerformed() {
             assertThat("An annotation requested to " + action.name() +
                             " feature " + feature.getKey() + ", however after performing this operation " +
-                            "the feature is not in desired state" ,
+                            "the feature is not in desired state",
                     ProfileAssume.isFeatureEnabled(feature),
                     is(action == FeatureAction.ENABLE || action == FeatureAction.ENABLE_AND_RESET));
         }
@@ -189,13 +192,29 @@ public class KeycloakContainerFeaturesController {
         Set<UpdateFeature> ret = new HashSet<>();
 
         ret.addAll(Arrays.stream(annotatedElement.getAnnotationsByType(EnableFeature.class))
-                .map(annotation -> new UpdateFeature(annotation.value(), annotation.skipRestart(),
-                        state == State.BEFORE ? FeatureAction.ENABLE : FeatureAction.DISABLE_AND_RESET, annotatedElement))
+                .map(annotation -> {
+                    if (state == State.BEFORE) {
+                        return new UpdateFeature(annotation.value(), annotation.skipRestart(),FeatureAction.ENABLE, annotatedElement);
+                    } else if (Profile.getInstance().getDisabledFeatures().contains(annotation.value())) {
+                        // only disable if it should be
+                        return new UpdateFeature(annotation.value(), annotation.skipRestart(),FeatureAction.DISABLE_AND_RESET, annotatedElement);
+                    } else {
+                        return new UpdateFeature(annotation.value(), annotation.skipRestart(),FeatureAction.ENABLE, annotatedElement);
+                    }
+                })
                 .collect(Collectors.toSet()));
 
         ret.addAll(Arrays.stream(annotatedElement.getAnnotationsByType(DisableFeature.class))
-                .map(annotation -> new UpdateFeature(annotation.value(), annotation.skipRestart(),
-                        state == State.BEFORE ? FeatureAction.DISABLE : FeatureAction.ENABLE_AND_RESET, annotatedElement))
+                .map(annotation -> {
+                    if (state == State.BEFORE) {
+                        return new UpdateFeature(annotation.value(), annotation.skipRestart(), FeatureAction.DISABLE, annotatedElement);
+                    } else if (Profile.getInstance().getDisabledFeatures().contains(annotation.value())) {
+                        // we do not want to enable features that should be disabled by default
+                        return new UpdateFeature(annotation.value(), annotation.skipRestart(), FeatureAction.DISABLE_AND_RESET, annotatedElement);
+                    } else {
+                        return new UpdateFeature(annotation.value(), annotation.skipRestart(), FeatureAction.ENABLE_AND_RESET, annotatedElement);
+                    }
+                })
                 .collect(Collectors.toSet()));
 
         return ret;
@@ -222,7 +241,7 @@ public class KeycloakContainerFeaturesController {
 
         return false;
     }
-    
+
     public void handleEnableFeaturesAnnotationBeforeClass(@Observes(precedence = 1) BeforeClass event) throws Exception {
         checkAnnotatedElementForFeatureAnnotations(event.getTestClass().getJavaClass(), State.BEFORE);
     }


### PR DESCRIPTION
Fixes the flakyiness of the OID4VC tests. The [OID4VCGrantFeatureTest](https://github.com/keycloak/keycloak/blob/main/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCGrantFeatureTest.java) introduces a side-effect, that fails the following OID4VCI tests(thus the succeed if only the failed once are restarted). 
Since the Feature test disabled an by-default disabled (experimental)feature and the test-framework enables all features that where disabled-by-annotation after the test, the OID4VCI-Feature was set to enabled in the testcontext. However, since the the following tests require a restart, they are disabled in the newley started instance, but enabled in the test-context.
The PR sets the feature state in the After-Test to the value set in the current profile or in the defaults(e.g. all EXPERIMENTAL will stay disabled).

closes [#28982](https://github.com/keycloak/keycloak/issues/28982)
closes [#28983](https://github.com/keycloak/keycloak/issues/28983)
closes [#28984](https://github.com/keycloak/keycloak/issues/28984)
closes [#28985](https://github.com/keycloak/keycloak/issues/28985)
closes [#28986](https://github.com/keycloak/keycloak/issues/28986)
closes [#28987](https://github.com/keycloak/keycloak/issues/28987) 
closes [#28988](https://github.com/keycloak/keycloak/issues/28988) 
closes [#28989](https://github.com/keycloak/keycloak/issues/28989) 
closes [#28990](https://github.com/keycloak/keycloak/issues/28990) 
closes [#28991](https://github.com/keycloak/keycloak/issues/28991) 
closes [#28992](https://github.com/keycloak/keycloak/issues/28992) 
closes [#28993](https://github.com/keycloak/keycloak/issues/28993) 
closes [#28994](https://github.com/keycloak/keycloak/issues/28994) 
closes [#28995](https://github.com/keycloak/keycloak/issues/28995) 
closes [#28996](https://github.com/keycloak/keycloak/issues/28996) 
