### PR TITLE
Improvements to refresh token rotation

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -457,3 +457,9 @@ The following variables were deprecated in the Admin theme:
 The following variables from the environment script injected into the page of the Admin theme are deprecated:
 
 * `authUrl`. Do not use this variable.
+
+= Methods to get and set current refresh token in client session are now deprecated
+
+The methods `String getCurrentRefreshToken()`, `void setCurrentRefreshToken(String currentRefreshToken)`, `int getCurrentRefreshTokenUseCount()`, and `void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount)` in the interface `org.keycloak.models.AuthenticatedClientSessionModel` are deprecated. They have been replaced by similar methods that require an identifier as a parameter such as `getRefreshToken(String reuseId)` to manage multiple refresh tokens within a client session.
+The methods will be removed in one of the future {project_name} releases. It might be {project_name} 27 release.
+

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
@@ -177,52 +177,6 @@ public class AuthenticatedClientSessionAdapter implements AuthenticatedClientSes
     }
 
     @Override
-    public int getCurrentRefreshTokenUseCount() {
-        return entity.getCurrentRefreshTokenUseCount();
-    }
-
-    @Override
-    public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-        ClientSessionUpdateTask task = new ClientSessionUpdateTask() {
-
-            @Override
-            public void runUpdate(AuthenticatedClientSessionEntity entity) {
-                entity.setCurrentRefreshTokenUseCount(currentRefreshTokenUseCount);
-            }
-
-            @Override
-            public boolean isOffline() {
-                return offline;
-            }
-        };
-
-        update(task);
-    }
-
-    @Override
-    public String getCurrentRefreshToken() {
-        return entity.getCurrentRefreshToken();
-    }
-
-    @Override
-    public void setCurrentRefreshToken(String currentRefreshToken) {
-        ClientSessionUpdateTask task = new ClientSessionUpdateTask() {
-
-            @Override
-            public void runUpdate(AuthenticatedClientSessionEntity entity) {
-                entity.setCurrentRefreshToken(currentRefreshToken);
-            }
-
-            @Override
-            public boolean isOffline() {
-                return offline;
-            }
-        };
-
-        update(task);
-    }
-
-    @Override
     public String getAction() {
         return entity.getAction();
     }
@@ -329,8 +283,6 @@ public class AuthenticatedClientSessionAdapter implements AuthenticatedClientSes
                 UserSessionModel userSession = getUserSession();
                 entity.setAction(null);
                 entity.setRedirectUri(null);
-                entity.setCurrentRefreshToken(null);
-                entity.setCurrentRefreshTokenUseCount(-1);
                 entity.setTimestamp(Time.currentTime());
                 entity.getNotes().clear();
                 entity.getNotes().put(AuthenticatedClientSessionModel.STARTED_AT_NOTE, String.valueOf(entity.getTimestamp()));

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
@@ -956,8 +956,6 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
         entity.setClientId(clientId);
         entity.setRedirectUri(clientSession.getRedirectUri());
         entity.setTimestamp(clientSession.getTimestamp());
-        entity.setCurrentRefreshToken(clientSession.getCurrentRefreshToken());
-        entity.setCurrentRefreshTokenUseCount(clientSession.getCurrentRefreshTokenUseCount());
         entity.setOffline(offline);
 
         return entity;

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
@@ -182,26 +182,6 @@ public class JpaChangesPerformer<K, V extends SessionEntity> implements SessionC
                 }
 
                 @Override
-                public String getCurrentRefreshToken() {
-                    return entity.getCurrentRefreshToken();
-                }
-
-                @Override
-                public void setCurrentRefreshToken(String currentRefreshToken) {
-                    throw new IllegalStateException("not implemented");
-                }
-
-                @Override
-                public int getCurrentRefreshTokenUseCount() {
-                    return entity.getCurrentRefreshTokenUseCount();
-                }
-
-                @Override
-                public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-                    throw new IllegalStateException("not implemented");
-                }
-
-                @Override
                 public String getNote(String name) {
                     return entity.getNotes().get(name);
                 }
@@ -311,16 +291,6 @@ public class JpaChangesPerformer<K, V extends SessionEntity> implements SessionC
                     }
 
                     @Override
-                    public void setCurrentRefreshToken(String currentRefreshToken) {
-                        clientSessionModel.setCurrentRefreshToken(currentRefreshToken);
-                    }
-
-                    @Override
-                    public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-                        clientSessionModel.setCurrentRefreshTokenUseCount(currentRefreshTokenUseCount);
-                    }
-
-                    @Override
                     public void setAction(String action) {
                         clientSessionModel.setAction(action);
                     }
