### PR TITLE
quarkus-next: Replace deprecated QUARKUS_PROFILE_PROP constant

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -43,8 +43,8 @@ import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigurationException;
-import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.smallrye.config.ConfigValue;
@@ -545,7 +545,7 @@ class KeycloakProcessor {
 
         if (profile != null) {
             properties.put(Environment.PROFILE, profile);
-            properties.put(ProfileManager.QUARKUS_PROFILE_PROP, profile);
+            properties.put(LaunchMode.current().getProfileKey(), profile);
         }
 
         properties.put(QUARKUS_PROPERTY_ENABLED, String.valueOf(QuarkusPropertiesConfigSource.getConfigurationFile() != null));

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.configuration.ProfileManager;
 import io.smallrye.config.SmallRyeConfig;
 
 import org.apache.commons.lang3.SystemUtils;
@@ -116,7 +115,7 @@ public final class Environment {
 
     public static void setProfile(String profile) {
         System.setProperty(PROFILE, profile);
-        System.setProperty(ProfileManager.QUARKUS_PROFILE_PROP, profile);
+        System.setProperty(LaunchMode.current().getProfileKey(), profile);
         System.setProperty(SmallRyeConfig.SMALLRYE_CONFIG_PROFILE, profile);
         if (isTestLaunchMode()) {
             System.setProperty("mp.config.profile", profile);


### PR DESCRIPTION
Closes: #29438

I decided to determine the property name/key based on the launch mode, which means it can be either `quarkus.profile` (for prod and dev mode) or `quarkus.test.profile` (for test mode).

I think this approach is in alignment with the Quarkus guidelines. Otherwise, if we would like to stick with a constant, it can be done via `LaunchMode.NORMAL.getProfileKey()`.

cc: @vmuzikar @shawkins 
