### PR TITLE
Using _system client when account client is disabled for email actions

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/SystemClientUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/SystemClientUtil.java
@@ -43,7 +43,7 @@ public class SystemClientUtil {
     public static ClientModel getSystemClient(RealmModel realm) {
         // Try to return builtin "account" client first
         ClientModel client = realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
-        if (client != null) {
+        if (client != null && client.isEnabled()) {
             return client;
         }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -60,6 +60,7 @@ import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.models.utils.RoleUtils;
+import org.keycloak.models.utils.SystemClientUtil;
 import org.keycloak.policy.PasswordPolicyNotMetException;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
@@ -1112,11 +1113,8 @@ public class UserResource {
             throw ErrorResponse.error("Client id missing", Status.BAD_REQUEST);
         }
 
-        if (clientId == null) {
-            clientId = Constants.ACCOUNT_MANAGEMENT_CLIENT_ID;
-        }
 
-        ClientModel client = realm.getClientByClientId(clientId);
+        ClientModel client = clientId != null ? realm.getClientByClientId(clientId) : SystemClientUtil.getSystemClient(realm);
         if (client == null) {
             logger.debugf("Client %s doesn't exist", clientId);
             throw ErrorResponse.error("Client doesn't exist", Status.BAD_REQUEST);


### PR DESCRIPTION
The idea is to use the `_system` client with `SystemClientUtil.getSystemClient` method when the `account` client is disabled to execute email actions.

Closes #17857

