### PR TITLE
OIDC dynamic client registration with response_type=none

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
@@ -95,7 +95,7 @@ public class DescriptionConverter {
 
         try {
             OIDCResponseType responseType = OIDCResponseType.parse(oidcResponseTypes);
-            client.setStandardFlowEnabled(responseType.hasResponseType(OIDCResponseType.CODE));
+            client.setStandardFlowEnabled(responseType.hasResponseType(OIDCResponseType.CODE) || responseType.hasResponseType(OIDCResponseType.NONE));
             client.setImplicitFlowEnabled(responseType.isImplicitOrHybridFlow());
 
             if (oidcGrantTypes != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -204,6 +204,30 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
     }
 
     @Test
+    public void createClientResponseTypeNone() throws ClientRegistrationException {
+        OIDCClientRepresentation client = createRep();
+        client.setResponseTypes(List.of("none"));
+        OIDCClientRepresentation response = reg.oidc().create(client);
+
+        assertNotNull(response.getRegistrationAccessToken());
+        assertNotNull(response.getClientIdIssuedAt());
+        assertNotNull(response.getClientId());
+        assertNotNull(response.getClientSecret());
+        assertEquals(0, response.getClientSecretExpiresAt().intValue());
+        assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
+        assertEquals("RegistrationAccessTokenTest", response.getClientName());
+        assertEquals("http://root", response.getClientUri());
+        assertEquals(1, response.getRedirectUris().size());
+        assertEquals("http://redirect", response.getRedirectUris().get(0));
+        assertEquals(List.of("code", "none"), response.getResponseTypes());
+        assertEquals(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN), response.getGrantTypes());
+        assertEquals(OIDCLoginProtocol.CLIENT_SECRET_BASIC, response.getTokenEndpointAuthMethod());
+        Assert.assertNull(response.getUserinfoSignedResponseAlg());
+        assertEquals("http://frontchannel", response.getFrontChannelLogoutUri());
+        assertTrue(response.getFrontchannelLogoutSessionRequired());
+    }
+
+    @Test
     public void updateClientError() throws ClientRegistrationException {
         try {
             OIDCClientRepresentation response = create();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/OIDCBasicResponseTypeNoneTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/OIDCBasicResponseTypeNoneTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oidc.flows;
+
+import org.junit.Before;
+import org.keycloak.events.Details;
+import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.util.OAuthClient;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test for response_type=none
+ *
+ * @author <a href="mailto:ggrazian@redhat.com">Giuseppe Graziano</a>
+ */
+public class OIDCBasicResponseTypeNoneTest extends AbstractOIDCResponseTypeTest {
+
+    @Before
+    public void clientConfiguration() {
+        clientManagerBuilder().standardFlow(true).implicitFlow(false);
+
+        oauth.clientId("test-app");
+        oauth.responseType(OIDCResponseType.NONE);
+    }
+
+
+    @Override
+    protected boolean isFragment() {
+        return false;
+    }
+
+    @Override
+    protected List<IDToken> testAuthzResponseAndRetrieveIDTokens(OAuthClient.AuthorizationEndpointResponse authzResponse, EventRepresentation loginEvent) {
+        Assert.assertEquals(OIDCResponseType.NONE, loginEvent.getDetails().get(Details.RESPONSE_TYPE));
+
+        Assert.assertNull(authzResponse.getCode());
+        Assert.assertNull(authzResponse.getAccessToken());
+        Assert.assertNull(authzResponse.getIdToken());
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
When `response_type=code` or `response_type=none` in the OIDC client registration request, the standard flow is always enabled.


Added a test to check the OIDC response when `response_type=code` in the auth request.

Closes #19564 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
