### PR TITLE
Explicitly configure publication for NPM packages

### DIFF
--- a/js/apps/account-ui/package.json
+++ b/js/apps/account-ui/package.json
@@ -13,6 +13,9 @@
   "files": [
     "lib"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "wireit",
     "build": "wireit",

--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "admin-ui",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "wireit",

--- a/js/apps/keycloak-server/package.json
+++ b/js/apps/keycloak-server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "keycloak-server",
+  "private": true,
   "type": "module",
   "scripts": {
     "start": "wireit",

--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -11,6 +11,9 @@
   "engines": {
     "node": ">=18"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "wireit",
     "lint": "wireit",

--- a/js/libs/keycloak-js/package.json
+++ b/js/libs/keycloak-js/package.json
@@ -30,6 +30,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "wireit",
     "duplicate-types": "shx cp dist/keycloak.d.ts dist/keycloak.d.mts && shx cp dist/keycloak-authz.d.ts dist/keycloak-authz.d.mts",

--- a/js/libs/ui-shared/package.json
+++ b/js/libs/ui-shared/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "wireit",
     "lint": "wireit"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "root",
+  "private": true,
   "type": "module",
   "packageManager": "pnpm@9.1.0+sha256.22e36fba7f4880ecf749a5ca128b8435da085ecd49575e7fb9e64d6bf4fad394",
   "scripts": {

--- a/themes/src/main/resources/theme/keycloak/common/resources/package.json
+++ b/themes/src/main/resources/theme/keycloak/common/resources/package.json
@@ -1,5 +1,6 @@
 {
   "name": "keycloak-npm-dependencies",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "pnpm build:clean && rollup --config",


### PR DESCRIPTION
Explicitly configures whether NPM packages in the workspace should be published and what their level of access should be. This prevents issues publishing these packages by accident or with the [wrong level of access](https://docs.npmjs.com/creating-and-publishing-an-organization-scoped-package#publishing-a-private-organization-scoped-package).