### PR TITLE
add: non clear aws-wrapper info

### DIFF
--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -263,7 +263,7 @@ ADD --chmod=0666 https://github.com/awslabs/aws-advanced-jdbc-wrapper/releases/d
 +
 See the <@links.server id="containers" /> {section} for details on how to build optimized images, and the <@links.operator id="customizing-keycloak" /> {section} on how to run optimized and non-optimized images with the {project_name} Operator.
 . Configure {project_name} to run with the following parameters:
-`db-url`:: Insert `aws-wrapper` to the regular PostgreSQL JDBC URL resulting in a URL like `+jdbc:aws-wrapper:postgresql://...+`.
+`db-url`:: Use regular PostgreSQL JDBC URL in  format `jdbc:postgresql://<aurora.clusterEndpoint.hostname>:<port>/<db-name>`.
 `db-driver`:: Set to `software.amazon.jdbc.Driver` to use the AWS JDBC wrapper.
 
 == Preparing for MySQL server


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Hi there,

During working on setting Keycloak on AWS ECS with Aurora Postgresql, I noticed that existing information is a bit misleading. 
Inserting `aws-wrapper` in `db-url` was resulting with:
`ERROR: Driver does not support the provided URL`.
Seems like latest AWS Advanced wrapped does not need it. 

Tested on:
https://quay.io/repository/3sky/keycloak-aurora
tags: 24.0.5, 25.0, 25.0.1.
aws-advanced-jdbc-wrapper version was 2.3.6