### PR TITLE
Enable hibernate statistics logging

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -10,6 +10,12 @@ public class DatabaseOptions {
             .buildTime(true)
             .build();
 
+    public static final Option<Boolean> DB_LOG_HIBERNATE_STATISTICS = new OptionBuilder<>("db-log-statistics", Boolean.class)
+            .category(OptionCategory.DATABASE)
+            .defaultValue(Boolean.FALSE)
+            .description("Enable Hibernate statistics gathering and logging.")
+            .build();
+
     public static final Option<String> DB_DRIVER = new OptionBuilder<>("db-driver", String.class)
             .category(OptionCategory.DATABASE)
             .description("The fully qualified class name of the JDBC driver. If not set, a default driver is set accordingly to the chosen database.")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -50,6 +50,7 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.TruststoreOptions;
 import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderFactory;
@@ -64,6 +65,8 @@ import org.keycloak.theme.ClasspathThemeProviderFactory;
 import org.keycloak.truststore.TruststoreBuilder;
 import org.keycloak.userprofile.DeclarativeUserProfileProviderFactory;
 
+import static org.hibernate.cfg.SessionEventSettings.LOG_SESSION_METRICS;
+import static org.hibernate.cfg.StatisticsSettings.GENERATE_STATISTICS;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getKcConfigValue;
 
 @Recorder
@@ -192,6 +195,11 @@ public class KeycloakRecorder {
             @Override
             public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
                 propertyCollector.accept(AvailableSettings.DEFAULT_SCHEMA, Configuration.getRawValue("kc.db-schema"));
+
+                if (Configuration.isTrue(DatabaseOptions.DB_LOG_HIBERNATE_STATISTICS)) {
+                    propertyCollector.accept(GENERATE_STATISTICS, Boolean.TRUE.toString());
+                    propertyCollector.accept(LOG_SESSION_METRICS, Boolean.TRUE.toString());
+                }
             }
         };
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -22,6 +22,8 @@ final class DatabasePropertyMappers {
                         .mapFrom("db")
                         .transformer(DatabasePropertyMappers::transformDialect)
                         .build(),
+                fromOption(DatabaseOptions.DB_LOG_HIBERNATE_STATISTICS)
+                        .build(),
                 fromOption(DatabaseOptions.DB_DRIVER)
                         .mapFrom("db")
                         .to("quarkus.datasource.jdbc.driver")

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -476,6 +476,15 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void testDatabaseStatisticsLogging() {
+        ConfigArgsConfigSource.setCliArgs("");
+        assertEquals("false", createConfig().getRawValue("kc.db-log-statistics"));
+
+        ConfigArgsConfigSource.setCliArgs("--db-log-statistics=true");
+        assertEquals("true", createConfig().getRawValue("kc.db-log-statistics"));
+    }
+
+    @Test
     public void testTransactionTypeChangesDriver() {
         ConfigArgsConfigSource.setCliArgs("--db=mssql", "--transaction-xa-enabled=false");
         assertTrue(System.getProperty(CLI_ARGS, "").contains("mssql"));


### PR DESCRIPTION
Add hibernate.generate_statistics and hibernate.session.events.log to the ParsedPersistenceXmlDescriptor from the Java system properties

Closes #29786

