### PR TITLE
Ignore Accept-Language header for email themes

### DIFF
--- a/server-spi/src/main/java/org/keycloak/locale/LocaleSelectorProvider.java
+++ b/server-spi/src/main/java/org/keycloak/locale/LocaleSelectorProvider.java
@@ -19,6 +19,7 @@ package org.keycloak.locale;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.provider.Provider;
+import org.keycloak.theme.Theme;
 
 import java.util.Locale;
 
@@ -35,5 +36,9 @@ public interface LocaleSelectorProvider extends Provider {
      * @return
      */
     Locale resolveLocale(RealmModel realm, UserModel user);
+
+    default Locale resolveLocale(RealmModel realm, UserModel user, Theme.Type themeType) {
+        return resolveLocale(realm, user);
+    }
 
 }

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -21,6 +21,7 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
 import org.keycloak.urls.UrlType;
 
 import jakarta.ws.rs.core.HttpHeaders;
@@ -80,6 +81,10 @@ public interface KeycloakContext {
     ClientConnection getConnection();
 
     Locale resolveLocale(UserModel user);
+
+    default Locale resolveLocale(UserModel user, Theme.Type themeType) {
+        return resolveLocale(user);
+    }
 
     /**
      * Get current AuthenticationSessionModel, can be null out of the AuthenticationSession context.

--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -199,7 +199,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
         attributes.put("link", link);
         attributes.put("linkExpiration", expirationInMinutes);
         try {
-            Locale locale = session.getContext().resolveLocale(user);
+            Locale locale = session.getContext().resolveLocale(user, getTheme().getType());
             attributes.put("linkExpirationFormatter", new LinkExpirationFormatterMethod(getTheme().getMessages(locale), locale));
         } catch (IOException e) {
             throw new EmailException("Failed to template email", e);
@@ -214,7 +214,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
     protected EmailTemplate processTemplate(String subjectKey, List<Object> subjectAttributes, String template, Map<String, Object> attributes) throws EmailException {
         try {
             Theme theme = getTheme();
-            Locale locale = session.getContext().resolveLocale(user);
+            Locale locale = session.getContext().resolveLocale(user, theme.getType());
             attributes.put("locale", locale);
 
             Properties messages = theme.getEnhancedMessages(realm, locale);

--- a/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
@@ -25,6 +25,8 @@ import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import jakarta.ws.rs.core.HttpHeaders;
+import org.keycloak.theme.Theme;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -41,6 +43,11 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
 
     @Override
     public Locale resolveLocale(RealmModel realm, UserModel user) {
+        return resolveLocale(realm, user, null);
+    }
+
+    @Override
+    public Locale resolveLocale(RealmModel realm, UserModel user, Theme.Type themeType) {
         HttpHeaders requestHeaders = session.getContext().getRequestHeaders();
         AuthenticationSessionModel session = this.session.getContext().getAuthenticationSession();
 
@@ -48,7 +55,7 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
             return Locale.ENGLISH;
         }
 
-        Locale userLocale = getUserLocale(realm, session, user, requestHeaders);
+        Locale userLocale = getUserLocale(realm, session, user, requestHeaders, themeType);
         if (userLocale != null) {
             return userLocale;
         }
@@ -61,7 +68,7 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
         return Locale.ENGLISH;
     }
 
-    private Locale getUserLocale(RealmModel realm, AuthenticationSessionModel session, UserModel user, HttpHeaders requestHeaders) {
+    private Locale getUserLocale(RealmModel realm, AuthenticationSessionModel session, UserModel user, HttpHeaders requestHeaders, Theme.Type themeType) {
         Locale locale;
 
         locale = getUserSelectedLocale(realm, session);
@@ -72,6 +79,10 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
         locale = getUserProfileSelection(realm, user);
         if (locale != null) {
             return locale;
+        }
+
+        if(Theme.Type.EMAIL.equals(themeType)) {
+            return null;
         }
 
         locale = getClientSelectedLocale(realm, session);

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -30,6 +30,7 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
 import org.keycloak.urls.UrlType;
 
 import java.net.URI;
@@ -142,6 +143,11 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public Locale resolveLocale(UserModel user) {
         return session.getProvider(LocaleSelectorProvider.class).resolveLocale(getRealm(), user);
+    }
+
+    @Override
+    public Locale resolveLocale(UserModel user, Theme.Type themeType) {
+        return session.getProvider(LocaleSelectorProvider.class).resolveLocale(getRealm(), user, themeType);
     }
 
     @Override


### PR DESCRIPTION
Added new method to resolve locale in `KeycloakContext` and `LocaleSelectorProvider` with addition of the theme type parameter to avoid using `Accept-Language` header when email themes are used.

Closes #10233

