### PR TITLE
Add ProviderConfigProperty type for int values (#29511)

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/IntComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/IntComponent.tsx
@@ -1,0 +1,37 @@
+import { FormGroup, TextInput } from "@patternfly/react-core";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { HelpItem } from "@keycloak/keycloak-ui-shared";
+
+import { convertToName } from "./DynamicComponents";
+import type { ComponentProps } from "./components";
+
+export const IntComponent = ({
+  name,
+  label,
+  helpText,
+  defaultValue,
+  isDisabled = false,
+  required,
+}: ComponentProps) => {
+  const { t } = useTranslation();
+  const { register } = useFormContext();
+
+  return (
+    <FormGroup
+      label={t(label!)}
+      labelIcon={<HelpItem helpText={t(helpText!)} fieldLabelId={`${label}`} />}
+      fieldId={name!}
+      isRequired={required}
+    >
+      <TextInput
+        id={name!}
+        type="number"
+        data-testid={name}
+        isDisabled={isDisabled}
+        defaultValue={defaultValue?.toString()}
+        {...register(convertToName(name!))}
+      />
+    </FormGroup>
+  );
+};

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -16,6 +16,7 @@ import { StringComponent } from "./StringComponent";
 import { TextComponent } from "./TextComponent";
 import { UrlComponent } from "./UrlComponent";
 import { UserProfileAttributeListComponent } from "./UserProfileAttributeListComponent";
+import { IntComponent } from "./IntComponent";
 
 export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
   isDisabled?: boolean;
@@ -27,6 +28,7 @@ const ComponentTypes = [
   "String",
   "Text",
   "boolean",
+  "int",
   "List",
   "Role",
   "Script",
@@ -49,6 +51,7 @@ export const COMPONENTS: {
   String: StringComponent,
   Text: TextComponent,
   boolean: BooleanComponent,
+  int: IntComponent,
   List: ListComponent,
   Role: RoleComponent,
   Script: ScriptComponent,

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -28,6 +28,7 @@ import java.util.List;
  */
 public class ProviderConfigProperty {
     public static final String BOOLEAN_TYPE="boolean";
+    public static final String INT_TYPE = "int";
     public static final String STRING_TYPE="String";
 
     /**


### PR DESCRIPTION
This allows developers to restrict the input for a configurable property to integers.

Fixes #29511

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
