### PR TITLE
fix: add quotes to cygwin condition

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -27,7 +27,7 @@ GREP="grep"
 DIRNAME="$(dirname "$RESOLVED_NAME")"
 
 abs_path () {
-  if [ -z $IS_CYGWIN ] ; then
+  if [ -z "$IS_CYGWIN" ] ; then
     echo "$DIRNAME/$1"
   else
     cygpath -w "$DIRNAME/$1"


### PR DESCRIPTION
This test was not working correctly on AIX in POSIX mode.

closes: #30967

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
