### PR TITLE
Client type OIDC base

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
@@ -20,6 +20,7 @@ package org.keycloak.common.util;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -88,5 +89,9 @@ public class CollectionUtil {
         return iteratorCollection.stream()
                 .filter(searchCollection::contains)
                 .collect(Collectors.toSet());
+    }
+
+    public static <T> Set<T> collectionToSet(Collection<T> collection) {
+        return collection == null ? null : new HashSet<>(collection);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
@@ -19,6 +19,7 @@
 package org.keycloak.client.clienttype;
 
 import org.keycloak.models.ClientModel;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
 
 import java.util.Map;
@@ -47,4 +48,5 @@ public interface ClientType {
 
     // Augment at the client type
     ClientModel augment(ClientModel client);
+    ClientRepresentation augment(ClientRepresentation representation);
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -415,7 +415,7 @@ public class RepresentationToModel {
     public static void updateClient(ClientRepresentation rep, ClientModel resource, KeycloakSession session) {
 
         if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES)) {
-            if (!ObjectUtil.isEqualOrBothNull(rep.getType(), rep.getType())) {
+            if (!ObjectUtil.isEqualOrBothNull(resource.getType(), rep.getType())) {
                 throw new ClientTypeException("Not supported to change client type");
             }
             if (rep.getType() != null) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -61,6 +61,7 @@ import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.common.util.UriUtils;
@@ -336,6 +337,7 @@ public class RepresentationToModel {
             ClientTypeManager mgr = session.getProvider(ClientTypeManager.class);
             ClientType clientType = mgr.getClientType(realm, resourceRep.getType());
             client = clientType.augment(client);
+            resourceRep = clientType.augment(resourceRep);
         }
 
         updateClientProperties(client, resourceRep, true);
@@ -526,8 +528,8 @@ public class RepresentationToModel {
             // Client Secret
             add(updatePropertyAction(client::setSecret, () -> determineNewSecret(client, rep)));
             // Redirect uris / Web origins
-            add(updatePropertyAction(client::setRedirectUris, () -> collectionToSet(rep.getRedirectUris()), client::getRedirectUris));
-            add(updatePropertyAction(client::setWebOrigins, () -> collectionToSet(rep.getWebOrigins()), () -> defaultWebOrigins(client)));
+            add(updatePropertyAction(client::setRedirectUris, () -> CollectionUtil.collectionToSet(rep.getRedirectUris()), client::getRedirectUris));
+            add(updatePropertyAction(client::setWebOrigins, () -> CollectionUtil.collectionToSet(rep.getWebOrigins()), () -> defaultWebOrigins(client)));
         }};
 
         // Extended client attributes
@@ -1643,12 +1645,6 @@ public class RepresentationToModel {
         representation.setClientId(client.getId());
 
         return toModel(representation, authorization, client);
-    }
-
-    private static <T> Set<T> collectionToSet(Collection<T> collection) {
-        return Optional.ofNullable(collection)
-                .map(HashSet::new)
-                .orElse(null);
     }
 
     private static void updateOrganizationBroker(RealmModel realm, IdentityProviderRepresentation representation, KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeDefaultedClientRepresentation.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeDefaultedClientRepresentation.java
@@ -1,0 +1,492 @@
+package org.keycloak.services.clienttype.client;
+
+import org.keycloak.client.clienttype.ClientType;
+import org.keycloak.common.util.CollectionUtil;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TypeDefaultedClientRepresentation extends ClientRepresentation {
+
+    private final ClientType clientType;
+    private final ClientRepresentation delegate;
+
+    public TypeDefaultedClientRepresentation(ClientType clientType, ClientRepresentation delegate) {
+        this.clientType = clientType;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public void setId(String id) {
+        delegate.setId(id);
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public void setName(String name) {
+        delegate.setName(name);
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public void setDescription(String description) {
+        delegate.setDescription(description);
+    }
+
+    @Override
+    public String getType() {
+        return delegate.getType();
+    }
+
+    @Override
+    public void setType(String type) {
+        delegate.setType(type);
+    }
+
+    @Override
+    public String getClientId() {
+        return delegate.getClientId();
+    }
+
+    @Override
+    public void setClientId(String clientId) {
+        delegate.setClientId(clientId);
+    }
+
+    @Override
+    public Boolean isEnabled() {
+        return delegate.isEnabled();
+    }
+
+    @Override
+    public void setEnabled(Boolean enabled) {
+        delegate.setEnabled(enabled);
+    }
+
+    @Override
+    public Boolean isStandardFlowEnabled() {
+        return TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
+                .orDefault(clientType, delegate::isStandardFlowEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setStandardFlowEnabled(Boolean standardFlowEnabled) {
+        delegate.setStandardFlowEnabled(standardFlowEnabled);
+    }
+
+    @Override
+    public Boolean isBearerOnly() {
+        return TypedClientSimpleAttribute.BEARER_ONLY
+                .orDefault(clientType, delegate::isBearerOnly, Boolean.class);
+    }
+
+    @Override
+    public void setBearerOnly(Boolean bearerOnly) {
+        delegate.setBearerOnly(bearerOnly);
+    }
+
+    @Override
+    public Boolean isConsentRequired() {
+        return TypedClientSimpleAttribute.CONSENT_REQUIRED
+                .orDefault(clientType, delegate::isConsentRequired, Boolean.class);
+    }
+
+    @Override
+    public void setConsentRequired(Boolean consentRequired) {
+        delegate.setConsentRequired(consentRequired);
+    }
+
+    @Override
+    public Boolean isDirectAccessGrantsEnabled() {
+        return TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+                .orDefault(clientType, delegate::isDirectAccessGrantsEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setDirectAccessGrantsEnabled(Boolean directAccessGrantsEnabled) {
+        delegate.setDirectAccessGrantsEnabled(directAccessGrantsEnabled);
+    }
+
+    @Override
+    public Boolean isAlwaysDisplayInConsole() {
+        return TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+                .orDefault(clientType, delegate::isAlwaysDisplayInConsole, Boolean.class);
+    }
+
+    @Override
+    public void setAlwaysDisplayInConsole(Boolean alwaysDisplayInConsole) {
+        delegate.setAlwaysDisplayInConsole(alwaysDisplayInConsole);
+    }
+
+    @Override
+    public Boolean isSurrogateAuthRequired() {
+        return delegate.isSurrogateAuthRequired();
+    }
+
+    @Override
+    public void setSurrogateAuthRequired(Boolean surrogateAuthRequired) {
+        delegate.setSurrogateAuthRequired(surrogateAuthRequired);
+    }
+
+    @Override
+    public String getRootUrl() {
+        return delegate.getRootUrl();
+    }
+
+    @Override
+    public void setRootUrl(String rootUrl) {
+        delegate.setRootUrl(rootUrl);
+    }
+
+    @Override
+    public String getAdminUrl() {
+        return delegate.getAdminUrl();
+    }
+
+    @Override
+    public void setAdminUrl(String adminUrl) {
+        delegate.setAdminUrl(adminUrl);
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return delegate.getBaseUrl();
+    }
+
+    @Override
+    public void setBaseUrl(String baseUrl) {
+        delegate.setBaseUrl(baseUrl);
+    }
+
+    @Override
+    public String getClientAuthenticatorType() {
+        return delegate.getClientAuthenticatorType();
+    }
+
+    @Override
+    public void setClientAuthenticatorType(String clientAuthenticatorType) {
+        delegate.setClientAuthenticatorType(clientAuthenticatorType);
+    }
+
+    @Override
+    public String getSecret() {
+        return delegate.getSecret();
+    }
+
+    @Override
+    public void setSecret(String secret) {
+        delegate.setSecret(secret);
+    }
+
+    @Override
+    public String getRegistrationAccessToken() {
+        return delegate.getRegistrationAccessToken();
+    }
+
+    @Override
+    public void setRegistrationAccessToken(String registrationAccessToken) {
+        delegate.setRegistrationAccessToken(registrationAccessToken);
+    }
+
+    @Override
+    public Boolean isFrontchannelLogout() {
+        return TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
+                .orDefault(clientType, delegate::isFrontchannelLogout, Boolean.class);
+    }
+
+    @Override
+    public void setFrontchannelLogout(Boolean frontchannelLogout) {
+        delegate.setFrontchannelLogout(frontchannelLogout);
+    }
+
+    @Override
+    public List<ProtocolMapperRepresentation> getProtocolMappers() {
+        return delegate.getProtocolMappers();
+    }
+
+    @Override
+    public void setProtocolMappers(List<ProtocolMapperRepresentation> protocolMappers) {
+        delegate.setProtocolMappers(protocolMappers);
+    }
+
+    @Override
+    public String getClientTemplate() {
+        return delegate.getClientTemplate();
+    }
+
+    @Override
+    public Boolean isUseTemplateConfig() {
+        return delegate.isUseTemplateConfig();
+    }
+
+    @Override
+    public Boolean isUseTemplateScope() {
+        return delegate.isUseTemplateScope();
+    }
+
+    @Override
+    public Boolean isUseTemplateMappers() {
+        return delegate.isUseTemplateMappers();
+    }
+
+    @Override
+    public List<String> getDefaultClientScopes() {
+        return delegate.getDefaultClientScopes();
+    }
+
+    @Override
+    public void setDefaultClientScopes(List<String> defaultClientScopes) {
+        delegate.setDefaultClientScopes(defaultClientScopes);
+    }
+
+    @Override
+    public List<String> getOptionalClientScopes() {
+        return delegate.getOptionalClientScopes();
+    }
+
+    @Override
+    public void setOptionalClientScopes(List<String> optionalClientScopes) {
+        delegate.setOptionalClientScopes(optionalClientScopes);
+    }
+
+    @Override
+    public ResourceServerRepresentation getAuthorizationSettings() {
+        return delegate.getAuthorizationSettings();
+    }
+
+    @Override
+    public void setAuthorizationSettings(ResourceServerRepresentation authorizationSettings) {
+        delegate.setAuthorizationSettings(authorizationSettings);
+    }
+
+    @Override
+    public Map<String, Boolean> getAccess() {
+        return delegate.getAccess();
+    }
+
+    @Override
+    public void setAccess(Map<String, Boolean> access) {
+        delegate.setAccess(access);
+    }
+
+    @Override
+    public String getOrigin() {
+        return delegate.getOrigin();
+    }
+
+    @Override
+    public void setOrigin(String origin) {
+        delegate.setOrigin(origin);
+    }
+
+    @Override
+    public Boolean isImplicitFlowEnabled() {
+        return TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
+                .orDefault(clientType, delegate::isImplicitFlowEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setImplicitFlowEnabled(Boolean implicitFlowEnabled) {
+        delegate.setImplicitFlowEnabled(implicitFlowEnabled);
+    }
+
+    @Override
+    public Boolean isServiceAccountsEnabled() {
+        return TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
+                .orDefault(clientType, delegate::isServiceAccountsEnabled, Boolean.class);
+    }
+
+    @Override
+    public void setServiceAccountsEnabled(Boolean serviceAccountsEnabled) {
+        delegate.setServiceAccountsEnabled(serviceAccountsEnabled);
+    }
+
+    @Override
+    public Boolean getAuthorizationServicesEnabled() {
+        return delegate.getAuthorizationServicesEnabled();
+    }
+
+    @Override
+    public void setAuthorizationServicesEnabled(Boolean authorizationServicesEnabled) {
+        delegate.setAuthorizationServicesEnabled(authorizationServicesEnabled);
+    }
+
+    @Override
+    public Boolean isDirectGrantsOnly() {
+        return delegate.isDirectGrantsOnly();
+    }
+
+    @Override
+    public void setDirectGrantsOnly(Boolean directGrantsOnly) {
+        delegate.setDirectGrantsOnly(directGrantsOnly);
+    }
+
+    @Override
+    public String getProtocol() {
+        return TypedClientSimpleAttribute.PROTOCOL
+                .orDefault(clientType, delegate::getProtocol, String.class);
+    }
+
+    @Override
+    public void setProtocol(String protocol) {
+        delegate.setProtocol(protocol);
+    }
+
+    @Override
+    public Boolean isPublicClient() {
+        return TypedClientSimpleAttribute.PUBLIC_CLIENT
+                .orDefault(clientType, delegate::isPublicClient, Boolean.class);
+    }
+
+    @Override
+    public void setPublicClient(Boolean publicClient) {
+        delegate.setPublicClient(publicClient);
+    }
+
+    @Override
+    public Boolean isFullScopeAllowed() {
+        return delegate.isFullScopeAllowed();
+    }
+
+    @Override
+    public void setFullScopeAllowed(Boolean fullScopeAllowed) {
+        delegate.setFullScopeAllowed(fullScopeAllowed);
+    }
+
+    @Override
+    public List<String> getWebOrigins() {
+        Set<String> webOrigins = TypedClientSimpleAttribute.WEB_ORIGINS
+                .orDefault(clientType, () -> CollectionUtil.collectionToSet(delegate.getWebOrigins()), Set.class);
+
+        return webOrigins == null ? null : new ArrayList<>(webOrigins);
+    }
+
+    @Override
+    public void setWebOrigins(List<String> webOrigins) {
+        delegate.setWebOrigins(webOrigins);
+    }
+
+    @Override
+    public String[] getDefaultRoles() {
+        return delegate.getDefaultRoles();
+    }
+
+    @Override
+    public void setDefaultRoles(String[] defaultRoles) {
+        delegate.setDefaultRoles(defaultRoles);
+    }
+
+    @Override
+    public Integer getNotBefore() {
+        return delegate.getNotBefore();
+    }
+
+    @Override
+    public void setNotBefore(Integer notBefore) {
+        delegate.setNotBefore(notBefore);
+    }
+
+    @Override
+    public List<String> getRedirectUris() {
+        Set<String> redirectUris = TypedClientSimpleAttribute.REDIRECT_URIS
+            .orDefault(clientType, () -> CollectionUtil.collectionToSet(delegate.getRedirectUris()), Set.class);
+
+        return redirectUris == null ? null : new ArrayList<>(redirectUris);
+    }
+
+    @Override
+    public void setRedirectUris(List<String> redirectUris) {
+        delegate.setRedirectUris(redirectUris);
+    }
+
+    private String getAttribute(String name) {
+        TypedClientExtendedAttribute attribute = TypedClientExtendedAttribute.getAttributesByName().get(name);
+        if (attribute != null) {
+            return attribute.orDefault(clientType, () -> getAttributesSafe().get(name), String.class);
+        } else {
+            return delegate.getAttributes().get(name);
+        }
+    }
+
+    private Map<String, String> getAttributesSafe() {
+        if (delegate.getAttributes() == null) {
+            return new HashMap<>();
+        }
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+        // Start with attributes set on the delegate.
+        Map<String, String> attributes = new HashMap<>(getAttributesSafe());
+
+        // Get extended client type attributes and values from the client type configuration.
+        Set<String> extendedClientTypeAttributes =
+                clientType.getConfiguration().entrySet().stream()
+                        .map(Map.Entry::getKey)
+                        .filter(entry -> TypedClientExtendedAttribute.getAttributesByName().containsKey(entry))
+                        .collect(Collectors.toSet());
+
+        // Augment client type attributes on top of attributes on the delegate.
+        for (String entry : extendedClientTypeAttributes) {
+            attributes.put(entry, getAttribute(entry));
+        }
+
+        return attributes;
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        delegate.setAttributes(attributes);
+    }
+
+    @Override
+    public Map<String, String> getAuthenticationFlowBindingOverrides() {
+        return delegate.getAuthenticationFlowBindingOverrides();
+    }
+
+    @Override
+    public void setAuthenticationFlowBindingOverrides(Map<String, String> authenticationFlowBindingOverrides) {
+        delegate.setAuthenticationFlowBindingOverrides(authenticationFlowBindingOverrides);
+    }
+
+    @Override
+    public Integer getNodeReRegistrationTimeout() {
+        return delegate.getNodeReRegistrationTimeout();
+    }
+
+    @Override
+    public void setNodeReRegistrationTimeout(Integer nodeReRegistrationTimeout) {
+        delegate.setNodeReRegistrationTimeout(nodeReRegistrationTimeout);
+    }
+
+    @Override
+    public Map<String, Integer> getRegisteredNodes() {
+        return delegate.getRegisteredNodes();
+    }
+
+    @Override
+    public void setRegisteredNodes(Map<String, Integer> registeredNodes) {
+        delegate.setRegisteredNodes(registeredNodes);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientSimpleAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientSimpleAttribute.java
@@ -112,6 +112,14 @@ interface TypedClientAttribute {
         return clientGetter.get();
     }
 
+    default <T> T orDefault(ClientType clientType, Supplier<T> clientGetter, Class<T> tClass) {
+        var typeValue = clientGetter.get();
+        if (typeValue != null) {
+            return typeValue;
+        }
+        return clientType.getDefaultValue(getPropertyName(), tClass);
+    }
+
     default <T> void setClientAttribute(ClientType clientType, T newValue, Consumer<T> clientSetter, Class<T> tClass) {
         String propertyName = getPropertyName();
         Object nonApplicableValue = getNonApplicableValue();

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientType.java
@@ -20,8 +20,10 @@ package org.keycloak.services.clienttype.impl;
 
 import org.keycloak.client.clienttype.ClientType;
 import org.keycloak.models.ClientModel;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
 import org.keycloak.services.clienttype.client.TypeAwareClientModelDelegate;
+import org.keycloak.services.clienttype.client.TypeDefaultedClientRepresentation;
 
 import java.util.Map;
 
@@ -72,5 +74,10 @@ public class DefaultClientType implements ClientType {
     @Override
     public ClientModel augment(ClientModel client) {
         return new TypeAwareClientModelDelegate(this, () -> client);
+    }
+
+    @Override
+    public ClientRepresentation augment(ClientRepresentation representation) {
+        return new TypeDefaultedClientRepresentation(this, representation);
     }
 }

--- a/services/src/main/resources/keycloak-default-client-types.json
+++ b/services/src/main/resources/keycloak-default-client-types.json
@@ -12,6 +12,65 @@
       }
     },
     {
+      "name": "oidc",
+      "provider": "default",
+      "config": {
+        "authorizationServicesEnabled": {
+          "applicable": true,
+          "default-value": false
+        },
+        "consentRequired": {
+          "applicable": true,
+          "default-value": false
+        },
+        "directAccessGrantsEnabled": {
+          "applicable": true,
+          "default-value": false
+        },
+        "frontchannelLogout": {
+          "applicable": true,
+          "default-value": false
+        },
+        "fullScopeAllowed": {
+          "applicable": true,
+          "default-value": true
+        },
+        "implicitFlowEnabled": {
+          "applicable": true,
+          "default-value": false
+        },
+        "nodeReRegistrationTimeout": {
+          "applicable": true,
+          "default-value": -1
+        },
+        "oauth2.device.authorization.grant.enabled": {
+          "applicable": true,
+          "default-value": "false"
+        },
+        "oidc.ciba.grant.enabled": {
+          "applicable": true,
+          "default-value": "false"
+        },
+        "protocol": {
+          "applicable": true,
+          "default-value": "openid-connect",
+          "read-only": true
+        },
+        "publicClient": {
+          "applicable": true,
+          "default-value": true
+        },
+        "serviceAccountsEnabled": {
+          "applicable": true,
+          "default-value": false
+        },
+        "standardFlowEnabled": {
+          "applicable": true,
+          "default-value": false
+        }
+      }
+    },
+    {
       "name": "service-account",
       "provider": "default",
       "config": {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.keycloak.common.Profile.Feature.CLIENT_TYPES;
@@ -164,10 +165,9 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
 
         assertEquals(0, clientTypes.getRealmClientTypes().size());
 
-        List<String> globalClientTypeNames = clientTypes.getGlobalClientTypes().stream()
-                .map(ClientTypeRepresentation::getName)
+        List<ClientTypeRepresentation> globalClientTypeNames = clientTypes.getGlobalClientTypes().stream()
                 .collect(Collectors.toList());
-        Assert.assertNames(globalClientTypeNames, "sla", "service-account");
+        assertNames(globalClientTypeNames, "sla", "service-account");
 
         ClientTypeRepresentation serviceAccountType = clientTypes.getGlobalClientTypes().stream()
                 .filter(clientType -> "service-account".equals(clientType.getName()))
@@ -184,7 +184,6 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         cfg = serviceAccountType.getConfig().get("tosUri");
         assertPropertyConfig("tosUri", cfg, false, null, null);
     }
-
 
     @Test
     public void testClientTypesAdminRestAPI_realmTypes() {
@@ -278,7 +277,7 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         List<String> names = clientTypes.stream()
                 .map(ClientTypeRepresentation::getName)
                 .collect(Collectors.toList());
-        Assert.assertNames(names, expectedNames);
+        assertThat(names, hasItems(expectedNames));
     }
 
 


### PR DESCRIPTION
Creating OIDC client type with applicable fields for OIDC based clients. In the future, this could be a basis for other OIDC types of clients or may be chosen as a default when selecting OIDC protocol.

No auth flow is enabled for this type by default, but one or more applicable flows may be specified during client creation.

In order to have default values for client type fields that are not read-only, we have to augment the ClientRepresentation.

https://github.com/keycloak/keycloak/issues/29422