### PR TITLE
Backport: changed to use adminUrl instead (#30441)

### DIFF
--- a/js/apps/admin-ui/src/clients/ClientsSection.tsx
+++ b/js/apps/admin-ui/src/clients/ClientsSection.tsx
@@ -1,5 +1,6 @@
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
+import { useEnvironment } from "@keycloak/keycloak-ui-shared";
 import {
   AlertVariant,
   Badge,
@@ -29,6 +30,7 @@ import {
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
 import { useRealm } from "../context/realm-context/RealmContext";
+import { Environment } from "../environment";
 import helpUrls from "../help-urls";
 import { emptyFormatter, exportClient } from "../util";
 import { convertClientToUrl } from "../utils/client-url";
@@ -73,8 +75,8 @@ const ClientDescription = (client: ClientRepresentation) => (
 );
 
 const ClientHomeLink = (client: ClientRepresentation) => {
-  const { adminClient } = useAdminClient();
-  const href = convertClientToUrl(client, adminClient.baseUrl);
+  const { environment } = useEnvironment<Environment>();
+  const href = convertClientToUrl(client, environment);
 
   if (!href) {
     return "—";

--- a/js/apps/admin-ui/src/utils/client-url.test.ts
+++ b/js/apps/admin-ui/src/utils/client-url.test.ts
@@ -7,7 +7,8 @@ describe("convertClientToUrl", () => {
     const baseUrl = "http://something";
 
     //when
-    const result = convertClientToUrl({ baseUrl }, "");
+    //@ts-ignore
+    const result = convertClientToUrl({ baseUrl }, { serverBaseUrl: "" });
 
     //then
     expect(result).toBe(baseUrl);
@@ -16,13 +17,17 @@ describe("convertClientToUrl", () => {
   it("when root url constrains ${authAdminUrl}", () => {
     //given
     const rootUrl = "${authAdminUrl}";
-    const baseUrl = "/else";
+    const adminUrl = "/else";
 
     //when
-    const result = convertClientToUrl({ rootUrl, baseUrl }, "/admin");
+    const result = convertClientToUrl(
+      { rootUrl, adminUrl },
+      //@ts-ignore
+      { adminBaseUrl: "/admin" },
+    );
 
     //then
-    expect(result).toBe("/admin/else");
+    expect(result).toBe("/admin");
   });
 
   it("when root url constrains ${authBaseUrl}", () => {
@@ -31,10 +36,14 @@ describe("convertClientToUrl", () => {
     const baseUrl = "/something";
 
     //when
-    const result = convertClientToUrl({ rootUrl, baseUrl }, "/admin");
+    const result = convertClientToUrl(
+      { rootUrl, baseUrl },
+      //@ts-ignore
+      { serverBaseUrl: "/admin" },
+    );
 
     //then
-    expect(result).toBe("/admin/something");
+    expect(result).toBe("/admin");
   });
 
   it("when baseUrl when rootUrl is not set", () => {
@@ -42,7 +51,11 @@ describe("convertClientToUrl", () => {
     const baseUrl = "/another";
 
     //when
-    const result = convertClientToUrl({ rootUrl: undefined, baseUrl }, "");
+    const result = convertClientToUrl(
+      { rootUrl: undefined, baseUrl },
+      //@ts-ignore
+      { serverBaseUrl: "" },
+    );
 
     //then
     expect(result).toBe("/another");
@@ -54,7 +67,11 @@ describe("convertClientToUrl", () => {
     const rootUrl = "http://test.nl";
 
     //when
-    const result = convertClientToUrl({ rootUrl, baseUrl }, "");
+    const result = convertClientToUrl(
+      { rootUrl, baseUrl },
+      //@ts-ignore
+      { serverBaseUrl: "" },
+    );
 
     //then
     expect(result).toBe("http://test.nl/another");
@@ -65,20 +82,13 @@ describe("convertClientToUrl", () => {
     const rootUrl = "http://test.nl";
 
     //when
-    const result = convertClientToUrl({ rootUrl, baseUrl: undefined }, "");
+    const result = convertClientToUrl(
+      { rootUrl, baseUrl: undefined },
+      //@ts-ignore
+      { serverBaseUrl: "" },
+    );
 
     //then
     expect(result).toBe("http://test.nl");
-  });
-
-  it("should it return ${authBaseUrl} when baseUrl is not set?", () => {
-    //given
-    const rootUrl = "${authBaseUrl}";
-
-    //when
-    const result = convertClientToUrl({ rootUrl, baseUrl: undefined }, "");
-
-    //then
-    expect(result).toBeUndefined();
   });
 });

--- a/js/apps/admin-ui/src/utils/client-url.ts
+++ b/js/apps/admin-ui/src/utils/client-url.ts
@@ -1,23 +1,22 @@
 import ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type { Environment } from "../environment";
 import { joinPath } from "./joinPath";
 
 export const convertClientToUrl = (
   { rootUrl, baseUrl }: ClientRepresentation,
-  adminClientBaseUrl: string,
+  environment: Environment,
 ) => {
   // absolute base url configured, use base url is
   if (baseUrl?.startsWith("http")) {
     return baseUrl;
   }
 
-  if (
-    (rootUrl === "${authBaseUrl}" || rootUrl === "${authAdminUrl}") &&
-    baseUrl
-  ) {
-    return rootUrl.replace(
-      /\$\{(authAdminUrl|authBaseUrl)\}/,
-      joinPath(adminClientBaseUrl, baseUrl),
-    );
+  if (rootUrl === "${authAdminUrl}") {
+    return rootUrl.replace(/\$\{(authAdminUrl)\}/, environment.adminBaseUrl);
+  }
+
+  if (rootUrl === "${authBaseUrl}") {
+    return rootUrl.replace(/\$\{(authBaseUrl)\}/, environment.serverBaseUrl);
   }
 
   if (rootUrl?.startsWith("http")) {


### PR DESCRIPTION
* changed to use adminUrl instead

fixes: #19070
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

* changed to make use of "frondend url" and "adminUrl"

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

---------

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit e3649eb86a4487771f06a02b0cd486272732e937)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
