### PR TITLE
Remove Edge from supported web drivers

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -141,11 +141,6 @@
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-edge-driver</artifactId>
-                <version>${selenium.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-remote-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/BrowserDriverUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/BrowserDriverUtil.java
@@ -19,7 +19,6 @@ package org.keycloak.testsuite.util;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 
 /**
@@ -39,9 +38,5 @@ public class BrowserDriverUtil {
 
     public static boolean isDriverFirefox(WebDriver driver) {
         return isDriverInstanceOf(driver, FirefoxDriver.class);
-    }
-
-    public static boolean isDriverEdge(WebDriver driver) {
-        return isDriverInstanceOf(driver, EdgeDriver.class);
     }
 }


### PR DESCRIPTION
Removes Edge from supported drivers as it seems it is no longer maintained and we don't have intentions to test it.

Closes #29921