### PR TITLE
Filtering organization groups when managing or processing groups

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
@@ -290,4 +290,10 @@ public class GroupAdapter implements GroupModel {
     public boolean escapeSlashesInGroupPath() {
         return KeycloakModelUtils.escapeSlashesInGroupPath(keycloakSession);
     }
+
+    @Override
+    public Type getType() {
+        if (isUpdated()) return updated.getType();
+        return cached.getType();
+    }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -41,6 +41,7 @@ import org.keycloak.models.ClientProvider;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientScopeProvider;
 import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.GroupProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakTransaction;
@@ -1170,8 +1171,8 @@ public class RealmCacheSession implements CacheRealmProvider {
     }
 
     @Override
-    public GroupModel createGroup(RealmModel realm, String id, String name, GroupModel toParent) {
-        GroupModel group = getGroupDelegate().createGroup(realm, id, name, toParent);
+    public GroupModel createGroup(RealmModel realm, String id, Type type, String name, GroupModel toParent) {
+        GroupModel group = getGroupDelegate().createGroup(realm, id, type, name, toParent);
         return groupAdded(realm, group, toParent);
     }
 
@@ -1602,5 +1603,11 @@ public class RealmCacheSession implements CacheRealmProvider {
             return localizationTexts.get(key);
         }
         return null;
+    }
+
+    @Override
+    public void preRemove(RealmModel realm) {
+        listInvalidations.add(realm.getId());
+        getGroupDelegate().preRemove(realm);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
@@ -19,6 +19,7 @@ package org.keycloak.models.cache.infinispan.entities;
 
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.cache.infinispan.DefaultLazyLoader;
@@ -42,6 +43,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
     private final LazyLoader<GroupModel, Set<String>> roleMappings;
     private final LazyLoader<GroupModel, Set<String>> subGroups;
     private final LazyLoader<GroupModel, Long> subGroupsCount;
+    private final Type type;
 
     public CachedGroup(Long revision, RealmModel realm, GroupModel group) {
         super(revision, group.getId());
@@ -52,6 +54,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
         this.roleMappings = new DefaultLazyLoader<>(source -> source.getRoleMappingsStream().map(RoleModel::getId).collect(Collectors.toSet()), Collections::emptySet);
         this.subGroups = new DefaultLazyLoader<>(source -> source.getSubGroupsStream().map(GroupModel::getId).collect(Collectors.toSet()), Collections::emptySet);
         this.subGroupsCount = new DefaultLazyLoader<>(GroupModel::getSubGroupsCount, () -> 0L);
+        this.type = group.getType();
     }
 
     public String getRealm() {
@@ -84,5 +87,9 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
 
     public Long getSubGroupsCount(Supplier<GroupModel> group) {
         return subGroupsCount.get(group);
+    }
+
+    public Type getType() {
+        return type;
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_0_0_OrganizationGroupType.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_0_0_OrganizationGroupType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.connections.jpa.updater.liquibase.custom;
+
+import liquibase.exception.CustomChangeException;
+import liquibase.statement.core.RawSqlStatement;
+
+public class JpaUpdate26_0_0_OrganizationGroupType extends CustomKeycloakTask {
+
+    @Override
+    protected void generateStatementsImpl() throws CustomChangeException {
+        String groupTable = getTableName("KEYCLOAK_GROUP");
+        String orgTable = getTableName("ORG");
+
+        if ("mariadb".equals(database.getShortName())) {
+            statements.add(new RawSqlStatement("UPDATE " + groupTable + " SET TYPE = 1 WHERE CONVERT(NAME USING utf8) IN (SELECT CONVERT(ID USING utf8) FROM " +  orgTable + ")"));
+        } else {
+            statements.add(new RawSqlStatement("UPDATE " + groupTable + " SET TYPE = 1 WHERE NAME IN (SELECT ID FROM " +  orgTable + ")"));
+        }
+    }
+
+    @Override
+    protected String getTaskId() {
+        return "Update type and id for organization groups";
+    }
+
+}
+
+

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -318,6 +318,11 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
     }
 
     @Override
+    public Type getType() {
+        return Type.valueOf(group.getType());
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !(o instanceof GroupModel)) return false;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupAttributeEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupAttributeEntity.java
@@ -37,6 +37,7 @@ import jakarta.persistence.Table;
  */
 @NamedQueries({
         @NamedQuery(name="getGroupAttributesByNameAndValue", query="select attr from GroupAttributeEntity attr where attr.name = :name and attr.value = :value"),
+        @NamedQuery(name="deleteGroupAttributesByRealm", query="delete from  GroupAttributeEntity a where a.group IN (select u from GroupEntity u where u.realm=:realm)")
 })
 @Table(name="GROUP_ATTRIBUTE")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupEntity.java
@@ -28,17 +28,18 @@ import java.util.LinkedList;
  * @version $Revision: 1 $
  */
 @NamedQueries({
-        @NamedQuery(name="getGroupIdsByParent", query="select u.id from GroupEntity u where u.realm = :realm and u.parentId = :parent order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsByParentAndName", query="select u.id from GroupEntity u where u.realm = :realm and u.parentId = :parent and u.name = :search order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsByParentAndNameContaining", query="select u.id from GroupEntity u where u.realm = :realm and u.parentId = :parent and lower(u.name) like lower(concat('%',:search,'%')) order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsByRealm", query="select u.id from GroupEntity u where u.realm = :realm  order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsByNameContaining", query="select u.id from GroupEntity u where u.realm = :realm and lower(u.name) like lower(concat('%',:search,'%')) order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsByNameContainingFromIdList", query="select u.id from GroupEntity u where u.realm = :realm and lower(u.name) like lower(concat('%',:search,'%')) and u.id in :ids order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsByName", query="select u.id from GroupEntity u where u.realm = :realm and u.name = :search order by u.name ASC"),
-        @NamedQuery(name="getGroupIdsFromIdList", query="select u.id from GroupEntity u where u.realm = :realm and u.id in :ids order by u.name ASC"),
-        @NamedQuery(name="getGroupCountByNameContainingFromIdList", query="select count(u) from GroupEntity u where u.realm = :realm and lower(u.name) like lower(concat('%',:search,'%')) and u.id in :ids"),
-        @NamedQuery(name="getGroupCount", query="select count(u) from GroupEntity u where u.realm = :realm"),
-        @NamedQuery(name="getGroupCountByParent", query="select count(u) from GroupEntity u where u.realm = :realm and u.parentId = :parent")
+        @NamedQuery(name="getGroupIdsByParent", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and u.parentId = :parent order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsByParentAndName", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and u.parentId = :parent and u.name = :search order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsByParentAndNameContaining", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and u.parentId = :parent and lower(u.name) like lower(concat('%',:search,'%')) order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsByRealm", query="select u.id from GroupEntity u where u.realm = :realm  and u.type = 0 order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsByNameContaining", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and lower(u.name) like lower(concat('%',:search,'%')) order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsByNameContainingFromIdList", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and lower(u.name) like lower(concat('%',:search,'%')) and u.id in :ids order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsByName", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and u.name = :search order by u.name ASC"),
+        @NamedQuery(name="getGroupIdsFromIdList", query="select u.id from GroupEntity u where u.realm = :realm and u.type = 0 and u.id in :ids order by u.name ASC"),
+        @NamedQuery(name="getGroupCountByNameContainingFromIdList", query="select count(u) from GroupEntity u where u.realm = :realm and u.type = 0 and lower(u.name) like lower(concat('%',:search,'%')) and u.id in :ids"),
+        @NamedQuery(name="getGroupCount", query="select count(u) from GroupEntity u where u.realm = :realm and u.type = 0"),
+        @NamedQuery(name="getGroupCountByParent", query="select count(u) from GroupEntity u where u.realm = :realm and u.type = 0 and u.parentId = :parent"),
+        @NamedQuery(name="deleteGroupsByRealm", query="delete from GroupEntity g where g.realm = :realm")
 })
 @Entity
 @Table(name="KEYCLOAK_GROUP",
@@ -65,6 +66,9 @@ public class GroupEntity {
 
     @Column(name = "REALM_ID")
     private String realm;
+
+    @Column(name = "TYPE")
+    private int type;
 
     @OneToMany(
             cascade = CascadeType.REMOVE,
@@ -112,6 +116,14 @@ public class GroupEntity {
 
     public void setParentId(String parentId) {
         this.parentId = parentId;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public void setType(int type) {
+        this.type = type;
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationDomainEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationDomainEntity.java
@@ -25,6 +25,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
 /**
@@ -34,6 +36,9 @@ import jakarta.persistence.Table;
  */
 @Entity
 @Table(name="ORG_DOMAIN")
+@NamedQueries({
+        @NamedQuery(name="deleteOrganizationDomainsByRealm", query="delete from  OrganizationDomainEntity d where d.organization IN (select o from OrganizationEntity o where o.realmId=:realmId)")
+})
 public class OrganizationDomainEntity {
 
     @Id

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationEntity.java
@@ -43,7 +43,8 @@ import jakarta.persistence.Table;
                 " where o.realmId = :realmId AND (o.name = :search OR d.name = :search) order by o.name ASC"),
         @NamedQuery(name="getByNameOrDomainContained", query="select distinct o from OrganizationEntity o inner join OrganizationDomainEntity d ON o.id = d.organization.id" +
                 " where o.realmId = :realmId AND (lower(o.name) like concat('%',:search,'%') OR d.name like concat('%',:search,'%')) order by o.name ASC"),
-        @NamedQuery(name="getCount", query="select count(o) from OrganizationEntity o where o.realmId = :realmId")
+        @NamedQuery(name="getCount", query="select count(o) from OrganizationEntity o where o.realmId = :realmId"),
+        @NamedQuery(name="deleteOrganizationsByRealm", query="delete from OrganizationEntity o where o.realmId = :realmId")
 })
 public class OrganizationEntity {
 

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -39,6 +39,7 @@ import jakarta.persistence.criteria.Root;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.GroupProvider;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
@@ -451,11 +452,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
     }
 
     private GroupModel createOrganizationGroup(String orgId) {
-        GroupModel group = groupProvider.createGroup(getRealm(), null, orgId);
-
-        group.setSingleAttribute(ORGANIZATION_ATTRIBUTE, orgId);
-
-        return group;
+        return groupProvider.createGroup(getRealm(), null, Type.ORGANIZATION, orgId, null);
     }
 
     private GroupModel getOrganizationGroup(OrganizationModel organization) {

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProviderFactory.java
@@ -38,6 +38,8 @@ import org.keycloak.provider.ProviderEvent;
 
 public class JpaOrganizationProviderFactory implements OrganizationProviderFactory {
 
+    public static final String ID = "jpa";
+
     @Override
     public OrganizationProvider create(KeycloakSession session) {
         return new JpaOrganizationProvider(session);
@@ -60,18 +62,13 @@ public class JpaOrganizationProviderFactory implements OrganizationProviderFacto
 
     @Override
     public String getId() {
-        return "jpa";
+        return ID;
     }
 
     private void handleEvents(ProviderEvent event) {
         if (event instanceof RealmPostCreateEvent) {
             RealmModel realm = ((RealmPostCreateEvent) event).getCreatedRealm();
             configureAuthenticationFlows(realm);
-        }
-        if (event instanceof RealmRemovedEvent) {
-            KeycloakSession session = ((RealmRemovedEvent) event).getKeycloakSession();
-            OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
-            provider.removeAll();
         }
         if (event instanceof GroupEvent) {
             GroupEvent groupEvent = (GroupEvent) event;

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -75,7 +75,7 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
         return realm;
     }
 
-    String getGroupId() {
+    public String getGroupId() {
         return entity.getGroupId();
     }
 
@@ -137,8 +137,6 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
         if (attributes == null) {
             return;
         }
-        // make sure the kc.org attribute is never removed or updated
-        attributes.put(ORGANIZATION_ATTRIBUTE, getGroup().getAttributes().get(OrganizationModel.ORGANIZATION_ATTRIBUTE));
         Set<String> attrsToRemove = getAttributes().keySet();
         attrsToRemove.removeAll(attributes.keySet());
         attrsToRemove.forEach(group::removeAttribute);
@@ -148,9 +146,7 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
     @Override
     public Map<String, List<String>> getAttributes() {
         if (attributes == null) {
-            attributes = new HashMap<>(ofNullable(getGroup().getAttributes()).orElse(Map.of()));
-            // do not expose the kc.org attribute
-            attributes.remove(OrganizationModel.ORGANIZATION_ATTRIBUTE);
+            attributes = ofNullable(getGroup().getAttributes()).orElse(Map.of());
         }
         return attributes;
     }

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -28,4 +28,21 @@
         <addUniqueConstraint tableName="ORG" columnNames="REALM_ID, ALIAS" constraintName="UK_ORG_ALIAS"/>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.0.0-org-group">
+        <addColumn tableName="KEYCLOAK_GROUP">
+            <column name="TYPE" type="INT" defaultValueNumeric="0"/>
+        </addColumn>
+        <update tableName="KEYCLOAK_GROUP">
+            <column name="TYPE" valueNumeric="0" type="INT"/>
+        </update>
+        <addNotNullConstraint tableName="KEYCLOAK_GROUP" columnName="TYPE" columnDataType="INT"/>
+        <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate26_0_0_OrganizationGroupType"/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.0.0-org-indexes">
+        <createIndex tableName="ORG_DOMAIN" indexName="IDX_ORG_DOMAIN_ORG_ID">
+            <column name="ORG_ID" type="VARCHAR(255)"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -31,6 +31,8 @@ import org.keycloak.exportimport.ExportOptions;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
@@ -458,7 +460,7 @@ public class ExportUtils {
 
         if (options.isGroupsAndRolesIncluded()) {
             List<String> groups = user.getGroupsStream()
-                    .filter(g -> !g.getAttributes().containsKey(OrganizationModel.ORGANIZATION_ATTRIBUTE))
+                    .filter(g -> Type.REALM.equals(g.getType()))
                     .map(ModelToRepresentation::buildGroupPath).collect(Collectors.toList());
             userRep.setGroups(groups);
         }

--- a/model/storage-private/src/main/java/org/keycloak/storage/GroupStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/GroupStorageManager.java
@@ -19,6 +19,7 @@ package org.keycloak.storage;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.GroupProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -119,8 +120,8 @@ public class GroupStorageManager extends AbstractStorageManager<GroupStorageProv
     }
 
     @Override
-    public GroupModel createGroup(RealmModel realm, String id, String name, GroupModel toParent) {
-        return localStorage().createGroup(realm, id, name, toParent);
+    public GroupModel createGroup(RealmModel realm, String id, Type type, String name, GroupModel toParent) {
+        return localStorage().createGroup(realm, id, type, name, toParent);
     }
 
     @Override
@@ -136,6 +137,11 @@ public class GroupStorageManager extends AbstractStorageManager<GroupStorageProv
     @Override
     public void addTopLevelGroup(RealmModel realm, GroupModel subGroup) {
         localStorage().addTopLevelGroup(realm, subGroup);
+    }
+
+    @Override
+    public void preRemove(RealmModel realm) {
+        localStorage().preRemove(realm);
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -172,7 +172,6 @@ public class ModelToRepresentation {
     @Deprecated
     public static Stream<GroupRepresentation> toGroupHierarchy(KeycloakSession session, RealmModel realm, boolean full) {
         return session.groups().getTopLevelGroupsStream(realm, null, null)
-                .filter(g -> !g.getAttributes().containsKey(OrganizationModel.ORGANIZATION_ATTRIBUTE))
                 .map(g -> toGroupHierarchy(g, full));
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/GroupModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/GroupModel.java
@@ -30,6 +30,33 @@ import java.util.stream.Stream;
  */
 public interface GroupModel extends RoleMapperModel {
 
+    enum Type {
+        REALM(0),
+        ORGANIZATION(1);
+
+        private final int value;
+
+        Type(int value) {
+            this.value = value;
+        }
+
+        public static Type valueOf(int value) {
+            Type[] values = values();
+
+            for (int i = 0; i < values.length; i++) {
+                if (values[i].value == value) {
+                    return values[i];
+                }
+            }
+
+            throw new IllegalArgumentException("No type found with value " + value);
+        }
+
+        public int intValue() {
+            return value;
+        }
+    }
+
     interface GroupEvent extends ProviderEvent {
         RealmModel getRealm();
         GroupModel getGroup();
@@ -291,5 +318,9 @@ public interface GroupModel extends RoleMapperModel {
 
     default boolean escapeSlashesInGroupPath() {
         return GroupProvider.DEFAULT_ESCAPE_SLASHES;
+    }
+
+    default Type getType() {
+        return Type.REALM;
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/GroupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/GroupProvider.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models;
 
+import org.keycloak.models.GroupModel.Type;
 import org.keycloak.provider.Provider;
 import org.keycloak.storage.group.GroupLookupProvider;
 
@@ -158,7 +159,7 @@ public interface GroupProvider extends Provider, GroupLookupProvider {
      *
      * @param realm Realm.
      * @param name Name.
-     * @throws ModelDuplicateException If there is already a top-level group with the given name 
+     * @throws ModelDuplicateException If there is already a top-level group with the given name
      * @return Model of the created group.
      */
     default GroupModel createGroup(RealmModel realm, String name) {
@@ -172,7 +173,7 @@ public interface GroupProvider extends Provider, GroupLookupProvider {
      * @param realm Realm.
      * @param id Id.
      * @param name Name.
-     * @throws ModelDuplicateException If a group with given id already exists or there is a top-level group with the given name 
+     * @throws ModelDuplicateException If a group with given id already exists or there is a top-level group with the given name
      * @return Model of the created group
      */
     default GroupModel createGroup(RealmModel realm, String id, String name) {
@@ -203,7 +204,22 @@ public interface GroupProvider extends Provider, GroupLookupProvider {
      * @throws ModelDuplicateException If a group with the given id already exists or the toParent group has a subgroup with the given name
      * @return Model of the created group
      */
-    GroupModel createGroup(RealmModel realm, String id, String name, GroupModel toParent);
+    default GroupModel createGroup(RealmModel realm, String id, String name, GroupModel toParent) {
+        return createGroup(realm, id, Type.REALM, name, toParent);
+    }
+
+    /**
+     * Creates a new group with the given name, id, name and parent to the given realm.
+     *
+     * @param realm Realm.
+     * @param id Id, will be generated if {@code null}.
+     * @param type the group type. if not set, defaults to {@link Type#REALM}
+     * @param name Name.
+     * @param toParent Parent group, or {@code null} if the group is top level group
+     * @throws ModelDuplicateException If a group with the given id already exists or the toParent group has a subgroup with the given name
+     * @return Model of the created group
+     */
+    GroupModel createGroup(RealmModel realm, String id, Type type, String name, GroupModel toParent);
 
     /**
      * Removes the given group for the given realm.
@@ -237,4 +253,12 @@ public interface GroupProvider extends Provider, GroupLookupProvider {
      * @throws ModelDuplicateException If there is already a top level group name with the same name
      */
     void addTopLevelGroup(RealmModel realm, GroupModel subGroup);
+
+    /**
+     * Called when a realm is removed.
+     * Should remove all groups that belong to the realm.
+     *
+     * @param realm a reference to the realm
+     */
+    void preRemove(RealmModel realm);
 }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
@@ -134,9 +134,9 @@ public class OrganizationsResource {
         // check if are searching orgs by attribute.
         if (StringUtil.isNotBlank(searchQuery)) {
             Map<String, String> attributes = SearchQueryUtils.getFields(searchQuery);
-            return provider.getAllStream(attributes, first, max).map(Organizations::toRepresentation);
+            return provider.getAllStream(attributes, first, max).map(Organizations::toBriefRepresentation);
         } else {
-            return provider.getAllStream(search, exact, first, max).map(Organizations::toRepresentation);
+            return provider.getAllStream(search, exact, first, max).map(Organizations::toBriefRepresentation);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationGroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationGroupTest.java
@@ -19,19 +19,16 @@ package org.keycloak.testsuite.organization.admin;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.keycloak.testsuite.admin.group.GroupSearchTest.buildSearchQuery;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 import org.junit.Test;
-import org.keycloak.admin.client.resource.GroupResource;
-import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.ModelValidationException;
@@ -39,8 +36,9 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.jpa.JpaOrganizationProviderFactory;
+import org.keycloak.organization.jpa.OrganizationAdapter;
 import org.keycloak.representations.idm.GroupRepresentation;
-import org.keycloak.representations.idm.ManagementPermissionRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -50,165 +48,37 @@ import org.keycloak.testsuite.runonserver.RunOnServer;
 public class OrganizationGroupTest extends AbstractOrganizationTest {
 
     @Test
-    public void testManageOrgGroupsViaDifferentAPIs() {
-        // test realm contains some groups initially
-        List<GroupRepresentation> getAllBefore = testRealm().groups().groups();
-        long countBefore = testRealm().groups().count().get("count");
-
-        List<String> orgIds = new ArrayList<>();
-        // create 5 organizations
-        for (int i = 0; i < 5; i++) {
-            OrganizationRepresentation expected = createOrganization("myorg" + i);
-            OrganizationResource organization = testRealm().organizations().get(expected.getId());
-            expected.setAttributes(Map.of());
-            organization.update(expected).close();
-            OrganizationRepresentation existing = organization.toRepresentation();
-            orgIds.add(expected.getId());
-            assertNotNull(existing);
-        }
-
-        // create one top-level group and one subgroup
-        GroupRepresentation topGroup = createGroup(testRealm(), "top");
-        GroupRepresentation level2Group = new GroupRepresentation();
-        level2Group.setName("level2");
-        testRealm().groups().group(topGroup.getId()).subGroup(level2Group);
-
-        // check that count queries include org related groups
-        assertEquals(countBefore + 7, (long) testRealm().groups().count().get("count"));
-
-        // check that search queries include org related groups but those can't be updated
-        assertEquals(getAllBefore.size() + 6, testRealm().groups().groups().size());
-        // we need to pull full representation of the group, otherwise org related attributes are lost in the representation
-        List<GroupRepresentation> groups = testRealm().groups().query(buildSearchQuery(OrganizationModel.ORGANIZATION_ATTRIBUTE, orgIds.get(0)), false, 0, 10, false);
-        assertEquals(1, groups.size());
-        GroupRepresentation orgGroupRep = groups.get(0);
-        GroupResource group = testRealm().groups().group(orgGroupRep.getId());
-
-        try {
-            // group to be updated is organization related group
-            group.update(topGroup);
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success, the group could not be updated
-        }
-
-        try {
-            // cannot update a group with the attribute reserved for organization related groups
-            testRealm().groups().group(topGroup.getId()).update(orgGroupRep);
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success, the group could not be updated
-        }
-
-        try {
-            // cannot remove organization related group
-            group.remove();
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success, the group could not be removed
-        }
-
-        try {
-            // cannot manage organization related group permissions
-            group.setPermissions(new ManagementPermissionRepresentation(true));
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success, the group's permissions cannot be managed
-        }
-
-        // try to add subgroup to an org related group
-        try (Response response = group.subGroup(topGroup)) {
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-        }
-
-        // try to add org related group as a subgroup to a group
-        try (Response response = testRealm().groups().group(topGroup.getId()).subGroup(orgGroupRep)) {
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-        }
-
-        try {
-            // cannot manage organization related group role mappers
-            group.roles().realmLevel().add(null);
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success
-        }
-
-        try {
-            // cannot manage organization related group role mappers
-            group.roles().realmLevel().remove(null);
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success
-        }
-
-        try {
-            // cannot manage organization related group role mappers
-            group.roles().clientLevel(testRealm().clients().findByClientId("test-app").get(0).getId()).add(null);
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success
-        }
-
-        try {
-            // cannot manage organization related group role mappers
-            group.roles().clientLevel(testRealm().clients().findByClientId("test-app").get(0).getId()).remove(null);
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success
-        }
-
-        // cannot add top level group with reserved attribute for organizations
-        String id = orgGroupRep.getId();
-        String name = orgGroupRep.getName();
-        orgGroupRep.setId(null);
-        orgGroupRep.setName(null);
-        try (Response response = testRealm().groups().add(orgGroupRep)) {
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-        } finally {
-            orgGroupRep.setId(id);
-            orgGroupRep.setName(name);
-        }
-
-        try {
-            // cannot add organization related group as a default group
-            testRealm().addDefaultGroup(orgGroupRep.getId());
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success
-        }
-
-        OrganizationRepresentation org = createOrganization();
-        UserRepresentation userRep = addMember(testRealm().organizations().get(org.getId()));
-
-        try {
-            // cannot join organization related group
-            testRealm().users().get(userRep.getId()).joinGroup(orgGroupRep.getId());
-            fail("Expected BadRequestException");
-        } catch (BadRequestException ex) {
-            // success
-        }
-    }
-
-    @Test
     public void testManagingOrganizationGroupNotInOrganizationScope() {
         String id = createOrganization().getId();
         String memberId = addMember(testRealm().organizations().get(id)).getId();
 
         getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
-            OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
-            OrganizationModel organization = provider.getById(id);
+            OrganizationProvider provider = session.getProvider(OrganizationProvider.class, JpaOrganizationProviderFactory.ID);
+            OrganizationAdapter organization = (OrganizationAdapter) provider.getById(id);
             RealmModel realm = session.getContext().getRealm();
-            GroupModel orgGroup = session.groups().getGroupByName(realm, null, organization.getId());
+            GroupModel orgGroup = session.groups().getGroupById(realm, organization.getGroupId());
+            assertNotNull(orgGroup);
 
             try {
                 orgGroup.setName("fail");
                 fail("can not manage");
             } catch (ModelValidationException ignore) {
+                try {
+                    orgGroup.setName(organization.getId());
+                } catch (ModelValidationException ignore2) {}
             }
 
             try {
                 orgGroup.setSingleAttribute(OrganizationModel.ORGANIZATION_ATTRIBUTE, "fail");
+                fail("can not manage");
+            } catch (ModelValidationException ignore) {
+                try {
+                    orgGroup.setSingleAttribute(OrganizationModel.ORGANIZATION_ATTRIBUTE, organization.getId());
+                } catch (ModelValidationException ignore2) {}
+            }
+
+            try {
+                orgGroup.setSingleAttribute("something", "fail");
                 fail("can not manage");
             } catch (ModelValidationException ignore) {
             }
@@ -256,6 +126,44 @@ public class OrganizationGroupTest extends AbstractOrganizationTest {
                 fail("can not manage");
             } catch (ModelValidationException ignore) {
             }
+        });
+    }
+
+    @Test
+    public void testOrganizationGroupsNotAvailableFromGroupAPI() {
+        Set<String> orgIds = new HashSet<>();
+
+        for (int i = 0; i < 10; i++) {
+            orgIds.add(createOrganization("org-" + i).getId());
+        }
+
+        assertEquals(orgIds.size(), testRealm().organizations().getAll().size());
+        assertTrue(testRealm().groups().groups().stream().map(GroupRepresentation::getId).noneMatch(orgIds::contains));
+    }
+
+    @Test
+    public void testOrganizationGroupsNotAvailableFromUserAPI() {
+        OrganizationRepresentation organization = createOrganization();
+        UserRepresentation member = addMember(testRealm().organizations().get(organization.getId()));
+        UserResource userResource = testRealm().users().get(member.getId());
+        assertTrue(userResource.groups().isEmpty());
+        assertEquals(0, userResource.groupsCount(null).get("count").intValue());
+        assertEquals(0, userResource.groupsCount(organization.getId()).get("count").intValue());
+    }
+
+    @Test
+    public void testDeleteGroupOnOrganizationRemoval() {
+        String id = createOrganization().getId();
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider provider = session.getProvider(OrganizationProvider.class, JpaOrganizationProviderFactory.ID);
+            OrganizationAdapter organization = (OrganizationAdapter) provider.getById(id);
+            RealmModel realm = session.getContext().getRealm();
+            GroupModel group = session.groups().getGroupById(realm, organization.getGroupId());
+            assertNotNull(group);
+            provider.remove(organization);
+            group = session.groups().getGroupById(realm, organization.getId());
+            assertNull(group);
         });
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/exportimport/OrganizationExportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/exportimport/OrganizationExportTest.java
@@ -163,7 +163,10 @@ public class OrganizationExportTest extends AbstractOrganizationTest {
         exportImport.setAction(ExportImportConfig.ACTION_IMPORT);
         exportImport.setFile(targetFilePath);
         exportImport.runImport();
-        getCleanup().addCleanup(() -> testRealm().remove());
+        getCleanup().addCleanup(() -> {
+            testRealm().remove();
+            getTestContext().getTestRealmReps().clear();
+        });
 
         return testRealm().toRepresentation();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -21,14 +21,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
+import java.util.HashMap;
 import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.GroupMembershipMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.organization.admin.AbstractOrganizationTest;
 import org.keycloak.testsuite.util.OAuthClient.AccessTokenResponse;
@@ -54,5 +64,36 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         Map<String, Object> claim = (Map<String, Object>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(claim, notNullValue());
         assertThat(claim.get(organizationName), notNullValue());
+    }
+
+    @Test
+    public void testOrganizationNotAddedByGroupMapper() throws Exception {
+        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        addMember(organization);
+        ClientRepresentation client = testRealm().clients().findByClientId("direct-grant").get(0);
+        ClientResource clientResource = testRealm().clients().get(client.getId());
+        clientResource.getProtocolMappers().createMapper(createGroupMapper()).close();
+
+        oauth.clientId("direct-grant");
+        oauth.scope("openid organization");
+        AccessTokenResponse response = oauth.doGrantAccessTokenRequest("password", memberEmail, memberPassword);
+        assertThat(response.getScope(), containsString("organization"));
+        AccessToken accessToken = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        assertThat(accessToken.getOtherClaims().get("groups"), nullValue());
+    }
+
+    @NotNull
+    private static ProtocolMapperRepresentation createGroupMapper() {
+        ProtocolMapperRepresentation groupMapper = new ProtocolMapperRepresentation();
+        groupMapper.setName("groups");
+        groupMapper.setProtocolMapper(GroupMembershipMapper.PROVIDER_ID);
+        groupMapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        Map<String, String> config = new HashMap<>();
+        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "groups.groups");
+        config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
+        config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
+        groupMapper.setConfig(config);
+        return groupMapper;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
@@ -346,18 +346,6 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
     }
 
     @Test
-    public void testDeleteGroupOnOrganizationRemoval() {
-        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
-        addMember(organization);
-
-        assertTrue(testRealm().groups().groups("", 0, 100, false).stream().anyMatch(group -> group.getAttributes().containsKey("kc.org")));
-
-        organization.delete().close();
-
-        assertFalse(testRealm().groups().groups("", 0, 100, false).stream().anyMatch(group -> group.getAttributes().containsKey("kc.org")));
-    }
-
-    @Test
     public void testSearchMembers() {
 
         // create test users, ordered by username (e-mail).


### PR DESCRIPTION
* Adds a `type` to groups to filter organization groups from group queries. The reason for using a type is to avoid a nullable column and potentially impact database indexes and also eventually leverage groups for purposes other than realm and organization
* Adds filtering to the user cache layer to filter organization groups when returning the groups the user is a member
* Organization groups are no longer shown in the Group and User UIs and this improves the UX
* Organization groups are no longer added to tokens when using a group mapper
* Listing organizations will not automatically fetch their groups because the attributes are removed from the representation
* Deleting a realm will remove organization and groups using a query rather than iterate over groups/orgs as before
* Adding a database index on `ORG_DOMAIN` for the `ORG_ID`. Queries run a lot faster when listing organizations. For instance, from `Execution Time: 129.512 ms` to `Execution Time: 0.084 ms` in a database with 100k organizations each one with 10 domains.
