### PR TITLE
Allow requests from local IPv6 addresses

### DIFF
--- a/common/src/main/java/org/keycloak/common/enums/SslRequired.java
+++ b/common/src/main/java/org/keycloak/common/enums/SslRequired.java
@@ -51,10 +51,23 @@ public enum SslRequired {
     private boolean isLocal(String remoteAddress) {
         try {
             InetAddress inetAddress = InetAddress.getByName(remoteAddress);
-            return inetAddress.isAnyLocalAddress() || inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress();
+            return inetAddress.isAnyLocalAddress() || inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress() || inetAddress.isLinkLocalAddress() || isUniqueLocal(inetAddress);
         } catch (UnknownHostException e) {
             return false;
         }
+    }
+
+    /**
+     * Check if the address is within IPv6 unique local address (ULA) range RFC4193.
+     */
+    private boolean isUniqueLocal(InetAddress address) {
+        if (address instanceof java.net.Inet6Address) {
+            byte[] addr = address.getAddress();
+            // Check if address is in unique local range fc00::/7
+            return ((byte) (addr[0] & 0b11111110)) == (byte) 0xFC;
+        }
+
+        return false;
     }
 
 }

--- a/docs/documentation/server_admin/topics/realms/ssl.adoc
+++ b/docs/documentation/server_admin/topics/realms/ssl.adoc
@@ -17,7 +17,7 @@ image:images/general-tab.png[General Tab]
 . Set *Require SSL* to one of the following SSL modes:
 
 * *External requests*
-  Users can interact with {project_name} without SSL so long as they stick to private IP addresses such as `localhost`, `127.0.0.1`, `10.x.x.x`, `192.168.x.x`, and `172.16.x.x`.
+  Users can interact with {project_name} without SSL so long as they stick to private IPv4 addresses such as `localhost`, `127.0.0.1`, `10.x.x.x`, `192.168.x.x`, `172.16.x.x` or IPv6 link-local and unique-local addresses.
   If you try to access {project_name} without SSL from a non-private IP address, you will get an error.
 
 * *None*


### PR DESCRIPTION
This change allows local IPv6 clients to make clear text HTTP requests when administrator selects "External requests" for "Require SSL" setting ([link](https://www.keycloak.org/docs/latest/server_admin/#_ssl_modes)). Previously requests from private IPv4 addresses were allowed but requests from private IPv6 addresses were rejected.

Fixes #30678

### Details 

In case of IPv6 the private address ranges are following:

|address type|binary prefix|IPv6 notation|
|-|-|-|
| Link-local unicast ([link](https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.6)) | 1111 1110 10 | FE80::/10 |
| Unique local (ULA, [link](https://datatracker.ietf.org/doc/html/rfc4193#section-1))  | 1111 110 | FC00::/7 |
| Site-local unicast (deprecated, [link](https://datatracker.ietf.org/doc/html/rfc4291#page-11)) | 1111 1110 11 | FEF0::/10 |

Currently, there is no method in JDK that would cover ULA address range, therefore this PR proposes to add a method to check for that.

While the JDK method `Inet4Address.isSiteLocalAddress()` covers private address ranges for IPv4 ([link](https://github.com/openjdk/jdk17u/blob/c9d83d392f3809bf536afdcb52142ee6916acff0/src/java.base/share/classes/java/net/Inet4Address.java#L210-L221)), the IPv6 version `Inet6Address.isSiteLocalAddress()` only covers site-local unicast address range ([link](https://github.com/openjdk/jdk17u/blob/c9d83d392f3809bf536afdcb52142ee6916acff0/src/java.base/share/classes/java/net/Inet6Address.java#L332-L335)). According to [RFC4291 section2.5.7](https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.7) this address range is now deprecated and should be considered as global address by new implementation

> The special behavior of this prefix defined in [RFC3513] must no longer be supported in new implementations (i.e., new implementations must treat this prefix as Global Unicast).
>
> Existing implementations and deployments may continue to use this prefix.

This PR does not suggest removing call  `InetAddress.isSiteLocalAddress()` since it checks for IPv4 private addresses.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
