### PR TITLE
operator bootstrap admin handling

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -308,4 +308,10 @@ stringData:
 When running on a Kubernetes or OpenShift environment well-known locations of trusted certificates are included automatically.
 This includes `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` and the `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` when present.
 
+=== Admin Bootstrapping
+
+When you create a new instance the Keycloak CR spec.bootstrapAdmin stanza may be used to configure the bootstrap user and/or service account. If you do not specify anything for the spec.bootstrapAdmin, the operator will create a Secret named "metadata.name"-initial-admin with a username temp-admin and a generated password. If you specify a Secret name for bootstrap admin user, then the Secret will need to contain username and password key value pairs. If you specify a Secret name for bootstrap admin service account, then the Secret will need to contain client-id and client-secret key value pairs.
+
+If a master realm has already been created for you cluster, then the spec.boostrapAdmin is effectively ignored. If you need to create a recovery admin account, then you'll need to run the CLI command against a Pod directly.
+
 </@tmpl.guide>

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -310,7 +310,7 @@ This includes `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` and the `/v
 
 === Admin Bootstrapping
 
-When you create a new instance the Keycloak CR spec.bootstrapAdmin stanza may be used to configure the bootstrap user and/or service account. If you do not specify anything for the spec.bootstrapAdmin, the operator will create a Secret named "metadata.name"-initial-admin with a username temp-admin and a generated password. If you specify a Secret name for bootstrap admin user, then the Secret will need to contain username and password key value pairs. If you specify a Secret name for bootstrap admin service account, then the Secret will need to contain client-id and client-secret key value pairs.
+When you create a new instance the Keycloak CR spec.bootstrapAdmin stanza may be used to configure the bootstrap user and/or service account. If you do not specify anything for the spec.bootstrapAdmin, the operator will create a Secret named "metadata.name"-initial-admin with a username temp-admin and a generated password. If you specify a Secret name for bootstrap admin user, then the Secret will need to contain `username` and `password` key value pairs. If you specify a Secret name for bootstrap admin service account, then the Secret will need to contain `client-id` and `client-secret` key value pairs.
 
 If a master realm has already been created for you cluster, then the spec.boostrapAdmin is effectively ignored. If you need to create a recovery admin account, then you'll need to run the CLI command against a Pod directly.
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
@@ -2,23 +2,36 @@ package org.keycloak.operator.controllers;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ResourceDiscriminator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.processing.dependent.Creator;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.Utils;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @KubernetesDependent(labelSelector = Constants.DEFAULT_LABELS_AS_STRING, resourceDiscriminator = KeycloakAdminSecretDependentResource.NameResourceDiscriminator.class)
 public class KeycloakAdminSecretDependentResource extends KubernetesDependentResource<Secret, Keycloak> implements Creator<Secret, Keycloak>, GarbageCollected<Keycloak> {
+
+    public static class EnabledCondition implements Condition<Ingress, Keycloak> {
+        @Override
+        public boolean isMet(DependentResource<Ingress, Keycloak> dependentResource, Keycloak primary,
+                Context<Keycloak> context) {
+            return Optional.ofNullable(primary.getSpec().getBootstrapAdminSpec()).map(BootstrapAdminSpec::getUser)
+                    .map(BootstrapAdminSpec.User::getSecret).filter(s -> s.equals(KeycloakAdminSecretDependentResource.getName(primary))).isPresent();
+        }
+    }
 
     public static class NameResourceDiscriminator implements ResourceDiscriminator<Secret, Keycloak> {
         @Override
@@ -39,8 +52,9 @@ public class KeycloakAdminSecretDependentResource extends KubernetesDependentRes
                 .addToLabels(Utils.allInstanceLabels(primary))
                 .withNamespace(primary.getMetadata().getNamespace())
                 .endMetadata()
+                .withType("Opaque")
                 .withType("kubernetes.io/basic-auth")
-                .addToData("username", Utils.asBase64("admin"))
+                .addToData("username", Utils.asBase64("temp-admin"))
                 .addToData("password", Utils.asBase64(UUID.randomUUID().toString().replace("-", "")))
                 .build();
     }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
@@ -29,7 +29,7 @@ public class KeycloakAdminSecretDependentResource extends KubernetesDependentRes
         public boolean isMet(DependentResource<Ingress, Keycloak> dependentResource, Keycloak primary,
                 Context<Keycloak> context) {
             return Optional.ofNullable(primary.getSpec().getBootstrapAdminSpec()).map(BootstrapAdminSpec::getUser)
-                    .map(BootstrapAdminSpec.User::getSecret).filter(s -> s.equals(KeycloakAdminSecretDependentResource.getName(primary))).isPresent();
+                    .map(BootstrapAdminSpec.User::getSecret).filter(s -> !s.equals(KeycloakAdminSecretDependentResource.getName(primary))).isEmpty();
         }
     }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -105,22 +105,12 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
 
         Log.debugf("--- Reconciling Keycloak: %s in namespace: %s", kcName, namespace);
 
+        // TODO - these modifications to the resource belong in a webhook because dependents run first
         boolean modifiedSpec = false;
         if (kc.getSpec().getInstances() == null) {
             // explicitly set defaults - and let another reconciliation happen
             // this avoids ensuring unintentional modifications have not been made to the cr
             kc.getSpec().setInstances(1);
-            modifiedSpec = true;
-        }
-        var bootstrapAdmin = kc.getSpec().getBootstrapAdminSpec();
-        if (bootstrapAdmin == null) {
-            bootstrapAdmin = new BootstrapAdminSpec();
-        }
-        if (bootstrapAdmin.getUser() == null) {
-            bootstrapAdmin.setUser(new BootstrapAdminSpec.User());
-        }
-        if (bootstrapAdmin.getUser() == null) {
-            bootstrapAdmin.getUser().setSecret(KeycloakAdminSecretDependentResource.getName(kc));
             modifiedSpec = true;
         }
         if (kc.getSpec().getIngressSpec() != null && kc.getSpec().getIngressSpec().isIngressEnabled()

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -89,11 +89,19 @@ public class KeycloakDistConfigurator {
     /* ---------- Configuration of first-class citizen fields ---------- */
 
     void configureBootstrapAdmin() {
-        optionMapper(keycloakCR -> keycloakCR.getSpec().getBootstrapAdminSpec())
+        optionMapper(Function.identity())
                 .mapOption("bootstrap-admin-username",
-                        spec -> Optional.ofNullable(spec.getUser()).map(BootstrapAdminSpec.User::getSecret).map(s -> new SecretKeySelector("username", s, null)).orElse(null))
+                        keycloakCR -> Optional.ofNullable(keycloakCR.getSpec().getBootstrapAdminSpec())
+                                .map(BootstrapAdminSpec::getUser).map(BootstrapAdminSpec.User::getSecret)
+                                .or(() -> Optional.of(KeycloakAdminSecretDependentResource.getName(keycloakCR)))
+                                .map(s -> new SecretKeySelector("username", s, null)).orElse(null))
                 .mapOption("bootstrap-admin-password",
-                        spec -> Optional.ofNullable(spec.getUser()).map(BootstrapAdminSpec.User::getSecret).map(s -> new SecretKeySelector("password", s, null)).orElse(null))
+                        keycloakCR -> Optional.ofNullable(keycloakCR.getSpec().getBootstrapAdminSpec())
+                                .map(BootstrapAdminSpec::getUser).map(BootstrapAdminSpec.User::getSecret)
+                                .or(() -> Optional.of(KeycloakAdminSecretDependentResource.getName(keycloakCR)))
+                                .map(s -> new SecretKeySelector("password", s, null)).orElse(null));
+
+        optionMapper(keycloakCR -> keycloakCR.getSpec().getBootstrapAdminSpec())
                 .mapOption("bootstrap-admin-client-id",
                         spec -> Optional.ofNullable(spec.getService()).map(BootstrapAdminSpec.Service::getSecret).map(s -> new SecretKeySelector("client-id", s, null)).orElse(null))
                 .mapOption("bootstrap-admin-client-secret",

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -28,6 +28,7 @@ import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusAggregator;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.DatabaseSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
@@ -73,6 +74,7 @@ public class KeycloakDistConfigurator {
         configureCache();
         configureProxy();
         configureManagement();
+        configureBootstrapAdmin();
     }
 
     /**
@@ -85,6 +87,18 @@ public class KeycloakDistConfigurator {
     }
 
     /* ---------- Configuration of first-class citizen fields ---------- */
+
+    void configureBootstrapAdmin() {
+        optionMapper(keycloakCR -> keycloakCR.getSpec().getBootstrapAdminSpec())
+                .mapOption("bootstrap-admin-username",
+                        spec -> Optional.ofNullable(spec.getUser()).map(BootstrapAdminSpec.User::getSecret).map(s -> new SecretKeySelector("username", s, null)).orElse(null))
+                .mapOption("bootstrap-admin-password",
+                        spec -> Optional.ofNullable(spec.getUser()).map(BootstrapAdminSpec.User::getSecret).map(s -> new SecretKeySelector("password", s, null)).orElse(null))
+                .mapOption("bootstrap-admin-client-id",
+                        spec -> Optional.ofNullable(spec.getService()).map(BootstrapAdminSpec.Service::getSecret).map(s -> new SecretKeySelector("client-id", s, null)).orElse(null))
+                .mapOption("bootstrap-admin-client-secret",
+                        spec -> Optional.ofNullable(spec.getService()).map(BootstrapAdminSpec.Service::getSecret).map(s -> new SecretKeySelector("client-secret", s, null)).orElse(null));
+    }
 
     void configureHostname() {
         optionMapper(keycloakCR -> keycloakCR.getSpec().getHostnameSpec())

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
 
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.CacheSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.DatabaseSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
@@ -114,6 +115,10 @@ public class KeycloakSpec {
     @JsonProperty("scheduling")
     @JsonPropertyDescription("In this section you can configure Keycloak's scheduling")
     private SchedulingSpec schedulingSpec;
+
+    @JsonProperty("bootstrapAdmin")
+    @JsonPropertyDescription("In this section you can configure Keycloak's bootstrap admin - will be used only for inital cluster creation.")
+    private BootstrapAdminSpec bootstrapAdminSpec;
 
     public HttpSpec getHttpSpec() {
         return httpSpec;
@@ -263,5 +268,13 @@ public class KeycloakSpec {
 
     public void setSchedulingSpec(SchedulingSpec schedulingSpec) {
         this.schedulingSpec = schedulingSpec;
+    }
+    
+    public BootstrapAdminSpec getBootstrapAdminSpec() {
+        return bootstrapAdminSpec;
+    }
+
+    public void setBootstrapAdminSpec(BootstrapAdminSpec bootstrapAdminSpec) {
+        this.bootstrapAdminSpec = bootstrapAdminSpec;
     }
 }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
@@ -1,0 +1,64 @@
+package org.keycloak.operator.crds.v2alpha1.deployment.spec;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public class BootstrapAdminSpec {
+
+    public static class User {
+        @JsonPropertyDescription("Name of the secret with the username and password")
+    	private String secret;
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+    }
+
+    public static class Service {
+        @JsonPropertyDescription("Name of the Secret with the client-id and client-secret")
+    	private String secret;
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+
+    }
+
+    //private Integer expiration;
+    @JsonPropertyDescription("Configures the bootstrap admin user")
+    private User user;
+    @JsonPropertyDescription("Configures the bootstrap admin service account")
+    private Service service;
+
+    /*public Integer getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Integer expiration) {
+        this.expiration = expiration;
+    }*/
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Service getService() {
+        return service;
+    }
+
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+}

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 public class BootstrapAdminSpec {
 
     public static class User {
-        @JsonPropertyDescription("Name of the secret with the username and password")
+        @JsonPropertyDescription("Name of the Secret that contains the username and password keys")
     	private String secret;
 
         public String getSecret() {
@@ -18,7 +18,7 @@ public class BootstrapAdminSpec {
     }
 
     public static class Service {
-        @JsonPropertyDescription("Name of the Secret with the client-id and client-secret")
+        @JsonPropertyDescription("Name of the Secret that contains the client-id and client-secret keys")
     	private String secret;
 
         public String getSecret() {

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
@@ -1,7 +1,12 @@
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import io.sundr.builder.annotations.Buildable;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class BootstrapAdminSpec {
 
     public static class User {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -154,6 +154,18 @@ public class KeycloakDistConfiguratorTest {
 
         testFirstClassCitizen(expectedValues);
     }
+    
+    @Test
+    public void bootstrapAdmin() {
+        final Map<String, String> expectedValues = Map.of(
+                "bootstrap-admin-username", "something",
+                "bootstrap-admin-password", "something",
+                "bootstrap-admin-client-id", "else",
+                "bootstrap-admin-client-secret", "else"
+        );
+
+        testFirstClassCitizen(expectedValues);
+    }
 
     /* UTILS */
 

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -72,6 +72,11 @@ spec:
         name: my-secret
   httpManagement:
     port: 9003
+  bootstrapAdmin:
+    user:
+      secret: something
+    service:
+      secret: else
   unsupported:
     podTemplate:
       metadata:


### PR DESCRIPTION
This is layered on the other bootstrap changes. After looking at the implementation possiblities a little more, I think it makes more sense to manage things at a secret level - giving us 2 secrets to worry about instead of 4 - and just assume the keys by convention.

To minimize the number of api server interactions per reconciliation we also won't attempt to write back values into user provided secrets - if the user specifies the secret, then we expect it to exist and the fields be present. We can of course add optional handling if that seems warrented.

@vmuzikar WDYT?