### PR TITLE
Upgrade to Keycloak 25 - Table 'USER_CONSENT' is specified twice on MySQL/MariaDB database

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-25.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-25.0.0.xml
@@ -118,10 +118,7 @@
 
     <changeSet author="keycloak" id="unique-consentuser">
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
-            <or>
-                <dbms type="mariadb"/>
-                <dbms type="postgresql"/>
-            </or>
+            <dbms type="postgresql"/>
         </preConditions>
         <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate25_0_0_ConsentConstraints"/>
         <dropUniqueConstraint tableName="USER_CONSENT" constraintName="UK_JKUWUVD56ONTGSUHOGM8UEWRT"/>
@@ -131,7 +128,10 @@
 
     <changeSet author="keycloak" id="unique-consentuser-mysql">
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
-            <dbms type="mysql"/>
+            <or>
+                <dbms type="mysql"/>
+                <dbms type="mariadb"/>
+            </or>
         </preConditions>
         <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate25_0_0_MySQL_ConsentConstraints"/>
         <dropUniqueConstraint tableName="USER_CONSENT" constraintName="UK_JKUWUVD56ONTGSUHOGM8UEWRT"/>


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/30300 

ref. @cgeorgilakis @ahus1 from original commit https://github.com/keycloak/keycloak/commit/4bca804d5aa60308415ea5ef2727d3ddc3f7605a

**Upgrade to Keycloak 25 - Table 'USER_CONSENT' is specified twice on MySQL/MariaDB database**