### PR TITLE
Normalize built-in flow descriptions to start with an uppercase letter

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -78,7 +78,7 @@ public class DefaultAuthenticationFlows {
     public static void registrationFlow(RealmModel realm, boolean migrate) {
         AuthenticationFlowModel registrationFlow = new AuthenticationFlowModel();
         registrationFlow.setAlias(REGISTRATION_FLOW);
-        registrationFlow.setDescription("registration flow");
+        registrationFlow.setDescription("Registration flow");
         registrationFlow.setProviderId("basic-flow");
         registrationFlow.setTopLevel(true);
         registrationFlow.setBuiltIn(true);
@@ -87,7 +87,7 @@ public class DefaultAuthenticationFlows {
 
         AuthenticationFlowModel registrationFormFlow = new AuthenticationFlowModel();
         registrationFormFlow.setAlias(REGISTRATION_FORM_FLOW);
-        registrationFormFlow.setDescription("registration form");
+        registrationFormFlow.setDescription("Registration form");
         registrationFormFlow.setProviderId("form-flow");
         registrationFormFlow.setTopLevel(false);
         registrationFormFlow.setBuiltIn(true);
@@ -292,7 +292,7 @@ public class DefaultAuthenticationFlows {
     public static void browserFlow(RealmModel realm, boolean migrate) {
         AuthenticationFlowModel browser = new AuthenticationFlowModel();
         browser.setAlias(BROWSER_FLOW);
-        browser.setDescription("browser based authentication");
+        browser.setDescription("Browser based authentication");
         browser.setProviderId("basic-flow");
         browser.setTopLevel(true);
         browser.setBuiltIn(true);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
@@ -122,7 +122,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         LinkedList<FlowExecutions> expected = new LinkedList<>();
         String[] kerberosAuthExpectedChoices = KerberosUtils.isKerberosSupportExpected() ? new String[]{REQUIRED, ALTERNATIVE, DISABLED} : new String[]{DISABLED};
 
-        AuthenticationFlowRepresentation flow = newFlow("browser", "browser based authentication", "basic-flow", true, true);
+        AuthenticationFlowRepresentation flow = newFlow("browser", "Browser based authentication", "basic-flow", true, true);
         addExecExport(flow, null, false, "auth-cookie", false, null, ALTERNATIVE, 10);
         addExecExport(flow, null, false, "auth-spnego", false, null, DISABLED, 20);
         addExecExport(flow, null, false, "identity-provider-redirector", false, null, ALTERNATIVE, 25);
@@ -192,7 +192,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "OTP Form", "auth-otp-form", false, 5, 1, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
         expected.add(new FlowExecutions(flow, execs));
 
-         flow = newFlow("registration", "registration flow", "basic-flow", true, true);
+        flow = newFlow("registration", "Registration flow", "basic-flow", true, true);
         addExecExport(flow, "registration form", false, "registration-page-form", true, null, REQUIRED, 10);
 
         execs = new LinkedList<>();


### PR DESCRIPTION
This to address the inconsistency between the description for the "browser" and "registration", and the other flows.

Fixes #31291 

Since this applies to only new instances of Keycloak, should the description be migrated for already initialized instances as well?

![image](https://github.com/user-attachments/assets/3a1457e0-5f87-428d-8088-fe2ffa7a70fc)