@@ -379,16 +349,6 @@ public class JpaChangesPerformer<K, V extends SessionEntity> implements SessionC
                     public void setNotes(Map<String, String> notes) {
                         clientSessionModel.getNotes().keySet().forEach(clientSessionModel::removeNote);
                         notes.forEach((k, v) -> clientSessionModel.setNote(k, v));
-                    }
-
-                    @Override
-                    public String getCurrentRefreshToken() {
-                        return clientSessionModel.getCurrentRefreshToken();
-                    }
-
-                    @Override
-                    public int getCurrentRefreshTokenUseCount() {
-                        return clientSessionModel.getCurrentRefreshTokenUseCount();
                     }
 
                     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/AuthenticatedClientSessionEntity.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/AuthenticatedClientSessionEntity.java
@@ -52,9 +52,6 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
 
     private Map<String, String> notes = new ConcurrentHashMap<>();
 
-    private String currentRefreshToken;
-    private int currentRefreshTokenUseCount;
-
     private final UUID id;
 
     private transient String userSessionId;
@@ -123,22 +120,6 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
 
     public void setNotes(Map<String, String> notes) {
         this.notes = notes;
-    }
-
-    public String getCurrentRefreshToken() {
-        return currentRefreshToken;
-    }
-
-    public void setCurrentRefreshToken(String currentRefreshToken) {
-        this.currentRefreshToken = currentRefreshToken;
-    }
-
-    public int getCurrentRefreshTokenUseCount() {
-        return currentRefreshTokenUseCount;
-    }
-
-    public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-        this.currentRefreshTokenUseCount = currentRefreshTokenUseCount;
     }
 
     public UUID getId() {
@@ -214,8 +195,6 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
             Map<String, String> notes = session.getNotes();
             KeycloakMarshallUtil.writeMap(notes, KeycloakMarshallUtil.STRING_EXT, KeycloakMarshallUtil.STRING_EXT, output);
 
-            MarshallUtil.marshallString(session.getCurrentRefreshToken(), output);
-            KeycloakMarshallUtil.marshall(session.getCurrentRefreshTokenUseCount(), output);
         }
 
 
@@ -233,9 +212,6 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
             Map<String, String> notes = KeycloakMarshallUtil.readMap(input, KeycloakMarshallUtil.STRING_EXT, KeycloakMarshallUtil.STRING_EXT,
                     new KeycloakMarshallUtil.ConcurrentHashMapBuilder<>());
             sessionEntity.setNotes(notes);
-
-            sessionEntity.setCurrentRefreshToken(MarshallUtil.unmarshallString(input));
-            sessionEntity.setCurrentRefreshTokenUseCount(KeycloakMarshallUtil.unmarshallInteger(input));
 
             return sessionEntity;
         }

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -189,26 +189,6 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
     }
 
     @Override
-    public String getCurrentRefreshToken() {
-        return getData().getCurrentRefreshToken();
-    }
-
-    @Override
-    public void setCurrentRefreshToken(String currentRefreshToken) {
-        getData().setCurrentRefreshToken(currentRefreshToken);
-    }
-
-    @Override
-    public int getCurrentRefreshTokenUseCount() {
-        return getData().getCurrentRefreshTokenUseCount();
-    }
-
-    @Override
-    public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-        getData().setCurrentRefreshTokenUseCount(currentRefreshTokenUseCount);
-    }
-
-    @Override
     public String getAction() {
         return getData().getAction();
     }
@@ -302,10 +282,6 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
         private Set<String> protocolMappers;
         @JsonProperty("roles")
         private Set<String> roles;
-        @JsonProperty("currentRefreshToken")
-        private String currentRefreshToken;
-        @JsonProperty("currentRefreshTokenUseCount")
-        private int currentRefreshTokenUseCount;
 
         public String getAuthMethod() {
             return authMethod;
@@ -379,20 +355,5 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
             this.roles = roles;
         }
 
