### PR TITLE
Invalid default/options in JavaKeystoreKeyProviderFactory algorithm property

### DIFF
--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
@@ -119,7 +119,9 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
     private static ProviderConfigProperty mergedAlgorithmProperties() {
         List<String> ecAlgorithms = List.of(Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
         List<String> algorithms = Stream.concat(Attributes.RS_ALGORITHM_PROPERTY.getOptions().stream(), ecAlgorithms.stream()).toList();
-        return new ProviderConfigProperty(Attributes.ALGORITHM_KEY, "Algorithm", "Intended algorithm for the key", LIST_TYPE, algorithms.toArray());
+        return new ProviderConfigProperty(Attributes.RS_ALGORITHM_PROPERTY.getName(), Attributes.RS_ALGORITHM_PROPERTY.getLabel(),
+                Attributes.RS_ALGORITHM_PROPERTY.getHelpText(), Attributes.RS_ALGORITHM_PROPERTY.getType(),
+                Attributes.RS_ALGORITHM_PROPERTY.getDefaultValue(), algorithms.toArray(String[]::new));
 
     }
 


### PR DESCRIPTION
Closes #29426

Backport for 24.
PR:             https://github.com/keycloak/keycloak/pull/29747
Commit:         https://github.com/keycloak/keycloak/commit/9dfaab6d821e33500600c937e1465b5123ade17a
PR branch:      backport-29747-24.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/24.0

