### PR TITLE
Make sure configuration is loaded with mapped/transformed properties …

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -280,6 +280,7 @@ public final class Picocli {
         }
 
         try {
+            getConfig(); // ensure the config is initialized before the interceptor is disabled
             PropertyMappingInterceptor.disable(); // we don't want the mapped / transformed properties, we want what the user effectively supplied
             List<String> ignoredBuildTime = new ArrayList<>();
             List<String> ignoredRunTime = new ArrayList<>();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -22,9 +22,16 @@ import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.utils.KeycloakDistribution;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
@@ -65,6 +72,17 @@ public class StartDevCommandDistTest {
     @Launch({ "start-dev", "--verbose" })
     void testVerboseAfterCommand(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @DisabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "A drive letter in URI can cause a problem.")
+    void testConfigKeystoreAbsolutePath(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("start-dev", "--config-keystore=" + Paths.get("src/test/resources/keystore").toAbsolutePath().normalize(),
+                "--config-keystore-password=secret");
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.hibernate"));
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.keycloak"));
+        assertTrue(cliResult.getOutput().contains("Listening on:"));
         cliResult.assertStartedDevMode();
     }
 


### PR DESCRIPTION
…at first

* edited Picocli and added a corresponding test for Windows

Closes: #29329

Co-authored-by: Vaclav Muzikar <vmuzikar@redhat.com>
Signed-off-by: Peter Zaoral <pzaoral@redhat.com>

The configuration needs to be loaded before we disable the interceptor. Otherwise the config sources like `config-keystore` or `config-file` would be initialised with the untransformed values. Such behaviour can cause issues in some cases - for example a raw path to a keystore-config source on Windows that contains colon, whereas the URI format is required.

The fix was also tested on a local Windows environment prior to PR creation.