### PR TITLE
Adding dummyHash to DirectGrant request in case user does not exists.…

### DIFF
--- a/crypto/default/src/test/java/org/keycloak/crypto/def/test/CryptoPerfTest.java
+++ b/crypto/default/src/test/java/org/keycloak/crypto/def/test/CryptoPerfTest.java
@@ -138,7 +138,7 @@ public class CryptoPerfTest {
         perfTest(new Runnable() {
             @Override
             public void run() {
-                provider.encode("password", -1);
+                provider.encodedCredential("password", -1);
             }
         }, "testPbkdf512", 1);
     }

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -302,6 +302,11 @@ the `SingleUseObjectKeyModel` also changed to keep consistency with the method n
 The previous `getExpiration` method is now deprecated and you should prefer using new newly introduced `getExp` method
 to avoid overflow after 2038.
 
+= Method encode deprecated on PasswordHashProvider
+
+Method `String encode(String rawPassword, int iterations)` on the interface `org.keycloak.credential.hash.PasswordHashProvider` is deprecated. The method will be removed in
+one of the future {project_name} releases. It might be {project_name} 27 release.
+
 = Resteasy util class is deprecated
 
 `org.keycloak.common.util.Resteasy` has been deprecated. You should use the `org.keycloak.util.KeycloakSessionUtil` to obtain the `KeycloakSession` instead.

