### PR TITLE
Display disabled information from user in group assignment

### DIFF
--- a/js/apps/admin-ui/src/groups/Members.tsx
+++ b/js/apps/admin-ui/src/groups/Members.tsx
@@ -9,8 +9,9 @@ import {
   DropdownList,
   MenuToggle,
   ToolbarItem,
+  Label,
 } from "@patternfly/react-core";
-import { EllipsisVIcon } from "@patternfly/react-icons";
+import { EllipsisVIcon, InfoCircleIcon } from "@patternfly/react-icons";
 import { uniqBy } from "lodash-es";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -52,9 +53,15 @@ const MemberOfRenderer = (member: MembersOf) => {
 
 const UserDetailLink = (user: MembersOf) => {
   const { realm } = useRealm();
+  const { t } = useTranslation();
   return (
     <Link key={user.id} to={toUser({ realm, id: user.id!, tab: "settings" })}>
-      {user.username}
+      {user.username}{" "}
+      {!user.enabled && (
+        <Label color="red" icon={<InfoCircleIcon />}>
+          {t("disabled")}
+        </Label>
+      )}
     </Link>
   );
 };

--- a/js/apps/admin-ui/src/groups/MembersModal.tsx
+++ b/js/apps/admin-ui/src/groups/MembersModal.tsx
@@ -1,5 +1,6 @@
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-import { Button, Modal, ModalVariant } from "@patternfly/react-core";
+import { Button, Modal, ModalVariant, Label } from "@patternfly/react-core";
+import { InfoCircleIcon } from "@patternfly/react-icons";
 import { differenceBy } from "lodash-es";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -13,6 +14,20 @@ type MemberModalProps = {
   membersQuery: (first?: number, max?: number) => Promise<UserRepresentation[]>;
   onAdd: (users: UserRepresentation[]) => Promise<void>;
   onClose: () => void;
+};
+
+const UserDetail = (user: UserRepresentation) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      {user.username}{" "}
+      {!user.enabled && (
+        <Label color="red" icon={<InfoCircleIcon />}>
+          {t("disabled")}
+        </Label>
+      )}
+    </>
+  );
 };
 
 export const MemberModal = ({
@@ -88,10 +103,12 @@ export const MemberModal = ({
           {
             name: "username",
             displayKey: "username",
+            cellRenderer: UserDetail,
           },
           {
             name: "email",
             displayKey: "email",
+            cellFormatters: [emptyFormatter()],
           },
           {
             name: "lastName",


### PR DESCRIPTION
Closes #30682

I have made the following improvements to the group management:
- Whether an employee is deactivated is now displayed in the GroupMembers and Members assignment table
- I have added the emptyFormatter for the email in the user assignment


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
