### PR TITLE
fix: persist refresh token for IDP token exchange

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceServerStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceServerStore.java
@@ -74,7 +74,9 @@ public class JPAResourceServerStore implements ResourceServerStore {
             query.setParameter("serverId", id);
             List<String> result = query.getResultList();
             for (String policyId : result) {
-                entityManager.remove(entityManager.getReference(PolicyEntity.class, policyId));
+                PolicyEntity policyEntity = entityManager.find(PolicyEntity.class, policyId);
+                policyEntity.getAssociatedPolicies().clear();
+                entityManager.remove(policyEntity);
             }
         }
 

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -240,8 +240,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
 
                 }
                 model.setToken(response);
-                tokenResponse = newResponse;
                 session.users().updateFederatedIdentity(authorizedClient.getRealm(), tokenSubject, model);
+                tokenResponse = newResponse;
             } else if (exp != null) {
                 tokenResponse.setExpiresIn(exp - currentTime);
             }
@@ -428,7 +428,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
 
         try {
             BrokeredIdentityContext identity = extractIdentity(tokenResponse, accessToken, idToken);
-            
+
             if (!identity.getId().equals(idToken.getSubject())) {
                 throw new IdentityBrokerException("Mismatch between the subject in the id_token and the subject from the user_info endpoint");
             }
@@ -462,7 +462,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             if (!getConfig().isDisableNonce()) {
                 identity.getContextData().put(BROKER_NONCE_PARAM, idToken.getOtherClaims().get(OIDCLoginProtocol.NONCE_PARAM));
             }
-            
+
             if (getConfig().isStoreToken()) {
                 if (tokenResponse.getExpiresIn() > 0) {
                     long accessTokenExpiration = Time.currentTime() + tokenResponse.getExpiresIn();
@@ -580,7 +580,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         }
         if (tokenResponse != null) identity.getContextData().put(FEDERATED_ACCESS_TOKEN_RESPONSE, tokenResponse);
         if (tokenResponse != null) processAccessTokenResponse(identity, tokenResponse);
-        
+
         return identity;
     }
 
@@ -741,7 +741,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         if (!ignoreAudience && !token.hasAudience(getConfig().getClientId())) {
             throw new IdentityBrokerException("Wrong audience from token.");
         }
-        
+
         if (!ignoreAudience && (token.getIssuedFor() != null && !getConfig().getClientId().equals(token.getIssuedFor()))) {
             throw new IdentityBrokerException("Token issued for does not match client id");
         }
@@ -785,7 +785,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         String requestedIssuer = params == null ? null : params.getFirst(OAuth2Constants.SUBJECT_ISSUER);
         if (requestedIssuer == null) requestedIssuer = issuer;
         if (requestedIssuer.equals(getConfig().getAlias())) return true;
-        
+
         String trustedIssuers = getConfig().getIssuer();
 
         if (trustedIssuers != null && trustedIssuers.length() > 0) {
@@ -797,7 +797,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
                 }
             }
         }
-        
+
         return false;
     }
 
@@ -836,19 +836,19 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(identity, userInfo, getConfig().getAlias());
 
         identity.setId(id);
-        
+
         if (givenName != null) {
             identity.setFirstName(givenName);
         }
-        
+
         if (familyName != null) {
             identity.setLastName(familyName);
         }
-        
+
         if (givenName == null && familyName == null) {
             identity.setName(name);
         }
-        
+
         identity.setEmail(email);
 
         identity.setBrokerUserId(getConfig().getAlias() + "." + id);
