### PR TITLE
Fix invalid parameter '{3h}' to '{3}' for spanish translation

### DIFF
--- a/themes/src/main/resources-community/theme/base/email/messages/messages_es.properties
+++ b/themes/src/main/resources-community/theme/base/email/messages/messages_es.properties
@@ -28,7 +28,7 @@ emailTestBody=Este es un mensaje de prueba
 emailTestBodyHtml=<p> Este es un mensaje de prueba </p>
 identityProviderLinkSubject=Enlace {0}
 identityProviderLinkBody=Alguien quiere vincular su cuenta "{1}" con la cuenta "{0}" del usuario {2}. Si ha sido usted, haga clic en el siguiente enlace para vincular las cuentas \n\n{3}\n\nEste enlace expirará en {5}.\n\nSi no desea vincular la cuenta, simplemente ignore este mensaje. Si vincula las cuentas, podrá iniciar sesión en {1} a través de {0}.
-identityProviderLinkBodyHtml=<p>Alguien quiere vincular su <b>{1}</b> cuenta con <b>{0}</b> cuenta del usuario {2}. Si ha sido usted, haga clic en el siguiente enlace para vincular las cuentas</p><p><a href="{3h}">Enlace para confirmar el vínculo de cuentas</a></p><p>Este enlace expirará en {5}.</p><p>Si no desea vincular la cuenta, simplemente ignore este mensaje. Si vincula las cuentas, podrá iniciar sesión en {1} a través de {0}.</p>
+identityProviderLinkBodyHtml=<p>Alguien quiere vincular su <b>{1}</b> cuenta con <b>{0}</b> cuenta del usuario {2}. Si ha sido usted, haga clic en el siguiente enlace para vincular las cuentas</p><p><a href="{3}">Enlace para confirmar el vínculo de cuentas</a></p><p>Este enlace expirará en {5}.</p><p>Si no desea vincular la cuenta, simplemente ignore este mensaje. Si vincula las cuentas, podrá iniciar sesión en {1} a través de {0}.</p>
 
 requiredAction.CONFIGURE_TOTP=Configurar OTP
 requiredAction.TERMS_AND_CONDITIONS=Términos y condiciones


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Closes #30591 