### PR TITLE
TestSuite PoC - Add support to configure lifecycle for realms and clients

### DIFF
--- a/test-poc/base/src/test/java/org/keycloak/test/base/GlobalManagedResourcesTest.java
+++ b/test-poc/base/src/test/java/org/keycloak/test/base/GlobalManagedResourcesTest.java
@@ -13,9 +13,9 @@ import org.keycloak.test.framework.injection.LifeCycle;
 import java.util.List;
 
 @KeycloakIntegrationTest
-public class ManagedResourcesTest {
+public class GlobalManagedResourcesTest {
 
-    @TestRealm(lifecycle = LifeCycle.CLASS)
+    @TestRealm(lifecycle = LifeCycle.GLOBAL)
     RealmResource realmResource;
 
     @TestClient
@@ -23,14 +23,14 @@ public class ManagedResourcesTest {
 
     @Test
     public void testCreatedRealm() {
-        Assertions.assertEquals("ManagedResourcesTest", realmResource.toRepresentation().getRealm());
+        Assertions.assertEquals("DefaultRealmConfig", realmResource.toRepresentation().getRealm());
     }
 
     @Test
     public void testCreatedClient() {
-        Assertions.assertEquals("ManagedResourcesTest", clientResource.toRepresentation().getClientId());
+        Assertions.assertEquals("GlobalManagedResourcesTest", clientResource.toRepresentation().getClientId());
 
-        List<ClientRepresentation> clients = realmResource.clients().findByClientId("ManagedResourcesTest");
+        List<ClientRepresentation> clients = realmResource.clients().findByClientId("GlobalManagedResourcesTest");
         Assertions.assertEquals(1, clients.size());
     }
 

--- a/test-poc/base/src/test/java/org/keycloak/test/base/ManagedResources2Test.java
+++ b/test-poc/base/src/test/java/org/keycloak/test/base/ManagedResources2Test.java
@@ -13,7 +13,7 @@ import org.keycloak.test.framework.injection.LifeCycle;
 import java.util.List;
 
 @KeycloakIntegrationTest
-public class ManagedResourcesTest {
+public class ManagedResources2Test {
 
     @TestRealm(lifecycle = LifeCycle.CLASS)
     RealmResource realmResource;
@@ -23,14 +23,14 @@ public class ManagedResourcesTest {
 
     @Test
     public void testCreatedRealm() {
-        Assertions.assertEquals("ManagedResourcesTest", realmResource.toRepresentation().getRealm());
+        Assertions.assertEquals("ManagedResources2Test", realmResource.toRepresentation().getRealm());
     }
 
     @Test
     public void testCreatedClient() {
-        Assertions.assertEquals("ManagedResourcesTest", clientResource.toRepresentation().getClientId());
+        Assertions.assertEquals("ManagedResources2Test", clientResource.toRepresentation().getClientId());
 
-        List<ClientRepresentation> clients = realmResource.clients().findByClientId("ManagedResourcesTest");
+        List<ClientRepresentation> clients = realmResource.clients().findByClientId("ManagedResources2Test");
         Assertions.assertEquals(1, clients.size());
     }
 

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/KeycloakIntegrationTestExtension.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/KeycloakIntegrationTestExtension.java
@@ -1,24 +1,24 @@
 package org.keycloak.test.framework;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.keycloak.test.framework.injection.Registry;
 
-public class KeycloakIntegrationTestExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
-
-    @Override
-    public void beforeAll(ExtensionContext context) {
-        if (isExtensionEnabled(context)) {
-            getRegistry(context).beforeAll(context.getRequiredTestClass());
-        }
-    }
+public class KeycloakIntegrationTestExtension implements BeforeEachCallback, AfterEachCallback, AfterAllCallback {
 
     @Override
     public void beforeEach(ExtensionContext context) {
         if (isExtensionEnabled(context)) {
             getRegistry(context).beforeEach(context.getRequiredTestInstance());
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (isExtensionEnabled(context)) {
+            getRegistry(context).afterEach();
         }
     }
 

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/TestClient.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/TestClient.java
@@ -1,5 +1,6 @@
 package org.keycloak.test.framework;
 
+import org.keycloak.test.framework.injection.LifeCycle;
 import org.keycloak.test.framework.realm.ClientConfig;
 import org.keycloak.test.framework.realm.DefaultClientConfig;
 
@@ -13,5 +14,7 @@ import java.lang.annotation.Target;
 public @interface TestClient {
 
     Class<? extends ClientConfig> config() default DefaultClientConfig.class;
+
+    LifeCycle lifecycle() default LifeCycle.CLASS;
 
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/TestRealm.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/TestRealm.java
@@ -1,5 +1,6 @@
 package org.keycloak.test.framework;
 
+import org.keycloak.test.framework.injection.LifeCycle;
 import org.keycloak.test.framework.realm.DefaultRealmConfig;
 import org.keycloak.test.framework.realm.RealmConfig;
 
@@ -13,5 +14,7 @@ import java.lang.annotation.Target;
 public @interface TestRealm {
 
     Class<? extends RealmConfig> config() default DefaultRealmConfig.class;
+
+    LifeCycle lifecycle() default LifeCycle.CLASS;
 
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/admin/KeycloakAdminClientSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/admin/KeycloakAdminClientSupplier.java
@@ -27,14 +27,9 @@ public class KeycloakAdminClientSupplier implements Supplier<Keycloak, TestAdmin
         KeycloakTestServer testServer = registry.getDependency(KeycloakTestServer.class, wrapper);
 
         Keycloak keycloak = Keycloak.getInstance(testServer.getBaseUrl(), "master", "admin", "admin", "admin-cli");
-        wrapper.setValue(keycloak);
+        wrapper.setValue(keycloak, LifeCycle.GLOBAL);
 
         return wrapper;
-    }
-
-    @Override
-    public LifeCycle getLifeCycle() {
-        return LifeCycle.GLOBAL;
     }
 
     @Override

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/InstanceWrapper.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/InstanceWrapper.java
@@ -12,6 +12,7 @@ public class InstanceWrapper<T, A extends Annotation> {
     private final A annotation;
     private final Set<InstanceWrapper<T, A>> dependencies = new HashSet<>();
     private T value;
+    private LifeCycle lifeCycle;
     private final Map<String, Object> notes = new HashMap<>();
 
     public InstanceWrapper(Supplier<T, A> supplier, A annotation) {
@@ -19,14 +20,16 @@ public class InstanceWrapper<T, A extends Annotation> {
         this.annotation = annotation;
     }
 
-    public InstanceWrapper(Supplier<T, A> supplier, A annotation, T value) {
+    public InstanceWrapper(Supplier<T, A> supplier, A annotation, T value, LifeCycle lifeCycle) {
         this.supplier = supplier;
         this.annotation = annotation;
         this.value = value;
+        this.lifeCycle = lifeCycle;
     }
 
-    public void setValue(T value) {
+    public void setValue(T value, LifeCycle lifeCycle) {
         this.value = value;
+        this.lifeCycle = lifeCycle;
     }
 
     public Supplier<T, A> getSupplier() {
@@ -35,6 +38,10 @@ public class InstanceWrapper<T, A extends Annotation> {
 
     public T getValue() {
         return value;
+    }
+
+    public LifeCycle getLifeCycle() {
+        return lifeCycle;
     }
 
     public A getAnnotation() {

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/LifeCycle.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/LifeCycle.java
@@ -3,6 +3,7 @@ package org.keycloak.test.framework.injection;
 public enum LifeCycle {
 
     GLOBAL,
-    CLASS
+    CLASS,
+    METHOD
 
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Supplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Supplier.java
@@ -10,8 +10,6 @@ public interface Supplier<T, S extends Annotation> {
 
     InstanceWrapper<T, S> getValue(Registry registry, S annotation);
 
-    LifeCycle getLifeCycle();
-
     boolean compatible(InstanceWrapper<T, S> a, InstanceWrapper<T, S> b);
 
     default void close(T instance) {}

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/server/KeycloakTestServerSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/server/KeycloakTestServerSupplier.java
@@ -28,12 +28,7 @@ public class KeycloakTestServerSupplier implements Supplier<KeycloakTestServer, 
 
         keycloakTestServer.start(serverConfig);
 
-        return new InstanceWrapper<>(this, annotation, keycloakTestServer);
-    }
-
-    @Override
-    public LifeCycle getLifeCycle() {
-        return LifeCycle.GLOBAL;
+        return new InstanceWrapper<>(this, annotation, keycloakTestServer, LifeCycle.GLOBAL);
     }
 
     @Override

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/ChromeWebDriverSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/ChromeWebDriverSupplier.java
@@ -22,12 +22,7 @@ public class ChromeWebDriverSupplier implements Supplier<WebDriver, TestWebDrive
     @Override
     public InstanceWrapper<WebDriver, TestWebDriver> getValue(Registry registry, TestWebDriver annotation) {
         final var driver = new ChromeDriver();
-        return new InstanceWrapper<>(this, annotation, driver);
-    }
-
-    @Override
-    public LifeCycle getLifeCycle() {
-        return LifeCycle.GLOBAL;
+        return new InstanceWrapper<>(this, annotation, driver, LifeCycle.GLOBAL);
     }
 
     @Override

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/FirefoxWebDriverSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/FirefoxWebDriverSupplier.java
@@ -22,12 +22,7 @@ public class FirefoxWebDriverSupplier implements Supplier<WebDriver, TestWebDriv
     @Override
     public InstanceWrapper<WebDriver, TestWebDriver> getValue(Registry registry, TestWebDriver annotation) {
         final var driver = new FirefoxDriver();
-        return new InstanceWrapper<>(this, annotation, driver);
-    }
-
-    @Override
-    public LifeCycle getLifeCycle() {
-        return LifeCycle.GLOBAL;
+        return new InstanceWrapper<>(this, annotation, driver, LifeCycle.GLOBAL);
     }
 
     @Override


### PR DESCRIPTION
Realms and clients can be set to global, class, or method. This needed a little bit of changes to the registry and suppliers around lifecycle management, including adding a way to destroy things with global lifecycle.

I may have even outsmarted myself when implementing the Registry as it actually works if a realm has method lifecycle, while the client has class (or global), as the client is re-created automatically if the realm is deleted.

I did not implement the optimalisation that we don't need to delete a client if a realm is being deleted, that can be done as a follow-up.

Closes #30610

Signed-off-by: stianst <stianst@gmail.com>
