### PR TITLE
Use the Keycloak server URL for common resources

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -96,15 +96,9 @@ public class AccountConsole implements AccountResourceProvider {
     @NoCache
     @Path("{any:.*}")
     public Response getMainPage() throws IOException, FreeMarkerException {
-        // Get the URI info of the server and admin console.
         final var serverUriInfo = session.getContext().getUri(UrlType.FRONTEND);
-        final var adminUriInfo = session.getContext().getUri(UrlType.ADMIN);
-
-        // Get the base URLs of the server and admin console.
         final var serverBaseUri = serverUriInfo.getBaseUri();
-        final var adminBaseUri = adminUriInfo.getBaseUri();
-
-        // Strip any trailing slashes from the URLs.
+        // Strip any trailing slashes from the URL.
         final var serverBaseUrl = serverBaseUri.toString().replaceFirst("/+$", "");
 
         final var map = new HashMap<String, Object>();
@@ -124,7 +118,7 @@ public class AccountConsole implements AccountResourceProvider {
         map.put("realm", realm);
         map.put("clientId", Constants.ACCOUNT_CONSOLE_CLIENT_ID);
         map.put("resourceUrl", Urls.themeRoot(serverBaseUri).getPath() + "/" + Constants.ACCOUNT_MANAGEMENT_CLIENT_ID + "/" + theme.getName());
-        map.put("resourceCommonUrl", Urls.themeRoot(adminBaseUri).getPath() + "/common/keycloak");
+        map.put("resourceCommonUrl", Urls.themeRoot(serverBaseUri).getPath() + "/common/keycloak");
         map.put("resourceVersion", Version.RESOURCES_VERSION);
 
         String[] referrer = getReferrer();


### PR DESCRIPTION
Changes the bootstrapping for the account console, so that the Keycloak server URL is used (`--hostname`) to serve common resources, rather than the admin console URL (`--hostname-admin`).

Closes #30541

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
