### PR TITLE
Fix usage of management port in the documentation

### DIFF
--- a/docs/guides/server/containers.adoc
+++ b/docs/guides/server/containers.adoc
@@ -133,7 +133,7 @@ To start the image, run:
 
 [source, bash]
 ----
-podman|docker run --name mykeycloak -p 8443:8443 \
+podman|docker run --name mykeycloak -p 8443:8443 -p 9000:9000 \
         -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=change_me \
         mykeycloak \
         start --optimized
@@ -141,9 +141,9 @@ podman|docker run --name mykeycloak -p 8443:8443 \
 
 {project_name} starts in production mode, using only secured HTTPS communication, and is available on `https://localhost:8443`.
 
-Health check endpoints are available at `https://localhost:8443/health`, `https://localhost:8443/health/ready` and `https://localhost:8443/health/live`.
+Health check endpoints are available at `https://localhost:9000/health`, `https://localhost:9000/health/ready` and `https://localhost:9000/health/live`.
 
-Opening up `https://localhost:8443/metrics` leads to a page containing operational metrics that could be used by your monitoring solution.
+Opening up `https://localhost:9000/metrics` leads to a page containing operational metrics that could be used by your monitoring solution.
 
 == Exposing the container to a different port
 


### PR DESCRIPTION
Health and metrics endpoints are documented as being served on port 8443 instead of 9000 in [the guide about Running Keycloak in a container](https://www.keycloak.org/server/containers#_starting_the_optimized_keycloak_container_image).

Closes #30652
