### PR TITLE
Remove the timeout in authChecker when page is unloaded

### DIFF
--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -1,6 +1,17 @@
 const CHECK_INTERVAL_MILLISECS = 2000;
 const initialSession = getSession();
 
+let timeout;
+
+// Remove the timeout when unloading to avoid execution of the
+// checkCookiesAndSetTimer when the page is already submitted
+addEventListener("beforeunload", () => {
+  if (timeout) {
+    clearTimeout(timeout);
+    timeout = undefined;
+  }
+});
+
 export function checkCookiesAndSetTimer(loginRestartUrl) {
   if (initialSession) {
     // We started with a session, so there is nothing to do, exit.
@@ -11,9 +22,9 @@ export function checkCookiesAndSetTimer(loginRestartUrl) {
 
   if (!session) {
     // The session is not present, check again later.
-    setTimeout(
+    timeout = setTimeout(
       () => checkCookiesAndSetTimer(loginRestartUrl),
-      CHECK_INTERVAL_MILLISECS
+      CHECK_INTERVAL_MILLISECS,
     );
   } else {
     // Redirect to the login restart URL. This can typically automatically login user due the SSO
@@ -29,7 +40,9 @@ function getCookieByName(name) {
   for (const cookie of document.cookie.split(";")) {
     const [key, value] = cookie.split("=").map((value) => value.trim());
     if (key === name) {
-      return value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+      return value.startsWith('"') && value.endsWith('"')
+        ? value.slice(1, -1)
+        : value;
     }
   }
   return null;


### PR DESCRIPTION
Closes #30334

Just removing the timeout if the page is unloaded. It avoids the execution of the timer after the login page has been submitted. There are other some minor changes done by lint at commit.