### PR TITLE
Testsuite PoC - Injection framework support for multiple instances

### DIFF
--- a/test-poc/examples/src/test/java/org/keycloak/test/examples/GlobalManagedResourcesTest.java
+++ b/test-poc/examples/src/test/java/org/keycloak/test/examples/GlobalManagedResourcesTest.java
@@ -28,17 +28,17 @@ public class GlobalManagedResourcesTest {
 
     @Test
     public void testCreatedRealm() {
-        Assertions.assertEquals(DefaultRealmConfig.class.getSimpleName(), realmResource.toRepresentation().getRealm());
+        Assertions.assertEquals("default", realmResource.toRepresentation().getRealm());
     }
 
     @Test
     public void testCreatedClient() {
-        Assertions.assertEquals(DefaultClientConfig.class.getSimpleName(), clientResource.toRepresentation().getClientId());
+        Assertions.assertEquals("default", clientResource.toRepresentation().getClientId());
     }
 
     @Test
     public void testCreatedUser() {
-        Assertions.assertEquals(DefaultUserConfig.class.getSimpleName().toLowerCase(), userResource.toRepresentation().getUsername());
+        Assertions.assertEquals("default", userResource.toRepresentation().getUsername());
     }
 
 }

--- a/test-poc/examples/src/test/java/org/keycloak/test/examples/ManagedResources2Test.java
+++ b/test-poc/examples/src/test/java/org/keycloak/test/examples/ManagedResources2Test.java
@@ -23,14 +23,14 @@ public class ManagedResources2Test {
 
     @Test
     public void testCreatedRealm() {
-        Assertions.assertEquals(ManagedResources2Test.class.getSimpleName(), realmResource.toRepresentation().getRealm());
+        Assertions.assertEquals("default", realmResource.toRepresentation().getRealm());
     }
 
     @Test
     public void testCreatedClient() {
-        Assertions.assertEquals(ManagedResources2Test.class.getSimpleName(), clientResource.toRepresentation().getClientId());
+        Assertions.assertEquals("default", clientResource.toRepresentation().getClientId());
 
-        List<ClientRepresentation> clients = realmResource.clients().findByClientId(ManagedResources2Test.class.getSimpleName());
+        List<ClientRepresentation> clients = realmResource.clients().findByClientId("default");
         Assertions.assertEquals(1, clients.size());
     }
 

--- a/test-poc/examples/src/test/java/org/keycloak/test/examples/ManagedResourcesTest.java
+++ b/test-poc/examples/src/test/java/org/keycloak/test/examples/ManagedResourcesTest.java
@@ -28,20 +28,20 @@ public class ManagedResourcesTest {
 
     @Test
     public void testCreatedRealm() {
-        Assertions.assertEquals(ManagedResourcesTest.class.getSimpleName(), realmResource.toRepresentation().getRealm());
+        Assertions.assertEquals("default", realmResource.toRepresentation().getRealm());
     }
 
     @Test
     public void testCreatedClient() {
-        Assertions.assertEquals(ManagedResourcesTest.class.getSimpleName(), clientResource.toRepresentation().getClientId());
+        Assertions.assertEquals("default", clientResource.toRepresentation().getClientId());
 
-        List<ClientRepresentation> clients = realmResource.clients().findByClientId(ManagedResourcesTest.class.getSimpleName());
+        List<ClientRepresentation> clients = realmResource.clients().findByClientId("default");
         Assertions.assertEquals(1, clients.size());
     }
 
     @Test
     public void testCreatedUser() {
-        Assertions.assertEquals(ManagedResourcesTest.class.getSimpleName().toLowerCase(), userResource.toRepresentation().getUsername());
+        Assertions.assertEquals("default", userResource.toRepresentation().getUsername());
     }
 
 }

--- a/test-poc/examples/src/test/java/org/keycloak/test/examples/MultipleInstancesTest.java
+++ b/test-poc/examples/src/test/java/org/keycloak/test/examples/MultipleInstancesTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.test.framework.annotations.KeycloakIntegrationTest;
 import org.keycloak.test.framework.annotations.TestClient;
 import org.keycloak.test.framework.annotations.TestRealm;
@@ -16,7 +17,7 @@ public class MultipleInstancesTest {
     @TestRealm
     RealmResource realm1;
 
-    @TestRealm(ref = "other-realm")
+    @TestRealm
     RealmResource realm2;
 
     @TestRealm(ref = "another", config = CustomRealmConfig.class)
@@ -31,8 +32,11 @@ public class MultipleInstancesTest {
     @Test
     public void testMultipleInstances() {
         Assertions.assertEquals("default", realm1.toRepresentation().getRealm());
-        Assertions.assertEquals("other-realm", realm2.toRepresentation().getRealm());
+        Assertions.assertEquals("default", realm2.toRepresentation().getRealm());
+        Assertions.assertEquals(realm1, realm2);
+
         Assertions.assertEquals("another", realm3.toRepresentation().getRealm());
+
         Assertions.assertEquals("client1", client.toRepresentation().getClientId());
         Assertions.assertEquals("default", client2.toRepresentation().getClientId());
     }

--- a/test-poc/examples/src/test/java/org/keycloak/test/examples/MultipleInstancesTest.java
+++ b/test-poc/examples/src/test/java/org/keycloak/test/examples/MultipleInstancesTest.java
@@ -1,0 +1,48 @@
+package org.keycloak.test.examples;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.test.framework.annotations.KeycloakIntegrationTest;
+import org.keycloak.test.framework.annotations.TestClient;
+import org.keycloak.test.framework.annotations.TestRealm;
+import org.keycloak.test.framework.realm.RealmConfig;
+
+@KeycloakIntegrationTest
+public class MultipleInstancesTest {
+
+    @TestRealm
+    RealmResource realm1;
+
+    @TestRealm(ref = "other-realm")
+    RealmResource realm2;
+
+    @TestRealm(ref = "another", config = CustomRealmConfig.class)
+    RealmResource realm3;
+
+    @TestClient(ref = "client1")
+    ClientResource client;
+
+    @TestClient
+    ClientResource client2;
+
+    @Test
+    public void testMultipleInstances() {
+        Assertions.assertEquals("default", realm1.toRepresentation().getRealm());
+        Assertions.assertEquals("other-realm", realm2.toRepresentation().getRealm());
+        Assertions.assertEquals("another", realm3.toRepresentation().getRealm());
+        Assertions.assertEquals("client1", client.toRepresentation().getClientId());
+        Assertions.assertEquals("default", client2.toRepresentation().getClientId());
+    }
+
+
+    public static class CustomRealmConfig implements RealmConfig {
+        @Override
+        public RealmRepresentation getRepresentation() {
+            return new RealmRepresentation();
+        }
+    }
+
+}

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/annotations/TestClient.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/annotations/TestClient.java
@@ -15,6 +15,8 @@ public @interface TestClient {
 
     Class<? extends ClientConfig> config() default DefaultClientConfig.class;
 
+    String ref() default "default";
+
     LifeCycle lifecycle() default LifeCycle.CLASS;
 
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/annotations/TestRealm.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/annotations/TestRealm.java
@@ -17,4 +17,5 @@ public @interface TestRealm {
 
     LifeCycle lifecycle() default LifeCycle.CLASS;
 
+    String ref() default "default";
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/annotations/TestUser.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/annotations/TestUser.java
@@ -17,4 +17,5 @@ public @interface TestUser {
 
     LifeCycle lifecycle() default LifeCycle.CLASS;
 
+    String ref() default "default";
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/InstanceContext.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/InstanceContext.java
@@ -15,6 +15,7 @@ public class InstanceContext<T, A extends Annotation> {
     private T value;
     private Class<? extends T> requestedValueType;
     private LifeCycle lifeCycle;
+    private final String ref;
     private final Map<String, Object> notes = new HashMap<>();
 
     public InstanceContext(Registry registry, Supplier<T, A> supplier, A annotation, Class<? extends T> requestedValueType) {
@@ -23,6 +24,7 @@ public class InstanceContext<T, A extends Annotation> {
         this.annotation = annotation;
         this.requestedValueType = requestedValueType;
         this.lifeCycle = supplier.getLifeCycle(annotation);
+        this.ref = supplier.getRef(annotation);
     }
 
     public <D> D getDependency(Class<D> typeClazz) {
@@ -51,6 +53,10 @@ public class InstanceContext<T, A extends Annotation> {
 
     public LifeCycle getLifeCycle() {
         return lifeCycle;
+    }
+
+    public String getRef() {
+        return ref;
     }
 
     public A getAnnotation() {

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Registry.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Registry.java
@@ -147,17 +147,15 @@ public class Registry {
         while (!requestedInstances.isEmpty()) {
             RequestedInstance requestedInstance = requestedInstances.remove(0);
 
-            if (getDeployedInstance(requestedInstance) != null) {
-                throw new RuntimeException("Instance ref redefinition: " + requestedInstance.getRef());
-            }
+            if (getDeployedInstance(requestedInstance) == null) {
+                InstanceContext instance = new InstanceContext(this, requestedInstance.getSupplier(), requestedInstance.getAnnotation(), requestedInstance.getValueType());
+                instance.setValue(requestedInstance.getSupplier().getValue(instance));
+                deployedInstances.add(instance);
 
-            InstanceContext instance = new InstanceContext(this, requestedInstance.getSupplier(), requestedInstance.getAnnotation(), requestedInstance.getValueType());
-            instance.setValue(requestedInstance.getSupplier().getValue(instance));
-            deployedInstances.add(instance);
-
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.tracev("Created instance: {0}",
-                        requestedInstance.getSupplier().getClass().getSimpleName());
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.tracev("Created instance: {0}",
+                            requestedInstance.getSupplier().getClass().getSimpleName());
+                }
             }
         }
     }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/RequestedInstance.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/RequestedInstance.java
@@ -8,12 +8,14 @@ public class RequestedInstance<T, A extends Annotation> {
     private final A annotation;
     private final Class<? extends T> valueType;
     private final LifeCycle lifeCycle;
+    private final String ref;
 
     public RequestedInstance(Supplier<T, A> supplier, A annotation, Class<? extends T> valueType) {
         this.supplier = supplier;
         this.annotation = annotation;
         this.valueType = valueType;
         this.lifeCycle = supplier.getLifeCycle(annotation);
+        this.ref = supplier.getRef(annotation);
     }
 
     public Supplier<T, A> getSupplier() {
@@ -30,5 +32,9 @@ public class RequestedInstance<T, A extends Annotation> {
 
     public LifeCycle getLifeCycle() {
         return lifeCycle;
+    }
+
+    public String getRef() {
+        return ref;
     }
 }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Supplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/Supplier.java
@@ -27,6 +27,20 @@ public interface Supplier<T, S extends Annotation> {
         return getDefaultLifecycle();
     }
 
+    default String getRef(S annotation) {
+        if (annotation != null) {
+            Optional<Method> ref = Arrays.stream(annotation.annotationType().getMethods()).filter(m -> m.getName().equals("ref")).findFirst();
+            if (ref.isPresent()) {
+                try {
+                    return (String) ref.get().invoke(annotation);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return "";
+    }
+
     default LifeCycle getDefaultLifecycle() {
         return LifeCycle.CLASS;
     }

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/realm/ClientSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/realm/ClientSupplier.java
@@ -33,7 +33,7 @@ public class ClientSupplier implements Supplier<ClientResource, TestClient> {
         ClientRepresentation clientRepresentation = config.getRepresentation();
 
         if (clientRepresentation.getClientId() == null) {
-            String clientId = instanceContext.getLifeCycle().equals(LifeCycle.GLOBAL) ? config.getClass().getSimpleName() : instanceContext.getRegistry().getCurrentContext().getRequiredTestClass().getSimpleName();
+            String clientId = instanceContext.getRef();
             clientRepresentation.setClientId(clientId);
         }
 

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/realm/RealmSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/realm/RealmSupplier.java
@@ -32,7 +32,7 @@ public class RealmSupplier implements Supplier<RealmResource, TestRealm> {
         RealmRepresentation realmRepresentation = config.getRepresentation();
 
         if (realmRepresentation.getRealm() == null) {
-            String realmName = instanceContext.getLifeCycle().equals(LifeCycle.GLOBAL) ? config.getClass().getSimpleName() : instanceContext.getRegistry().getCurrentContext().getRequiredTestClass().getSimpleName();
+            String realmName = instanceContext.getRef();
             realmRepresentation.setRealm(realmName);
         }
 

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/realm/UserSupplier.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/realm/UserSupplier.java
@@ -33,7 +33,7 @@ public class UserSupplier implements Supplier<UserResource, TestUser> {
         UserRepresentation userRepresentation = config.getRepresentation();
 
         if (userRepresentation.getUsername() == null) {
-            String username = instanceContext.getLifeCycle().equals(LifeCycle.GLOBAL) ? config.getClass().getSimpleName() : instanceContext.getRegistry().getCurrentContext().getRequiredTestClass().getSimpleName();
+            String username = instanceContext.getRef();
             userRepresentation.setUsername(username);
         }
 

--- a/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/RegistryTest.java
+++ b/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/RegistryTest.java
@@ -208,6 +208,35 @@ public class RegistryTest {
         assertRunning(test.child, test.child.getParent());
     }
 
+    @Test
+    public void testMultiplRef() {
+        MultipleRefTest refTest = new MultipleRefTest();
+        registry.beforeEach(refTest);
+
+        MockParentValue def1 = refTest.def;
+        MockParentValue a1 = refTest.a;
+
+        Assertions.assertNotSame(refTest.def, refTest.a);
+        Assertions.assertNotSame(refTest.def, refTest.b);
+        Assertions.assertNotSame(refTest.a, refTest.b);
+
+        assertRunning(refTest.def, refTest.a, refTest.b);
+
+        registry.afterEach();
+
+        registry.beforeEach(refTest);
+        assertRunning(refTest.def, refTest.a, refTest.b);
+
+        Assertions.assertSame(def1, refTest.def);
+        Assertions.assertSame(a1, refTest.a);
+
+        registry.afterEach();
+        assertRunning(refTest.def, refTest.a, refTest.b);
+
+        registry.afterAll();
+        assertClosed(refTest.def, refTest.a, refTest.b);
+    }
+
     public static void assertRunning(Object... values) {
         MatcherAssert.assertThat(MockInstances.INSTANCES, Matchers.hasItems(values));
         MatcherAssert.assertThat(MockInstances.INSTANCES, Matchers.hasSize(values.length));
@@ -242,5 +271,16 @@ public class RegistryTest {
 
         @MockParentAnnotation
         MockParentValue parent;
+    }
+
+    public static final class MultipleRefTest {
+        @MockParentAnnotation()
+        MockParentValue def;
+
+        @MockParentAnnotation(ref = "a")
+        MockParentValue a;
+
+        @MockParentAnnotation(ref = "b")
+        MockParentValue b;
     }
 }

--- a/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/mocks/MockParentAnnotation.java
+++ b/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/mocks/MockParentAnnotation.java
@@ -8,4 +8,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface MockParentAnnotation {
+
+    String ref() default "";
+
 }


### PR DESCRIPTION
The test framework supports injecting multiple instances of the same resource type. These instances must have a different `ref` (an identifier for instances). If an instance does not have a ref, a "default" value is assigned. There can be only one instance of a given type without a specified `ref` in the test class.

The `ref` identifiers are unique only to the type of an instance. That means this is valid:

```java
@TestRealm
RealmResource realm;    // ref="default"

@TestClient
ClientResource client;    // ref="default"

@TestUser
UserResource user;    // ref="default"

@TestRealm(ref="anotherOne")
RealmResource realm2;    // ref="anotherOne"

@TestClient(ref="anotherOne")
ClientResource client2;    // ref="anotherOne"

@TestRealm
RealmResource realm3; // ref="default"
```
In this case realm == realm3

If there is a deployed instance found that could fit the requested instance, the Registry has the following behavior to the deployed instance:

| same ref? | same config? | same lifecycle? | result                       |
|-----------|--------------|-----------------|------------------------------|
| yes       | yes          | yes             | reuse                        |
| yes       | yes          | no              | destroy and create a new one |
| yes       | no           | yes             | destroy and create a new one |
| yes       | no           | no              | destroy and create a new one |
| no        | -            | -               | keep and create a new one    |



`TestWebDriver`, `TestAdminClient`, `KeycloakIntegrationTest`, and `TestPage` are ignored in this PR.

Realms, clients, and users have their names set to their `ref`.


As this should lay down the basic concept of multiple instances of the same type being deployed within the framework, other issues may follow, for example:

- add a mechanism to specify to which realm a client and a user belong with the `realm-ref` attribute in the annotation
  `@TestUser(realm-ref="realmWithUsers")`
- allow multiple instances of the same page class

Closes #30613