### PR TITLE
LDAPSyncTest - additional removal of users at the end of the test

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -344,6 +344,16 @@ public class LDAPSyncTest extends AbstractLDAPTest {
             Assert.assertEquals("user1", user1.getFirstAttribute(LDAPConstants.LDAP_ID));
         });
 
+        // Remove all users from model - required step before the next test execution especially when running against external AD
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            // Remove all users from model
+            UserStoragePrivateUtil.userLocalStorage(session)
+                    .searchForUserStream(ctx.getRealm(), Collections.emptyMap())
+                    .collect(Collectors.toList())
+                    .forEach(user -> UserStoragePrivateUtil.userLocalStorage(session).removeUser(ctx.getRealm(), user));
+        });
+
         // Revert config changes
         ComponentRepresentation ldapRep = testRealm().components().component(ldapModelId).toRepresentation();
         ldapRep.getConfig().putSingle(LDAPConstants.UUID_LDAP_ATTRIBUTE, origUuidAttrName);


### PR DESCRIPTION
Necessary when running with external AD

Closes #27499

Signed-off-by: Pavel Drozd <pdrozd@redhat.com>
(cherry picked from commit be7775a9bee8debe35be6d1b2cf2df2838d6ca5a)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
