### PR TITLE
Remove `web_modules` from `.gitignore`

### DIFF
--- a/themes/.gitignore
+++ b/themes/.gitignore
@@ -1,2 +1,1 @@
-web_modules
 vendor


### PR DESCRIPTION
Removes the `web_modules` directory from the `.gitignore` of the themes, as this was previously only used by the Account V2 theme, which no longer exists.