### PR TITLE
Make persistent sessions co-exist with remote cache feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,10 @@ jobs:
     if: needs.conditional.outputs.ci-store == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    strategy:
+      matrix:
+        variant: [ "pus-ec", "pus-rc" ]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 
@@ -328,11 +332,24 @@ jobs:
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
 
-      - name: Run base tests without cache
+      - name: Run base tests
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh persistent-sessions`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dauth.server.feature="persistent-user-sessions" -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          case "${{ matrix.variant }}" in
+            pus-ec)
+              VARIANT="-Dauth.server.feature=persistent-user-sessions"
+              ;;
+            pus-rc)
+              VARIANT="-Pinfinispan-server -Dauth.server.feature=persistent-user-sessions,multi-site,remote-cache"
+              ;;
+            *)
+              echo "Unknown Matrix element"
+              exit 1
+              ;;
+          esac
+          echo "Variant: $VARIANT"
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus $VARIANT -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()
@@ -349,7 +366,7 @@ jobs:
         if: always()
         uses: ./.github/actions/archive-surefire-reports
         with:
-          job-id: store-integration-tests-${{ matrix.db }}
+          job-id: store-integration-tests-${{ matrix.variant }}
 
       - name: EC2 Maven Logs
         if: failure()

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
@@ -425,6 +425,10 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
 
         // Try lookup userSession from remoteCache
         Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
+        if (cache == null) {
+            return null;
+        }
+
         RemoteCache remoteCache = InfinispanUtil.getRemoteCache(cache);
 
         if (remoteCache != null) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -38,6 +38,8 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
+
 public class ClientSessionPersistentChangelogBasedTransaction extends PersistentSessionsChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> {
 
     private static final Logger LOG = Logger.getLogger(ClientSessionPersistentChangelogBasedTransaction.class);
@@ -55,7 +57,7 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
                                                             ArrayBlockingQueue<PersistentUpdate> batchingQueue,
                                                             SerializeExecutionsByKey<UUID> serializerOnline,
                                                             SerializeExecutionsByKey<UUID> serializerOffline) {
-        super(session, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, serializerOnline, serializerOffline);
+        super(session, CLIENT_SESSION_CACHE_NAME, cache, offlineCache, remoteCacheInvoker, lifespanMsLoader, maxIdleTimeMsLoader, offlineLifespanMsLoader, offlineMaxIdleTimeMsLoader, batchingQueue, serializerOnline, serializerOffline);
         this.userSessionTx = userSessionTx;
     }
 
@@ -63,7 +65,9 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
         SessionUpdatesList<AuthenticatedClientSessionEntity> myUpdates = getUpdates(offline).get(key);
         if (myUpdates == null) {
             SessionEntityWrapper<AuthenticatedClientSessionEntity> wrappedEntity = null;
-            wrappedEntity = getCache(offline).get(key);
+            if (getCache(offline) != null) {
+                wrappedEntity = getCache(offline).get(key);
+            }
 
             if (wrappedEntity == null) {
                 LOG.debugf("client-session not found in cache for sessionId=%s, offline=%s, loading from persister", key, offline);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -65,8 +65,9 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
         SessionUpdatesList<AuthenticatedClientSessionEntity> myUpdates = getUpdates(offline).get(key);
         if (myUpdates == null) {
             SessionEntityWrapper<AuthenticatedClientSessionEntity> wrappedEntity = null;
-            if (getCache(offline) != null) {
-                wrappedEntity = getCache(offline).get(key);
+            Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> cache = getCache(offline);
+            if (cache != null) {
+                wrappedEntity = cache.get(key);
             }
 
             if (wrappedEntity == null) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/PersistentSessionsChangelogBasedTransaction.java
@@ -19,7 +19,6 @@ package org.keycloak.models.sessions.infinispan.changes;
 
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
-import org.keycloak.common.Profile;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -27,17 +26,14 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.sessions.infinispan.SessionFunction;
 import org.keycloak.models.sessions.infinispan.entities.SessionEntity;
 import org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheInvoker;
+import org.keycloak.models.utils.KeycloakModelUtils;
 
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.stream.Stream;
-
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.USER_SESSION_CACHE_NAME;
 
 abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends SessionEntity> extends AbstractKeycloakTransaction implements SessionsChangelogBasedTransaction<K, V> {
 
@@ -54,6 +50,7 @@ abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends S
     private final SessionFunction<V> offlineMaxIdleTimeMsLoader;
 
     public PersistentSessionsChangelogBasedTransaction(KeycloakSession session,
+                                                       String cacheName,
                                                        Cache<K, SessionEntityWrapper<V>> cache,
                                                        Cache<K, SessionEntityWrapper<V>> offlineCache,
                                                        RemoteCacheInvoker remoteCacheInvoker,
@@ -66,46 +63,49 @@ abstract public class PersistentSessionsChangelogBasedTransaction<K, V extends S
                                                        SerializeExecutionsByKey<K> serializerOffline) {
         kcSession = session;
 
-        if (!Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
-            throw new IllegalStateException("Persistent user sessions are not enabled");
-        }
+        changesPerformers = new LinkedList<>();
 
-        if (! (
-                cache.getName().equals(USER_SESSION_CACHE_NAME)
-                        || cache.getName().equals(CLIENT_SESSION_CACHE_NAME)
-                        || cache.getName().equals(OFFLINE_USER_SESSION_CACHE_NAME)
-                        || cache.getName().equals(OFFLINE_CLIENT_SESSION_CACHE_NAME)
-        )) {
-            throw new IllegalStateException("Cache name is not valid for persistent user sessions: " + cache.getName());
-        }
-
-        changesPerformers = List.of(
-                new JpaChangesPerformer<>(cache.getName(), batchingQueue),
-                new EmbeddedCachesChangesPerformer<>(cache, serializerOnline) {
-                    @Override
-                    public boolean shouldConsumeChange(V entity) {
-                        return !entity.isOffline();
-                    }
-                },
-                new EmbeddedCachesChangesPerformer<>(offlineCache, serializerOffline){
-                    @Override
-                    public boolean shouldConsumeChange(V entity) {
-                        return entity.isOffline();
-                    }
-                },
-                new RemoteCachesChangesPerformer<>(session, cache, remoteCacheInvoker) {
-                    @Override
-                    public boolean shouldConsumeChange(V entity) {
-                        return !entity.isOffline();
-                    }
-                },
-                new RemoteCachesChangesPerformer<>(session, offlineCache, remoteCacheInvoker) {
-                    @Override
-                    public boolean shouldConsumeChange(V entity) {
-                        return entity.isOffline();
-                    }
+        if (batchingQueue != null) {
+            changesPerformers.add(new JpaChangesPerformer<>(cacheName, batchingQueue));
+        } else {
+            changesPerformers.add(new JpaChangesPerformer<>(cacheName, null) {
+                @Override
+                public void applyChanges() {
+                    KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(),
+                            super::applyChangesSynchronously);
                 }
-        );
+            });
+        }
+
+        if (cache != null) {
+            changesPerformers.add(new EmbeddedCachesChangesPerformer<>(cache, serializerOnline) {
+                @Override
+                public boolean shouldConsumeChange(V entity) {
+                    return !entity.isOffline();
+                }
+            });
+            changesPerformers.add(new RemoteCachesChangesPerformer<>(session, cache, remoteCacheInvoker) {
+                @Override
+                public boolean shouldConsumeChange(V entity) {
+                    return !entity.isOffline();
+                }
+            });
+        }
+
+        if (offlineCache != null) {
+            changesPerformers.add(new EmbeddedCachesChangesPerformer<>(offlineCache, serializerOffline){
+                @Override
+                public boolean shouldConsumeChange(V entity) {
+                    return entity.isOffline();
+                }
+            });
+            changesPerformers.add(new RemoteCachesChangesPerformer<>(session, offlineCache, remoteCacheInvoker) {
+                @Override
+                public boolean shouldConsumeChange(V entity) {
+                    return entity.isOffline();
+                }
+            });
+        }
 
         this.cache = cache;
         this.offlineCache = offlineCache;

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -56,8 +56,9 @@ public class UserSessionPersistentChangelogBasedTransaction extends PersistentSe
         SessionUpdatesList<UserSessionEntity> myUpdates = getUpdates(offline).get(key);
         if (myUpdates == null) {
             SessionEntityWrapper<UserSessionEntity> wrappedEntity = null;
-            if (getCache(offline) != null) {
-                wrappedEntity = getCache(offline).get(key);
+            Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
+            if (cache != null) {
+                wrappedEntity = cache.get(key);
             }
 
             if (wrappedEntity == null) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserSessionProviderFactory.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.KeycloakSession;
@@ -67,7 +68,7 @@ public class RemoteUserSessionProviderFactory implements UserSessionProviderFact
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return InfinispanUtils.isRemoteInfinispan();
+        return InfinispanUtils.isRemoteInfinispan() && !Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/util/InfinispanKeyGenerator.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/util/InfinispanKeyGenerator.java
@@ -52,7 +52,7 @@ public class InfinispanKeyGenerator {
     }
 
 
-    private <K> K generateKey(KeycloakSession session, Cache<K, ?> cache, KeyGenerator<K> keyGenerator) {
+    protected <K> K generateKey(KeycloakSession session, Cache<K, ?> cache, KeyGenerator<K> keyGenerator) {
         String cacheName = cache.getName();
 
         // "wantsLocalKey" is true if route is not attached to the sticky session cookie. Without attached route, We want the key, which will be "owned" by this node.

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/session/LastSessionRefreshUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/session/LastSessionRefreshUnitTest.java
@@ -21,6 +21,7 @@ import org.infinispan.Cache;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.Retry;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
@@ -32,6 +33,7 @@ import org.keycloak.models.sessions.infinispan.changes.sessions.SessionData;
 import org.keycloak.models.sessions.infinispan.entities.UserSessionEntity;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.ProfileAssume;
 import org.keycloak.testsuite.runonserver.RunOnServer;
 import org.keycloak.timer.TimerProvider;
 
@@ -63,6 +65,7 @@ public class LastSessionRefreshUnitTest extends AbstractKeycloakTest {
 
     @Test
     public void testLastSessionRefreshCounters() {
+        ProfileAssume.assumeFeatureDisabled(Profile.Feature.REMOTE_CACHE);
         testingClient.server().run(new  LastSessionRefreshServerCounterTest());
     }
 
@@ -107,6 +110,7 @@ public class LastSessionRefreshUnitTest extends AbstractKeycloakTest {
 
     @Test
     public void testLastSessionRefreshIntervals() {
+        ProfileAssume.assumeFeatureDisabled(Profile.Feature.REMOTE_CACHE);
         testingClient.server().run(new  LastSessionRefreshServerIntervalsTest());
     }
 


### PR DESCRIPTION
Closes #30855

Results with 50 logins+logouts per second, single-site ROSA, single site Aurora -> almost no change in the response times

Single user (so all other data is in memory), 3 pods, 4 CPU requested, 5 min run, ~1,5 vCPU per pod, Aurora 16.1

```
./benchmark.sh eu-west-1 --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=${KEYCLOAK_URL} --realm-name=test-realm --ramp-up=20 --measurement=300 --clients-per-realm=1 --users-per-realm=1 --users-per-sec=50 --logout-percentage=100 --log-http-on-failure
```

Scenario: volatile / persistent / persistent nocache

CPU usage database: 13 / 33 / 36

Commit count: 38 / 250 / 360

![image](https://github.com/keycloak/keycloak/assets/3957921/af5fa997-fb99-4f92-9ef3-8f73ff0b9291)

![image](https://github.com/keycloak/keycloak/assets/3957921/a1f15b36-8be6-4680-b174-896661dda347)

![image](https://github.com/keycloak/keycloak/assets/3957921/1b76d52e-9278-4918-8b1a-eb085b20f7eb)



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
