### PR TITLE
fix: adds a check for duplicate users/clients to simplify cmd errors

### DIFF
--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -88,7 +88,7 @@ public interface ServicesLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id=10, value="Failed to add user '%s' to realm '%s': user with username exists")
     void addUserFailedUserExists(String user, String realm);
-
+    
     @LogMessage(level = ERROR)
     @Message(id=11, value="Failed to add user '%s' to realm '%s'")
     void addUserFailed(@Cause Throwable t, String user, String realm);
@@ -465,10 +465,15 @@ public interface ServicesLogger extends BasicLogger {
     void scriptEngineCreated(String engineName, String engineVersion, String mimeType);
 
     @LogMessage(level = DEBUG)
-    @Message(id=107, value="Skipping create admin user. Admin already exists in realm '%s'.")
-    void addAdminUserFailedAdminExists(String realm);
+    @Message(id=107, value="Skipping create admin user. User(s) already exist in realm '%s'.")
+    void addAdminUserFailedUsersExist(String realm);
 
     @LogMessage(level = WARN)
     @Message(id=108, value="URI '%s' doesn't match any trustedHost or trustedDomain")
     void uriDoesntMatch(String uri);
+    
+    @LogMessage(level = ERROR)
+    @Message(id=109, value="Failed to add client '%s' to realm '%s': client with client ID exists")
+    void addClientFailedClientExists(String clientId, String realm);
+
 }

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -23,6 +23,7 @@ import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserCredentialModel;
@@ -43,7 +44,7 @@ import org.keycloak.utils.StringUtil;
 public class ApplianceBootstrap {
 
     public static final String DEFAULT_TEMP_ADMIN_USERNAME = "temp-admin";
-    public static final String DEFAULT_TEMP_ADMIN_SERVICE = "temp-admin-service";
+    public static final String DEFAULT_TEMP_ADMIN_SERVICE = "temp-admin";
     public static final int DEFAULT_TEMP_ADMIN_EXPIRATION = 120;
 
     private final KeycloakSession session;
@@ -113,7 +114,14 @@ public class ApplianceBootstrap {
         return true;
     }
 
-    public void createTemporaryMasterRealmAdminUser(String username, String password, /*Integer expriationMinutes,*/ boolean initialUser) {
+    /**
+     * Create a temporary admin user
+     * @param username
+     * @param password
+     * @param initialUser if true only create the user if no other users exist
+     * @return false if the user could not be created
+     */
+    public boolean createTemporaryMasterRealmAdminUser(String username, String password, /*Integer expriationMinutes,*/ boolean initialUser) {
         RealmModel realm = session.realms().getRealmByName(Config.getAdminRealm());
         session.getContext().setRealm(realm);
 
@@ -121,26 +129,38 @@ public class ApplianceBootstrap {
         //expriationMinutes = expriationMinutes == null ? DEFAULT_TEMP_ADMIN_EXPIRATION : expriationMinutes;
 
         if (initialUser && session.users().getUsersCount(realm) > 0) {
-            ServicesLogger.LOGGER.addAdminUserFailedAdminExists(Config.getAdminRealm());
-            return;
+            ServicesLogger.LOGGER.addAdminUserFailedUsersExist(Config.getAdminRealm());
+            return false;
         }
 
-        UserModel adminUser = session.users().addUser(realm, username);
-        adminUser.setEnabled(true);
-        // TODO: is this appropriate, does it need to be managed?
-        // adminUser.setSingleAttribute("temporary_admin", Boolean.TRUE.toString());
-        // also set the expiration - could be relative to a creation timestamp, or computed
-
-        UserCredentialModel usrCredModel = UserCredentialModel.password(password);
-        adminUser.credentialManager().updateCredential(usrCredModel);
-
-        RoleModel adminRole = realm.getRole(AdminRoles.ADMIN);
-        adminUser.grantRole(adminRole);
-
-        ServicesLogger.LOGGER.createdTemporaryAdminUser(username);
+        try {
+            UserModel adminUser = session.users().addUser(realm, username);
+            adminUser.setEnabled(true);
+            // TODO: is this appropriate, does it need to be managed?
+            // adminUser.setSingleAttribute("temporary_admin", Boolean.TRUE.toString());
+            // also set the expiration - could be relative to a creation timestamp, or computed
+    
+            UserCredentialModel usrCredModel = UserCredentialModel.password(password);
+            adminUser.credentialManager().updateCredential(usrCredModel);
+    
+            RoleModel adminRole = realm.getRole(AdminRoles.ADMIN);
+            adminUser.grantRole(adminRole);
+    
+            ServicesLogger.LOGGER.createdTemporaryAdminUser(username);
+        } catch (ModelDuplicateException e) {
+            ServicesLogger.LOGGER.addUserFailedUserExists(username, Config.getAdminRealm());
+            return false;
+        }
+        return true;
     }
 
-    public void createTemporaryMasterRealmAdminService(String clientId, String clientSecret /*, Integer expriationMinutes*/) {
+    /**
+     * Create a temporary admin service account
+     * @param clientId the client ID
+     * @param clientSecret the client secret
+     * @return false if the service account could not be created
+     */
+    public boolean createTemporaryMasterRealmAdminService(String clientId, String clientSecret /*, Integer expriationMinutes*/) {
         RealmModel realm = session.realms().getRealmByName(Config.getAdminRealm());
         session.getContext().setRealm(realm);
 
@@ -154,17 +174,23 @@ public class ApplianceBootstrap {
         adminClient.setPublicClient(false);
         adminClient.setSecret(clientSecret);
 
-        ClientModel adminClientModel = ClientManager.createClient(session, realm, adminClient);
-
-        new ClientManager(new RealmManager(session)).enableServiceAccount(adminClientModel);
-        UserModel serviceAccount = session.users().getServiceAccount(adminClientModel);
-        RoleModel adminRole = realm.getRole(AdminRoles.ADMIN);
-        serviceAccount.grantRole(adminRole);
-
-        // TODO: set temporary
-        // also set the expiration - could be relative to a creation timestamp, or computed
-
-        ServicesLogger.LOGGER.createdTemporaryAdminService(clientId);
+        try {
+            ClientModel adminClientModel = ClientManager.createClient(session, realm, adminClient);
+    
+            new ClientManager(new RealmManager(session)).enableServiceAccount(adminClientModel);
+            UserModel serviceAccount = session.users().getServiceAccount(adminClientModel);
+            RoleModel adminRole = realm.getRole(AdminRoles.ADMIN);
+            serviceAccount.grantRole(adminRole);
+    
+            // TODO: set temporary
+            // also set the expiration - could be relative to a creation timestamp, or computed
+    
+            ServicesLogger.LOGGER.createdTemporaryAdminService(clientId);
+        } catch (ModelDuplicateException e) {
+            ServicesLogger.LOGGER.addClientFailedClientExists(clientId, Config.getAdminRealm());
+            return false;
+        }
+        return true;
     }
 
     public void createMasterRealmUser(String username, String password) {


### PR DESCRIPTION
also changes temp-admin-service to temp-admin

closes: #31160

A duplicate user check was requested by @pedroigor - to consolidate exception handling / logging the ApplianceBootstrap methods now return booleans.

~~It was also brought up in a change that the client and user can have the same name - this is a very small change just tacked on to this PR, but it can be separated if needed - cc @Pepo48 that will need documentation changes as well.~~

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
