### PR TITLE
Add UPDATE event to the client-roles condition

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
@@ -90,6 +90,7 @@ public class ClientRolesCondition extends AbstractClientPolicyConditionProvider<
             case BACKCHANNEL_TOKEN_RESPONSE:
             case PUSHED_AUTHORIZATION_REQUEST:
             case REGISTERED:
+            case UPDATE:
             case UPDATED:
             case SAML_AUTHN_REQUEST:
             case SAML_LOGOUT_REQUEST:


### PR DESCRIPTION
Closes #30284

Just adding the `UPDATE` event to the `client-roles` condition. The client role condition cannot be executed in `REGISTER` (because in a client creation roles are always empty) but it can be checked in update to see if the client has one of the configured roles. A test was added that checks that an `UPDATE` event triggers the execution of the policy.