### PR TITLE
Do not generate secret when client rep do not specifiy public or bearer

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -563,7 +563,7 @@ public class RepresentationToModel {
     }
 
     private static String determineNewSecret(ClientModel client, ClientRepresentation rep) {
-        if (Boolean.TRUE.equals(rep.isPublicClient()) || Boolean.TRUE.equals(rep.isBearerOnly())) {
+        if (client.isPublicClient() || client.isBearerOnly()) {
             // Clear out the secret with null
             return null;
         }


### PR DESCRIPTION
Closes #31444

The PR changes to use the model instead of the representation to check for public and bearer-only. The model has already been modified at that point so it contains the new values if passed. Test changed to cover the failed scenario.
