### PR TITLE
Adding SAML protocol mapper to map organization membership

### DIFF
--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/saml/OrganizationMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/saml/OrganizationMembershipMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.organization.protocol.mappers.saml;
+
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
+import org.keycloak.dom.saml.v2.assertion.AttributeType;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.protocol.saml.SamlProtocol;
+import org.keycloak.protocol.saml.mappers.AbstractSAMLProtocolMapper;
+import org.keycloak.protocol.saml.mappers.AttributeStatementHelper;
+import org.keycloak.protocol.saml.mappers.SAMLAttributeStatementMapper;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+
+public class OrganizationMembershipMapper extends AbstractSAMLProtocolMapper implements SAMLAttributeStatementMapper, EnvironmentDependentProviderFactory {
+
+    public static final String ID = "saml-organization-membership-mapper";
+    public static final String ORGANIZATION_ATTRIBUTE_NAME = "organization";
+
+    public static ProtocolMapperModel create() {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+
+        mapper.setName("organization");
+        mapper.setProtocolMapper(ID);
+        mapper.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
+
+        return mapper;
+
+    }
+
+    @Override
+    public void transformAttributeStatement(AttributeStatementType attributeStatement, ProtocolMapperModel mappingModel, KeycloakSession session, UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+        OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
+
+        if (!provider.isEnabled()) {
+            return;
+        }
+
+        UserModel user = userSession.getUser();
+        OrganizationModel organization = provider.getByMember(user);
+
+        if (organization == null || !organization.isEnabled()) {
+            return;
+        }
+
+        AttributeType attribute = new AttributeType(ORGANIZATION_ATTRIBUTE_NAME);
+        attribute.setFriendlyName(ORGANIZATION_ATTRIBUTE_NAME);
+        attribute.setNameFormat(JBossSAMLURIConstants.ATTRIBUTE_FORMAT_BASIC.get());
+        attribute.addAttributeValue(organization.getName());
+        attributeStatement.addAttribute(new AttributeStatementType.ASTChoiceType(attribute));
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Organization Membership";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return AttributeStatementHelper.ATTRIBUTE_STATEMENT_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Add an attribute to the assertion with information about the organization membership.";
+    }
+
+    @Override
+    public boolean isSupported(Scope config) {
+        return Profile.isFeatureEnabled(Feature.ORGANIZATION);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -39,7 +39,7 @@ import org.keycloak.protocol.oidc.mappers.AddressMapper;
 import org.keycloak.protocol.oidc.mappers.AllowedWebOriginsProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.AudienceResolveProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.FullNameMapper;
-import org.keycloak.protocol.oidc.mappers.OrganizationMembershipMapper;
+import org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper;
 import org.keycloak.protocol.oidc.mappers.UserAttributeMapper;
 import org.keycloak.protocol.oidc.mappers.UserClientRoleMappingMapper;
 import org.keycloak.protocol.oidc.mappers.UserPropertyMapper;

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -25,7 +25,7 @@ org.keycloak.protocol.oidc.mappers.RoleNameMapper
 org.keycloak.protocol.oidc.mappers.UserSessionNoteMapper
 org.keycloak.protocol.oidc.mappers.GroupMembershipMapper
 org.keycloak.protocol.oidc.mappers.AudienceProtocolMapper
-org.keycloak.protocol.oidc.mappers.OrganizationMembershipMapper
+org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper
 org.keycloak.protocol.oidc.mappers.AudienceResolveProtocolMapper
 org.keycloak.protocol.oidc.mappers.AllowedWebOriginsProtocolMapper
 org.keycloak.protocol.oidc.mappers.AcrProtocolMapper
@@ -56,3 +56,4 @@ org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCTypeMapper
 org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCContextMapper
 org.keycloak.protocol.oidc.mappers.SessionStateMapper
 org.keycloak.protocol.oidc.mappers.SubMapper
+org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationSAMLProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationSAMLProtocolMapperTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.organization.admin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.keycloak.testsuite.util.SamlStreams.assertionsUnencrypted;
+import static org.keycloak.testsuite.util.SamlStreams.attributeStatements;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import jakarta.ws.rs.core.UriBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
+import org.keycloak.dom.saml.v2.assertion.AttributeStatementType.ASTChoiceType;
+import org.keycloak.dom.saml.v2.assertion.AttributeType;
+import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.SamlProtocol;
+import org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+import org.keycloak.services.resources.RealmsResource;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.saml.RoleMapperTest;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.Matchers;
+import org.keycloak.testsuite.util.SamlClient;
+import org.keycloak.testsuite.util.SamlClientBuilder;
+
+@EnableFeature(Feature.ORGANIZATION)
+public class OrganizationSAMLProtocolMapperTest extends AbstractOrganizationTest {
+
+    @Test
+    public void testAttribute() {
+        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        addMember(organization);
+        String clientId = "saml-client";
+        testRealm().clients().create(ClientBuilder.create()
+                .protocol(SamlProtocol.LOGIN_PROTOCOL)
+                .clientId(clientId)
+                .redirectUris("*")
+                .attribute(SamlConfigAttributes.SAML_CLIENT_SIGNATURE_ATTRIBUTE, Boolean.FALSE.toString())
+                .build()).close();
+
+        SAMLDocumentHolder samlResponse = new SamlClientBuilder()
+                .authnRequest(RealmsResource
+                        .protocolUrl(UriBuilder.fromUri(getAuthServerRoot()))
+                        .build(TEST_REALM_NAME, SamlProtocol.LOGIN_PROTOCOL), clientId, RoleMapperTest.SAML_ASSERTION_CONSUMER_URL_EMPLOYEE_2, SamlClient.Binding.POST)
+                .build()
+                .login().user(memberEmail, memberPassword).build()
+                .login().user(memberEmail, memberPassword).build()
+                .getSamlResponse(SamlClient.Binding.POST);
+
+        assertThat(samlResponse.getSamlObject(), Matchers.isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        AttributeType orgAttribute = attributeStatements(assertionsUnencrypted(samlResponse.getSamlObject()))
+                .flatMap((Function<AttributeStatementType, Stream<ASTChoiceType>>) attributeStatementType -> attributeStatementType.getAttributes().stream())
+                .map(ASTChoiceType::getAttribute)
+                .filter(attribute -> OrganizationMembershipMapper.ORGANIZATION_ATTRIBUTE_NAME.equals(attribute.getName()))
+                .findAny()
+                .orElse(null);
+        Assert.assertNotNull(orgAttribute);
+        List<Object> values = orgAttribute.getAttributeValue();
+        Assert.assertEquals(1, values.size());
+        Assert.assertEquals(organizationName, values.get(0));
+    }
+}


### PR DESCRIPTION
Closes #28732

* Moving mappers to their respective packages within the `org.keycloak.organization` namespace
* Updates both SAML and OIDC mappers to not run when the feature is disabled in the realm or the organization itself is disabled as per https://github.com/keycloak/keycloak/pull/29279.

The other part of the issue that introduces test coverage for using SAML brokers with an organization depends on https://github.com/keycloak/keycloak/pull/29269 because there are conflicts.