### PR TITLE
Aligning the JS build and caching with the main build

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -7,11 +7,6 @@ inputs:
     required: false
     default: "20"
 
-  working-directory:
-    description: The working directory where the `pnpm-lock.yaml` file is located.
-    required: false
-    default: ""
-
 runs:
   using: composite
   steps:
@@ -38,11 +33,13 @@ runs:
         path: |
           ~/.cache/Cypress
           ${{ steps.pnpm-cache.outputs.store-path }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('${{ inputs.working-directory }}/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
-      working-directory: ${{ inputs.working-directory }}
       shell: bash
-      run: pnpm install --prefer-offline --frozen-lockfile
+      # Run the store prune after the installation to avoid having caches which grow over time
+      run: |
+        pnpm install --prefer-offline --frozen-lockfile
+        pnpm store prune

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -43,17 +43,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
-          check-latest: true
-          cache: maven
-
       - name: Build Keycloak
+        uses: ./.github/actions/build-keycloak
+
+      - name: Prepare archive for upload
         run: |
-          ./mvnw clean install --errors -DskipTests -DskipTestsuite -DskipExamples -Pdistribution
           mv ./quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz ./keycloak-999.0.0-SNAPSHOT.tar.gz
 
       - name: Upload Keycloak dist
@@ -164,10 +158,7 @@ jobs:
           name: keycloak
 
       - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
+        uses: ./.github/actions/java-setup
 
       - name: Start Keycloak server
         run: |
@@ -258,10 +249,7 @@ jobs:
           name: keycloak
 
       - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
+        uses: ./.github/actions/java-setup
 
       - name: Start Keycloak server
         run: |


### PR DESCRIPTION
Closes #31845

Looking at the performance, the build time of the Keycloak archive reduced from about 6:15 minutes 4:45 minutes, saving 1:30 minutes, most likely due to the pnpm caching.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
