### PR TITLE
Align `authServerUrl` environment variable

### DIFF
--- a/js/apps/account-ui/README.md
+++ b/js/apps/account-ui/README.md
@@ -22,7 +22,7 @@ import { KeycloakProvider } from "@keycloak/keycloak-account-ui";
 //...
 
 <KeycloakProvider environment={{
-      authUrl: "http://localhost:8080",
+      authServerUrl: "http://localhost:8080",
       realm: "master",
       clientId: "security-admin-console"
   }}>

--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -148,7 +148,7 @@
 <![CDATA[
   <script id="environment" type="application/json">
     {
-      "authUrl": "${authUrl}",
+      "authServerUrl": "${authUrl}",
       "baseUrl": "${baseUrl}",
       "realm": "${realm.name}",
       "clientId": "${clientId}",

--- a/js/apps/account-ui/src/api.ts
+++ b/js/apps/account-ui/src/api.ts
@@ -85,7 +85,7 @@ export async function getIssuer(context: KeycloakContext<BaseEnvironment>) {
     {},
     new URL(
       joinPath(
-        context.environment.authUrl +
+        context.environment.authServerUrl +
           "/realms/" +
           context.environment.realm +
           "/.well-known/openid-credential-issuer",

--- a/js/apps/account-ui/src/api/methods.ts
+++ b/js/apps/account-ui/src/api/methods.ts
@@ -134,7 +134,7 @@ export async function linkAccount(
 ) {
   const redirectUri = encodeURIComponent(
     joinPath(
-      context.environment.authUrl,
+      context.environment.authServerUrl,
       "realms",
       context.environment.realm,
       "account",

--- a/js/apps/account-ui/src/api/request.ts
+++ b/js/apps/account-ui/src/api/request.ts
@@ -50,7 +50,13 @@ export async function request(
 
 export const url = (environment: BaseEnvironment, path: string) =>
   new URL(
-    joinPath(environment.authUrl, "realms", environment.realm, "account", path),
+    joinPath(
+      environment.authServerUrl,
+      "realms",
+      environment.realm,
+      "account",
+      path,
+    ),
   );
 
 export const token = (keycloak: Keycloak) =>

--- a/js/apps/account-ui/src/i18n.ts
+++ b/js/apps/account-ui/src/i18n.ts
@@ -28,7 +28,7 @@ export const i18n = createInstance({
   },
   backend: {
     loadPath: joinPath(
-      environment.authUrl,
+      environment.authServerUrl,
       `resources/${environment.realm}/account/{{lng}}`,
     ),
     parse: (data: string) => {

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -127,7 +127,6 @@
       "realm": "${loginRealm!"master"}",
       "clientId": "${clientId}",
       "authServerUrl": "${authServerUrl}",
-      "authUrl": "${authUrl}",
       "consoleBaseUrl": "${consoleBaseUrl}",
       "resourceUrl": "${resourceUrl}",
       "masterRealm": "${masterRealm}",

--- a/js/apps/admin-ui/src/admin-client.ts
+++ b/js/apps/admin-ui/src/admin-client.ts
@@ -24,7 +24,7 @@ export async function initAdminClient(
   const adminClient = new KeycloakAdminClient();
 
   adminClient.setConfig({ realmName: environment.realm });
-  adminClient.baseUrl = environment.authUrl;
+  adminClient.baseUrl = environment.authServerUrl;
   adminClient.registerTokenProvider({
     async getAccessToken() {
       try {

--- a/js/apps/admin-ui/src/identity-providers/add/SamlGeneralSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/SamlGeneralSettings.tsx
@@ -54,7 +54,7 @@ export const SamlGeneralSettings = ({
         >
           <FormattedLink
             title={t("samlEndpointsLabel")}
-            href={`${environment.authUrl}/realms/${realm}/broker/${alias}/endpoint/descriptor`}
+            href={`${environment.authServerUrl}/realms/${realm}/broker/${alias}/endpoint/descriptor`}
             isInline
           />
         </FormGroup>

--- a/js/libs/ui-shared/src/context/KeycloakContext.tsx
+++ b/js/libs/ui-shared/src/context/KeycloakContext.tsx
@@ -49,7 +49,7 @@ export const KeycloakProvider = <T extends BaseEnvironment>({
   const [error, setError] = useState<unknown>();
   const keycloak = useMemo(() => {
     const keycloak = new Keycloak({
-      url: environment.authUrl,
+      url: environment.authServerUrl,
       realm: environment.realm,
       clientId: environment.clientId,
     });

--- a/js/libs/ui-shared/src/context/environment.ts
+++ b/js/libs/ui-shared/src/context/environment.ts
@@ -16,8 +16,13 @@ export type Feature = {
 };
 
 export type BaseEnvironment = {
-  /** The URL to the root of the auth server. */
-  authUrl: string;
+  /**
+   * The URL to the root of the Keycloak server, this is **NOT** always equivalent to the URL of the Admin Console.
+   * For example, the Keycloak server could be hosted on `auth.example.com` and Admin Console may be hosted on `admin.example.com`.
+   *
+   * @see {@link https://www.keycloak.org/server/hostname#_administration_console}
+   */
+  authServerUrl: string;
   /** The URL to the root of the account console. */
   baseUrl: string;
   /** The realm used to authenticate the user to the Account Console. */
@@ -33,8 +38,6 @@ export type BaseEnvironment = {
 };
 
 export type AdminEnvironment = BaseEnvironment & {
-  /** The URL to the root of the auth server. */
-  authServerUrl: string;
   /** The name of the master realm. */
   masterRealm: string;
   /** The URL to the base of the Admin UI. */
@@ -60,7 +63,6 @@ const realm =
   location.pathname.match("/realms/(.*?)/account")?.[1];
 
 const defaultEnvironment: AdminEnvironment & AccountEnvironment = {
-  authUrl: "http://localhost:8180",
   authServerUrl: "http://localhost:8180",
   baseUrl: `http://localhost:8180/realms/${realm ?? DEFAULT_REALM}/account/`,
   realm: realm ?? DEFAULT_REALM,


### PR DESCRIPTION
Aligns the `authServerUrl` environment variable between the Admin and Account consoles, so that they both contain the URL to the Keycloak server. This also removes the `authUrl` environment variable (which contains the [URL to the Admin console](https://www.keycloak.org/server/hostname#_administration_console)), since it is not needed anywhere in the Admin console.

Closes #29641
