### PR TITLE
Tokens generated by client-to-client TE should manage sessions for the target client

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/ImpersonationSessionNote.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/ImpersonationSessionNote.java
@@ -6,7 +6,8 @@ package org.keycloak.models;
 public enum ImpersonationSessionNote implements UserSessionNoteDescriptor {
     IMPERSONATOR_ID("Impersonator User ID"),
     IMPERSONATOR_USERNAME("Impersonator Username"),
-    IMPERSONATOR_CLIENT("Impersonator Client");
+    IMPERSONATOR_CLIENT("Impersonator Client"),
+    IMPERSONATOR_TARGETCLIENT("Impersonator Target Client");
 
     final String displayName;
 


### PR DESCRIPTION
Closes #30614

Draft for the moment. The idea of the PR is that target client is assigned to the TE session. This way we can retrieve the real target client used to create the tokens. This means a few changes in `TokenManager` and `AuthenticationManager`. Besides I have also used real transient sessions for TE if no refresh tokens are requested (similar to what we are doing for `service_credentials`). If there is no refresh token involved TE is just a token with a lifespam with no session associated. If you think that session should only be transient when the client is not `isUseRefreshToken` just let me know. Test added with a similar case to the issue and also another test get a refresh token and refresh it.

@pedroigor @mposolda FYI.