@@ -977,7 +977,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     @Override
     public void preprocessFederatedIdentity(KeycloakSession session, RealmModel realm, BrokeredIdentityContext context) {
         AuthenticationSessionModel authenticationSession = session.getContext().getAuthenticationSession();
-        
+
         if (authenticationSession == null || getConfig().isDisableNonce()) {
             // no interacting with the brokered OP, likely doing token exchanges or no nonce
             return;

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -241,6 +241,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
                 }
                 model.setToken(response);
                 tokenResponse = newResponse;
+                session.users().updateFederatedIdentity(authorizedClient.getRealm(), tokenSubject, model);
             } else if (exp != null) {
                 tokenResponse.setExpiresIn(exp - currentTime);
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
@@ -22,10 +22,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.util.ProtocolMapperUtil.createHardcodedClaim;
+
+import java.io.IOException;
+import java.util.Set;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
@@ -52,6 +56,9 @@ import org.keycloak.models.IdentityProviderMapperSyncMode;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.models.jpa.JpaRealmProviderFactory;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AccessTokenResponse;
@@ -139,14 +146,13 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
 
         ClientRepresentation client = consumerRealm.clients().findByClientId("test-app").get(0);
 
-        Client httpClient = AdminClientUtil.createResteasyClient();
-
-        try {
+        try (Client httpClient = AdminClientUtil.createResteasyClient()) {
             WebTarget exchangeUrl = httpClient.target(ServerURLs.getAuthServerContextRoot() + "/auth")
                     .path("/realms")
                     .path(bc.consumerRealmName())
                     .path("protocol/openid-connect/token");
             // test user info validation.
+            AccessTokenResponse externalToInternalTokenResponse;
             try (Response response = exchangeUrl.request()
                     .header(HttpHeaders.AUTHORIZATION, BasicAuthHelper.createHeader(
                             client.getClientId(), client.getSecret()))
@@ -160,14 +166,96 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
 
                     ))) {
                 assertThat(response.getStatus(), equalTo(200));
+                externalToInternalTokenResponse = response.readEntity(AccessTokenResponse.class);
                 UserRepresentation user = consumerRealm.users().search(bc.getUserLogin()).get(0);
                 getCleanup(bc.consumerRealmName()).addUserId(user.getId());
                 assertThat(user.getAttributes().get("mapped-from-claim").get(0), equalTo("hard-coded"));
             }
-        } finally {
-            httpClient.close();
+
+            try (Response response = exchangeUrl.request()
+                    .header(HttpHeaders.AUTHORIZATION, BasicAuthHelper.createHeader(
+                            client.getClientId(), client.getSecret()))
+                    .post(Entity.form(
+                            new Form()
+                                    .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE)
+                                    .param(OAuth2Constants.SUBJECT_TOKEN, externalToInternalTokenResponse.getToken())
+                                    .param(OAuth2Constants.SUBJECT_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE)
+                                    .param(OAuth2Constants.REQUESTED_ISSUER, bc.getIDPAlias())
+                                    .param(OAuth2Constants.SCOPE, OAuth2Constants.SCOPE_OPENID)
+
+                    ))) {
+                assertThat(response.getStatus(), equalTo(200));
+                AccessTokenResponse internalToExternalTokenResponse = response.readEntity(AccessTokenResponse.class);
+            }
         }
     }
