### PR TITLE
Ignore unused optional NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,32 @@
     "typescript-eslint": "^7.10.0",
     "wireit": "^0.14.4"
   },
+  "pnpm": {
+    "ignoredOptionalDependencies": [
+      "@types/c3",
+      "bootstrap-datepicker",
+      "bootstrap-sass",
+      "bootstrap-select",
+      "bootstrap-slider",
+      "bootstrap-switch",
+      "bootstrap-touchspin",
+      "c3",
+      "d3",
+      "datatables.net",
+      "datatables.net-colreorder",
+      "datatables.net-colreorder-bs",
+      "datatables.net-select",
+      "drmonty-datatables-colvis",
+      "eonasdan-bootstrap-datetimepicker",
+      "font-awesome-sass",
+      "google-code-prettify",
+      "jquery-match-height",
+      "moment",
+      "moment-timezone",
+      "patternfly-bootstrap-combobox",
+      "patternfly-bootstrap-treeview"
+    ]
+  },
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1466,41 +1466,20 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/c3@0.6.4':
-    resolution: {integrity: sha512-W7i7oSmHsXYhseZJsIYexelv9HitGsWdQhx3mcy4NWso+GedpCYr02ghpkNvnZ4oTIjNeISdrOnM70s7HiuV+g==}
-
   '@types/chai@4.3.16':
     resolution: {integrity: sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==}
-
-  '@types/d3-array@1.2.12':
-    resolution: {integrity: sha512-zIq9wCg/JO7MGC6vq3HRDaVYkqgSPIDjpo3JhAQxl7PHYVPA5D9SMiBfjW/ZoAvPd2a+rkovqBg0nS0QOChsJQ==}
 
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
-  '@types/d3-axis@1.0.19':
-    resolution: {integrity: sha512-rXxE2jJYv6kar/6YWS8rM0weY+jjvnJvBxHKrIUqt3Yzomrfbf5tncpKG6jq6Aaw6TZyBcb1bxEWc0zGzcmbiw==}
-
   '@types/d3-axis@3.0.6':
     resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
-
-  '@types/d3-brush@1.1.8':
-    resolution: {integrity: sha512-tPVjYAjJt02fgazF9yiX/309sj6qhIiIopLuHhP4FFFq9VKqu9NQBeCK3ger0RHVZGs9RKaSBUWyPUzii5biGQ==}
 
   '@types/d3-brush@3.0.6':
     resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
 
-  '@types/d3-chord@1.0.14':
-    resolution: {integrity: sha512-W9rCIbSAhwtmydW5iGg9dwTQIi3SGBOh68/T3ke3PyOgejuSLozmtAMaWNViGaGJCeuM4aFJHTUHQvMedl4ugA==}
-
   '@types/d3-chord@3.0.6':
     resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
-
-  '@types/d3-collection@1.0.13':
-    resolution: {integrity: sha512-v0Rgw3IZebRyamcwVmtTDCZ8OmQcj4siaYjNc7wGMZT7PmdSHawGsCOQMxyLvZ7lWjfohYLK0oXtilMOMgfY8A==}
-
-  '@types/d3-color@1.4.5':
-    resolution: {integrity: sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g==}
 
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
@@ -1511,26 +1490,14 @@ packages:
   '@types/d3-delaunay@6.0.4':
     resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
 
-  '@types/d3-dispatch@1.0.12':
-    resolution: {integrity: sha512-vrhleoVNhGJGx7GQZ4207lYGyMbW/yj/iJTSvLKyfAp8nXFF+19dnMpPN/nEVs6fudIsQc7ZelBFUMe3aJDmKw==}
-
   '@types/d3-dispatch@3.0.6':
     resolution: {integrity: sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==}
