### PR TITLE
Use a default Java version from root POM

### DIFF
--- a/adapters/saml/core-jakarta/pom.xml
+++ b/adapters/saml/core-jakarta/pom.xml
@@ -14,6 +14,8 @@
     <name>Keycloak SAML Client Adapter Core Jakarta</name>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 

--- a/adapters/saml/core-public/pom.xml
+++ b/adapters/saml/core-public/pom.xml
@@ -32,6 +32,8 @@
 
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     </properties>

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/ecp/EcpAuthenticationHandler.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/ecp/EcpAuthenticationHandler.java
@@ -36,13 +36,13 @@ import org.keycloak.saml.processing.web.util.PostBindingUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
-import javax.xml.soap.MessageFactory;
-import javax.xml.soap.SOAPBody;
-import javax.xml.soap.SOAPEnvelope;
-import javax.xml.soap.SOAPException;
-import javax.xml.soap.SOAPHeader;
-import javax.xml.soap.SOAPHeaderElement;
-import javax.xml.soap.SOAPMessage;
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.SOAPBody;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPHeader;
+import jakarta.xml.soap.SOAPHeaderElement;
+import jakarta.xml.soap.SOAPMessage;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>

--- a/adapters/saml/wildfly-elytron-jakarta/pom.xml
+++ b/adapters/saml/wildfly-elytron-jakarta/pom.xml
@@ -36,6 +36,8 @@
           Reason is the transition to Jakarta APIs.
     -->
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <jakarta-transformer-sources>${project.basedir}/../wildfly-elytron/src</jakarta-transformer-sources>
         <jakarta-transformer-target>${project.basedir}/src</jakarta-transformer-target>
     </properties>

--- a/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
@@ -36,6 +36,8 @@
           Reason is the transition to Jakarta APIs.
     -->
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <jakarta-transformer-sources>${project.basedir}/../wildfly-subsystem/src</jakarta-transformer-sources>
         <jakarta-transformer-target>${project.basedir}/src</jakarta-transformer-target>
     </properties>

--- a/adapters/spi/adapter-spi/pom.xml
+++ b/adapters/spi/adapter-spi/pom.xml
@@ -31,6 +31,8 @@
     <description/>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <keycloak.osgi.export>
             org.keycloak.adapters.spi.*
         </keycloak.osgi.export>

--- a/adapters/spi/jboss-adapter-core/pom.xml
+++ b/adapters/spi/jboss-adapter-core/pom.xml
@@ -30,6 +30,11 @@
     <name>Common JBoss/Wildfly Core Classes</name>
     <description/>
 
+    <properties>
+         <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/adapters/spi/undertow-adapter-spi/pom.xml
+++ b/adapters/spi/undertow-adapter-spi/pom.xml
@@ -31,6 +31,8 @@
     <description/>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <keycloak.osgi.export>
             org.keycloak.adapters.undertow.*
         </keycloak.osgi.export>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -32,6 +32,8 @@
     <description>Common library and dependencies shared with server and all adapters</description>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <keycloak.osgi.export>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,6 +32,8 @@
     <description/>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <keycloak.osgi.export>

--- a/crypto/default/pom.xml
+++ b/crypto/default/pom.xml
@@ -30,6 +30,11 @@
     <name>Keycloak Crypto Default</name>
     <description/>
 
+    <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/crypto/fips1402/pom.xml
+++ b/crypto/fips1402/pom.xml
@@ -30,12 +30,6 @@
     <name>Keycloak Crypto FIPS 140-2 Integration</name>
     <description/>
 
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -31,7 +31,6 @@
 
     <properties>
         <javadoc.branding>Keycloak ${project.version}</javadoc.branding>
-        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -81,7 +80,6 @@
                     <maxmemory>2400m</maxmemory>
                     <encoding>UTF-8</encoding>
                     <includeDependencySources>true</includeDependencySources>
