### PR TITLE
fix: additional consolidation / refinement of argument parsing

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -156,8 +156,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
                 // the weaknesses here:
                 // - needs to know all of the short name options that accept a value
                 // - does not know all of the picocli parsing rules. picocli will accept -cffile, and short option grouping - that's not accounted for
-                // - does not understand spi options, they will be assumed to be unary
-                if (mapper != null || SHORT_OPTIONS_ACCEPTING_VALUE.contains(key)) {
+                if (mapper != null || SHORT_OPTIONS_ACCEPTING_VALUE.contains(key) || arg.startsWith("--spi")) {
                     i++; // consume next as a value to the key
                     value = args.get(i);
                 } else {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSourceTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSourceTest.java
@@ -33,5 +33,12 @@ public class ConfigArgsConfigSourceTest {
         ConfigArgsConfigSource.parseConfigArgs(Arrays.asList("--key=value", "-cf", "file", "command", "arg", "--db", "value"), (key, value) -> values.add(key+'='+value), values::add);
         assertEquals(Arrays.asList("--key=value", "-cf=file", "command", "arg", "--db=value"), values);
     }
+    
+    @Test
+    public void testParseArgsWithSpi() {
+        List<String> values = new ArrayList<>();
+        ConfigArgsConfigSource.parseConfigArgs(Arrays.asList("--spi-some-thing-enabled=value", "--spi-some-thing-else", "other-value"), (key, value) -> values.add(key+'='+value), ignored -> {});
+        assertEquals(Arrays.asList("--spi-some-thing-enabled=value", "--spi-some-thing-else=other-value"), values);
+    }
 
 }

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -60,7 +59,6 @@ import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_SHORT_NA
 public class CLITestExtension extends QuarkusMainTestExtension {
 
     private static final String SYS_PROPS = "sys-props";
-    private static final String KEY_VALUE_SEPARATOR = "[=]";
     private KeycloakDistribution dist;
     private DatabaseContainer databaseContainer;
     private InfinispanContainer infinispanContainer;
@@ -73,24 +71,17 @@ public class CLITestExtension extends QuarkusMainTestExtension {
         getStore(context).put(SYS_PROPS, new HashMap<>(System.getProperties()));
 
         if (launch != null && distConfig == null) {
-            for (String arg : launch.value()) {
-                if (arg.contains(CONFIG_FILE_SHORT_NAME) || arg.contains(CONFIG_FILE_LONG_NAME)) {
-                    Pattern kvSeparator = Pattern.compile(KEY_VALUE_SEPARATOR);
-                    String[] cfKeyValue = kvSeparator.split(arg);
-                    setProperty(KeycloakPropertiesConfigSource.KEYCLOAK_CONFIG_FILE_PROP, cfKeyValue[1]);
+            ConfigArgsConfigSource.parseConfigArgs(List.of(launch.value()), (arg, value) -> {
+                if (arg.equals(CONFIG_FILE_SHORT_NAME) || arg.equals(CONFIG_FILE_LONG_NAME)) {
+                    setProperty(KeycloakPropertiesConfigSource.KEYCLOAK_CONFIG_FILE_PROP, value);
                 } else if (arg.startsWith("-D")) {
-                    // allow setting system properties from JVM tests
-                    int keyValueSeparator = arg.indexOf('=');
-
-                    if (keyValueSeparator == -1) {
-                        continue;
-                    }
-
-                    String name = arg.substring(2, keyValueSeparator);
-                    String value = arg.substring(keyValueSeparator + 1);
-                    setProperty(name, value);
+                    setProperty(arg, value);
                 }
-            }
+            }, arg -> {
+                if (arg.startsWith("-D")) {
+                    setProperty(arg, "");
+                }
+            });
         }
 
         configureDatabase(context);


### PR DESCRIPTION
closes: #26339 #31578

Took another pass over the various parsing we are doing to make another consolidation. It is possible that we could do the initial parsing / filtering to a better structure than just a list of strings to avoid the key parsing in subsequent passes. However that changes quite a bit of logic so it doesn't seem worth it.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
