### PR TITLE
Missing auth checks in some admin endpoints (#166)

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/services/resources/admin/TestLdapConnectionResource.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/resources/admin/TestLdapConnectionResource.java
@@ -16,9 +16,7 @@
  */
 package org.keycloak.services.resources.admin;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
-import org.keycloak.common.ClientConnection;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
@@ -89,6 +87,7 @@ public class TestLdapConnectionResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     public Response testLDAPConnection(TestLdapConnectionRepresentation config) {
+        auth.realm().requireManageRealm();
         try {
             LDAPServerCapabilitiesManager.testLDAP(config, session, realm);
             return Response.noContent().build();

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientRegistrationPolicyResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientRegistrationPolicyResource.java
@@ -74,6 +74,7 @@ public class ClientRegistrationPolicyResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_REGISTRATION_POLICY)
     @Operation( summary="Base path for retrieve providers with the configProperties properly filled")
     public Stream<ComponentTypeRepresentation> getProviders() {
+        auth.realm().requireViewRealm();
         return session.getKeycloakSessionFactory().getProviderFactoriesStream(ClientRegistrationPolicy.class)
                 .map((ProviderFactory factory) -> {
                     ClientRegistrationPolicyFactory clientRegFactory = (ClientRegistrationPolicyFactory) factory;

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -1062,6 +1062,7 @@ public class UserResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
     @Operation()
     public Map<String, List<String>> getUnmanagedAttributes() {
+        auth.users().requireView(user);
         UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
 
         UserProfile profile = provider.create(USER_API, user);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -51,6 +51,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.TestLdapConnectionRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
@@ -375,7 +376,11 @@ public class PermissionsTest extends AbstractKeycloakTest {
 
         invoke(new InvocationWithResponse() {
             public void invoke(RealmResource realm, AtomicReference<Response> response) {
-                response.set(realm.testLDAPConnection("nosuch", "nosuch", "nosuch", "nosuch", "nosuch", "nosuch"));
+                TestLdapConnectionRepresentation config = new TestLdapConnectionRepresentation(
+                        "nosuch", "nosuch", "nosuch", "nosuch", "nosuch", "nosuch");
+                response.set(realm.testLDAPConnection(config.getAction(), config.getConnectionUrl(), config.getBindDn(),
+                        config.getBindCredential(), config.getUseTruststoreSpi(), config.getConnectionTimeout()));
+                response.set(realm.testLDAPConnection(config));
             }
         }, Resource.REALM, true);
 
@@ -1460,6 +1465,11 @@ public class PermissionsTest extends AbstractKeycloakTest {
         }, Resource.USER, false);
         invoke(new Invocation() {
             public void invoke(RealmResource realm) {
+                realm.users().get(user.getId()).getUnmanagedAttributes();
+            }
+        }, Resource.USER, false);
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
                 realm.users().get(user.getId()).update(user);
             }
         }, Resource.USER, true);
@@ -1755,6 +1765,11 @@ public class PermissionsTest extends AbstractKeycloakTest {
         invoke(new Invocation() {
             public void invoke(RealmResource realm) {
                 realm.components().query("nosuch");
+            }
+        }, Resource.REALM, false);
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
+                realm.clientRegistrationPolicy().getProviders();
             }
         }, Resource.REALM, false);
         invoke(new InvocationWithResponse() {


### PR DESCRIPTION
Closes keycloak/keycloak-private#156

Backport to main.