-                    <source>${maven.compiler.source}</source>
                     <failOnError>true</failOnError>
                     <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                     <dependencySourceIncludes>

--- a/docs/documentation/header-maven-plugin/pom.xml
+++ b/docs/documentation/header-maven-plugin/pom.xml
@@ -48,7 +48,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${maven.plugins.version}</version>
                 <configuration>
                     <goalPrefix>header</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/docs/documentation/pom.xml
+++ b/docs/documentation/pom.xml
@@ -29,9 +29,6 @@
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.plexus.utils>4.0.0</version.plexus.utils>
-
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <modules>
@@ -64,15 +61,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${version.compiler.plugin}</version>
-                    <configuration>
-                        <source>${maven.compiler.target}</source>
-                        <target>${maven.compiler.source}</target>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/docs/guides/pom.xml
+++ b/docs/guides/pom.xml
@@ -42,9 +42,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.0</version>
                 <executions>

--- a/docs/maven-plugin/pom.xml
+++ b/docs/maven-plugin/pom.xml
@@ -31,12 +31,6 @@
     <description>Keycloak Guides Maven Plugin</description>
     <packaging>maven-plugin</packaging>
 
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -29,12 +29,6 @@
     <name>Keycloak LDAP UserStoreProvider</name>
     <description />
 
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/federation/sssd/pom.xml
+++ b/federation/sssd/pom.xml
@@ -9,12 +9,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <artifactId>keycloak-sssd-federation</artifactId>
     <name>Keycloak SSSD Federation</name>
     <description/>
@@ -46,6 +40,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>

--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -23,11 +23,6 @@
         <groupId>org.keycloak</groupId>
         <version>999.0.0-SNAPSHOT</version>
     </parent>
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -30,10 +30,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-
         <keycloak.connectionsJpa.driver>org.h2.Driver</keycloak.connectionsJpa.driver>
         <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>
         <keycloak.connectionsJpa.user>sa</keycloak.connectionsJpa.user>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -15,11 +15,7 @@
     <artifactId>keycloak-operator</artifactId>
 
     <properties>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
@@ -154,10 +150,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.build.version}</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
             </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
     <packaging>pom</packaging>
 
     <properties>
+        <!-- Maven -->
+        <maven.version>3.9.8</maven.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+
         <project.version.npm>999.0.0-SNAPSHOT</project.version.npm>
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
@@ -183,8 +189,7 @@
         <assertj-core.version>3.22.0</assertj-core.version>
         
         <!-- Maven Plugins -->
-        <maven.version>3.9.8</maven.version>
-        <maven.plugins.version>3.11.0</maven.plugins.version>
+        <maven.plugins.version>3.13.1</maven.plugins.version>
         <replacer.plugin.version>1.4.1</replacer.plugin.version>
         <jboss.as.plugin.version>7.5.Final</jboss.as.plugin.version>
         <jmeter.plugin.version>1.9.0</jmeter.plugin.version>
@@ -207,7 +212,11 @@
         <surefire.memory.metaspace>96m</surefire.memory.metaspace>
         <surefire.memory.metaspace.max>512m</surefire.memory.metaspace.max>
         <surefire.memory.settings>-Xms${surefire.memory.Xms} -Xmx${surefire.memory.Xmx} -XX:MetaspaceSize=${surefire.memory.metaspace} -XX:MaxMetaspaceSize=${surefire.memory.metaspace.max}</surefire.memory.settings>
-        <surefire.system.args></surefire.system.args>
+        <!-- See: https://github.com/keycloak/keycloak/issues/9899 -->
+        <surefire.system.args>
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+        </surefire.system.args>
 
         <!-- webauthn support -->
         <webauthn4j.version>0.21.5.RELEASE</webauthn4j.version>
