### PR TITLE
fix: removed audience for tokens returned by Token Exchange endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -423,7 +423,6 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
 
         TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(realm, targetClient, event, this.session, targetUserSession, clientSessionCtx)
                 .generateAccessToken();
-        responseBuilder.getAccessToken().issuedFor(client.getClientId());
 
         if (audience != null) {
             responseBuilder.getAccessToken().addAudience(audience);
@@ -437,7 +436,6 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         if (requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE)
             && OIDCAdvancedConfigWrapper.fromClientModel(client).isUseRefreshToken()) {
             responseBuilder.generateRefreshToken();
-            responseBuilder.getRefreshToken().issuedFor(client.getClientId());
         }
 
         String scopeParam = clientSessionCtx.getClientSession().getNote(OAuth2Constants.SCOPE);


### PR DESCRIPTION
removed issuedFor (aud) on accesstoken and refreshtokens returned by Token Exchange endpoints since all other endpoints are expecting audience to match target client

Fix #28440 and #25788 