### PR TITLE
Implement a basic PoC of an injectable WebDriver

### DIFF
--- a/test-poc/base/src/test/java/org/keycloak/test/base/NoAdminUserKeycloakTestServerConfig.java
+++ b/test-poc/base/src/test/java/org/keycloak/test/base/NoAdminUserKeycloakTestServerConfig.java
@@ -1,0 +1,19 @@
+package org.keycloak.test.base;
+
+import org.keycloak.test.framework.server.KeycloakTestServerConfig;
+
+import java.util.Optional;
+
+public class NoAdminUserKeycloakTestServerConfig implements KeycloakTestServerConfig {
+
+    @Override
+    public Optional<String> adminUserName() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> adminUserPassword() {
+        return Optional.empty();
+    }
+
+}

--- a/test-poc/base/src/test/java/org/keycloak/test/base/WelcomePageTest.java
+++ b/test-poc/base/src/test/java/org/keycloak/test/base/WelcomePageTest.java
@@ -1,0 +1,24 @@
+package org.keycloak.test.base;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.test.framework.KeycloakIntegrationTest;
+import org.keycloak.test.framework.page.WelcomePage;
+import org.keycloak.test.framework.webdriver.TestWebDriver;
+import org.openqa.selenium.WebDriver;
+
+@KeycloakIntegrationTest(config = NoAdminUserKeycloakTestServerConfig.class)
+public class WelcomePageTest {
+
+    @TestWebDriver
+    WebDriver driver;
+
+    @Test
+    public void testCreateUser() {
+        final var welcomePage = new WelcomePage(driver);
+        welcomePage.navigateTo();
+        welcomePage.fillRegistration("admin", "admin");
+        welcomePage.submit();
+        welcomePage.assertUserCreated();
+    }
+
+}

--- a/test-poc/framework/pom.xml
+++ b/test-poc/framework/pom.xml
@@ -44,6 +44,18 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-junit5</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.21.0</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-firefox-driver</artifactId>
+            <version>4.21.0</version>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/page/WelcomePage.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/page/WelcomePage.java
@@ -1,0 +1,51 @@
+package org.keycloak.test.framework.page;
+
+import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class WelcomePage {
+
+    private final WebDriver driver;
+
+    @FindBy(id = "username")
+    private WebElement usernameInput;
+
+    @FindBy(id = "password")
+    private WebElement passwordInput;
+
+    @FindBy(id = "password-confirmation")
+    private WebElement passwordConfirmationInput;
+
+    @FindBy(css = "[type=submit]")
+    private WebElement submitButton;
+
+    @FindBy(css = ".pf-v5-c-alert")
+    private WebElement pageAlert;
+
+    public WelcomePage(WebDriver driver) {
+        this.driver = driver;
+        PageFactory.initElements(driver, this);
+    }
+
+    public void navigateTo() {
+        driver.get("http://localhost:8080");
+    }
+
+    public void fillRegistration(String username, String password) {
+        usernameInput.sendKeys(username);
+        passwordInput.sendKeys(password);
+        passwordConfirmationInput.sendKeys(password);
+    }
+
+    public void submit() {
+        submitButton.click();
+    }
+
+    public void assertUserCreated() {
+        Assertions.assertTrue(pageAlert.getText().contains("User created"));
+    }
+
+}

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/server/EmbeddedKeycloakTestServer.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/server/EmbeddedKeycloakTestServer.java
@@ -13,8 +13,8 @@ public class EmbeddedKeycloakTestServer implements KeycloakTestServer {
 
     @Override
     public void start(KeycloakTestServerConfig serverConfig) {
-        System.setProperty("keycloakAdmin", "admin");
-        System.setProperty("keycloakAdminPassword", "admin");
+        serverConfig.adminUserName().ifPresent(username -> System.setProperty("keycloakAdmin", username));
+        serverConfig.adminUserPassword().ifPresent(password -> System.setProperty("keycloakAdminPassword", password));
 
         List<String> rawOptions = new LinkedList<>();
         rawOptions.add("start-dev");

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/server/KeycloakTestServerConfig.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/server/KeycloakTestServerConfig.java
@@ -2,6 +2,7 @@ package org.keycloak.test.framework.server;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public interface KeycloakTestServerConfig {
@@ -12,6 +13,14 @@ public interface KeycloakTestServerConfig {
 
     default Set<String> features() {
         return Collections.emptySet();
+    }
+
+    default Optional<String> adminUserName() {
+        return Optional.of("admin");
+    }
+
+    default Optional<String> adminUserPassword() {
+        return Optional.of("admin");
     }
 
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/FirefoxWebDriverSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/FirefoxWebDriverSupplier.java
@@ -1,0 +1,43 @@
+package org.keycloak.test.framework.webdriver;
+
+import org.keycloak.test.framework.injection.InstanceWrapper;
+import org.keycloak.test.framework.injection.LifeCycle;
+import org.keycloak.test.framework.injection.Registry;
+import org.keycloak.test.framework.injection.Supplier;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+
+public class FirefoxWebDriverSupplier implements Supplier<WebDriver, TestWebDriver> {
+
+    @Override
+    public Class<TestWebDriver> getAnnotationClass() {
+        return TestWebDriver.class;
+    }
+
+    @Override
+    public Class<WebDriver> getValueType() {
+        return WebDriver.class;
+    }
+
+    @Override
+    public InstanceWrapper<WebDriver, TestWebDriver> getValue(Registry registry, TestWebDriver annotation) {
+        final var driver = new FirefoxDriver();
+        return new InstanceWrapper<>(this, annotation, driver);
+    }
+
+    @Override
+    public LifeCycle getLifeCycle() {
+        return LifeCycle.GLOBAL;
+    }
+
+    @Override
+    public boolean compatible(InstanceWrapper<WebDriver, TestWebDriver> a, InstanceWrapper<WebDriver, TestWebDriver> b) {
+        return true;
+    }
+
+    @Override
+    public void close(WebDriver instance) {
+        instance.close();
+    }
+
+}

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/TestWebDriver.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/TestWebDriver.java
@@ -1,0 +1,10 @@
+package org.keycloak.test.framework.webdriver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TestWebDriver { }

--- a/test-poc/framework/src/main/resources/META-INF/services/org.keycloak.test.framework.injection.Supplier
+++ b/test-poc/framework/src/main/resources/META-INF/services/org.keycloak.test.framework.injection.Supplier
@@ -1,4 +1,5 @@
 org.keycloak.test.framework.admin.KeycloakAdminClientSupplier
-org.keycloak.test.framework.server.KeycloakTestServerSupplier
-org.keycloak.test.framework.realm.RealmSupplier
 org.keycloak.test.framework.realm.ClientSupplier
+org.keycloak.test.framework.realm.RealmSupplier
+org.keycloak.test.framework.server.KeycloakTestServerSupplier
+org.keycloak.test.framework.webdriver.FirefoxWebDriverSupplier


### PR DESCRIPTION
Implements a basic injectable WebDriver with a sample test for the welcome page. This only implements the Firefox driver until we have a system in place to allow multiple suppliers of an implementation (see ##30377). This does not yet implement page objects in it's final form, which will be done under #42.

Closes #30376