@@ -1543,6 +1552,15 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <doclint>none</doclint>
+                        <failOnError>false</failOnError>
+                        <excludePackageNames>cx.*:org.freedesktop*:org.jvnet*</excludePackageNames>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>com.lazerycode.jmeter</groupId>
                     <artifactId>jmeter-maven-plugin</artifactId>
                     <version>${jmeter.plugin.version}</version>
@@ -1734,19 +1752,6 @@
 
     <profiles>
         <profile>
-            <id>jdk9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <surefire.system.args>
-                    --add-opens=java.base/java.lang=ALL-UNNAMED
-                    --add-opens=java.base/java.util=ALL-UNNAMED
-                </surefire.system.args>
-            </properties>
-        </profile>
-
-        <profile>
             <id>testsuite</id>
             <activation>
                 <property>
@@ -1834,42 +1839,6 @@
             <modules>
                 <module>operator</module>
             </modules>
-        </profile>
-
-        <profile>
-            <id>doclint-java8-disable</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <doclint>none</doclint>
-                            <failOnError>false</failOnError>
-                            <excludePackageNames>cx.*:org.freedesktop*:org.jvnet*</excludePackageNames>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>built-with-jdk-9-or-later</id>
-            <activation>
-                <!-- only activate this on JDK 9 or later as this option is unknown for JDK 8, and as it is not necessary for JDK 8 -->
-                <!-- support for running with JDK 8 is still necessary for some downstream integration tests -->
-                <jdk>(9,)</jdk>
-            </activation>
-            <properties>
-                <!-- Minimum Java version supported for running Keycloak -->
-                <!-- maven.compiler.target and maven.compiler.source already set to 1.8 in the parent pom -->
-                <!-- other modules will configure a higher Java version (for example, Quarkus) -->
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
         </profile>
 
         <profile>

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -181,6 +181,7 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -32,23 +32,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven.compiler.plugin.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
     
     <modules>
         <module>config-api</module>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -631,6 +631,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/saml-core-api/pom.xml
+++ b/saml-core-api/pom.xml
@@ -31,6 +31,8 @@
     <description/>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     </properties>

--- a/saml-core/pom.xml
+++ b/saml-core/pom.xml
@@ -31,6 +31,8 @@
     <description/>
 
     <properties>
+        <!-- We still need to support EAP 8, set the Java version to 11. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <timestamp>${maven.build.timestamp}</timestamp>
         <skip.security-manager.tests>true</skip.security-manager.tests>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>

--- a/server-spi/pom.xml
+++ b/server-spi/pom.xml
@@ -30,12 +30,6 @@
     <name>Keycloak Server SPI</name>
     <description/>
 
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -32,10 +32,6 @@
 
     <properties>
         <version.swagger.doclet>1.1.2</version.swagger.doclet>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/test-poc/pom.xml
+++ b/test-poc/pom.xml
@@ -32,12 +32,6 @@
     <name>Keycloak Test Parent</name>
     <description>Keycloak Test Parent</description>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
-    </properties>
-
     <modules>
         <module>base</module>
         <module>framework</module>

--- a/testsuite/integration-arquillian/servers/adapter-spi/pom.xml
+++ b/testsuite/integration-arquillian/servers/adapter-spi/pom.xml
@@ -18,19 +18,7 @@
     </modules>
 
     <properties>
-        <ant.jvm.args>-Dnone</ant.jvm.args>
+        <!-- For more information, see https://github.com/apache/ant/pull/200 -->
+        <ant.jvm.args>-Djava.security.manager=allow</ant.jvm.args>
     </properties>
-
-    <profiles>
-        <profile>
-            <id>jdk17+</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <!--For more information, see https://github.com/apache/ant/pull/200-->
-                <ant.jvm.args>-Djava.security.manager=allow</ant.jvm.args>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
@@ -33,10 +33,6 @@
     <properties>
         <js-adapter.version>${project.version}</js-adapter.version>
         <js-adapter.file.path>${project.basedir}/target/classes/javascript</js-adapter.file.path>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -45,10 +45,6 @@
         <mvel.version>2.5.2.Final</mvel.version>
         <systemrules.version>1.19.0</systemrules.version>
         <common.resources>${basedir}/../../servers/auth-server/common</common.resources>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
     </properties>
     
     <dependencies>
