### PR TITLE
Backport removed useless cell formatter (#30422)

### DIFF
--- a/js/apps/admin-ui/src/events/EventsSection.tsx
+++ b/js/apps/admin-ui/src/events/EventsSection.tsx
@@ -28,7 +28,7 @@ import {
   Tooltip,
 } from "@patternfly/react-core";
 import { CheckCircleIcon, WarningTriangleIcon } from "@patternfly/react-icons";
-import { cellWidth, expandable } from "@patternfly/react-table";
+import { cellWidth } from "@patternfly/react-table";
 import { pickBy } from "lodash-es";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
@@ -468,7 +468,6 @@ export default function EventsSection() {
                   {
                     name: "time",
                     displayKey: "time",
-                    cellFormatters: [expandable],
                     cellRenderer: (row) =>
                       formatDate(new Date(row.time!), FORMAT_DATE_AND_TIME),
                   },


### PR DESCRIPTION
fixes: #30306

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit bdf6dff279fc29ce5c3a7a7b8a6062edde6e0c7a)
