### PR TITLE
Do not send attributes when unlocking the user

### DIFF
--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -318,6 +318,7 @@ export default function EditUser() {
                     user={user}
                     bruteForce={bruteForced}
                     userProfileMetadata={userProfileMetadata}
+                    refresh={refresh}
                     save={save}
                   />
                 </PageSection>

--- a/js/apps/admin-ui/src/user/UserForm.tsx
+++ b/js/apps/admin-ui/src/user/UserForm.tsx
@@ -52,6 +52,7 @@ export type UserFormProps = {
   bruteForce?: BruteForced;
   userProfileMetadata?: UserProfileMetadata;
   save: (user: UserFormFields) => void;
+  refresh?: () => void;
   onGroupsUpdate?: (groups: GroupRepresentation[]) => void;
 };
 
@@ -65,6 +66,7 @@ export const UserForm = ({
   },
   userProfileMetadata,
   save,
+  refresh,
   onGroupsUpdate,
 }: UserFormProps) => {
   const { adminClient } = useAdminClient();
@@ -94,8 +96,11 @@ export const UserForm = ({
 
   const unLockUser = async () => {
     try {
-      await adminClient.attackDetection.del({ id: user!.id! });
+      await adminClient.users.update({ id: user!.id! }, { enabled: true });
       addAlert(t("unlockSuccess"), AlertVariant.success);
+      if (refresh) {
+        refresh();
+      }
     } catch (error) {
       addError("unlockError", error);
     }
@@ -279,9 +284,6 @@ export const UserForm = ({
               onChange={(_event, value) => {
                 unLockUser();
                 setLocked(value);
-                save({
-                  enabled: !value,
-                });
               }}
               isChecked={locked}
               isDisabled={!locked}


### PR DESCRIPTION
Closes #31165

* Also removes the additional `DELETE` request because the `PUT` request that enables the user is already clearing the login failures for the user
* As the additional call to `brute-force/users/{user_id}` was removed the change is also firing an admin event to indicate when the user is unlocked
* There is one potential improvement here to how we handle updates when the account is temporarily disabled. It applies to the current state and the new changes herein introduced. When the user is temporarily disabled, the `enabled` field is set to `false`. If the administrator clicks the `Save` button it will end up disabling the user instead of keep the user enabled (in the database) so that when the temporary lockout is removed the user can log in again. Not changing this now and not sure if makes sense to fix that.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
