### PR TITLE
Fix javadoc generation issue

### DIFF
--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -67,6 +67,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
javadoc distribution was broken by https://github.com/keycloak/keycloak/pull/30920, this is a quick fix so we can get releases working again.