### PR TITLE
fix(operator): Use the new image to actually perform a database migration

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -461,13 +461,13 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
         var reconciledContainer = reconciledDeployment.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         if (!previousContainer.getImage().equals(reconciledContainer.getImage())
-                && previousDeployment.getStatus().getReplicas() > 1) {
+                && previousDeployment.getStatus().getReplicas() > 0) {
             // TODO Check if migration is really needed (e.g. based on actual KC version); https://github.com/keycloak/keycloak/issues/10441
             Log.info("Detected changed Keycloak image, assuming Keycloak upgrade. Scaling down the deployment to one instance to perform a safe database migration");
             Log.infof("original image: %s; new image: %s", previousContainer.getImage(), reconciledContainer.getImage());
 
             reconciledContainer.setImage(previousContainer.getImage());
-            reconciledDeployment.getSpec().setReplicas(1);
+            reconciledDeployment.getSpec().setReplicas(0);
 
             reconciledDeployment.getMetadata().getAnnotations().put(Constants.KEYCLOAK_MIGRATING_ANNOTATION, Boolean.TRUE.toString());
         }


### PR DESCRIPTION
This fixes #30449.

This change makes the operator behave as described in the issue.
I think this is the way it should work according to the documentation as it is advised to shutdown keycloak completely before doing upgrades.

Assuming you have a set of three pods, the way it is right now the operator performs a database upgrade on keycloak-1 with keycloak-0 still running on the old version if keycloak-1 is able to get to that point, which it does not if for example the infinispan version is incompatible, in that scenario the whole process is stuck with one pod on the old version and a second one on the new version not coming up at all.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
