### PR TITLE
feat: Add passwordrules support for Safari in update password page

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/CustomUpdatePasswordAuthenticator.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/CustomUpdatePasswordAuthenticator.java
@@ -1,0 +1,54 @@
+package org.keycloak.policy;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.PasswordPolicy;
+
+public class CustomUpdatePasswordAuthenticator implements Authenticator {
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        KeycloakSession session = context.getSession();
+        RealmModel realm = context.getRealm();
+        PasswordPolicy policy = realm.getPasswordPolicy();
+
+        Integer minLength = policy.getPolicyConfig("length");
+        Integer maxLength = policy.getPolicyConfig("maxLength");
+        Boolean requireDigits = policy.getPolicyConfig("digits") != null;
+        Boolean requireLowerCase = policy.getPolicyConfig("lowerCase") != null;
+        Boolean requireUpperCase = policy.getPolicyConfig("upperCase") != null;
+
+        context.getAuthenticationSession().setAuthNote("minLength", minLength != null ? minLength.toString() : "0");
+        context.getAuthenticationSession().setAuthNote("maxLength", maxLength != null ? maxLength.toString() : "0");
+        context.getAuthenticationSession().setAuthNote("requireDigits", requireDigits.toString());
+        context.getAuthenticationSession().setAuthNote("requireLowerCase", requireLowerCase.toString());
+        context.getAuthenticationSession().setAuthNote("requireUpperCase", requireUpperCase.toString());
+
+        context.success();
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return false;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/policy/CustomUpdatePasswordAuthenticatorFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/CustomUpdatePasswordAuthenticatorFactory.java
@@ -1,0 +1,71 @@
+package org.keycloak.policy;
+
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CustomUpdatePasswordAuthenticatorFactory implements AuthenticatorFactory {
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new CustomUpdatePasswordAuthenticator();
+    }
+
+    @Override
+    public void init(org.keycloak.Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return "custom-update-password-authenticator";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Custom Update Password Authenticator";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return new AuthenticationExecutionModel.Requirement[]{AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.DISABLED};
+    }
+
+    @Override
+    public String getHelpText() {
+        return "";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Arrays.asList();
+    }
+}

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+org.keycloak.policy.CustomUpdatePasswordAuthenticatorFactory

--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -1,9 +1,9 @@
 <#import "template.ftl" as layout>
 <#import "password-commons.ftl" as passwordCommons>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm'); section>
-    <#if section = "header">
+    <#if section == "header">
         ${msg("updatePasswordTitle")}
-    <#elseif section = "form">
+    <#elseif section == "form">
         <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
@@ -14,6 +14,12 @@
                         <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}"
                                autofocus autocomplete="new-password"
                                aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
+                               pattern=".{${authenticationSession.getAuthNote('minLength')},${authenticationSession.getAuthNote('maxLength')}}"
+                               title="Password must contain at least ${authenticationSession.getAuthNote('minLength')} characters"
+                               passwordrules="minlength: ${authenticationSession.getAuthNote('minLength')}; maxlength: ${authenticationSession.getAuthNote('maxLength')};
+                               <#if authenticationSession.getAuthNote('minLowerCase') != "0"> required: lower; </#if>
+                               <#if authenticationSession.getAuthNote('minUpperCase') != "0"> required: upper; </#if>
+                               <#if authenticationSession.getAuthNote('minDigits') != "0"> required: digit; </#if>"
                         />
                         <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button" aria-label="${msg('showPassword')}"
                                 aria-controls="password-new"  data-password-toggle
@@ -55,7 +61,6 @@
                             ${kcSanitize(messagesPerField.get('password-confirm'))?no_esc}
                         </span>
                     </#if>
-
                 </div>
             </div>
 


### PR DESCRIPTION
- Implement CustomUpdatePasswordAuthenticator to retrieve password policy configurations and set them as auth notes.
- Create CustomUpdatePasswordAuthenticatorFactory to register the custom authenticator.
- Update login-update-password.ftl to include passwordrules attribute based on the retrieved password policy configurations, allowing Safari to auto-generate passwords according to the specified rules.

Files Modified:
- src/main/java/org/keycloak/policy/CustomUpdatePasswordAuthenticator.java
- src/main/java/org/keycloak/policy/CustomUpdatePasswordAuthenticatorFactory.java
- src/main/resources/theme/keycloak/login/login-update-password.ftl

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
