### PR TITLE
Cache node binary for Windows to avoid download failures

### DIFF
--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -40,6 +40,7 @@ runs:
       shell: bash
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          choco install zstandard
+          # zstd binary might be missing in older versions, install only when necessary
+          which zstd > /dev/null || choco install zstandard
         fi
         tar -C ~/ --use-compress-program="zstd -d" -xf m2-keycloak.tzts

--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -28,15 +28,37 @@ runs:
           ~/.m2/repository/*/*
           !~/.m2/repository/org/keycloak
         key: ${{ steps.weekly-cache-key.outputs.key }}
+        # Enable cross-os archive use the cache on both Linux and Windows
+        enableCrossOsArchive: true
+
+    - id: download-node-for-windows
+      # This is necessary as the build which creates the cache will run on a Linux node and therefore will never download the Windows artifact by default.
+      # If we wouldn't download it manually, it would be downloaded on each Windows build, which proved to be unstable as downloads would randomly fail in the middle of the download.
+      if: inputs.create-cache-if-it-doesnt-exist == 'true' && steps.cache-maven-repository.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        export VERSION=$(mvn help:evaluate -Dexpression=node.version -q -DforceStdout  | cut -c 2-)
+        curl -Lf https://nodejs.org/dist/v${VERSION}/win-x64/node.exe --create-dirs -o ~/.m2/repository/com/github/eirslett/node/${VERSION}/node-${VERSION}-win-x64.exe
+
+    - shell: powershell
+      name: Link the cached Maven repository to the OS-dependent location
+      if: inputs.create-cache-if-it-doesnt-exist == 'false' && runner.os == 'Windows'
+      # The cache restore in the next step uses the relative path which was valid on Linux and that is part of the archive it downloads.
+      # You'll see that path when you enable debugging for the GitHub workflow on Windows.
+      # On Windows, the .m2 folder is in different location, so move all the contents to the right folder here.
+      # Also, not using the C: drive will speed up the build, see https://github.com/actions/runner-images/issues/8755
+      run: |
+        mkdir -p ../../../.m2/repository
+        cmd /c mklink /d $HOME\.m2\repository D:\.m2\repository
 
     - id: restore-maven-repository
       name: Maven cache
       uses: actions/cache/restore@v4
       if: inputs.create-cache-if-it-doesnt-exist == 'false'
       with:
-        # Two asterisks are needed to make the follow-up exclusion work
-        # see https://github.com/actions/toolkit/issues/713 for the upstream issue
+        # This needs to repeat the same path pattern as above to find the matching cache
         path: |
           ~/.m2/repository/*/*
           !~/.m2/repository/org/keycloak
         key: ${{ steps.weekly-cache-key.outputs.key }}
+        enableCrossOsArchive: true


### PR DESCRIPTION
Closes #31835

Example run: https://github.com/ahus1/keycloak/actions/runs/10212432968/job/28256048867

Looking at the logs, you'll find the following which shows that Node.js is no longer downloaded during the test execution, but picked up from the Maven repo's cache.

This has been run after clearing the existing caches in that repository, so the cache has been created in the previous build step of the run, so it contains the newly added Node.js Windows binary.

```
2024-08-02T08:44:34.1712147Z [INFO] --- frontend:1.15.0:install-node-and-pnpm (default) @ keycloak-js-adapter-jar ---
2024-08-02T08:44:34.2459170Z [INFO] Installing node version v20.13.0
2024-08-02T08:44:34.2460998Z [INFO] Copying node binary from C:\Users\runneradmin\.m2\repository\com\github\eirslett\node\20.13.0\node-20.13.0-win-x64.exe to D:\a\keycloak\keycloak\node\node.exe
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
