### PR TITLE
Ensure issued_client_type is always added to successful token-exchange response

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -437,11 +437,15 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
             responseBuilder.getAccessToken().setSessionId(null);
         }
 
+        String issuedTokenType;
         if (requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE)
                 && OIDCAdvancedConfigWrapper.fromClientModel(client).isUseRefreshToken()
                 && targetUserSession.getPersistenceState() != UserSessionModel.SessionPersistenceState.TRANSIENT) {
             responseBuilder.generateRefreshToken();
             responseBuilder.getRefreshToken().issuedFor(client.getClientId());
+            issuedTokenType = OAuth2Constants.REFRESH_TOKEN_TYPE;
+        } else {
+            issuedTokenType = OAuth2Constants.ACCESS_TOKEN_TYPE;
         }
 
         String scopeParam = clientSessionCtx.getClientSession().getNote(OAuth2Constants.SCOPE);
@@ -450,6 +454,8 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         }
 
         AccessTokenResponse res = responseBuilder.build();
+        res.setOtherClaims(OAuth2Constants.ISSUED_TOKEN_TYPE, issuedTokenType);
+
         event.detail(Details.AUDIENCE, targetClient.getClientId())
             .user(targetUser);
 


### PR DESCRIPTION
`issued_token_type` was missing in the Access token response of the client-to-client token-exchange use-case.

- Compute `issued_token_type` response parameter based on requested_token_type and client configuration
- `issued_token_type` is a required response parameter as per [RFC8693 2.2.1](https://datatracker.ietf.org/doc/html/rfc8693#section-2.2.1)
- Added test to ClientTokenExchangeTest that requests an access-token as requested-token-type

Fixes #31548

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
