### PR TITLE
Do not compare user DN using DN comparison as AD can login via username@domain

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
@@ -74,7 +74,7 @@ public class LDAPServerCapabilitiesManager {
             if (component != null) {
                 LDAPConfig ldapConfig = new LDAPConfig(component.getConfig());
                 if (Objects.equals(URI.create(config.getConnectionUrl()), URI.create(ldapConfig.getConnectionUrl()))
-                        && Objects.equals(LDAPDn.fromString(config.getBindDn()), LDAPDn.fromString(ldapConfig.getBindDN()))) {
+                        && config.getBindDn() != null && config.getBindDn().equalsIgnoreCase(ldapConfig.getBindDN())) {
                     bindCredential = ldapConfig.getBindCredential();
                 }
             }


### PR DESCRIPTION
Closes #31196

Just changing DN comparison for a equalsIgnoreCase. Cannot add test because this is only valid for AD. If you prefer direct equals or something more complicated just let me know, but I decided to do it simple.