### PR TITLE
Use provided scope for maven-plugin dependencies

### DIFF
--- a/docs/guides/pom.xml
+++ b/docs/guides/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>keycloak-guides-maven-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/docs/maven-plugin/pom.xml
+++ b/docs/maven-plugin/pom.xml
@@ -36,6 +36,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -47,6 +48,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -56,6 +58,25 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/DirectoryCopyVisitor.java
+++ b/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/DirectoryCopyVisitor.java
@@ -1,0 +1,39 @@
+package org.keycloak.guides.maven;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class DirectoryCopyVisitor extends SimpleFileVisitor<Path> {
+
+	private Path targetDir;
+	private Path sourceDir;
+
+	public DirectoryCopyVisitor(Path targetDir) {
+		this.targetDir = targetDir;
+	}
+
+	@Override
+	public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+		if (sourceDir == null) {
+			sourceDir = dir;
+		} else {
+			Path relativePath = sourceDir.relativize(dir);
+			Files.createDirectories(targetDir.resolve(relativePath));
+		}
+		
+		return	FileVisitResult.CONTINUE;
+	}
+
+	@Override
+	public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+		Path relativePath = sourceDir.relativize(file);
+		Files.copy(file, targetDir.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
+		return FileVisitResult.CONTINUE;
+	}
+
+}

--- a/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/GuideMojo.java
+++ b/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/GuideMojo.java
@@ -7,9 +7,9 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
+import java.nio.file.Files;
 
 @Mojo(name = "keycloak-guide", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class GuideMojo extends AbstractMojo {
@@ -29,7 +29,7 @@ public class GuideMojo extends AbstractMojo {
             Log log = getLog();
             File topDir = new File(sourceDir);
 
-            for (File srcDir: topDir.listFiles(d -> d.isDirectory() && !d.getName().equals("templates"))) {
+            for (File srcDir : topDir.listFiles(d -> d.isDirectory() && !d.getName().equals("templates"))) {
                 if (srcDir.getName().equals("target") || srcDir.getName().equals("src")) {
                     // those are standard maven folders, ignore them
                     continue;
@@ -41,7 +41,8 @@ public class GuideMojo extends AbstractMojo {
                 }
 
                 if (srcDir.getName().equals("images")) {
-                    FileUtils.copyDirectoryStructure(srcDir, targetDir);
+                    log.info("Copy files from " + srcDir + " to " + targetDir);
+                    Files.walkFileTree(srcDir.toPath(), new DirectoryCopyVisitor(targetDir.toPath()));
                 } else {
                     log.info("Guide dir: " + srcDir.getAbsolutePath());
                     log.info("Target dir: " + targetDir.getAbsolutePath());

--- a/docs/maven-plugin/src/test/java/org/keycloak/guides/maven/DirectoryCopyVisitorTest.java
+++ b/docs/maven-plugin/src/test/java/org/keycloak/guides/maven/DirectoryCopyVisitorTest.java
@@ -1,0 +1,55 @@
+package org.keycloak.guides.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DirectoryCopyVisitorTest {
+
+	@TempDir
+	Path temp;
+
+	private Path srcDir;
+	private Path targetDir;
+
+	@BeforeEach
+	void setUpDirectories() throws IOException {
+		srcDir = temp.resolve("source");
+		targetDir = temp.resolve("target");
+		Files.createDirectories(srcDir);
+		Files.createDirectories(targetDir);
+	}
+
+	@Test
+	void copyDirectoriesMultipleLevels() throws IOException {
+		Path level1 = srcDir.resolve("level1");
+		Path level2a = level1.resolve("level2a");
+		Path level2b = level1.resolve("level2b");
+		Path level3 = level2a.resolve("level3");
+		Files.createDirectories(level3);
+		Files.createDirectories(level2b);
+		Files.createFile(srcDir.resolve("rootfile"));
+		Files.createFile(level1.resolve("l1file"));
+		Files.createFile(level2b.resolve("l2filea"));
+		Files.createFile(level2b.resolve("l2fileb"));
+
+		Files.walkFileTree(srcDir, new DirectoryCopyVisitor(targetDir));
+
+		assertEquals(List.of("level1", "rootfile"), listDirContent(targetDir));
+		assertEquals(List.of("l1file", "level2a", "level2b"), listDirContent(targetDir.resolve("level1")));
+		assertEquals(List.of("level3"), listDirContent(targetDir.resolve("level1").resolve("level2a")));
+		assertEquals(List.of(), listDirContent(targetDir.resolve("level1").resolve("level2a").resolve("level3")));
+		assertEquals(List.of("l2filea", "l2fileb"), listDirContent(targetDir.resolve("level1").resolve("level2b")));
+	}
+
+	private List<String> listDirContent(Path path) throws IOException {
+		return Files.list(path).map(Path::getFileName).map(Path::toString).sorted().toList();
+	}
+}


### PR DESCRIPTION
As the maven-plugin-plugin suggests, dependencies to the maven runtime should be in provided scope.

Closes #30542