### PR TITLE
Clear entries in remote caches and force events on the remote site

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
@@ -511,10 +511,10 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
 
     @Override
     public void removeUserSessions(RealmModel realm) {
-        // Don't send message to all DCs, just to all cluster nodes in current DC. The remoteCache will notify client listeners for removed userSessions.
+        // Send message to all DCs as each site might have different entries in the cache
         clusterEventsSenderTx.addEvent(
                 RemoveUserSessionsEvent.createEvent(RemoveUserSessionsEvent.class, InfinispanUserSessionProviderFactory.REMOVE_USER_SESSIONS_EVENT, session, realm.getId(), true),
-                ClusterProvider.DCNotify.LOCAL_DC_ONLY);
+                ClusterProvider.DCNotify.ALL_DCS);
 
         session.getProvider(UserSessionPersisterProvider.class).removeUserSessions(realm, false);
     }
@@ -526,8 +526,6 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
 
     // public for usage in the testsuite
     public void removeLocalUserSessions(String realmId, boolean offline) {
-        FuturesHelper futures = new FuturesHelper();
-
         Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
         Cache<String, SessionEntityWrapper<UserSessionEntity>> localCache = CacheDecorators.localCache(cache);
         Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> clientSessionCache = getClientSessionCache(offline);
@@ -537,40 +535,43 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
 
         final AtomicInteger userSessionsSize = new AtomicInteger();
 
-        localCacheStoreIgnore
-                .entrySet()
-                .stream()
-                .filter(SessionPredicate.create(realmId))
-                .map(Mappers.userSessionEntity())
-                .forEach(new Consumer<UserSessionEntity>() {
+        removeEntriesByRealm(realmId, localCacheStoreIgnore, userSessionsSize, localCache, localClientSessionCache);
 
-                    @Override
-                    public void accept(UserSessionEntity userSessionEntity) {
-                        userSessionsSize.incrementAndGet();
-
-                        // Remove session from remoteCache too. Use removeAsync for better perf
-                        Future future = localCache.removeAsync(userSessionEntity.getId());
-                        futures.addTask(future);
-                        userSessionEntity.getAuthenticatedClientSessions().forEach((clientUUID, clientSessionId) -> {
-                            Future f = localClientSessionCache.removeAsync(clientSessionId);
-                            futures.addTask(f);
-                        });
-                    }
-
-                });
-
-
-        futures.waitForAllToFinish();
+        // iterate over the remote entries as well to ensure they are purged
+        removeEntriesByRealm(realmId, getCache(offline), userSessionsSize, getCache(offline), getClientSessionCache(offline));
 
         log.debugf("Removed %d sessions in realm %s. Offline: %b", (Object) userSessionsSize.get(), realmId, offline);
     }
 
+    private static void removeEntriesByRealm(String realmId, Cache<String, SessionEntityWrapper<UserSessionEntity>> sessions, AtomicInteger userSessionsSize, Cache<String, SessionEntityWrapper<UserSessionEntity>> localCache, Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> clientSessions) {
+        FuturesHelper futures = new FuturesHelper();
+
+        sessions
+                .entrySet()
+                .stream()
+                .filter(SessionPredicate.create(realmId))
+                .map(Mappers.userSessionEntity())
+                .forEach((Consumer<UserSessionEntity>) userSessionEntity -> {
+                    userSessionsSize.incrementAndGet();
+
+                    // Remove session from remoteCache too. Use removeAsync for better perf
+                    Future future = localCache.removeAsync(userSessionEntity.getId());
+                    futures.addTask(future);
+                    userSessionEntity.getAuthenticatedClientSessions().forEach((clientUUID, clientSessionId) -> {
+                        Future f = clientSessions.removeAsync(clientSessionId);
+                        futures.addTask(f);
+                    });
+                });
+
+        futures.waitForAllToFinish();
+    }
+
     @Override
     public void onRealmRemoved(RealmModel realm) {
-        // Don't send message to all DCs, just to all cluster nodes in current DC. The remoteCache will notify client listeners for removed userSessions.
+        // Send message to all DCs, as each DC might have different entries in their site cache
         clusterEventsSenderTx.addEvent(
                 RealmRemovedSessionEvent.createEvent(RealmRemovedSessionEvent.class, InfinispanUserSessionProviderFactory.REALM_REMOVED_SESSION_EVENT, session, realm.getId(), true),
-                ClusterProvider.DCNotify.LOCAL_DC_ONLY);
+                ClusterProvider.DCNotify.ALL_DCS);
 
         UserSessionPersisterProvider sessionsPersister = session.getProvider(UserSessionPersisterProvider.class);
         if (sessionsPersister != null) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remotestore/RemoteCacheInvoker.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remotestore/RemoteCacheInvoker.java
