### PR TITLE
Fix test LDAP connection with multiple ldap connection urls (#31267)

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
@@ -102,14 +102,13 @@ public class LDAPServerCapabilitiesManager {
      * @param config
      * @param ldapConfig
      * @return
-     * @throws ModelValidationException if an invalid URL is provided
      */
     private static boolean checkLdapConnectionUrl(TestLdapConnectionRepresentation config, LDAPConfig ldapConfig) {
         // There could be multiple connection URIs separated via spaces.
         String[] configConnectionUrls = config.getConnectionUrl().trim().split(" ");
         String[] ldapConfigConnectionUrls = ldapConfig.getConnectionUrl().trim().split(" ");
         if (configConnectionUrls.length != ldapConfigConnectionUrls.length) {
-            throw new ModelValidationException("LDAP Connection URL mismatch. Number of provided URLs does not match stored URLs.");
+            return false;
         }
         boolean urlsMatch = true;
         for (int i = 0; i < configConnectionUrls.length && urlsMatch; i++) {

--- a/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
@@ -27,6 +27,7 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.TestLdapConnectionRepresentation;
@@ -73,7 +74,7 @@ public class LDAPServerCapabilitiesManager {
             ComponentModel component = realm.getComponent(config.getComponentId());
             if (component != null) {
                 LDAPConfig ldapConfig = new LDAPConfig(component.getConfig());
-                if (Objects.equals(URI.create(config.getConnectionUrl()), URI.create(ldapConfig.getConnectionUrl()))
+                if (checkLdapConnectionUrl(config, ldapConfig)
                         && config.getBindDn() != null && config.getBindDn().equalsIgnoreCase(ldapConfig.getBindDN())) {
                     bindCredential = ldapConfig.getBindCredential();
                 }
@@ -92,6 +93,29 @@ public class LDAPServerCapabilitiesManager {
         configMap.putSingle(LDAPConstants.READ_TIMEOUT, timeoutStr);
         configMap.add(LDAPConstants.START_TLS, config.getStartTls());
         return new LDAPConfig(configMap);
+    }
+
+    /**
+     * Ensure provided connection URI matches parsed LDAP connection URI.
+     *
+     * See: https://docs.oracle.com/javase/jndi/tutorial/ldap/misc/url.html
+     * @param config
+     * @param ldapConfig
+     * @return
+     * @throws ModelValidationException if an invalid URL is provided
+     */
+    private static boolean checkLdapConnectionUrl(TestLdapConnectionRepresentation config, LDAPConfig ldapConfig) {
+        // There could be multiple connection URIs separated via spaces.
+        String[] configConnectionUrls = config.getConnectionUrl().trim().split(" ");
+        String[] ldapConfigConnectionUrls = ldapConfig.getConnectionUrl().trim().split(" ");
+        if (configConnectionUrls.length != ldapConfigConnectionUrls.length) {
+            throw new ModelValidationException("LDAP Connection URL mismatch. Number of provided URLs does not match stored URLs.");
+        }
+        boolean urlsMatch = true;
+        for (int i = 0; i < configConnectionUrls.length && urlsMatch; i++) {
+            urlsMatch = Objects.equals(URI.create(configConnectionUrls[i]), URI.create(ldapConfigConnectionUrls[i]));
+        }
+        return urlsMatch;
     }
 
     public static Set<LDAPCapabilityRepresentation> queryServerCapabilities(TestLdapConnectionRepresentation config, KeycloakSession session,


### PR DESCRIPTION
Previously, the given connection string was check with URI.create(..) which failed when multiple space separated LDAP URLs were given.

Fixes #31267

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
