### PR TITLE
Upgrade to Quarkus 3.13.2

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -136,6 +136,14 @@ This endpoint supports filters and pagination.
 
 = CLI import placeholder replacement
 
-The CLI command `kc.[sh|bat] import` now has placeholder replacement enabled. Previously placeholder replacement was only enabled for realm import at startup. 
+The CLI command `kc.[sh|bat] import` now has placeholder replacement enabled. Previously placeholder replacement was only enabled for realm import at startup.
 
 If you wish to disable placeholder replacement for the `import` command, add the system property `-Dkeycloak.migration.replace-placeholders=false`
+
+= Keystore and trust store default format change
+
+{project_name} now determines the format of the keystore and trust store based on the file extension. If the file extension is `.p12`, `.pkcs12` or `.pfx`, the format is PKCS12. If the file extension is `.jks`, `.keystore` or `.truststore`, the format is JKS. If the file extension is `.pem`, `.crt` or `.key`, the format is PEM.
+
+You can still override automatic detection by specifying the `https-key-store-type` and `https-trust-store-type` explicitly. Restrictions for the FIPS strict mode stays unchanged.
+
+NOTE: The `+spi-truststore-file-*+` options and the truststore related options `+https-trust-store-*+` are deprecated, we strongly recommend to use System Truststore. For more details refer to the relevant https://www.keycloak.org/server/keycloak-truststore[guide].

--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -144,6 +144,6 @@ If you wish to disable placeholder replacement for the `import` command, add the
 
 {project_name} now determines the format of the keystore and trust store based on the file extension. If the file extension is `.p12`, `.pkcs12` or `.pfx`, the format is PKCS12. If the file extension is `.jks`, `.keystore` or `.truststore`, the format is JKS. If the file extension is `.pem`, `.crt` or `.key`, the format is PEM.
 
-You can still override automatic detection by specifying the `https-key-store-type` and `https-trust-store-type` explicitly. Restrictions for the FIPS strict mode stays unchanged.
+You can still override automatic detection by specifying the `https-key-store-type` and `https-trust-store-type` explicitly. The same applies to the management interface and its `https-management-key-store-type`. Restrictions for the FIPS strict mode stay unchanged.
 
 NOTE: The `+spi-truststore-file-*+` options and the truststore related options `+https-trust-store-*+` are deprecated, we strongly recommend to use System Truststore. For more details refer to the relevant https://www.keycloak.org/server/keycloak-truststore[guide].

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -165,7 +165,7 @@
                     </goals>
                     <configuration>
                         <properties>
-                            <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies> 
+                            <quarkus.package.jar.filter-optional-dependencies>true</quarkus.package.jar.filter-optional-dependencies>
                         </properties>
                     </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.8.5</quarkus.version>
-        <quarkus.build.version>3.8.5</quarkus.build.version>
+        <quarkus.version>3.13.1</quarkus.version>
+        <quarkus.build.version>3.13.1</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 
@@ -111,7 +111,7 @@
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>2.0.0.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
         <log4j.version>1.2.17</log4j.version>
         <resteasy-legacy.version>4.7.7.Final</resteasy-legacy.version>
-        <resteasy.version>6.2.7.Final</resteasy.version>
+        <resteasy.version>6.2.9.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
         <owasp.html.sanitizer.version>20240325.1</owasp.html.sanitizer.version>
         <slf4j.version>2.0.6</slf4j.version>
@@ -124,7 +124,7 @@
         <undertow.version>${undertow-legacy.version}</undertow.version>
         <undertow-legacy.version>2.2.24.Final</undertow-legacy.version>
         <undertow-jakarta.version>2.3.2.Final</undertow-jakarta.version>
-        <wildfly-elytron.version>2.2.3.Final</wildfly-elytron.version>
+        <wildfly-elytron.version>2.5.0.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
         <woodstox.version>6.0.3</woodstox.version>
         <wildfly.common.quarkus.aligned.version>1.5.4.Final-format-001</wildfly.common.quarkus.aligned.version>
