### PR TITLE
Fix AuthenticatedClientSessionEntity protostream encoding

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/AuthenticatedClientSessionEntity.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/AuthenticatedClientSessionEntity.java
@@ -152,9 +152,9 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
     AuthenticatedClientSessionEntity(String realmId, String authMethod, String redirectUri, int timestamp, String action, Map<String, String> notes, UUID id) {
         super(realmId);
         this.authMethod = authMethod;
-        this.redirectUri = redirectUri;
+        this.redirectUri = Marshalling.emptyStringToNull(redirectUri);
         this.timestamp = timestamp;
-        this.action = action;
+        this.action = Marshalling.emptyStringToNull(action);
         this.notes = notes;
         this.id = id;
     }


### PR DESCRIPTION
For String fields that may be null, convert an empty string to null when reading from Protostream

Fixes #30511

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
