### PR TITLE
fix: removes the warning of ignored buildtime options, unless changed

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -64,7 +64,6 @@ import org.keycloak.config.Option;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
 import org.keycloak.quarkus.runtime.cli.command.Build;
-import org.keycloak.quarkus.runtime.cli.command.HelpAllMixin;
 import org.keycloak.quarkus.runtime.cli.command.ImportRealmMixin;
 import org.keycloak.quarkus.runtime.cli.command.Main;
 import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
@@ -349,8 +348,11 @@ public final class Picocli {
                     }
 
                     if (mapper.isBuildTime() && !options.includeBuildTime) {
-                        ignoredBuildTime.add(mapper.getFrom());
-                        continue;
+                        String currentValue = getRawPersistedProperty(mapper.getFrom()).orElse(null);
+                        if (!configValueStr.equals(currentValue)) {
+                            ignoredBuildTime.add(mapper.getFrom());
+                            continue;
+                        }
                     }
                     if (mapper.isRunTime() && !options.includeRuntime) {
                         ignoredRunTime.add(mapper.getFrom());
@@ -368,9 +370,11 @@ public final class Picocli {
             Logger logger = Logger.getLogger(Picocli.class); // logger can't be instantiated in a class field
 
             if (!ignoredBuildTime.isEmpty()) {
-                outputIgnoredProperties(ignoredBuildTime, true, logger);
+                logger.warn(format("The following build time non-cli options have values that differ from what is persisted - the new values will NOT be used until another build is run: %s\n",
+                        String.join(", ", ignoredBuildTime)));
             } else if (!ignoredRunTime.isEmpty()) {
-                outputIgnoredProperties(ignoredRunTime, false, logger);
+                logger.warn(format("The following run time non-cli options were found, but will be ignored during build time: %s\n",
+                        String.join(", ", ignoredRunTime)));
             }
 
             if (!disabledBuildTime.isEmpty()) {
@@ -448,12 +452,6 @@ public final class Picocli {
             }
         }
         disabledInUse.add(sb.toString());
-    }
-
-    private static void outputIgnoredProperties(List<String> properties, boolean build, Logger logger) {
-        logger.warn(format("The following %s time non-cli options were found, but will be ignored during %s time: %s\n",
-                build ? "build" : "run", build ? "run" : "build",
-                String.join(", ", properties)));
     }
 
     private static void outputDisabledProperties(Set<String> properties, boolean build, Logger logger) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -159,6 +159,16 @@ public class StartCommandDistTest {
     }
 
     @Test
+    @RawDistOnly(reason = "Containers are immutable")
+    void testWarningWhenOverridingNonCliBuildOptionsDuringStart(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("build", "--features=preview");
+        cliResult.assertBuild();
+        dist.setEnvVar("KC_DB", "postgres");
+        cliResult = dist.run("start", "--optimized", "--hostname=localhost", "--http-enabled=true");
+        cliResult.assertMessage("The following build time non-cli options have values that differ from what is persisted - the new values will NOT be used until another build is run: kc.db");
+    }
+
+    @Test
     @Launch({CONFIG_FILE_LONG_NAME + "=src/test/resources/non-existing.conf", "start"})
     void testInvalidConfigFileOption(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;


### PR DESCRIPTION
closes: #28654

@mabartos @Pepo48 @vmuzikar we can instead output a message that looks more like the auto-build with the actual values if that is preferable.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
