### PR TITLE
Add suffix to keycloak-authz-client artifact in keycloak repository

### DIFF
--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -11,11 +11,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>keycloak-authz-client</artifactId>
+    <artifactId>keycloak-authz-client-tests</artifactId>
     <packaging>jar</packaging>
 
     <name>Keycloak Authz: Client API</name>
-    <description>KeyCloak AuthZ: Client API</description>
+    <description>Keycloak Authz: Client API. This module is supposed to be used just in the Keycloak repository for the testsuite. It is NOT supposed to be used by the 3rd party applications.
+        For the use by 3rd party applications, please use `org.keycloak:keycloak-authz-client` module.</description>
 
     <dependencies>
         <dependency>

--- a/authz/policy-enforcer/pom.xml
+++ b/authz/policy-enforcer/pom.xml
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-authz-client</artifactId>
+            <artifactId>keycloak-authz-client-tests</artifactId>
         </dependency>
 
         <!-- Built-in Elytron/Jakarta Servlet integration  -->

--- a/boms/adapter/pom.xml
+++ b/boms/adapter/pom.xml
@@ -61,7 +61,8 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-authz-client</artifactId>
+                <!-- TODO: Adapter bom should not reference the "-tests" version. Should be improved later -->
+                <artifactId>keycloak-authz-client-tests</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-authz-client</artifactId>
+            <artifactId>keycloak-authz-client-tests</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.resteasy.reactive</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1103,7 +1103,7 @@
             <!-- Authorization -->
             <dependency>
                 <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-authz-client</artifactId>
+                <artifactId>keycloak-authz-client-tests</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1675,7 +1675,7 @@
                 </dependency>
                 <dependency>
                     <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-authz-client</artifactId>
+                    <artifactId>keycloak-authz-client-tests</artifactId>
                 </dependency>
 
                 <!--UNDERTOW-->

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -179,7 +179,7 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-authz-client</artifactId>
+            <artifactId>keycloak-authz-client-tests</artifactId>
         </dependency>
         <!-- Dependency on services from integration-arquillian -->
         <dependency>


### PR DESCRIPTION
closes #30926

This is related to the PR https://github.com/keycloak/keycloak-client/pull/7 and should be merged together with that one.

Created https://github.com/keycloak/keycloak/issues/31372 as a follow-up issue for figure how to update adapter BOM.
