### PR TITLE
fix: check for blank password / client secret

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminService.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminService.java
@@ -78,6 +78,9 @@ public class BootstrapAdminService extends AbstractNonServerCommand {
             if (!clientSecret.equals(confirmClientSecret)) {
                 throw new PropertyException("Client secrets do not match");
             }
+            if (clientSecret.isBlank()) {
+                throw new PropertyException("Client secret must not be blank");
+            }
         } else {
             clientSecret = getFromEnv(clientSecretEnv);
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminUser.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminUser.java
@@ -78,6 +78,9 @@ public class BootstrapAdminUser extends AbstractNonServerCommand {
             if (!password.equals(confirmPassword)) {
                 throw new PropertyException("Passwords do not match");
             }
+            if (password.isBlank()) {
+                throw new PropertyException("Password must not be blank");
+            }
         } else {
             password = getFromEnv(passwordEnv);
         }


### PR DESCRIPTION
This is the bare minimum for generally validating the password / client secret. The ApplianceBootstrap already checks for blank before doing the creation of the user / service account.

closes: #30540

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
