### PR TITLE
Re-add notes about not supporting DPoP and holder-of-key in the remaining adapters

### DIFF
--- a/docs/documentation/server_admin/topics/clients/oidc/con-advanced-settings.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-advanced-settings.adoc
@@ -92,6 +92,11 @@ In the following cases, {project_name} will verify the client sending the access
 
 See https://datatracker.ietf.org/doc/html/draft-ietf-oauth-mtls-08#section-3[Mutual TLS Client Certificate Bound Access Tokens] in the OAuth 2.0 Mutual TLS Client Authentication and Certificate Bound Access Tokens for more details.
 
+[NOTE]
+====
+{project_name} client adapters do not support holder-of-key token verification. {project_name} adapters treat access and refresh tokens as bearer tokens.
+====
+
 [[_dpop-bound-tokens]]
 *OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP)*
 
@@ -119,6 +124,11 @@ In the following cases, {project_name} will verify the client sending the access
 * A logout request is sent to a non-OIDC compliant {project_name} proprietary logout endpoint Logout endpoint with a holder-of-key refresh token. This verification is done only for public clients as described above.
 
 See https://datatracker.ietf.org/doc/html/rfc9449[OAuth 2.0 Demonstrating Proof of Possession (DPoP)] for more details.
+
+[NOTE]
+====
+{project_name} client adapters do not support DPoP holder-of-key token verification. {project_name} adapters treat access and refresh tokens as bearer tokens.
+====
 
 :tech_feature_name: DPoP
 :tech_feature_id: dpop


### PR DESCRIPTION
Closes #30874

I'm just re-adding two notes about adapters. There are some adapters that are still in place, `keycloak.js` for example, and people asked if we had implemented those features for it as the notes were removed. If you think this is not needed just let me know and I will explain it in the issue before closing it.