### PR TITLE
Fixed feedback discussions

### DIFF
--- a/js/apps/admin-ui/src/components/bread-crumb/PageBreadCrumbs.tsx
+++ b/js/apps/admin-ui/src/components/bread-crumb/PageBreadCrumbs.tsx
@@ -25,7 +25,7 @@ export const PageBreadCrumbs = () => {
   const crumbs = uniqBy(
     useBreadcrumbs(routesWithCrumbs, {
       disableDefaults: true,
-      excludePaths: ["/", `/${realm}`],
+      excludePaths: ["/", `/${realm}`, `/${realm}/page-section`],
     }),
     elementText,
   );

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -70,7 +70,7 @@ export const PageHandler = ({
       } else {
         await adminClient.components.create(updatedComponent);
       }
-      addAlert("itemSaveSuccessful");
+      addAlert(t("itemSaveSuccessful"));
     } catch (error) {
       addError("itemSaveError", error);
     }

--- a/js/apps/admin-ui/src/page/routes.tsx
+++ b/js/apps/admin-ui/src/page/routes.tsx
@@ -3,7 +3,7 @@ import type { AppRouteObject } from "../routes";
 import { lazy } from "react";
 
 export type PageListParams = { realm?: string; providerId: string };
-export type PageParams = { realm: string; providerId: string; id?: string };
+export type PageParams = { realm: string; providerId: string; id: string };
 
 const PageList = lazy(() => import("./PageList"));
 const Page = lazy(() => import("./Page"));
@@ -18,15 +18,28 @@ const PageListRoute: AppRouteObject = {
 };
 
 const PageDetailRoute: AppRouteObject = {
-  path: "/:realm/page/:providerId/:id?",
+  path: "/:realm/page-section/:providerId/:id",
   element: <Page />,
-  breadcrumb: (t) => t("page"),
+  breadcrumb: (t) => t("details"),
   handle: {
     access: "view-realm",
   },
 };
 
-const routes: AppRouteObject[] = [PageListRoute, PageDetailRoute];
+const AddPageDetailRoute: AppRouteObject = {
+  path: "/:realm/page-section/:providerId/add",
+  element: <Page />,
+  breadcrumb: (t) => t("add"),
+  handle: {
+    access: "view-realm",
+  },
+};
+
+const routes: AppRouteObject[] = [
+  PageDetailRoute,
+  AddPageDetailRoute,
+  PageListRoute,
+];
 
 export const toPage = (params: PageListParams): Partial<Path> => ({
   pathname: generatePath(PageListRoute.path, params),
@@ -34,6 +47,10 @@ export const toPage = (params: PageListParams): Partial<Path> => ({
 
 export const toDetailPage = (params: PageParams): Partial<Path> => ({
   pathname: generatePath(PageDetailRoute.path, params),
+});
+
+export const addDetailPage = (params: Partial<PageParams>): Partial<Path> => ({
+  pathname: generatePath(AddPageDetailRoute.path, params),
 });
 
 export default routes;


### PR DESCRIPTION
You can now specify which fields are displayed in the list by implementing:

```java
    @Override
    public Map<String, Object> getTypeMetadata() {
        Map<String, Object> metaData = new HashMap<>();
        metaData.put("displayFields", List.of("name", "prio"));
        return metaData;
    }
```
This will show only `name` and `prio` and use the first field (e.g. `name`) on the detail screen

see: #24805
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
