### PR TITLE
Add default stack in cache-ispn.xml

### DIFF
--- a/docs/guides/high-availability/concepts-threads.adoc
+++ b/docs/guides/high-availability/concepts-threads.adoc
@@ -34,13 +34,14 @@ Low numbers ensure fast response times for all clients, even if there is an occa
 === JGroups connection pool
 
 The combined number of executor threads in all {project_name} nodes in the cluster should not exceed the number of threads available in JGroups thread pool to avoid the error `org.jgroups.util.ThreadPool: thread pool is full`.
-To see the error the first time it happens, the system property `jgroups.thread_dumps_threshold` needs to be set to `1`, as otherwise the message appears only after 10000 threads have been rejected.
+To see the error the first time it happens, the system property `jgroups.thread_dumps_threshold` needs to be set to `1`, as otherwise the message appears only after 10000 requests have been rejected.
 
 --
 include::partials/threads/executor-jgroups-thread-calculation.adoc[]
 --
 
-Use the metrics `vendor_jgroups_tcp_get_thread_pool_size` to monitor the total JGroup threads in the pool and `vendor_jgroups_tcp_get_thread_pool_size_active` for the threads active in the pool.
+Use metrics to monitor the total JGroup threads in the pool and for the threads active in the pool.
+When using TCP as the JGroups transport protocol, the metrics `vendor_jgroups_tcp_get_thread_pool_size` and `vendor_jgroups_tcp_get_thread_pool_size_active` are available for monitoring. When using UDP, the metrics `vendor_jgroups_udp_get_thread_pool_size` and `vendor_jgroups_udp_get_thread_pool_size_active` are available.
 This is useful to monitor that limiting the Quarkus thread pool size keeps the number of active JGroup threads below the maximum JGroup thread pool size.
 
 [#load-shedding]

--- a/quarkus/runtime/src/main/resources/cache-ispn.xml
+++ b/quarkus/runtime/src/main/resources/cache-ispn.xml
@@ -22,7 +22,7 @@
         xmlns="urn:infinispan:config:15.0">
 
     <cache-container name="keycloak">
-        <transport lock-timeout="60000"/>
+        <transport lock-timeout="60000" stack="udp"/>
         <local-cache name="realms" simple-cache="true">
             <encoding>
                 <key media-type="application/x-java-object"/>


### PR DESCRIPTION
A bug in Infinispan prevents the metrics to be registered if the "stack" is not specified.
Change the default configuration shipped with Keycloak to use the UDP stack as default.
UDP is the default in previous Keycloak versions.

Fixes #31218

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
