### PR TITLE
Persist revoke tokens with remote cache feature

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanSingleUseObjectProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanSingleUseObjectProvider.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.sessions.infinispan.remote;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -33,15 +34,23 @@ import org.keycloak.models.sessions.infinispan.remote.transaction.SingleUseObjec
 public class RemoteInfinispanSingleUseObjectProvider implements SingleUseObjectProvider {
 
     private final static Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+    public static final SingleUseObjectValueEntity REVOKED_TOKEN_VALUE = new SingleUseObjectValueEntity(Collections.emptyMap());
 
     private final SingleUseObjectTransaction transaction;
+    private final RevokeTokenConsumer revokeTokenConsumer;
 
-    public RemoteInfinispanSingleUseObjectProvider(SingleUseObjectTransaction transaction) {
+    public RemoteInfinispanSingleUseObjectProvider(SingleUseObjectTransaction transaction, RevokeTokenConsumer revokeTokenConsumer) {
         this.transaction = Objects.requireNonNull(transaction);
+        this.revokeTokenConsumer = Objects.requireNonNull(revokeTokenConsumer);
+
     }
 
     @Override
     public void put(String key, long lifespanSeconds, Map<String, String> notes) {
+        if (key.endsWith(REVOKED_KEY)) {
+            revokeToken(key, lifespanSeconds);
+            return;
+        }
         transaction.put(key, wrap(notes), lifespanSeconds, TimeUnit.SECONDS);
     }
 
@@ -93,11 +102,21 @@ public class RemoteInfinispanSingleUseObjectProvider implements SingleUseObjectP
         return transaction.getCache().withFlags(Flag.FORCE_RETURN_VALUE);
     }
 
+    private void revokeToken(String key, long lifespanSeconds) {
+        transaction.put(key, REVOKED_TOKEN_VALUE, lifespanSeconds, TimeUnit.SECONDS);
+        var token = key.substring(0, key.length() - REVOKED_KEY.length());
+        revokeTokenConsumer.onTokenRevoke(token, lifespanSeconds);
+    }
+
     private static Map<String, String> unwrap(SingleUseObjectValueEntity entity) {
         return entity == null ? null : entity.getNotes();
     }
 
     private static SingleUseObjectValueEntity wrap(Map<String, String> notes) {
         return new SingleUseObjectValueEntity(notes);
+    }
+
+    public interface RevokeTokenConsumer {
+        void onTokenRevoke(String token, long lifespanSeconds);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanSingleUseObjectProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanSingleUseObjectProviderFactory.java
@@ -18,41 +18,69 @@
 package org.keycloak.models.sessions.infinispan.remote;
 
 import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.common.util.Time;
 import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.SingleUseObjectProviderFactory;
+import org.keycloak.models.session.RevokedToken;
+import org.keycloak.models.session.RevokedTokenPersisterProvider;
 import org.keycloak.models.sessions.infinispan.entities.SingleUseObjectValueEntity;
 import org.keycloak.models.sessions.infinispan.remote.transaction.SingleUseObjectTransaction;
+import org.keycloak.models.utils.PostMigrationEvent;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.provider.ProviderEvent;
+import org.keycloak.provider.ProviderEventListener;
+import org.keycloak.provider.ServerInfoAwareProviderFactory;
 
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.ACTION_TOKEN_CACHE;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.getRemoteCache;
+import static org.keycloak.models.SingleUseObjectProvider.REVOKED_KEY;
+import static org.keycloak.models.sessions.infinispan.InfinispanSingleUseObjectProviderFactory.CONFIG_PERSIST_REVOKED_TOKENS;
+import static org.keycloak.models.sessions.infinispan.InfinispanSingleUseObjectProviderFactory.DEFAULT_PERSIST_REVOKED_TOKENS;
+import static org.keycloak.models.sessions.infinispan.InfinispanSingleUseObjectProviderFactory.LOADED;
+import static org.keycloak.models.sessions.infinispan.remote.RemoteInfinispanSingleUseObjectProvider.REVOKED_TOKEN_VALUE;
+import static org.keycloak.models.sessions.infinispan.remote.RemoteInfinispanSingleUseObjectProvider.RevokeTokenConsumer;
+import static org.keycloak.storage.datastore.DefaultDatastoreProviderFactory.setupClearExpiredRevokedTokensScheduledTask;
 
-public class RemoteInfinispanSingleUseObjectProviderFactory implements SingleUseObjectProviderFactory<RemoteInfinispanSingleUseObjectProvider>, EnvironmentDependentProviderFactory {
+public class RemoteInfinispanSingleUseObjectProviderFactory implements SingleUseObjectProviderFactory<RemoteInfinispanSingleUseObjectProvider>, EnvironmentDependentProviderFactory, ProviderEventListener, ServerInfoAwareProviderFactory {
 
     private final static Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+    private static final RevokeTokenConsumer VOLATILE_REVOKE_TOKEN = (token, lifespanSeconds) -> {
+    };
+    // max of 16 remote cache puts concurrently.
+    private static final int REVOKED_TOKENS_IMPORT_CONCURRENCY = 16;
 
     private volatile RemoteCache<String, SingleUseObjectValueEntity> cache;
+    private volatile boolean persistRevokedTokens;
 
     @Override
     public RemoteInfinispanSingleUseObjectProvider create(KeycloakSession session) {
         assert cache != null;
-        return new RemoteInfinispanSingleUseObjectProvider(createAndEnlistTransaction(session));
+        return new RemoteInfinispanSingleUseObjectProvider(createAndEnlistTransaction(session), createRevokeTokenConsumer(session));
     }
 
     @Override
     public void init(Config.Scope config) {
-
+        persistRevokedTokens = config.getBoolean(CONFIG_PERSIST_REVOKED_TOKENS, DEFAULT_PERSIST_REVOKED_TOKENS);
     }
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
         cache = getRemoteCache(factory, ACTION_TOKEN_CACHE);
+        factory.register(this);
         logger.debug("Provided initialized.");
     }
 
@@ -76,9 +104,76 @@ public class RemoteInfinispanSingleUseObjectProviderFactory implements SingleUse
         return InfinispanUtils.isRemoteInfinispan();
     }
 
+    @Override
+    public Map<String, String> getOperationalInfo() {
+        Map<String, String> info = new HashMap<>();
+        info.put(CONFIG_PERSIST_REVOKED_TOKENS, Boolean.toString(persistRevokedTokens));
+        return info;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+        builder.property()
+                .name(CONFIG_PERSIST_REVOKED_TOKENS)
+                .type("boolean")
+                .helpText("If revoked tokens are stored persistently across restarts")
+                .defaultValue(DEFAULT_PERSIST_REVOKED_TOKENS)
+                .add();
+
+        return builder.build();
+    }
+
+    @Override
+    public void onEvent(ProviderEvent event) {
+        if (!(event instanceof PostMigrationEvent pme)) {
+            return;
+        }
+        if (!persistRevokedTokens) {
+            //nothing to do
+            return;
+        }
+
+        // preload revoked tokens from the database and register cleanup expired tokens task
+        KeycloakSessionFactory sessionFactory = pme.getFactory();
+        setupClearExpiredRevokedTokensScheduledTask(sessionFactory);
+        try (var session = sessionFactory.create()) {
+            preloadRevokedTokens(session);
+        }
+    }
+
     private SingleUseObjectTransaction createAndEnlistTransaction(KeycloakSession session) {
         var tx = new SingleUseObjectTransaction(cache);
         session.getTransactionManager().enlistAfterCompletion(tx);
         return tx;
     }
+
+    private RevokedTokenPersisterProvider getRevokedTokenPersisterProvider(KeycloakSession session) {
+        return session.getProvider(RevokedTokenPersisterProvider.class);
+    }
+
+    private RevokeTokenConsumer createRevokeTokenConsumer(KeycloakSession session) {
+        return persistRevokedTokens ? getRevokedTokenPersisterProvider(session)::revokeToken : VOLATILE_REVOKE_TOKEN;
+    }
+
+    private void preloadRevokedTokens(KeycloakSession session) {
+        var provider = getRevokedTokenPersisterProvider(session);
+        if (cache.get(LOADED) == null) {
+            logger.debug("Preloading revoked tokens from database.");
+            var currentTime = Time.currentTime();
+            Flowable.fromStream(provider.getAllRevokedTokens())
+                    .filter(revokedToken -> revokedToken.expiry() - currentTime > 0) // skip expired tokens
+                    .flatMapCompletable(token -> preloadToken(token, currentTime), false, REVOKED_TOKENS_IMPORT_CONCURRENCY)
+                    .blockingAwait();
+            cache.put(LOADED, REVOKED_TOKEN_VALUE);
+            logger.debug("Preload completed.");
+        }
+    }
+
+    private Completable preloadToken(RevokedToken token, long currentTime) {
+        var lifespan = token.expiry() - currentTime;
+        return Completable.fromCompletionStage(cache.putIfAbsentAsync(token.tokenId() + REVOKED_KEY, REVOKED_TOKEN_VALUE, lifespan, TimeUnit.SECONDS));
+    }
+
+
 }


### PR DESCRIPTION
Stores the revoked tokens into the database and preloads them during startup.

Fixes #31760

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
