### PR TITLE
TE should create a transient session when there is no initial session in client-to-client exchange

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -298,6 +298,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         String accessToken = response.getAccessToken();
         TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(accessToken, AccessToken.class);
         AccessToken token = accessTokenVerifier.parse().getToken();
+        Assert.assertNotNull(token.getSessionId());
         Assert.assertEquals(token.getPreferredUsername(), "user");
         assertTrue(token.getRealmAccess() == null || !token.getRealmAccess().isUserInRole("example"));
 
@@ -306,6 +307,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
+            Assert.assertEquals(token.getSessionId(), exchangedToken.getSessionId());
             Assert.assertEquals("client-exchanger", exchangedToken.getIssuedFor());
             Assert.assertEquals("target", exchangedToken.getAudience()[0]);
             Assert.assertEquals(exchangedToken.getPreferredUsername(), "user");
@@ -318,6 +320,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
+            Assert.assertEquals(token.getSessionId(), exchangedToken.getSessionId());
             Assert.assertEquals("legal", exchangedToken.getIssuedFor());
             Assert.assertEquals("target", exchangedToken.getAudience()[0]);
             Assert.assertEquals(exchangedToken.getPreferredUsername(), "user");
@@ -338,12 +341,16 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         oauth.clientId("my-service-account");
         OAuthClient.AccessTokenResponse response = oauth.doClientCredentialsGrantAccessTokenRequest("secret");
         String accessToken = response.getAccessToken();
+        TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(accessToken, AccessToken.class);
+        AccessToken token = accessTokenVerifier.parse().getToken();
+        Assert.assertNull(token.getSessionId());
 
         {
             response = oauth.doTokenExchange(TEST, accessToken, "target", "my-service-account", "secret");
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
+            Assert.assertNull(exchangedToken.getSessionId());
             Assert.assertEquals("my-service-account", exchangedToken.getIssuedFor());
             Assert.assertEquals("target", exchangedToken.getAudience()[0]);
             Assert.assertEquals(exchangedToken.getPreferredUsername(), "service-account-my-service-account");


### PR DESCRIPTION
Closes #30614

When there is no initial session (`client_credentials` for example) the TE was creating a new persistent session which generated issues later on. The idea of this PR is that, if there is no initial session, it means it was a transient session and the new session created by TE should be transient too. Tests modified to check that `client_credentials` request generates no session and a normal request maintains the initial session.