### PR TITLE
Call super constructor in subclasses of WebApplicationException

### DIFF
--- a/services/src/main/java/org/keycloak/services/CorsErrorResponseException.java
+++ b/services/src/main/java/org/keycloak/services/CorsErrorResponseException.java
@@ -35,6 +35,7 @@ public class CorsErrorResponseException extends WebApplicationException {
     private final Response.Status status;
 
     public CorsErrorResponseException(Cors cors, String error, String errorDescription, Response.Status status) {
+        super(error, status);
         this.cors = cors;
         this.error = error;
         this.errorDescription = errorDescription;

--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -36,6 +36,7 @@ public class ErrorPageException extends WebApplicationException {
 
     
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
+        super(errorMessage, status);
         this.session = session;
         this.status = status;
         this.errorMessage = errorMessage;

--- a/services/src/main/java/org/keycloak/services/ErrorResponseException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorResponseException.java
@@ -36,6 +36,7 @@ public class ErrorResponseException extends WebApplicationException {
     private final Response.Status status;
 
     public ErrorResponseException(String error, String errorDescription, Response.Status status) {
+        super(error, status);
         this.response = null;
         this.error = error;
         this.errorDescription = errorDescription;


### PR DESCRIPTION
Frameworks like Datadog dd-trace-java java agent inspect the known WebApplicationException and mark the exception as an HTTP 500, because that is the default for the non argument constructor.

Closes https://github.com/keycloak/keycloak/issues/29451

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
