### PR TITLE
Remove Appium from supported web drivers

### DIFF
--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -310,20 +310,6 @@ Although technically they can be run with almost every test in the testsuite, th
 You can rely on automatic driver downloads which is provided by [Arquillian Drone](http://arquillian.org/arquillian-extension-drone/#_automatic_download). To do so just omit the `-Dwebdriver.{browser}.driver` CLI argument when running the tests.
 By default latest driver version is always downloaded. To download a specific version, add `-DfirefoxDriverVersion` or `-DchromeDriverVersion` CLI argument.
 
-#### Mobile browsers
-The support for testing with the mobile browsers is implemented using the [Appium](http://appium.io/) project.
-This means the tests can be run with a real mobile browser in a real mobile OS. However, only emulators/simulators of mobile devices are supported at the moment (no physical devices) in our testsuite.
-
-First, you need to install the Appium server. If you have Node.js and npm installed on your machine, you can do that with: `npm install -g appium`. For further details and requirements please refer to the [official Appium documentation](http://appium.io/docs/en/about-appium/intro/).
-The tests will try to start the Appium server automatically but you can do it manually as well (just by executing `appium`).
-
-To use a mobile browser you need to create a virtual device. The most convenient way to do so is to install the desired platform's IDE - either [Android Studio](https://developer.android.com/studio/) (for Android devices) or [Xcode](https://developer.apple.com/xcode/) (for iOS devices) - then you can create a device (smartphone/tablet) there. For details please refer to documentation of those IDEs.
-
-**Tips & tricks:**
-* If the AVD name contains any spaces, you need to replace them with underscores when specifying the `-Dappium.avd=...`.
-* It's probable that a freshly created device will contain an outdated Chrome version. To update to the latest version (without using the Play Store) you need to download an `.apk` for Chrome and install it with `adb install -r path/to/chrome.apk`.
-* Chrome on Android uses ChromeDriver similarly to regular desktop Chrome. The ChromeDriver is bundled with the Appium server. To use a newer ChromeDriver please follow the [Appium documentation](http://appium.io/docs/en/writing-running-appium/web/chromedriver/).
-
 ## Disabling TLS (SSL) in the tests
 
 All tests are executed with TLS by default. In order to disable it, you need to switch the `auth.server.ssl.required` property off.

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -53,7 +53,6 @@
         <undertow.version>${undertow-jakarta.version}</undertow.version>
         <undertow-embedded.version>1.0.0.Final</undertow-embedded.version>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <appium.client.version>9.2.2</appium.client.version>
         <jakarta.persistence-legacy.version>2.2.3</jakarta.persistence-legacy.version>
         <smallrye.jandex.version>3.0.5</smallrye.jandex.version>
         <commons.validator.version>1.8.0</commons.validator.version>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/LocaleDropdown.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/LocaleDropdown.java
@@ -1,7 +1,5 @@
 package org.keycloak.testsuite.console.page.fragment;
 
-import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.ios.IOSDriver;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.fragment.Root;
 import org.jboss.logging.Logger;
@@ -11,8 +9,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
 import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 
@@ -40,24 +36,12 @@ public class LocaleDropdown {
 
     public void selectByText(String text) {
         // open the menu
-        if (driver instanceof IOSDriver) { // TODO: Fix this! It's a very, very, ... very nasty hack for Safari on iOS - see KEYCLOAK-7947
-            ((IOSDriver) driver).executeScript("arguments[0].setAttribute('style', 'display: block')", dropDownMenu);
-        } else if (driver instanceof AndroidDriver) { // Android needs to tap (no cursor)
-            currentLocaleLink.click();
-        } else {
-            Actions actions = new Actions(driver);
-            log.info("Moving mouse cursor to the localization menu");
-            actions.moveToElement(currentLocaleLink, -10, 0)
-                    .moveToElement(currentLocaleLink).perform();
-        }
+        Actions actions = new Actions(driver);
+        log.info("Moving mouse cursor to the localization menu");
+        actions.moveToElement(currentLocaleLink, -10, 0)
+                .moveToElement(currentLocaleLink).perform();
 
         // click desired locale
         clickLink(dropDownMenu.findElement(By.xpath("./li/a[text()='" + text + "']")));
-    }
-
-    public void selectAndAssert(String text) {
-        assertNotEquals(text, getSelected());
-        selectByText(text);
-        assertEquals(text, getSelected());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/drone/KeycloakDronePostSetup.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/drone/KeycloakDronePostSetup.java
@@ -19,7 +19,6 @@ package org.keycloak.testsuite.drone;
 
 import java.util.concurrent.TimeUnit;
 
-import io.appium.java_client.AppiumDriver;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
@@ -65,7 +64,7 @@ public class KeycloakDronePostSetup {
             webDriverProducer.set(remoteWebDriver);
         }
 
-        if (drone instanceof WebDriver webDriver && !(drone instanceof AppiumDriver)) {
+        if (drone instanceof WebDriver webDriver) {
             configureDriverSettings(webDriver);
             webDriverProducer.set(webDriver);
         } else {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/drone/KeycloakWebDriverConfigurator.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/drone/KeycloakWebDriverConfigurator.java
@@ -51,7 +51,6 @@ public class KeycloakWebDriverConfigurator {
 
         DesiredCapabilities capabilitiesToAdd = new DesiredCapabilities();
         updateCapabilityKeys("htmlUnit", webDriverCfg, capabilitiesToAdd);
-        updateCapabilityKeys("appium", webDriverCfg, capabilitiesToAdd);
         acceptAllSSLCerts(webDriverCfg, capabilitiesToAdd);
 
         BrowserCapabilities browserCap = registryInstance.get().getEntryFor(webDriverCfg.getBrowser());

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -1,6 +1,5 @@
 package org.keycloak.testsuite.util;
 
-import io.appium.java_client.android.AndroidDriver;
 import org.apache.commons.lang3.StringUtils;
 import org.keycloak.testsuite.page.AbstractPatternFlyAlert;
 import org.openqa.selenium.By;
@@ -144,10 +143,6 @@ public final class UIUtils {
         }
 
         WebDriver driver = getCurrentDriver();
-        if (driver instanceof AndroidDriver) {
-            AndroidDriver androidDriver = (AndroidDriver) driver;
-            androidDriver.hideKeyboard(); // stability improvement
-        }
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.testsuite;
 
-import io.appium.java_client.AppiumDriver;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -302,24 +301,6 @@ public abstract class AbstractKeycloakTest {
 
     protected void resetRealmSession(String realmName) {
         deleteAllCookiesForRealm(realmName);
-
-        if (driver instanceof AppiumDriver) { // smartphone drivers don't support cookies deletion
-            try {
-                log.info("resetting realm session");
-
-                final RealmRepresentation realmRep = adminClient.realm(realmName).toRepresentation();
-
-                deleteAllSessionsInRealm(realmName); // logout users
-
-                if (realmRep.isInternationalizationEnabled()) { // reset the locale
-                    String locale = getDefaultLocaleName(realmRep.getRealm());
-                    loginPage.localeDropdown().selectByText(locale);
-                    log.info("locale reset to " + locale);
-                }
-            } catch (NotFoundException e) {
-                log.warn("realm not found");
-            }
-        }
     }
 
     protected String getDefaultLocaleName(String realmName) {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -31,7 +31,7 @@
         <property name="htmlUnitWebClientOptions">cssEnabled=false;historyPageCacheLimit=1</property>
 
         <!-- firefox -->
-        <property name="firefoxBinary">${firefox_binary}</property> <!-- we need to use 'firefoxBinary' instead of 'firefox_binary' due to some weird conflict with Appium -->
+        <property name="firefoxBinary">${firefox_binary}</property>
         <property name="firefoxLogLevel">OFF</property>
         <property name="firefoxLegacy">${firefoxLegacyDriver}</property>
         <property name="firefoxDriverVersion">${firefoxDriverVersion}</property>
@@ -42,16 +42,6 @@
         <property name="chromeBinary">${chromeBinary}</property>
         <property name="chromeArguments">${chromeArguments}</property>
         <property name="chromeDriverVersion">${chromeDriverVersion}</property>
-
-        <!-- appium -->
-        <property name="appium.platformName">${appium.platformName}</property>
-        <property name="appium.deviceName">${appium.deviceName}</property>
-        <property name="appium.browserName">${appium.browserName}</property>
-        <property name="appium.avd">${appium.avd}</property>
-        <property name="appium.automationName">${appium.automationName}</property>
-        <property name="appium.noReset">${appium.noReset}</property>
-        <property name="appium.fullReset">${appium.fullReset}</property>
-        <property name="appium.nativeWebScreenshot">true</property> <!-- there's some issue when taking screenshot using the chromedriver therefore we need to take screenshots of the whole screen (using adb) instead -->
     </extension>
 
     <extension qualifier="drone">

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -226,14 +226,6 @@
         <chromeArguments>--headless --window-size=1920,1080 --remote-allow-origins=* --ignore-ssl-errors=yes --ignore-certificate-errors</chromeArguments>
         <chromeDriverVersion/>
 
-        <appium.platformName/>
-        <appium.deviceName/>
-        <appium.browserName/>
-        <appium.avd/>
-        <appium.automationName/>
-        <appium.noReset/>
-        <appium.fullReset/>
-
         <frontend.console.output>true</frontend.console.output>
         <backends.console.output>true</backends.console.output>
 
@@ -601,14 +593,6 @@
                             <firefoxDriverVersion>${firefoxDriverVersion}</firefoxDriverVersion>
                             <firefoxUserPreferences>${firefoxUserPreferences}</firefoxUserPreferences>
                             <firefoxArguments>${firefoxArguments}</firefoxArguments>
-
-                            <appium.platformName>${appium.platformName}</appium.platformName>
-                            <appium.deviceName>${appium.deviceName}</appium.deviceName>
-                            <appium.browserName>${appium.browserName}</appium.browserName>
-                            <appium.avd>${appium.avd}</appium.avd>
-                            <appium.automationName>${appium.automationName}</appium.automationName>
-                            <appium.noReset>${appium.noReset}</appium.noReset>
-                            <appium.fullReset>${appium.fullReset}</appium.fullReset>
 
                             <project.version>${project.version}</project.version>
 
@@ -1643,12 +1627,6 @@
                             <artifactId>guava</artifactId>
                         </exclusion>
                     </exclusions>
-                </dependency>
-
-                <dependency>
-                    <groupId>io.appium</groupId>
-                    <artifactId>java-client</artifactId>
-                    <version>${appium.client.version}</version>
                 </dependency>
 
                 <!--


### PR DESCRIPTION
Removes Appium  from supported drivers as it seems it is no longer maintained and we don't have intentions to test it.

Partially closes #29921