### PR TITLE
Fix: Corrected media type/format string for SD-JWT-VC

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/Format.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/Format.java
@@ -40,7 +40,7 @@ public enum Format {
     /**
      * SD-JWT-Credentials {@see https://drafts.oauth.net/oauth-sd-jwt-vc/draft-ietf-oauth-sd-jwt-vc.html}
      */
-    SD_JWT_VC("sd-jwt_vc");
+    SD_JWT_VC("vc+sd-jwt");
 
     private String value;
 


### PR DESCRIPTION
This commit fixes the incorrect media type/format string for SD-JWT-VC by updating the relevant string constant in the Format class.

closes: #29620