@@ -148,7 +148,7 @@
         <com.apicatalog.titanium-json-ld.version>1.3.3</com.apicatalog.titanium-json-ld.version>
         <io.setl.rdf-urdna.version>1.1</io.setl.rdf-urdna.version>
 
-        <liquibase.version>4.25.1</liquibase.version>
+        <liquibase.version>4.27.0</liquibase.version>
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <servlet.api.40.version>2.0.0.Final</servlet.api.40.version>
         <twitter4j.version>4.1.2</twitter4j.version>
@@ -159,12 +159,12 @@
         <postgresql.version>16</postgresql.version>
         <aurora-postgresql.version>16.1</aurora-postgresql.version>
         <aws-jdbc-wrapper.version>2.3.1</aws-jdbc-wrapper.version>
-        <postgresql-jdbc.version>42.7.2</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.3</postgresql-jdbc.version>
         <mariadb.version>10.11</mariadb.version>
-        <mariadb-jdbc.version>3.3.3</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.4.0</mariadb-jdbc.version>
         <mssql.version>2022-latest</mssql.version>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->
-        <mssql-jdbc.version>12.4.2.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.6.3.jre11</mssql-jdbc.version>
         <oracledb.version>19.3</oracledb.version>
         <!-- this is the oracle driver version also used in the Quarkus BOM -->
         <oracle-jdbc.version>23.3.0.23.09</oracle-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.13.1</quarkus.version>
