### PR TITLE
Temporarily disable Snyk

### DIFF
--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -33,7 +33,7 @@ jobs:
         - documentation.yml
         - js-ci.yml
         - operator-ci.yml
-        - snyk-analysis.yml
+       #- snyk-analysis.yml
         - trivy-analysis.yml
 
     steps:


### PR DESCRIPTION
The Snyk job is temporarily disabled, to prevent the failure of other nightly builds it is also required to comment the line where Snyk is refered.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
