### PR TITLE
31250 Add JPA implementation for IDPProvider

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
@@ -40,7 +40,6 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.IdentityProviderMapperModel;
-import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.OAuth2DeviceConfig;
 import org.keycloak.models.OTPPolicy;
 import org.keycloak.models.ParConfig;
@@ -127,7 +126,6 @@ public class CachedRealm extends AbstractExtendableRevisioned {
     protected MultivaluedMap<String, ComponentModel> componentsByParent = new MultivaluedHashMap<>();
     protected MultivaluedMap<String, ComponentModel> componentsByParentAndType = new ConcurrentMultivaluedHashMap<>();
     protected Map<String, ComponentModel> components;
-    protected List<IdentityProviderModel> identityProviders;
 
     protected Map<String, String> browserSecurityHeaders;
     protected Map<String, String> smtpConfig;
@@ -145,7 +143,6 @@ public class CachedRealm extends AbstractExtendableRevisioned {
 
     protected AuthenticationFlowModel browserFlow;
     protected AuthenticationFlowModel registrationFlow;
-    protected AuthenticationFlowModel orgRegistrationFlow;
     protected AuthenticationFlowModel directGrantFlow;
     protected AuthenticationFlowModel resetCredentialsFlow;
     protected AuthenticationFlowModel clientAuthenticationFlow;
@@ -195,7 +192,6 @@ public class CachedRealm extends AbstractExtendableRevisioned {
         loginWithEmailAllowed = model.isLoginWithEmailAllowed();
         duplicateEmailsAllowed = model.isDuplicateEmailsAllowed();
         resetPasswordAllowed = model.isResetPasswordAllowed();
-        identityFederationEnabled = model.isIdentityFederationEnabled();
         editUsernameAllowed = model.isEditUsernameAllowed();
         organizationsEnabled = model.isOrganizationsEnabled();
         //--- brute force settings
@@ -248,10 +244,6 @@ public class CachedRealm extends AbstractExtendableRevisioned {
 
         requiredCredentials = model.getRequiredCredentialsStream().collect(Collectors.toList());
         userActionTokenLifespans = Collections.unmodifiableMap(new HashMap<>(model.getUserActionTokenLifespans()));
-
-        this.identityProviders = model.getIdentityProvidersStream().map(IdentityProviderModel::new)
-                .collect(Collectors.toList());
-        this.identityProviders = Collections.unmodifiableList(this.identityProviders);
 
         this.identityProviderMapperSet = model.getIdentityProviderMappersStream().collect(Collectors.toSet());
         for (IdentityProviderMapperModel mapper : identityProviderMapperSet) {
@@ -561,10 +553,6 @@ public class CachedRealm extends AbstractExtendableRevisioned {
         return passwordPolicy;
     }
 
-    public boolean isIdentityFederationEnabled() {
-        return identityFederationEnabled;
-    }
-
     public Map<String, String> getSmtpConfig() {
         return smtpConfig;
     }
@@ -615,10 +603,6 @@ public class CachedRealm extends AbstractExtendableRevisioned {
 
     public boolean isAdminEventsDetailsEnabled() {
         return adminEventsDetailsEnabled;
-    }
-
-    public List<IdentityProviderModel> getIdentityProviders() {
-        return identityProviders;
     }
 
     public boolean isInternationalizationEnabled() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaIDPProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaIDPProvider.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.jpa;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.jboss.logging.Logger;
+import org.keycloak.broker.provider.IdentityProvider;
+import org.keycloak.broker.provider.IdentityProviderFactory;
+import org.keycloak.broker.social.SocialIdentityProvider;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.IDPProvider;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.jpa.entities.IdentityProviderEntity;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.utils.StringUtil;
+
+import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
+import static org.keycloak.utils.StreamsUtil.closing;
+
+/**
+ * A JPA based implementation of {@link IDPProvider}.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class JpaIDPProvider implements IDPProvider {
+
+    protected static final Logger logger = Logger.getLogger(IDPProvider.class);
+
+    private final EntityManager em;
+    private final KeycloakSession session;
+
+    public JpaIDPProvider(KeycloakSession session) {
+        this.session = session;
+        this.em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+
+    @Override
+    public IdentityProviderModel create(IdentityProviderModel identityProvider) {
+        IdentityProviderEntity entity = new IdentityProviderEntity();
+        if (identityProvider.getInternalId() == null) {
+            entity.setInternalId(KeycloakModelUtils.generateId());
+        } else {
+            entity.setInternalId(identityProvider.getInternalId());
+        }
+
+        entity.setAlias(identityProvider.getAlias());
+        entity.setRealmId(this.getRealm().getId());
+        entity.setDisplayName(identityProvider.getDisplayName());
+        entity.setProviderId(identityProvider.getProviderId());
+        entity.setEnabled(identityProvider.isEnabled());
+        entity.setStoreToken(identityProvider.isStoreToken());
+        entity.setAddReadTokenRoleOnCreate(identityProvider.isAddReadTokenRoleOnCreate());
+        entity.setTrustEmail(identityProvider.isTrustEmail());
+        entity.setAuthenticateByDefault(identityProvider.isAuthenticateByDefault());
+        entity.setFirstBrokerLoginFlowId(identityProvider.getFirstBrokerLoginFlowId());
+        entity.setPostBrokerLoginFlowId(identityProvider.getPostBrokerLoginFlowId());
+        entity.setConfig(identityProvider.getConfig());
+        entity.setLinkOnly(identityProvider.isLinkOnly());
+        em.persist(entity);
+        // flush so that constraint violations are flagged and converted into model exception now rather than at the end of the tx.
+        em.flush();
+
+        identityProvider.setInternalId(entity.getInternalId());
+        return identityProvider;
+    }
+
+    @Override
+    public void update(IdentityProviderModel identityProvider) {
+        // find idp by id and update it.
+        IdentityProviderEntity entity = this.getEntityById(identityProvider.getInternalId(), true);
+        entity.setAlias(identityProvider.getAlias());
+        entity.setDisplayName(identityProvider.getDisplayName());
+        entity.setEnabled(identityProvider.isEnabled());
+        entity.setTrustEmail(identityProvider.isTrustEmail());
+        entity.setAuthenticateByDefault(identityProvider.isAuthenticateByDefault());
+        entity.setFirstBrokerLoginFlowId(identityProvider.getFirstBrokerLoginFlowId());
+        entity.setPostBrokerLoginFlowId(identityProvider.getPostBrokerLoginFlowId());
+        entity.setAddReadTokenRoleOnCreate(identityProvider.isAddReadTokenRoleOnCreate());
+        entity.setStoreToken(identityProvider.isStoreToken());
+        entity.setConfig(identityProvider.getConfig());
+        entity.setLinkOnly(identityProvider.isLinkOnly());
+
+        // flush so that constraint violations are flagged and converted into model exception now rather than at the end of the tx.
+        em.flush();
+
+        // send identity provider updated event.
+        RealmModel realm = this.getRealm();
+        session.getKeycloakSessionFactory().publish(new RealmModel.IdentityProviderUpdatedEvent() {
+
+            @Override
+            public RealmModel getRealm() {
+                return realm;
+            }
+
+            @Override
+            public IdentityProviderModel getUpdatedIdentityProvider() {
+                return identityProvider;
+            }
+
+            @Override
+            public KeycloakSession getKeycloakSession() {
+                return session;
+            }
+        });
+    }
+
+    @Override
+    public boolean remove(String alias) {
+        // find provider by alias in the DB and remove it.
+        IdentityProviderEntity entity = this.getEntityByAlias(alias);
+
+        if (entity != null) {
+            em.remove(entity);
+            // flush so that constraint violations are flagged and converted into model exception now rather than at the end of the tx.
+            em.flush();
+
+            // send identity provider removed event.
+            RealmModel realm = this.getRealm();
+            IdentityProviderModel model = toModel(entity);
+            session.getKeycloakSessionFactory().publish(new RealmModel.IdentityProviderRemovedEvent() {
+
+                @Override
+                public RealmModel getRealm() {
+                    return realm;
+                }
+
+                @Override
+                public IdentityProviderModel getRemovedIdentityProvider() {
+                    return model;
+                }
+
+                @Override
+                public KeycloakSession getKeycloakSession() {
+                    return session;
+                }
+            });
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void removeAll() {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaDelete<IdentityProviderEntity> delete = builder.createCriteriaDelete(IdentityProviderEntity.class);
+        Root<IdentityProviderEntity> idp = delete.from(IdentityProviderEntity.class);
+        delete.where(builder.equal(idp.get("realmId"), this.getRealm().getId()));
+        this.em.createQuery(delete).executeUpdate();
+    }
+
+    @Override
+    public IdentityProviderModel getById(String internalId) {
+        return toModel(getEntityById(internalId, false));
+    }
+
+    @Override
+    public IdentityProviderModel getByAlias(String alias) {
+        return toModel(getEntityByAlias(alias));
+    }
+
+    @Override
+    public Stream<IdentityProviderModel> getAllStream(String search, Integer first, Integer max) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<IdentityProviderEntity> query = builder.createQuery(IdentityProviderEntity.class);
+        Root<IdentityProviderEntity> idp = query.from(IdentityProviderEntity.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(builder.equal(idp.get("realmId"), getRealm().getId()));
+
+        if (StringUtil.isNotBlank(search)) {
+            if (search.startsWith("\"") && search.endsWith("\"")) {
+                // exact search - alias must be an exact match
+                search = search.substring(1, search.length() - 1);
+                predicates.add(builder.equal(idp.get("alias"), search));
+            } else {
+                search = search.replace("%", "\\%").replace("_", "\\_").replace("*", "%");
+                if (!search.endsWith("%")) {
+                    search += "%"; // default to prefix search
+                }
+
+                predicates.add(builder.like(builder.lower(idp.get("alias")), search.toLowerCase(), '\\'));
+            }
+        }
+
+        query.orderBy(builder.asc(idp.get("alias")));
+        TypedQuery<IdentityProviderEntity> typedQuery = em.createQuery(query.select(idp).where(predicates.toArray(Predicate[]::new)));
+        return closing(paginateQuery(typedQuery, first, max).getResultStream()).map(this::toModel);
+    }
+
+    @Override
+    public Stream<IdentityProviderModel> getAllStream(Map<String, String> attrs, Integer first, Integer max) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<IdentityProviderEntity> query = builder.createQuery(IdentityProviderEntity.class);
+        Root<IdentityProviderEntity> idp = query.from(IdentityProviderEntity.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(builder.equal(idp.get("realmId"), getRealm().getId()));
+
+        if (attrs != null) {
+            for (Map.Entry<String, String> entry : attrs.entrySet()) {
+                if (StringUtil.isBlank(entry.getKey())) {
+                    continue;
+                }
+                Join<IdentityProviderEntity, Object> configJoin = idp.join("config", JoinType.LEFT);
+                predicates.add(builder.and(
+                        builder.equal(configJoin.get("name"), entry.getKey()),
+                        builder.equal(configJoin.get("value"), entry.getValue())));
+            }
+        }
+
+        query.orderBy(builder.asc(idp.get("alias")));
+        TypedQuery<IdentityProviderEntity> typedQuery = em.createQuery(query.select(idp).where(predicates.toArray(Predicate[]::new)));
+        return closing(paginateQuery(typedQuery, first, max).getResultStream()).map(this::toModel);
+    }
+
+    @Override
+    public long count() {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> query = builder.createQuery(Long.class);
+        Root<IdentityProviderEntity> idp = query.from(IdentityProviderEntity.class);
+        query.select(builder.count(query.from(IdentityProviderEntity.class)));
+        query.where(builder.equal(idp.get("realmId"), getRealm().getId()));
+        return em.createQuery(query).getSingleResult();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private IdentityProviderEntity getEntityById(String id, boolean failIfNotFound) {
+        IdentityProviderEntity entity = em.find(IdentityProviderEntity.class, id);
+        if (entity == null) {
+            if (failIfNotFound) {
+                throw new ModelException("Identity Provider with internal id [" + id + "] does not exist");
+            }
+            return null;
+        }
+
+        // check realm to ensure this entity is fetched in the context of the correct realm.
+        if (!this.getRealm().getId().equals(entity.getRealmId())) {
+            throw new ModelException("Identity Provider with internal id [" + entity.getInternalId() + "] does not belong to realm [" + getRealm().getName() + "]");
+        }
+        return entity;
+    }
+
+    private IdentityProviderEntity getEntityByAlias(String alias) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<IdentityProviderEntity> query = builder.createQuery(IdentityProviderEntity.class);
+        Root<IdentityProviderEntity> idp = query.from(IdentityProviderEntity.class);
+
+        Predicate predicate = builder.and(builder.equal(idp.get("realmId"), getRealm().getId()),
+                builder.equal(idp.get("alias"), alias));
+
+        TypedQuery<IdentityProviderEntity> typedQuery = em.createQuery(query.select(idp).where(predicate));
+        try {
+            return typedQuery.getSingleResult();
+        } catch (NoResultException nre) {
+            return null;
+        }
+    }
+
+    private IdentityProviderModel toModel(IdentityProviderEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        IdentityProviderModel identityProviderModel = getModelFromProviderFactory(entity.getProviderId());
+        identityProviderModel.setProviderId(entity.getProviderId());
+        identityProviderModel.setAlias(entity.getAlias());
+        identityProviderModel.setDisplayName(entity.getDisplayName());
+        identityProviderModel.setInternalId(entity.getInternalId());
+        Map<String, String> config = new HashMap<>(entity.getConfig());
+        identityProviderModel.setConfig(config);
+        identityProviderModel.setEnabled(entity.isEnabled());
+        identityProviderModel.setLinkOnly(entity.isLinkOnly());
+        identityProviderModel.setTrustEmail(entity.isTrustEmail());
+        identityProviderModel.setAuthenticateByDefault(entity.isAuthenticateByDefault());
+        identityProviderModel.setFirstBrokerLoginFlowId(entity.getFirstBrokerLoginFlowId());
+        identityProviderModel.setPostBrokerLoginFlowId(entity.getPostBrokerLoginFlowId());
+        identityProviderModel.setStoreToken(entity.isStoreToken());
+        identityProviderModel.setAddReadTokenRoleOnCreate(entity.isAddReadTokenRoleOnCreate());
+
+        return identityProviderModel;
+    }
+
+    private IdentityProviderModel getModelFromProviderFactory(String providerId) {
+
+        IdentityProviderFactory factory = (IdentityProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(IdentityProvider.class, providerId);
+        if (factory == null) {
+            factory = (IdentityProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(SocialIdentityProvider.class, providerId);
+        }
+
+        if (factory != null) {
+            return factory.createConfig();
+        } else {
+            logger.warn("Couldn't find a suitable identity provider factory for " + providerId);
+            return new IdentityProviderModel();
+        }
+    }
+
+    private RealmModel getRealm() {
+        RealmModel realm = session.getContext().getRealm();
+        if (realm == null) {
+            throw new IllegalStateException("Session not bound to a realm");
+        }
+        return realm;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaIDPProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaIDPProviderFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.jpa;
+
+import org.keycloak.Config;
+import org.keycloak.models.IDPProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * A JPA based implementation of {@link IDPProviderFactory}.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class JpaIDPProviderFactory implements IDPProviderFactory<JpaIDPProvider> {
+
+    public static final String ID = "jpa";
+
+    @Override
+    public JpaIDPProvider create(KeycloakSession session) {
+        return new JpaIDPProvider(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -194,6 +194,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
                 .setParameter("realmId", realm.getId()).executeUpdate();
         session.groups().preRemove(adapter);
 
+        session.identityProviders().removeAll();
+
         em.createNamedQuery("removeClientInitialAccessByRealm")
                 .setParameter("realm", realm).executeUpdate();
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IdentityProviderEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IdentityProviderEntity.java
@@ -23,10 +23,8 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
 import java.util.Map;
@@ -43,9 +41,8 @@ public class IdentityProviderEntity {
     @Access(AccessType.PROPERTY) // we do this because relationships often fetch id, but not entity.  This avoids an extra SQL
     protected String internalId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "REALM_ID")
-    protected RealmEntity realm;
+    @Column(name = "REALM_ID")
+    protected String realmId;
 
     @Column(name="PROVIDER_ID")
     private String providerId;
@@ -102,12 +99,12 @@ public class IdentityProviderEntity {
         this.providerId = providerId;
     }
 
-    public RealmEntity getRealm() {
-        return this.realm;
+    public String getRealmId() {
+        return this.realmId;
     }
 
-    public void setRealm(RealmEntity realm) {
-        this.realm = realm;
+    public void setRealmId(String realmId) {
+        this.realmId = realmId;
     }
 
     public String getAlias() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -168,15 +168,15 @@ public class RealmEntity {
     @Column(name="VALUE")
     @CollectionTable(name="REALM_EVENTS_LISTENERS", joinColumns={ @JoinColumn(name="REALM_ID") })
     protected Set<String> eventsListeners;
-    
+
     @ElementCollection
     @Column(name="VALUE")
     @CollectionTable(name="REALM_ENABLED_EVENT_TYPES", joinColumns={ @JoinColumn(name="REALM_ID") })
     protected Set<String> enabledEventTypes;
-    
+
     @Column(name="ADMIN_EVENTS_ENABLED")
     protected boolean adminEventsEnabled;
-    
+
     @Column(name="ADMIN_EVENTS_DETAILS_ENABLED")
     protected boolean adminEventsDetailsEnabled;
 
@@ -186,7 +186,7 @@ public class RealmEntity {
     @Column(name="DEFAULT_ROLE")
     protected String defaultRoleId;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true)
     protected List<IdentityProviderEntity> identityProviders = new LinkedList<>();
 
     @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
@@ -304,7 +304,7 @@ public class RealmEntity {
     public void setVerifyEmail(boolean verifyEmail) {
         this.verifyEmail = verifyEmail;
     }
-    
+
     public boolean isLoginWithEmailAllowed() {
         return loginWithEmailAllowed;
     }
@@ -312,7 +312,7 @@ public class RealmEntity {
     public void setLoginWithEmailAllowed(boolean loginWithEmailAllowed) {
         this.loginWithEmailAllowed = loginWithEmailAllowed;
     }
-    
+
     public boolean isDuplicateEmailsAllowed() {
         return duplicateEmailsAllowed;
     }
@@ -538,7 +538,7 @@ public class RealmEntity {
     public void setEventsListeners(Set<String> eventsListeners) {
         this.eventsListeners = eventsListeners;
     }
-    
+
     public Set<String> getEnabledEventTypes() {
         if (enabledEventTypes == null) {
             enabledEventTypes = new HashSet<>();
@@ -549,7 +549,7 @@ public class RealmEntity {
     public void setEnabledEventTypes(Set<String> enabledEventTypes) {
         this.enabledEventTypes = enabledEventTypes;
     }
-    
+
     public boolean isAdminEventsEnabled() {
         return adminEventsEnabled;
     }
@@ -627,7 +627,7 @@ public class RealmEntity {
     }
 
     public void addIdentityProvider(IdentityProviderEntity entity) {
-        entity.setRealm(this);
+        entity.setRealmId(this.id);
         getIdentityProviders().add(entity);
     }
 
@@ -675,7 +675,7 @@ public class RealmEntity {
         }
         return authenticators;
     }
-    
+
     public void setAuthenticatorConfigs(Collection<AuthenticatorConfigEntity> authenticators) {
         this.authenticators = authenticators;
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -186,9 +186,6 @@ public class RealmEntity {
     @Column(name="DEFAULT_ROLE")
     protected String defaultRoleId;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true)
-    protected List<IdentityProviderEntity> identityProviders = new LinkedList<>();
-
     @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
     Collection<IdentityProviderMapperEntity> identityProviderMappers = new LinkedList<>();
 
@@ -613,22 +610,6 @@ public class RealmEntity {
 
     public void setAttributes(Collection<RealmAttributeEntity> attributes) {
         this.attributes = attributes;
-    }
-
-    public List<IdentityProviderEntity> getIdentityProviders() {
-        if (identityProviders == null) {
-            identityProviders = new LinkedList<>();
-        }
-        return this.identityProviders;
-    }
-
-    public void setIdentityProviders(List<IdentityProviderEntity> identityProviders) {
-        this.identityProviders = identityProviders;
-    }
-
-    public void addIdentityProvider(IdentityProviderEntity entity) {
-        entity.setRealmId(this.id);
-        getIdentityProviders().add(entity);
     }
 
     public boolean isInternationalizationEnabled() {

--- a/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.IDPProviderFactory
+++ b/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.IDPProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2024 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.models.jpa.JpaIDPProviderFactory

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProvider.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProvider.java
@@ -20,6 +20,7 @@ package org.keycloak.storage.datastore;
 import org.keycloak.models.ClientProvider;
 import org.keycloak.models.ClientScopeProvider;
 import org.keycloak.models.GroupProvider;
+import org.keycloak.models.IDPProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleProvider;
@@ -49,6 +50,7 @@ public class DefaultDatastoreProvider implements DatastoreProvider, StoreManager
     private ClientProvider clientProvider;
     private ClientScopeProvider clientScopeProvider;
     private GroupProvider groupProvider;
+    private IDPProvider idpProvider;
     private UserLoginFailureProvider userLoginFailureProvider;
     private RealmProvider realmProvider;
     private RoleProvider roleProvider;
@@ -208,6 +210,14 @@ public class DefaultDatastoreProvider implements DatastoreProvider, StoreManager
             groupProvider = getGroupProvider();
         }
         return groupProvider;
+    }
+
+    @Override
+    public IDPProvider identityProviders() {
+        if (idpProvider == null) {
+            idpProvider = session.getProvider(IDPProvider.class);
+        }
+        return idpProvider;
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/storage/DatastoreProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/DatastoreProvider.java
@@ -20,6 +20,7 @@ package org.keycloak.storage;
 import org.keycloak.models.ClientProvider;
 import org.keycloak.models.ClientScopeProvider;
 import org.keycloak.models.GroupProvider;
+import org.keycloak.models.IDPProvider;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleProvider;
 import org.keycloak.models.SingleUseObjectProvider;
@@ -39,6 +40,8 @@ public interface DatastoreProvider extends Provider {
 
     GroupProvider groups();
 
+    IDPProvider identityProviders();
+
     UserLoginFailureProvider loginFailures();
 
     RealmProvider realms();
@@ -46,7 +49,7 @@ public interface DatastoreProvider extends Provider {
     RoleProvider roles();
 
     SingleUseObjectProvider singleUseObjects();
-    
+
     UserProvider users();
 
     UserSessionProvider userSessions();

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakSession.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakSession.java
@@ -204,6 +204,13 @@ public interface KeycloakSession extends AutoCloseable {
 
     SingleUseObjectProvider singleUseObjects();
 
+    /**
+     * Returns the default IDP provider .
+     *
+     * @return the default IDP provider.
+     */
+    IDPProvider identityProviders();
+
     @Override
     void close();
 

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -441,13 +441,35 @@ public interface RealmModel extends RoleContainerModel {
 
     /**
      * Returns identity providers as a stream.
+     *
      * @return Stream of {@link IdentityProviderModel}. Never returns {@code null}.
+     * @deprecated Use {@link IDPProvider#getAllStream()} instead.
      */
+    @Deprecated
     Stream<IdentityProviderModel> getIdentityProvidersStream();
 
+    /**
+     * @deprecated Use {@link IDPProvider#getByAlias(String)} instead.
+     */
+    @Deprecated
     IdentityProviderModel getIdentityProviderByAlias(String alias);
+
+    /**
+     * @deprecated Use {@link IDPProvider#create(IdentityProviderModel)} instead.
+     */
+    @Deprecated
     void addIdentityProvider(IdentityProviderModel identityProvider);
+
+    /**
+     * @deprecated Use {@link IDPProvider#remove(String)} instead.
+     */
+    @Deprecated
     void removeIdentityProviderByAlias(String alias);
+
+    /**
+     * @deprecated Use {@link IDPProvider#update(IdentityProviderModel)} instead.
+     */
+    @Deprecated
     void updateIdentityProvider(IdentityProviderModel identityProvider);
 
     /**
@@ -495,7 +517,7 @@ public interface RealmModel extends RoleContainerModel {
     /**
      * Removes given component. Will call preRemove() method of ComponentFactory.
      * Also calls {@code this.removeComponents(component.getId())}.
-     * 
+     *
      * @param component to be removed
      */
     void removeComponent(ComponentModel component);
@@ -616,6 +638,10 @@ public interface RealmModel extends RoleContainerModel {
      */
     void setDefaultRole(RoleModel role);
 
+    /**
+     * @deprecated use {@link IDPProvider#isIdentityFederationEnabled()} instead.
+     */
+    @Deprecated
     boolean isIdentityFederationEnabled();
 
     boolean isInternationalizationEnabled();
@@ -693,7 +719,7 @@ public interface RealmModel extends RoleContainerModel {
     ClientScopeModel addClientScope(String name);
 
     /**
-     * Creates new client scope with the given internal ID and name. 
+     * Creates new client scope with the given internal ID and name.
      * If given name contains spaces, those are replaced by underscores.
      * @param id {@code String} id of the client scope.
      * @param name {@code String} name of the client scope.
@@ -716,10 +742,10 @@ public interface RealmModel extends RoleContainerModel {
     ClientScopeModel getClientScopeById(String id);
 
     /**
-     * Adds given client scope among default/optional client scopes of this realm. 
+     * Adds given client scope among default/optional client scopes of this realm.
      * The scope will be assigned to each new client.
      * @param clientScope to be added
-     * @param defaultScope if {@code true} the scope will be added among default client scopes, 
+     * @param defaultScope if {@code true} the scope will be added among default client scopes,
      * if {@code false} it will be added among optional client scopes
      */
     void addDefaultClientScope(ClientScopeModel clientScope, boolean defaultScope);
@@ -742,16 +768,16 @@ public interface RealmModel extends RoleContainerModel {
 
     /**
      * Returns default client scopes of this realm either default ones or optional ones.
-     * @param defaultScope if {@code true} default client scopes are returned, 
+     * @param defaultScope if {@code true} default client scopes are returned,
      * if {@code false} optional client scopes are returned.
      * @return Stream of {@link ClientScopeModel}. Never returns {@code null}.
      */
     Stream<ClientScopeModel> getDefaultClientScopesStream(boolean defaultScope);
 
     /**
-     * Adds a role as a composite to default role of this realm. 
+     * Adds a role as a composite to default role of this realm.
      * @param role to be added
-     */ 
+     */
     default void addToDefaultRoles(RoleModel role) {
         getDefaultRole().addCompositeRole(role);
     }

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
@@ -25,6 +25,7 @@ import org.keycloak.keys.DefaultKeyManager;
 import org.keycloak.models.ClientProvider;
 import org.keycloak.models.ClientScopeProvider;
 import org.keycloak.models.GroupProvider;
+import org.keycloak.models.IDPProvider;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
@@ -314,6 +315,11 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
     @Override
     public SingleUseObjectProvider singleUseObjects() {
         return getDatastoreProvider().singleUseObjects();
+    }
+
+    @Override
+    public IDPProvider identityProviders() {
+        return getDatastoreProvider().identityProviders();
     }
 
     @Override

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
@@ -27,7 +27,9 @@ import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionPr
 import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionSpi;
 import org.keycloak.connections.jpa.updater.liquibase.lock.LiquibaseDBLockProviderFactory;
 import org.keycloak.events.jpa.JpaEventStoreProviderFactory;
+import org.keycloak.models.IDPSpi;
 import org.keycloak.models.dblock.DBLockSpi;
+import org.keycloak.models.jpa.JpaIDPProviderFactory;
 import org.keycloak.models.jpa.session.JpaRevokedTokensPersisterProviderFactory;
 import org.keycloak.models.jpa.session.JpaUserSessionPersisterProviderFactory;
 import org.keycloak.models.session.RevokedTokenPersisterSpi;
@@ -74,6 +76,7 @@ public class Jpa extends KeycloakModelParameters {
       .add(DBLockSpi.class)
 
       //required for FederatedIdentityModel
+      .add(IDPSpi.class)
       .add(IdentityProviderSpi.class)
 
       .build();
@@ -88,6 +91,7 @@ public class Jpa extends KeycloakModelParameters {
       .add(JpaClientScopeProviderFactory.class)
       .add(JpaEventStoreProviderFactory.class)
       .add(JpaGroupProviderFactory.class)
+      .add(JpaIDPProviderFactory.class)
       .add(JpaRealmProviderFactory.class)
       .add(JpaRoleProviderFactory.class)
       .add(JpaUpdaterProviderFactory.class)
@@ -120,6 +124,7 @@ public class Jpa extends KeycloakModelParameters {
         cf.spi("client").defaultProvider("jpa")
           .spi("clientScope").defaultProvider("jpa")
           .spi("group").defaultProvider("jpa")
+          .spi("idp").defaultProvider("jpa")
           .spi("role").defaultProvider("jpa")
           .spi("user").defaultProvider("jpa")
           .spi("realm").defaultProvider("jpa")


### PR DESCRIPTION
- Add JPA implementation for IDPProvider (31250)
- Make the provider available via session (31252)
- Deprecate IDP-related methods in RealmModel (31253)

Closes #31250
Closes #31252
Closes #31253
Closes #21954

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
