### PR TITLE
OAuth 2.0 Device Polling Interval - Realms settings/Token Tab +- to change value not working

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -184,7 +184,7 @@ export const RealmSettingsTokensTab = ({
                         field.onChange(
                           Number(field?.value) > 0
                             ? Number(field?.value) - 1
-                            : 0
+                            : 0,
                         )
                       }
                       onChange={(event) => {

--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -179,8 +179,8 @@ export const RealmSettingsTokensTab = ({
                       id="oAuthDevicePollingInterval"
                       value={field.value}
                       min={0}
-                      onPlus={() => field.onChange(field.value || 0 + 1)}
-                      onMinus={() => field.onChange(field.value || 0 - 1)}
+                      onPlus={() => field.onChange(Number(field?.value) + 1)}
+                      onMinus={() => field.onChange((Number(field?.value) > 0) ? Number(field?.value) - 1 : 0)}
                       onChange={(event) => {
                         const newValue = Number(event.currentTarget.value);
                         field.onChange(!isNaN(newValue) ? newValue : 0);

--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -180,7 +180,13 @@ export const RealmSettingsTokensTab = ({
                       value={field.value}
                       min={0}
                       onPlus={() => field.onChange(Number(field?.value) + 1)}
-                      onMinus={() => field.onChange((Number(field?.value) > 0) ? Number(field?.value) - 1 : 0)}
+                      onMinus={() =>
+                        field.onChange(
+                          Number(field?.value) > 0
+                            ? Number(field?.value) - 1
+                            : 0
+                        )
+                      }
                       onChange={(event) => {
                         const newValue = Number(event.currentTarget.value);
                         field.onChange(!isNaN(newValue) ? newValue : 0);


### PR DESCRIPTION
The input was taking a String type variable. Fixed it by converting it to a number so that numeric calculations can be done on it. Also, applied a condition for Minus button so that the count is never less than zero since the default value is 0.

Fixes #29551 