### PR TITLE
Client type configuration inheritance

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ClientTypeRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ClientTypeRepresentation.java
@@ -33,6 +33,9 @@ public class ClientTypeRepresentation {
     @JsonProperty("provider")
     private String provider;
 
+    @JsonProperty("parent")
+    private String parent;
+
     @JsonProperty("config")
     private Map<String, PropertyConfig> config;
 
@@ -58,6 +61,14 @@ public class ClientTypeRepresentation {
 
     public void setConfig(Map<String, PropertyConfig> config) {
         this.config = config;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String parent) {
+        this.parent = parent;
     }
 
     public static class PropertyConfig {

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
@@ -19,9 +19,8 @@
 package org.keycloak.client.clienttype;
 
 import org.keycloak.models.ClientModel;
-import org.keycloak.representations.idm.ClientTypeRepresentation;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * TODO:client-types javadocs
@@ -39,7 +38,7 @@ public interface ClientType {
     // Return the value of particular option (if it can be provided by clientType) or return null if this option is not provided by client type
     <T> T getTypeValue(String optionName, Class<T> optionType);
 
-    Map<String, ClientTypeRepresentation.PropertyConfig> getConfig();
+    Set<String> getOptionNames();
 
     // Augment at the client type
     ClientModel augment(ClientModel client);

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientType.java
@@ -19,8 +19,9 @@
 package org.keycloak.client.clienttype;
 
 import org.keycloak.models.ClientModel;
+import org.keycloak.representations.idm.ClientTypeRepresentation;
 
-import java.util.Set;
+import java.util.Map;
 
 /**
  * TODO:client-types javadocs
@@ -38,7 +39,7 @@ public interface ClientType {
     // Return the value of particular option (if it can be provided by clientType) or return null if this option is not provided by client type
     <T> T getTypeValue(String optionName, Class<T> optionType);
 
-    Set<String> getOptionNames();
+    Map<String, ClientTypeRepresentation.PropertyConfig> getConfig();
 
     // Augment at the client type
     ClientModel augment(ClientModel client);

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
@@ -41,7 +41,6 @@ public class ClientTypeException extends ModelException {
         DUPLICATE_CLIENT_TYPE("Duplicated client type name"),
         CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION("Cannot change property of client as it is not allowed by the specified client type."),
         CLIENT_TYPE_NOT_FOUND("Client type not found."),
-        PARENT_CLIENT_TYPE_NOT_FOUND("Client type parent not found."),
         CLIENT_TYPE_FAILED_TO_LOAD("Failed to load client type.");
 
         private final String message;

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeException.java
@@ -29,10 +29,6 @@ public class ClientTypeException extends ModelException {
         super(message, parameters);
     }
 
-    private ClientTypeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public enum Message {
         /**
          * Register all client type exception messages through this enum to keep things consistent across the services.
@@ -45,6 +41,7 @@ public class ClientTypeException extends ModelException {
         DUPLICATE_CLIENT_TYPE("Duplicated client type name"),
         CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION("Cannot change property of client as it is not allowed by the specified client type."),
         CLIENT_TYPE_NOT_FOUND("Client type not found."),
+        PARENT_CLIENT_TYPE_NOT_FOUND("Client type parent not found."),
         CLIENT_TYPE_FAILED_TO_LOAD("Failed to load client type.");
 
         private final String message;
@@ -55,10 +52,6 @@ public class ClientTypeException extends ModelException {
 
         public ClientTypeException exception(Object... parameters) {
             return new ClientTypeException(message, parameters);
-        }
-
-        public ClientTypeException exception(String message, Throwable cause) {
-            return new ClientTypeException(message, cause);
         }
 
         public String getMessage() {

--- a/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/client/clienttype/ClientTypeProvider.java
@@ -27,7 +27,7 @@ import org.keycloak.representations.idm.ClientTypeRepresentation;
 public interface ClientTypeProvider extends Provider {
 
     // Return client types for the model returned
-    ClientType getClientType(ClientTypeRepresentation clientTypeRep);
+    ClientType getClientType(ClientTypeRepresentation clientTypeRep, ClientType parent);
 
     // TODO:client-types type-safety here. The returned clientType should have correctly casted client type configuration
     // Used when creating/updating clientType. The JSON configuration is validated to be checked if it matches the good format for client type

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -655,8 +655,8 @@ public class RepresentationToModel {
     }
 
     /**
-     * Create Supplier to update property, if not null.
-     * Captures {@link ClientTypeException} if thrown by the setter.
+     * Create Supplier to update property.
+     * Captures and returns {@link ClientTypeException} if thrown by the setter.
      *
      * @param modelSetter setter to call.
      * @param representationGetter getter supplying the property update.
@@ -687,9 +687,7 @@ public class RepresentationToModel {
     private static <T> Supplier<ClientTypeException> updatePropertyAction(Consumer<T> modelSetter, Supplier<T>... getters) {
         Stream<T> firstNonNullSupplied = Stream.of(getters)
                 .map(Supplier::get)
-                .map(Optional::ofNullable)
-                .filter(Optional::isPresent)
-                .map(Optional::get);
+                .filter(Objects::nonNull);
         return updateProperty(modelSetter, () -> firstNonNullSupplied.findFirst().orElse(null));
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -27,7 +27,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -21,6 +21,8 @@ package org.keycloak.services.clienttype;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -102,8 +104,13 @@ public class DefaultClientTypeManager implements ClientTypeManager {
             throw ClientTypeException.Message.CLIENT_TYPE_NOT_FOUND.exception();
         }
 
+        ClientType parent = null;
+        if (clientType.getParent() != null) {
+            parent = getClientType(realm, clientType.getParent());
+        }
+
         ClientTypeProvider provider = session.getProvider(ClientTypeProvider.class, clientType.getProvider());
-        return provider.getClientType(clientType);
+        return provider.getClientType(clientType, parent);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -48,8 +48,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isStandardFlowEnabled() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
+                .getClientAttribute(clientType, super::isStandardFlowEnabled, Boolean.class);
     }
 
     @Override
@@ -60,8 +60,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isBearerOnly() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.BEARER_ONLY
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.BEARER_ONLY
+                .getClientAttribute(clientType, super::isBearerOnly, Boolean.class);
     }
 
     @Override
@@ -72,8 +72,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isConsentRequired() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.CONSENT_REQUIRED
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.CONSENT_REQUIRED
+                .getClientAttribute(clientType, super::isConsentRequired, Boolean.class);
     }
 
     @Override
@@ -84,8 +84,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isDirectAccessGrantsEnabled() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+                .getClientAttribute(clientType, super::isDirectAccessGrantsEnabled, Boolean.class);
     }
 
     @Override
@@ -96,8 +96,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isAlwaysDisplayInConsole() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+                .getClientAttribute(clientType, super::isAlwaysDisplayInConsole, Boolean.class);
     }
 
     @Override
@@ -108,8 +108,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isFrontchannelLogout() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
+                .getClientAttribute(clientType, super::isFrontchannelLogout, Boolean.class);
     }
 
     @Override
@@ -120,8 +120,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isImplicitFlowEnabled() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
+                .getClientAttribute(clientType, super::isImplicitFlowEnabled, Boolean.class);
     }
 
     @Override
@@ -132,8 +132,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isServiceAccountsEnabled() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
+                .getClientAttribute(clientType, super::isServiceAccountsEnabled, Boolean.class);
     }
 
     @Override
@@ -145,7 +145,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     @Override
     public String getProtocol() {
         return TypedClientSimpleAttribute.PROTOCOL
-                .getClientAttribute(clientType, String.class);
+                .getClientAttribute(clientType, super::getProtocol, String.class);
     }
 
     @Override
@@ -156,8 +156,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isPublicClient() {
-        return Boolean.TRUE.equals(TypedClientSimpleAttribute.PUBLIC_CLIENT
-                .getClientAttribute(clientType, Boolean.class));
+        return TypedClientSimpleAttribute.PUBLIC_CLIENT
+                .getClientAttribute(clientType, super::isPublicClient, Boolean.class);
     }
 
     @Override
@@ -169,7 +169,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     @Override
     public Set<String> getWebOrigins() {
         return TypedClientSimpleAttribute.WEB_ORIGINS
-                .getClientAttribute(clientType, Set.class);
+                .getClientAttribute(clientType, super::getWebOrigins, Set.class);
     }
 
     @Override
@@ -193,7 +193,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     @Override
     public Set<String> getRedirectUris() {
         return TypedClientSimpleAttribute.REDIRECT_URIS
-                .getClientAttribute(clientType, Set.class);
+                .getClientAttribute(clientType, super::getRedirectUris, Set.class);
     }
 
     @Override
@@ -238,7 +238,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     public String getAttribute(String name) {
         TypedClientExtendedAttribute attribute = TypedClientExtendedAttribute.getAttributesByName().get(name);
         if (attribute != null) {
-            return attribute.getClientAttribute(clientType, String.class);
+            return attribute.getClientAttribute(clientType, () -> super.getAttribute(name), String.class);
         } else {
             return super.getAttribute(name);
         }
@@ -251,8 +251,9 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
         // Get extended client type attributes and values from the client type configuration.
         Set<String> extendedClientTypeAttributes =
-                clientType.getConfig().keySet().stream()
-                .filter(optionName -> TypedClientExtendedAttribute.getAttributesByName().containsKey(optionName))
+                clientType.getConfig().entrySet().stream()
+                .map(Map.Entry::getKey)
+                .filter(entry -> TypedClientExtendedAttribute.getAttributesByName().containsKey(entry))
                 .collect(Collectors.toSet());
 
         // Augment client type attributes on top of attributes on the delegate.

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -251,9 +251,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
         // Get extended client type attributes and values from the client type configuration.
         Set<String> extendedClientTypeAttributes =
-                clientType.getConfig().entrySet().stream()
-                .map(Map.Entry::getKey)
-                .filter(entry -> TypedClientExtendedAttribute.getAttributesByName().containsKey(entry))
+                clientType.getOptionNames().stream()
+                .filter(optionName -> TypedClientExtendedAttribute.getAttributesByName().containsKey(optionName))
                 .collect(Collectors.toSet());
 
         // Augment client type attributes on top of attributes on the delegate.

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -48,8 +48,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isStandardFlowEnabled() {
-        return TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.STANDARD_FLOW_ENABLED
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -60,8 +60,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isBearerOnly() {
-        return TypedClientSimpleAttribute.BEARER_ONLY
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.BEARER_ONLY
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -72,8 +72,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isConsentRequired() {
-        return TypedClientSimpleAttribute.CONSENT_REQUIRED
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.CONSENT_REQUIRED
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -84,8 +84,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isDirectAccessGrantsEnabled() {
-        return TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.DIRECT_ACCESS_GRANTS_ENABLED
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -96,8 +96,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isAlwaysDisplayInConsole() {
-        return TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.ALWAYS_DISPLAY_IN_CONSOLE
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -108,8 +108,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isFrontchannelLogout() {
-        return TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.FRONTCHANNEL_LOGOUT
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -120,8 +120,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isImplicitFlowEnabled() {
-        return TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.IMPLICIT_FLOW_ENABLED
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -132,8 +132,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isServiceAccountsEnabled() {
-        return TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.SERVICE_ACCOUNTS_ENABLED
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -156,8 +156,8 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
     @Override
     public boolean isPublicClient() {
-        return TypedClientSimpleAttribute.PUBLIC_CLIENT
-                .getClientAttribute(clientType, Boolean.class);
+        return Boolean.TRUE.equals(TypedClientSimpleAttribute.PUBLIC_CLIENT
+                .getClientAttribute(clientType, Boolean.class));
     }
 
     @Override
@@ -251,9 +251,9 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
         // Get extended client type attributes and values from the client type configuration.
         Set<String> extendedClientTypeAttributes =
-                clientType.getOptionNames().stream()
-                        .filter(optionName -> TypedClientExtendedAttribute.getAttributesByName().containsKey(optionName))
-                        .collect(Collectors.toSet());
+                clientType.getConfig().keySet().stream()
+                .filter(optionName -> TypedClientExtendedAttribute.getAttributesByName().containsKey(optionName))
+                .collect(Collectors.toSet());
 
         // Augment client type attributes on top of attributes on the delegate.
         for (String entry : extendedClientTypeAttributes) {

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 enum TypedClientSimpleAttribute implements TypedClientAttribute {
     // Top Level client attributes
@@ -120,7 +121,7 @@ enum TypedClientExtendedAttribute implements TypedClientAttribute {
 interface TypedClientAttribute {
     Logger logger = Logger.getLogger(TypedClientAttribute.class);
 
-    default <T> T getClientAttribute(ClientType clientType, Class<T> tClass) {
+    default <T> T getClientAttribute(ClientType clientType, Supplier<T> clientGetter, Class<T> tClass) {
         String propertyName = getPropertyName();
         Object nonApplicableValue = getNonApplicableValue();
 
@@ -134,7 +135,9 @@ interface TypedClientAttribute {
             }
         }
 
-        return clientType.getTypeValue(propertyName, tClass);
+        T typeValue = clientType.getTypeValue(propertyName, tClass);
+        // If the value is not supplied by the client type, delegate to the client getter.
+        return typeValue == null ? clientGetter.get() : typeValue;
     }
 
     default <T> void setClientAttribute(ClientType clientType, T newValue, Consumer<T> clientSetter, Class<T> tClass) {

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -148,8 +148,8 @@ interface TypedClientAttribute {
         }
 
         // If there is an attempt to change a value for an applicable field with a read-only value set, then throw an exception.
-        T oldVal = clientType.getTypeValue(propertyName, tClass);
-        if (!ObjectUtil.isEqualOrBothNull(oldVal, newValue)) {
+        T readOnlyValue = clientType.getTypeValue(propertyName, tClass);
+        if (readOnlyValue != null && !readOnlyValue.equals(newValue)) {
             throw ClientTypeException.Message.CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION.exception(propertyName);
         }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
@@ -34,8 +34,8 @@ public class DefaultClientTypeProvider implements ClientTypeProvider {
     private static final Logger logger = Logger.getLogger(DefaultClientTypeProvider.class);
 
     @Override
-    public ClientType getClientType(ClientTypeRepresentation clientTypeRep) {
-        return new DefaultClientType(clientTypeRep);
+    public ClientType getClientType(ClientTypeRepresentation clientTypeRep, ClientType parent) {
+        return new DefaultClientType(clientTypeRep, parent);
     }
 
     @Override

--- a/services/src/main/resources/keycloak-default-client-types.json
+++ b/services/src/main/resources/keycloak-default-client-types.json
@@ -14,6 +14,9 @@
       "name": "oidc",
       "provider": "default",
       "config": {
+        "alwaysDisplayInConsole": {
+          "applicable": true
+        },
         "authorizationServicesEnabled": {
           "applicable": true
         },
@@ -59,6 +62,7 @@
     {
       "name": "service-account",
       "provider": "default",
+      "parent": "oidc",
       "config": {
         "alwaysDisplayInConsole": {
           "applicable": false
@@ -96,10 +100,6 @@
         },
         "policyUri": {
           "applicable": false
-        },
-        "protocol": {
-          "applicable": true,
-          "value": "openid-connect"
         },
         "publicClient": {
           "applicable": true,


### PR DESCRIPTION
Implementation for Client Type inheritance.

Can specify "parent" client type field to inherit defined client type fields of a parent.

closes #30213 