### PR TITLE
Improvements for ldap test authentication (24.0)

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/TestLdapConnectionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/TestLdapConnectionRepresentation.java
@@ -16,10 +16,15 @@ public class TestLdapConnectionRepresentation {
     }
 
     public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential, String useTruststoreSpi, String connectionTimeout) {
-        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, null, null);
+        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, null, null, null);
     }
 
     public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential, String useTruststoreSpi, String connectionTimeout, String startTls, String authType) {
+        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, startTls, authType, null);
+    }
+
+    public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential,
+            String useTruststoreSpi, String connectionTimeout, String startTls, String authType, String componentId) {
         this.action = action;
         this.connectionUrl = connectionUrl;
         this.bindDn = bindDn;
@@ -28,6 +33,7 @@ public class TestLdapConnectionRepresentation {
         this.connectionTimeout = connectionTimeout;
         this.startTls = startTls;
         this.authType = authType;
+        this.componentId = componentId;
     }
 
     public String getAction() {


### PR DESCRIPTION
Closes #30434

Backport for 24.0.

PR: https://github.com/keycloak/keycloak/pull/30439
Commit: https://github.com/keycloak/keycloak/commit/c51640546d1488e4af9b7e66026720a18d580fb4
PR branch: backport-30439-24.0
Target branch: https://github.com/keycloak/keycloak/tree/release/24.0

