### PR TITLE
Output Vite build directly into Maven target directory

### DIFF
--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -56,13 +56,6 @@
             <resource>
                 <directory>maven-resources</directory>
             </resource>
-            <resource>
-                <directory>dist</directory>
-                <targetPath>theme/keycloak.v3/account/resources</targetPath>
-                <excludes>
-                    <exclude>index.html</exclude>
-                </excludes>
-            </resource>
         </resources>
 
         <plugins>

--- a/js/apps/account-ui/vite.config.ts
+++ b/js/apps/account-ui/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig(({ mode }) => {
       port: 5173,
     },
     build: {
+      outDir: "target/classes/theme/keycloak.v3/account/resources",
       ...lib,
       sourcemap: true,
       target: "esnext",

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -56,13 +56,6 @@
             <resource>
                 <directory>maven-resources</directory>
             </resource>
-            <resource>
-                <directory>dist</directory>
-                <targetPath>theme/keycloak.v2/admin/resources</targetPath>
-                <excludes>
-                    <exclude>index.html</exclude>
-                </excludes>
-            </resource>
         </resources>
 
         <plugins>

--- a/js/apps/admin-ui/vite.config.ts
+++ b/js/apps/admin-ui/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     port: 5174,
   },
   build: {
+    outDir: "target/classes/theme/keycloak.v2/admin/resources",
     sourcemap: true,
     target: "esnext",
     modulePreload: false,

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -26,7 +26,5 @@
     <properties>
         <!-- The JavaScript projects use the non-standard 'src' folder for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>
-        <!-- The child projects will package from the 'dist' folder, which is listed as a resource, but isn't a source folder -->
-        <maven.build.cache.exclude.value.1>dist</maven.build.cache.exclude.value.1>
     </properties>
 </project>


### PR DESCRIPTION
Follow up of #30464, see https://github.com/keycloak/keycloak/pull/30464#discussion_r1642482833. Changes the output directory for Vite to the target directory of Maven, mitigating the need to copy these resources in Maven, and simplifying the build cache plugin configuration.