### PR TITLE
Fix creating user with non-existent groups using API issue #12640

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -152,7 +152,13 @@ public class UsersResource {
 
             UserResource.updateUserFromRep(profile, user, rep, session, false);
             RepresentationToModel.createFederatedIdentities(rep, session, realm, user);
-            RepresentationToModel.createGroups(session, rep, realm, user);
+            try{
+                RepresentationToModel.createGroups(session, rep, realm, user);
+            }catch (RuntimeException e){
+                if(e.getMessage().contains("Unable to find group specificed by path")){
+                    throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
+                }
+            }
 
             RepresentationToModel.createCredentials(rep, session, realm, user, true);
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), user.getId()).representation(rep).success();


### PR DESCRIPTION
### Fix creating user with non-existent groups using API issue #12640
This PR addresses issue #12640 where creating a user via the REST API with a non-existent group results in an internal server error.
#### Changes:
Now, the non-existent group situation is handled in UsersResource.createUser().

Closes #12640 
