### PR TITLE
Vault configuration category available to the export command

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractExportImportCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractExportImportCommand.java
@@ -55,7 +55,6 @@ public abstract class AbstractExportImportCommand extends AbstractStartCommand i
                         optionCategory != OptionCategory.HOSTNAME_V1 &&
                         optionCategory != OptionCategory.HOSTNAME_V2 &&
                         optionCategory != OptionCategory.METRICS &&
-                        optionCategory != OptionCategory.VAULT &&
                         optionCategory != OptionCategory.SECURITY &&
                         optionCategory != OptionCategory.CACHE &&
                         optionCategory != OptionCategory.HEALTH).collect(Collectors.toList());

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -105,6 +105,15 @@ Management:
                        server (not recommended). If set to true, the management interface is
                        disabled. Default: false.
 
+Vault:
+
+--vault <provider>   Enables a vault provider. Possible values are: file, keystore.
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
+--vault-file <file>  Path to the keystore file.
+--vault-pass <pass>  Password for the vault keystore.
+--vault-type <type>  Specifies the type of the keystore file. Default: PKCS12.
+
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -105,6 +105,15 @@ Management:
                        server (not recommended). If set to true, the management interface is
                        disabled. Default: false.
 
+Vault:
+
+--vault <provider>   Enables a vault provider. Possible values are: file, keystore.
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
+--vault-file <file>  Path to the keystore file.
+--vault-pass <pass>  Password for the vault keystore.
+--vault-type <type>  Specifies the type of the keystore file. Default: PKCS12.
+
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -105,6 +105,15 @@ Management:
                        server (not recommended). If set to true, the management interface is
                        disabled. Default: false.
 
+Vault:
+
+--vault <provider>   Enables a vault provider. Possible values are: file, keystore.
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
+--vault-file <file>  Path to the keystore file.
+--vault-pass <pass>  Password for the vault keystore.
+--vault-type <type>  Specifies the type of the keystore file. Default: PKCS12.
+
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -105,6 +105,15 @@ Management:
                        server (not recommended). If set to true, the management interface is
                        disabled. Default: false.
 
+Vault:
+
+--vault <provider>   Enables a vault provider. Possible values are: file, keystore.
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
+--vault-file <file>  Path to the keystore file.
+--vault-pass <pass>  Password for the vault keystore.
+--vault-type <type>  Specifies the type of the keystore file. Default: PKCS12.
+
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Possible values


### PR DESCRIPTION
Closes #29376

* Makes it possible to run the `export` command using the options from the `Vault` category when using the CLI. Without this, it won't be possible to export realms that rely on vault secrets for certain components such as the LDAP provider and their credentials.
