### PR TITLE
REALM_CLIENT attribute to recognize realm clients

### DIFF
--- a/js/apps/admin-ui/src/clients/utils.ts
+++ b/js/apps/admin-ui/src/clients/utils.ts
@@ -4,7 +4,8 @@ import type { TFunction } from "i18next";
 /**
  * Checks if a client is intended to be used for authenticating a to a realm.
  */
-export const isRealmClient = (client: ClientRepresentation) => !client.protocol;
+export const isRealmClient = (client: ClientRepresentation): boolean =>
+  client.attributes?.["realm_client"] === true.toString();
 
 /**
  * Gets a human readable name for the specified protocol.

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -181,4 +181,7 @@ public final class Constants {
 
     // attribute name used in apps to mark that it is an admin console and its azp is allowed
     public static final String SECURITY_ADMIN_CONSOLE_ATTR = "security.admin.console";
+
+    //attribute name used to mark a client as realm client
+    public static final String REALM_CLIENT = "realm_client";
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -737,6 +737,13 @@ public class ModelToRepresentation {
         rep.setNodeReRegistrationTimeout(clientModel.getNodeReRegistrationTimeout());
         rep.setClientAuthenticatorType(clientModel.getClientAuthenticatorType());
 
+        String clientId = clientModel.getClientId();
+        final String realmClientSuffix = "-realm";
+        //check if client is realm client
+        if(clientId != null && clientId.endsWith(realmClientSuffix) && session.realms().getRealmByName(clientId.substring(0, clientId.length() - realmClientSuffix.length())) != null) {
+            rep.getAttributes().put(Constants.REALM_CLIENT, String.valueOf(true));
+        }
+
         // adding the secret if non public or bearer only
         if (clientModel.isBearerOnly() || clientModel.isPublicClient()) {
             rep.setSecret(null);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -21,6 +21,7 @@ import static java.util.Optional.ofNullable;
 import static org.keycloak.models.utils.StripSecretsUtils.stripSecrets;
 
 import org.jboss.logging.Logger;
+import org.keycloak.Config;
 import org.keycloak.authentication.otp.OTPApplicationProvider;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.AuthorizationProviderFactory;
@@ -737,12 +738,7 @@ public class ModelToRepresentation {
         rep.setNodeReRegistrationTimeout(clientModel.getNodeReRegistrationTimeout());
         rep.setClientAuthenticatorType(clientModel.getClientAuthenticatorType());
 
-        String clientId = clientModel.getClientId();
-        final String realmClientSuffix = "-realm";
-        //check if client is realm client
-        if(clientId != null && clientId.endsWith(realmClientSuffix) && session.realms().getRealmByName(clientId.substring(0, clientId.length() - realmClientSuffix.length())) != null) {
-            rep.getAttributes().put(Constants.REALM_CLIENT, String.valueOf(true));
-        }
+        rep.getAttributes().put(Constants.REALM_CLIENT, String.valueOf(isRealmClient(clientModel.getClientId(), clientModel.getRealm(), session)));
 
         // adding the secret if non public or bearer only
         if (clientModel.isBearerOnly() || clientModel.isPublicClient()) {
@@ -783,6 +779,23 @@ public class ModelToRepresentation {
         }
 
         return rep;
+    }
+
+    private static boolean isRealmClient(String clientId, RealmModel realm, KeycloakSession session) {
+        final String realmClientSuffix = "-realm";
+
+        if (clientId == null) {
+            return false;
+        }
+        if (Constants.BROKER_SERVICE_CLIENT_ID.equals(clientId)) {
+            return true;
+        }
+        if (Config.getAdminRealm().equals(realm.getName())) {
+            return clientId.endsWith(realmClientSuffix) && session.realms().getRealmByName(clientId.substring(0, clientId.length() - realmClientSuffix.length())) != null;
+        }
+        else {
+            return Constants.REALM_MANAGEMENT_CLIENT_ID.equals(clientId);
+        }
     }
 
     public static IdentityProviderRepresentation toBriefRepresentation(RealmModel realm, IdentityProviderModel identityProviderModel) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -96,6 +96,11 @@ public class ClientTest extends AbstractAdminTest {
         Assert.assertNames(realm.clients().findAll(), "account", "account-console", "realm-management", "security-admin-console", "broker", Constants.ADMIN_CLI_CLIENT_ID);
     }
 
+    @Test
+    public void getRealmClients() {
+        assertTrue(realm.clients().findAll().stream().filter(client->client.getAttributes().get(Constants.REALM_CLIENT) != null).allMatch(clientRepresentation -> clientRepresentation.getClientId().endsWith("-realm")));
+    }
+
     private ClientRepresentation createClient() {
         return createClient(null);
     }
@@ -122,7 +127,7 @@ public class ClientTest extends AbstractAdminTest {
 
         return rep;
     }
-    
+
     private ClientRepresentation createClientNonPublic() {
         ClientRepresentation rep = new ClientRepresentation();
         rep.setClientId("my-app");
@@ -142,7 +147,7 @@ public class ClientTest extends AbstractAdminTest {
 
         return rep;
     }
-    
+
     @Test
     public void createClientVerifyWithSecret() {
         String id = createClientNonPublic().getId();
@@ -442,14 +447,14 @@ public class ClientTest extends AbstractAdminTest {
 
         assertAdminEvents.assertEvent(realmId, OperationType.CREATE, AdminEventPaths.roleResourceCompositesPath(Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + REALM_NAME), Collections.singletonList(role), ResourceType.REALM_ROLE);
 
-        assertThat(realm.roles().get(Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + REALM_NAME).getRoleComposites().stream().map(RoleRepresentation::getName).collect(Collectors.toSet()), 
+        assertThat(realm.roles().get(Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + REALM_NAME).getRoleComposites().stream().map(RoleRepresentation::getName).collect(Collectors.toSet()),
                 hasItem(role.getName()));
 
         realm.clients().get(id).roles().deleteRole("test");
 
         assertAdminEvents.assertEvent(realmId, OperationType.DELETE, AdminEventPaths.clientRoleResourcePath(id, "test"), ResourceType.CLIENT_ROLE);
 
-        assertThat(realm.roles().get(Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + REALM_NAME).getRoleComposites().stream().map(RoleRepresentation::getName).collect(Collectors.toSet()), 
+        assertThat(realm.roles().get(Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + REALM_NAME).getRoleComposites().stream().map(RoleRepresentation::getName).collect(Collectors.toSet()),
                 not(hasItem(role)));
     }
 
@@ -558,7 +563,7 @@ public class ClientTest extends AbstractAdminTest {
 
         realm.clients().get(id).registerNode(Collections.singletonMap("node", "foo#"));
     }
-    
+
     @Test
     public void nodes() {
         testingClient.testApp().clearAdminActions();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -98,7 +98,9 @@ public class ClientTest extends AbstractAdminTest {
 
     @Test
     public void getRealmClients() {
-        assertTrue(realm.clients().findAll().stream().filter(client->client.getAttributes().get(Constants.REALM_CLIENT) != null).allMatch(clientRepresentation -> clientRepresentation.getClientId().endsWith("-realm")));
+        assertTrue(realm.clients().findAll().stream().filter(client-> client.getAttributes().get(Constants.REALM_CLIENT).equals("true"))
+                .map(ClientRepresentation::getClientId)
+                .allMatch(clientId -> clientId.equals(Constants.REALM_MANAGEMENT_CLIENT_ID) || clientId.equals(Constants.BROKER_SERVICE_CLIENT_ID) || clientId.endsWith("-realm")));
     }
 
     private ClientRepresentation createClient() {


### PR DESCRIPTION
This PR changes how a client is recognized as a realm client. Previously, the admin UI recognized a client as a realm client when `client.protocol` was null. Now, a `REALM_CLIENT` attribute is set for the client when the `clientId` is equal to `{realm}-realm`, where `{realm}` is the name of an existing realm.

Closes #29413


