### PR TITLE
Convert chapter client registration chapters from securing apps into guides

### DIFF
--- a/docs/documentation/securing_apps/topics.adoc
+++ b/docs/documentation/securing_apps/topics.adoc
@@ -22,8 +22,6 @@ include::topics/saml/java/java-adapters-product.adoc[]
 endif::[]
 include::topics/saml/saml-errors.adoc[]
 
-include::topics/client-registration.adoc[]
-include::topics/client-registration/client-registration-cli.adoc[]
 ifeval::[{project_community}==true]
 include::topics/token-exchange/token-exchange.adoc[]
 endif::[]

--- a/docs/documentation/server_admin/topics/clients/client-policies.adoc
+++ b/docs/documentation/server_admin/topics/clients/client-policies.adoc
@@ -16,7 +16,7 @@ Client Policies realize the following points mentioned as follows.
 
 Setting policies on what configuration a client can have::
     Configuration settings on the client can be enforced by client policies during client creation/update, but also during OpenID Connect requests to {project_name} server, which are related to particular client.
-    {project_name} supports similar thing also through the Client Registration Policies described in the link:{adapterguide_link}#_client_registration_policies[{adapterguide_name}].
+    {project_name} supports similar thing also through the *Client Registration Policies* described in the *Client registration service* from link:{securing_apps_link}[{securing_apps_name}].
     However, Client Registration Policies can only cover OIDC Dynamic Client Registration. Client Policies cover not only what Client Registration Policies can do, but other client
     registration and configuration ways. The current plans are for Client Registration to be replaced by Client Policies.
 
@@ -165,7 +165,7 @@ There is JSON Editor available in the Admin Console, which simplifies the creati
 
 == Backward Compatibility
 
-Client Policies can replace Client Registration Policies described in the link:{adapterguide_link}#_client_registration_policies[{adapterguide_name}].
+Client Policies can replace Client Registration Policies described in the *Client registration service* from link:{securing_apps_link}[{securing_apps_name}].
 However, Client Registration Policies also still co-exist. This means that for example during a Dynamic Client Registration request to create/update a client, both client policies and
 client registration policies are applied.
 

--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -125,4 +125,5 @@
 
 :section: guide
 :sections: guides
+:securing_apps_name: Securing applications Guides
 :securing_apps_link: https://www.keycloak.org/guides#securing-apps

--- a/docs/guides/securing-apps/client-registration-cli.adoc
+++ b/docs/guides/securing-apps/client-registration-cli.adoc
@@ -1,5 +1,10 @@
-[[_client_registration_cli]]
-== Automating Client Registration with the CLI
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
+
+<@tmpl.guide
+title="Client registration CLI"
+priority=60
+summary="Automating Client Registration with the CLI">
 
 The Client Registration CLI is a command-line interface (CLI) tool for application developers to configure new clients in a self-service manner when integrating with {project_name}. It is specifically designed to interact with {project_name} Client Registration REST endpoints.
 
@@ -11,11 +16,11 @@ To allow a particular user to use `Client Registration CLI`, the {project_name} 
 
 
 [[_configuring_a_user_for_client_registration_cli]]
-=== Configuring a new regular user for use with Client Registration CLI
+== Configuring a new regular user for use with Client Registration CLI
 
 .Procedure
 
