### PR TITLE
Testsuite PoC - Implement a ChromeWebDriverSupplier (#30377)

### DIFF
--- a/misc/keycloak-test-helper/pom.xml
+++ b/misc/keycloak-test-helper/pom.xml
@@ -35,7 +35,8 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <scope>provided</scope>
+            <version>2.35.0</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@
         <jmeter.version>2.10</jmeter.version>
         <junit.version>4.13.2</junit.version>
         <picketlink.version>2.7.0.Final</picketlink.version>
-        <selenium.version>2.35.0</selenium.version>
         <!-- Needs to be aligned with Quarkus, see e.g. https://github.com/quarkusio/quarkus-quickstarts/blob/2.13.5.Final/getting-started-async/pom.xml#L14 -->
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <xml-apis.version>1.4.01</xml-apis.version>
@@ -677,20 +676,6 @@
                 <groupId>org.apache.directory.api</groupId>
                 <artifactId>api-ldap-codec-standalone</artifactId>
                 <version>${apacheds.codec.version}</version>
-            </dependency>
-
-            <!-- Selenium -->
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-java</artifactId>
-                <version>${selenium.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-chrome-driver</artifactId>
-                <version>${selenium.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.jmeter</groupId>

--- a/test-poc/framework/pom.xml
+++ b/test-poc/framework/pom.xml
@@ -31,6 +31,10 @@
     <packaging>jar</packaging>
     <description>PoC JUnit 5 testing framework for Keycloak</description>
 
+    <properties>
+        <selenium.version>4.21.0</selenium.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -47,13 +51,19 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.21.0</version>
+            <version>${selenium.version}</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>4.21.0</version>
+            <version>${selenium.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>${selenium.version}</version>
             <type>pom</type>
         </dependency>
     </dependencies>

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/ChromeWebDriverSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/ChromeWebDriverSupplier.java
@@ -5,9 +5,9 @@ import org.keycloak.test.framework.injection.LifeCycle;
 import org.keycloak.test.framework.injection.Registry;
 import org.keycloak.test.framework.injection.Supplier;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 
-public class FirefoxWebDriverSupplier implements Supplier<WebDriver, TestWebDriver> {
+public class ChromeWebDriverSupplier implements Supplier<WebDriver, TestWebDriver> {
 
     @Override
     public Class<TestWebDriver> getAnnotationClass() {
@@ -21,7 +21,7 @@ public class FirefoxWebDriverSupplier implements Supplier<WebDriver, TestWebDriv
 
     @Override
     public InstanceWrapper<WebDriver, TestWebDriver> getValue(Registry registry, TestWebDriver annotation) {
-        final var driver = new FirefoxDriver();
+        final var driver = new ChromeDriver();
         return new InstanceWrapper<>(this, annotation, driver);
     }
 
@@ -39,5 +39,4 @@ public class FirefoxWebDriverSupplier implements Supplier<WebDriver, TestWebDriv
     public void close(WebDriver instance) {
         instance.quit();
     }
-
 }

--- a/test-poc/framework/src/main/resources/META-INF/services/org.keycloak.test.framework.injection.Supplier
+++ b/test-poc/framework/src/main/resources/META-INF/services/org.keycloak.test.framework.injection.Supplier
@@ -2,4 +2,5 @@ org.keycloak.test.framework.admin.KeycloakAdminClientSupplier
 org.keycloak.test.framework.realm.ClientSupplier
 org.keycloak.test.framework.realm.RealmSupplier
 org.keycloak.test.framework.server.KeycloakTestServerSupplier
+org.keycloak.test.framework.webdriver.ChromeWebDriverSupplier
 org.keycloak.test.framework.webdriver.FirefoxWebDriverSupplier


### PR DESCRIPTION
Implemets an injectable Selenium ChromeWebDriver supplier. This PR does not have a mechanism to choose an implementation of web driver supplier, as it should be done in a separate issue. More information can be found on the issue this PR closes. This is a follow-up to #30376.

Closes keycloak#30377