### PR TITLE
changed the accessibility of method AuthzClient.createPatSupplier to public

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java
@@ -256,7 +256,7 @@ public class AuthzClient {
         }
     }
 
-    private TokenCallable createPatSupplier(String userName, String password) {
+    public TokenCallable createPatSupplier(String userName, String password) {
         if (patSupplier == null) {
             patSupplier = createRefreshableAccessTokenSupplier(userName, password);
         }


### PR DESCRIPTION
Fixes issue: #29986 

Update: change accessibility of method [AuthzClient.createPatSupplier(String userName, String password)](https://github.com/keycloak/keycloak/blob/320f8eb1b403fb6e970a497b4da75e4963b0daa1/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java#L259) to public.