### PR TITLE
Allow members joining multiple organizations

### DIFF
--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -17,12 +17,16 @@
 
 package org.keycloak.admin.client.resource;
 
+import java.util.List;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
 
 public interface OrganizationMemberResource {
 
@@ -32,4 +36,9 @@ public interface OrganizationMemberResource {
 
     @DELETE
     Response delete();
+
+    @Path("organizations")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> getOrganizations();
 }

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -67,11 +67,6 @@ public interface OrganizationMembersResource {
             @QueryParam("max") Integer max
     );
 
-    @Path("{id}/organization")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    OrganizationRepresentation getOrganization(@PathParam("id") String id);
-
     @Path("{id}")
     OrganizationMemberResource member(@PathParam("id") String id);
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/CachedMembership.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/CachedMembership.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.cache.infinispan.organization;
+
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.cache.infinispan.entities.AbstractRevisioned;
+import org.keycloak.models.cache.infinispan.entities.InRealm;
+
+public class CachedMembership extends AbstractRevisioned implements InRealm {
+
+    private final RealmModel realm;
+    private final boolean managed;
+    private final boolean isMember;
+
+    public CachedMembership(Long revision, String key, RealmModel realm, boolean managed, boolean isMember) {
+        super(revision, key);
+        this.realm = realm;
+        this.managed = managed;
+        this.isMember = isMember;
+    }
+
+    @Override
+    public String getRealm() {
+        return realm.getId();
+    }
+
+    public boolean isManaged() {
+        return managed;
+    }
+
+    public boolean isMember() {
+        return isMember;
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/CachedOrganizationIds.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/CachedOrganizationIds.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.cache.infinispan.organization;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.cache.infinispan.entities.AbstractRevisioned;
+import org.keycloak.models.cache.infinispan.entities.InRealm;
+
+public class CachedOrganizationIds extends AbstractRevisioned implements InRealm {
+
+    private final RealmModel realm;
+    private final Set<String> orgIds = new HashSet<>();
+
+    public CachedOrganizationIds(Long revision, String id, RealmModel realm, Stream<OrganizationModel> organizations) {
+        super(revision, id);
+        this.realm = realm;
+        organizations.map(OrganizationModel::getId).forEach(orgIds::add);
+    }
+
+    @Override
+    public String getRealm() {
+        return realm.getId();
+    }
+
+    public Set<String> getOrgIds() {
+        return orgIds;
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
@@ -161,7 +161,7 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
     }
 
     @Override
-    public OrganizationModel getByMember(UserModel member) {
+    public Stream<OrganizationModel> getByMember(UserModel member) {
         return orgDelegate.getByMember(member);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/OrganizationAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/OrganizationAdapter.java
@@ -158,6 +158,11 @@ public class OrganizationAdapter implements OrganizationModel {
     }
 
     @Override
+    public boolean isMember(UserModel user) {
+        return delegate.isMember(this, user);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof OrganizationModel)) return false;

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/OrganizationAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/OrganizationAdapter.java
@@ -36,11 +36,13 @@ public class OrganizationAdapter implements OrganizationModel {
     private final CacheRealmProvider realmCache;
     private final CachedOrganization cached;
     private final OrganizationProvider delegate;
+    private final InfinispanOrganizationProvider organizationCache;
 
-    public OrganizationAdapter(CachedOrganization cached, CacheRealmProvider realmCache, OrganizationProvider delegate) {
+    public OrganizationAdapter(CachedOrganization cached, CacheRealmProvider realmCache, OrganizationProvider delegate, InfinispanOrganizationProvider organizationCache) {
         this.cached = cached;
         this.realmCache = realmCache;
         this.delegate = delegate;
+        this.organizationCache = organizationCache;
         this.modelSupplier = this::getOrganizationModel;
     }
 
@@ -62,8 +64,8 @@ public class OrganizationAdapter implements OrganizationModel {
 
     private void getDelegateForUpdate() {
         if (updated == null) {
-            realmCache.registerInvalidation(cached.getId());
             updated = modelSupplier.get();
+            organizationCache.registerOrganizationInvalidation(updated);
             if (updated == null) throw new IllegalStateException("Not found in database");
         }
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationEntity.java
@@ -44,7 +44,8 @@ import jakarta.persistence.Table;
         @NamedQuery(name="getByNameOrDomainContained", query="select distinct o from OrganizationEntity o inner join OrganizationDomainEntity d ON o.id = d.organization.id" +
                 " where o.realmId = :realmId AND (lower(o.name) like concat('%',:search,'%') OR d.name like concat('%',:search,'%')) order by o.name ASC"),
         @NamedQuery(name="getCount", query="select count(o) from OrganizationEntity o where o.realmId = :realmId"),
-        @NamedQuery(name="deleteOrganizationsByRealm", query="delete from OrganizationEntity o where o.realmId = :realmId")
+        @NamedQuery(name="deleteOrganizationsByRealm", query="delete from OrganizationEntity o where o.realmId = :realmId"),
+        @NamedQuery(name="getGroupsByMember", query="select m.groupId from UserGroupMembershipEntity m join GroupEntity g on g.id = m.groupId where g.type = 1 and m.user.id = :userId")
 })
 public class OrganizationEntity {
 

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -125,8 +125,9 @@ public class JpaOrganizationProvider implements OrganizationProvider {
                 GroupModel group = getOrganizationGroup(entity);
 
                 if (group != null) {
+                    OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
                     //TODO: won't scale, requires a better mechanism for bulk deleting users
-                    userProvider.getGroupMembersStream(realm, group).forEach(userModel -> removeMember(organization, userModel));
+                    userProvider.getGroupMembersStream(realm, group).forEach(userModel -> provider.removeMember(organization, userModel));
                     groupProvider.removeGroup(realm, group);
                 }
 

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -206,6 +206,11 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
     }
 
     @Override
+    public boolean isMember(UserModel user) {
+        return provider.isMember(this, user);
+    }
+
+    @Override
     public OrganizationEntity getEntity() {
         return entity;
     }

--- a/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -469,10 +469,6 @@ public class ExportUtils {
             userRep.setGroups(groups);
         }
 
-        if (userRep.getAttributes() != null) {
-            userRep.getAttributes().remove(OrganizationModel.ORGANIZATION_ATTRIBUTE);
-        }
-
         return userRep;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -248,7 +248,6 @@ public class ModelToRepresentation {
         }
         if (attributes != null && !copy.isEmpty()) {
             Map<String, List<String>> attrs = new HashMap<>(copy);
-            attrs.remove(OrganizationModel.ORGANIZATION_ATTRIBUTE);
             rep.setAttributes(attrs);
         }
 

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -77,4 +77,6 @@ public interface OrganizationModel {
     Stream<IdentityProviderModel> getIdentityProviders();
 
     boolean isManaged(UserModel user);
+
+    boolean isMember(UserModel user);
 }

--- a/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -142,10 +142,10 @@ public interface OrganizationProvider extends Provider {
     /**
      * Returns the {@link OrganizationModel} that the {@code member} belongs to.
      *
-     * @param member the member of a organization
-     * @return the organization the {@code member} belongs to or {@code null} if the user doesn't belong to any.
+     * @param member the member of an organization
+     * @return the organizations the {@code member} belongs to or an empty stream if the user doesn't belong to any.
      */
-    OrganizationModel getByMember(UserModel member);
+    Stream<OrganizationModel> getByMember(UserModel member);
 
     /**
      * Associate the given {@link IdentityProviderModel} with the given {@link OrganizationModel}.
@@ -195,6 +195,17 @@ public interface OrganizationProvider extends Provider {
      * @return {@code true} if the {@code member} is managed by the given {@code organization}. Otherwise, returns {@code false}
      */
     boolean isManagedMember(OrganizationModel organization, UserModel member);
+
+    /**
+     * Indicates if the given {@code user} is a member of the given {@code organization}.
+     *
+     * @param organization the organization
+     * @param user the member
+     * @return {@code true} if the user is a member. Otherwise, {@code false}
+     */
+    default boolean isMember(OrganizationModel organization, UserModel user) {
+        return getMemberById(organization, user.getId()) != null;
+    }
 
     /**
      * <p>Removes a member from the organization.

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/inviteorg/InviteOrgActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/inviteorg/InviteOrgActionTokenHandler.java
@@ -84,19 +84,19 @@ public class InviteOrgActionTokenHandler extends AbstractActionTokenHandler<Invi
 
         OrganizationModel organization = orgProvider.getById(token.getOrgId());
 
-        if (orgProvider.getByMember(user) != null) {
-            event.user(user).error(Errors.USER_ORG_MEMBER_ALREADY);
-            return session.getProvider(LoginFormsProvider.class)
-                    .setAuthenticationSession(authSession)
-                    .setInfo(Messages.ORG_MEMBER_ALREADY, user.getUsername())
-                    .createInfoPage();
-        }
-
         if (organization == null) {
             event.user(user).error(Errors.ORG_NOT_FOUND);
             return session.getProvider(LoginFormsProvider.class)
                     .setAuthenticationSession(authSession)
                     .setInfo(Messages.ORG_NOT_FOUND, token.getOrgId())
+                    .createInfoPage();
+        }
+
+        if (organization.isMember(user)) {
+            event.user(user).error(Errors.USER_ORG_MEMBER_ALREADY);
+            return session.getProvider(LoginFormsProvider.class)
+                    .setAuthenticationSession(authSession)
+                    .setInfo(Messages.ORG_MEMBER_ALREADY, user.getUsername())
                     .createInfoPage();
         }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -549,7 +549,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 OrganizationModel organization = resolveOrganization(session, user);
 
                 if (organization != null) {
-                    attributes.put("org", new OrganizationBean(session, organization, user));
+                    attributes.put("org", new OrganizationBean(organization, user));
                 }
             }
         }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/OrganizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/OrganizationBean.java
@@ -23,11 +23,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationDomainModel;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.organization.OrganizationProvider;
 
 public class OrganizationBean {
 
@@ -37,16 +35,12 @@ public class OrganizationBean {
     private final boolean isMember;
     private final Map<String, List<String>> attributes;
 
-    public OrganizationBean(KeycloakSession session, OrganizationModel organization, UserModel user) {
+    public OrganizationBean(OrganizationModel organization, UserModel user) {
         this.name = organization.getName();
         this.alias = organization.getAlias();
         this.domains = organization.getDomains().map(OrganizationDomainModel::getName).collect(Collectors.toSet());
-        this.isMember = user != null && organization.equals(getOrganizationProvider(session).getByMember(user));
+        this.isMember = user != null && organization.isMember(user);
         this.attributes = Collections.unmodifiableMap(organization.getAttributes());
-    }
-
-    private static OrganizationProvider getOrganizationProvider(KeycloakSession session) {
-        return session.getProvider(OrganizationProvider.class);
     }
 
     public String getName() {

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -33,7 +33,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
@@ -52,7 +51,6 @@ public class OrganizationInvitationResource {
 
     private final KeycloakSession session;
     private final RealmModel realm;
-    private final OrganizationProvider provider;
     private final OrganizationModel organization;
     private final AdminEventBuilder adminEvent;
     private final int tokenExpiration;
@@ -60,7 +58,6 @@ public class OrganizationInvitationResource {
     public OrganizationInvitationResource(KeycloakSession session, OrganizationModel organization, AdminEventBuilder adminEvent) {
         this.session = session;
         this.realm = session.getContext().getRealm();
-        this.provider = session.getProvider(OrganizationProvider.class);
         this.organization = organization;
         this.adminEvent = adminEvent;
         this.tokenExpiration = getTokenExpiration();
@@ -74,9 +71,7 @@ public class OrganizationInvitationResource {
         UserModel user = session.users().getUserByEmail(realm, email);
 
         if (user != null) {
-            OrganizationModel org = provider.getByMember(user);
-
-            if (org != null && org.equals(organization)) {
+            if (organization.isMember(user)) {
                 throw ErrorResponse.error("User already a member of the organization", Status.CONFLICT);
             }
 

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.organization.admin.resource;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.Consumes;
@@ -178,29 +179,27 @@ public class OrganizationMemberResource {
         throw ErrorResponse.error("Not a member of the organization", Status.BAD_REQUEST);
     }
 
-    @Path("{id}/organization")
+    @Path("{id}/organizations")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns the organization associated with the user that has the specified id")
-    public OrganizationRepresentation getOrganization(@PathParam("id") String id) {
+    @Operation(summary = "Returns the organizations associated with the user that has the specified id")
+    public Stream<OrganizationRepresentation> getOrganizations(@PathParam("id") String id) {
         if (StringUtil.isBlank(id)) {
             throw ErrorResponse.error("id cannot be null", Status.BAD_REQUEST);
         }
 
         UserModel member = getMember(id);
-        OrganizationModel organization = provider.getByMember(member);
 
-        if (organization == null) {
-            throw ErrorResponse.error("Not associated with an organization", Status.NOT_FOUND);
-        }
+        return provider.getByMember(member).map((org) -> {
+            OrganizationRepresentation organization = new OrganizationRepresentation();
 
-        OrganizationRepresentation rep = new OrganizationRepresentation();
+            organization.setId(org.getId());
+            organization.setName(org.getName());
 
-        rep.setId(organization.getId());
-
-        return rep;
+            return organization;
+        });
     }
 
     private UserModel getMember(String id) {

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/broker/IdpAddOrganizationMemberAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/broker/IdpAddOrganizationMemberAuthenticator.java
@@ -30,6 +30,7 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.utils.Organizations;
 
 import static org.keycloak.organization.utils.Organizations.isEnabledAndOrganizationsPresent;
 
@@ -41,9 +42,10 @@ public class IdpAddOrganizationMemberAuthenticator extends AbstractIdpAuthentica
 
     @Override
     protected void authenticateImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
-        OrganizationProvider provider = context.getSession().getProvider(OrganizationProvider.class);
+        KeycloakSession session = context.getSession();
+        OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
         UserModel user = context.getUser();
-        OrganizationModel organization = (OrganizationModel) context.getSession().getAttribute(OrganizationModel.class.getName());
+        OrganizationModel organization = Organizations.resolveOrganization(session);
 
         if (organization == null) {
             context.attempted();
@@ -75,7 +77,7 @@ public class IdpAddOrganizationMemberAuthenticator extends AbstractIdpAuthentica
             return false;
         }
 
-        OrganizationModel organization = (OrganizationModel) session.getAttribute(OrganizationModel.class.getName());
+        OrganizationModel organization = Organizations.resolveOrganization(session);
 
         if (organization == null || !organization.isEnabled()) {
             return false;

--- a/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
@@ -26,6 +26,7 @@ import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.organization.utils.Organizations;
 
 public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean {
 
@@ -74,7 +75,7 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
             return false;
         }
 
-        OrganizationModel organization = (OrganizationModel) session.getAttribute(OrganizationModel.class.getName());
+        OrganizationModel organization = Organizations.resolveOrganization(session);
 
         if (organization != null && !organization.getId().equals(model.getOrganizationId())) {
             return false;

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
 import org.keycloak.Config;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.common.Profile;
@@ -84,14 +86,15 @@ public class OrganizationMembershipMapper extends AbstractOIDCProtocolMapper imp
         }
 
         UserModel user = userSession.getUser();
-        OrganizationModel organization = provider.getByMember(user);
+        Stream<OrganizationModel> organizations = provider.getByMember(user).filter(OrganizationModel::isEnabled);
+        Map<String, Map<String, Object>> claim = new HashMap<>();
 
-        if (organization == null || !organization.isEnabled()) {
+        organizations.forEach(organization -> claim.put(organization.getAlias(), Map.of()));
+
+        if (claim.isEmpty()) {
             return;
         }
 
-        Map<String, Map<String, Object>> claim = new HashMap<>();
-        claim.put(organization.getAlias(), Map.of());
         token.getOtherClaims().put(OAuth2Constants.ORGANIZATION, claim);
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -210,7 +210,7 @@ public class LinkedAccountsResource {
         }
 
         if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
-            if (Organizations.resolveBroker(session, user).stream()
+            if (Organizations.resolveHomeBroker(session, user).stream()
                     .map(IdentityProviderModel::getAlias)
                     .anyMatch(providerAlias::equals)) {
                 throw ErrorResponse.error(translateErrorMessage(Messages.FEDERATED_IDENTITY_BOUND_ORGANIZATION), Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -1082,7 +1082,6 @@ public class UserResource {
 
         attributes.remove(UserModel.USERNAME);
         attributes.remove(UserModel.EMAIL);
-        attributes.remove(OrganizationModel.ORGANIZATION_ATTRIBUTE);
 
         return attributes.entrySet().stream()
                 .filter(entry -> ofNullable(entry.getValue()).orElse(emptyList()).stream().anyMatch(StringUtil::isNotBlank))

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
@@ -354,12 +354,6 @@ public class DeclarativeUserProfileProviderFactory implements UserProfileProvide
                     attribute.addValidators(List.of(new AttributeValidatorMetadata(OrganizationMemberValidator.ID)));
                 }
             }
-
-            metadata.addAttribute(OrganizationModel.ORGANIZATION_ATTRIBUTE, -1,
-                            new AttributeValidatorMetadata(OrganizationMemberValidator.ID),
-                            new AttributeValidatorMetadata(ImmutableAttributeValidator.ID))
-                    .addReadCondition((c) -> false)
-                    .addWriteCondition((c) -> false);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationThemeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationThemeTest.java
@@ -152,7 +152,8 @@ public class OrganizationThemeTest extends AbstractOrganizationTest {
         oauth.clientId("broker-app");
         loginPage.open(bc.consumerRealmName());
         loginPage.loginUsername("tom");
-        loginPage.login("tom", "password");
+        Assert.assertTrue(driver.getPageSource().contains("Sign-in to myorg organization"));
+        loginPage.login("password");
         waitForPage(driver, "update account information", false);
         Assert.assertTrue("Driver should be on the consumer realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -123,12 +123,13 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
     public void testIdentityFirstUserNotExistEmailMatchBrokerDomainNoPublicBroker() {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         IdentityProviderRepresentation idpRep = organization.identityProviders().getIdentityProviders().get(0);
+        idpRep.getConfig().remove(IdentityProviderRedirectMode.EMAIL_MATCH.getKey());
         idpRep.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
         testRealm().identityProviders().get(idpRep.getAlias()).update(idpRep);
 
         openIdentityFirstLoginPage("user@neworg.org", false, null, false, false);
 
-        Assert.assertFalse(driver.getPageSource().contains("Your email domain matches the neworg organization but you don't have an account yet."));
+        Assert.assertTrue(driver.getPageSource().contains("Your email domain matches the neworg organization but you don't have an account yet."));
         Assert.assertTrue(loginPage.isUsernameInputPresent());
         Assert.assertFalse(loginPage.isPasswordInputPresent());
         // self-registration link shown because there is no public broker and user can choose to register
@@ -221,6 +222,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
         IdentityProviderRepresentation brokerRep = broker.toRepresentation();
         brokerRep.getConfig().put(OrganizationModel.BROKER_PUBLIC, Boolean.TRUE.toString());
+        brokerRep.getConfig().remove(IdentityProviderRedirectMode.EMAIL_MATCH.getKey());
         testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
 
         openIdentityFirstLoginPage(bc.getUserEmail(), true, brokerRep, false, true);
@@ -243,6 +245,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
         IdentityProviderRepresentation brokerRep = broker.toRepresentation();
+        brokerRep.getConfig().remove(IdentityProviderRedirectMode.EMAIL_MATCH.getKey());
         brokerRep.getConfig().put(OrganizationModel.BROKER_PUBLIC, Boolean.TRUE.toString());
         testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
 
@@ -445,6 +448,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         OrganizationResource org1 = testRealm().organizations().get(createOrganization(org1Name).getId());
         IdentityProviderRepresentation org1Broker = org1.identityProviders().getIdentityProviders().get(0);
         org1Broker.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
+        org1Broker.getConfig().remove(IdentityProviderRedirectMode.EMAIL_MATCH.getKey());
         org1Broker.getConfig().put(OrganizationModel.BROKER_PUBLIC, Boolean.TRUE.toString());
         testRealm().identityProviders().get(org1Broker.getAlias()).update(org1Broker);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -417,7 +417,6 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         List<FederatedIdentityRepresentation> federatedIdentities = testRealm().users().get(user.getId()).getFederatedIdentity();
         assertEquals(1, federatedIdentities.size());
         assertEquals(bc.getIDPAlias(), federatedIdentities.get(0).getIdentityProvider());
-        
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/cache/OrganizationCacheTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/cache/OrganizationCacheTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.organization.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.models.OrganizationDomainModel;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.organization.admin.AbstractOrganizationTest;
+import org.keycloak.testsuite.runonserver.RunOnServer;
+
+@EnableFeature(Feature.ORGANIZATION)
+public class OrganizationCacheTest extends AbstractOrganizationTest {
+
+    @Before
+    public void onBefore() {
+        createOrganization("orga");
+        createOrganization("orgb");
+    }
+
+    @After
+    public void onAfter() {
+        List<UserRepresentation> users = testRealm().users().search("member");
+
+        if (!users.isEmpty()) {
+            UserRepresentation member = users.get(0);
+            testRealm().users().get(member.getId()).remove();
+        }
+    }
+
+    @Test
+    public void testGetByDomain() {
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel acme = orgProvider.getByDomainName("orga.org");
+            assertNotNull(acme);
+            acme.setDomains(Set.of(new OrganizationDomainModel("acme.org")));
+        });
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel acme = orgProvider.getByDomainName("orga.org");
+            assertNull(acme);
+            acme = orgProvider.getByDomainName("acme.org");
+            assertNotNull(acme);
+        });
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel acme = orgProvider.getByDomainName("acme.org");
+            assertNotNull(acme);
+            orgProvider.remove(acme);
+        });
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel acme = orgProvider.getByDomainName("acme.org");
+            assertNull(acme);
+        });
+    }
+
+    @Test
+    public void testGetByMember() {
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel orga = orgProvider.getByDomainName("orga.org");
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().addUser(realm, "member");
+            member.setEnabled(true);
+            orgProvider.addMember(orga, member);
+            OrganizationModel orgb = orgProvider.getByDomainName("orgb.org");
+            orgProvider.addMember(orgb, member);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            Stream<OrganizationModel> memberOf = orgProvider.getByMember(member);
+            assertEquals(2, memberOf.count());
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel orga = orgProvider.getByDomainName("orga.org");
+            orgProvider.remove(orga);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            Stream<OrganizationModel> memberOf = orgProvider.getByMember(member);
+            assertEquals(1, memberOf.count());
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            OrganizationModel orgb = orgProvider.getByDomainName("orgb.org");
+            orgProvider.removeMember(orgb, member);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            Stream<OrganizationModel> memberOf = orgProvider.getByMember(member);
+            assertEquals(0, memberOf.count());
+        });
+    }
+
+    @Test
+    public void testGetByMemberId() {
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel orga = orgProvider.getByDomainName("orga.org");
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().addUser(realm, "member");
+            member.setEnabled(true);
+            orgProvider.addMember(orga, member);
+            OrganizationModel orgb = orgProvider.getByDomainName("orgb.org");
+            orgProvider.addMember(orgb, member);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.getByDomainName("orga.org");
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            UserModel memberOf = orgProvider.getMemberById(org, member.getId());
+            assertNotNull(memberOf);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.getByDomainName("orga.org");
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            orgProvider.removeMember(org, member);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel orga = orgProvider.getByDomainName("orga.org");
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            assertNull(orgProvider.getMemberById(orga, member.getId()));
+            OrganizationModel orgb = orgProvider.getByDomainName("orgb.org");
+            assertNotNull(orgProvider.getMemberById(orgb, member.getId()));
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel orgb = orgProvider.getByDomainName("orgb.org");
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            assertEquals(1, orgProvider.getByMember(member).count());
+            orgProvider.remove(orgb);
+        });
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            assertEquals(0, orgProvider.getByMember(member).count());
+        });
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationSAMLProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationSAMLProtocolMapperTest.java
@@ -36,6 +36,7 @@ import org.keycloak.dom.saml.v2.assertion.AttributeType;
 import org.keycloak.protocol.saml.SamlConfigAttributes;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import org.keycloak.services.resources.RealmsResource;
@@ -53,6 +54,8 @@ public class OrganizationSAMLProtocolMapperTest extends AbstractOrganizationTest
     @Test
     public void testAttribute() {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        IdentityProviderRepresentation broker = organization.identityProviders().getIdentityProviders().get(0);
+        organization.identityProviders().get(broker.getAlias()).delete().close();
         addMember(organization);
         String clientId = "saml-client";
         testRealm().clients().create(ClientBuilder.create()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberAuthenticationTest.java
@@ -74,7 +74,7 @@ public class OrganizationMemberAuthenticationTest extends AbstractOrganizationTe
     }
 
     @Test
-    public void testAuthenticateUnmanagedMemberWehnProviderDisabled() throws IOException {
+    public void testAuthenticateUnmanagedMemberWhenProviderDisabled() throws IOException {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         UserRepresentation member = addMember(organization, "contractor@contractor.org");
 


### PR DESCRIPTION
Closes #30747

* Removes the constraints we have today to allow users to join multiple organizations
* Most of the changes are related to changing methods and places to support users/members associated with multiple organizations
* A member of different organizations is a managed member in only one of the organizations. By that, we ensure members always have a single source of truth for their identities. This PR depends on https://github.com/keycloak/keycloak/issues/30743 and should be updated accordingly.
* The `OrganizationAuthenticator` was refactored to make it simpler and to support members of multiple organizations
* Removing `kc.org` user attribute
* Introducing cache to some query methods that were previously relying on the `kc.org` user attribute