### PR TITLE
Caches the id-to-user mapping for the evaluation in the current session

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultEvaluation.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultEvaluation.java
@@ -168,19 +168,33 @@ public class DefaultEvaluation implements Evaluation {
                 return user.isMemberOf(group);
             }
 
+            private final String USER_CACHE_SESSION_ATTRIBUTE = DefaultEvaluation.class.getName() + ".userCache";
             private UserModel getUser(String id, KeycloakSession session) {
-                RealmModel realm = session.getContext().getRealm();
-                UserModel user = session.users().getUserById(realm, id);
+                @SuppressWarnings("unchecked") HashMap<String, UserModel> cache = (HashMap<String, UserModel>) session.getAttribute(USER_CACHE_SESSION_ATTRIBUTE);
+                if (cache == null) {
+                    cache = new HashMap<>();
+                    session.setAttribute(USER_CACHE_SESSION_ATTRIBUTE, cache);
+                }
+                UserModel user = cache.get(id);
 
                 if (Objects.isNull(user)) {
-                    user = session.users().getUserByUsername(realm ,id);
+                    if (cache.containsKey(id)) {
+                        return null;
+                    }
+                    RealmModel realm = session.getContext().getRealm();
+                    user = session.users().getUserById(realm, id);
+                    if (Objects.isNull(user)) {
+                        user = session.users().getUserByUsername(realm, id);
+                    }
+                    if (Objects.isNull(user)) {
+                        user = session.users().getUserByEmail(realm, id);
+                    }
+                    if (Objects.isNull(user)) {
+                        user = session.users().getServiceAccount(realm.getClientById(id));
+                    }
                 }
-                if (Objects.isNull(user)) {
-                    user = session.users().getUserByEmail(realm, id);
-                }
-                if (Objects.isNull(user)) {
-                    user = session.users().getServiceAccount(realm.getClientById(id));
-                }
+
+                cache.put(id, user);
 
                 return user;
             }


### PR DESCRIPTION
Closes #31519
Closes #31614

This will avoid the situation when on each evaluation for a service account, there are first three misses for user-by-id, user-by-username and user-by-email.  

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
