### PR TITLE
Fix recovery codes issue #26104

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -100,6 +100,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
 
+import static org.keycloak.authentication.requiredactions.RecoveryAuthnCodesAction.AUTH_NOTE_INITIAL_GENERATED_CODES;
 import static org.keycloak.models.UserModel.RequiredAction.UPDATE_PASSWORD;
 
 /**
@@ -250,7 +251,10 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 attributes.put("totp", totpBean);
                 break;
             case LOGIN_RECOVERY_AUTHN_CODES_CONFIG:
-                attributes.put("recoveryAuthnCodesConfigBean", new RecoveryAuthnCodesBean());
+                RecoveryAuthnCodesBean recoveryCodesBean = new RecoveryAuthnCodesBean();
+                attributes.put("recoveryAuthnCodesConfigBean", recoveryCodesBean);
+                // Store the generated codes in the authentication session
+                authenticationSession.setAuthNote(AUTH_NOTE_INITIAL_GENERATED_CODES, recoveryCodesBean.getGeneratedRecoveryAuthnCodesAsString());
                 break;
             case LOGIN_RECOVERY_AUTHN_CODES_INPUT:
                 attributes.put("recoveryAuthnCodesInputBean", new RecoveryAuthnCodeInputLoginBean(session, realm, user));


### PR DESCRIPTION
### Fix recovery codes issue #26104
This PR addresses issue #26104 where the recovery codes were not properly validated on the server side after being generated.
#### Changes
Added validation logic in RecoveryAuthnCodesAction to ensure that the recovery codes submitted by the user match the codes generated by the server. 
The server-generated codes are recorded in FreeMarkerLoginFormsProvider when generating the codes.

Closes #26104