-
-  '@types/d3-drag@1.2.8':
-    resolution: {integrity: sha512-QM6H8E6r9/51BcE4NEluQ0f9dTECCTDEALJSQIWn183+Mtz/6KvEjOxW8VzKYSnhhL+qMljMKKA1WOUUf/4Qhw==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
-  '@types/d3-dsv@1.2.8':
-    resolution: {integrity: sha512-x1m1s0lVstZQ5/Kzp4bVIMee3fFuDm+hphVnvrYA7wU16XqwgbCBfeVvHYZzVQQIy4jyi3MEtgduLVuwIRCKLQ==}
-
   '@types/d3-dsv@3.0.7':
     resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
-
-  '@types/d3-ease@1.0.13':
-    resolution: {integrity: sha512-VAA4H8YNaNN0+UNIlpkwkLOj7xL5EGdyiQpdlAvOIRHckjGFCLK8eMoUd4+IMNEhQgweq0Yk/Dfzr70xhUo6hA==}
 
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
@@ -1538,122 +1505,59 @@ packages:
   '@types/d3-fetch@3.0.7':
     resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
 
-  '@types/d3-force@1.2.7':
-    resolution: {integrity: sha512-zySqZfnxn67RVEGWzpD9dQA0AbNIp4Rj0qGvAuUdUNfGLrwuGCbEGAGze5hEdNaHJKQT2gTqr6j+qAzncm11ew==}
-
   '@types/d3-force@3.0.9':
     resolution: {integrity: sha512-IKtvyFdb4Q0LWna6ymywQsEYjK/94SGhPrMfEr1TIc5OBeziTi+1jcCvttts8e0UWZIxpasjnQk9MNk/3iS+kA==}
-
-  '@types/d3-format@1.4.5':
-    resolution: {integrity: sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==}
 
   '@types/d3-format@3.0.4':
     resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
 
-  '@types/d3-geo@1.12.7':
-    resolution: {integrity: sha512-QetZrWWjuMfCe0BHLjD+dOThlgk7YGZ2gj+yhFAbDN5TularNBEQiBs5/CIgX0+IBDjt7/fbkDd5V70J1LjjKA==}
-
   '@types/d3-geo@3.1.0':
     resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
-
-  '@types/d3-hierarchy@1.1.11':
-    resolution: {integrity: sha512-lnQiU7jV+Gyk9oQYk0GGYccuexmQPTp08E0+4BidgFdiJivjEvf+esPSdZqCZ2C7UwTWejWpqetVaU8A+eX3FA==}
 
   '@types/d3-hierarchy@3.1.7':
     resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
-  '@types/d3-interpolate@1.4.5':
-    resolution: {integrity: sha512-k9L18hXXv7OvK4PqW1kSFYIzasGOvfhPUWmHFkoZ8/ci99EAmY4HoF6zMefrHl0SGV7XYc7Qq2MNh8dK3edg5A==}
-
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
-
-  '@types/d3-path@1.0.11':
-    resolution: {integrity: sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==}
 
   '@types/d3-path@3.1.0':
     resolution: {integrity: sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==}
 
-  '@types/d3-polygon@1.0.10':
-    resolution: {integrity: sha512-+hbHsFdCMs23vk9p/SpvIkHkCpl0vxkP2qWR2vEk0wRi0BXODWgB/6aHnfrz/BeQnk20XzZiQJIZ+11TGxuYMQ==}
-
   '@types/d3-polygon@3.0.2':
     resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
-
-  '@types/d3-quadtree@1.0.13':
-    resolution: {integrity: sha512-BAQD6gTHnXqmI7JRhXwM2pEYJJF27AT1f6zCC192BKAUhigzd5HZjdje5ufRXmYcUM/fr2IJ9KqVMeXaljmmOw==}
 
   '@types/d3-quadtree@3.0.6':
     resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
 
-  '@types/d3-queue@3.0.10':
-    resolution: {integrity: sha512-kYb7UeXKaOWJIkPx1Rx79+D/3wx69XXpkQ8+MWctAu4CUTdVnSOF/AKqC9bgf42sDuL1Fj0eeQSyU62HRqRHWg==}
-
-  '@types/d3-random@1.1.5':
-    resolution: {integrity: sha512-gB5CR+7xYMj56pt5zmSyDBjTNMEy96PdfUb2qBaAT9bmPcf4P/YHfhhTI5y8JoiqaSRLJY+3mqtaE9loBgB6Ng==}
-
   '@types/d3-random@3.0.3':
     resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
-
-  '@types/d3-request@1.0.9':
-    resolution: {integrity: sha512-gD2991YKzdQu5lJGhWHEjptxQvWRZKwZF3QdWqjnqrWfVd15e7/WuL6X2Pl/4sRyLKaXWbB2xuk1tSBPVLlNhg==}
 
   '@types/d3-scale-chromatic@3.0.3':
     resolution: {integrity: sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw==}
 
-  '@types/d3-scale@1.0.22':
-    resolution: {integrity: sha512-9XHVg/pVr+4qbowUNKHYNouFCXQUQ0ZZr1ppGgh10DVUaEb6nKuyPj0May0mmTiLhuDEaa9di1t0Hmg6lYTSFw==}
-
   '@types/d3-scale@4.0.8':
     resolution: {integrity: sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==}
-
-  '@types/d3-selection@1.4.6':
-    resolution: {integrity: sha512-0MhJ/LzJe6/vQVxiYJnvNq5CD/MF6Qy0dLp4BEQ6Dz8oOaB0EMXfx1GGeBFSW+3VzgjaUrxK6uECDQj9VLa/Mg==}
 
   '@types/d3-selection@3.0.10':
     resolution: {integrity: sha512-cuHoUgS/V3hLdjJOLTT691+G2QoqAjCVLmr4kJXR4ha56w1Zdu8UUQ5TxLRqudgNjwXeQxKMq4j+lyf9sWuslg==}
 
-  '@types/d3-shape@1.3.12':
-    resolution: {integrity: sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==}
-
   '@types/d3-shape@3.1.6':
     resolution: {integrity: sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==}
-
-  '@types/d3-time-format@2.3.4':
-    resolution: {integrity: sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==}
 
   '@types/d3-time-format@4.0.3':
     resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
 
-  '@types/d3-time@1.1.4':
-    resolution: {integrity: sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==}
-
   '@types/d3-time@3.0.3':
     resolution: {integrity: sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==}
-
-  '@types/d3-timer@1.0.12':
-    resolution: {integrity: sha512-Tv9tkA4y3UvGQnrHyYAQhf5x/297FuYwotS4UW2TpwLblvRahbyL8r9HFYTJLPfPRqS63hwlqRItjKGmKtJxNg==}
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
-  '@types/d3-transition@1.3.5':
-    resolution: {integrity: sha512-gVj9AXXkoj0yKr1jsPJFkKoYTEmSdaYh8W7XBeRIhcspFX9b3MSwLxTerVHeEPXer9kYLvZfAINk8HcjWhwZSQ==}
-
   '@types/d3-transition@3.0.8':
     resolution: {integrity: sha512-ew63aJfQ/ms7QQ4X7pk5NxQ9fZH/z+i24ZfJ6tJSfqxJMrYLiK01EAs2/Rtw/JreGUsS3pLPNV644qXFGnoZNQ==}
 
-  '@types/d3-voronoi@1.1.12':
-    resolution: {integrity: sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==}
-
-  '@types/d3-zoom@1.8.7':
-    resolution: {integrity: sha512-HJWci3jXwFIuFKDqGn5PmuwrhZvuFdrnUmtSKCLXFAWyf2lAIUKMKh1/lHOkWBl/f4KVupGricJiqkQy+cVTog==}
-
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
-
-  '@types/d3@4.13.15':
-    resolution: {integrity: sha512-D1yRBsDCC8BBUHfl7DHfEXAX1+RkwdmrwTSMB+dhCPuzIyj4dc3b+fkKnvMWj7tqx3YeoM/QsZnZ13IkkbhTUw==}
 
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
@@ -2078,27 +1982,6 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  bootstrap-datepicker@1.10.0:
-    resolution: {integrity: sha512-lWxtSYddAQOpbAO8UhYhHLcK6425eWoSjb5JDvZU3ePHEPF6A3eUr51WKaFy4PccU19JRxUG6wEU3KdhtKfvpg==}
-
-  bootstrap-sass@3.4.3:
-    resolution: {integrity: sha512-vPgFnGMp1jWZZupOND65WS6mkR8rxhJxndT/AcMbqcq1hHMdkcH4sMPhznLzzoHOHkSCrd6J9F8pWBriPCKP2Q==}
-
-  bootstrap-select@1.12.2:
-    resolution: {integrity: sha512-Fj1VstB55LigEEYQb6ZOi/ok+uaqnslRxS8Qo9Q+F46WWDhhXAeNpjBhjEMlxQjPs9yqYZf2hf/mxVRWab8sow==}
-
-  bootstrap-slider@9.10.0:
-    resolution: {integrity: sha512-a9MtENtt4r3ttPW5mpIpOFmCaIsm37EGukOgw5cfHlxKvsUSN8AN9JtwKrKuqgEnxs86kUSsMvMn8kqewMorKw==}
-
-  bootstrap-switch@3.3.4:
-    resolution: {integrity: sha512-7YQo+Ir6gCUqC36FFp1Zvec5dRF/+obq+1drMtdIMi9Xc84Kx63Evi0kdcp4HfiGsZpiz6IskyYDNlSKcxsL7w==}
-    peerDependencies:
-      bootstrap: ^3.1.1
-      jquery: '>=1.9.0'
-
-  bootstrap-touchspin@3.1.1:
-    resolution: {integrity: sha512-o5pgzdr8Ma5hQKS3JE1uNq/jkx8qCG+KhJXSlvYCmX2wTxva2sS2Kq3idGN+tP5e1bZJQgkbqwP9TdEEx+R+6Q==}
-
   bootstrap@3.4.1:
     resolution: {integrity: sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==}
     engines: {node: '>=6'}
@@ -2140,9 +2023,6 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
-
-  c3@0.4.24:
-    resolution: {integrity: sha512-mVCFtN5ZWUT5UE7ilFQ7KBQ7TUCdKIq6KsDt1hH/1m6gC1tBjvzFTO7fqhaiWHfhNOjjM7makschdhg6DkWQMA==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2401,9 +2281,6 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
-  d3@3.5.17:
-    resolution: {integrity: sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg==}
-
   dagre@0.8.5:
     resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
 
@@ -2426,24 +2303,6 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
-
-  datatables.net-bs@2.0.7:
-    resolution: {integrity: sha512-e6IXGcLKDxGzUNIKiJaSa7yIDIIaDK8QcF8letCPHyEHWfmYlENEvfGNFOUAL6JOnZodbIIc5XDI/9K1PcEzHg==}
-
-  datatables.net-colreorder-bs@1.3.3:
-    resolution: {integrity: sha512-+DPim/DhbSIqr2rhRvYNrAMFNZgl372PiKEAv5YeyjYMzc8+6kX8Vinpb3Bg0PDgEdPqEWqJ6H18pBCKhXppgg==}
-
-  datatables.net-colreorder@1.7.2:
-    resolution: {integrity: sha512-F8TYMFXtWLtsjciwS7hkP/Fbp3XS6WHuHLc+iMFtQqiQmbMo/59GK7YSxKuxSoqTTJU/opaPXQYjODnIuNEc/g==}
-
-  datatables.net-select@1.2.7:
-    resolution: {integrity: sha512-C3XDi7wpruGjDXV36dc9hN/FrAX9GOFvBZ7+KfKJTBNkGFbbhdzHS91SMeGiwRXPYivAyxfPTcVVndVaO83uBQ==}
-
-  datatables.net@1.13.11:
-    resolution: {integrity: sha512-AE6RkMXziRaqzPcu/pl3SJXeRa6fmXQG/fVjuRESujvkzqDCYEeKTTpPMuVJSGYJpPi32WGSphVNNY1G4nSN/g==}
-
-  datatables.net@2.0.7:
-    resolution: {integrity: sha512-cyW+HZwkMzb4bLrao/SS9/i64ZHiw5nYhXl+OwuOPgddG+R9O11iOEke8wYsdiyOQmjv2mE6xkEmRMZwHZc8zw==}
 
   dayjs@1.11.11:
     resolution: {integrity: sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==}
@@ -2589,9 +2448,6 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  drmonty-datatables-colvis@1.1.2:
-    resolution: {integrity: sha512-1kL4fbsBEkQQTl83eQ8G/vRGcCiM6Hn3O8Tp473tG4YSsBDcxETDDSxb8qC+fQjHZ3jUCptWj3lG/L8rI6NBNw==}
-
   duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
 
@@ -2624,14 +2480,6 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-
-  eonasdan-bootstrap-datetimepicker@4.17.49:
-    resolution: {integrity: sha512-7KZeDpkj+A6AtPR3XjX8gAnRPUkPSfW0OmMANG1dkUOPMtLSzbyoCjDIdEcfRtQPU5X0D9Gob7wWKn0h4QWy7A==}
-    peerDependencies:
-      bootstrap: ^3.3
-      jquery: ^1.8.3 || ^2.0 || ^3.0
-      moment: ^2.10
-      moment-timezone: ^0.4.0 || ^0.5.0
 
   es-abstract@1.23.3:
     resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
@@ -2925,9 +2773,6 @@ packages:
   focus-trap@7.5.2:
     resolution: {integrity: sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==}
 
-  font-awesome-sass@4.7.0:
-    resolution: {integrity: sha512-apO2Nw3XP/Zv7fLxa+MnPnvJ/GdkH6qWrLrtN5oQrFL7RPprzHKROjN94jgyoxM+T7PQBhY9F/SwOKbBaLyXxg==}
-
   font-awesome@4.7.0:
     resolution: {integrity: sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==}
     engines: {node: '>=0.10.3'}
@@ -3073,9 +2918,6 @@ packages:
     resolution: {integrity: sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==}
     engines: {node: '>=0.6.0'}
     hasBin: true
-
-  google-code-prettify@1.0.5:
-    resolution: {integrity: sha512-Y47Bw63zJKCuqTuhTZC1ct4e/0ADuMssxXhnrP8QHq71tE2aYBKG6wQwXr8zya0zIUd0mKN3XTlI5AME4qm6NQ==}
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -3417,9 +3259,6 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  jquery-match-height@0.7.2:
-    resolution: {integrity: sha512-qSyC0GBc4zUlgBcxfyyumJSVUm50T6XuJEIz59cKaI28VXMUT95mZ6KiIjhMIMbG8IiJhh65FtQO1XD42TAcwg==}
-
   jquery@3.4.1:
     resolution: {integrity: sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==}
 
@@ -3747,12 +3586,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  moment-timezone@0.4.1:
-    resolution: {integrity: sha512-5cNPVUwaVJDCe9JM8m/qz17f9SkaI8rpnRUyDJi2K5HAd6EwhuQ3n5nLclZkNC/qJnomKgQH2TIu70Gy2dxFKA==}
-
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
-
   monaco-editor@0.49.0:
     resolution: {integrity: sha512-2I8/T3X/hLxB2oPHgqcNYUVdA/ZEFShT7IAujifIPMfKkNbLOqY8XCoyHCXrsdjb36dW9MwoTwBCFpXKMwNwaQ==}
 
@@ -3922,13 +3755,6 @@ packages:
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
-
-  patternfly-bootstrap-combobox@1.1.7:
-    resolution: {integrity: sha512-6KptS6UnS8jOwLuqsjokiNUYjOf3G4bSahiSHhkQMdfvG0b4sZkUgOFWdMJ8zBXaZGVe8T324GQoXqiJdJxMuw==}
-
-  patternfly-bootstrap-treeview@2.1.10:
-    resolution: {integrity: sha512-P9+iFu34CwX+R5Fd7/EWbxTug0q9mDj53PnZIIh5ie54KX2kD0+54lCWtpD9SVylDwDtDv3n3A6gbFVkx7HsuA==}
-    engines: {node: '>= 0.10.0'}
 
   patternfly@3.59.5:
     resolution: {integrity: sha512-SMQynv9eFrWWG0Ujta5+jPjxHdQB3xkTLiDW5VP8XXc0nGUxXb4EnZh21qiMeGGJYaKpu9CzaPEpCvuBxgYWHQ==}
@@ -5095,6 +4921,30 @@ packages:
       react:
         optional: true
 
+ignoredOptionalDependencies:
+  - '@types/c3'
+  - bootstrap-datepicker
+  - bootstrap-sass
+  - bootstrap-select
+  - bootstrap-slider
+  - bootstrap-switch
+  - bootstrap-touchspin
+  - c3
+  - d3
+  - datatables.net
+  - datatables.net-colreorder
+  - datatables.net-colreorder-bs
+  - datatables.net-select
+  - drmonty-datatables-colvis
+  - eonasdan-bootstrap-datetimepicker
+  - font-awesome-sass
+  - google-code-prettify
+  - jquery-match-height
+  - moment
+  - moment-timezone
+  - patternfly-bootstrap-combobox
+  - patternfly-bootstrap-treeview
+
 snapshots:
 
   '@4tw/cypress-drag-drop@2.2.5(cypress@13.10.0)':
@@ -6048,46 +5898,19 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/c3@0.6.4':
-    dependencies:
-      '@types/d3': 4.13.15
-    optional: true
-
   '@types/chai@4.3.16': {}
 
-  '@types/d3-array@1.2.12':
-    optional: true
-
   '@types/d3-array@3.2.1': {}
-
-  '@types/d3-axis@1.0.19':
-    dependencies:
-      '@types/d3-selection': 1.4.6
-    optional: true
 
   '@types/d3-axis@3.0.6':
     dependencies:
       '@types/d3-selection': 3.0.10
 
-  '@types/d3-brush@1.1.8':
-    dependencies:
-      '@types/d3-selection': 1.4.6
-    optional: true
-
   '@types/d3-brush@3.0.6':
     dependencies:
       '@types/d3-selection': 3.0.10
 
-  '@types/d3-chord@1.0.14':
-    optional: true
-
   '@types/d3-chord@3.0.6': {}
-
-  '@types/d3-collection@1.0.13':
-    optional: true
-
-  '@types/d3-color@1.4.5':
-    optional: true
 
   '@types/d3-color@3.1.3': {}
 
@@ -6098,27 +5921,13 @@ snapshots:
 
   '@types/d3-delaunay@6.0.4': {}
 
-  '@types/d3-dispatch@1.0.12':
-    optional: true
-
   '@types/d3-dispatch@3.0.6': {}
-
-  '@types/d3-drag@1.2.8':
-    dependencies:
-      '@types/d3-selection': 1.4.6
-    optional: true
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.10
 
-  '@types/d3-dsv@1.2.8':
-    optional: true
-
   '@types/d3-dsv@3.0.7': {}
-
-  '@types/d3-ease@1.0.13':
-    optional: true
 
   '@types/d3-ease@3.0.2': {}
 
@@ -6126,163 +5935,54 @@ snapshots:
     dependencies:
       '@types/d3-dsv': 3.0.7
 
-  '@types/d3-force@1.2.7':
-    optional: true
-
   '@types/d3-force@3.0.9': {}
 
-  '@types/d3-format@1.4.5':
-    optional: true
-
   '@types/d3-format@3.0.4': {}
-
-  '@types/d3-geo@1.12.7':
-    dependencies:
-      '@types/geojson': 7946.0.14
-    optional: true
 
   '@types/d3-geo@3.1.0':
     dependencies:
       '@types/geojson': 7946.0.14
 
-  '@types/d3-hierarchy@1.1.11':
-    optional: true
-
   '@types/d3-hierarchy@3.1.7': {}
-
-  '@types/d3-interpolate@1.4.5':
-    dependencies:
-      '@types/d3-color': 1.4.5
-    optional: true
 
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
-  '@types/d3-path@1.0.11':
-    optional: true
-
   '@types/d3-path@3.1.0': {}
-
-  '@types/d3-polygon@1.0.10':
-    optional: true
 
   '@types/d3-polygon@3.0.2': {}
 
-  '@types/d3-quadtree@1.0.13':
-    optional: true
-
   '@types/d3-quadtree@3.0.6': {}
-
-  '@types/d3-queue@3.0.10':
-    optional: true
-
-  '@types/d3-random@1.1.5':
-    optional: true
 
   '@types/d3-random@3.0.3': {}
 
-  '@types/d3-request@1.0.9':
-    dependencies:
-      '@types/d3-dsv': 1.2.8
-    optional: true
-
   '@types/d3-scale-chromatic@3.0.3': {}
-
-  '@types/d3-scale@1.0.22':
-    dependencies:
-      '@types/d3-time': 1.1.4
-    optional: true
 
   '@types/d3-scale@4.0.8':
     dependencies:
       '@types/d3-time': 3.0.3
 
-  '@types/d3-selection@1.4.6':
-    optional: true
-
   '@types/d3-selection@3.0.10': {}
-
-  '@types/d3-shape@1.3.12':
-    dependencies:
-      '@types/d3-path': 1.0.11
-    optional: true
 
   '@types/d3-shape@3.1.6':
     dependencies:
       '@types/d3-path': 3.1.0
 
-  '@types/d3-time-format@2.3.4':
-    optional: true
-
   '@types/d3-time-format@4.0.3': {}
-
-  '@types/d3-time@1.1.4':
-    optional: true
 
   '@types/d3-time@3.0.3': {}
 
-  '@types/d3-timer@1.0.12':
-    optional: true
-
   '@types/d3-timer@3.0.2': {}
-
-  '@types/d3-transition@1.3.5':
-    dependencies:
-      '@types/d3-selection': 1.4.6
-    optional: true
 
   '@types/d3-transition@3.0.8':
     dependencies:
       '@types/d3-selection': 3.0.10
 
-  '@types/d3-voronoi@1.1.12':
-    optional: true
-
-  '@types/d3-zoom@1.8.7':
-    dependencies:
-      '@types/d3-interpolate': 1.4.5
-      '@types/d3-selection': 1.4.6
-    optional: true
-
   '@types/d3-zoom@3.0.8':
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.10
-
-  '@types/d3@4.13.15':
-    dependencies:
-      '@types/d3-array': 1.2.12
-      '@types/d3-axis': 1.0.19
-      '@types/d3-brush': 1.1.8
-      '@types/d3-chord': 1.0.14
-      '@types/d3-collection': 1.0.13
-      '@types/d3-color': 1.4.5
-      '@types/d3-dispatch': 1.0.12
-      '@types/d3-drag': 1.2.8
-      '@types/d3-dsv': 1.2.8
-      '@types/d3-ease': 1.0.13
-      '@types/d3-force': 1.2.7
-      '@types/d3-format': 1.4.5
-      '@types/d3-geo': 1.12.7
-      '@types/d3-hierarchy': 1.1.11
-      '@types/d3-interpolate': 1.4.5
-      '@types/d3-path': 1.0.11
-      '@types/d3-polygon': 1.0.10
-      '@types/d3-quadtree': 1.0.13
-      '@types/d3-queue': 3.0.10
-      '@types/d3-random': 1.1.5
-      '@types/d3-request': 1.0.9
-      '@types/d3-scale': 1.0.22
-      '@types/d3-selection': 1.4.6
-      '@types/d3-shape': 1.3.12
-      '@types/d3-time': 1.1.4
-      '@types/d3-time-format': 2.3.4
-      '@types/d3-timer': 1.0.12
-      '@types/d3-transition': 1.3.5
-      '@types/d3-voronoi': 1.1.12
-      '@types/d3-zoom': 1.8.7
-    optional: true
 
   '@types/d3@7.4.3':
     dependencies:
@@ -6827,31 +6527,6 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  bootstrap-datepicker@1.10.0:
-    dependencies:
-      jquery: 3.7.1
-    optional: true
-
-  bootstrap-sass@3.4.3:
-    optional: true
-
-  bootstrap-select@1.12.2:
-    dependencies:
-      jquery: 3.7.1
-    optional: true
-
-  bootstrap-slider@9.10.0:
-    optional: true
-
-  bootstrap-switch@3.3.4(bootstrap@3.4.1)(jquery@3.4.1):
-    dependencies:
-      bootstrap: 3.4.1
-      jquery: 3.4.1
-    optional: true
-
-  bootstrap-touchspin@3.1.1:
-    optional: true
-
   bootstrap@3.4.1: {}
 
   brace-expansion@1.1.11:
@@ -6894,11 +6569,6 @@ snapshots:
       ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
-
-  c3@0.4.24:
-    dependencies:
-      d3: 3.5.17
-    optional: true
 
   cac@6.7.14: {}
 
@@ -7202,9 +6872,6 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  d3@3.5.17:
-    optional: true
-
   dagre@0.8.5:
     dependencies:
       graphlib: 2.1.8
@@ -7236,41 +6903,6 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-
-  datatables.net-bs@2.0.7:
-    dependencies:
-      datatables.net: 2.0.7
-      jquery: 3.7.1
-    optional: true
-
-  datatables.net-colreorder-bs@1.3.3:
-    dependencies:
-      datatables.net-bs: 2.0.7
-      datatables.net-colreorder: 1.7.2
-      jquery: 3.7.1
-    optional: true
-
-  datatables.net-colreorder@1.7.2:
-    dependencies:
-      datatables.net: 1.13.11
-      jquery: 3.7.1
-    optional: true
-
-  datatables.net-select@1.2.7:
-    dependencies:
-      datatables.net: 1.13.11
-      jquery: 3.7.1
-    optional: true
-
-  datatables.net@1.13.11:
-    dependencies:
-      jquery: 3.7.1
-    optional: true
-
-  datatables.net@2.0.7:
-    dependencies:
-      jquery: 3.7.1
-    optional: true
 
   dayjs@1.11.11: {}
 
@@ -7422,11 +7054,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  drmonty-datatables-colvis@1.1.2:
-    dependencies:
-      jquery: 3.7.1
-    optional: true
-
   duplexify@3.7.1:
     dependencies:
       end-of-stream: 1.4.4
@@ -7464,14 +7091,6 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@4.5.0: {}
-
-  eonasdan-bootstrap-datetimepicker@4.17.49(bootstrap@3.4.1)(jquery@3.4.1)(moment-timezone@0.4.1)(moment@2.30.1):
-    dependencies:
-      bootstrap: 3.4.1
-      jquery: 3.4.1
-      moment: 2.30.1
-      moment-timezone: 0.4.1
-    optional: true
 
   es-abstract@1.23.3:
     dependencies:
@@ -7932,9 +7551,6 @@ snapshots:
     dependencies:
       tabbable: 6.2.0
 
-  font-awesome-sass@4.7.0:
-    optional: true
-
   font-awesome@4.7.0: {}
 
   for-each@0.3.3:
@@ -8094,9 +7710,6 @@ snapshots:
   gonzales-pe@4.3.0:
     dependencies:
       minimist: 1.2.8
-
-  google-code-prettify@1.0.5:
-    optional: true
 
   gopd@1.0.1:
     dependencies:
@@ -8396,9 +8009,6 @@ snapshots:
       set-function-name: 2.0.2
 
   jju@1.4.0: {}
-
-  jquery-match-height@0.7.2:
-    optional: true
 
   jquery@3.4.1: {}
 
@@ -8758,14 +8368,6 @@ snapshots:
       requirejs: 2.3.6
       requirejs-config-file: 4.0.0
 
-  moment-timezone@0.4.1:
-    dependencies:
-      moment: 2.30.1
-    optional: true
-
-  moment@2.30.1:
-    optional: true
-
   monaco-editor@0.49.0: {}
 
   ms@2.1.2: {}
@@ -8914,43 +8516,11 @@ snapshots:
 
   pathval@2.0.0: {}
 
-  patternfly-bootstrap-combobox@1.1.7:
-    optional: true
-
-  patternfly-bootstrap-treeview@2.1.10:
-    dependencies:
-      bootstrap: 3.4.1
-      jquery: 3.7.1
-    optional: true
-
   patternfly@3.59.5:
     dependencies:
       bootstrap: 3.4.1
       font-awesome: 4.7.0
       jquery: 3.4.1
-    optionalDependencies:
-      '@types/c3': 0.6.4
-      bootstrap-datepicker: 1.10.0
-      bootstrap-sass: 3.4.3
-      bootstrap-select: 1.12.2
-      bootstrap-slider: 9.10.0
-      bootstrap-switch: 3.3.4(bootstrap@3.4.1)(jquery@3.4.1)
-      bootstrap-touchspin: 3.1.1
-      c3: 0.4.24
-      d3: 3.5.17
-      datatables.net: 1.13.11
-      datatables.net-colreorder: 1.7.2
-      datatables.net-colreorder-bs: 1.3.3
-      datatables.net-select: 1.2.7
-      drmonty-datatables-colvis: 1.1.2
-      eonasdan-bootstrap-datetimepicker: 4.17.49(bootstrap@3.4.1)(jquery@3.4.1)(moment-timezone@0.4.1)(moment@2.30.1)
-      font-awesome-sass: 4.7.0
-      google-code-prettify: 1.0.5
-      jquery-match-height: 0.7.2
-      moment: 2.30.1
-      moment-timezone: 0.4.1
-      patternfly-bootstrap-combobox: 1.1.7
-      patternfly-bootstrap-treeview: 2.1.10
 
   pcg@1.0.0:
     dependencies:


### PR DESCRIPTION
Ignores several optional NPM dependencies that are not actually used. This is to reduce the number of installed dependencies and to allow us to comply with Cloud Native Computing Foundation guidelines around dependencies.