### PR TITLE
Allow empty CSP header in headers provider

### DIFF
--- a/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersProvider.java
+++ b/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersProvider.java
@@ -106,24 +106,25 @@ public class DefaultSecurityHeadersProvider implements SecurityHeadersProvider {
 
         // TODO This will be refactored as part of introducing a more strict CSP header
         if (options != null) {
-            ContentSecurityPolicyBuilder csp = ContentSecurityPolicyBuilder.create(
-                    headers.getFirst(CONTENT_SECURITY_POLICY.getHeaderName()).toString());
-
             if (options.isAllowAnyFrameAncestor()) {
                 headers.remove(BrowserSecurityHeaders.X_FRAME_OPTIONS.getHeaderName());
+            }
 
-                if (csp.isDefaultFrameAncestors()) {
+            Object cspVal = headers.getFirst(CONTENT_SECURITY_POLICY.getHeaderName());
+            if (cspVal != null) {
+                ContentSecurityPolicyBuilder csp = ContentSecurityPolicyBuilder.create(cspVal.toString());
+                if (options.isAllowAnyFrameAncestor() && csp.isDefaultFrameAncestors()) {
                     // only remove frame ancestors if defined to default 'self'
                     csp.frameAncestors(null);
                 }
-            }
 
-            String allowedFrameSrc = options.getAllowedFrameSrc();
-            if (allowedFrameSrc != null) {
-                csp.addFrameSrc(allowedFrameSrc);
-            }
+                String allowedFrameSrc = options.getAllowedFrameSrc();
+                if (allowedFrameSrc != null) {
+                    csp.addFrameSrc(allowedFrameSrc);
+                }
 
-            headers.putSingle(CONTENT_SECURITY_POLICY.getHeaderName(), csp.build());
+                headers.putSingle(CONTENT_SECURITY_POLICY.getHeaderName(), csp.build());
+            }
         }
     }
 


### PR DESCRIPTION
Closes #29458

A regression in CSP when you configure it to not send anything. When I did the improvements in https://github.com/keycloak/keycloak/issues/24568 I didn't think that you can configure to not send (disable) the header and it throws a NPE.