-        <quarkus.build.version>3.13.1</quarkus.build.version>
+        <quarkus.version>3.13.2</quarkus.version>
+        <quarkus.build.version>3.13.2</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -87,7 +87,7 @@ public class HttpOptions {
     public static final Option<String> HTTPS_KEY_STORE_TYPE = new OptionBuilder<>("https-key-store-type", String.class)
             .category(OptionCategory.HTTP)
             .description("The type of the key store file. " +
-                    "If not given, the type is automatically detected based on the file name. " +
+                    "If not given, the type is automatically detected based on the file extension. " +
                     "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
             .build();
 
@@ -106,7 +106,7 @@ public class HttpOptions {
     public static final Option<String> HTTPS_TRUST_STORE_TYPE = new OptionBuilder<>("https-trust-store-type", String.class)
             .category(OptionCategory.HTTP)
             .description("The type of the trust store file. " +
-                    "If not given, the type is automatically detected based on the file name. " +
+                    "If not given, the type is automatically detected based on the file extension. " +
                     "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
             .deprecated("Use the System Truststore instead, see the docs for details.")
             .build();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/PropertyException.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/PropertyException.java
@@ -23,4 +23,8 @@ public class PropertyException extends RuntimeException {
         super(message);
     }
 
+    public PropertyException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -23,6 +23,7 @@ import static org.keycloak.quarkus.runtime.Environment.isDevProfile;
 import static org.keycloak.quarkus.runtime.cli.Picocli.println;
 import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.getAllCliArgs;
 
+import io.quarkus.runtime.LaunchMode;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.Messages;
@@ -31,7 +32,6 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
 import io.quarkus.bootstrap.runner.RunnerClassLoader;
 
-import io.quarkus.runtime.configuration.ProfileManager;
 import io.smallrye.config.ConfigValue;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -131,7 +131,7 @@ public final class Build extends AbstractCommand implements Runnable {
     }
 
     private void cleanTempResources() {
-        if (!ProfileManager.getLaunchMode().isDevOrTest()) {
+        if (!LaunchMode.current().isDevOrTest()) {
             // only needed for dev/testing purposes
             getHomePath().resolve("quarkus-artifact.properties").toFile().delete();
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -30,6 +30,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
+import io.smallrye.config.ConfigValue;
 import io.smallrye.config.PropertiesConfigSource;
 
 import org.keycloak.quarkus.runtime.cli.command.Main;
@@ -91,15 +92,14 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
     }
 
     @Override
-    public String getValue(String propertyName) {
-        Map<String, String> properties = getProperties();
-        String value = properties.get(propertyName);
+    public ConfigValue getConfigValue(String propertyName) {
+        ConfigValue value = super.getConfigValue(propertyName);
 
         if (value != null) {
             return value;
         }
 
-        return properties.get(propertyName.replace(OPTION_PART_SEPARATOR_CHAR, '.'));
+        return super.getConfigValue(propertyName.replace(OPTION_PART_SEPARATOR_CHAR, '.'));
     }
 
     private static Map<String, String> parseArguments() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
@@ -63,7 +63,21 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
 
     @Override
     protected ConfigSource loadConfigSource(URL url, int ordinal) throws IOException {
-        return new PropertiesConfigSource(transform(ConfigSourceUtil.urlToMap(url)), url.toString(), ordinal);
+        // a workaround for https://github.com/smallrye/smallrye-config/issues/1207
+        // replace by the following line when fixed:
+        // return new PropertiesConfigSource(transform(ConfigSourceUtil.urlToMap(url)), url.toString(), ordinal);
+        var cs = new PropertiesConfigSource(transform(ConfigSourceUtil.urlToMap(url)), url.toString(), ordinal) {
+            private String name;
+            @Override
+            public String getName() {
+                return name;
+            }
+            public void setName(String name) {
+                this.name = name;
+            }
+        };
+        cs.setName(url.toString());
+        return cs;
     }
 
     public static class InClassPath extends KeycloakPropertiesConfigSource implements ConfigSourceProvider {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import io.smallrye.config.ConfigValue;
 import io.smallrye.config.PropertiesConfigSource;
 import org.keycloak.quarkus.runtime.Environment;
 
@@ -54,7 +55,7 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
     private static final ThreadLocal<Boolean> ENABLED = ThreadLocal.withInitial(() -> true);
 
     private PersistedConfigSource() {
-        super(readProperties(), "", 200);
+        super(readProperties(), NAME, 200);
     }
 
     public static PersistedConfigSource getInstance() {
@@ -67,15 +68,15 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
     }
 
     @Override
-    public String getValue(String propertyName) {
+    public ConfigValue getConfigValue(String propertyName) {
         if (isEnabled()) {
-            String value = super.getValue(propertyName);
+            ConfigValue value = super.getConfigValue(propertyName);
 
             if (value != null) {
                 return value;
             }
 
-            return super.getValue(propertyName.replace(Configuration.OPTION_PART_SEPARATOR_CHAR, '.'));
+            return super.getConfigValue(propertyName.replace(Configuration.OPTION_PART_SEPARATOR_CHAR, '.'));
         }
 
         return null;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
@@ -57,7 +57,10 @@ public final class QuarkusPropertiesConfigSource extends AbstractLocationConfigS
             return false;
         }
 
-        return NAME.equals(value.getConfigSourceName());
+        // workaround for https://github.com/smallrye/smallrye-config/issues/1207
+        // replace by the following line when fixed:
+        // return NAME.equals(value.getConfigSourceName());
+        return value.getConfigSourceName() != null && value.getConfigSourceName().endsWith(FILE_NAME);
     }
 
     public static Path getConfigurationFile() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -146,9 +146,9 @@ public final class HttpPropertyMappers {
             try {
                 TlsUtils.computeTrustOptions(config, config.trustStorePassword);
             } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to load 'https-trust-store' material.", e);
+                throw new PropertyException("Failed to load 'https-trust-store' material.", e);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Unable to determine 'https-trust-store-type' automatically. " +
+                throw new PropertyException("Unable to determine 'https-trust-store-type' automatically. " +
                         "Adjust the file extension or specify the property.", e);
             }
         }
@@ -170,9 +170,9 @@ public final class HttpPropertyMappers {
             try {
                 TlsUtils.computeKeyStoreOptions(config, config.keyStorePassword, config.keyStoreAliasPassword);
             } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to load 'https-key-store' material.", e);
+                throw new PropertyException("Failed to load 'https-key-store' material.", e);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Unable to determine 'https-key-store-type' automatically. " +
+                throw new PropertyException("Unable to determine 'https-key-store-type' automatically. " +
                         "Adjust the file extension or specify the property.", e);
             }
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -146,10 +146,10 @@ public final class HttpPropertyMappers {
             try {
                 TlsUtils.computeTrustOptions(config, config.trustStorePassword);
             } catch (IOException e) {
-                throw new PropertyException(Messages.httpsConfigurationNotSet());
+                throw new IllegalArgumentException("Failed to load 'https-trust-store' material.", e);
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Unable to determine 'https-trust-store-type' automatically. " +
-                        "Adjust the file extension or specify the property.");
+                        "Adjust the file extension or specify the property.", e);
             }
         }
 
@@ -170,10 +170,10 @@ public final class HttpPropertyMappers {
             try {
                 TlsUtils.computeKeyStoreOptions(config, config.keyStorePassword, config.keyStoreAliasPassword);
             } catch (IOException e) {
-                throw new PropertyException(Messages.httpsConfigurationNotSet());
+                throw new IllegalArgumentException("Failed to load 'https-key-store' material.", e);
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Unable to determine 'https-key-store-type' automatically. " +
-                        "Adjust the file extension or specify the property.");
+                        "Adjust the file extension or specify the property.", e);
             }
         }
 

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.transaction-manager.default-transaction-timeout=300
 quarkus.arc.ignored-split-packages=org.keycloak.*
 
 # No need to generate dependencies list
-quarkus.package.include-dependency-list=false
+quarkus.package.jar.include-dependency-list=false
 
 # we do not want running dev services in distribution
 quarkus.devservices.enabled=false

--- a/quarkus/server/src/main/resources/application.properties
+++ b/quarkus/server/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Inherit all configuration from the default runtime settings and sets those specific to the distribution
 
 quarkus.package.output-name=keycloak
-quarkus.package.type=mutable-jar
+quarkus.package.jar.type=mutable-jar
 quarkus.package.output-directory=lib
-quarkus.package.user-providers-directory=../providers
+quarkus.package.jar.user-providers-directory=../providers
 quarkus.package.main-class=keycloak

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -117,6 +117,7 @@
                     <argLine>-Djdk.net.hosts.file=${project.build.testOutputDirectory}/hosts_file -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.security=ALL-UNNAMED -Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory</argLine>
                     <systemPropertyVariables>
                         <kc.quarkus.tests.dist>${kc.quarkus.tests.dist}</kc.quarkus.tests.dist>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -147,8 +147,18 @@ public class FipsDistTest {
             RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
             Path truststorePath = rawDist.getDistPath().resolve("conf").resolve("server.keystore").toAbsolutePath();
 
-            // https-trust-store-type should be automatically set to pkcs12 in fips-mode=non-strict
             CLIResult cliResult = dist.run("--verbose", "start", "--fips-mode=non-strict", "--https-key-store-password=passwordpassword",
+                    "--https-trust-store-file=" + truststorePath, "--https-trust-store-password=passwordpassword");
+            cliResult.assertError("Unable to determine 'https-trust-store-type' automatically. Adjust the file extension or specify the property.");
+
+            dist.stop();
+
+            dist.copyOrReplaceFileFromClasspath("/server.keystore.pkcs12", Path.of("conf", "server.p12"));
+
+            rawDist = dist.unwrap(RawKeycloakDistribution.class);
+            truststorePath = rawDist.getDistPath().resolve("conf").resolve("server.p12").toAbsolutePath();
+
+            cliResult = dist.run("--verbose", "start", "--fips-mode=non-strict", "--https-key-store-password=passwordpassword",
                     "--https-trust-store-file=" + truststorePath, "--https-trust-store-password=passwordpassword");
             cliResult.assertStarted();
         });

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -165,8 +165,8 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file name. If 'fips-mode' is set to 'strict' and no
-                       value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
+                       no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
@@ -179,7 +179,7 @@ HTTP(S):
                        instead, see the docs for details.
 --https-trust-store-type <type>
                      DEPRECATED. The type of the trust store file. If not given, the type is
-                       automatically detected based on the file name. If 'fips-mode' is set to
+                       automatically detected based on the file extension. If 'fips-mode' is set to
                        'strict' and no value is set, it defaults to 'BCFKS'. Use the System
                        Truststore instead, see the docs for details.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -237,8 +237,8 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file name. If 'fips-mode' is set to 'strict' and no
-                       value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
+                       no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
@@ -251,7 +251,7 @@ HTTP(S):
                        instead, see the docs for details.
 --https-trust-store-type <type>
                      DEPRECATED. The type of the trust store file. If not given, the type is
-                       automatically detected based on the file name. If 'fips-mode' is set to
+                       automatically detected based on the file extension. If 'fips-mode' is set to
                        'strict' and no value is set, it defaults to 'BCFKS'. Use the System
                        Truststore instead, see the docs for details.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -166,8 +166,8 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file name. If 'fips-mode' is set to 'strict' and no
-                       value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
+                       no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
@@ -180,7 +180,7 @@ HTTP(S):
                        instead, see the docs for details.
 --https-trust-store-type <type>
                      DEPRECATED. The type of the trust store file. If not given, the type is
-                       automatically detected based on the file name. If 'fips-mode' is set to
+                       automatically detected based on the file extension. If 'fips-mode' is set to
                        'strict' and no value is set, it defaults to 'BCFKS'. Use the System
                        Truststore instead, see the docs for details.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -238,8 +238,8 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file name. If 'fips-mode' is set to 'strict' and no
-                       value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
+                       no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
@@ -252,7 +252,7 @@ HTTP(S):
                        instead, see the docs for details.
 --https-trust-store-type <type>
                      DEPRECATED. The type of the trust store file. If not given, the type is
-                       automatically detected based on the file name. If 'fips-mode' is set to
+                       automatically detected based on the file extension. If 'fips-mode' is set to
                        'strict' and no value is set, it defaults to 'BCFKS'. Use the System
                        Truststore instead, see the docs for details.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -145,8 +145,8 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file name. If 'fips-mode' is set to 'strict' and no
-                       value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
+                       no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
@@ -159,7 +159,7 @@ HTTP(S):
                        instead, see the docs for details.
 --https-trust-store-type <type>
                      DEPRECATED. The type of the trust store file. If not given, the type is
-                       automatically detected based on the file name. If 'fips-mode' is set to
+                       automatically detected based on the file extension. If 'fips-mode' is set to
                        'strict' and no value is set, it defaults to 'BCFKS'. Use the System
                        Truststore instead, see the docs for details.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -217,8 +217,8 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file name. If 'fips-mode' is set to 'strict' and no
-                       value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
+                       no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
@@ -231,7 +231,7 @@ HTTP(S):
                        instead, see the docs for details.
 --https-trust-store-type <type>
                      DEPRECATED. The type of the trust store file. If not given, the type is
-                       automatically detected based on the file name. If 'fips-mode' is set to
+                       automatically detected based on the file extension. If 'fips-mode' is set to
                        'strict' and no value is set, it defaults to 'BCFKS'. Use the System
                        Truststore instead, see the docs for details.
 

--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -192,7 +192,10 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
             props.put("mail.smtp.ssl.socketFactory", factory);
             if (configurator.getProvider().getPolicy() == HostnameVerificationPolicy.ANY) {
                 props.setProperty("mail.smtp.ssl.trust", "*");
-                props.put("mail.smtp.ssl.checkserveridentity", Boolean.FALSE.toString());
+                props.put("mail.smtp.ssl.checkserveridentity", Boolean.FALSE.toString()); // this should be the default but seems to be impl specific, so set it explicitly just to be sure
+            }
+            else {
+                props.put("mail.smtp.ssl.checkserveridentity", Boolean.TRUE.toString());
             }
         }
     }


### PR DESCRIPTION
Closes #31676
Closes #30165

Keycloak 26 will be based on the next Quarkus LTS which will be 3.14/3.15. We can start following latest Quarkus releases in `main` until then.