### PR TITLE
Improvements for ldap test authentication (25.0)

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/TestLdapConnectionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/TestLdapConnectionRepresentation.java
@@ -16,10 +16,15 @@ public class TestLdapConnectionRepresentation {
     }
 
     public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential, String useTruststoreSpi, String connectionTimeout) {
-        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, null, null);
+        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, null, null, null);
     }
 
     public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential, String useTruststoreSpi, String connectionTimeout, String startTls, String authType) {
+        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, startTls, authType, null);
+    }
+
+    public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential,
+            String useTruststoreSpi, String connectionTimeout, String startTls, String authType, String componentId) {
         this.action = action;
         this.connectionUrl = connectionUrl;
         this.bindDn = bindDn;
@@ -28,6 +33,7 @@ public class TestLdapConnectionRepresentation {
         this.connectionTimeout = connectionTimeout;
         this.startTls = startTls;
         this.authType = authType;
+        this.componentId = componentId;
     }
 
     public String getAction() {

--- a/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
@@ -16,12 +16,15 @@
  */
 package org.keycloak.services.managers;
 
+import java.net.URI;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import javax.naming.ldap.LdapContext;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
@@ -30,6 +33,7 @@ import org.keycloak.representations.idm.TestLdapConnectionRepresentation;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.representations.idm.LDAPCapabilityRepresentation;
+import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.store.ldap.LDAPContextManager;
 import org.keycloak.storage.ldap.idm.store.ldap.LDAPIdentityStore;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupTreeResolver;
@@ -63,8 +67,17 @@ public class LDAPServerCapabilitiesManager {
 
     public static LDAPConfig buildLDAPConfig(TestLdapConnectionRepresentation config, RealmModel realm) {
         String bindCredential = config.getBindCredential();
-        if (config.getComponentId() != null && ComponentRepresentation.SECRET_VALUE.equals(bindCredential)) {
-            bindCredential = realm.getComponent(config.getComponentId()).getConfig().getFirst(LDAPConstants.BIND_CREDENTIAL);
+        if (config.getComponentId() != null && !LDAPConstants.AUTH_TYPE.equals(LDAPConstants.AUTH_TYPE_NONE)
+                && ComponentRepresentation.SECRET_VALUE.equals(bindCredential)) {
+            // check the connection URL and the bind DN are the same to allow using the same configured password
+            ComponentModel component = realm.getComponent(config.getComponentId());
+            if (component != null) {
+                LDAPConfig ldapConfig = new LDAPConfig(component.getConfig());
+                if (Objects.equals(URI.create(config.getConnectionUrl()), URI.create(ldapConfig.getConnectionUrl()))
+                        && Objects.equals(LDAPDn.fromString(config.getBindDn()), LDAPDn.fromString(ldapConfig.getBindDN()))) {
+                    bindCredential = ldapConfig.getBindCredential();
+                }
+            }
         }
         MultivaluedHashMap<String, String> configMap = new MultivaluedHashMap<>();
         configMap.putSingle(LDAPConstants.AUTH_TYPE, config.getAuthType());


### PR DESCRIPTION
Closes #30434

Backport for 25.0.

PR: https://github.com/keycloak/keycloak/pull/30439
Commit: https://github.com/keycloak/keycloak/commit/c51640546d1488e4af9b7e66026720a18d580fb4
PR branch: backport-30439-25.0
Target branch: https://github.com/keycloak/keycloak/tree/release/25.0

