### PR TITLE
Improve Client Type Integration Tests

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
@@ -25,15 +25,44 @@ import org.keycloak.models.ModelException;
  */
 public class ClientTypeException extends ModelException {
 
-    public ClientTypeException(String message) {
-        super(message);
-    }
-
-    public ClientTypeException(String message, Object ... parameters) {
+    private ClientTypeException(String message, Object... parameters) {
         super(message, parameters);
     }
 
-    public ClientTypeException(String message, Throwable cause) {
+    private ClientTypeException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public enum Message {
+        /**
+         * Register all client type exception messages through this enum to keep things consistent across the services.
+         */
+        INVALID_CLIENT_TYPE("Invalid client type"),
+        CANNOT_CHANGE_CLIENT_TYPE("Not supported to change client type"),
+        INVALID_CLIENT_TYPE_PROVIDER("Did not find client type provider"),
+        CLIENT_TYPE_FIELD_NOT_APPLICABLE("Invalid configuration of 'applicable' property on client type"),
+        INVALID_CLIENT_TYPE_CONFIGURATION("Invalid configuration of property on client type"),
+        DUPLICATE_CLIENT_TYPE("Duplicated client type name"),
+        CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION("Cannot change property of client as it is not allowed by the specified client type."),
+        CLIENT_TYPE_NOT_FOUND("Client type not found."),
+        CLIENT_TYPE_FAILED_TO_LOAD("Failed to serialize client types to String.");
+
+        private final String message;
+
+        Message(String message) {
+            this.message = message;
+        }
+
+        public ClientTypeException exception(Object... parameters) {
+            return new ClientTypeException(message, parameters);
+        }
+
+        public ClientTypeException exception(String message, Throwable cause) {
+            return new ClientTypeException(message, cause);
+        }
+
+        public String getMessage() {
+            return message;
+        }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
@@ -45,7 +45,7 @@ public class ClientTypeException extends ModelException {
         DUPLICATE_CLIENT_TYPE("Duplicated client type name"),
         CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION("Cannot change property of client as it is not allowed by the specified client type."),
         CLIENT_TYPE_NOT_FOUND("Client type not found."),
-        CLIENT_TYPE_FAILED_TO_LOAD("Failed to serialize client types to String.");
+        CLIENT_TYPE_FAILED_TO_LOAD("Failed to load client type.");
 
         private final String message;
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -414,7 +414,7 @@ public class RepresentationToModel {
 
         if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES)) {
             if (!ObjectUtil.isEqualOrBothNull(resource.getType(), rep.getType())) {
-                throw new ClientTypeException("Not supported to change client type");
+                throw ClientTypeException.Message.CANNOT_CHANGE_CLIENT_TYPE.exception();
             }
             if (rep.getType() != null) {
                 RealmModel realm = session.getContext().getRealm();
@@ -545,9 +545,8 @@ public class RepresentationToModel {
                 .collect(Collectors.toList());
 
         if (propertyUpdateExceptions.size() > 0) {
-            throw new ClientTypeException(
-                    "Cannot change property of client as it is not allowed by the specified client type.",
-                    propertyUpdateExceptions.stream().map(ClientTypeException::getParameters).flatMap(Stream::of).toArray());
+            Object[] paramsWithFailures = propertyUpdateExceptions.stream().map(ClientTypeException::getParameters).flatMap(Stream::of).toArray();
+            throw ClientTypeException.Message.CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION.exception(paramsWithFailures);
         }
     }
 
@@ -698,7 +697,6 @@ public class RepresentationToModel {
                 .map(Optional::get);
         return updateProperty(modelSetter, () -> firstNonNullSupplied.findFirst().orElse(null));
     }
-
 
     private static String generateProtocolNameKey(String protocol, String name) {
         return String.format("%s%%%s", protocol, name);

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -69,6 +69,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
                 result = JsonSerialization.readValue(asStr, ClientTypesRepresentation.class);
                 result.setGlobalClientTypes(globalClientTypes);
             } catch (IOException ioe) {
+                logger.errorf("Failed to load client type for realm '%s'.", realm.getName());
                 throw ClientTypeException.Message.CLIENT_TYPE_FAILED_TO_LOAD.exception(ioe);
             }
         }
@@ -86,6 +87,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
             String asStr = JsonSerialization.writeValueAsString(noGlobalsCopy);
             realm.setAttribute(CLIENT_TYPE_REALM_ATTRIBUTE, asStr);
         } catch (IOException ioe) {
+            logger.errorf("Failed to load global client type.");
             throw ClientTypeException.Message.CLIENT_TYPE_FAILED_TO_LOAD.exception(ioe);
         }
     }
@@ -108,15 +110,15 @@ public class DefaultClientTypeManager implements ClientTypeManager {
     public ClientModel augmentClient(ClientModel client) throws ClientTypeException {
         if (client.getType() == null) {
             return client;
-        } else {
-            try {
-                ClientType clientType = getClientType(client.getRealm(), client.getType());
-                return new TypeAwareClientModelDelegate(clientType, () -> client);
-            } catch(ClientTypeException cte) {
-                logger.errorf("Could not augment client, %s, due to client type exception: %s",
-                        client, cte);
-                throw cte;
-            }
+        }
+
+        try {
+            ClientType clientType = getClientType(client.getRealm(), client.getType());
+            return new TypeAwareClientModelDelegate(clientType, () -> client);
+        } catch(ClientTypeException cte) {
+            logger.errorf("Could not augment client, %s, due to client type exception: %s",
+                    client, cte);
+            throw cte;
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -69,7 +69,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
                 result = JsonSerialization.readValue(asStr, ClientTypesRepresentation.class);
                 result.setGlobalClientTypes(globalClientTypes);
             } catch (IOException ioe) {
-                throw new ClientTypeException("Failed to deserialize client types from JSON string", ioe);
+                throw ClientTypeException.Message.CLIENT_TYPE_FAILED_TO_LOAD.exception(ioe);
             }
         }
         return result;
@@ -86,7 +86,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
             String asStr = JsonSerialization.writeValueAsString(noGlobalsCopy);
             realm.setAttribute(CLIENT_TYPE_REALM_ATTRIBUTE, asStr);
         } catch (IOException ioe) {
-            throw new ClientTypeException("Failed to serialize client types to String", ioe);
+            throw ClientTypeException.Message.CLIENT_TYPE_FAILED_TO_LOAD.exception(ioe);
         }
     }
 
@@ -97,7 +97,7 @@ public class DefaultClientTypeManager implements ClientTypeManager {
         ClientTypeRepresentation clientType = getClientTypeByName(clientTypes, typeName);
         if (clientType == null) {
             logger.errorf("Referenced client type '%s' not found", typeName);
-            throw new ClientTypeException("Client type not found");
+            throw ClientTypeException.Message.CLIENT_TYPE_NOT_FOUND.exception();
         }
 
         ClientTypeProvider provider = session.getProvider(ClientTypeProvider.class, clientType.getProvider());
@@ -136,13 +136,13 @@ public class DefaultClientTypeManager implements ClientTypeManager {
         ClientTypeProvider clientTypeProvider = session.getProvider(ClientTypeProvider.class, clientType.getProvider());
         if (clientTypeProvider == null) {
             logger.errorf("Did not find client type provider '%s' for the client type '%s'", clientType.getProvider(), clientType.getName());
-            throw new ClientTypeException("Did not find client type provider");
+            throw ClientTypeException.Message.INVALID_CLIENT_TYPE_PROVIDER.exception();
         }
 
         // Validate name is not duplicated
         if (currentNames.contains(clientType.getName())) {
             logger.errorf("Duplicated client type name '%s'", clientType.getName());
-            throw new ClientTypeException("Duplicated client type name");
+            throw ClientTypeException.Message.DUPLICATE_CLIENT_TYPE.exception();
         }
 
         clientType = clientTypeProvider.checkClientTypeConfig(clientType);

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManagerFactory.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManagerFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.client.clienttype.ClientTypeManagerFactory;
 import org.keycloak.common.Profile;
@@ -82,7 +83,8 @@ public class DefaultClientTypeManagerFactory implements ClientTypeManagerFactory
                         ClientTypesRepresentation globalTypesRep  = JsonSerialization.readValue(getClass().getResourceAsStream("/keycloak-default-client-types.json"), ClientTypesRepresentation.class);
                         this.globalClientTypes = DefaultClientTypeManager.validateAndCastConfiguration(session, globalTypesRep.getRealmClientTypes(), Collections.emptyList());
                     } catch (IOException e) {
-                        throw new IllegalStateException("Failed to deserialize global proposed client types from JSON.", e);
+                        logger.error("Failed to deserialize global proposed client types from JSON.");
+                        throw ClientTypeException.Message.CLIENT_TYPE_FAILED_TO_LOAD.exception(e);
                     }
                 }
             }

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -118,9 +118,7 @@ interface TypedClientAttribute {
         // If there is an attempt to change a value for an applicable field with a read-only value set, then throw an exception.
         T oldVal = clientType.getTypeValue(propertyName, tClass);
         if (!ObjectUtil.isEqualOrBothNull(oldVal, newValue)) {
-            throw new ClientTypeException(
-                    "Property " + propertyName + " is read-only due to client type " + clientType.getName(),
-                    propertyName);
+            throw ClientTypeException.Message.CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION.exception(propertyName);
         }
 
         // Delegate to clientSetter

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
@@ -47,13 +47,13 @@ public class DefaultClientTypeProvider implements ClientTypeProvider {
 
             if (propConfig.getApplicable() == null) {
                 logger.errorf("Property '%s' does not have 'applicable' configured for client type '%s'", propertyName, clientType.getName());
-                throw new ClientTypeException("Invalid configuration of 'applicable' property on client type");
+                throw ClientTypeException.Message.CLIENT_TYPE_FIELD_NOT_APPLICABLE.exception();
             }
 
             // Not supported to set value for properties, which are not applicable for the particular client
             if (!propConfig.getApplicable() && propConfig.getValue() != null) {
                 logger.errorf("Property '%s' is not applicable and so should not have read-only or default-value set for client type '%s'", propertyName, clientType.getName());
-                throw new ClientTypeException("Invalid configuration of property on client type");
+                throw ClientTypeException.Message.INVALID_CLIENT_TYPE_CONFIGURATION.exception();
             }
         }
 


### PR DESCRIPTION
Change to register specific client type exception messages as Enum, so that they are consistent across the code base and can be verified that the expected exception is thrown in the integration tests.

closes #30017