### PR TITLE
Ability to select the default role mapping filter

### DIFF
--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -133,7 +133,8 @@
       "masterRealm": "${masterRealm}",
       "resourceVersion": "${resourceVersion}",
       "logo": "${properties.logo!""}",
-      "logoUrl": "${properties.logoUrl!""}"
+      "logoUrl": "${properties.logoUrl!""}",
+      "defaultRoleMappingFilter": "${properties.defaultRoleMappingFilter!""}"
     }
   </script>
 </body>

--- a/js/apps/admin-ui/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/js/apps/admin-ui/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -20,6 +20,7 @@ import { KeycloakDataTable } from "../table-toolbar/KeycloakDataTable";
 import { ResourcesKey, Row, ServiceRole } from "./RoleMapping";
 import { getAvailableRoles } from "./queries";
 import { getAvailableClientRoles } from "./resource";
+import environment from "../../environment";
 
 type AddRoleMappingModalProps = {
   id: string;
@@ -49,7 +50,7 @@ export const AddRoleMappingModal = ({
   const [searchToggle, setSearchToggle] = useState(false);
 
   const [filterType, setFilterType] = useState<FilterType>(
-    canViewRealmRoles ? "roles" : "clients",
+    environment.defaultRoleMappingFilter == "clients" ? "clients" : (canViewRealmRoles ? "roles" : "clients"),
   );
   const [selectedRows, setSelectedRows] = useState<Row[]>([]);
   const [key, setKey] = useState(0);

--- a/js/apps/admin-ui/src/environment.ts
+++ b/js/apps/admin-ui/src/environment.ts
@@ -19,6 +19,8 @@ export type Environment = {
   logo: string;
   /** Indicates the url to be followed when Brand image is clicked */
   logoUrl: string;
+  /** Indicates the default role filter to present when mapping roles */
+  defaultRoleMappingFilter: string;
 };
 
 // During development the realm can be passed as a query parameter when redirecting back from Keycloak.
@@ -36,6 +38,7 @@ const defaultEnvironment: Environment = {
   resourceVersion: "unknown",
   logo: "/logo.svg",
   logoUrl: "",
+  defaultRoleMappingFilter: "",
 };
 
 // Merge the default and injected environment variables together.


### PR DESCRIPTION
Adds defaultRoleMappingFilter as a theme property to select the default filtering for the role mapping modal. If "clients" is set, it will always show client roles first. Otherwise, it will show realm roles first if the user can see them, otherwise client roles.

I went for a theme property partly because it was easier than a setting on the realm itself, and partly because its really only working in the presentation layer.

With this PR, you can add `defaultRoleMappingFilter=clients` to the theme.properties of an admin theme and the modal will show clients first.

The doc also needs updating, and potentially a test too, but I wanted to get some feedback first on the approach in case there were other ideas.

Closes #29348 