### PR TITLE
Change link to https://github.com/eclipse/microprofile/wiki/JWT_Auth

### DIFF
--- a/docs/documentation/server_admin/topics/clients/con-client-scopes.adoc
+++ b/docs/documentation/server_admin/topics/clients/con-client-scopes.adoc
@@ -29,7 +29,7 @@ This scope is also not defined in the OpenID Connect specification and not added
 +
 ** *microprofile-jwt*
 +
-This scope handles claims defined in the https://wiki.eclipse.org/MicroProfile/JWT_Auth[MicroProfile/JWT Auth Specification]. This scope defines a user property mapper for the *upn* claim and a realm role mapper for the *groups* claim. These mappers can be changed so different properties can be used to create the MicroProfile/JWT specific claims.
+This scope handles claims defined in the https://github.com/eclipse/microprofile/wiki/JWT_Auth[MicroProfile/JWT Auth Specification]. This scope defines a user property mapper for the *upn* claim and a realm role mapper for the *groups* claim. These mappers can be changed so different properties can be used to create the MicroProfile/JWT specific claims.
 +
 ** *offline_access*
 +

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -464,7 +464,7 @@ Cross-Datacenter Replication changes::
   not guaranteed as we don't test it anymore.
 
 ==== New optional client scope
-We have added a new `microprofile-jwt` optional client scope to handle the claims defined in the https://wiki.eclipse.org/MicroProfile/JWT_Auth[MicroProfile/JWT Auth Specification].
+We have added a new `microprofile-jwt` optional client scope to handle the claims defined in the https://github.com/eclipse/microprofile/wiki/JWT_Auth[MicroProfile/JWT Auth Specification].
 This new client scope defines protocol mappers to set the username of the authenticated user to the `upn` claim and to
 set the realm roles to the `groups` claim.
 


### PR DESCRIPTION
Closes #31219

Just changing the link to the URL https://github.com/eclipse/microprofile/wiki/JWT_Auth.
