### PR TITLE
Drop and merge offline session caches

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -244,7 +244,9 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         RemoteCacheManager remoteCacheManager = new RemoteCacheManager(builder.build());
 
         // establish connection to all caches
-        Arrays.stream(CLUSTERED_CACHE_NAMES).forEach(remoteCacheManager::getCache);
+        Arrays.stream(CLUSTERED_CACHE_NAMES)
+                .filter(InfinispanUtils::isNotOfflineSessionCache)
+                .forEach(remoteCacheManager::getCache);
         return remoteCacheManager;
 
     }

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/remote/RemoteInfinispanConnectionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/remote/RemoteInfinispanConnectionProvider.java
@@ -33,6 +33,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.util.concurrent.BlockingManager;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.connections.infinispan.TopologyInfo;
+import org.keycloak.infinispan.util.InfinispanUtils;
 
 public record RemoteInfinispanConnectionProvider(EmbeddedCacheManager embeddedCacheManager,
                                                  RemoteCacheManager remoteCacheManager,
@@ -65,6 +66,7 @@ public record RemoteInfinispanConnectionProvider(EmbeddedCacheManager embeddedCa
         // We assume rolling-upgrade between KC 25 and KC 26 is not available, in other words, KC 25 and KC 26 servers are not present in the same cluster.
         var stage = CompletionStages.aggregateCompletionStage();
         Arrays.stream(CLUSTERED_CACHE_NAMES)
+                .filter(InfinispanUtils::isNotOfflineSessionCache)
                 .map(this::getRemoteCache)
                 .map(RemoteCache::clearAsync)
                 .forEach(stage::dependsOn);

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/remote/RemoteLoadBalancerCheckProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/remote/RemoteLoadBalancerCheckProviderFactory.java
@@ -86,6 +86,7 @@ public class RemoteLoadBalancerCheckProviderFactory implements LoadBalancerCheck
             this.connectionProvider = provider;
 
             var remoteCacheChecks = Arrays.stream(CLUSTERED_CACHE_NAMES)
+                    .filter(InfinispanUtils::isNotOfflineSessionCache)
                     .map(s -> new RemoteCacheCheck(s, provider))
                     .collect(Collectors.toList());
             var sequencer = new ActionSequencer(connectionProvider.getExecutor("load-balancer-check"), false, null);

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/util/InfinispanUtils.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/util/InfinispanUtils.java
@@ -19,11 +19,15 @@ package org.keycloak.infinispan.util;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.models.sessions.infinispan.changes.remote.RemoveEntryPredicate;
 
 import static org.keycloak.common.Profile.Feature.MULTI_SITE;
 import static org.keycloak.common.Profile.Feature.REMOTE_CACHE;
 
 public final class InfinispanUtils {
+
+    private static final RemoveEntryPredicate<?,?> ALWAYS_FALSE = (key, value) -> false;
 
     private InfinispanUtils() {
     }
@@ -45,5 +49,15 @@ public final class InfinispanUtils {
     // true if running with embedded caches.
     public static boolean isEmbeddedInfinispan() {
         return !Profile.isFeatureEnabled(MULTI_SITE) || !Profile.isFeatureEnabled(REMOTE_CACHE);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <K, V> RemoveEntryPredicate<K, V> alwaysFalse() {
+        return (RemoveEntryPredicate<K, V>) ALWAYS_FALSE;
+    }
+
+    public static boolean isNotOfflineSessionCache(String name) {
+        return !InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME.equals(name) &&
+                !InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME.equals(name);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/marshalling/KeycloakModelSchema.java
+++ b/model/infinispan/src/main/java/org/keycloak/marshalling/KeycloakModelSchema.java
@@ -77,6 +77,7 @@ import org.keycloak.models.sessions.infinispan.entities.AuthenticationSessionEnt
 import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
 import org.keycloak.models.sessions.infinispan.entities.LoginFailureKey;
 import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
+import org.keycloak.models.sessions.infinispan.entities.SessionKey;
 import org.keycloak.models.sessions.infinispan.entities.SingleUseObjectValueEntity;
 import org.keycloak.models.sessions.infinispan.entities.UserSessionEntity;
 import org.keycloak.models.sessions.infinispan.events.RealmRemovedSessionEvent;
@@ -194,6 +195,7 @@ import org.keycloak.storage.managers.UserStorageSyncManager;
                 LoginFailureEntity.class,
                 LoginFailureKey.class,
                 RootAuthenticationSessionEntity.class,
+                SessionKey.class,
                 SingleUseObjectValueEntity.class,
                 UserSessionEntity.class,
                 ReplaceFunction.class

--- a/model/infinispan/src/main/java/org/keycloak/marshalling/Marshalling.java
+++ b/model/infinispan/src/main/java/org/keycloak/marshalling/Marshalling.java
@@ -147,6 +147,8 @@ public final class Marshalling {
     public static final int CACHE_KEY_INVALIDATION_EVENT = 65603;
     public static final int CLEAR_CACHE_EVENT = 65604;
 
+    public static final int SESSION_KEY = 65605;
+
     public static void configure(GlobalConfigurationBuilder builder) {
         builder.serialization()
                 .addContextInitializer(KeycloakModelSchema.INSTANCE);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/RemoveEntryPredicate.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/RemoveEntryPredicate.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.changes.remote;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.infinispan.client.hotrod.MetadataValue;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.keycloak.models.sessions.infinispan.changes.remote.updater.Updater;
+
+/**
+ * Represents a predicate to mass remove entries from a {@link RemoteCache}.
+ *
+ * @param <K> The key's type stored in the {@link RemoteCache}.
+ * @param <V> The value's type stored in the {@link RemoteCache}.
+ */
+public interface RemoveEntryPredicate<K, V> {
+
+    /**
+     * @param key   The entry's key to test.
+     * @param value The entry's value to test.
+     * @return {@code true} if the entry should be removed from the {@link RemoteCache}.
+     */
+    boolean shouldRemove(K key, V value);
+
+    /**
+     * @param entry The {@link RemoteCache} entry to test.
+     * @return {@code true} if the entry should be removed from the {@link RemoteCache}.
+     * @see #shouldRemove(Object, Object)
+     */
+    default boolean shouldRemove(Map.Entry<K, MetadataValue<V>> entry) {
+        return shouldRemove(entry.getKey(), entry.getValue().getValue());
+    }
+
+    /**
+     * @param updater The {@link Updater} to test.
+     * @return {@code true} if the entry tracked by the {@link Updater} should be removed from the {@link RemoteCache}.
+     */
+    default boolean shouldRemove(Updater<K, V> updater) {
+        return shouldRemove(updater.getKey(), updater.getValue());
+    }
+
+    /**
+     * Logical 'OR' between this {@link RemoveEntryPredicate} and {@code other}.
+     *
+     * @param other The other {@link RemoveEntryPredicate} to be logical 'OR' with.
+     * @return A {@link RemoveEntryPredicate} with a logical 'OR' between {@code this} and {@code other}.
+     */
+    default RemoveEntryPredicate<K, V> or(RemoveEntryPredicate<K, V> other) {
+        Objects.requireNonNull(other);
+        return (k, v) -> shouldRemove(k, v) || other.shouldRemove(k, v);
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/user/ClientSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/user/ClientSessionProvider.java
@@ -17,11 +17,11 @@
 
 package org.keycloak.models.sessions.infinispan.changes.remote.updater.user;
 
-import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.sessions.infinispan.entities.SessionKey;
 
 /**
  * An SPI for {@link ClientSessionMappingAdapter} to interact with the {@link RemoteCache}.
@@ -36,24 +36,24 @@ public interface ClientSessionProvider {
      * @return The {@link AuthenticatedClientSessionModel} instance or {@code null} if the client session does not exist
      * or was removed.
      */
-    AuthenticatedClientSessionModel getClientSession(String clientId, UUID clientSessionId);
+    AuthenticatedClientSessionModel getClientSession(String clientId, SessionKey clientSessionId);
 
     /**
-     * A non-blocking alternative to {@link #getClientSession(String, UUID)}.
+     * A non-blocking alternative to {@link #getClientSession(String, SessionKey)}.
      *
-     * @see #getClientSession(String, UUID)
+     * @see #getClientSession(String, SessionKey)
      */
-    CompletionStage<AuthenticatedClientSessionModel> getClientSessionAsync(String clientId, UUID clientSessionId);
+    CompletionStage<AuthenticatedClientSessionModel> getClientSessionAsync(String clientId, SessionKey clientSessionId);
 
     /**
      * Removes the client session associated with the {@link RemoteCache} key.
      * <p>
      * If {@code clientSessionId} is {@code null}, nothing is removed. The methods
-     * {@link #getClientSession(String, UUID)} and {@link #getClientSessionAsync(String, UUID)} will return {@code null}
+     * {@link #getClientSession(String, SessionKey)} and {@link #getClientSessionAsync(String, SessionKey)} will return {@code null}
      * for the session after this method is completed.
      *
      * @param clientSessionId The {@link RemoteCache} key to remove.
      */
-    void removeClientSession(UUID clientSessionId);
+    void removeClientSession(SessionKey clientSessionId);
 
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/SessionKey.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/SessionKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.entities;
+
+import java.util.Objects;
+
+import org.infinispan.protostream.annotations.Proto;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+import org.keycloak.marshalling.Marshalling;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+@ProtoTypeId(Marshalling.SESSION_KEY)
+@Proto
+public record SessionKey(String uuid, boolean offline) {
+
+    public SessionKey(String uuid, boolean offline) {
+        this.uuid = Objects.requireNonNull(uuid);
+        this.offline = offline;
+    }
+
+    public static SessionKey randomOnlineSessionKey() {
+        return new SessionKey(KeycloakModelUtils.generateId(), false);
+    }
+
+    public SessionKey withId(String uuid) {
+        return new SessionKey(uuid, offline);
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserLoginFailureProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteUserLoginFailureProvider.java
@@ -75,7 +75,7 @@ public class RemoteUserLoginFailureProvider implements UserLoginFailureProvider 
             log.tracef("removeAllUserLoginFailures(%s)%s", realm, getShortStackTrace());
         }
 
-        transaction.removeIf(entity -> Objects.equals(entity.getRealmId(), realm.getId()));
+        transaction.removeIf((key, value) -> Objects.equals(value.getRealmId(), realm.getId()));
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
@@ -17,14 +17,13 @@
 
 package org.keycloak.models;
 
-import org.keycloak.migration.MigrationModel;
-import org.keycloak.provider.Provider;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import org.keycloak.provider.Provider;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -39,7 +38,7 @@ public interface UserSessionProvider extends Provider {
     KeycloakSession getKeycloakSession();
 
     AuthenticatedClientSessionModel createClientSession(RealmModel realm, ClientModel client, UserSessionModel userSession);
-    
+
     /**
      * @deprecated Use {@link #getClientSession(UserSessionModel, ClientModel, String, boolean)} instead.
      */
@@ -204,7 +203,7 @@ public interface UserSessionProvider extends Provider {
      * @deprecated Deprecated as offline session preloading was removed in KC25. This method will be removed in KC27.
      */
     @Deprecated(forRemoval = true)
-    void importUserSessions(Collection<UserSessionModel> persistentUserSessions, boolean offline);
+    default void importUserSessions(Collection<UserSessionModel> persistentUserSessions, boolean offline) {}
 
     void close();
 

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/FeatureEnabledTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/FeatureEnabledTest.java
@@ -18,7 +18,6 @@
 package org.keycloak.testsuite.model.infinispan;
 
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.junit.Test;
@@ -35,12 +34,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.ACTION_TOKEN_CACHE;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHENTICATION_SESSIONS_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NAMES;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOCAL_CACHE_NAMES;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.WORK_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME;
 
 /**
  * Checks if the correct embedded or remote cache is started based on {@link org.keycloak.common.Profile.Feature}.
@@ -67,7 +64,11 @@ public class FeatureEnabledTest extends KeycloakModelTest {
         inComittedTransaction(session -> {
             var clusterProvider = session.getProvider(InfinispanConnectionProvider.class);
             Arrays.stream(CLUSTERED_CACHE_NAMES).forEach(s -> assertEmbeddedCacheDoesNotExists(clusterProvider, s));
-            Arrays.stream(CLUSTERED_CACHE_NAMES).forEach(s -> assertRemoteCacheExists(clusterProvider, s));
+            Arrays.stream(CLUSTERED_CACHE_NAMES)
+                    .filter(InfinispanUtils::isNotOfflineSessionCache)
+                    .forEach(s -> assertRemoteCacheExists(clusterProvider, s));
+            assertRemoteCacheDoesNotExists(clusterProvider, OFFLINE_CLIENT_SESSION_CACHE_NAME);
+            assertRemoteCacheDoesNotExists(clusterProvider, OFFLINE_USER_SESSION_CACHE_NAME);
 
         });
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/CrossDCInfinispan.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/CrossDCInfinispan.java
@@ -71,7 +71,7 @@ public class CrossDCInfinispan extends KeycloakModelParameters {
 
     @Override
     public void beforeSuite(Config cf) {
-        hotRodServerRule.createEmbeddedHotRodServer(cf.scope("connectionsInfinispan", "default"));
+        hotRodServerRule.createEmbeddedHotRodServer(cf.scope("connectionsInfinispan", "default"), s -> true);
     }
 
     private static String siteName(int node) {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/RemoteInfinispan.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/RemoteInfinispan.java
@@ -93,7 +93,7 @@ public class RemoteInfinispan extends KeycloakModelParameters {
 
     @Override
     public void beforeSuite(Config cf) {
-        hotRodServerRule.createEmbeddedHotRodServer(cf.scope("connectionsInfinispan", "default"));
+        hotRodServerRule.createEmbeddedHotRodServer(cf.scope("connectionsInfinispan", "default"), InfinispanUtils::isNotOfflineSessionCache);
     }
 
     private static String siteName(int node) {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/SessionTimeoutsTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/SessionTimeoutsTest.java
@@ -27,6 +27,7 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.util.Retry;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
@@ -214,6 +215,7 @@ public class SessionTimeoutsTest extends KeycloakModelTest {
                 return null;
             });
         } finally {
+            processExpiration(offline);
             setTimeOffset(0);
         }
     }
@@ -249,6 +251,7 @@ public class SessionTimeoutsTest extends KeycloakModelTest {
                 return null;
             });
         } finally {
+            processExpiration(offline);
             setTimeOffset(0);
         }
     }
@@ -325,8 +328,8 @@ public class SessionTimeoutsTest extends KeycloakModelTest {
                 Assert.assertNull(getUserSession(session, realm, sessions[0], offline));
                 return null;
             });
-            processExpiration(offline);
         } finally {
+            processExpiration(offline);
             setTimeOffset(0);
         }
     }
@@ -402,7 +405,7 @@ public class SessionTimeoutsTest extends KeycloakModelTest {
             return;
         }
 
-        var cacheName = offline ? InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME : InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
+        var cacheName = InfinispanUtils.isEmbeddedInfinispan() && offline ? InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME : InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
         var cache1 = hotRodServer.get().getHotRodCacheManager().getCache(cacheName);
         var cache2 = hotRodServer.get().getHotRodCacheManager2().getCache(cacheName);
         eventually(() -> "Wrong cache size. Site1: " + cache1.keySet() + ", Site2: " + cache2.keySet(),
@@ -415,7 +418,7 @@ public class SessionTimeoutsTest extends KeycloakModelTest {
             return;
         }
         // force expired entries to be removed from memory
-        var cacheName = offline ? InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME : InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
+        var cacheName = InfinispanUtils.isEmbeddedInfinispan() && offline ? InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME : InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
         hotRodServer.get().getHotRodCacheManager().getCache(cacheName).getAdvancedCache().getExpirationManager().processExpiration();
         hotRodServer.get().getHotRodCacheManager2().getCache(cacheName).getAdvancedCache().getExpirationManager().processExpiration();
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionInitializerTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionInitializerTest.java
@@ -41,6 +41,7 @@ import org.keycloak.models.UserProvider;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.session.UserSessionPersisterProvider;
+import org.keycloak.models.sessions.infinispan.entities.SessionKey;
 import org.keycloak.testsuite.model.HotRodServerRule;
 import org.keycloak.testsuite.model.KeycloakModelTest;
 import org.keycloak.testsuite.model.RequireProvider;
@@ -182,8 +183,9 @@ public class UserSessionInitializerTest extends KeycloakModelTest {
                         }
 
                         if (hotRodServer.isPresent()) {
-                            RemoteCache<String, Object> remoteSessions = provider.getRemoteCache(USER_SESSION_CACHE_NAME);
-                            containsSession.get().add(remoteSessions.containsKey(userSessionId.get()));
+                            var key = InfinispanUtils.isRemoteInfinispan() ? new SessionKey(userSessionId.get(), false) : userSessionId.get();
+                            RemoteCache<?, Object> remoteSessions = provider.getRemoteCache(USER_SESSION_CACHE_NAME);
+                            containsSession.get().add(remoteSessions.containsKey(key));
                         }
                     });
                 }


### PR DESCRIPTION
Use a single cache for online and offline sessions to reduce the number of RPC calls.

Fixes #30932

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
