### PR TITLE
Make Core Clients team code owner of Keycloak JS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,12 @@
 
 
 ###################################################################################################
+# Core Clients (@keycloak/core-clients-maintainers)
+###################################################################################################
+
+/js/libs/keycloak-js/                                       @keycloak/core-clients-maintainers
+
+###################################################################################################
 # Cloud Native (@keycloak/cloud-native-maintainers)
 ###################################################################################################
 
@@ -34,7 +40,7 @@
 /quarkus/                                                   @keycloak/cloud-native-maintainers @keycloak/maintainers
 /docs/guides/server/                                        @keycloak/cloud-native-maintainers @keycloak/maintainers
 /docs/guides/operator/                                      @keycloak/cloud-native-maintainers @keycloak/maintainers
-/integration/client-cli/admin-cli                           @keycloak/cloud-native-maintainers @keycloak/maintainers
+/integration/client-cli/admin-cli/                          @keycloak/cloud-native-maintainers @keycloak/maintainers
 
 ###################################################################################################
 # UI (@keycloak/ui-maintainers)


### PR DESCRIPTION
Makes the Core Clients team the code owner of the Keycloak JS adapter.