### PR TITLE
Pin Ansible version for Aurora Store IT tests to 9.x.y stream

### DIFF
--- a/.github/scripts/ansible/aws_ec2.sh
+++ b/.github/scripts/ansible/aws_ec2.sh
@@ -12,7 +12,7 @@ REGION=$2
 case $OPERATION in
   requirements)
     ansible-galaxy collection install -r requirements.yml
-    pip3 install --user boto3 botocore
+    pip3 install --user "ansible==9.*" boto3 botocore
   ;;
   create|delete|start|stop)
     if [ -f "env.yml" ]; then ANSIBLE_CUSTOM_VARS_ARG="-e @env.yml"; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,6 @@ jobs:
           export CLUSTER_NAME=keycloak_$(git rev-parse --short HEAD)
           echo "ec2_cluster=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           ./aws_ec2.sh requirements
-          pipx inject ansible-core boto3 botocore
           ./aws_ec2.sh create ${REGION}
           ./keycloak_ec2_installer.sh ${REGION} /tmp/keycloak.zip
           ./mvn_ec2_runner.sh ${REGION} "clean install -B -DskipTests -Pdistribution"


### PR DESCRIPTION
Closes #30201

@ahus1 We need to revert back to my original fix as the GH runner image does not stick to the versions included with the underlying Ubuntu release and the most recent image bumped the ansible-core version to 2.17 which is what causes our existing workflow to fail https://github.com/actions/runner-images/blob/ubuntu22/20240609.1/images/ubuntu/Ubuntu2204-Readme.md

My fork: https://github.com/ryanemerson/keycloak/actions/runs/9496482418