### PR TITLE
Filter out null values when looking up entries by ID

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -278,7 +278,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         query.setParameter("realm", realm.getId());
         Stream<String> roles = query.getResultStream();
 
-        return closing(roles.map(realm::getRoleById));
+        return closing(roles.map(realm::getRoleById).filter(Objects::nonNull));
     }
 
     @Override
@@ -331,7 +331,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
                 .setParameter("ids", ids.collect(Collectors.toList()));
 
         return closing(paginateQuery(query, first, max).getResultStream())
-                .map(g -> session.roles().getRoleById(realm, g));
+                .map(g -> session.roles().getRoleById(realm, g)).filter(Objects::nonNull);
     }
 
     @Override
@@ -555,7 +555,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
                 .setParameter("ids", idsList);
 
         return closing(paginateQuery(query, first, max).getResultStream())
-                .map(g -> session.groups().getGroupById(realm, g));
+                .map(g -> session.groups().getGroupById(realm, g)).filter(Objects::nonNull);
     }
 
     @Override
@@ -575,7 +575,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
 
         return closing(paginateQuery(query, first, max).getResultStream())
-                .map(g -> session.groups().getGroupById(realm, g));
+                .map(g -> session.groups().getGroupById(realm, g)).filter(Objects::nonNull);
     }
 
     @Override
@@ -892,7 +892,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
         TypedQuery<String> query = em.createQuery(queryBuilder);
         return closing(paginateQuery(query, firstResult, maxResults).getResultStream())
-                .map(id -> session.clients().getClientById(realm, id));
+                .map(id -> session.clients().getClientById(realm, id)).filter(Objects::nonNull);
     }
 
     @Override
@@ -937,7 +937,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
         TypedQuery<String> query = em.createQuery(queryBuilder);
         return closing(paginateQuery(query, firstResult, maxResults).getResultStream())
-                .map(id -> session.clients().getClientById(realm, id));
+                .map(id -> session.clients().getClientById(realm, id)).filter(Objects::nonNull);
     }
 
     @Override
@@ -1007,7 +1007,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         query.setParameter("realm", realm.getId());
         Stream<String> scopes = query.getResultStream();
 
-        return closing(scopes.map(realm::getClientScopeById));
+        return closing(scopes.map(realm::getClientScopeById).filter(Objects::nonNull));
     }
 
     @Override
@@ -1132,7 +1132,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
                 .setParameter("search", search);
         Stream<String> groups =  paginateQuery(query, first, max).getResultStream();
 
-        return closing(groups.map(id -> session.groups().getGroupById(realm, id)).sorted(GroupModel.COMPARE_BY_NAME).distinct());
+        return closing(groups.map(id -> session.groups().getGroupById(realm, id)).filter(Objects::nonNull).sorted(GroupModel.COMPARE_BY_NAME).distinct());
     }
 
     @Override


### PR DESCRIPTION
This should prevent null elements in the stream when doing concurrent operations.

Closes #28865

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
