### PR TITLE
MigrateTo25_0_0 does not complete within default transaction timeout

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -1455,6 +1455,16 @@ public class RealmCacheSession implements CacheRealmProvider {
         return assignedScopes;
     }
 
+    @Override
+    public void addClientScopeToAllClients(RealmModel realm, ClientScopeModel clientScope, boolean defaultClientScope) {
+        getClientDelegate().addClientScopeToAllClients(realm, clientScope, defaultClientScope);
+
+        // This will make sure to all invalidate all clients dependent on clientScope
+        listInvalidations.add(realm.getId());
+        cache.clientScopeRemoval(realm.getId(), invalidations);
+        invalidationEvents.add(ClientScopeRemovedEvent.create(clientScope.getId(), realm.getId()));
+    }
+
     // Don't cache ClientInitialAccessModel for now
     @Override
     public ClientInitialAccessModel createClientInitialAccessModel(RealmModel realm, int expiration, int count) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -1094,6 +1094,18 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     }
 
     @Override
+    public void addClientScopeToAllClients(RealmModel realm, ClientScopeModel clientScope, boolean defaultClientScope) {
+        if (realm.equals(clientScope.getRealm())) {
+            em.createNamedQuery("addClientScopeToAllClients")
+                    .setParameter("realmId", realm.getId())
+                    .setParameter("clientScopeId", clientScope.getId())
+                    .setParameter("clientProtocol", clientScope.getProtocol())
+                    .setParameter("defaultScope", defaultClientScope)
+                    .executeUpdate();
+        }
+    }
+
+    @Override
     public Map<String, ClientScopeModel> getClientScopes(RealmModel realm, ClientModel client, boolean defaultScope) {
         // Defaults to openid-connect
         String clientProtocol = client.getProtocol() == null ? OIDCLoginProtocol.LOGIN_PROTOCOL : client.getProtocol();

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientScopeClientMappingEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientScopeClientMappingEntity.java
@@ -36,7 +36,8 @@ import jakarta.persistence.Table;
         @NamedQuery(name="clientScopeClientMappingIdsByClient", query="select m.clientScopeId from ClientScopeClientMappingEntity m where m.clientId = :clientId and m.defaultScope = :defaultScope"),
         @NamedQuery(name="deleteClientScopeClientMapping", query="delete from ClientScopeClientMappingEntity where clientId = :clientId and clientScopeId = :clientScopeId"),
         @NamedQuery(name="deleteClientScopeClientMappingByClient", query="delete from ClientScopeClientMappingEntity where clientId = :clientId"),
-        @NamedQuery(name="deleteClientScopeClientMappingByClientScope", query="delete from ClientScopeClientMappingEntity where clientScopeId = :clientScopeId")
+        @NamedQuery(name="deleteClientScopeClientMappingByClientScope", query="delete from ClientScopeClientMappingEntity where clientScopeId = :clientScopeId"),
+        @NamedQuery(name="addClientScopeToAllClients", query="insert into ClientScopeClientMappingEntity (clientScopeId, defaultScope, clientId) select :clientScopeId, :defaultScope, client.id from ClientEntity client where client.realmId = :realmId and client.bearerOnly <> true and client.protocol = :clientProtocol")
 })
 @Entity
 @Table(name="CLIENT_SCOPE_CLIENT")

--- a/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo25_0_0.java
+++ b/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo25_0_0.java
@@ -56,11 +56,14 @@ public class MigrateTo25_0_0 implements Migration {
     protected void migrateRealm(KeycloakSession session, RealmModel realm) {
         MigrationProvider migrationProvider = session.getProvider(MigrationProvider.class);
 
-        // create 'basic' client scope in the realm.
-        ClientScopeModel basicScope = migrationProvider.addOIDCBasicClientScope(realm);
+        ClientScopeModel basicScope = KeycloakModelUtils.getClientScopeByName(realm, "basic");
+        if (basicScope == null) {
+            // create 'basic' client scope in the realm.
+            basicScope = migrationProvider.addOIDCBasicClientScope(realm);
 
-        //add basic scope to existing clients
-        realm.getClientsStream().forEach(c-> c.addClientScope(basicScope, true));
+            //add basic scope to all existing OIDC clients
+            session.clients().addClientScopeToAllClients(realm, basicScope, true);
+        }
 
         // offer a migration for persistent user sessions which was added in KC25
         session.sessions().migrate(VERSION.toString());

--- a/model/storage-private/src/main/java/org/keycloak/storage/ClientStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/ClientStorageManager.java
@@ -274,6 +274,11 @@ public class ClientStorageManager implements ClientProvider {
     }
 
     @Override
+    public void addClientScopeToAllClients(RealmModel realm, ClientScopeModel clientScope, boolean defaultClientScope) {
+        localStorage().addClientScopeToAllClients(realm, clientScope, defaultClientScope);
+    }
+
+    @Override
     public Map<ClientModel, Set<String>> getAllRedirectUrisOfEnabledClients(RealmModel realm) {
         return localStorage().getAllRedirectUrisOfEnabledClients(realm);
     }

--- a/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
@@ -125,6 +125,15 @@ public interface ClientProvider extends ClientLookupProvider, Provider {
     void removeClientScope(RealmModel realm, ClientModel client, ClientScopeModel clientScope);
 
     /**
+     * Add specified client scope to all non bearer-only clients in the realm, which have same protocol as specified client scope
+     *
+     * @param realm Realm
+     * @param clientScope client scope from the specified realm, which would be added to all clients
+     * @param defaultClientScope If true, then it will be added as "default" client scope. If false, then it will be added as "optional" client scope
+     */
+    void addClientScopeToAllClients(RealmModel realm, ClientScopeModel clientScope, boolean defaultClientScope);
+
+    /**
      * Returns a map of (rootUrl, {validRedirectUris}) for all enabled clients.
      * @param realm
      * @return


### PR DESCRIPTION
closes #29756

- PR introduces new method on `ClientProvider` interface `addClientScopeToAllClients` to add the specified client scope to all clients of same protocol, which are not bearerOnly clients. This use-case of adding clientScope to all clients can often happen during migration and hence can be good to have more effective method in the model (In the past, we also iterated over all clients, but now there are deployments with bigger number of clients and hence iterating over all clients is ideally something to avoid).

- Tested with realm with 5000 clients and with MySQL DB.
Migration time on my laptop before the fix: 281 seconds
Migration time on my laptop after the fix: 2 seconds 

- Cache layer: Adding clientScope must invalidate all clients from the cache. During initial migration, there are no clients in the cache anyway, but still, should be invalidated properly when calling this.

