### PR TITLE
Add protocol validation on creating client scope api #29199

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -87,6 +87,10 @@ public class ClientScopeResource {
         return new ProtocolMappersResource(session, clientScope, auth, adminEvent, manageCheck, viewCheck);
     }
 
+    public static void validateClientScopeProtocol(String protocol)throws ErrorResponseException{
+        if(protocol==null || (!protocol.equals("openid-connect") && !protocol.equals("saml"))) throw ErrorResponse.error("Unexpected protocol",Response.Status.BAD_REQUEST);
+    }
+
     /**
      * Base path for managing the role scope mappings for the client scope
      *

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -102,6 +102,7 @@ public class ClientScopesResource {
     public Response createClientScope(ClientScopeRepresentation rep) {
         auth.clients().requireManageClientScopes();
         ClientScopeResource.validateClientScopeName(rep.getName());
+        ClientScopeResource.validateClientScopeProtocol(rep.getProtocol());
         ClientScopeResource.validateDynamicClientScope(rep);
         try {
             ClientScopeModel clientModel = RepresentationToModel.createClientScope(session, realm, rep);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientScopeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientScopeTest.java
@@ -85,6 +85,15 @@ public class ClientScopeTest extends AbstractClientTest {
     }
 
     @Test
+    public void testValidateClientScopeProtocol(){
+        org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol("saml");
+        org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol("openid-connect");
+        assertThrows(ErrorResponseException.class,()-> org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol(null));
+        assertThrows(ErrorResponseException.class,()-> org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol("others"));
+
+
+    }
+    @Test
     public void testUpdateFailureWithInvalidScopeName() {
         // Creating first
         ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();


### PR DESCRIPTION
Protocol now is mandatory during client scope creation.

closes #29027


