### PR TITLE
Improve Identity Provider lookup for Backchannel Logout

### DIFF
--- a/core/src/main/java/org/keycloak/util/TokenUtil.java
+++ b/core/src/main/java/org/keycloak/util/TokenUtil.java
@@ -28,6 +28,7 @@ import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.LogoutToken;
 import org.keycloak.representations.RefreshToken;
 
 import java.io.IOException;
@@ -235,5 +236,14 @@ public class TokenUtil {
 
         return jwe.getContent();
 
+    }
+
+    public static boolean isLogoutOfflineSessions(LogoutToken logoutToken) {
+        if (logoutToken == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(logoutToken.getEvents()
+                .getOrDefault(TOKEN_BACKCHANNEL_LOGOUT_EVENT_REVOKE_OFFLINE_TOKENS, false)
+                .toString());
     }
 }

--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -484,7 +484,7 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
         protected final AuthenticationCallback callback;
         protected final RealmModel realm;
         protected final EventBuilder event;
-        private final AbstractOAuth2IdentityProvider provider;
+        protected final AbstractOAuth2IdentityProvider provider;
 
         protected final KeycloakSession session;
 


### PR DESCRIPTION
- Adds support for kc_idp_hint as additional form parameter to end_session endpoint (logout/backchannel-logout)
- Adds additional /backchannel-logout route to the OIDCIdentityProvider.OIDCEndpoint
- Refactored backchannel handling in LogoutEndpoint to be useable from OIDCIdentityProvider.OIDCEndpoint

Fixes #31664

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
