### PR TITLE
Non clustered Keycloak with External Infinispan feature

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -286,6 +286,13 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         }
 
         Marshalling.configure(gcb);
+
+        if (InfinispanUtils.isRemoteInfinispan()) {
+            // Disable JGroups, not required when the data is stored in the Remote Cache.
+            // The existing caches are local and do not require JGroups to work properly.
+            gcb.nonClusteredDefault();
+        }
+
         EmbeddedCacheManager cacheManager = new DefaultCacheManager(gcb.build());
         if (useKeycloakTimeService) {
             setTimeServiceToKeycloakTime(cacheManager);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/legacy/infinispan/CacheManagerFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/legacy/infinispan/CacheManagerFactory.java
@@ -347,6 +347,9 @@ public class CacheManagerFactory {
                   logger.warnf("remote-store configuration detected for cache '%s'. Explicit cache configuration ignored when using '%s' Feature", cacheName, Profile.Feature.REMOTE_CACHE.getKey());
                builders.remove(cacheName);
             }
+            // Disable JGroups, not required when the data is stored in the Remote Cache.
+            // The existing caches are local and do not require JGroups to work properly.
+            builder.getGlobalConfigurationBuilder().nonClusteredDefault();
         }
 
         var start = isStartEagerly();


### PR DESCRIPTION
Disables JGroups (clustering) when remote-cache feature is enabled

Fixes #31876

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
