### PR TITLE
fix: addresses cli erroneously wants a secret when env password is set (#30892)

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseAuthOptionsCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseAuthOptionsCmd.java
@@ -63,19 +63,19 @@ public abstract class BaseAuthOptionsCmd extends BaseGlobalOptionsCmd {
     @Option(names = "--user", description = "Username to login with")
     protected String user;
 
-    @Option(names = "--password", description = "Password to login with (prompted for if not specified, --user is used, and the env variable KC_CLI_PASSWORD is not defined)", defaultValue = "${env:KC_CLI_PASSWORD}")
+    @Option(names = "--password", description = "Password to login with (prompted for if not specified, --user is used, and the env variable KC_CLI_PASSWORD is not defined)")
     protected String password;
 
-    @Option(names = "--secret", description = "Secret to authenticate the client (prompted for if no --user nor --keystore is specified, and the env variable KC_CLI_CLIENT_SECRET is not defined)", defaultValue = "${env:KC_CLI_CLIENT_SECRET}")
+    @Option(names = "--secret", description = "Secret to authenticate the client (prompted for if no --user nor --keystore is specified, and the env variable KC_CLI_CLIENT_SECRET is not defined)")
     protected String secret;
 
     @Option(names = "--keystore", description = "Path to a keystore containing private key")
     protected String keystore;
 
-    @Option(names = "--storepass", description = "Keystore password (prompted for if not specified, --keystore is used, and the env variable KC_CLI_STORE_PASSWORD is undefined)", defaultValue = "${env:KC_CLI_STORE_PASSWORD}")
+    @Option(names = "--storepass", description = "Keystore password (prompted for if not specified, --keystore is used, and the env variable KC_CLI_STORE_PASSWORD is undefined)")
     protected String storePass;
 
-    @Option(names = "--keypass", description = "Key password (prompted for if not specified and --keystore is used without --storepass, \n                             otherwise defaults to keystore password)", defaultValue = "${env:KC_CLI_KEY_PASSWORD}")
+    @Option(names = "--keypass", description = "Key password (prompted for if not specified, --keystore is used without --storepass, and the env variable KC_CLI_KEY_PASSWORD is undefined, otherwise defaults to keystore password)")
     protected String keyPass;
 
     @Option(names = "--alias", description = "Alias of the key inside a keystore (defaults to the value of ClientId)")
@@ -84,7 +84,7 @@ public abstract class BaseAuthOptionsCmd extends BaseGlobalOptionsCmd {
     @Option(names = "--truststore", description = "Path to a truststore")
     protected String trustStore;
 
-    @Option(names = "--trustpass", description = "Truststore password (prompted for if not specified, --user is used, and the env variable KC_CLI_TRUSTSTORE_PASSWORD is not defined)", defaultValue = "${env:KC_CLI_TRUSTSTORE_PASSWORD}")
+    @Option(names = "--trustpass", description = "Truststore password (prompted for if not specified, --user is used, and the env variable KC_CLI_TRUSTSTORE_PASSWORD is not defined)")
     protected String trustPass;
 
     @Option(names = "--insecure", description = "Turns off TLS validation")
@@ -174,7 +174,10 @@ public abstract class BaseAuthOptionsCmd extends BaseGlobalOptionsCmd {
                 pass = configData.getTrustpass();
             }
             if (pass == null) {
-                pass = IoUtil.readSecret("Enter truststore password: ");
+            	pass = System.getenv("KC_CLI_TRUSTSTORE_PASSWORD");
+            }
+            if (pass == null) {
+            	pass = IoUtil.readSecret("Enter truststore password: ");
             }
 
             try {

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseConfigCredentialsCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseConfigCredentialsCmd.java
@@ -104,6 +104,9 @@ public class BaseConfigCredentialsCmd extends BaseAuthOptionsCmd {
 
             // if user was set there needs to be a password so we can authenticate
             if (password == null) {
+            	password = System.getenv("KC_CLI_PASSWORD");
+            }
+            if (password == null) {
                 password = readSecret("Enter password: ");
             }
             // if secret was set to be read from stdin, then ask for it
@@ -114,7 +117,10 @@ public class BaseConfigCredentialsCmd extends BaseAuthOptionsCmd {
             grantTypeForAuthentication = OAuth2Constants.CLIENT_CREDENTIALS;
             printErr("Logging into " + server + " as " + "service-account-" + clientId + " of realm " + realm);
             if (keystore == null && secret == null) {
-                secret = readSecret("Enter client secret: ");
+            	secret = System.getenv("KC_CLI_CLIENT_SECRET");
+            	if (secret == null) {
+            		secret = readSecret("Enter client secret: ");
+            	}
             }
         }
 
@@ -128,8 +134,17 @@ public class BaseConfigCredentialsCmd extends BaseAuthOptionsCmd {
             }
 
             if (storePass == null) {
+            	storePass = System.getenv("KC_CLI_STORE_PASSWORD");
+            }
+            if (keyPass == null) {
+            	keyPass = System.getenv("KC_CLI_KEY_PASSWORD");
+            }
+            
+            if (storePass == null) {
                 storePass = readSecret("Enter keystore password: ");
-                keyPass = readSecret("Enter key password: ");
+                if (keyPass == null) {
+                	keyPass = readSecret("Enter key password: ");
+                }
             }
 
             if (keyPass == null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/admin/KcAdmTest.java
@@ -672,5 +672,16 @@ public class KcAdmTest extends AbstractAdmCliTest {
         // should contain an error message
         assertExitCodeAndStreamSizes(exec, 0, 0, 1);
     }
+    
+    @Test
+    public void testEnvPasswordWithRegularCommand() {
+        execute("config credentials --server " + serverUrl + " --realm master --user admin --password admin");
+        KcAdmExec exec = KcAdmExec.newBuilder()
+                .argsLine("get users --format csv")
+                .env("KC_CLI_PASSWORD=ignoreme")
+                .execute();
+        // should not contain an error message
+        assertExitCodeAndStreamSizes(exec, 0, 1, 0);
+    }
 
 }


### PR DESCRIPTION
closes: #30866

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit aae1fa1417bf87cb0bd7ae9699a5a94eccf55814)
