### PR TITLE
Only store videos of failed Cypress tests

### DIFF
--- a/js/apps/admin-ui/cypress.config.js
+++ b/js/apps/admin-ui/cypress.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "cypress";
 import cypressSplit from "cypress-split";
 import fs from "node:fs";
+import { isAsyncFunction } from "node:util/types";
 
 const isCI = process.env.CI === "true";
 
@@ -23,8 +24,10 @@ export default defineConfig({
     slowTestThreshold: 30000,
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
     setupNodeEvents(on, config) {
-      on("after:spec", (spec, results) => {
-        if (results.video) {
+      // after:spec collides with cypressSplit function below and is overridden there
+
+      function afterSpecRemoveSuccessfulVideos(spec, results) {
+        if (results?.video) {
           // Do we have failures for any retry attempts?
           const failures = results.tests.some((test) =>
             test.attempts.some((attempt) => attempt.state === "failed"),
@@ -35,9 +38,27 @@ export default defineConfig({
             fs.unlinkSync(results.video);
           }
         }
-      });
+      }
 
-      cypressSplit(on, config);
+      function chainedOn(event, callback) {
+        if (event === "after:spec") {
+          if (isAsyncFunction(callback)) {
+            on(event, async (spec, results) => {
+              afterSpecRemoveSuccessfulVideos(spec, results);
+              await callback(spec, results);
+            });
+          } else {
+            on(event, (spec, results) => {
+              afterSpecRemoveSuccessfulVideos(spec, results);
+              callback(spec, results);
+            });
+          }
+        } else {
+          on(event, callback);
+        }
+      }
+
+      cypressSplit(chainedOn, config);
 
       return config;
     },


### PR DESCRIPTION
`cypressSplit` function overrides the `after:spec` trigger which
is used for removing videos of successful tests.

Fixes: #29471

Signed-off-by: Hynek Mlnarik <hmlnarik@redhat.com>
(cherry picked from commit 7daa2a047164afc194c38f90020e2a1a6550ba1b)
