### PR TITLE
task: removing 10 second poll for optional secrets / configmaps

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -154,7 +154,7 @@ public class KeycloakController implements Reconciler<Keycloak>, EventSourceInit
 
         var statefulSet = context.getSecondaryResource(StatefulSet.class);
 
-        if (!status.isReady() || statefulSet.filter(watchedResources::hasMissing).isPresent()) {
+        if (!status.isReady()) {
             updateControl.rescheduleAfter(10, TimeUnit.SECONDS);
         } else if (statefulSet.filter(watchedResources::isWatching).isPresent()) {
             updateControl.rescheduleAfter(config.keycloak().pollIntervalSeconds(), TimeUnit.SECONDS);


### PR DESCRIPTION
closes: #31680

While not strictly needed it seems fine to leave the boolean annotation - once we see one of the missing resources we have to update the hash anyway.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
