### PR TITLE
Fix ReCAPTCHA Enterprise failing due to new properties in response

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RecaptchaAssessmentResponse.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RecaptchaAssessmentResponse.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RecaptchaAssessmentResponse {
 
     @JsonProperty("name")
@@ -38,9 +39,14 @@ public class RecaptchaAssessmentResponse {
     @JsonProperty("event")
     private Event event;
 
+    @JsonProperty("accountDefenderAssessment")
+    private AccountDefenderAssessment accountDefenderAssessment;
+
     public String toString() {
-        return format("RecaptchaAssessmentResponse(name=%s, riskAnalysis=%s, tokenProperties=%s, event=%s)",
-                this.getName(), this.getRiskAnalysis(), this.getTokenProperties(), this.getEvent());
+        return format(
+                "RecaptchaAssessmentResponse(name=%s, riskAnalysis=%s, tokenProperties=%s, event=%s, accountDefenderAssessment=%s)",
+                this.getName(), this.getRiskAnalysis(), this.getTokenProperties(), this.getEvent(),
+                this.getAccountDefenderAssessment());
     }
 
     public String getName() {
@@ -73,6 +79,14 @@ public class RecaptchaAssessmentResponse {
 
     public void setEvent(Event event) {
         this.event = event;
+    }
+
+    public AccountDefenderAssessment getAccountDefenderAssessment() {
+        return accountDefenderAssessment;
+    }
+
+    public void setAccountDefenderAssessment(AccountDefenderAssessment accountDefenderAssessment) {
+        this.accountDefenderAssessment = accountDefenderAssessment;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -241,7 +255,26 @@ public class RecaptchaAssessmentResponse {
         public void setUserIpAddress(String userIpAddress) {
             this.userIpAddress = userIpAddress;
         }
+    }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AccountDefenderAssessment {
+
+        @JsonProperty("labels")
+        private String[] labels;
+
+        public String toString() {
+            return format("AccountDefenderAssessment(labels=%s)",
+                    this.getLabels() != null ? Arrays.toString(this.getLabels()) : "[]");
+        }
+
+        public String[] getLabels() {
+            return labels;
+        }
+
+        public void setLabels(String[] labels) {
+            this.labels = labels;
+        }
     }
 
 }


### PR DESCRIPTION
The assessment response added a new field called accountDefenderAssessment. This commit adds the new property, and also ensures new properties won't be problematic next time by ignoring unknown properties on the top level object.

Closes: #30917

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
