### PR TITLE
Modify xpath for account console logout in the webauthn tests

### DIFF
--- a/js/apps/account-ui/src/root/Header.tsx
+++ b/js/apps/account-ui/src/root/Header.tsx
@@ -45,6 +45,7 @@ export const Header = () => {
 
   return (
     <KeycloakMasthead
+      data-testid="page-header"
       keycloak={keycloak}
       features={{ hasManageAccount: false }}
       showNavToggle

--- a/js/libs/ui-shared/src/masthead/KeycloakDropdown.tsx
+++ b/js/libs/ui-shared/src/masthead/KeycloakDropdown.tsx
@@ -8,6 +8,7 @@ import { EllipsisVIcon } from "@patternfly/react-icons";
 import { ReactNode, useState } from "react";
 
 type KeycloakDropdownProps = Omit<DropdownProps, "toggle"> & {
+  "data-testid"?: string;
   isKebab?: boolean;
   title?: ReactNode;
   dropDownItems: ReactNode[];
@@ -29,6 +30,7 @@ export const KeycloakDropdown = ({
       }}
       toggle={(ref) => (
         <MenuToggle
+          data-testid={`${rest["data-testid"]}-toggle`}
           ref={ref}
           onClick={() => setOpen(!open)}
           isExpanded={open}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/AbstractLoggedInPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/AbstractLoggedInPage.java
@@ -36,7 +36,7 @@ import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 public abstract class AbstractLoggedInPage extends AbstractAccountPage {
     public static final String ACCOUNT_SECURITY_ID = "account-security";
 
-    @FindBy(xpath = "//div[@id='app']//header[@class='pf-v5-c-page__header']")
+    @FindBy(xpath = "//*[@data-testid='page-header']")
     private LoggedInPageHeader header;
 
     @FindBy(id = "page-sidebar")

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/fragments/AbstractHeader.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/fragments/AbstractHeader.java
@@ -43,23 +43,9 @@ public abstract class AbstractHeader extends AbstractFragmentWithMobileLayout {
         assertToolsBtnVisible(expected, getLogoutBtn());
     }
 
-    public void clickReferrerLink() {
-        clickToolsBtn(getReferrerLink());
-    }
-
-    public void assertReferrerLinkVisible(boolean expected) {
-        assertToolsBtnVisible(expected, getReferrerLink());
-    }
-
-    public String getReferrerLinkText() {
-        return getToolsBtnText(getReferrerLink());
-    }
-
     public abstract void clickOptions();
 
     protected abstract WebElement getLogoutBtn ();
-
-    protected abstract WebElement getReferrerLink();
 
     protected void clickToolsBtn(WebElement btn) {
         clickOptions();

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/fragments/LoggedInPageHeader.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/fragments/LoggedInPageHeader.java
@@ -27,40 +27,24 @@ import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 public class LoggedInPageHeader extends AbstractHeader {
-    @FindBy(xpath = "//*[@data-testid='options']//a[text() = 'Sign out']")
+    @FindBy(xpath = "//*[@data-testid='page-header']//*[text() = 'Sign out']")
     private WebElement logoutBtn;
-    @FindBy(xpath = "//*[@data-testid='options-kebab']//a[text() = 'Sign out']")
-    private WebElement logoutBtnMobile;
 
-    @FindBy(id = "referrerLink")
-    private WebElement referrerLink;
-    @FindBy(id = "referrerMobileLink")
-    private WebElement referrerLinkMobile;
-
-    @FindBy(xpath = "//*[@data-testid='options']")
+    @FindBy(xpath = "//*[@data-testid='options-toggle']")
     private WebElement options;
-    @FindBy(xpath = "//*[@data-testid='options-kebab']")
-    private WebElement optionsMobile;
-
-    @FindBy(id = "loggedInUser")
-    private WebElement toolbarLoggedInUser;
 
     @Override
     public void clickOptions() {
-        clickLink(isMobileLayout() ? optionsMobile : options);
+        clickLink(options);
     }
 
     @Override
     protected WebElement getLogoutBtn() {
-        return isMobileLayout() ? logoutBtnMobile : logoutBtn;
-    }
 
-    @Override
-    protected WebElement getReferrerLink() {
-        return isMobileLayout() ? referrerLinkMobile : referrerLink;
+        return logoutBtn;
     }
 
     public String getToolbarLoggedInUser() {
-        return getTextFromElement(toolbarLoggedInUser);
+        return getTextFromElement(options);
     }
 }


### PR DESCRIPTION
Closes #30024

Just changing the xpath to locate the dropdown and the logout correctly. I'm using the same tpe of path that is using [AbstractLoggedInPage](https://github.com/keycloak/keycloak/blob/main/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/AbstractLoggedInPage.java#L39). The webauthn tests passed locally.