-        public String getCurrentRefreshToken() {
-            return currentRefreshToken;
-        }
-
-        public void setCurrentRefreshToken(String currentRefreshToken) {
-            this.currentRefreshToken = currentRefreshToken;
-        }
-
-        public int getCurrentRefreshTokenUseCount() {
-            return currentRefreshTokenUseCount;
-        }
-
-        public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-            this.currentRefreshTokenUseCount = currentRefreshTokenUseCount;
-        }
     }
 }

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.session;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
@@ -257,6 +258,7 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
         return getId();
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     protected static class PersistentClientSessionData {
 
         @JsonProperty("authMethod")

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -82,7 +82,7 @@ public final class Constants {
     public static final String TOKEN = "token";
     public static final String TAB_ID = "tab_id";
     public static final String CLIENT_DATA = "client_data";
-
+    public static final String REUSE_ID = "reuse_id";
     public static final String SKIP_LOGOUT = "skip_logout";
     public static final String KEY = "key";
 

--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -66,27 +66,55 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     void detachFromUserSession();
     UserSessionModel getUserSession();
 
-    default String getRefreshToken(String id) {
-        return getNote(REFRESH_TOKEN_PREFIX + id);
-    }
-    default void setRefreshToken(String id,String refreshTokenId) {
-        setNote(REFRESH_TOKEN_PREFIX + id, refreshTokenId);
+    /**
+     * @deprecated use {@link #getRefreshToken(String)}
+     */
+    @Deprecated
+    default String getCurrentRefreshToken() {
+        return null;
     }
 
-    default int getRefreshTokenUseCount(String id) {
-        String count = getNote(REFRESH_TOKEN_USE_PREFIX + id);
+    /**
+     *  @deprecated use {@link #setRefreshToken(String, String)}}
+     */
+    @Deprecated
+    default void setCurrentRefreshToken(String currentRefreshToken) {
+    }
+
+    /**
+     * @deprecated use {@link #getRefreshTokenUseCount(String)}
+     */
+    @Deprecated
+    default int getCurrentRefreshTokenUseCount() {
+        return 0;
+    }
+
+    /**
+     * deprecated use {@link #setRefreshTokenUseCount(String, int)}
+     */
+    @Deprecated
+    default void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
+    }
+
+    default String getRefreshToken(String reuseId) {
+        return getNote(REFRESH_TOKEN_PREFIX + reuseId);
+    }
+    default void setRefreshToken(String reuseId, String refreshTokenId) {
+        setNote(REFRESH_TOKEN_PREFIX + reuseId, refreshTokenId);
+    }
+    default int getRefreshTokenUseCount(String reuseId) {
+        String count = getNote(REFRESH_TOKEN_USE_PREFIX + reuseId);
         return count == null ? 0 : Integer.parseInt(count);
     }
-    default void setRefreshTokenUseCount(String id, int refreshTokenUseCount) {
-        setNote(REFRESH_TOKEN_USE_PREFIX + id, String.valueOf(refreshTokenUseCount));
+    default void setRefreshTokenUseCount(String reuseId, int refreshTokenUseCount) {
+        setNote(REFRESH_TOKEN_USE_PREFIX + reuseId, String.valueOf(refreshTokenUseCount));
     }
-
-    default int getRefreshTokenLastRefresh(String id) {
-        String timestamp = getNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + id);
+    default int getRefreshTokenLastRefresh(String reuseId) {
+        String timestamp = getNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + reuseId);
         return timestamp == null ? 0 : Integer.parseInt(timestamp);
     }
-    default void setRefreshTokenLastRefresh(String id, int refreshTokenLastRefresh) {
-        setNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + id, String.valueOf(refreshTokenLastRefresh));
+    default void setRefreshTokenLastRefresh(String reuseId, int refreshTokenLastRefresh) {
+        setNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + reuseId, String.valueOf(refreshTokenLastRefresh));
     }
 
     String getNote(String name);

--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -31,6 +31,9 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     final String STARTED_AT_NOTE = "startedAt";
     final String USER_SESSION_STARTED_AT_NOTE = "userSessionStartedAt";
     final String USER_SESSION_REMEMBER_ME_NOTE = "userSessionRememberMe";
+    final String REFRESH_TOKEN_PREFIX = "refreshTokenPrefix";
+    final String REFRESH_TOKEN_USE_PREFIX = "refreshTokenUsePrefix";
+    final String REFRESH_TOKEN_LAST_REFRESH_PREFIX = "refreshTokenLastRefreshPrefix";
 
     String getId();
 
@@ -63,11 +66,28 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     void detachFromUserSession();
     UserSessionModel getUserSession();
 
-    String getCurrentRefreshToken();
-    void setCurrentRefreshToken(String currentRefreshToken);
+    default String getRefreshToken(String id) {
+        return getNote(REFRESH_TOKEN_PREFIX + id);
+    }
+    default void setRefreshToken(String id,String refreshTokenId) {
+        setNote(REFRESH_TOKEN_PREFIX + id, refreshTokenId);
+    }
 
-    int getCurrentRefreshTokenUseCount();
-    void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount);
+    default int getRefreshTokenUseCount(String id) {
+        String count = getNote(REFRESH_TOKEN_USE_PREFIX + id);
+        return count == null ? 0 : Integer.parseInt(count);
+    }
+    default void setRefreshTokenUseCount(String id, int refreshTokenUseCount) {
+        setNote(REFRESH_TOKEN_USE_PREFIX + id, String.valueOf(refreshTokenUseCount));
+    }
+
+    default int getRefreshTokenLastRefresh(String id) {
+        String timestamp = getNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + id);
+        return timestamp == null ? 0 : Integer.parseInt(timestamp);
+    }
+    default void setRefreshTokenLastRefresh(String id, int refreshTokenLastRefresh) {
+        setNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + id, String.valueOf(refreshTokenLastRefresh));
+    }
 
     String getNote(String name);
     void setNote(String name, String value);
