### PR TITLE
Update the note on proc-creating-user.adoc

### DIFF
--- a/docs/documentation/server_admin/topics/users/proc-creating-user.adoc
+++ b/docs/documentation/server_admin/topics/users/proc-creating-user.adoc
@@ -18,7 +18,7 @@ You create users in the realm where you intend to have applications needed by th
 
 ifdef::standalone[]
 +
-NOTE: *Username* is the only required field.
+NOTE: *Email* is the only required field.
 +   
 . Click *Save*. After saving the details, the *Management* page for the new user is displayed.  
 endif::[]


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
The note says "*Username* is the only required field." but on the admin console, Email is the only required field.