### PR TITLE
Improve consent deletion when a realm is removed (22.0)

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-22_0_12.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-22_0_12.adoc
@@ -1,0 +1,5 @@
+= Improving performance for deletion of user consents
+
+When a client scope or the full realm are deleted the associated user consents should also be removed. A new index over the table `USER_CONSENT_CLIENT_SCOPE` has been added to increase the performance.
+
+Note that, if the table contains more than 300.000 entries, by default {project_name} skips the creation of the indexes during the automatic schema migration and logs the SQL statements to the console instead. The statements must be run manually in the DB after {project_name}'s startup. Check the link:{upgradingguide_link}[{upgradingguide_name}] for details on how to configure a different limit.

--- a/docs/documentation/upgrading/topics/keycloak/changes.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes.adoc
@@ -1,5 +1,9 @@
 == Migration Changes
 
+=== Migrating to 22.0.12
+
+include::changes-22_0_12.adoc[leveloffset=3]
+
 === Migrating to 22.0.10
 
 include::changes-22_0_10.adoc[leveloffset=3]

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserConsentClientScopeEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserConsentClientScopeEntity.java
@@ -34,11 +34,11 @@ import jakarta.persistence.Table;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @NamedQueries({
-        @NamedQuery(name="deleteUserConsentClientScopesByRealm", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.user IN (select user from UserEntity user where user.realmId = :realmId))"),
+        //@NamedQuery(name="deleteUserConsentClientScopesByRealm", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.user IN (select user from UserEntity user where user.realmId = :realmId))"),
         @NamedQuery(name="deleteUserConsentClientScopesByRealmAndLink", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.user IN (select u from UserEntity u where u.realmId=:realmId and u.federationLink=:link))"),
         @NamedQuery(name="deleteUserConsentClientScopesByUser", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.user = :user)"),
         @NamedQuery(name="deleteUserConsentClientScopesByClientScope", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.scopeId = :scopeId"),
-        @NamedQuery(name="deleteUserConsentClientScopesByClient", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.clientId = :clientId)"),
+        //@NamedQuery(name="deleteUserConsentClientScopesByClient", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.clientId = :clientId)"),
         @NamedQuery(name="deleteUserConsentClientScopesByExternalClient", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.clientStorageProvider = :clientStorageProvider and consent.externalClientId = :externalClientId)"),
         @NamedQuery(name="deleteUserConsentClientScopesByClientStorageProvider", query="delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (select consent from UserConsentEntity consent where consent.clientStorageProvider = :clientStorageProvider)"),
 })

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserConsentEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserConsentEntity.java
@@ -45,7 +45,7 @@ import java.util.LinkedList;
         @NamedQuery(name="userConsentByUserAndClient", query="select consent from UserConsentEntity consent where consent.user.id = :userId and consent.clientId = :clientId"),
         @NamedQuery(name="userConsentByUserAndExternalClient", query="select consent from UserConsentEntity consent where consent.user.id = :userId and consent.clientStorageProvider = :clientStorageProvider and consent.externalClientId = :externalClientId"),
         @NamedQuery(name="userConsentsByUser", query="select consent from UserConsentEntity consent where consent.user.id = :userId"),
-        @NamedQuery(name="deleteUserConsentsByRealm", query="delete from UserConsentEntity consent where consent.user IN (select user from UserEntity user where user.realmId = :realmId)"),
+        //@NamedQuery(name="deleteUserConsentsByRealm", query="delete from UserConsentEntity consent where consent.user IN (select user from UserEntity user where user.realmId = :realmId)"),
         @NamedQuery(name="deleteUserConsentsByRealmAndLink", query="delete from UserConsentEntity consent where consent.user IN (select u from UserEntity u where u.realmId=:realmId and u.federationLink=:link)"),
         @NamedQuery(name="deleteUserConsentsByUser", query="delete from UserConsentEntity consent where consent.user = :user"),
         @NamedQuery(name="deleteUserConsentsByClient", query="delete from UserConsentEntity consent where consent.clientId = :clientId"),

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-18.0.15.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-18.0.15.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="18.0.15-30992-index-consent">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="USER_CONSENT_CLIENT_SCOPE" indexName="IDX_USCONSENT_SCOPE_ID" />
+            </not>
+        </preConditions>
+        <createIndex tableName="USER_CONSENT_CLIENT_SCOPE" indexName="IDX_USCONSENT_SCOPE_ID">
+            <column name="SCOPE_ID" type="VARCHAR(36)"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -73,6 +73,7 @@
     <include file="META-INF/jpa-changelog-15.0.0.xml"/>
     <include file="META-INF/jpa-changelog-17.0.0.xml"/>
     <include file="META-INF/jpa-changelog-18.0.0.xml"/>
+    <include file="META-INF/jpa-changelog-18.0.15.xml"/>
     <include file="META-INF/jpa-changelog-19.0.0.xml"/>
     <include file="META-INF/jpa-changelog-20.0.0.xml"/>
     <include file="META-INF/jpa-changelog-21.0.2.xml"/>

--- a/model/jpa/src/main/resources/META-INF/queries-default.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-default.properties
@@ -16,3 +16,12 @@ deleteClientSessionsByRealm=delete from PersistentClientSessionEntity sess where
 deleteClientSessionsByUser=delete from PersistentClientSessionEntity sess where sess.userSessionId IN (\
   select u.userSessionId from PersistentUserSessionEntity u \
   where u.userId = :userId)
+
+deleteUserConsentClientScopesByRealm=delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (\
+  select consent from UserConsentEntity consent where consent.user IN (select user from UserEntity user where user.realmId = :realmId))
+
+deleteUserConsentsByRealm=delete from UserConsentEntity consent where consent.user IN (\
+  select user from UserEntity user where user.realmId = :realmId)
+
+deleteUserConsentClientScopesByClient=delete from UserConsentClientScopeEntity grantedScope where grantedScope.userConsent IN (\
+  select consent from UserConsentEntity consent where consent.clientId = :clientId)

--- a/model/jpa/src/main/resources/META-INF/queries-mariadb.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-mariadb.properties
@@ -13,3 +13,11 @@ deleteClientSessionsByRealm[native]=delete c from OFFLINE_CLIENT_SESSION c join 
 
 deleteClientSessionsByUser[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
  where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = :userId
+
+deleteUserConsentClientScopesByRealm[native]=delete cc from USER_CONSENT_CLIENT_SCOPE cc join USER_CONSENT uc join USER_ENTITY u \
+ where cc.USER_CONSENT_ID = uc.ID and uc.USER_ID = u.ID and u.REALM_ID=:realmId
+
+deleteUserConsentsByRealm[native]=delete uc from USER_CONSENT uc join USER_ENTITY u where uc.USER_ID = u.ID and u.REALM_ID = :realmId
+
+deleteUserConsentClientScopesByClient[native]=delete cc from USER_CONSENT_CLIENT_SCOPE cc join USER_CONSENT uc \
+ where cc.USER_CONSENT_ID = uc.ID and uc.CLIENT_ID = :clientId

--- a/model/jpa/src/main/resources/META-INF/queries-mysql.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-mysql.properties
@@ -13,3 +13,11 @@ deleteClientSessionsByRealm[native]=delete c from OFFLINE_CLIENT_SESSION c join 
 
 deleteClientSessionsByUser[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
  where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = :userId
+
+deleteUserConsentClientScopesByRealm[native]=delete cc from USER_CONSENT_CLIENT_SCOPE cc join USER_CONSENT uc join USER_ENTITY u \
+ where cc.USER_CONSENT_ID = uc.ID and uc.USER_ID = u.ID and u.REALM_ID=:realmId
+
+deleteUserConsentsByRealm[native]=delete uc from USER_CONSENT uc join USER_ENTITY u where uc.USER_ID = u.ID and u.REALM_ID = :realmId
+
+deleteUserConsentClientScopesByClient[native]=delete cc from USER_CONSENT_CLIENT_SCOPE cc join USER_CONSENT uc \
+ where cc.USER_CONSENT_ID = uc.ID and uc.CLIENT_ID = :clientId


### PR DESCRIPTION
Closes #30992

PR: https://github.com/keycloak/keycloak/pull/31071
Commit: https://github.com/keycloak/keycloak/commit/ce195b81f82e21c97616431cd6fb0e3b05b4e729
PR branch: backport-31071-22.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/22.0

Backport for #30992 in 22.0. In this branch the commit was modified to not remove the default queries file and therefore the new queries are added in all the prop files.