@@ -451,10 +447,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
         </plugins>
 
     </build>
@@ -822,10 +814,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${maven-compiler-plugin.version}</version>
                     </plugin>
                 </plugins>
             </build>

--- a/testsuite/integration-arquillian/tests/other/sssd/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/sssd/pom.xml
@@ -15,9 +15,6 @@
 
     <properties>
         <exclude.sssd>**/sssd/**/*Test.java</exclude.sssd>
-        <maven.compiler.release>11</maven.compiler.release>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <build>

--- a/testsuite/integration-arquillian/tests/other/webauthn/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/webauthn/pom.xml
@@ -14,9 +14,6 @@
 
     <properties>
         <firefoxUserPreferences>${project.build.directory}/dependency/firefox-user-preferences.js</firefoxUserPreferences>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -77,7 +77,7 @@
         <auth.server.keystore>${auth.server.config.dir}/keycloak.jks</auth.server.keystore>
         <auth.server.keystore.password>secret</auth.server.keystore.password>
         <auth.server.keystore.type>jks</auth.server.keystore.type>
-        <auth.server.jvm.args.extra/>
+        <auth.server.jvm.args.extra>${default.modular.jvm.options}</auth.server.jvm.args.extra>
 
         <auth.server.jboss.artifactId>integration-arquillian-servers-auth-server-${auth.server}</auth.server.jboss.artifactId>
         <auth.server.jboss.skip.unpack>${auth.server.undertow}</auth.server.jboss.skip.unpack>
@@ -132,7 +132,7 @@
         <app.server.truststore.password>secret</app.server.truststore.password>
         <app.server.keystore>${app.server.keystore.dir}/adapter.jks</app.server.keystore>
         <app.server.keystore.password>secret</app.server.keystore.password>
-        <app.server.jvm.args.extra/>
+        <app.server.jvm.args.extra>${default.modular.jvm.options}</app.server.jvm.args.extra>
 
         <cache.server.legacy>false</cache.server.legacy>
         <cache.server.home>${containers.home}/cache-server-${cache.server}</cache.server.home>
@@ -1895,26 +1895,6 @@
                 <auth.server.https.port>8443</auth.server.https.port>
                 <auth.server.management.port>9990</auth.server.management.port>
                 <auth.server.management.port.jmx>9999</auth.server.management.port.jmx>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>java11-auth-server</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <properties>
-                <auth.server.jvm.args.extra>${default.modular.jvm.options}</auth.server.jvm.args.extra>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>java11-app-server</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <properties>
-                <app.server.jvm.args.extra>${default.modular.jvm.options}</app.server.jvm.args.extra>
             </properties>
         </profile>
 

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -15,10 +15,6 @@
     <packaging>jar</packaging>
     
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-
         <keycloak.connectionsJpa.driver>org.h2.Driver</keycloak.connectionsJpa.driver>
         <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>
         <keycloak.connectionsJpa.user>sa</keycloak.connectionsJpa.user>


### PR DESCRIPTION
Sets all the Maven compiler specific properties to Java 17, unless older compiler targets are needed for specific POMs, in which case they are overwritten selectively to an older version. This allows us to assume a base version of 17 everywhere in the project, rather than just in specific areas where this version was previously overwritten selectively.

This also upgrades Maven to the latest version, as well as some relevant plugins such as the [Maven Plugin Plugin](https://maven.apache.org/plugin-tools/maven-plugin-plugin/), and ensures that only a single version of these dependencies is used in the entire project.

Additionally, any profiles that were previously only triggered on specific JDK versions that have a version of 17 or higher have now been in-lined, as we can now safely assume this is the minimum version we support.

Closes #30275