### PR TITLE
[account-ui] Move PatternFly dependencies into peer dependencies and make them external

### DIFF
--- a/js/apps/account-ui/package.json
+++ b/js/apps/account-ui/package.json
@@ -24,11 +24,6 @@
     "test": "wireit"
   },
   "dependencies": {
-    "@keycloak/keycloak-ui-shared": "workspace:*",
-    "@patternfly/patternfly": "^5.3.1",
-    "@patternfly/react-core": "^5.3.4",
-    "@patternfly/react-icons": "^5.3.2",
-    "@patternfly/react-table": "^5.3.4",
     "i18next": "^23.12.3",
     "i18next-http-backend": "^2.5.2",
     "keycloak-js": "workspace:*",
@@ -39,6 +34,13 @@
     "react-i18next": "^15.0.1",
     "react-router-dom": "^6.24.1"
   },
+  "peerDependencies": {
+    "@keycloak/keycloak-ui-shared": "workspace:*",
+    "@patternfly/patternfly": "^5.3.1",
+    "@patternfly/react-core": "^5.3.4",
+    "@patternfly/react-icons": "^5.3.2",
+    "@patternfly/react-table": "^5.3.4"
+  },
   "devDependencies": {
     "@keycloak/keycloak-admin-client": "workspace:*",
     "@playwright/test": "^1.46.0",
@@ -48,6 +50,7 @@
     "@vitejs/plugin-react-swc": "^3.7.0",
     "lightningcss": "^1.26.0",
     "vite": "^5.4.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "vite-plugin-checker": "^0.7.2",
     "vite-plugin-dts": "^4.0.2"
   },

--- a/js/apps/account-ui/package.json
+++ b/js/apps/account-ui/package.json
@@ -49,8 +49,8 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "lightningcss": "^1.26.0",
-    "vite": "^5.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
+    "vite": "^5.4.0",
     "vite-plugin-checker": "^0.7.2",
     "vite-plugin-dts": "^4.0.2"
   },

--- a/js/apps/account-ui/vite.config.ts
+++ b/js/apps/account-ui/vite.config.ts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import { defineConfig, loadEnv } from "vite";
 import { checker } from "vite-plugin-checker";
 import dts from "vite-plugin-dts";
@@ -43,6 +44,11 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         input,
         external,
+        plugins: [
+          peerDepsExternal({
+            includeDependencies: true,
+          }),
+        ],
       },
     },
     plugins,

--- a/js/libs/ui-shared/package.json
+++ b/js/libs/ui-shared/package.json
@@ -45,9 +45,6 @@
   },
   "dependencies": {
     "@keycloak/keycloak-admin-client": "workspace:*",
-    "@patternfly/react-core": "^5.3.4",
-    "@patternfly/react-icons": "^5.3.2",
-    "@patternfly/react-styles": "^5.3.1",
     "i18next": "^23.12.3",
     "keycloak-js": "workspace:*",
     "lodash-es": "^4.17.21",
@@ -55,6 +52,11 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "7.52.2",
     "react-i18next": "^15.0.1"
+  },
+  "peerDependencies": {
+    "@patternfly/react-core": "^5.3.4",
+    "@patternfly/react-icons": "^5.3.2",
+    "@patternfly/react-styles": "^5.3.1"
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         version: 1.26.0
       rollup-plugin-peer-deps-external:
         specifier: ^2.2.4
-        version: 2.2.4(rollup@4.19.0)
+        version: 2.2.4(rollup@4.20.0)
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.2.0)(lightningcss@1.26.0)(terser@5.31.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       lightningcss:
         specifier: ^1.26.0
         version: 1.26.0
+      rollup-plugin-peer-deps-external:
+        specifier: ^2.2.4
+        version: 2.2.4(rollup@4.19.0)
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.2.0)(lightningcss@1.26.0)(terser@5.31.3)


### PR DESCRIPTION
According to #31526, embedding the PatternFly code into the `account-ui` library make the `PageContext` duplicated.
This breaks the sidebar because `isManagedSidebar` uses this context.

Moving these dependencies into peer dependencies and make them external evacuate the code of PatternFly away, letting the opportunity to the final bundler to pack all this "library mix" properly.