### PR TITLE
Fix partial_import_test

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/partial_import_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/partial_import_test.spec.ts
@@ -120,6 +120,7 @@ describe("Partial import test", () => {
     //clear button should be disabled if there is nothing in the dialog
     modal.clearButton().should("be.disabled");
     modal.textArea().get(".view-lines").should("have.text", "");
+    modal.textArea().get(".view-lines").click();
     modal.textArea().type("{}", { force: true });
     modal.textArea().get(".view-lines").should("have.text", "{}");
     modal.clearButton().should("not.be.disabled");


### PR DESCRIPTION
Apparently, not all the time the `type` ensures that the cursor is active in the field. So far it passed 5 times [in the contributor's repo actions](https://github.com/hmlnarik/keycloak/actions/runs/9581221711).

Fixes: #30492

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
