### PR TITLE
Add event for ClientScope created

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -1021,8 +1021,23 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         entity.setName(name);
         entity.setRealmId(realm.getId());
         em.persist(entity);
+
+        ClientScopeModel clientScope = new ClientScopeAdapter(realm, em, session, entity);
+        session.getKeycloakSessionFactory().publish(new ClientScopeModel.ClientScopeCreatedEvent() {
+
+            @Override
+            public KeycloakSession getKeycloakSession() {
+                return session;
+            }
+
+            @Override
+            public ClientScopeModel getClientScope() {
+                return clientScope;
+            }
+        });
+
         em.flush();
-        return new ClientScopeAdapter(realm, em, session, entity);
+        return clientScope;
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/ClientScopeModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientScopeModel.java
@@ -34,6 +34,12 @@ public interface ClientScopeModel extends ProtocolMapperContainerModel, ScopeCon
         KeycloakSession getKeycloakSession();
     }
 
+    interface ClientScopeCreatedEvent extends ProviderEvent {
+        ClientScopeModel getClientScope();
+
+        KeycloakSession getKeycloakSession();
+    }
+
     String getId();
 
     String getName();


### PR DESCRIPTION
closes #30795 

A very simple change that allows to react with event-listeners if a new clientScope is created.