--- a/server-spi/src/main/java/org/keycloak/credential/hash/PasswordHashProvider.java
+++ b/server-spi/src/main/java/org/keycloak/credential/hash/PasswordHashProvider.java
@@ -30,6 +30,10 @@ public interface PasswordHashProvider extends Provider {
 
     PasswordCredentialModel encodedCredential(String rawPassword, int iterations);
 
+    /**
+     * Exists due the backwards compatibility. It is recommended to use {@link #encodedCredential(String, int)}
+     */
+    @Deprecated
     default
     String encode(String rawPassword, int iterations) {
         return rawPassword;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -21,12 +21,11 @@ import org.jboss.logging.Logger;
 import org.keycloak.authentication.AbstractFormAuthenticator;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.credential.hash.PasswordHashProvider;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.ModelDuplicateException;
-import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
@@ -100,21 +99,9 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         return challengeResponse;
     }
 
-    protected void dummyHash(AuthenticationFlowContext context) {
-        PasswordPolicy passwordPolicy = context.getRealm().getPasswordPolicy();
-        PasswordHashProvider provider;
-        if (passwordPolicy != null && passwordPolicy.getHashAlgorithm() != null) {
-            provider = context.getSession().getProvider(PasswordHashProvider.class, passwordPolicy.getHashAlgorithm());
-        } else {
-            provider = context.getSession().getProvider(PasswordHashProvider.class);
-        }
-        int iterations = passwordPolicy != null ? passwordPolicy.getHashIterations() : -1;
-        provider.encode("SlightlyLongerDummyPassword", iterations);
-    }
-
     public void testInvalidUser(AuthenticationFlowContext context, UserModel user) {
         if (user == null) {
-            dummyHash(context);
+            AuthenticatorUtils.dummyHash(context);
             context.getEvent().error(Errors.USER_NOT_FOUND);
             Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
             context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java
@@ -20,6 +20,7 @@ package org.keycloak.authentication.authenticators.directgrant;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -71,6 +72,7 @@ public class ValidateUsername extends AbstractDirectGrantAuthenticator {
 
 
         if (user == null) {
+            AuthenticatorUtils.dummyHash(context);
             context.getEvent().error(Errors.USER_NOT_FOUND);
             Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid user credentials");
             context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
@@ -79,6 +81,7 @@ public class ValidateUsername extends AbstractDirectGrantAuthenticator {
 
         String bruteForceError = getDisabledByBruteForceEventError(context, user);
         if (bruteForceError != null) {
+            AuthenticatorUtils.dummyHash(context);
             context.getEvent().user(user);
             context.getEvent().error(bruteForceError);
             Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid user credentials");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/PasswordHashingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/PasswordHashingTest.java
@@ -213,7 +213,7 @@ public class PasswordHashingTest extends AbstractTestRealmKeycloakTest {
                 Pbkdf2Sha512PasswordHashProviderFactory.DEFAULT_ITERATIONS,
                 0,
                 256);
-        String encodedPassword = specificKeySizeHashProvider.encode(password, -1);
+        String encodedPassword = specificKeySizeHashProvider.encodedCredential(password, -1).getPasswordSecretData().getValue();
 
         // Create a user with the encoded password, simulating a user import from a different system using a specific key size
         UserRepresentation user = UserBuilder.create().username(username).password(encodedPassword).build();
@@ -416,7 +416,7 @@ public class PasswordHashingTest extends AbstractTestRealmKeycloakTest {
         BiFunction<PasswordHashProvider, Integer, Long> hasher = (provider, iterations) -> {
             long result = 0L;
             for (String password : plainTextPasswords) {
-                String encoded = provider.encode(password, iterations);
+                String encoded = provider.encodedCredential(password, iterations).getPasswordSecretData().getValue();
                 result += encoded.hashCode();
             }
             return result;


### PR DESCRIPTION
… Fix dummyHash for normal login requests

closes #12298

### Summary of changes

- PR adds dummyHash to direct grant requests
- PR fixes dummyHash for regular login requests, which was broken due the Argon2 change

### Details

Before this PR, it is easily possible to enumerate Keycloak users as there is significant difference between the DirectGrant (OAuth2 resource owner password credentials) request of:

- Existing username, but invalid password
- Non-existing username

The latter is much faster (around 2-3 times) and hence can be easily used to detect if user exists.

This PR tries to mitigate the difference to simulate the password validation for non-existing user as well (by using `dummyHash` method). This method is already used for regular browser user logins.

However during the work on this, I figured that `AbstractUsernameFormAuthenticator.dummyHash` method was broken for the Argon2 provider because it used method `PasswordHashProvider.encode(String rawPassword, int iterations)`, which in case of `Argon2PasswordHashProvider` does nothing (it just return the given password). I've fixed this to use `PasswordHashProvider.encodedCredential` method (which works as expected for both Argon2 and Pbkdf2 providers).

Also I've made the method `PasswordHashProvider.encode` deprecated to avoid similar issues in the future (it was used anyway just in the test and in this `dummyHash` method).

I am adding the numbers on my laptop (PR adds the difference making it harder to reliably enumerate users). There is however still one remaining issue that very first request is slower for the existing user as long as the user is NOT in the cache as it seems there are multiple DB lookups (like the request for retrieve roles, password credentials etc). I did not addressed this one, but rather consider it as a follow-up as AFAIK there is some effort in progress to optimize lookup the user to avoid using multiple queries.

```
BEFORE CHANGE:

10:09:14,445 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 1: 154 ms
10:09:14,531 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 2: 86 ms
10:09:14,631 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 3: 100 ms
10:09:14,712 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 4: 81 ms
10:09:14,790 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 5: 78 ms
10:09:14,828 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 1: 38 ms
10:09:14,867 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 2: 39 ms
10:09:14,907 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 3: 40 ms
10:09:14,949 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 4: 42 ms
10:09:14,989 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 5: 39 ms
10:09:14,991 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] calling all TestCleanup
java.lang.AssertionError: Times in ms of 5 attempts: For invalid password: 499. For invalid username: 198


AFTER CHANGE:

12:05:49,383 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 1: 150 ms
12:05:49,466 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 2: 82 ms
12:05:49,545 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 3: 79 ms
12:05:49,639 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 4: 94 ms
12:05:49,745 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] Invalid password 5: 105 ms
12:05:49,839 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 1: 94 ms
12:05:49,914 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 2: 75 ms
12:05:49,978 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 3: 64 ms
12:05:50,048 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 4: 92 ms
12:05:50,124 INFO  [org.keycloak.testsuite.oauth.ResourceOwnerPasswordCredentialsGrantTest] User not found 5: 76 ms
```


