### PR TITLE
BACKPORT: Automatically re-authenticate on single-logout (#28723)

### DIFF
--- a/js/apps/account-ui/src/root/KeycloakContext.tsx
+++ b/js/apps/account-ui/src/root/KeycloakContext.tsx
@@ -41,15 +41,17 @@ export const KeycloakProvider = ({
   const calledOnce = useRef(false);
   const [init, setInit] = useState(false);
   const [error, setError] = useState<unknown>();
-  const keycloak = useMemo(
-    () =>
-      new Keycloak({
-        url: environment.authUrl,
-        realm: environment.realm,
-        clientId: environment.clientId,
-      }),
-    [environment],
-  );
+  const keycloak = useMemo(() => {
+    const keycloak = new Keycloak({
+      url: environment.authUrl,
+      realm: environment.realm,
+      clientId: environment.clientId,
+    });
+
+    keycloak.onAuthLogout = () => keycloak.login();
+
+    return keycloak;
+  }, [environment]);
 
   useEffect(() => {
     // only needed in dev mode
@@ -57,13 +59,12 @@ export const KeycloakProvider = ({
       return;
     }
 
-    const init = () => {
-      return keycloak.init({
+    const init = () =>
+      keycloak.init({
         onLoad: "check-sso",
         pkceMethod: "S256",
         responseMode: "query",
       });
-    };
 
     init()
       .then(() => setInit(true))

--- a/js/apps/admin-ui/src/keycloak.ts
+++ b/js/apps/admin-ui/src/keycloak.ts
@@ -8,6 +8,8 @@ export const keycloak = new Keycloak({
   clientId: environment.clientId,
 });
 
+keycloak.onAuthLogout = () => keycloak.login();
+
 export async function initKeycloak() {
   const authenticated = await keycloak.init({
     onLoad: "check-sso",


### PR DESCRIPTION
Automatically forces the user to re-authenticate from the Admin and Account consoles when a single-logout occurs.

Closes #23832
Closes #23833

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
Signed-off-by: Jon Koops <jonkoops@gmail.com>
Co-authored-by: Jon Koops <jonkoops@gmail.com>
(cherry picked from commit 957859d8465e3e72c036dca88f6ef73b5ade650e)
