### PR TITLE
Enhance StartDevCommandDistTest to detect problems with URI scheme on Windows

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -22,9 +22,16 @@ import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.utils.KeycloakDistribution;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
@@ -65,6 +72,17 @@ public class StartDevCommandDistTest {
     @Launch({ "start-dev", "--verbose" })
     void testVerboseAfterCommand(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @DisabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "A drive letter in URI can cause a problem.")
+    void testConfigKeystoreAbsolutePath(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("start-dev", "--config-keystore=" + Paths.get("src/test/resources/keystore").toAbsolutePath().normalize(),
+                "--config-keystore-password=secret");
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.hibernate"));
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.keycloak"));
+        assertTrue(cliResult.getOutput().contains("Listening on:"));
         cliResult.assertStartedDevMode();
     }
 


### PR DESCRIPTION
* added a test - a Windows drive letter within URI can cause issues

Related-to: https://github.com/keycloak/keycloak/issues/29329

Signed-off-by: Peter Zaoral <pzaoral@redhat.com>

Note:
#29329 was fixed earlier in #25333.