### PR TITLE
Run JS CI upon change in services

### DIFF
--- a/.github/actions/conditional/conditions
+++ b/.github/actions/conditional/conditions
@@ -40,6 +40,7 @@ tsconfig.eslint.json                        js
 tsconfig.json                               js
 js/                                         js
 rest/admin-ui-ext/                          js
+services/                                   js
 js/apps/account-ui/                         ci ci-webauthn
 js/libs/ui-shared/                          ci ci-webauthn
 


### PR DESCRIPTION
In the recent past, JS CI was broken several times due to changes in REST API without notification because JS CI is not run upon change in `services`. This PR aims to narrow down this gap.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
