### PR TITLE
fix: adding weak validation of spi options

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -47,6 +47,8 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
  */
 public class ConfigArgsConfigSource extends PropertiesConfigSource {
 
+    public static final String SPI_OPTION_PREFIX = "--spi";
+
     public static final Set<String> SHORT_OPTIONS_ACCEPTING_VALUE = Set.of(Main.PROFILE_SHORT_NAME, Main.CONFIG_FILE_SHORT_NAME);
 
     public static final String CLI_ARGS = "kc.config.args";
@@ -156,7 +158,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
                 // the weaknesses here:
                 // - needs to know all of the short name options that accept a value
                 // - does not know all of the picocli parsing rules. picocli will accept -cffile, and short option grouping - that's not accounted for
-                if (mapper != null || SHORT_OPTIONS_ACCEPTING_VALUE.contains(key) || arg.startsWith("--spi")) {
+                if (mapper != null || SHORT_OPTIONS_ACCEPTING_VALUE.contains(key) || arg.startsWith(SPI_OPTION_PREFIX)) {
                     i++; // consume next as a value to the key
                     value = args.get(i);
                 } else {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -51,6 +51,20 @@ public class StartCommandDistTest {
         assertTrue(result.getErrorOutput().contains("spi argument --spi-events-listener-jboss-logging-success-level requires a value"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }
+    
+    @Test
+    @Launch({ "build", "--spi-events-listener-jboss-logging-success-level=debug" })
+    void warnSpiRuntimeAtBuildtime(LaunchResult result) {
+        assertTrue(result.getOutput().contains("The following run time options were found, but will be ignored during build time: kc.spi-events-listener-jboss-logging-success-level"),
+                () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
+    }
+    
+    @Test
+    @Launch({ "start", "--optimized", "--http-enabled=true", "--hostname-strict=false", "--spi-events-listener-jboss-logging-enabled=false" })
+    void warnSpiBuildtimeAtRuntime(LaunchResult result) {
+        assertTrue(result.getOutput().contains("The following build time options have values that differ from what is persisted - the new values will NOT be used until another build is run: kc.spi-events-listener-jboss-logging-enabled"),
+                () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
+    }
 
     @Test
     @Launch({ "--profile=dev", "start" })
@@ -175,7 +189,7 @@ public class StartCommandDistTest {
         cliResult.assertBuild();
         dist.setEnvVar("KC_DB", "postgres");
         cliResult = dist.run("start", "--optimized", "--hostname=localhost", "--http-enabled=true");
-        cliResult.assertMessage("The following build time non-cli options have values that differ from what is persisted - the new values will NOT be used until another build is run: kc.db");
+        cliResult.assertMessage("The following build time options have values that differ from what is persisted - the new values will NOT be used until another build is run: kc.db");
     }
 
     @Test


### PR DESCRIPTION
closes: #27298

This adds spi option validation based upon the naming convention and scanning all config sources - not just the cli.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
