### PR TITLE
Internal read-only attributes have precedence over unmanaged attribute policy

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -94,6 +94,10 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
 
     @Override
     public boolean isReadOnly(String name) {
+        if (isReadOnlyFromMetadata(name) || isReadOnlyInternalAttribute(name)) {
+            return true;
+        }
+
         if (!isManagedAttribute(name)) {
             return !isAllowEditUnmanagedAttribute();
         }
@@ -108,10 +112,6 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
             if (isServiceAccountUser()) {
                 return false;
             }
-        }
-
-        if (isReadOnlyFromMetadata(name) || isReadOnlyInternalAttribute(name)) {
-            return true;
         }
 
         return getMetadata(name) == null;


### PR DESCRIPTION
Closes #30240

Signed-off-by: Pedro Igor <pigor.craveiro@gmail.com>

Conflicts:
    server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
