### PR TITLE
Add briefRepresentation query parameter to getUsersInRole endpoint

### DIFF
--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -120,9 +120,8 @@ public interface RoleResource {
 
     /**
      * Get role members.
-     * <p/>
-     * Returns users that have the given role, sorted by username ascending, paginated according to the query
-     * parameters.
+     * <p>Returns users that have the given role, sorted by username ascending, paginated according to the query
+     * parameters.</p>
      *
      * @param firstResult Pagination offset
      * @param maxResults Pagination size
@@ -133,11 +132,27 @@ public interface RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> getUserMembers(@QueryParam("first") Integer firstResult,
             @QueryParam("max") Integer maxResults);
+
+    /**
+     * Get role members.
+     * <p>Returns users that have the given role, sorted by username ascending, paginated according to the query
+     * parameters.</p>
+     *
+     * @param briefRepresentation If the user should be returned in brief or full representation
+     * @param firstResult Pagination offset
+     * @param maxResults Pagination size
+     * @return a list of users with the given role
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getUserMembers(@QueryParam("briefRepresentation") Boolean briefRepresentation,
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults);
     
     /**
-     * Get role groups
-     * <p/>
-     * Returns groups that have the given role
+     * Get role groups.
+     * <p>Returns groups that have the given role.</p>
      *
      * @return a list of groups with the given role
      */
@@ -147,9 +162,8 @@ public interface RoleResource {
     Set<GroupRepresentation> getRoleGroupMembers();
 
     /**
-     * Get role groups
-     * <p/>
-     * Returns groups that have the given role, paginated according to the query parameters
+     * Get role groups.
+     * <p>Returns groups that have the given role, paginated according to the query parameters.</p>
      *
      * @param firstResult Pagination offset
      * @param maxResults  Pagination size
@@ -162,9 +176,8 @@ public interface RoleResource {
                                                @QueryParam("max") Integer maxResults);
 
     /**
-     * Get role members
-     * <p/>
-     * Returns users that have the given role
+     * Get role members.
+     * <p>Returns users that have the given role.</p>
      *
      * @return a set of users with the given role
      *
@@ -177,9 +190,8 @@ public interface RoleResource {
     Set<UserRepresentation> getRoleUserMembers();
 
     /**
-     * Get role members
-     * <p/>
-     * Returns users that have the given role, paginated according to the query parameters
+     * Get role members.
+     * <p>Returns users that have the given role, paginated according to the query parameters.</p>
      *
      * @param firstResult Pagination offset
      * @param maxResults  Pagination size

--- a/js/apps/admin-ui/src/realm-roles/UsersInRoleTab.tsx
+++ b/js/apps/admin-ui/src/realm-roles/UsersInRoleTab.tsx
@@ -30,6 +30,7 @@ export const UsersInRoleTab = () => {
       return adminClient.clients.findUsersWithRole({
         roleName: role.name!,
         id: clientId,
+        briefRepresentation: true,
         first,
         max,
       });
@@ -37,6 +38,7 @@ export const UsersInRoleTab = () => {
 
     return adminClient.roles.findUsersWithRole({
       name: role.name!,
+      briefRepresentation: true,
       first,
       max,
     });

--- a/js/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/js/libs/keycloak-admin-client/src/resources/clients.ts
@@ -139,7 +139,13 @@ export class Clients extends Resource<{ realm?: string }> {
   });
 
   public findUsersWithRole = this.makeRequest<
-    { id: string; roleName: string; first?: number; max?: number },
+    {
+      id: string;
+      roleName: string;
+      briefRepresentation?: boolean;
+      first?: number;
+      max?: number;
+    },
     UserRepresentation[]
   >({
     method: "GET",

--- a/js/libs/keycloak-admin-client/src/resources/roles.ts
+++ b/js/libs/keycloak-admin-client/src/resources/roles.ts
@@ -58,7 +58,12 @@ export class Roles extends Resource<{ realm?: string }> {
   });
 
   public findUsersWithRole = this.makeRequest<
-    { name: string; first?: number; max?: number },
+    {
+      name: string;
+      briefRepresentation?: boolean;
+      first?: number;
+      max?: number;
+    },
     UserRepresentation[]
   >({
     method: "GET",

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -733,7 +733,10 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
         TypedQuery<UserEntity> query = em.createNamedQuery("usersInRole", UserEntity.class);
         query.setParameter("roleId", role.getId());
 
-        return closing(paginateQuery(query, firstResult, maxResults).getResultStream().map(user -> new UserAdapter(session, realm, em, user)));
+        final UserProvider users = session.users();
+        return closing(paginateQuery(query, firstResult, maxResults).getResultStream())
+                .map(userEntity -> users.getUserById(realm, userEntity.getId()))
+                .filter(Objects::nonNull);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
@@ -239,8 +239,10 @@ public class ClientRolesTest extends AbstractClientTest {
         // pagination
         List<UserRepresentation> usersInRole1 = roleResource.getUserMembers(0, 5);
         assertEquals(createUsernames(0, 5), extractUsernames(usersInRole1));
-        List<UserRepresentation> usersInRole2 = roleResource.getUserMembers(5, 10);
+        Assert.assertNotNull("Not in full representation", usersInRole1.get(0).getNotBefore());
+        List<UserRepresentation> usersInRole2 = roleResource.getUserMembers(true, 5, 10);
         assertEquals(createUsernames(5, 10), extractUsernames(usersInRole2));
+        Assert.assertNull("Not in brief representation", usersInRole2.get(0).getNotBefore());
     }
 
     private static List<String> createUsernames(int startIndex, int endIndex) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmRolesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmRolesTest.java
@@ -352,12 +352,14 @@ public class RealmRolesTest extends AbstractAdminTest {
 
         List<UserRepresentation> roleUserMembers = roleResource.getUserMembers(0, 1);
         assertEquals(Collections.singletonList("test-role-member"), extractUsernames(roleUserMembers));
+        Assert.assertNotNull("Not in full representation", roleUserMembers.get(0).getNotBefore());
 
-        roleUserMembers = roleResource.getUserMembers(1, 1);
+        roleUserMembers = roleResource.getUserMembers(true, 1, 1);
         assertThat(roleUserMembers, hasSize(1));
         assertEquals(Collections.singletonList("test-role-member2"), extractUsernames(roleUserMembers));
+        Assert.assertNull("Not in brief representation", roleUserMembers.get(0).getNotBefore());
 
-        roleUserMembers = roleResource.getUserMembers(2, 1);
+        roleUserMembers = roleResource.getUserMembers(true, 2, 1);
         assertThat(roleUserMembers, is(empty()));
     }
 


### PR DESCRIPTION
Closes #29480

Adding the `briefRepresentation` to the `getUsersInRole` endpoint for clients and realm roles. The idea is to use this query parameter to `true` and avoid extra queries needed to retrieve the full user representation. The PR is following the same idea used in #5517 for [KEYCLOAK-8150](https://issues.redhat.com/browse/KEYCLOAK-8150) to manage the user listing.

Using `briefRepresentation` the queries I see listing users in a role are just two:

```
2024-06-20 11:27:00,078 DEBUG [org.hibernate.SQL] (executor-thread-13) select ue1_0.ID,ue1_0.CREATED_TIMESTAMP,ue1_0.EMAIL,ue1_0.EMAIL_CONSTRAINT,ue1_0.EMAIL_VERIFIED,ue1_0.ENABLED,ue1_0.FEDERATION_LINK,ue1_0.FIRST_NAME,ue1_0.LAST_NAME,ue1_0.NOT_BEFORE,ue1_0.REALM_ID,ue1_0.SERVICE_ACCOUNT_CLIENT_LINK,ue1_0.USERNAME from USER_ROLE_MAPPING urme1_0,USER_ENTITY ue1_0 where urme1_0.ROLE_ID=? and ue1_0.ID=urme1_0.USER_ID order by ue1_0.USERNAME offset ? rows fetch first ? rows only
2024-06-20 11:27:00,079 DEBUG [org.hibernate.SQL] (executor-thread-13) select furme1_0.USER_ID from FED_USER_ROLE_MAPPING furme1_0 where furme1_0.ROLE_ID=? and furme1_0.REALM_ID=? offset ? rows fetch first ? rows only
```