### PR TITLE
Remove Opera from supported web drivers

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -154,11 +154,6 @@
                 <artifactId>selenium-remote-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-opera-driver</artifactId>
-                <version>${selenium.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/BrowserDriverUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/BrowserDriverUtil.java
@@ -21,7 +21,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.opera.OperaDriver;
 import org.openqa.selenium.safari.SafariDriver;
 
 /**
@@ -41,10 +40,6 @@ public class BrowserDriverUtil {
 
     public static boolean isDriverFirefox(WebDriver driver) {
         return isDriverInstanceOf(driver, FirefoxDriver.class);
-    }
-
-    public static boolean isDriverOpera(WebDriver driver) {
-        return isDriverInstanceOf(driver, OperaDriver.class);
     }
 
     public static boolean isDriverEdge(WebDriver driver) {


### PR DESCRIPTION
Removes Opera from the supported web drivers, as we do not actually test against it anywhere. This is also the driver for the now longer supported version of Opera that isn't based on Chromium like modern versions of Opera. The driver itself is also [no longer maintained](https://github.com/SeleniumHQ/selenium/issues/10379).

Since we're already testing against Chrome, which uses the same engine, we no longer need to test against Opera in general.

Works towards closing #29921