### PR TITLE
Upgrade Groovy dependencies to latest version

### DIFF
--- a/distribution/maven-plugins/pom.xml
+++ b/distribution/maven-plugins/pom.xml
@@ -31,7 +31,8 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.12</version>
+            <version>3.0.21</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -63,7 +64,7 @@
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
-                    <version>1.6</version>
+                    <version>3.0.2</version>
                     <executions>
                         <execution>
                             <id>compile-groovy</id>


### PR DESCRIPTION
Upgrades the Groovy dependencies to the latest version, which makes the build for the `licenses-processor` plugin compatible with Java 17 targets.