### PR TITLE
Allow user to configure prompt parameter for google sign-in

### DIFF
--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
@@ -55,6 +55,11 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         return ProviderConfigurationBuilder.create()
+                .property().name("prompt")
+                .label("Prompt")
+                .helpText("Set 'prompt' query parameter when logging in with Google. The allowed values are none, consent and select_account. " +
+                        "If no value is specified and the user has not previously authorized access, then the user is shown a consent screen.")
+                .type(ProviderConfigProperty.STRING_TYPE).add()
                 .property().name("hostedDomain")
                 .label("Hosted Domain")
                 .helpText("Set 'hd' query parameter when logging in with Google. Google will list accounts only for this " +

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
@@ -57,7 +57,7 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
         return ProviderConfigurationBuilder.create()
                 .property().name("prompt")
                 .label("Prompt")
-                .helpText("Set 'prompt' query parameter when logging in with Google. The allowed values are none, consent and select_account. " +
+                .helpText("Set 'prompt' query parameter when logging in with Google. The allowed values are 'none', 'consent' and 'select_account'. " +
                         "If no value is specified and the user has not previously authorized access, then the user is shown a consent screen.")
                 .type(ProviderConfigProperty.STRING_TYPE).add()
                 .property().name("hostedDomain")

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
@@ -54,6 +54,8 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
+        // The supported authentication URI parameters can be found in the google identity documentation
+        // See: https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters
         return ProviderConfigurationBuilder.create()
                 .property().name("prompt")
                 .label("Prompt")


### PR DESCRIPTION
Allow user to configure prompt parameter for google sign-in.

The supported parameters are described in the [openid-connect section in the sign-in with google documentation](https://developers.google.com/identity/openid-connect/openid-connect#re-consent)

Fixes #16750

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