+
+    @Test
+    public void testWithLinkedFederationProviderTokenExchangeInternalToExternalWithStore() throws IOException {
+        testingClient.server(bc.consumerRealmName()).run(KcOidcBrokerTokenExchangeTest::setupRealm);
+        try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(
+                realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias()))
+                .setStoreToken(true)
+                .update()) {
+            testWithLinkedFederationProviderTokenExchangeInternalToExternal(true);
+        }
+    }
+
+    @Test
+    public void testWithLinkedFederationProviderTokenExchangeInternalToExternalWithoutStore() throws IOException {
+        testingClient.server(bc.consumerRealmName()).run(KcOidcBrokerTokenExchangeTest::setupRealm);
+        try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(
+                realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias()))
+                .setStoreToken(false)
+                .update()) {
+            testWithLinkedFederationProviderTokenExchangeInternalToExternal(false);
+        }
+    }
+
+    public void testWithLinkedFederationProviderTokenExchangeInternalToExternal(boolean storeToken) {
+
+        final RealmResource consumerRealm = realmsResouce().realm(bc.consumerRealmName());
+        final int expires = realmsResouce().realm(bc.providerRealmName()).toRepresentation().getAccessTokenLifespan();
+        final ClientRepresentation brokerApp = ApiUtil.findClientByClientId(consumerRealm, "broker-app").toRepresentation();
+
+        logInAsUserInIDPForFirstTimeAndAssertSuccess();
+        final String code = oauth.parseLoginResponse().getCode();
+        oauth.client(brokerApp.getClientId(), brokerApp.getSecret());
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
+        assertThat(tokenResponse.getError(), nullValue());
+        assertThat(tokenResponse.getAccessToken(), notNullValue());
+
+        String realmName = bc.consumerRealmName();
+        String userName = bc.getUserLogin();
+        String idpAlias = bc.getIDPAlias();
+
+        String oldTokenFromDatabase = testingClient.server().fetch(session -> {
+            RealmModel realm = session.realms().getRealmByName(realmName);
+            UserModel user = session.users().getUserByUsername(realm, userName);
+            return session.getProvider(UserProvider.class, JpaRealmProviderFactory.PROVIDER_ID).getFederatedIdentity(realm, user, idpAlias).getToken();
+        }, String.class);
+
+        setTimeOffset(expires + 10);
+
+        tokenResponse = oauth.doRefreshTokenRequest(tokenResponse.getRefreshToken());
+        assertThat(tokenResponse.getError(), nullValue());
+        assertThat(tokenResponse.getAccessToken(), notNullValue());
+
+        exchangeToIdP(brokerApp, tokenResponse.getAccessToken(), expires);
+
+        if (storeToken) {
+            /* Ensure that the tokens are persisted to the database as they would otherwise not be present on other nodes or on server restart */
+            String newTokenFromDatabase = testingClient.server().fetch(session -> {
+                RealmModel realm = session.realms().getRealmByName(realmName);
+                UserModel user = session.users().getUserByUsername(realm, userName);
+                return session.getProvider(UserProvider.class, JpaRealmProviderFactory.PROVIDER_ID).getFederatedIdentity(realm, user, idpAlias).getToken();
+            }, String.class);
+
+            assertThat(newTokenFromDatabase, not(equalTo(oldTokenFromDatabase)));
+        }
+
+    }
+
 
     @Test
     public void testSupportedTokenTypesWhenValidatingSubjectToken() throws Exception {
@@ -316,6 +404,8 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
         client.setSecret("secret");
         client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         client.setFullScopeAllowed(false);
+        client.setRedirectUris(Set.of(OAuthClient.AUTH_SERVER_ROOT + "/*"));
+
         ClientModel brokerApp = realm.getClientByClientId("broker-app");
 
         AdminPermissionManagement management = AdminPermissions.management(session, realm);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -16,6 +16,8 @@ import org.keycloak.representations.idm.FederatedIdentityRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.resources.admin.ClearRealmCacheResource;
+import org.keycloak.services.resources.admin.ClearUserCacheResource;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.broker.oidc.TestKeycloakOidcIdentityProviderFactory;
 import org.keycloak.testsuite.forms.RegisterWithUserProfileTest;
@@ -142,6 +144,69 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
 
         assertThat(firstLoginAccessToken, not(equalTo(secondLoginAccessToken)));
         assertThat(firstLoginRefreshToken, is(equalTo(secondLoginRefreshToken)));
+    }
+
+    @Test
+    public void testPersistRefreshTokenOnClearCache() throws Exception {
+        // Step 1: Set up the identity provider and user in the provider realm
+        IdentityProviderResource idp = realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias());
+        IdentityProviderRepresentation representation = idp.toRepresentation();
+        representation.setStoreToken(true);
+        idp.update(representation);
+
+        // Create a test user in the provider realm
+        createUser(bc.providerRealmName(), "brucewayne", BrokerTestConstants.USER_PASSWORD, "Bruce", "Wayne", "brucewayne@gotham.com");
+
+        oauth.clientId("broker-app");
+        loginPage.open(bc.consumerRealmName());
+        logInWithIdp(bc.getIDPAlias(), "brucewayne", BrokerTestConstants.USER_PASSWORD);
+
+        // Step 2: Obtain the stored token from the federated identity
+        String storedToken = testingClient.server(bc.consumerRealmName()).fetchString(session -> {
+            RealmModel realmModel = session.getContext().getRealm();
+            UserModel userModel = session.users().getUserByUsername(realmModel, "brucewayne");
+            FederatedIdentityModel fedIdentity = session.users().getFederatedIdentitiesStream(realmModel, userModel).findFirst().orElse(null);
+            return fedIdentity != null ? fedIdentity.getToken() : null;
+        });
+        assertThat(storedToken, not(nullValue()));
+
+        AccessTokenResponse tokenResponse = JsonSerialization.readValue(storedToken.substring(1, storedToken.length() - 1).replace("\\", ""), AccessTokenResponse.class);
+        String firstLoginAccessToken = tokenResponse.getToken();
+        assertThat(firstLoginAccessToken, not(nullValue()));
+        String firstLoginRefreshToken = tokenResponse.getRefreshToken();
+        assertThat(firstLoginRefreshToken, not(nullValue()));
+
+        // Step 3: Clear user and realm caches
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            ClearUserCacheResource clearUserCacheResource = new ClearUserCacheResource(session, null, null);
+            clearUserCacheResource.clearUserCache();
+
+            ClearRealmCacheResource clearRealmCacheResource = new ClearRealmCacheResource(session, null, null);
+            clearRealmCacheResource.clearRealmCache();
+        });
+
+        // Step 4: Logout and log back in
+        AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), "brucewayne");
+        loginPage.open(bc.consumerRealmName());
+        logInWithIdp(bc.getIDPAlias(), "brucewayne", BrokerTestConstants.USER_PASSWORD);
+
+        // Step 5: Fetch the stored token - access token should have been updated, but the refresh token should remain the same
+        storedToken = testingClient.server(bc.consumerRealmName()).fetchString(session -> {
+            RealmModel realmModel = session.getContext().getRealm();
+            UserModel userModel = session.users().getUserByUsername(realmModel, "brucewayne");
+            FederatedIdentityModel fedIdentity = session.users().getFederatedIdentitiesStream(realmModel, userModel).findFirst().orElse(null);
+            return fedIdentity != null ? fedIdentity.getToken() : null;
+        });
+
+        tokenResponse = JsonSerialization.readValue(storedToken.substring(1, storedToken.length() - 1).replace("\\", ""), AccessTokenResponse.class);
+        String secondLoginAccessToken = tokenResponse.getToken();
+        assertThat(secondLoginAccessToken, not(nullValue()));
+        String secondLoginRefreshToken = tokenResponse.getRefreshToken();
+        assertThat(secondLoginRefreshToken, not(nullValue()));
+
+        // Ensure the access token has changed, but the refresh token remains the same
+        assertThat(firstLoginAccessToken, not(equalTo(secondLoginAccessToken)));
+        assertThat(firstLoginRefreshToken, equalTo(secondLoginRefreshToken));
     }
 
     /**


### PR DESCRIPTION
Closes #39502

Save the newly refreshed token in the database, so that on keycloak restart/session purge scenario, subsequent token refresh exchanges always uses the updated refresh token.
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
