### PR TITLE
Revise ObjectMapper construction (#16295)

### DIFF
--- a/services/src/main/java/org/keycloak/services/util/ObjectMapperResolver.java
+++ b/services/src/main/java/org/keycloak/services/util/ObjectMapperResolver.java
@@ -40,7 +40,7 @@ public class ObjectMapperResolver implements ContextResolver<ObjectMapper> {
     protected ObjectMapper mapper;
 
     public ObjectMapperResolver() {
-        mapper = createStreamSerializer();
+        mapper = ObjectMapperInitializer.OBJECT_MAPPER;
     }
 
     public static ObjectMapper createStreamSerializer() {
@@ -57,11 +57,21 @@ public class ObjectMapperResolver implements ContextResolver<ObjectMapper> {
             mapper.enable(SerializationFeature.INDENT_OUTPUT);
         }
 
+        // allow to discover jackson mappers on the classpath
+        if (Boolean.parseBoolean(System.getProperty("keycloak.jsonEnableJacksonModuleDiscovery", "true"))) {
+            mapper.findAndRegisterModules();
+        }
+
         return mapper;
     }
 
     @Override
     public ObjectMapper getContext(Class<?> type) {
         return mapper;
+    }
+
+    private static class ObjectMapperInitializer {
+
+        private static final ObjectMapper OBJECT_MAPPER = createStreamSerializer();
     }
 }


### PR DESCRIPTION
Previously, an ObjectMapper was created multiple times during startup: two times during bootstrap and one additional time for the first request sent to Keycloak. Additionally, Jackson modules, e.g., support for JSR310 java.time types were not registered even though they were present on the classpath.

This PR revises the initialization of the ObjectMapper.

- Ensure "StreamSerializer" ObjectMapper is only initialized once
- Ensure that jackson modules on the classpath are properly

Fixes #16295

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