-. Log in to the Admin Console (for example, http://localhost:8080{kc_admins_path}) as [command]`admin`.
+. Log in to the Admin Console (for example, http://localhost:8080) as [command]`admin`.
 . Select a realm to administer.
 . If you want to use an existing user, select that user to edit; otherwise, create a new user.
 
@@ -28,7 +33,7 @@ To allow a particular user to use `Client Registration CLI`, the {project_name} 
 +
 [NOTE]
 ====
-These permissions grant the user the capability to perform operations without the use of <<_initial_access_token,Initial Access Token>> or <<_registration_access_token,Registration Access Token>>.
+These permissions grant the user the capability to perform operations without the use of Initial Access Token or Registration Access Token (see <@links.securingapps id="client-registration" anchor="_authentication" /> for more information).
 ====
 
 It is possible to not assign any [command]`realm-management` roles to a user. In that case, a user can still log in with the Client Registration CLI but cannot use it without an Initial Access Token. Trying to perform any operations without a token results in a *403 Forbidden* error.
@@ -36,7 +41,7 @@ It is possible to not assign any [command]`realm-management` roles to a user. In
 The administrator can issue Initial Access Tokens from the Admin Console in the Clients area on the *Initial Access Token* tab.
 
 [[_configuring_a_client_for_use_with_client_registration_cli]]
-=== Configuring a client for use with the Client Registration CLI
+== Configuring a client for use with the Client Registration CLI
 
 By default, the server recognizes the Client Registration CLI as the [filename]`admin-cli` client, which is configured automatically for every new realm. No additional client configuration is necessary when logging in with a user name.
 
@@ -64,7 +69,7 @@ When you run the [command]`kcreg config credentials`, use the [command]`--secret
 * With the service account enabled, you can omit specifying the user when running [command]`kcreg config credentials` and only provide the client secret or keystore information.
 
 [[_installing_client_registration_cli]]
-=== Installing the Client Registration CLI
+== Installing the Client Registration CLI
 
 The Client Registration CLI is packaged inside the {project_name} Server distribution. You can find execution scripts inside the [filename]`bin` directory. The Linux script is called [filename]`kcreg.sh`, and the Windows script is called [filename]`kcreg.bat`.
 
@@ -89,7 +94,7 @@ c:\> kcreg
 
 
 [[_using_client_registration_cli]]
-=== Using the Client Registration CLI
+== Using the Client Registration CLI
 
 .Procedure
 
@@ -102,7 +107,7 @@ For example, on:
 +
 [options="npwrap",subs="attributes+"]
 ----
-$ kcreg.sh config credentials --server http://localhost:8080{kc_base_path} --realm demo --user user --client reg-cli
+$ kcreg.sh config credentials --server http://localhost:8080 --realm demo --user user --client reg-cli
 $ kcreg.sh create -s clientId=my_client -s 'redirectUris=["http://localhost:8980/myapp/*"]'
 $ kcreg.sh get my_client
 ----
@@ -110,7 +115,7 @@ $ kcreg.sh get my_client
 +
 [options="npwrap",subs="attributes+"]
 ----
-c:\> kcreg config credentials --server http://localhost:8080{kc_base_path} --realm demo --user user --client reg-cli
+c:\> kcreg config credentials --server http://localhost:8080 --realm demo --user user --client reg-cli
 c:\> kcreg create -s clientId=my_client -s "redirectUris=[\"http://localhost:8980/myapp/*\"]"
 c:\> kcreg get my_client
 ----
@@ -138,7 +143,7 @@ c:\> kcreg config truststore --trustpass %PASSWORD% %HOMEPATH%\.keycloak\trustst
 
 
 [[_logging_in]]
-==== Logging in
+=== Logging in
 
 .Procedure
 
@@ -170,7 +175,7 @@ See [filename]`kcreg config credentials --help` for more information about start
 
 
 [[_working_with_alternative_configurations]]
-==== Working with alternative configurations
+=== Working with alternative configurations
 
 By default, the Client Registration CLI automatically maintains a configuration file at a default location, [filename]`./.keycloak/kcreg.config`, under the user's home directory. You can use the [command]`--config` option to point to a different file or location to maintain multiple authenticated sessions in parallel. It is the safest way to perform operations tied to a single configuration file from a single thread.
 
@@ -183,7 +188,7 @@ You might want to avoid storing secrets inside a configuration file by using the
 
 
 [[_initial_access_and_registration_access_tokens]]
-==== Initial Access and Registration Access Tokens
+=== Initial Access and Registration Access Tokens
 
 Developers who do not have an account configured at the {project_name} server they want to use can use the Client Registration CLI. This is possible only when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how and when to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it.
 
@@ -223,13 +228,13 @@ When using an Initial Access Token, the server response includes a newly issued 
 
 The Client Registration CLI automatically uses its private configuration file to save and use this token with its associated client. As long as the same configuration file is used for all client operations, the developer does not need to authenticate to read, update, or delete a client that was created this way.
 
-See <<_client_registration, Client Registration>> for more information about Initial Access and Registration Access Tokens.
+See <@links.securingapps id="client-registration" anchor="_authentication" /> for more information about Initial Access and Registration Access Tokens.
 
 Run the [command]`kcreg config initial-token --help` and [command]`kcreg config registration-token --help` commands for more information on how to configure tokens with the Client Registration CLI.
 
 
 [[_performing_crud_operations]]
-==== Creating a client configuration
+=== Creating a client configuration
 
 The first task after authenticating with credentials or configuring an Initial Access Token is usually to create a new client. Often you might want to use a prepared JSON file as a template and set or override some of the attributes.
 
@@ -252,7 +257,7 @@ You can use [command]`kcreg attrs` to list available attributes. Keep in mind th
 template and should not specify them as arguments to the [command]`kcreg create` command.
 
 
-==== Retrieving a client configuration
+=== Retrieving a client configuration
 
 You can retrieve an existing client by using the [command]`kcreg get` command.
 
@@ -287,7 +292,7 @@ C:\> kcreg get myclient -e install > keycloak.json
 Run the [command]`kcreg get --help` command for more information about the [command]`kcreg get` command.
 
 
-==== Modifying a client configuration
+=== Modifying a client configuration
 
 There are two methods for updating a client configuration.
 
@@ -343,7 +348,7 @@ C:\> kcreg update myclient --merge -d redirectUris -f mychanges.json
 Run the [command]`kcreg update --help` command for more information about the [command]`kcreg update` command.
 
 
-==== Deleting a client configuration
+=== Deleting a client configuration
 
 Use the following example to delete a client.
 
@@ -362,7 +367,7 @@ Run the [command]`kcreg delete --help` command for more information about the [c
 
 
 [[_refreshing_invalid_registration_access_tokens]]
-==== Refreshing invalid Registration Access Tokens
+=== Refreshing invalid Registration Access Tokens
 
 When performing a create, read, update, and delete (CRUD) operation using the [command]`--no-config` mode, the Client Registration CLI cannot handle Registration Access Tokens for you. In that case, it is possible to lose track of the most recently issued Registration Access Token for a client, which makes it impossible to perform any further CRUD operations on that client without authenticating with an account that has *manage-clients* permissions.
 
@@ -372,8 +377,10 @@ Run the [command]`kcreg update-token --help` command for more information about 
 
 
 [[_troubleshooting_2]]
-=== Troubleshooting
+== Troubleshooting
 
 * Q: When logging in, I get an error: *Parameter client_assertion_type is missing [invalid_client]*.
 +
 A: This error means your client is configured with [filename]`Signed JWT` token credentials, which means you have to use the [command]`--keystore` parameter when logging in.
+
+</@tmpl.guide>

--- a/docs/guides/securing-apps/client-registration.adoc
+++ b/docs/guides/securing-apps/client-registration.adoc
@@ -1,12 +1,16 @@
-[[_client_registration]]
-== Using the client registration service
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
+
+<@tmpl.guide
+title="Client registration service"
+priority=50
+summary="Using the client registration service">
 
 In order for an application or service to utilize {project_name} it has to register a client in {project_name}.
-An admin can do this through the admin console (or admin REST endpoints), but clients can also register themselves through the {project_name} client
-registration service.
+An admin can do this through the admin console (or admin REST endpoints), but clients can also register themselves through the {project_name} client registration service.
 
 The Client Registration Service provides built-in support for {project_name} Client Representations, OpenID Connect Client Meta Data and SAML Entity Descriptors.
-The Client Registration Service endpoint is `{kc_realms_path}/<realm>/clients-registrations/<provider>`.
+The Client Registration Service endpoint is `/realms/<realm>/clients-registrations/<provider>`.
 
 The built-in supported `providers` are: 
 
@@ -17,12 +21,12 @@ The built-in supported `providers` are:
 
 The following sections will describe how to use the different providers. 
 
-=== Authentication
+== Authentication
 
 To invoke the Client Registration Services you usually need a token. The token can be a bearer token, an initial access token or a registration access token.
 There is an alternative to register new client without any token as well, but then you need to configure Client Registration Policies (see below).
 
-==== Bearer token
+=== Bearer token
 
 The bearer token can be issued on behalf of a user or a Service Account. The following permissions are required to invoke the endpoints (see link:{adminguide_link}[{adminguide_name}] for more details):
 
@@ -33,7 +37,7 @@ The bearer token can be issued on behalf of a user or a Service Account. The fol
 If you are using a bearer token to create clients it's recommend to use a token from a Service Account with only the `create-client` role (see link:{adminguide_link}[{adminguide_name}] for more details).
 
 [[_initial_access_token]]
-==== Initial Access Token
+=== Initial Access Token
 
 The recommended approach to registering new clients is by using initial access tokens.
 An initial access token can only be used to create clients and has a configurable expiration as well as a configurable limit on how many clients can be created. 
@@ -55,8 +59,9 @@ For example:
 ----
 Authorization: bearer eyJhbGciOiJSUz...
 ----            
+
 [[_registration_access_token]]
-==== Registration Access Token
+=== Registration Access Token
 
 When you create a client through the Client Registration Service the response will include a registration access token.
 The registration access token provides access to retrieve the client configuration later, but also to update or delete the client.
@@ -68,30 +73,30 @@ If a client was created outside of the Client Registration Service it won't have
 You can create one through the admin console. This can also be useful if you lose the token for a particular client.
 To create a new token find the client in the admin console and click on `Credentials`. Then click on `Generate registration access token`.
 
-=== {project_name} Representations
+== {project_name} Representations
 
 The `default` client registration provider can be used to create, retrieve, update and delete a client.
 It uses {project_name} Client Representation format which provides support for configuring clients exactly as they can be configured through the admin
 console, including for example configuring protocol mappers.
 
-To create a client create a Client Representation (JSON) then perform an HTTP POST request to `{kc_realms_path}/<realm>/clients-registrations/default`.
+To create a client create a Client Representation (JSON) then perform an HTTP POST request to `/realms/<realm>/clients-registrations/default`.
 
 It will return a Client Representation that also includes the registration access token.
 You should save the registration access token somewhere if you want to retrieve the config, update or delete the client later. 
 
-To retrieve the Client Representation perform an HTTP GET request to `{kc_realms_path}/<realm>/clients-registrations/default/<client id>`.
+To retrieve the Client Representation perform an HTTP GET request to `/realms/<realm>/clients-registrations/default/<client id>`.
 
 It will also return a new registration access token. 
 
 To update the Client Representation perform an HTTP PUT request with the updated Client Representation to:
-`{kc_realms_path}/<realm>/clients-registrations/default/<client id>`.
+`/realms/<realm>/clients-registrations/default/<client id>`.
 
 It will also return a new registration access token. 
 
 To delete the Client Representation perform an HTTP DELETE request to:
-`{kc_realms_path}/<realm>/clients-registrations/default/<client id>`
+`/realms/<realm>/clients-registrations/default/<client id>`
 
-=== {project_name} adapter configuration
+== {project_name} adapter configuration
 
 The `installation` client registration provider can be used to retrieve the adapter configuration for a client.
 In addition to token authentication you can also authenticate with client credentials using HTTP basic authentication.
@@ -102,29 +107,29 @@ To do this include the following header in the request:
 Authorization: basic BASE64(client-id + ':' + client-secret)
 ----        
 
-To retrieve the Adapter Configuration then perform an HTTP GET request to `{kc_realms_path}/<realm>/clients-registrations/install/<client id>`.
+To retrieve the Adapter Configuration then perform an HTTP GET request to `/realms/<realm>/clients-registrations/install/<client id>`.
 
 No authentication is required for public clients.
 This means that for the JavaScript adapter you can load the client configuration directly from {project_name} using the above URL.
 
-=== OpenID Connect Dynamic Client Registration
+== OpenID Connect Dynamic Client Registration
 
 {project_name} implements https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect Dynamic Client Registration], which extends https://datatracker.ietf.org/doc/html/rfc7591[OAuth 2.0 Dynamic Client Registration Protocol] and https://datatracker.ietf.org/doc/html/rfc7592[OAuth 2.0 Dynamic Client Registration Management Protocol].
 
-The endpoint to use these specifications to register clients in {project_name} is `{kc_realms_path}/<realm>/clients-registrations/openid-connect[/<client id>]`.
+The endpoint to use these specifications to register clients in {project_name} is `/realms/<realm>/clients-registrations/openid-connect[/<client id>]`.
 
-This endpoint can also be found in the OpenID Connect Discovery endpoint for the realm, `{kc_realms_path}/<realm>/.well-known/openid-configuration`.
+This endpoint can also be found in the OpenID Connect Discovery endpoint for the realm, `/realms/<realm>/.well-known/openid-configuration`.
 
-=== SAML Entity Descriptors
+== SAML Entity Descriptors
 
 The SAML Entity Descriptor endpoint only supports using SAML v2 Entity Descriptors to create clients.
 It doesn't support retrieving, updating or deleting clients.
 For those operations the {project_name} representation endpoints should be used.
 When creating a client a {project_name} Client Representation is returned with details about the created client, including a registration access token.
 
-To create a client perform an HTTP POST request with the SAML Entity Descriptor to `{kc_realms_path}/<realm>/clients-registrations/saml2-entity-descriptor`.
+To create a client perform an HTTP POST request with the SAML Entity Descriptor to `/realms/<realm>/clients-registrations/saml2-entity-descriptor`.
 
-=== Example using CURL
+== Example using CURL
 
 The following example creates a client with the clientId `myclient` using CURL. You need to replace `eyJhbGciOiJSUz...` with a proper initial access token or
 bearer token.
@@ -135,10 +140,10 @@ curl -X POST \
     -d '{ "clientId": "myclient" }' \
     -H "Content-Type:application/json" \
     -H "Authorization: bearer eyJhbGciOiJSUz..." \
-    http://localhost:8080{kc_realms_path}/master/clients-registrations/default
+    http://localhost:8080/realms/master/clients-registrations/default
 ----
 
-=== Example using Java Client Registration API
+== Example using Java Client Registration API
 
 The Client Registration Java API makes it easy to use the Client Registration Service using Java.
 To use include the dependency `org.keycloak:keycloak-client-registration-api:>VERSION<` from Maven. 
@@ -154,7 +159,7 @@ ClientRepresentation client = new ClientRepresentation();
 client.setClientId(CLIENT_ID);
 
 ClientRegistration reg = ClientRegistration.create()
-    .url("http://localhost:8080{kc_base_path}", "myrealm")
+    .url("http://localhost:8080", "myrealm")
     .build();
 
 reg.auth(Auth.token(token));
@@ -165,7 +170,7 @@ String registrationAccessToken = client.getRegistrationAccessToken();
 ----
 
 [[_client_registration_policies]]
-=== Client Registration Policies
+== Client Registration Policies
 
 NOTE: The current plans are for the Client Registration Policies to be removed in favor of the Client Policies described in the link:{adminguide_link}#_client_policies[{adminguide_name}].
 Client Policies are more flexible and support more use cases.
@@ -213,3 +218,4 @@ realm roles or client roles of other clients.
 * Client Disabled Policy - Newly registered client will be disabled. This means that admin needs to manually approve and enable all newly registered clients.
 This policy is not used by default even for anonymous registration.
 
+</@tmpl.guide>

--- a/docs/guides/securing-apps/oidc-layers.adoc
+++ b/docs/guides/securing-apps/oidc-layers.adoc
@@ -6,7 +6,7 @@ title="Secure applications and services with OpenID Connect"
 priority=10
 summary="Using OpenID Connect with Keycloak to secure applications and services">
 
-include::partials/oidc/available-endpoints.adoc[]
+<#include "partials/oidc/available-endpoints.adoc" />
 
 include::partials/oidc/supported-grant-types.adoc[]
 

--- a/docs/guides/securing-apps/partials/oidc/available-endpoints.adoc
+++ b/docs/guides/securing-apps/partials/oidc/available-endpoints.adoc
@@ -91,7 +91,7 @@ on the client advanced settings, which triggers the token introspection.
 
 The dynamic client registration endpoint is used to dynamically register clients.
 
-For more details, see the <<_client_registration,Client Registration chapter>> and the
+For more details, see the <@links.securingapps id="client-registration" /> {section} and the
 https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect Dynamic Client Registration specification].
 
 [[_token_revocation_endpoint]]


### PR DESCRIPTION
Closes #31332
Closes #31333

Moving to guides the registration chapters.
