### PR TITLE
Avoid conflicts when writing to session stores by checking for concurrent requests within the JVM

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -128,7 +128,11 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
                     offlineSessionsCache,
                     clientSessionCache,
                     offlineClientSessionsCache,
-                    asyncQueuePersistentUpdate
+                    asyncQueuePersistentUpdate,
+                    serializerSession,
+                    serializerOfflineSession,
+                    serializerClientSession,
+                    serializerOfflineClientSession
             );
         }
         return new InfinispanUserSessionProvider(

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -19,7 +19,6 @@ package org.keycloak.models.sessions.infinispan.changes;
 
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
-import org.keycloak.common.Profile;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -53,8 +52,10 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
                                                             SessionFunction<AuthenticatedClientSessionEntity> offlineLifespanMsLoader,
                                                             SessionFunction<AuthenticatedClientSessionEntity> offlineMaxIdleTimeMsLoader,
                                                             UserSessionPersistentChangelogBasedTransaction userSessionTx,
-                                                            ArrayBlockingQueue<PersistentUpdate> batchingQueue) {
-        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue);
+                                                            ArrayBlockingQueue<PersistentUpdate> batchingQueue,
+                                                            SerializeExecutionsByKey<UUID> sessions,
+                                                            SerializeExecutionsByKey<UUID> offlineSessions) {
+        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, sessions, offlineSessions);
         this.userSessionTx = userSessionTx;
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -53,9 +53,9 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
                                                             SessionFunction<AuthenticatedClientSessionEntity> offlineMaxIdleTimeMsLoader,
                                                             UserSessionPersistentChangelogBasedTransaction userSessionTx,
                                                             ArrayBlockingQueue<PersistentUpdate> batchingQueue,
-                                                            SerializeExecutionsByKey<UUID> sessions,
-                                                            SerializeExecutionsByKey<UUID> offlineSessions) {
-        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, sessions, offlineSessions);
+                                                            SerializeExecutionsByKey<UUID> serializerOnline,
+                                                            SerializeExecutionsByKey<UUID> serializerOffline) {
+        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, serializerOnline, serializerOffline);
         this.userSessionTx = userSessionTx;
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
@@ -62,8 +62,8 @@ abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends S
                                                        SessionFunction<V> offlineLifespanMsLoader,
                                                        SessionFunction<V> offlineMaxIdleTimeMsLoader,
                                                        ArrayBlockingQueue<PersistentUpdate> batchingQueue,
-                                                       SerializeExecutionsByKey<K> sessions,
-                                                       SerializeExecutionsByKey<K> offlineSessions) {
+                                                       SerializeExecutionsByKey<K> serializerOnline,
+                                                       SerializeExecutionsByKey<K> serializerOffline) {
         kcSession = session;
 
         if (!Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
@@ -81,13 +81,13 @@ abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends S
 
         changesPerformers = List.of(
                 new JpaChangesPerformer<>(cache.getName(), batchingQueue),
-                new EmbeddedCachesChangesPerformer<>(cache, sessions) {
+                new EmbeddedCachesChangesPerformer<>(cache, serializerOnline) {
                     @Override
                     public boolean shouldConsumeChange(V entity) {
                         return !entity.isOffline();
                     }
                 },
-                new EmbeddedCachesChangesPerformer<>(offlineCache, offlineSessions){
+                new EmbeddedCachesChangesPerformer<>(offlineCache, serializerOffline){
                     @Override
                     public boolean shouldConsumeChange(V entity) {
                         return entity.isOffline();

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
@@ -61,7 +61,9 @@ abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends S
                                                        SessionFunction<V> maxIdleTimeMsLoader,
                                                        SessionFunction<V> offlineLifespanMsLoader,
                                                        SessionFunction<V> offlineMaxIdleTimeMsLoader,
-                                                       ArrayBlockingQueue<PersistentUpdate> batchingQueue) {
+                                                       ArrayBlockingQueue<PersistentUpdate> batchingQueue,
+                                                       SerializeExecutionsByKey<K> sessions,
+                                                       SerializeExecutionsByKey<K> offlineSessions) {
         kcSession = session;
 
         if (!Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
@@ -79,13 +81,13 @@ abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends S
 
         changesPerformers = List.of(
                 new JpaChangesPerformer<>(cache.getName(), batchingQueue),
-                new EmbeddedCachesChangesPerformer<>(cache) {
+                new EmbeddedCachesChangesPerformer<>(cache, sessions) {
                     @Override
                     public boolean shouldConsumeChange(V entity) {
                         return !entity.isOffline();
                     }
                 },
-                new EmbeddedCachesChangesPerformer<>(offlineCache){
+                new EmbeddedCachesChangesPerformer<>(offlineCache, offlineSessions){
                     @Override
                     public boolean shouldConsumeChange(V entity) {
                         return entity.isOffline();

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -19,7 +19,6 @@ package org.keycloak.models.sessions.infinispan.changes;
 
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
-import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
@@ -45,8 +44,10 @@ public class UserSessionPersistentChangelogBasedTransaction extends PersistentSe
                                                           SessionFunction<UserSessionEntity> maxIdleTimeMsLoader,
                                                           SessionFunction<UserSessionEntity> offlineLifespanMsLoader,
                                                           SessionFunction<UserSessionEntity> offlineMaxIdleTimeMsLoader,
-                                                          ArrayBlockingQueue<PersistentUpdate> batchingQueue) {
-        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue);
+                                                          ArrayBlockingQueue<PersistentUpdate> batchingQueue,
+                                                          SerializeExecutionsByKey<String> sessions,
+                                                          SerializeExecutionsByKey<String> offlineSessions) {
+        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, sessions, offlineSessions);
     }
 
     public SessionEntityWrapper<UserSessionEntity> get(RealmModel realm, String key, boolean offline) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -45,9 +45,9 @@ public class UserSessionPersistentChangelogBasedTransaction extends PersistentSe
                                                           SessionFunction<UserSessionEntity> offlineLifespanMsLoader,
                                                           SessionFunction<UserSessionEntity> offlineMaxIdleTimeMsLoader,
                                                           ArrayBlockingQueue<PersistentUpdate> batchingQueue,
-                                                          SerializeExecutionsByKey<String> sessions,
-                                                          SerializeExecutionsByKey<String> offlineSessions) {
-        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, sessions, offlineSessions);
+                                                          SerializeExecutionsByKey<String> serializerOnline,
+                                                          SerializeExecutionsByKey<String> serializerOffline) {
+        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, serializerOnline, serializerOffline);
     }
 
     public SessionEntityWrapper<UserSessionEntity> get(RealmModel realm, String key, boolean offline) {


### PR DESCRIPTION
Closes #29392

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
