### PR TITLE
Add support to select supplier for a given type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ node_modules
 
 # JENV
 .java-version
+
+.env

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/config/Config.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/config/Config.java
@@ -1,0 +1,57 @@
+package org.keycloak.test.framework.config;
+
+import org.keycloak.test.framework.injection.ValueTypeAlias;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public class Config {
+
+    private final static Config instance = new Config();
+
+    private Properties localEnv = new Properties();
+
+    private Config() {
+        File envFile = new File(".env");
+        if (envFile.isFile()) {
+            try {
+                localEnv.load(new FileInputStream(envFile));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Config getInstance() {
+        return instance;
+    }
+
+    public String getSelectedSupplier(Class valueType) {
+        return getString("kc-test-" + ValueTypeAlias.getAlias(valueType));
+    }
+
+    public String getString(String key) {
+        String propKey = key.replace('-', '.');
+        String envKey = key.replace('-', '_').toUpperCase();
+
+        String value = System.getProperty(propKey);
+        if (value != null) {
+            return value;
+        }
+
+        value = System.getenv(envKey);
+        if (value != null) {
+            return value;
+        }
+
+        value = localEnv.getProperty(envKey);
+        if (value != null) {
+            return value;
+        }
+
+        return null;
+    }
+
+}

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/database/DevFileDatabaseSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/database/DevFileDatabaseSupplier.java
@@ -2,10 +2,16 @@ package org.keycloak.test.framework.database;
 
 public class DevFileDatabaseSupplier extends AbstractDatabaseSupplier {
 
+    public static final String VENDOR = "dev-file";
+
     @Override
     TestDatabase getTestDatabase() {
-        DatabaseConfig databaseConfig = new DatabaseConfig().vendor("dev-file");
+        DatabaseConfig databaseConfig = new DatabaseConfig().vendor(VENDOR);
         return new TestDatabase(databaseConfig);
     }
 
+    @Override
+    public String getAlias() {
+        return VENDOR;
+    }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/database/DevMemDatabaseSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/database/DevMemDatabaseSupplier.java
@@ -2,10 +2,16 @@ package org.keycloak.test.framework.database;
 
 public class DevMemDatabaseSupplier extends AbstractDatabaseSupplier {
 
+    public static final String VENDOR = "dev-mem";
+
     @Override
     TestDatabase getTestDatabase() {
-        DatabaseConfig databaseConfig = new DatabaseConfig().vendor("dev-mem");
+        DatabaseConfig databaseConfig = new DatabaseConfig().vendor(VENDOR);
         return new TestDatabase(databaseConfig);
     }
 
+    @Override
+    public String getAlias() {
+        return VENDOR;
+    }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/database/PostgresDatabaseSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/database/PostgresDatabaseSupplier.java
@@ -2,14 +2,20 @@ package org.keycloak.test.framework.database;
 
 public class PostgresDatabaseSupplier extends AbstractDatabaseSupplier {
 
+    public static final String VENDOR = "postgres";
+
     @Override
     TestDatabase getTestDatabase() {
         DatabaseConfig databaseConfig = new DatabaseConfig()
-                .vendor("postgres")
+                .vendor(VENDOR)
                 .username("keycloak")
                 .password("keycloak")
                 .containerImage("the-postgres-container:the-version");
         return new TestDatabase(databaseConfig);
     }
 
+    @Override
+    public String getAlias() {
+        return VENDOR;
+    }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Supplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Supplier.java
@@ -14,4 +14,8 @@ public interface Supplier<T, S extends Annotation> {
 
     default void close(T instance) {}
 
+    default String getAlias() {
+        return getClass().getSimpleName();
+    }
+
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/ValueTypeAlias.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/ValueTypeAlias.java
@@ -1,0 +1,25 @@
+package org.keycloak.test.framework.injection;
+
+import org.keycloak.test.framework.database.TestDatabase;
+import org.keycloak.test.framework.server.KeycloakTestServer;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Map;
+
+public class ValueTypeAlias {
+
+    private static final Map<Class, String> aliases = Map.of(
+            WebDriver.class, "browser",
+            KeycloakTestServer.class, "server",
+            TestDatabase.class, "database"
+    );
+
+    public static String getAlias(Class clazz) {
+        String alias = aliases.get(clazz);
+        if (alias == null) {
+            alias = clazz.getSimpleName();
+        }
+        return alias;
+    }
+
+}

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/server/DistributionKeycloakTestServerSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/server/DistributionKeycloakTestServerSupplier.java
@@ -12,4 +12,8 @@ public class DistributionKeycloakTestServerSupplier extends AbstractKeycloakTest
         return true;
     }
 
+    @Override
+    public String getAlias() {
+        return "distribution";
+    }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/server/EmbeddedKeycloakTestServerSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/server/EmbeddedKeycloakTestServerSupplier.java
@@ -12,4 +12,8 @@ public class EmbeddedKeycloakTestServerSupplier extends AbstractKeycloakTestServ
         return true;
     }
 
+    @Override
+    public String getAlias() {
+        return "embedded";
+    }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/server/RemoteKeycloakTestServerSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/server/RemoteKeycloakTestServerSupplier.java
@@ -12,4 +12,8 @@ public class RemoteKeycloakTestServerSupplier extends AbstractKeycloakTestServer
         return false;
     }
 
+    @Override
+    public String getAlias() {
+        return "remote";
+    }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/ChromeWebDriverSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/ChromeWebDriverSupplier.java
@@ -34,4 +34,10 @@ public class ChromeWebDriverSupplier implements Supplier<WebDriver, TestWebDrive
     public void close(WebDriver instance) {
         instance.quit();
     }
+
+    @Override
+    public String getAlias() {
+        return "chrome";
+    }
+
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/FirefoxWebDriverSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/webdriver/FirefoxWebDriverSupplier.java
@@ -35,4 +35,8 @@ public class FirefoxWebDriverSupplier implements Supplier<WebDriver, TestWebDriv
         instance.quit();
     }
 
+    @Override
+    public String getAlias() {
+        return "firefox";
+    }
 }


### PR DESCRIPTION
Few things related to this:

* Provided class types can be given an alias through ValueTypeAlias, if not specified it will default to value type class.getSimpleName
* Suppliers can be given an alias by overriding getAlias, if not specified it will default to the suppliers class.getSimpleName
* Added a temporary config thing to make it easy to configure using system properties, env variables, or a local .env file

Closes #30609

Signed-off-by: stianst <stianst@gmail.com>
