### PR TITLE
fix: make the statefulset reconciliation wait for secret creation

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -308,4 +308,10 @@ stringData:
 When running on a Kubernetes or OpenShift environment well-known locations of trusted certificates are included automatically.
 This includes `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` and the `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` when present.
 
+=== Admin Bootstrapping
+
+When you create a new instance the Keycloak CR spec.bootstrapAdmin stanza may be used to configure the bootstrap user and/or service account. If you do not specify anything for the spec.bootstrapAdmin, the operator will create a Secret named "metadata.name"-initial-admin with a username temp-admin and a generated password. If you specify a Secret name for bootstrap admin user, then the Secret will need to contain `username` and `password` key value pairs. If you specify a Secret name for bootstrap admin service account, then the Secret will need to contain `client-id` and `client-secret` key value pairs.
+
+If a master realm has already been created for you cluster, then the spec.boostrapAdmin is effectively ignored. If you need to create a recovery admin account, then you'll need to run the CLI command against a Pod directly.
+
 </@tmpl.guide>

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakAdminSecretDependentResource.java
@@ -5,20 +5,32 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ResourceDiscriminator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.processing.dependent.Creator;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.Utils;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @KubernetesDependent(labelSelector = Constants.DEFAULT_LABELS_AS_STRING, resourceDiscriminator = KeycloakAdminSecretDependentResource.NameResourceDiscriminator.class)
 public class KeycloakAdminSecretDependentResource extends KubernetesDependentResource<Secret, Keycloak> implements Creator<Secret, Keycloak>, GarbageCollected<Keycloak> {
+    
+    public static class EnabledCondition implements Condition<Secret, Keycloak> {
+        @Override
+        public boolean isMet(DependentResource<Secret, Keycloak> dependentResource, Keycloak primary,
+                Context<Keycloak> context) {
+            return Optional.ofNullable(primary.getSpec().getBootstrapAdminSpec()).map(BootstrapAdminSpec::getUser)
+                    .map(BootstrapAdminSpec.User::getSecret).filter(s -> !s.equals(KeycloakAdminSecretDependentResource.getName(primary))).isEmpty();
+        }
+    }
 
     public static class NameResourceDiscriminator implements ResourceDiscriminator<Secret, Keycloak> {
         @Override
@@ -39,8 +51,9 @@ public class KeycloakAdminSecretDependentResource extends KubernetesDependentRes
                 .addToLabels(Utils.allInstanceLabels(primary))
                 .withNamespace(primary.getMetadata().getNamespace())
                 .endMetadata()
+                .withType("Opaque")
                 .withType("kubernetes.io/basic-auth")
-                .addToData("username", Utils.asBase64("admin"))
+                .addToData("username", Utils.asBase64("temp-admin"))
                 .addToData("password", Utils.asBase64(UUID.randomUUID().toString().replace("-", "")))
                 .build();
     }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -28,6 +28,7 @@ import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusAggregator;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.DatabaseSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
@@ -73,6 +74,7 @@ public class KeycloakDistConfigurator {
         configureCache();
         configureProxy();
         configureManagement();
+        configureBootstrapAdmin();
     }
 
     /**
@@ -85,6 +87,26 @@ public class KeycloakDistConfigurator {
     }
 
     /* ---------- Configuration of first-class citizen fields ---------- */
+
+    void configureBootstrapAdmin() {
+        optionMapper(Function.identity())
+                .mapOption("bootstrap-admin-username",
+                        keycloakCR -> Optional.ofNullable(keycloakCR.getSpec().getBootstrapAdminSpec())
+                                .map(BootstrapAdminSpec::getUser).map(BootstrapAdminSpec.User::getSecret)
+                                .or(() -> Optional.of(KeycloakAdminSecretDependentResource.getName(keycloakCR)))
+                                .map(s -> new SecretKeySelector("username", s, null)).orElse(null))
+                .mapOption("bootstrap-admin-password",
+                        keycloakCR -> Optional.ofNullable(keycloakCR.getSpec().getBootstrapAdminSpec())
+                                .map(BootstrapAdminSpec::getUser).map(BootstrapAdminSpec.User::getSecret)
+                                .or(() -> Optional.of(KeycloakAdminSecretDependentResource.getName(keycloakCR)))
+                                .map(s -> new SecretKeySelector("password", s, null)).orElse(null));
+
+        optionMapper(keycloakCR -> keycloakCR.getSpec().getBootstrapAdminSpec())
+                .mapOption("bootstrap-admin-client-id",
+                        spec -> Optional.ofNullable(spec.getService()).map(BootstrapAdminSpec.Service::getSecret).map(s -> new SecretKeySelector("client-id", s, null)).orElse(null))
+                .mapOption("bootstrap-admin-client-secret",
+                        spec -> Optional.ofNullable(spec.getService()).map(BootstrapAdminSpec.Service::getSecret).map(s -> new SecretKeySelector("client-secret", s, null)).orElse(null));
+    }
 
     void configureHostname() {
         optionMapper(keycloakCR -> keycloakCR.getSpec().getHostnameSpec())

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java
@@ -33,7 +33,6 @@ import io.javaoperatorsdk.operator.processing.dependent.Creator;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfigBuilder;
-import jakarta.inject.Inject;
 import org.keycloak.operator.Config;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.Utils;

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
 
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.CacheSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.DatabaseSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
@@ -114,6 +115,10 @@ public class KeycloakSpec {
     @JsonProperty("scheduling")
     @JsonPropertyDescription("In this section you can configure Keycloak's scheduling")
     private SchedulingSpec schedulingSpec;
+
+    @JsonProperty("bootstrapAdmin")
+    @JsonPropertyDescription("In this section you can configure Keycloak's bootstrap admin - will be used only for inital cluster creation.")
+    private BootstrapAdminSpec bootstrapAdminSpec;
 
     public HttpSpec getHttpSpec() {
         return httpSpec;
@@ -263,5 +268,13 @@ public class KeycloakSpec {
 
     public void setSchedulingSpec(SchedulingSpec schedulingSpec) {
         this.schedulingSpec = schedulingSpec;
+    }
+    
+    public BootstrapAdminSpec getBootstrapAdminSpec() {
+        return bootstrapAdminSpec;
+    }
+
+    public void setBootstrapAdminSpec(BootstrapAdminSpec bootstrapAdminSpec) {
+        this.bootstrapAdminSpec = bootstrapAdminSpec;
     }
 }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/BootstrapAdminSpec.java
@@ -1,0 +1,69 @@
+package org.keycloak.operator.crds.v2alpha1.deployment.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.sundr.builder.annotations.Buildable;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class BootstrapAdminSpec {
+
+    public static class User {
+        @JsonPropertyDescription("Name of the Secret that contains the username and password keys")
+    	private String secret;
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+    }
+
+    public static class Service {
+        @JsonPropertyDescription("Name of the Secret that contains the client-id and client-secret keys")
+    	private String secret;
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+
+    }
+
+    //private Integer expiration;
+    @JsonPropertyDescription("Configures the bootstrap admin user")
+    private User user;
+    @JsonPropertyDescription("Configures the bootstrap admin service account")
+    private Service service;
+
+    /*public Integer getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Integer expiration) {
+        this.expiration = expiration;
+    }*/
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Service getService() {
+        return service;
+    }
+
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -154,6 +154,18 @@ public class KeycloakDistConfiguratorTest {
 
         testFirstClassCitizen(expectedValues);
     }
+    
+    @Test
+    public void bootstrapAdmin() {
+        final Map<String, String> expectedValues = Map.of(
+                "bootstrap-admin-username", "something",
+                "bootstrap-admin-password", "something",
+                "bootstrap-admin-client-id", "else",
+                "bootstrap-admin-client-secret", "else"
+        );
+
+        testFirstClassCitizen(expectedValues);
+    }
 
     /* UTILS */
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -38,10 +38,13 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.operator.Config;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.Utils;
 import org.keycloak.operator.controllers.KeycloakDeploymentDependentResource;
+import org.keycloak.operator.controllers.KeycloakDistConfigurator;
 import org.keycloak.operator.controllers.WatchedResources;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakBuilder;
@@ -70,9 +73,19 @@ public class PodTemplateTest {
 
     @InjectMock
     WatchedResources watchedResources;
+    
+    @Inject
+    Config operatorConfig;
 
     @Inject
+    KeycloakDistConfigurator distConfigurator;
+    
     KeycloakDeploymentDependentResource deployment;
+    
+    @BeforeEach
+    protected void setup() {
+        this.deployment = new KeycloakDeploymentDependentResource(operatorConfig, watchedResources, distConfigurator);
+    }
 
     private StatefulSet getDeployment(PodTemplateSpec podTemplate, StatefulSet existingDeployment, Consumer<KeycloakSpecBuilder> additionalSpec) {
         var kc = new KeycloakBuilder().withNewMetadata().withName("instance").endMetadata().build();

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -72,6 +72,11 @@ spec:
         name: my-secret
   httpManagement:
     port: 9003
+  bootstrapAdmin:
+    user:
+      secret: something
+    service:
+      secret: else
   unsupported:
     podTemplate:
       metadata:


### PR DESCRIPTION
closes: #30004

@ahus1 @vmuzikar the issue here is that adding the KeycloakAdminSecretDependentResource EnabledCondition is causing the KeycloakAdminSecretDependentResource to be run more routinely after the KeycloakDeploymentDependentResource. When that happens it's creating another revision of the StatefulSet because the initial one is marked as having a missing secret. I'm not sure why yet, but that StatefulSet revision is not rolled out to the Pods in the test case with a non-existent image. So the Pods are staying at the initial revision, which causes the logic that scrapes the Pod status for the Keycloak status error message to not work. 

In general it would be good to avoid creating these short lived versions of the StatefulSet, so I added a depends on dependency between the two dependents.

Another solution / refinement, that is more involved, would be to only use the missing annotations for optional Secrets / ConfigMaps - or to simply let the optional case be handled by the general poll interval.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
