### PR TITLE
allow override of begin transaction in AbstractKeycloakTransaction

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/AbstractKeycloakTransaction.java
+++ b/server-spi/src/main/java/org/keycloak/models/AbstractKeycloakTransaction.java
@@ -17,8 +17,6 @@
 
 package org.keycloak.models;
 
-import org.jboss.logging.Logger;
-
 /**
  * Handles some common transaction logic related to start, rollback-only etc.
  *
@@ -33,6 +31,8 @@ public abstract class AbstractKeycloakTransaction implements KeycloakTransaction
         if (state != TransactionState.NOT_STARTED) {
             throw new IllegalStateException("Transaction already started");
         }
+
+        beginImpl();
 
         state = TransactionState.STARTED;
     }
@@ -82,6 +82,7 @@ public abstract class AbstractKeycloakTransaction implements KeycloakTransaction
         NOT_STARTED, STARTED, ROLLBACK_ONLY, FINISHED
     }
 
+    protected void beginImpl() {}
 
     protected abstract void commitImpl();
 


### PR DESCRIPTION
Allows overriding the "begin transaction", without requiring the downstream classes to know about the internal state.

Closes #31005.