### PR TITLE
Allow admin console whoami endpoint to applications that have a special attribute

### DIFF
--- a/js/apps/keycloak-server/scripts/security-admin-console-v2.json
+++ b/js/apps/keycloak-server/scripts/security-admin-console-v2.json
@@ -22,7 +22,9 @@
   "publicClient": true,
   "frontchannelLogout": false,
   "protocol": "openid-connect",
-  "attributes": {},
+  "attributes": {
+    "security.admin.console": "true"
+  },
   "authenticationFlowBindingOverrides": {},
   "fullScopeAllowed": true,
   "nodeReRegistrationTimeout": -1,

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -171,4 +171,7 @@ public final class Constants {
 
     // Sent to clients when authentication session expired, but user is already logged-in in current browser
     public static final String AUTHENTICATION_EXPIRED_MESSAGE = "authentication_expired";
+
+    // attribute name used in apps to mark that it is an admin console and its azp is allowed
+    public static final String SECURITY_ADMIN_CONSOLE_ATTR = "security.admin.console";
 }


### PR DESCRIPTION
Closes #29640

Adding an attribute that allows azp to whoami to that client. This allows testing a new admin console.
