### PR TITLE
quarkus-next: keystore/trust store type is determined based on file extension

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -1,0 +1,7 @@
+= Keystore and trust store default format change
+
+{project_name} now determines the format of the keystore and trust store based on the file extension. If the file extension is `.p12`, `.pkcs12` or `.pfx`, the format is PKCS12. If the file extension is `.jks`, `.keystore` or `.truststore`, the format is JKS. If the file extension is `.pem`, `.crt` or `.key`, the format is PEM.
+
+You can still override automatic detection by specifying the `https-key-store-type` and `https-trust-store-type` explicitly. Restrictions for the FIPS strict mode stays unchanged.
+
+NOTE: The `+spi-truststore-file-*+` options and the truststore related options `+https-trust-store-*+` are deprecated, we strongly recommend to use System Truststore. For more details refer to the relevant https://www.keycloak.org/server/keycloak-truststore[guide].

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -1,6 +1,10 @@
 [[migration-changes]]
 == Migration Changes
 
+=== Migrating to 26.0.0
+
+include::changes-26_0_0.adoc[leveloffset=3]
+
 === Migrating to 25.0.0
 
 include::changes-25_0_0.adoc[leveloffset=3]

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -87,7 +87,7 @@ public class HttpOptions {
     public static final Option<String> HTTPS_KEY_STORE_TYPE = new OptionBuilder<>("https-key-store-type", String.class)
             .category(OptionCategory.HTTP)
             .description("The type of the key store file. " +
-                    "If not given, the type is automatically detected based on the file name. " +
+                    "If not given, the type is automatically detected based on the file extension. " +
                     "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
             .build();
 
@@ -106,7 +106,7 @@ public class HttpOptions {
     public static final Option<String> HTTPS_TRUST_STORE_TYPE = new OptionBuilder<>("https-trust-store-type", String.class)
             .category(OptionCategory.HTTP)
             .description("The type of the trust store file. " +
-                    "If not given, the type is automatically detected based on the file name. " +
+                    "If not given, the type is automatically detected based on the file extension. " +
                     "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
             .deprecated("Use the System Truststore instead, see the docs for details.")
             .build();


### PR DESCRIPTION
- reflect the new [default truststore/keystore format mechanism](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9#keystore-and-trust-store-default-format-change), which causes some FipsDistTests to fail

Closes: #29207