### PR TITLE
Remove the transformed output directory before executing JakartaTransformer

### DIFF
--- a/adapters/saml/core-jakarta/pom.xml
+++ b/adapters/saml/core-jakarta/pom.xml
@@ -94,8 +94,8 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
+                                <delete dir="${jakarta-transformer-target}"/>
                                 <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
-                                    <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}" />
                                     <classpath>

--- a/adapters/saml/wildfly-elytron-jakarta/pom.xml
+++ b/adapters/saml/wildfly-elytron-jakarta/pom.xml
@@ -115,8 +115,8 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
+                                <delete dir="${jakarta-transformer-target}"/>
                                 <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
-                                    <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}" />
                                     <classpath>

--- a/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-jakarta-subsystem/pom.xml
@@ -55,8 +55,8 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
+                                <delete dir="${jakarta-transformer-target}"/>
                                 <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
-                                    <arg value="-o" />
                                     <arg value="${jakarta-transformer-sources}" />
                                     <arg value="${jakarta-transformer-target}" />
                                     <classpath>

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -93,24 +93,14 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath"/>
+                                <delete dir="${jakarta-transformer-target}"/>
                                 <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
-                                    <arg value="-o"/>
                                     <arg value="${jakarta-transformer-sources}"/>
                                     <arg value="${jakarta-transformer-target}"/>
                                     <classpath>
                                         <pathelement path="${plugin_classpath}"/>
                                     </classpath>
                                 </java>
-                                <!-- Possibility to override classes for admin-client-jee -->
-                                <!-- Remove this comment in that case
-                                <touch>
-                                    <fileset dir="${jakarta-transformer-target}"/>
-                                </touch>
-                                <copy todir="${jakarta-transformer-target}" overwrite="false">
-                                    <fileset dir="${jakarta-transformer-target}/tmp"/>
-                                </copy>
-                                <delete dir="${jakarta-transformer-target}/tmp"/>
-                                -->
                             </target>
                         </configuration>
                     </execution>

--- a/testsuite/integration-arquillian/test-apps/servlets-jakarta/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/servlets-jakarta/pom.xml
@@ -16,8 +16,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jakarta-transformer-sources>${project.basedir}/../servlets</jakarta-transformer-sources>
-        <jakarta-transformer-target>${project.basedir}</jakarta-transformer-target>
+        <jakarta-transformer-sources>${project.basedir}/../servlets/src</jakarta-transformer-sources>
+        <jakarta-transformer-target>${project.basedir}/src</jakarta-transformer-target>
     </properties>
 
     <dependencies>
@@ -96,21 +96,14 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath"/>
+                                <delete dir="${jakarta-transformer-target}"/>
                                 <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
-                                    <arg value="-o"/>
                                     <arg value="${jakarta-transformer-sources}"/>
-                                    <arg value="${jakarta-transformer-target}/tmp"/>
+                                    <arg value="${jakarta-transformer-target}"/>
                                     <classpath>
                                         <pathelement path="${plugin_classpath}"/>
                                     </classpath>
                                 </java>
-                                <touch>
-                                    <fileset dir="${jakarta-transformer-target}"/>
-                                </touch>
-                                <copy todir="${jakarta-transformer-target}" overwrite="false">
-                                    <fileset dir="${jakarta-transformer-target}/tmp"/>
-                                </copy>
-                                <delete dir="${jakarta-transformer-target}/tmp"/>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Closes #30086

Just adding a previous step to the `JakartaTransformer` execution in order to remove the destination folder. All the projects that use this transformation have no extra sources (they are totally empty), so no problem if we remove the destination folder before to not maintain old java files from previous executions.
