### PR TITLE
Testsuite PoC - Add more unit tests for the registry

### DIFF
--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/config/Config.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/config/Config.java
@@ -17,7 +17,7 @@ public class Config {
         return config.getOptionalValue("kc.test." + ValueTypeAlias.getAlias(valueType), String.class).orElse(null);
     }
 
-    private static SmallRyeConfig initConfig() {
+    public static SmallRyeConfig initConfig() {
         SmallRyeConfigBuilder configBuilder = new SmallRyeConfigBuilder()
                 .addDefaultSources()
                 .addDefaultInterceptors()

--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/ValueTypeAlias.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/injection/ValueTypeAlias.java
@@ -14,7 +14,7 @@ public class ValueTypeAlias {
             TestDatabase.class, "database"
     );
 
-    public static String getAlias(Class clazz) {
+    public static String getAlias(Class<?> clazz) {
         String alias = aliases.get(clazz);
         if (alias == null) {
             alias = clazz.getSimpleName();

--- a/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/ValueTypeAliasTest.java
+++ b/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/ValueTypeAliasTest.java
@@ -1,0 +1,20 @@
+package org.keycloak.test.framework.injection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.openqa.selenium.WebDriver;
+
+public class ValueTypeAliasTest {
+
+    @Test
+    public void withAlias() {
+        Assertions.assertEquals("browser", ValueTypeAlias.getAlias(WebDriver.class));
+    }
+
+    @Test
+    public void withoutAlias() {
+        Assertions.assertEquals("Keycloak", ValueTypeAlias.getAlias(Keycloak.class));
+    }
+
+}

--- a/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/mocks/MockParent2Supplier.java
+++ b/test-poc/framework/src/test/java/org/keycloak/test/framework/injection/mocks/MockParent2Supplier.java
@@ -5,14 +5,12 @@ import org.keycloak.test.framework.injection.LifeCycle;
 import org.keycloak.test.framework.injection.RequestedInstance;
 import org.keycloak.test.framework.injection.Supplier;
 
-public class MockParentSupplier implements Supplier<MockParentValue, MockParentAnnotation> {
+public class MockParent2Supplier implements Supplier<MockParentValue, MockParentAnnotation> {
 
     public static LifeCycle DEFAULT_LIFECYCLE = LifeCycle.CLASS;
-    public static boolean COMPATIBLE = true;
 
     public static void reset() {
         DEFAULT_LIFECYCLE = LifeCycle.CLASS;
-        COMPATIBLE = true;
     }
 
     @Override
@@ -32,7 +30,7 @@ public class MockParentSupplier implements Supplier<MockParentValue, MockParentA
 
     @Override
     public boolean compatible(InstanceContext<MockParentValue, MockParentAnnotation> a, RequestedInstance<MockParentValue, MockParentAnnotation> b) {
-        return COMPATIBLE;
+        return true;
     }
 
     @Override

--- a/test-poc/framework/src/test/resources/META-INF/services/org.keycloak.test.framework.injection.Supplier
+++ b/test-poc/framework/src/test/resources/META-INF/services/org.keycloak.test.framework.injection.Supplier
@@ -1,2 +1,3 @@
 org.keycloak.test.framework.injection.mocks.MockParentSupplier
+org.keycloak.test.framework.injection.mocks.MockParent2Supplier
 org.keycloak.test.framework.injection.mocks.MockChildSupplier


### PR DESCRIPTION
Add more tests for the registry, and fix a bug that was found with RegistryTest#testDependencyRequestedAfter (if a child was present in the test before the parent, the parent ended up being created twice).