### PR TITLE
Update KeysListTab.tsx

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -1199,6 +1199,7 @@ moveTo=Move to
 registerNodeManually=Register node manually
 redirectURI=Redirect URI
 publicKeys=Public keys
+publicKey=Public key
 emptyEventsInstructions=There are no more events types left to add
 periodicFullSync=Periodic full sync
 removeConfirmTitle_other=Remove groups?

--- a/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
@@ -109,7 +109,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
   );
 
   const [togglePublicKeyDialog, PublicKeyDialog] = useConfirmDialog({
-    titleKey: t("publicKeys").slice(0, -1),
+    titleKey: t("publicKeys"),
     messageKey: publicKey,
     continueButtonLabel: "close",
     continueButtonVariant: ButtonVariant.primary,
@@ -204,7 +204,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
                     variant="secondary"
                     id="kc-public-key"
                   >
-                    {t("publicKeys").slice(0, -1)}
+                    {t("publicKeys")}
                   </Button>
                 );
               } else if (type === "RSA") {
@@ -218,7 +218,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
                       variant="secondary"
                       id={publicKey}
                     >
-                      {t("publicKeys").slice(0, -1)}
+                      {t("publicKeys")}
                     </Button>
                     <Button
                       onClick={() => {
@@ -243,7 +243,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
                     variant="secondary"
                     id="kc-public-key"
                   >
-                    {t("publicKeys").slice(0, -1)}
+                    {t("publicKeys")}
                   </Button>
                 );
               } else return "";

--- a/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
@@ -109,7 +109,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
   );
 
   const [togglePublicKeyDialog, PublicKeyDialog] = useConfirmDialog({
-    titleKey: t("publicKeys"),
+    titleKey: t("publicKey"),
     messageKey: publicKey,
     continueButtonLabel: "close",
     continueButtonVariant: ButtonVariant.primary,
@@ -204,7 +204,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
                     variant="secondary"
                     id="kc-public-key"
                   >
-                    {t("publicKeys")}
+                    {t("publicKey")}
                   </Button>
                 );
               } else if (type === "RSA") {
@@ -218,7 +218,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
                       variant="secondary"
                       id={publicKey}
                     >
-                      {t("publicKeys")}
+                      {t("publicKey")}
                     </Button>
                     <Button
                       onClick={() => {
@@ -243,7 +243,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
                     variant="secondary"
                     id="kc-public-key"
                   >
-                    {t("publicKeys")}
+                    {t("publicKey")}
                   </Button>
                 );
               } else return "";


### PR DESCRIPTION
Remove slice, while locale set to other than English, it will trancate the last char.
For example, in Chinese (Taiwan)
<img width="339" alt="image" src="https://github.com/keycloak/keycloak/assets/22383656/8fd0492e-8655-4fb0-a0ed-284706fc5349">
