### PR TITLE
don't do multi select when type isn't multi

### DIFF
--- a/js/libs/ui-shared/src/controls/SelectControl.tsx
+++ b/js/libs/ui-shared/src/controls/SelectControl.tsx
@@ -115,7 +115,7 @@ export const SelectControl = <
             }
             onSelect={(event, v) => {
               event.stopPropagation();
-              if (Array.isArray(value)) {
+              if (variant.includes("multi") && Array.isArray(value)) {
                 const option = v.toString();
                 const key = isSelectBasedOptions(options)
                   ? options.find((o) => o.value === option)?.key

--- a/js/libs/ui-shared/src/controls/SwitchControl.tsx
+++ b/js/libs/ui-shared/src/controls/SwitchControl.tsx
@@ -25,11 +25,15 @@ export type SwitchControlProps<
 export const SwitchControl = <
   T extends FieldValues,
   P extends FieldPath<T> = FieldPath<T>,
->(
-  props: SwitchControlProps<T, P>,
-) => {
-  const fallbackValue = props.stringify ? "false" : false;
-  const defaultValue = props.defaultValue ?? (fallbackValue as PathValue<T, P>);
+>({
+  labelOn,
+  stringify,
+  defaultValue,
+  labelIcon,
+  ...props
+}: SwitchControlProps<T, P>) => {
+  const fallbackValue = stringify ? "false" : false;
+  const defValue = defaultValue ?? (fallbackValue as PathValue<T, P>);
   const { control } = useFormContext();
   return (
     <FormLabel
@@ -37,21 +41,21 @@ export const SwitchControl = <
       name={props.name}
       isRequired={props.rules?.required === true}
       label={props.label}
-      labelIcon={props.labelIcon}
+      labelIcon={labelIcon}
     >
       <Controller
         control={control}
         name={props.name}
-        defaultValue={defaultValue}
+        defaultValue={defValue}
         render={({ field: { onChange, value } }) => (
           <Switch
             {...props}
             id={props.name}
             data-testid={props.name}
-            label={props.labelOn}
-            isChecked={props.stringify ? value === "true" : value}
+            label={labelOn}
+            isChecked={stringify ? value === "true" : value}
             onChange={(e, checked) => {
-              const value = props.stringify ? checked.toString() : checked;
+              const value = stringify ? checked.toString() : checked;
               props.onChange?.(e, checked);
               onChange(value);
             }}


### PR DESCRIPTION
- **remove invalid attributes from switch**
- **don't do multi select when variant is not multi**

fixes: #29237
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
