### PR TITLE
Adding realmName to be logged by jboss-logging event listener

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Event.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Event.java
@@ -32,6 +32,7 @@ public class Event {
     private EventType type;
 
     private String realmId;
+    private String realmName;
 
     private String clientId;
 
@@ -75,6 +76,14 @@ public class Event {
 
     public void setRealmId(String realmId) {
         this.realmId = maxLength(realmId, 255);
+    }
+
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public void setRealmName(String realmName) {
+        this.realmName = realmName;
     }
 
     public String getClientId() {
@@ -131,6 +140,7 @@ public class Event {
         clone.time = time;
         clone.type = type;
         clone.realmId = realmId;
+        clone.realmName = realmName;
         clone.clientId = clientId;
         clone.userId = userId;
         clone.sessionId = sessionId;

--- a/server-spi-private/src/main/java/org/keycloak/events/EventBuilder.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventBuilder.java
@@ -104,11 +104,7 @@ public class EventBuilder {
 
     public EventBuilder realm(RealmModel realm) {
         event.setRealmId(realm == null ? null : realm.getId());
-        return this;
-    }
-
-    public EventBuilder realm(String realmId) {
-        event.setRealmId(realmId);
+        event.setRealmName(realm == null ? null : realm.getName());
         return this;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/events/admin/AdminEvent.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/admin/AdminEvent.java
@@ -28,6 +28,8 @@ public class AdminEvent {
     
     private String realmId;
 
+    private String realmName;
+
     private AuthDetails authDetails;
 
     /**
@@ -48,6 +50,7 @@ public class AdminEvent {
         this.id = toCopy.getId();
         this.time = toCopy.getTime();
         this.realmId = toCopy.getRealmId();
+        this.realmName = toCopy.getRealmName();
         this.authDetails = new AuthDetails(toCopy.getAuthDetails());
         this.resourceType = toCopy.getResourceTypeAsString();
         this.operationType = toCopy.getOperationType();
@@ -93,6 +96,17 @@ public class AdminEvent {
 
     public void setRealmId(String realmId) {
         this.realmId = realmId;
+    }
+
+    /**
+     * @return the name of the realm
+     */
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public void setRealmName(String realmName) {
+        this.realmName = realmName;
     }
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/events/admin/AuthDetails.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/admin/AuthDetails.java
@@ -23,6 +23,7 @@ package org.keycloak.events.admin;
 public class AuthDetails {
 
     private String realmId;
+    private String realmName;
 
     private String clientId;
 
@@ -33,6 +34,7 @@ public class AuthDetails {
     public AuthDetails() {}
     public AuthDetails(AuthDetails toCopy) {
         this.realmId = toCopy.getRealmId();
+        this.realmName = toCopy.getRealmName();
         this.clientId = toCopy.getClientId();
         this.userId = toCopy.getUserId();
         this.ipAddress = toCopy.getIpAddress();
@@ -44,6 +46,14 @@ public class AuthDetails {
 
     public void setRealmId(String realmId) {
         this.realmId = realmId;
+    }
+
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public void setRealmName(String realmName) {
+        this.realmName = realmName;
     }
 
     public String getClientId() {

--- a/services/src/main/java/org/keycloak/events/log/JBossLoggingEventListenerProvider.java
+++ b/services/src/main/java/org/keycloak/events/log/JBossLoggingEventListenerProvider.java
@@ -90,6 +90,8 @@ public class JBossLoggingEventListenerProvider implements EventListenerProvider 
             sanitize(sb, event.getType().toString());
             sb.append(", realmId=");
             sanitize(sb, event.getRealmId());
+            sb.append(", realmName=");
+            sanitize(sb, event.getRealmName());
             sb.append(", clientId=");
             sanitize(sb, event.getClientId());
             sb.append(", userId=");
@@ -145,6 +147,8 @@ public class JBossLoggingEventListenerProvider implements EventListenerProvider 
             sanitize(sb, adminEvent.getOperationType().toString());
             sb.append(", realmId=");
             sanitize(sb, adminEvent.getAuthDetails().getRealmId());
+            sb.append(", realmName=");
+            sanitize(sb, adminEvent.getAuthDetails().getRealmName());
             sb.append(", clientId=");
             sanitize(sb, adminEvent.getAuthDetails().getClientId());
             sb.append(", userId=");

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
@@ -103,11 +103,7 @@ public class AdminEventBuilder {
 
     public AdminEventBuilder realm(RealmModel realm) {
         adminEvent.setRealmId(realm.getId());
-        return this;
-    }
-
-    public AdminEventBuilder realm(String realmId) {
-        adminEvent.setRealmId(realmId);
+        adminEvent.setRealmName(realm.getName());
         return this;
     }
 
@@ -173,6 +169,7 @@ public class AdminEventBuilder {
         } else {
             authDetails.setRealmId(realm.getId());
         }
+        authDetails.setRealmName(realm.getName());
         adminEvent.setAuthDetails(authDetails);
         return this;
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -497,7 +497,7 @@ public class RealmAdminResource {
         // instead of the realm being deleted.
         AdminEventBuilder deleteAdminEvent = new AdminEventBuilder(auth.adminAuth().getRealm(), auth.adminAuth(), session, connection);
         deleteAdminEvent.operation(OperationType.DELETE).resource(ResourceType.REALM)
-                .realm(auth.adminAuth().getRealm().getId()).resourcePath(realm.getName()).success();
+                .realm(auth.adminAuth().getRealm()).resourcePath(realm.getName()).success();
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -154,7 +154,7 @@ public class RealmsAdminResource {
             // The create event is associated with the realm of the user executing the operation,
             // instead of the realm being created.
             AdminEventBuilder adminEvent = new AdminEventBuilder(auth.getRealm(), auth, session, clientConnection);
-            adminEvent.resource(ResourceType.REALM).realm(auth.getRealm().getId()).operation(OperationType.CREATE)
+            adminEvent.resource(ResourceType.REALM).realm(auth.getRealm()).operation(OperationType.CREATE)
                     .resourcePath(realm.getName())
                     .representation(ModelToRepresentation.toRepresentation(session, realm, false))
                     .success();


### PR DESCRIPTION
closes #27506

- This adds `realmName` to the jboss-logging logs for both "normal events" and "admin events" .

- It does not update `EventRepresentation` and also does not update stored events anyhow. But adds field `realmName` to both `org.keycloak.events.Event` and `org.keycloak.events.admin.AdminEvent`, so may be useful to consume realmName in custom event listeners if needed.

- PR does not update anything related to clients and users (Adding `username` or both `clientUUID` and `clientId` will have impact on performance as it may require further lookup of particular entity just because of logging. Hence if we ever add this, we can possibly add this on demand (configurable flag on the provider whether to add more details even if it has impact on performance). This can be possibly done as a follow-up if needed. 
