### PR TITLE
Allow empty key use in JWKS from identity provider

### DIFF
--- a/services/src/main/java/org/keycloak/keys/loader/OIDCIdentityProviderPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/OIDCIdentityProviderPublicKeyLoader.java
@@ -56,7 +56,7 @@ public class OIDCIdentityProviderPublicKeyLoader implements PublicKeyLoader {
         if (config.isUseJwksUrl()) {
             String jwksUrl = config.getJwksUrl();
             JSONWebKeySet jwks = JWKSHttpUtils.sendJwksRequest(session, jwksUrl);
-            return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG);
+            return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG, true);
         } else {
             try {
             	KeyWrapper publicKey = getSavedPublicKey();

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/broker/oidc/MissingUseJwksRestResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/broker/oidc/MissingUseJwksRestResource.java
@@ -57,7 +57,9 @@ public class MissingUseJwksRestResource {
                         .filter(certs -> !certs.isEmpty())
                         .orElseGet(() -> Collections.singletonList(k.getCertificate()));
                     if (k.getType().equals(KeyType.RSA)) {
-                        return b.rsa(k.getPublicKey(), certificates, k.getUse());
+                        JWK rsaKey = b.rsa(k.getPublicKey(), certificates, k.getUse());
+                        rsaKey.setPublicKeyUse(null);
+                        return rsaKey;
                     } else if (k.getType().equals(KeyType.EC)) {
                         JWK ecKey = b.ec(k.getPublicKey(), k.getUse());
                         ecKey.setPublicKeyUse(null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerIdpPublicKeyMissingUseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerIdpPublicKeyMissingUseTest.java
@@ -1,0 +1,38 @@
+package org.keycloak.testsuite.broker;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+import java.util.Map;
+
+
+import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_PROV_NAME;
+import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
+
+public class KcOidcBrokerIdpPublicKeyMissingUseTest extends AbstractBrokerTest {
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcOidcBrokerConfigurationWithIdpPublicKeyMissingUse();
+    }
+
+    private class KcOidcBrokerConfigurationWithIdpPublicKeyMissingUse extends KcOidcBrokerConfiguration {
+
+        @Override
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
+            IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
+            Map<String, String> config = idp.getConfig();
+            applyDefaultConfiguration(config, syncMode);
+            config.put("clientAuthMethod", OIDCLoginProtocol.CLIENT_SECRET_BASIC);
+            config.put(OIDCIdentityProviderConfig.JWKS_URL,
+                    getProviderRoot() + "/auth/realms/" + REALM_PROV_NAME + "/missing-use-jwks/jwks");
+            return idp;
+        }
+
+    }
+}


### PR DESCRIPTION
Closes #31823

This allows matching of the key from the identity provider's JWKS endpoint even if the use is not specified on the key.