### PR TITLE
ui: make Scope Details page's Description a textarea, like Roles'

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -117,7 +117,7 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
             )}
           </>
         )}
-        <TextControl
+        <TextAreaControl
           name="description"
           label={t("description")}
           labelIcon={t("scopeDescriptionHelp")}


### PR DESCRIPTION
The Scope Details page had its description field as a single line text field. This is inconsistent with the Roles page, which has it as a textarea allowing multiline editing.

It's true that the character limit is 255 (which is way too short and should probably be changed imo) but newlines are useful in tweets too :)

![image](https://github.com/keycloak/keycloak/assets/6652840/662abeba-b34c-43b2-8a0e-72b7fb98026e)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