@@ -114,24 +114,7 @@ public class RemoteCacheInvoker {
 
         switch (operation) {
             case REMOVE:
-                if (Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS) &&
-                    (remoteCache.getName().equals(USER_SESSION_CACHE_NAME)
-                     || remoteCache.getName().equals(CLIENT_SESSION_CACHE_NAME)
-                     || remoteCache.getName().equals(OFFLINE_USER_SESSION_CACHE_NAME)
-                     || remoteCache.getName().equals(OFFLINE_CLIENT_SESSION_CACHE_NAME))) {
-                    if (remoteCache.withFlags(Flag.FORCE_RETURN_VALUE).remove(key) == null) {
-                        logger.debugf("No existing entry for %s in the remote cache to remove, might have been evicted.", key);
-                        // force a remove to trigger an event on the remote DC to clear those
-                        remoteCache.put(key, new SessionEntityWrapper<>(null));
-                        if (remoteCache.withFlags(Flag.FORCE_RETURN_VALUE).remove(key) == null) {
-                            logger.warnf("Unable to trigger the remove in the remote cache %s for key %s", remoteCache.getName(), key);
-                        };
-                    }
-                    // second remove
-                    remoteCache.withFlags(Flag.FORCE_RETURN_VALUE).remove(key);
-                } else {
-                    remoteCache.remove(key);
-                }
+                remoteCache.remove(key);
                 break;
             case ADD:
                 remoteCache.put(key, sessionWrapper.forTransport(),
@@ -174,12 +157,8 @@ public class RemoteCacheInvoker {
                      || remoteCache.getName().equals(CLIENT_SESSION_CACHE_NAME)
                      || remoteCache.getName().equals(OFFLINE_USER_SESSION_CACHE_NAME)
                      || remoteCache.getName().equals(OFFLINE_CLIENT_SESSION_CACHE_NAME))) {
-                    logger.debugf("No existing entry for %s in the remote cache to remove, might have been evicted.", key);
-                    // force a remove to trigger an event on the remote DC to clear those
-                    remoteCache.put(key, new SessionEntityWrapper<>(null));
-                    if (remoteCache.withFlags(Flag.FORCE_RETURN_VALUE).remove(key) != null) {
-                        logger.warnf("Unable to trigger the remove in the remote cache %s for key %s", remoteCache.getName(), key);
-                    };
+                    logger.debugf("No existing entry for %s in the remote cache to remove, might have been evicted. A delete will force an eviction in the other DC.", key);
+                    remoteCache.remove(key);
                 }
                 logger.warnf("Not found entity to replace for key '%s'", key);
                 return;

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remotestore/RemoteCacheSessionListener.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remotestore/RemoteCacheSessionListener.java
@@ -130,10 +130,6 @@ public class RemoteCacheSessionListener<K, V extends SessionEntity>  {
 
 
         V remoteSession = remoteSessionVersioned.getValue().getEntity();
-        if (remoteSession == null) {
-            // this is a dummy value to trigger a remove event on the remote site
-            return;
-        }
         SessionEntityWrapper<V> newWrapper = new SessionEntityWrapper<>(remoteSession);
 
         logger.debugf("Read session entity wrapper from the remote cache: %s", remoteSession);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remotestore/RemoteCacheSessionListener.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remotestore/RemoteCacheSessionListener.java
@@ -130,6 +130,10 @@ public class RemoteCacheSessionListener<K, V extends SessionEntity>  {
 
 
         V remoteSession = remoteSessionVersioned.getValue().getEntity();
+        if (remoteSession == null) {
+            // this is a dummy value to trigger a remove event on the remote site
+            return;
+        }
         SessionEntityWrapper<V> newWrapper = new SessionEntityWrapper<>(remoteSession);
 
         logger.debugf("Read session entity wrapper from the remote cache: %s", remoteSession);


### PR DESCRIPTION
Closes #29592

Handles the following cases: 

* When removing the sessions for a realm, and an entry is not in the current site's local cache cache, but in the current site's remote cache: 
  * We're iterating over all entries in the external cache and remove the external ones as well. 
* When removing the sessions for a realm, and an entry is in the other site's local cache or the other site's external cache:
  * We're sending an event to all cluster sites and run the cleanup commands there as well.  
* When removing or updating a single session, but that session isn't present in the external cache, so there wouldn't be an event to be observed on the other site: 
  * We're adding a dummy entry and then removing it to force an event on the other site to trigger a clear on the other site's caches (both external and internal)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
