### PR TITLE
fix(operator): Scale statefulset to 0 to prepare for update (#30450)

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -461,13 +461,13 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
         var reconciledContainer = reconciledDeployment.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         if (!previousContainer.getImage().equals(reconciledContainer.getImage())
-                && previousDeployment.getStatus().getReplicas() > 1) {
+                && previousDeployment.getStatus().getReplicas() > 0) {
             // TODO Check if migration is really needed (e.g. based on actual KC version); https://github.com/keycloak/keycloak/issues/10441
             Log.info("Detected changed Keycloak image, assuming Keycloak upgrade. Scaling down the deployment to one instance to perform a safe database migration");
             Log.infof("original image: %s; new image: %s", previousContainer.getImage(), reconciledContainer.getImage());
 
             reconciledContainer.setImage(previousContainer.getImage());
-            reconciledDeployment.getSpec().setReplicas(1);
+            reconciledDeployment.getSpec().setReplicas(0);
 
             reconciledDeployment.getMetadata().getAnnotations().put(Constants.KEYCLOAK_MIGRATING_ANNOTATION, Boolean.TRUE.toString());
         }


### PR DESCRIPTION
When performing a keycloak update, the operator is supposed to make sure that potential database migrations are run with only one pod active. This change makes the operator scale down the stateful set to zero pods in preparation for the update. The next reconciliation loop will scale the stateful set back up and change the image, making sure migrations are being run on the first pod that is brought up. This also makes sure that the rollover works even if the infinispan versions are incompatible

Closes #30449

Signed-off-by: Schmidt, Sascha (sasschmidt) <sascha.schmidt@breuninger.de>
(cherry picked from commit 13ef6fb1c8564aa22003cf4d1507d982f63e2f5f)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
