### PR TITLE
Remove Internet Explorer from supported web drivers

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -141,11 +141,6 @@
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-ie-driver</artifactId>
-                <version>${selenium.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-edge-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>


### PR DESCRIPTION
Removes the Internet Explorer from the supported web drivers, as this driver is no longer maintained, nor do we actively run any tests against Internet Explorer.

Works towards closing #29921