### PR TITLE
Deprecate keycloak v1 and fix v2 login themes

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 dnf install -y java-21-openjdk-devel
 fips-mode-setup --enable --no-bootcfg
@@ -17,4 +17,4 @@ export JAVA_HOME=/etc/alternatives/java_sdk_21
 set -o pipefail
 
 # Profile app-server-wildfly needs to be explicitly set for FIPS tests
-./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dcom.redhat.fips=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dcom.redhat.fips=false $STRICT_OPTIONS -Dtest=$TESTS -Dlogin.theme.default=keycloak -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh

--- a/.github/scripts/run-ipa-tests.sh
+++ b/.github/scripts/run-ipa-tests.sh
@@ -47,4 +47,4 @@ echo "Building quarkus keyclok server with SSSD integration"
 ./mvnw install -nsu -B -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus
 
 echo "Executing SSSD tests"
-./mvnw -f testsuite/integration-arquillian/tests/other/sssd/pom.xml test -Psssd-testing -Pauth-server-quarkus
+./mvnw -f testsuite/integration-arquillian/tests/other/sssd/pom.xml test -Psssd-testing -Dlogin.theme.default=base -Pauth-server-quarkus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,11 @@ jobs:
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh jdk`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          if [ "$OSTYPE" == "msys" ]; then
+            ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS  "-Dwebdriver.chrome.driver=$ChromeWebDriver/chromedriver.exe" -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          else
+            ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS  "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver"     -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          fi
 
       - name: Build with JDK
         run:
@@ -349,7 +353,7 @@ jobs:
               ;;
           esac
           echo "Variant: $VARIANT"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus $VARIANT -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" $VARIANT -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()
@@ -497,7 +501,7 @@ jobs:
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh database`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Pdb-${{ matrix.db }} -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Pdb-${{ matrix.db }} "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()
@@ -590,7 +594,7 @@ jobs:
 
       - name: Run cluster tests
         run: |
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-cluster-quarkus,db-postgres -Dsession.cache.owners=2 -Dtest=**.cluster.** -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-cluster-quarkus,db-postgres "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" -Dsession.cache.owners=2 -Dtest=**.cluster.** -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()
@@ -756,7 +760,7 @@ jobs:
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh webauthn`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS -Dbrowser=${{ matrix.browser }} -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS -Dbrowser=${{ matrix.browser }} "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" "-Dwebdriver.gecko.driver=$GECKOWEBDRIVER/geckodriver" -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()
@@ -839,6 +843,7 @@ jobs:
           -Dmigration.import.file.name=migration-realm-${{ matrix.old-version }}.json \
           -Dauth.server.ssl.required=false \
           -Dauth.server.db.host=localhost \
+          "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" \
           -f testsuite/integration-arquillian/pom.xml 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -59,7 +59,9 @@ public class Profile {
 
         ADMIN2("New Admin Console", Type.DEFAULT, Feature.ADMIN_API),
 
-        LOGIN2("New Login Theme", Type.EXPERIMENTAL),
+        LOGIN2("New Login Theme", Type.DEFAULT),
+
+        LOGIN1("Legacy Login Theme", Type.DEPRECATED),
 
         DOCKER("Docker Registry protocol", Type.DISABLED_BY_DEFAULT),
 

--- a/docs/documentation/release_notes/topics/26_0_0.adoc
+++ b/docs/documentation/release_notes/topics/26_0_0.adoc
@@ -49,3 +49,9 @@ For more details, see link:{adminguide_link}#_ldap_connection_pool[Configuring t
 The `java-keystore` key provider, which allows loading a realm key from an external java keystore file, has been modified to manage all {project_name} algorithms. Besides, the keystore and key secrets, needed to retrieve the actual key from the store, can be configured using the link:{adminguide_link}#_vault-administration[vault]. Therefore a {project_name} realm can externalize any key to the encrypted file without sensitive data stored in the database.
 
 For more information about this subject, see link:{adminguide_link}#realm_keys[Configuring realm keys].
+
+= Deprecating `keycloak` login theme
+
+The `keycloak` login theme has been deprecated in favour of the new `keycloak.v2` and will be removed in a future version.
+While it remains the default for the new realms for compatibility reasons, it is strongly recommended to switch all the
+realm themes to `keycloak.v2`.

--- a/server-spi/src/main/java/org/keycloak/theme/ThemeSelectorProvider.java
+++ b/server-spi/src/main/java/org/keycloak/theme/ThemeSelectorProvider.java
@@ -52,9 +52,9 @@ public interface ThemeSelectorProvider extends Provider {
             return DEFAULT_V2;
         }
 
-        if ((type == Theme.Type.LOGIN) && Profile.isFeatureEnabled(Profile.Feature.LOGIN2)) {
-            return DEFAULT_V2;
-        }
+//        if ((type == Theme.Type.LOGIN) && Profile.isFeatureEnabled(Profile.Feature.LOGIN2)) {
+//            return DEFAULT_V2;
+//        }
 
         return DEFAULT;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -159,6 +159,8 @@ public abstract class AbstractKeycloakTest {
 
     private boolean resetTimeOffset;
 
+    private static String PREFERRED_DEFAULT_LOGIN_THEME = System.getProperty("login.theme.default");
+
     @Before
     public void beforeAbstractKeycloakTest() throws Exception {
         ProfileAssume.setTestContext(testContext);
@@ -491,7 +493,13 @@ public abstract class AbstractKeycloakTest {
             }
         }
 
-        log.debug("--importing realm: " + realm.getRealm());
+        // modify login theme if desired
+        if (PREFERRED_DEFAULT_LOGIN_THEME != null && ! PREFERRED_DEFAULT_LOGIN_THEME.isBlank() && realm.getLoginTheme() == null) {
+            log.debugf("Modifying login theme to %s", PREFERRED_DEFAULT_LOGIN_THEME);
+            realm.setLoginTheme(PREFERRED_DEFAULT_LOGIN_THEME);
+        }
+
+         log.debug("--importing realm: " + realm.getRealm());
         try {
             adminClient.realms().realm(realm.getRealm()).remove();
             log.debug("realm already existed on server, re-importing");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ServerInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ServerInfoTest.java
@@ -59,7 +59,7 @@ public class ServerInfoTest extends AbstractKeycloakTest {
         Assert.assertNames(info.getThemes().get("account"), "base", "keycloak.v3", "custom-account-provider");
         Assert.assertNames(info.getThemes().get("admin"), "base", "keycloak.v2");
         Assert.assertNames(info.getThemes().get("email"), "base", "keycloak");
-        Assert.assertNames(info.getThemes().get("login"), "address", "base", "environment-agnostic", "keycloak", "organization");
+        Assert.assertNames(info.getThemes().get("login"), "address", "base", "environment-agnostic", "keycloak", "keycloak.v2", "organization");
         Assert.assertNames(info.getThemes().get("welcome"), "keycloak");
 
         assertNotNull(info.getEnums());

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -210,6 +210,7 @@
         <browser.strict.cookies>false</browser.strict.cookies>
         <webdriverDownloadBinaries>true</webdriverDownloadBinaries>
         <droneInstantiationTimeoutInSeconds>60</droneInstantiationTimeoutInSeconds>
+        <login.theme.default/>
         <github.username/>
         <github.secretToken/>
         <ieDriverArch>Win32</ieDriverArch>
@@ -514,6 +515,7 @@
                             <htmlUnitBrowserVersion>${htmlUnitBrowserVersion}</htmlUnitBrowserVersion>
                             <webdriverDownloadBinaries>${webdriverDownloadBinaries}</webdriverDownloadBinaries>
                             <droneInstantiationTimeoutInSeconds>${droneInstantiationTimeoutInSeconds}</droneInstantiationTimeoutInSeconds>
+                            <login.theme.default>${login.theme.default}</login.theme.default>
 
                             <github.username>${github.username}</github.username>
                             <github.secretToken>${github.secretToken}</github.secretToken>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -27,7 +27,6 @@
     <script type="importmap">
         {
             "imports": {
-                "alpinejs": "${url.resourcesCommonPath}/node_modules/alpinejs/dist/module.esm.js",
                 "rfc4648": "${url.resourcesCommonPath}/node_modules/rfc4648/lib/rfc4648.js"
             }
         }
@@ -57,30 +56,7 @@
              class="${properties.kcHeaderWrapperClass!}">${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}</div>
     </div>
 </div>
-<div class="pf-v5-c-login"
-    x-data="{
-        open: false,
-        toggle() {
-            if (this.open) {
-                return this.close()
-            }
-
-            this.$refs.button.focus()
-
-            this.open = true
-        },
-        close(focusAfter) {
-            if (! this.open) return
-
-            this.open = false
-
-            focusAfter && focusAfter.focus()
-        }
-    }"
-    x-on:keydown.escape.prevent.stop="close($refs.button)"
-    x-on:focusin.window="! $refs.panel?.contains($event.target) && close()"
-    x-id="['language-select']"
->
+<div class="pf-v5-c-login">
   <div class="pf-v5-c-login__container">
     <main class="pf-v5-c-login__main">
       <header class="pf-v5-c-login__main-header">
@@ -206,11 +182,6 @@
     </main>
   </div>
 </div>
-<script type="module">
-    import Alpine from "alpinejs";
-
-    Alpine.start();
-</script>
 </body>
 </html>
 </#macro>

--- a/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
@@ -27,3 +27,6 @@ kcFormClass=pf-v5-c-form
 kcFormCardClass=card-pf
 
 kcResetFlowIcon=pf-icon fas fa-share-square
+
+kcSelectAuthListItemClass= pf-v5-c-data-list__item pf-m-clickable select-auth-box-parent
+kcSelectAuthListItemHeadingClass=pf-v5-u-font-family-heading select-auth-box-headline

--- a/themes/src/main/resources/theme/keycloak.v2/login/user-profile-commons.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/user-profile-commons.ftl
@@ -35,62 +35,25 @@
 		</#if>
 
 		<#nested "beforeField" attribute>
-		<div class="${properties.kcFormGroupClass!}" 
-		  <#if attribute.multivalued && attribute.values?has_content>
-		  x-data="{
-				values: [${(attribute.values?map(s -> s!''?js_string)?map(s -> '{ value: \'' + s + '\'}')?join(", ")!'')}],
-				kcMultivalued: ${attribute.html5DataAnnotations?keys?seq_contains('kcMultivalued')?string('true', 'false')}
-			}"
-		<#else>
-		  x-data="{
-				values: [{ value: '${(attribute.value!'')}' }],
-				kcMultivalued: ${attribute.html5DataAnnotations?keys?seq_contains('kcMultivalued')?string('true', 'false')}
-			}"
-			</#if>
-		>
-			<label for="${attribute.name}" class="${properties.kcLabelClass!}">
-				<span class="pf-v5-c-form__label-text">
-					${advancedMsg(attribute.displayName!'')}
-					<#if attribute.required>
-						<span class="pf-v5-c-form__label-required" aria-hidden="true">&#42;</span>
-					</#if>
-				</span>
-			</label>
-			<template x-for="(item, index) in values">
-			<div :class="kcMultivalued ? 'pf-v5-c-input-group' : ''">
-				<div :class="kcMultivalued ? 'pf-v5-c-input-group__item pf-m-fill' : ''">
-					<span class="${properties.kcInputClass!}" >
-						<#if attribute.annotations.inputHelperTextBefore??>
-							<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
-						</#if>
-							<@inputFieldByType attribute=attribute/>
-						<#if messagesPerField.existsError('${attribute.name}')>
-							<span id="input-error-${attribute.name}" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-								${kcSanitize(messagesPerField.get('${attribute.name}'))?no_esc}
-							</span>
-						</#if>
-						<#if attribute.annotations.inputHelperTextAfter??>
-							<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
-						</#if>
-					</span>
-				</div>
-				<div class="pf-v5-c-input-group__item" x-show="kcMultivalued">
-					<button
-						class="pf-v5-c-button pf-m-control"
-						type="button"
-						:id="$id('kc-remove-${attribute.name}')"
-						x-bind:disabled="index == 0 && values.length == 1"
-						x-on:click="values.splice(index, 1); $dispatch('bind')"
-					>
-						<svg fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img" style="vertical-align: -0.125em;"><path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zM124 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H124z"></path></svg>
-					</button>
-				</div>
+		<div class="${properties.kcFormGroupClass!}">
+			<div class="${properties.kcLabelWrapperClass!}">
+				<label for="${attribute.name}" class="${properties.kcLabelClass!}">${advancedMsg(attribute.displayName!'')}</label>
+				<#if attribute.required>*</#if>
 			</div>
-			</template>
-			<button type="button" class="pf-v5-c-button pf-m-link" x-show="kcMultivalued" x-on:click="values.push({ value: '' }); $dispatch('bind')" id="kc-add-${attribute.name}">
-				<svg fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img" style="vertical-align: -0.125em;"><path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"></path></svg>
-				Add ${advancedMsg(attribute.displayName!'')}
-			</button>
+			<div class="${properties.kcInputWrapperClass!}">
+				<#if attribute.annotations.inputHelperTextBefore??>
+					<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
+				</#if>
+				<@inputFieldByType attribute=attribute/>
+				<#if messagesPerField.existsError('${attribute.name}')>
+					<span id="input-error-${attribute.name}" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+						${kcSanitize(messagesPerField.get('${attribute.name}'))?no_esc}
+					</span>
+				</#if>
+				<#if attribute.annotations.inputHelperTextAfter??>
+					<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
+				</#if>
+			</div>
 		</div>
 		<#nested "afterField" attribute>
 	</#list>
@@ -114,12 +77,18 @@
 		<@inputTagSelects attribute=attribute/>
 		<#break>
 	<#default>
-		<@inputTag attribute=attribute value=attribute.value!/>
+		<#if attribute.multivalued && attribute.values?has_content>
+			<#list attribute.values as value>
+				<@inputTag attribute=attribute value=value!''/>
+			</#list>
+		<#else>
+			<@inputTag attribute=attribute value=attribute.value!''/>
+		</#if>
 	</#switch>
 </#macro>
 
 <#macro inputTag attribute value>
-	<input type="<@inputTagType attribute=attribute/>" :id="kcMultivalued ? $id('${attribute.name}') : '${attribute.name}'" name="${attribute.name}" :value="item.value" class="${properties.kcInputClass!}"
+	<input type="<@inputTagType attribute=attribute/>" id="${attribute.name}" name="${attribute.name}" value="${(value!'')}" class="${properties.kcInputClass!}"
 		aria-invalid="<#if messagesPerField.existsError('${attribute.name}')>true</#if>"
 		<#if attribute.readOnly>disabled</#if>
 		<#if attribute.autocomplete??>autocomplete="${attribute.autocomplete}"</#if>


### PR DESCRIPTION
This PR contains everything apart from running the testsuite in GHA from #30319, and on top of it marks the `keycloak` login theme as deprecated in favour of `keycloak.v2`, while keeping the `keycloak` login theme still the one selected in the new realm for compatibility purpose.

Merging this PR would merge most of the commits in #30319. Subsequently that PR would be changed to switch to `keycloak.v2` for GHA.

cc: @ssilvert @edewit 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
