### PR TITLE
prevent freemarker exceptions from unavailable properties

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
@@ -6,7 +6,7 @@
     ${msg("recovery-code-config-header")}
 <#elseif section = "form">
     <!-- warning -->
-    <div class="pf-c-alert pf-m-warning pf-m-inline ${properties.kcRecoveryCodesWarning}" aria-label="Warning alert">
+    <div class="pf-c-alert pf-m-warning pf-m-inline ${properties.kcRecoveryCodesWarning!}" aria-label="Warning alert">
         <div class="pf-c-alert__icon">
             <i class="pficon-warning-triangle-o" aria-hidden="true"></i>
         </div>
@@ -26,7 +26,7 @@
     </ol>
 
     <!-- actions -->
-    <div class="${properties.kcRecoveryCodesActions}">
+    <div class="${properties.kcRecoveryCodesActions!}">
         <button id="printRecoveryCodes" class="pf-c-button pf-m-link" type="button">
             <i class="pficon-print"></i> ${msg("recovery-codes-print")}
         </button>
@@ -40,7 +40,7 @@
 
     <!-- confirmation checkbox -->
     <div class="${properties.kcFormOptionsClass!}">
-        <input class="${properties.kcCheckInputClass}" type="checkbox" id="kcRecoveryCodesConfirmationCheck" name="kcRecoveryCodesConfirmationCheck" 
+        <input class="${properties.kcCheckInputClass!}" type="checkbox" id="kcRecoveryCodesConfirmationCheck" name="kcRecoveryCodesConfirmationCheck"
         onchange="document.getElementById('saveRecoveryAuthnCodesBtn').disabled = !this.checked;"
         />
         <label for="kcRecoveryCodesConfirmationCheck">${msg("recovery-codes-confirmation-message")}</label>

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -5,7 +5,7 @@
     <#if section = "title">
         title
     <#elseif section = "header">
-        <span class="${properties.kcWebAuthnKeyIcon}"></span>
+        <span class="${properties.kcWebAuthnKeyIcon!}"></span>
         ${kcSanitize(msg("webauthn-registration-title"))?no_esc}
     <#elseif section = "form">
 


### PR DESCRIPTION
There were some properties in Freemarker templates in `base` theme which had unset empty default values. This yielded in Freemarker exceptions during runtime if a custom theme inherits from `base` but hasn't declared these properties in `theme.properties`.

This PR fixes this behavior as it adds the empty default "values".

Closes #30220