### PR TITLE
Convert chapter docker registry from securing apps into guides

### DIFF
--- a/docs/documentation/securing_apps/topics.adoc
+++ b/docs/documentation/securing_apps/topics.adoc
@@ -41,7 +41,6 @@ include::topics/saml/java/java-adapters-product.adoc[]
 endif::[]
 include::topics/saml/saml-errors.adoc[]
 
-include::topics/docker/docker-overview.adoc[]
 include::topics/client-registration.adoc[]
 include::topics/client-registration/client-registration-cli.adoc[]
 ifeval::[{project_community}==true]

--- a/docs/guides/securing-apps/docker-registry.adoc
+++ b/docs/guides/securing-apps/docker-registry.adoc
@@ -1,5 +1,10 @@
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
 
-== Configuring a Docker registry to use {project_name}
+<@tmpl.guide
+title="Docker registry"
+priority=40
+summary="Configuring a Docker registry to use {project_name}">
 
 NOTE: Docker authentication is disabled by default. To enable see the https://www.keycloak.org/server/features[Enabling and disabling features] {section}.
 
@@ -7,9 +12,7 @@ This section describes how you can configure a Docker registry to use {project_n
 
 For more information on how to set up and configure a Docker registry, see the link:https://distribution.github.io/distribution/about/configuration/[Docker Registry Configuration Guide].
 
-
-
-=== Docker registry configuration file installation
+== Docker registry configuration file installation
 
 For users with more advanced Docker registry configurations, it is generally recommended to provide your own registry configuration file.  The {project_name} Docker provider supports this mechanism via the _Registry Config File_ Format Option.  Choosing this option will generate output similar to the following:
 
@@ -17,31 +20,30 @@ For users with more advanced Docker registry configurations, it is generally rec
 ----
 auth:
   token:
-    realm: http://localhost:8080{kc_realms_path}/master/protocol/docker-v2/auth
+    realm: http://localhost:8080/realms/master/protocol/docker-v2/auth
     service: docker-test
-    issuer: http://localhost:8080{kc_realms_path}/master
+    issuer: http://localhost:8080/realms/master
 ----
 
 This output can then be copied into any existing registry config file.  See the link:https://distribution.github.io/distribution/about/configuration/[registry config file specification] for more information on how the file should be set up, or start with link:https://github.com/distribution/distribution/blob/main/cmd/registry/config-example.yml[a basic example].
 
 WARNING: Don't forget to configure the `rootcertbundle` field with the location of the {project_name} realm's public key.  The auth configuration will not work without this argument.
 
-
-=== Docker registry environment variable override installation
+== Docker registry environment variable override installation
 
 Often times it is appropriate to use a simple environment variable override for develop or POC Docker registries. While this approach is usually not recommended for production use, it can be helpful when one requires quick-and-dirty way to stand up a registry. Simply use the _Variable Override_ Format Option from the client details, and an output should appear like the one below:
 
 [source,subs="attributes+"]
 ----
-REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080{kc_realms_path}/master/protocol/docker-v2/auth
+REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080/realms/master/protocol/docker-v2/auth
 REGISTRY_AUTH_TOKEN_SERVICE: docker-test
-REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080{kc_realms_path}/master
+REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080/realms/master
 ----
 
 WARNING: Don't forget to configure the `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` override with the location of the {project_name} realm's public key.  The auth configuration will not work without this argument.
 
 
-=== Docker Compose YAML File
+== Docker Compose YAML File
 
 WARNING: This installation method is meant to be an easy way to get a docker registry authenticating against a {project_name} server.  It is intended for development purposes only and should never be used in a production or production-like environment.
 
@@ -50,7 +52,7 @@ The zip file installation mechanism provides a quickstart for developers who wan
 .Procedure
 
  1. From the desired realm, create a client configuration. At this point you will not have a Docker registry - the quickstart will take care of that part.
- 2. Choose the "Docker Compose YAML" option from the from _Action_ menu and select the *Download adapter config* option to download the ZIP file.
+ 2. Choose the *Docker Compose YAML* option from the from _Action_ menu and select the *Download adapter config* option to download the ZIP file.
  3. Unzip the archive to the desired location, and open the directory.
  4. Start the Docker registry with `docker-compose up`
 
@@ -61,3 +63,5 @@ Once the above configuration has taken place, and the keycloak server and Docker
 	[user ~]# docker login localhost:5000 -u $username
 	Password: *******
 	Login Succeeded
+
+</@tmpl.guide>


### PR DESCRIPTION
Closes #31331

Just moving the docker registry chapter to guide. This one was easy.