### PR TITLE
Generate RESTART_AUTHENTICATION event on success

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -236,6 +236,10 @@ public class LoginActionsService {
             return checks.getResponse();
         }
 
+        event.user(authSession.getAuthenticatedUser());
+        event.detail(Details.USERNAME, authSession.getAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME));
+        event.detail(Details.AUTH_METHOD, authSession.getProtocol());
+
         String flowPath = authSession.getClientNote(AuthorizationEndpointBase.APP_INITIATED_FLOW);
         if (flowPath == null) {
             flowPath = AUTHENTICATE_PATH;
@@ -256,6 +260,7 @@ public class LoginActionsService {
 
         URI redirectUri = getLastExecutionUrl(flowPath, null, authSession.getClient().getClientId(), authSession.getTabId(), AuthenticationProcessor.getClientData(session, authSession));
         logger.debugf("Flow restart requested. Redirecting to %s", redirectUri);
+        event.success();
         return Response.status(Response.Status.FOUND).location(redirectUri).build();
     }
 


### PR DESCRIPTION
Closes #29385

Little PR to generate the RESTART_AUTHENTICATION event when success. It was not generated before. I added details for the attempted username and protocol, if you think some other detail is needed just let me know. Restart test modified to check the event is generated.