### PR TITLE
Protobuf schema compatibility check (maven plugin)

### DIFF
--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -99,4 +99,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.infinispan.maven-plugins</groupId>
+                <artifactId>proto-schema-compatibility-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>proto-schema-compatibility-check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <smallrye.openapi.generator.plugin.version>3.6.2</smallrye.openapi.generator.plugin.version>
         <openapi.generator.plugin.version>6.3.0</openapi.generator.plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
+        <infinispan.maven-plugins.version>1.0.5.Final</infinispan.maven-plugins.version>
 
         <!-- Surefire Settings -->
         <surefire.memory.Xms>512m</surefire.memory.Xms>
@@ -236,6 +237,9 @@
         <pnpm.args.install>install --prefer-offline --frozen-lockfile --ignore-scripts</pnpm.args.install>
         <!-- The clean step is skipped on Windows -->
         <js.skip.clean>false</js.skip.clean>
+
+        <!-- Set to true on release to update proto.lock files -->
+        <commitProtoLockChanges>false</commitProtoLockChanges>
     </properties>
 
     <url>http://keycloak.org</url>
@@ -1720,6 +1724,14 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build-helper-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.infinispan.maven-plugins</groupId>
+                    <artifactId>proto-schema-compatibility-maven-plugin</artifactId>
+                    <version>${infinispan.maven-plugins.version}</version>
+                    <configuration>
+                        <commitProtoLock>${commitProtoLockChanges}</commitProtoLock>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION

Closes #30243

In order for  the proto compatibility check to be effective, we need to ensure that all proto.lock files are committed to the repository on release. During a mvn build changes to the protobuf schemas are verified against the proto.lock files in the repository and if an incompatibility is introduced by a change to the code then the build will fail. Only committing the proto.lock per release, opposed to per PR, allows schema evolution between PRs for a given release without having to worry about proto.lock compatibility.

In Infinispan we commit the proto.lock files as a dedicated commit during the release process. I have created the following branch to add the same steps to the Keycloak release process: https://github.com/keycloak-rel/keycloak-rel/compare/main...ryanemerson:keycloak-rel:commit_protolock?expand=1

I don't have permissions to create a branch on https://github.com/keycloak-rel-testing/keycloak-rel, so if somebody could give me permission to do this, or assist me with this, that would be much appreciated :slightly_smiling_face:

Finally, the `proto-schema-compatibility-maven-plugin` should be added to all modules which generate proto schemas via `@ProtoSchema`.