### PR TITLE
Encode realm name in URL when fetching from `ui-ext` (#28703)

### DIFF
--- a/js/apps/admin-ui/src/context/auth/admin-ui-endpoint.ts
+++ b/js/apps/admin-ui/src/context/auth/admin-ui-endpoint.ts
@@ -11,8 +11,12 @@ export async function fetchAdminUI<T>(
   const baseUrl = adminClient.baseUrl;
 
   const response = await fetchWithError(
-    joinPath(baseUrl, "admin/realms", adminClient.realmName, endpoint) +
-      (query ? "?" + new URLSearchParams(query) : ""),
+    joinPath(
+      baseUrl,
+      "admin/realms",
+      encodeURIComponent(adminClient.realmName),
+      endpoint,
+    ) + (query ? "?" + new URLSearchParams(query) : ""),
     {
       method: "GET",
       headers: getAuthorizationHeaders(accessToken),


### PR DESCRIPTION
Closes #28702

Signed-off-by: jchong <jhchong92@gmail.com>
(cherry picked from commit dbd016d4ec1884be3dcc4a9d489a0532f8aacd15)
