### PR TITLE
Fix oid4vc mappers

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -373,11 +373,15 @@ public class OID4VCIssuerEndpoint {
 
         Map<String, Object> subjectClaims = new HashMap<>();
         protocolMappers
+                .stream()
+                .filter(mapper -> mapper.isTypeSupported(vcType))
                 .forEach(mapper -> mapper.setClaimsForSubject(subjectClaims, userSessionModel));
 
         subjectClaims.forEach((key, value) -> vc.getCredentialSubject().setClaims(key, value));
 
         protocolMappers
+                .stream()
+                .filter(mapper -> mapper.isTypeSupported(vcType))
                 .forEach(mapper -> mapper.setClaimsForCredential(vc, userSessionModel));
 
         LOGGER.debugf("The credential to sign is: %s", vc);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -335,6 +335,7 @@ public class OID4VCIssuerEndpointTest extends OID4VCTest {
     @Test
     public void testRequestCredential() {
         String token = getBearerToken(oauth);
+        ObjectMapper objectMapper = new ObjectMapper();
         testingClient
                 .server(TEST_REALM_NAME)
                 .run((session -> {
@@ -352,8 +353,7 @@ public class OID4VCIssuerEndpointTest extends OID4VCTest {
 
                     assertNotNull("A valid credential string should have been responded", jsonWebToken);
                     assertNotNull("The credentials should be included at the vc-claim.", jsonWebToken.getOtherClaims().get("vc"));
-                    VerifiableCredential credential = new ObjectMapper().convertValue(jsonWebToken.getOtherClaims().get("vc"), VerifiableCredential.class);
-                    log.warnf("The subject is %s", new ObjectMapper().writeValueAsString(credential.getCredentialSubject()));
+                    VerifiableCredential credential = objectMapper.convertValue(jsonWebToken.getOtherClaims().get("vc"), VerifiableCredential.class);
                     assertTrue("The static claim should be set.", credential.getCredentialSubject().getClaims().containsKey("VerifiableCredential"));
                     assertFalse("Only mappers supported for the requested type should have been evaluated.", credential.getCredentialSubject().getClaims().containsKey("AnotherCredentialType"));
                 }));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -76,7 +76,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -487,6 +486,8 @@ public class OID4VCIssuerEndpointTest extends OID4VCTest {
         assertEquals(List.of("VerifiableCredential"), credential.getType());
         assertEquals(URI.create("did:web:test.org"), credential.getIssuer());
         assertEquals("john@email.cz", credential.getCredentialSubject().getClaims().get("email"));
+        assertTrue("The static claim should be set.", credential.getCredentialSubject().getClaims().containsKey("VerifiableCredential"));
+        assertFalse("Only mappers supported for the requested type should have been evaluated.", credential.getCredentialSubject().getClaims().containsKey("AnotherCredentialType"));
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -353,7 +353,7 @@ public class OID4VCIssuerEndpointTest extends OID4VCTest {
                     assertNotNull("A valid credential string should have been responded", jsonWebToken);
                     assertNotNull("The credentials should be included at the vc-claim.", jsonWebToken.getOtherClaims().get("vc"));
                     VerifiableCredential credential = new ObjectMapper().convertValue(jsonWebToken.getOtherClaims().get("vc"), VerifiableCredential.class);
-
+                    log.warnf("The subject is %s", new ObjectMapper().writeValueAsString(credential.getCredentialSubject()));
                     assertTrue("The static claim should be set.", credential.getCredentialSubject().getClaims().containsKey("VerifiableCredential"));
                     assertFalse("Only mappers supported for the requested type should have been evaluated.", credential.getCredentialSubject().getClaims().containsKey("AnotherCredentialType"));
                 }));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -349,8 +349,13 @@ public class OID4VCIssuerEndpointTest extends OID4VCTest {
                     assertNotNull("A credential should be responded.", credentialResponse.getEntity());
                     CredentialResponse credentialResponseVO = OBJECT_MAPPER.convertValue(credentialResponse.getEntity(), CredentialResponse.class);
                     JsonWebToken jsonWebToken = TokenVerifier.create((String) credentialResponseVO.getCredential(), JsonWebToken.class).getToken();
-                    // correct signing and contents are verified in the JwtSigningServiceTest, thus we only check that it is a JWT
+
                     assertNotNull("A valid credential string should have been responded", jsonWebToken);
+                    assertNotNull("The credentials should be included at the vc-claim.", jsonWebToken.getOtherClaims().get("vc"));
+                    VerifiableCredential credential = new ObjectMapper().convertValue(jsonWebToken.getOtherClaims().get("vc"), VerifiableCredential.class);
+
+                    assertTrue("The static claim should be set.", credential.getCredentialSubject().getClaims().containsKey("VerifiableCredential"));
+                    assertFalse("Only mappers supported for the requested type should have been evaluated.", credential.getCredentialSubject().getClaims().containsKey("AnotherCredentialType"));
                 }));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
@@ -263,7 +263,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
         protocolMapperRepresentation.setConfig(
                 Map.of(
                         "subjectProperty", supportedType,
-                        "subjectValue", "true",
+                        "staticValue", "true",
                         "supportedCredentialTypes", supportedType)
         );
         return protocolMapperRepresentation;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
@@ -256,7 +256,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 
     public static ProtocolMapperRepresentation getStaticClaimMapper(String supportedType) {
         ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
-        protocolMapperRepresentation.setName("static-mapper");
+        protocolMapperRepresentation.setName(UUID.randomUUID().toString());
         protocolMapperRepresentation.setProtocol("oid4vc");
         protocolMapperRepresentation.setId(UUID.randomUUID().toString());
         protocolMapperRepresentation.setProtocolMapper("oid4vc-static-claim-mapper");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
@@ -188,7 +188,8 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
                         getRoleMapper(clientId),
                         getEmailMapper(),
                         getIdMapper(),
-                        getStaticClaimMapper()
+                        getStaticClaimMapper("VerifiableCredential"),
+                        getStaticClaimMapper("AnotherCredentialType")
                 )
         );
         return clientRepresentation;
@@ -253,7 +254,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
         return protocolMapperRepresentation;
     }
 
-    public static ProtocolMapperRepresentation getStaticClaimMapper() {
+    public static ProtocolMapperRepresentation getStaticClaimMapper(String supportedType) {
         ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
         protocolMapperRepresentation.setName("static-mapper");
         protocolMapperRepresentation.setProtocol("oid4vc");
@@ -261,9 +262,9 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
         protocolMapperRepresentation.setProtocolMapper("oid4vc-static-claim-mapper");
         protocolMapperRepresentation.setConfig(
                 Map.of(
-                        "subjectProperty", "static",
-                        "subjectValue", "Value",
-                        "supportedCredentialTypes", "VerifiableCredential")
+                        "subjectProperty", supportedType,
+                        "subjectValue", "true",
+                        "supportedCredentialTypes", supportedType)
         );
         return protocolMapperRepresentation;
     }


### PR DESCRIPTION
Evaluates the supportedTypes of the OID4VC mapper config.
Fixes #29805 