### PR TITLE
Fix sub-flow name / description editing

### DIFF
--- a/js/apps/admin-ui/src/authentication/components/EditFlow.tsx
+++ b/js/apps/admin-ui/src/authentication/components/EditFlow.tsx
@@ -81,7 +81,7 @@ export const EditFlow = ({ execution, onRowChange }: EditFlowProps) => {
           >
             <FormProvider {...form}>
               <TextControl
-                name="name"
+                name="displayName"
                 label={t("name")}
                 labelIcon={t("flowNameHelp")}
                 rules={{ required: { value: true, message: t("required") } }}


### PR DESCRIPTION
Fixes a mismatch between frontend and backend in the name of the property used to hold the name of a sub-flow which breaks the editing of the sub-flow name / description.

Fixes #30947.