### PR TITLE
Fix css selector for recovery-codes-list (#31260,#31287)

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
@@ -106,7 +106,7 @@
         }
 
         function parseRecoveryCodeList() {
-            var recoveryCodes = document.querySelectorAll(".kc-recovery-codes-list li");
+            var recoveryCodes = document.querySelectorAll("#kc-recovery-codes-list li");
             var recoveryCodeList = "";
 
             for (var i = 0; i < recoveryCodes.length; i++) {

--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
@@ -69,3 +69,46 @@ div.kc-logo-text span {
     border-color: transparent black transparent transparent;
 }
 
+/* Recovery codes */
+.kc-recovery-codes-warning {
+    margin-bottom: 32px;
+}
+.kc-recovery-codes-warning .pf-c-alert__description p {
+    font-size: 0.875rem;
+}
+
+#kc-recovery-codes-list {
+    list-style: none;
+    columns: 2;
+    margin: 16px 0;
+    padding: 16px 16px 8px 16px;
+    border: 1px solid #D2D2D2;
+}
+#kc-recovery-codes-list li {
+    margin-bottom: 8px;
+    font-size: 11px;
+}
+#kc-recovery-codes-list li span {
+    color: #6A6E73;
+    width: 16px;
+    text-align: right;
+    display: inline-block;
+    margin-right: 1px;
+}
+
+.kc-recovery-codes-actions {
+    margin-bottom: 24px;
+}
+.kc-recovery-codes-actions button {
+    padding-left: 0;
+}
+.kc-recovery-codes-actions button i {
+    margin-right: 8px;
+}
+
+.kc-recovery-codes-confirmation {
+    align-items: baseline;
+    margin-bottom: 16px;
+}
+
+/* End Recovery codes */

--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -589,18 +589,19 @@ ul#kc-totp-supported-apps {
 .kc-recovery-codes-warning .pf-c-alert__description p {
     font-size: 0.875rem;
 }
-.kc-recovery-codes-list {
+
+#kc-recovery-codes-list {
     list-style: none;
     columns: 2;
     margin: 16px 0;
     padding: 16px 16px 8px 16px;
     border: 1px solid #D2D2D2;
 }
-.kc-recovery-codes-list li {
+#kc-recovery-codes-list li {
     margin-bottom: 8px;
     font-size: 11px;
 }
-.kc-recovery-codes-list li span {
+#kc-recovery-codes-list li span {
     color: #6A6E73;
     width: 16px;
     text-align: right;


### PR DESCRIPTION
The recovery-codes-list should be addressed by element ID not by CSS class.
Also the css style from keycloak v1 login theme was not applied with keycloak.v2 login theme.

Fixes #31260
Fixes #31287

Fixed list rendering:
![image](https://github.com/user-attachments/assets/047665d7-a6d4-4274-8aad-30291eddf33c)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
