### PR TITLE
Remove TrustedHostClientRegistrationPolicyTest#testGithubDomain

### DIFF
--- a/services/src/test/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicyTest.java
+++ b/services/src/test/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicyTest.java
@@ -16,8 +16,6 @@
  */
 package org.keycloak.services.clientregistration.policy.impl;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -98,20 +96,6 @@ public class TrustedHostClientRegistrationPolicyTest {
         policy.checkURLTrusted("https://www.googlebot.com", policy.getTrustedHosts(), policy.getTrustedDomains());
         policy.checkURLTrusted("https://googlebot.com", policy.getTrustedHosts(), policy.getTrustedDomains());
         Assert.assertThrows(ClientRegistrationPolicyException.class, () -> policy.checkURLTrusted("https://www.othergooglebot.com",
-                policy.getTrustedHosts(), policy.getTrustedDomains()));
-    }
-
-    @Test
-    public void testGithubDomain() throws UnknownHostException {
-        TrustedHostClientRegistrationPolicyFactory factory = new TrustedHostClientRegistrationPolicyFactory();
-        ComponentModel model = createComponentModel("*.github.com");
-        TrustedHostClientRegistrationPolicy policy = (TrustedHostClientRegistrationPolicy) factory.create(session, model);
-
-        policy.verifyHost(InetAddress.getByName("www.github.com").getHostAddress());
-        policy.verifyHost(InetAddress.getByName("github.com").getHostAddress());
-        policy.checkURLTrusted("https://www.github.com", policy.getTrustedHosts(), policy.getTrustedDomains());
-        policy.checkURLTrusted("https://github.com", policy.getTrustedHosts(), policy.getTrustedDomains());
-        Assert.assertThrows(ClientRegistrationPolicyException.class, () -> policy.checkURLTrusted("https://othergithub.com",
                 policy.getTrustedHosts(), policy.getTrustedDomains()));
     }
 


### PR DESCRIPTION
Closes #29271

Just removing the test `TrustedHostClientRegistrationPolicyTest#testGithubDomain` because it's causing issues in some regions. The test tries to check reverse lookup using `github.com` but it seems that in different regions the reverse lookup returns microsoft (not github) domain. In general the previous test `testGoogleCrawlBot` is documented to work and this one was added to use more than one IP/hostname pair. So we are already covered by the other test but using just one IP.
