### PR TITLE
Upgrade maven cache extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,6 +20,6 @@
     <extension>
         <groupId>org.apache.maven.extensions</groupId>
         <artifactId>maven-build-cache-extension</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </extension>
 </extensions>

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -27,6 +27,6 @@
         <!-- The JavaScript projects use the non-standard 'src' folder for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>
         <!-- The child projects will package from the 'dist' folder, which is listed as a resource, but isn't a source folder -->
-        <maven.build.cache.exclude.value.1>${project.basedir}/dist</maven.build.cache.exclude.value.1>
+        <maven.build.cache.exclude.value.1>dist</maven.build.cache.exclude.value.1>
     </properties>
 </project>

--- a/quarkus/dist/pom.xml
+++ b/quarkus/dist/pom.xml
@@ -34,23 +34,11 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server-app</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server-deployment</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
Also ensure that JS project is not built too often, and the Quarkus distribution is not missed when sub-dependencies change.

Closes #30463

How to test: 

Run the following command twice. The second time should finish in less than 10 seconds, as it is only calculating hashes and copying cached artifacts to the local Maven repo.

```
./mvnw -Dmaven.build.cache.enabled=true install -DskipTests -am -pl quarkus/dist
```

If a source file is then changed (for example `InfinispanCacheRealmProviderFactory.java` or `AccountRow.tsx`), the final Quarkus ZIP file is rebuilt after building only those dependency that are essential.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
