### PR TITLE
Print keycloak's server response

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -19,7 +19,7 @@ export async function fetchWithError(
 
   if (!response.ok) {
     const responseData = await parseResponse(response);
-    throw new NetworkError("Network response was not OK.", {
+    throw new NetworkError(responseData, {
       response,
       responseData,
     });

--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -1,3 +1,5 @@
+const ERROR_FIELDS = ["error", "errorMessage"];
+
 export type NetworkErrorOptions = { response: Response; responseData: unknown };
 
 export class NetworkError extends Error {
@@ -19,7 +21,8 @@ export async function fetchWithError(
 
   if (!response.ok) {
     const responseData = await parseResponse(response);
-    throw new NetworkError(responseData, {
+    const description = getNetworkErrorMessage(responseData)
+    throw new NetworkError(description, {
       response,
       responseData,
     });
@@ -41,4 +44,21 @@ export async function parseResponse(response: Response): Promise<any> {
   } catch (error) {}
 
   return data;
+}
+
+
+function getNetworkErrorMessage(data: unknown): string {
+  if (typeof data !== "object" || data === null) {
+    return "Unable to determine error message.";
+  }
+
+  for (const key of ERROR_FIELDS) {
+    const value = (data as Record<string, unknown>)[key];
+
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "Network response was not OK."
 }

--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -21,7 +21,7 @@ export async function fetchWithError(
 
   if (!response.ok) {
     const responseData = await parseResponse(response);
-    const message = getErrorMessage(responseData)
+    const message = getErrorMessage(responseData);
     throw new NetworkError(message, {
       response,
       responseData,
@@ -46,7 +46,6 @@ export async function parseResponse(response: Response): Promise<any> {
   return data;
 }
 
-
 function getErrorMessage(data: unknown): string {
   if (typeof data !== "object" || data === null) {
     return "Unable to determine error message.";
@@ -60,5 +59,5 @@ function getErrorMessage(data: unknown): string {
     }
   }
 
-  return "Network response was not OK."
+  return "Network response was not OK.";
 }

--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -21,8 +21,8 @@ export async function fetchWithError(
 
   if (!response.ok) {
     const responseData = await parseResponse(response);
-    const description = getNetworkErrorMessage(responseData)
-    throw new NetworkError(description, {
+    const message = getErrorMessage(responseData)
+    throw new NetworkError(message, {
       response,
       responseData,
     });
@@ -47,7 +47,7 @@ export async function parseResponse(response: Response): Promise<any> {
 }
 
 
-function getNetworkErrorMessage(data: unknown): string {
+function getErrorMessage(data: unknown): string {
   if (typeof data !== "object" || data === null) {
     return "Unable to determine error message.";
   }


### PR DESCRIPTION
Simple change to see actual keycloak server error message and not a generic message.

Original generic message looks like this:
```
Error: Network response was not OK.
     at fetchWithError (file:///usr/src/app/node_modules/@keycloak/keycloak-admin-client/lib/utils/fetchWithError.js:14:15)
```

With this change you get the actual errors:
```
Error: {"errorMessage":"User exists with same username"}
     at fetchWithError (file:///usr/src/app/node_modules/@keycloak/keycloak-admin-client/lib/utils/fetchWithError.js:14:15)
```
```
Error: {"error":"HTTP 401 Unauthorized","error_description":"For more on this error consult the server log at the debug level."}
     at fetchWithError (file:///usr/src/app/node_modules/@keycloak/keycloak-admin-client/lib/utils/fetchWithError.js:14:15)
```

Closes #30829