### PR TITLE
Added suffix to keycloak-admin-client artifacts in keycloak repository

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/PublishedRealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/PublishedRealmRepresentation.java
@@ -17,11 +17,7 @@
 
 package org.keycloak.representations.idm;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.keycloak.common.util.PemUtils;
-
-import java.security.PublicKey;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -42,9 +38,6 @@ public class PublishedRealmRepresentation {
     @JsonProperty("tokens-not-before")
     protected int notBefore;
 
-    @JsonIgnore
-    protected volatile transient PublicKey publicKey;
-
     public String getRealm() {
         return realm;
     }
@@ -59,27 +52,6 @@ public class PublishedRealmRepresentation {
 
     public void setPublicKeyPem(String publicKeyPem) {
         this.publicKeyPem = publicKeyPem;
-        this.publicKey = null;
-    }
-
-
-    @JsonIgnore
-    public PublicKey getPublicKey() {
-        if (publicKey != null) return publicKey;
-        if (publicKeyPem != null) {
-            try {
-                publicKey = PemUtils.decodePublicKey(publicKeyPem);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return publicKey;
-    }
-
-    @JsonIgnore
-    public void setPublicKey(PublicKey publicKey) {
-        this.publicKey = publicKey;
-        this.publicKeyPem = PemUtils.encodeKey(publicKey);
     }
 
     public String getTokenServiceUrl() {

--- a/core/src/main/java/org/keycloak/representations/info/CryptoInfoRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/info/CryptoInfoRepresentation.java
@@ -20,11 +20,6 @@
 package org.keycloak.representations.info;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.crypto.CryptoProvider;
-import org.keycloak.common.util.KeystoreUtil;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -37,20 +32,6 @@ public class CryptoInfoRepresentation {
     private List<String> clientSignatureSymmetricAlgorithms;
 
     private List<String> clientSignatureAsymmetricAlgorithms;
-
-    public static CryptoInfoRepresentation create(List<String> clientSignatureSymmetricAlgorithms, List<String> clientSignatureAsymmetricAlgorithms) {
-        CryptoInfoRepresentation info = new CryptoInfoRepresentation();
-
-        CryptoProvider cryptoProvider = CryptoIntegration.getProvider();
-        info.cryptoProvider = cryptoProvider.getClass().getSimpleName();
-        info.supportedKeystoreTypes = CryptoIntegration.getProvider().getSupportedKeyStoreTypes()
-                .map(KeystoreUtil.KeystoreFormat::toString)
-                .collect(Collectors.toList());
-        info.clientSignatureSymmetricAlgorithms = clientSignatureSymmetricAlgorithms;
-        info.clientSignatureAsymmetricAlgorithms = clientSignatureAsymmetricAlgorithms;
-
-        return info;
-    }
 
     public String getCryptoProvider() {
         return cryptoProvider;

--- a/core/src/main/java/org/keycloak/representations/info/FeatureRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/info/FeatureRepresentation.java
@@ -1,39 +1,15 @@
 package org.keycloak.representations.info;
 
-import org.keycloak.common.Profile;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class FeatureRepresentation {
     private String name;
     private String label;
-    private Type type;
+    private FeatureType type;
     private boolean isEnabled;
     private Set<String> dependencies;
 
     public FeatureRepresentation() {
-    }
-
-    public FeatureRepresentation(Profile.Feature feature, boolean isEnabled) {
-        this.name = feature.name();
-        this.label = feature.getLabel();
-        this.type = Type.valueOf(feature.getType().name());
-        this.isEnabled = isEnabled;
-        this.dependencies = feature.getDependencies() != null ?
-                feature.getDependencies().stream().map(Enum::name).collect(Collectors.toSet()) : Collections.emptySet();
-    }
-
-    public static List<FeatureRepresentation> create() {
-        List<FeatureRepresentation> featureRepresentationList = new ArrayList<>();
-        Profile profile = Profile.getInstance();
-        final Map<Profile.Feature, Boolean> features = profile.getFeatures();
-        features.forEach((f, enabled) -> featureRepresentationList.add(new FeatureRepresentation(f, enabled)));
-        return featureRepresentationList;
     }
 
     public String getName() {
@@ -52,11 +28,11 @@ public class FeatureRepresentation {
         this.label = label;
     }
 
-    public Type getType() {
+    public FeatureType getType() {
         return type;
     }
 
-    public void setType(Type type) {
+    public void setType(FeatureType type) {
         this.type = type;
     }
 
@@ -75,13 +51,4 @@ public class FeatureRepresentation {
     public void setDependencies(Set<String> dependencies) {
         this.dependencies = dependencies;
     }
-}
-
-enum Type {
-    DEFAULT,
-    DISABLED_BY_DEFAULT,
-    PREVIEW,
-    PREVIEW_DISABLED_BY_DEFAULT,
-    EXPERIMENTAL,
-    DEPRECATED;
 }

--- a/core/src/main/java/org/keycloak/representations/info/FeatureType.java
+++ b/core/src/main/java/org/keycloak/representations/info/FeatureType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.info;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public enum FeatureType {
+    DEFAULT,
+    DISABLED_BY_DEFAULT,
+    PREVIEW,
+    PREVIEW_DISABLED_BY_DEFAULT,
+    EXPERIMENTAL,
+    DEPRECATED;
+}

--- a/core/src/main/java/org/keycloak/representations/info/ProfileInfoRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/info/ProfileInfoRepresentation.java
@@ -17,12 +17,8 @@
 
 package org.keycloak.representations.info;
 
-import org.keycloak.common.Profile;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -34,41 +30,36 @@ public class ProfileInfoRepresentation {
     private List<String> previewFeatures;
     private List<String> experimentalFeatures;
 
-    public static ProfileInfoRepresentation create() {
-        ProfileInfoRepresentation info = new ProfileInfoRepresentation();
-
-        Profile profile = Profile.getInstance();
-
-        info.name = profile.getName().name().toLowerCase();
-        info.disabledFeatures = names(profile.getDisabledFeatures());
-        info.previewFeatures = names(profile.getPreviewFeatures());
-        info.experimentalFeatures = names(profile.getExperimentalFeatures());
-
-        return info;
-    }
-
     public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public List<String> getDisabledFeatures() {
         return disabledFeatures;
     }
 
+    public void setDisabledFeatures(List<String> disabledFeatures) {
+        this.disabledFeatures = disabledFeatures;
+    }
+
     public List<String> getPreviewFeatures() {
         return previewFeatures;
+    }
+
+    public void setPreviewFeatures(List<String> previewFeatures) {
+        this.previewFeatures = previewFeatures;
     }
 
     public List<String> getExperimentalFeatures() {
         return experimentalFeatures;
     }
 
-    private static List<String> names(Set<Profile.Feature> featureSet) {
-        List<String> l = new LinkedList();
-        for (Profile.Feature f : featureSet) {
-            l.add(f.name());
-        }
-        return l;
+    public void setExperimentalFeatures(List<String> experimentalFeatures) {
+        this.experimentalFeatures = experimentalFeatures;
     }
 
 }

--- a/core/src/main/java/org/keycloak/representations/info/SystemInfoRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/info/SystemInfoRepresentation.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.representations.info;
 
-import org.keycloak.common.Version;
 
 import java.util.Date;
 import java.util.Locale;
@@ -43,9 +42,9 @@ public class SystemInfoRepresentation {
     private String userTimezone;
     private String userLocale;
 
-    public static SystemInfoRepresentation create(long serverStartupTime) {
+    public static SystemInfoRepresentation create(long serverStartupTime, String serverVersion) {
         SystemInfoRepresentation rep = new SystemInfoRepresentation();
-        rep.version = Version.VERSION;
+        rep.version = serverVersion;
         rep.serverTime = new Date().toString();
         rep.uptimeMillis = System.currentTimeMillis() - serverStartupTime;
         rep.uptime = formatUptime(rep.uptimeMillis);

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
+            <artifactId>keycloak-admin-client-tests</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/integration/admin-client-jee/pom.xml
+++ b/integration/admin-client-jee/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>keycloak-admin-client-jee-tests</artifactId>
     <name>Keycloak Admin REST Client JavaEE For Tests</name>
     <description>Keycloak Admin REST Client. This module is supposed to be used just in the Keycloak repository for the testsuite. It is NOT supposed to be used by the 3rd party applications.
-        For the use by 3rd party applications, please use `org.keycloak:keycloak-admin-client` module.
+        For the use by 3rd party applications, please use `org.keycloak:keycloak-admin-client-jee` module.
     </description>
 
     <properties>

--- a/integration/admin-client-jee/pom.xml
+++ b/integration/admin-client-jee/pom.xml
@@ -26,9 +26,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>keycloak-admin-client-jee</artifactId>
-    <name>Keycloak Admin REST Client JavaEE</name>
-    <description/>
+    <artifactId>keycloak-admin-client-jee-tests</artifactId>
+    <name>Keycloak Admin REST Client JavaEE For Tests</name>
+    <description>Keycloak Admin REST Client. This module is supposed to be used just in the Keycloak repository for the testsuite. It is NOT supposed to be used by the 3rd party applications.
+        For the use by 3rd party applications, please use `org.keycloak:keycloak-admin-client` module.
+    </description>
 
     <properties>
         <resteasy.version>${resteasy-legacy.version}</resteasy.version>

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -26,9 +26,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>keycloak-admin-client</artifactId>
-    <name>Keycloak Admin REST Client</name>
-    <description/>
+    <artifactId>keycloak-admin-client-tests</artifactId>
+    <name>Keycloak Admin REST Client for tests</name>
+    <description>Keycloak Admin REST Client. This module is supposed to be used just in the Keycloak repository for the testsuite. It is NOT supposed to be used by the 3rd party applications.
+        For the use by 3rd party applications, please use `org.keycloak:keycloak-admin-client` module.
+    </description>
 
     <properties>
         <jakarta-transformer-sources>${project.basedir}/../admin-client-jee/src</jakarta-transformer-sources>

--- a/misc/keycloak-test-helper/pom.xml
+++ b/misc/keycloak-test-helper/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
+            <artifactId>keycloak-admin-client-tests</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -989,12 +989,12 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-admin-client-jee</artifactId>
+                <artifactId>keycloak-admin-client-jee-tests</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-admin-client</artifactId>
+                <artifactId>keycloak-admin-client-tests</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/test-poc/framework/pom.xml
+++ b/test-poc/framework/pom.xml
@@ -34,7 +34,7 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
+            <artifactId>keycloak-admin-client-tests</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1727,7 +1727,7 @@
 
                 <dependency>
                     <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-admin-client</artifactId>
+                    <artifactId>keycloak-admin-client-tests</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.keycloak</groupId>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
+            <artifactId>keycloak-admin-client-tests</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
closes #30796 
closes #30798
 
This PR renames `keycloak-admin-client` to `keycloak-admin-client-tests` . Similarly for JEE admin client.

This approach assume that `keycloak` repository won't contain `keycloak-admin-client` module anymore as that module will be present in the `keycloak-client` repository and will be released from that repository whenever new release of `keycloak-admin-client` is needed.

There is also minor refactoring done, so the representation classes in `core` module don't have much logic related to the server (some implementation logic was moved to server class `ServerInfoAdminResource` )

The related PR is https://github.com/keycloak/keycloak-client/pull/1
