### PR TITLE
Enable parameter forwarding in keycloak-js.

### DIFF
--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -162,6 +162,10 @@ function Keycloak (config) {
                 kc.acrValues = initOptions.acrValues;
             }
 
+            if (initOptions.forwardParameters) {
+              kc.forwardParameters = initOptions.forwardParameters;
+            }
+
             if (typeof initOptions.messageReceiveTimeout === 'number' && initOptions.messageReceiveTimeout > 0) {
                 kc.messageReceiveTimeout = initOptions.messageReceiveTimeout;
             } else {
@@ -475,6 +479,13 @@ function Keycloak (config) {
 
         if ((options && options.acrValues) || kc.acrValues) {
             url += '&acr_values=' + encodeURIComponent(options.acrValues || kc.acrValues);
+        }
+
+        if ((options && options.forwardParameters) || kc.forwardParameters) {
+          var forwardParameters = (options && options.forwardParameters) || kc.forwardParameters;
+          url = Object.keys(forwardParameters).reduce(function (url, forwardParameter) {
+              return url + "&" + forwardParameter + "=" + encodeURIComponent(forwardParameters[forwardParameter]);
+          }, url);
         }
 
         if (kc.pkceMethod) {


### PR DESCRIPTION
See https://github.com/keycloak/keycloak/discussions/13094

Fixes keycloak/keycloak-js#20

With this in place, to specify params for forwarding:

First, in Keycloak UI set the names of params to forward (i.e. "foo" and "bar" below)

<img width="1169" alt="Screenshot 2024-07-26 at 14 47 20" src="https://github.com/user-attachments/assets/1ff05c25-aca2-4745-91ac-586f2560ed9a">

Then in the js client, also specify the params in the init() call, with values:

```javascript
keycloak.init({
    forwardParameters: {
      'foo': 123,
      'bar': 456
      ...
    }
})
```

Now calls to the IDP will also include the above params.