@@ -77,8 +97,6 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     default void restartClientSession() {
         setAction(null);
         setRedirectUri(null);
-        setCurrentRefreshToken(null);
-        setCurrentRefreshTokenUseCount(-1);
         setTimestamp(Time.currentTime());
         for (String note : getNotes().keySet()) {
             if (!AuthenticatedClientSessionModel.USER_SESSION_STARTED_AT_NOTE.equals(note)

--- a/services/src/test/java/org/keycloak/protocol/TestAuthenticatedClientSessionModel.java
+++ b/services/src/test/java/org/keycloak/protocol/TestAuthenticatedClientSessionModel.java
@@ -38,26 +38,6 @@ public class TestAuthenticatedClientSessionModel implements AuthenticatedClientS
     }
 
     @Override
-    public String getCurrentRefreshToken() {
-        return null;
-    }
-
-    @Override
-    public void setCurrentRefreshToken(String currentRefreshToken) {
-
-    }
-
-    @Override
-    public int getCurrentRefreshTokenUseCount() {
-        return 0;
-    }
-
-    @Override
-    public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-
-    }
-
-    @Override
     public String getNote(String name) {
         return notes.get(name);
     }

--- a/services/src/test/java/org/keycloak/protocol/docker/mapper/TestAuthenticatedClientSessionModel.java
+++ b/services/src/test/java/org/keycloak/protocol/docker/mapper/TestAuthenticatedClientSessionModel.java
@@ -38,26 +38,6 @@ class TestAuthenticatedClientSessionModel implements AuthenticatedClientSessionM
     }
 
     @Override
-    public String getCurrentRefreshToken() {
-        return null;
-    }
-
-    @Override
-    public void setCurrentRefreshToken(String currentRefreshToken) {
-
-    }
-
-    @Override
-    public int getCurrentRefreshTokenUseCount() {
-        return 0;
-    }
-
-    @Override
-    public void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
-
-    }
-
-    @Override
     public String getNote(String name) {
         return notes.get(name);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-24.0.4.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-24.0.4.json
@@ -2217,7 +2217,7 @@
   "realm" : "Migration",
   "notBefore" : 0,
   "defaultSignatureAlgorithm" : "RS256",
-  "revokeRefreshToken" : false,
+  "revokeRefreshToken" : true,
   "refreshTokenMaxReuse" : 0,
   "accessTokenLifespan" : 300,
   "accessTokenLifespanForImplicitFlow" : 900,


### PR DESCRIPTION
With `Revoke Refresh Token` enabled, only the last used refresh token with its number of uses was saved. In this way it was impossible to use refresh tokens with the same client on multiple browser tabs.

To address this, when a refresh token is used each refresh token is saved in the client session notes along with the number of token uses. In this way it is possible to keep track of the used tokens and detect if the maximum number of uses is reached.

In `Revoke Refresh Tokens` settings in addition to `Refresh Token Max Reuse` is now possible to enter a `Refresh Token Reuse Period` (in seconds). 

When a refresh token is used it can remain valid for a specified duration. To address this, in the client session notes is saved the last refresh timestamp for each refresh token.

As a possible side effect I see a large number of notes saved for each refresh token in the client session.

Closes #14122
