### PR TITLE
Use regular CREATE TABLE instead of CREATE TEMPORARY

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate25_0_0_MySQL_ConsentConstraints.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate25_0_0_MySQL_ConsentConstraints.java
@@ -35,7 +35,7 @@ public class JpaUpdate25_0_0_MySQL_ConsentConstraints extends CustomKeycloakTask
                         " AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE)"
         ));
         statements.add(new RawSqlStatement(
-                "  CREATE TEMPORARY TABLE TEMP_USER_CONSENT_IDS" +
+                "  CREATE TABLE TEMP_USER_CONSENT_IDS" +
                         " AS SELECT uc.ID FROM "+userConsentTable+" uc INNER JOIN (" +
                         " SELECT CLIENT_ID, USER_ID, MAX(LAST_UPDATED_DATE) AS MAX_UPDATED_DATE" +
                         " FROM "+userConsentTable+" GROUP BY CLIENT_ID, USER_ID HAVING COUNT(*) > 1 )" +
@@ -44,7 +44,7 @@ public class JpaUpdate25_0_0_MySQL_ConsentConstraints extends CustomKeycloakTask
         ));
         statements.add(new DeleteStatement(null, null, database.correctObjectName("USER_CONSENT", Table.class))
                 .setWhere("ID IN (SELECT ID FROM TEMP_USER_CONSENT_IDS)"));
-        statements.add(new RawSqlStatement("DROP TEMPORARY TABLE IF EXISTS TEMP_USER_CONSENT_IDS"));
+        statements.add(new RawSqlStatement("DROP TABLE IF EXISTS TEMP_USER_CONSENT_IDS"));
 
         statements.add(new RawSqlStatement(
                 " DELETE FROM "+ userConsentClientScopeTable + " WHERE USER_CONSENT_ID IN (" +
@@ -55,7 +55,7 @@ public class JpaUpdate25_0_0_MySQL_ConsentConstraints extends CustomKeycloakTask
                         " AND uc.EXTERNAL_CLIENT_ID = max_dates.EXTERNAL_CLIENT_ID AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE )"
         ));
         statements.add(new RawSqlStatement(
-                "CREATE TEMPORARY TABLE TEMP_USER_CONSENT_IDS2" +
+                "CREATE TABLE TEMP_USER_CONSENT_IDS2" +
                         " AS SELECT uc.ID FROM "+userConsentTable+" uc INNER JOIN (" +
                         " SELECT CLIENT_STORAGE_PROVIDER, EXTERNAL_CLIENT_ID, USER_ID, MAX(LAST_UPDATED_DATE) AS MAX_UPDATED_DATE" +
                         " FROM "+userConsentTable+" GROUP BY CLIENT_STORAGE_PROVIDER, EXTERNAL_CLIENT_ID, USER_ID HAVING COUNT(*) > 1 )" +
@@ -64,7 +64,7 @@ public class JpaUpdate25_0_0_MySQL_ConsentConstraints extends CustomKeycloakTask
         ));
         statements.add(new DeleteStatement(null, null, database.correctObjectName("USER_CONSENT", Table.class))
                 .setWhere("ID IN (SELECT ID FROM TEMP_USER_CONSENT_IDS2)"));
-        statements.add(new RawSqlStatement("DROP TEMPORARY TABLE IF EXISTS TEMP_USER_CONSENT_IDS2"));
+        statements.add(new RawSqlStatement("DROP TABLE IF EXISTS TEMP_USER_CONSENT_IDS2"));
     }
 
     @Override


### PR DESCRIPTION
Some hosted/managed environments like google CloudSQL, might not support this type of statement (i.e. when using replication and GTID) as seen in https://github.com/keycloak/keycloak/issues/30631

Since we are dropping the table anyway it seems a regular CREATE statement should work fine here.

Closes #30631

Signed-off-by: mike-pt <mike-pt@users.noreply.github.com>
