### PR TITLE
Renaming the team cross-dc team to SRE

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -39,7 +39,7 @@ team/core-shared:
   - area/infinispan
   - area/storage
 
-team/cross-dc:
+team/sre:
 
 team/ui:
   - area/account/ui


### PR DESCRIPTION
The team's focus changed to handle all things around running Keycloak in production environments and under load, so the name changes with it.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
