### PR TITLE
Allow to configure if users are automatically redirected when the email domain matches an organization

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3192,3 +3192,5 @@ linkUpdateError=Could not update link to identity provider\: {{error}}
 noResultsFound=No results found
 linkedOrganization=Linked organization
 send=Send
+redirectWhenEmailMatches=Redirect when email domain matches
+redirectWhenEmailMatchesHelp=Automatically redirect the user to this identity provider when the email domain matches the domain

--- a/js/apps/admin-ui/src/organizations/LinkIdentityProviderModal.tsx
+++ b/js/apps/admin-ui/src/organizations/LinkIdentityProviderModal.tsx
@@ -145,6 +145,14 @@ export const LinkIdentityProviderModal = ({
             labelIcon={t("shownOnLoginPageHelp")}
             stringify
           />
+          <DefaultSwitchControl
+            name={convertAttributeNameToForm(
+              "config.kc.org.broker.redirect.mode.email-matches",
+            )}
+            label={t("redirectWhenEmailMatches")}
+            labelIcon={t("redirectWhenEmailMatchesHelp")}
+            stringify
+          />
         </Form>
       </FormProvider>
     </Modal>

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -29,6 +29,24 @@ public interface OrganizationModel {
     String ORGANIZATION_DOMAIN_ATTRIBUTE = "kc.org.domain";
     String BROKER_PUBLIC = "kc.org.broker.public";
 
+    enum IdentityProviderRedirectMode {
+        EMAIL_MATCH("kc.org.broker.redirect.mode.email-matches");
+
+        private final String key;
+
+        IdentityProviderRedirectMode(String key) {
+            this.key = key;
+        }
+
+        public boolean isSet(IdentityProviderModel broker) {
+            return Boolean.parseBoolean(broker.getConfig().get(key));
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+
     String getId();
 
     void setName(String name);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
@@ -32,6 +32,7 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.models.OrganizationModel.IdentityProviderRedirectMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.GroupRepresentation;
@@ -117,6 +118,7 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
         }
         // set the idp domain to the first domain used to create the org.
         broker.getConfig().put(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, orgDomains[0]);
+        broker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.TRUE.toString());
         testRealm.identityProviders().create(broker).close();
         testCleanup.addCleanup(testRealm.identityProviders().get(broker.getAlias())::remove);
         testRealm.organizations().get(id).identityProviders().addIdentityProvider(broker.getAlias()).close();
@@ -201,7 +203,7 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
         assertFalse(driver.getPageSource().contains("kc.org"));
         updateAccountInformationPage.updateAccountInformation(bc.getUserLogin(), email, "Firstname", "Lastname");
         assertThat(appPage.getRequestType(),is(AppPage.RequestType.AUTH_RESPONSE));
-        
+
         assertIsMember(email, organization);
     }
 


### PR DESCRIPTION
Closes #30050

* Introduces a switch to the identity provider to choose whether users are automatically redirected to the identity provider when the email domain matches the domain set to the broker
* Makes it possible to provide additional settings to change how/when the redirect should happen. That is why I'm using a `enum`. I initially tried to use a single UI setting for the possible different "redirect modes" but I think we will end up having separate options as they might not be mutually exclusive.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
