### PR TITLE
Invalid default/options in JavaKeystoreKeyProviderFactory algorithm property

### DIFF
--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
@@ -119,7 +119,9 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
     private static ProviderConfigProperty mergedAlgorithmProperties() {
         List<String> ecAlgorithms = List.of(Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
         List<String> algorithms = Stream.concat(Attributes.RS_ALGORITHM_PROPERTY.getOptions().stream(), ecAlgorithms.stream()).toList();
-        return new ProviderConfigProperty(Attributes.ALGORITHM_KEY, "Algorithm", "Intended algorithm for the key", LIST_TYPE, algorithms.toArray());
+        return new ProviderConfigProperty(Attributes.RS_ALGORITHM_PROPERTY.getName(), Attributes.RS_ALGORITHM_PROPERTY.getLabel(),
+                Attributes.RS_ALGORITHM_PROPERTY.getHelpText(), Attributes.RS_ALGORITHM_PROPERTY.getType(),
+                Attributes.RS_ALGORITHM_PROPERTY.getDefaultValue(), algorithms.toArray(String[]::new));
 
     }
 


### PR DESCRIPTION
Closes #29426

A minor regression issue when EC was added to the java keystore (in 24.0.0). The default value was misconfigured with the options and the options were not passed. So I'm just re-using the same values from the original definition except the options which add the EC values. I have not added a test because it's just the `algorithm` option specification for the provider.

If you think this needs backport to 24.x just let me know.