### PR TITLE
BACKPORT: use stringify on use meta data descriptor (#31717)

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
@@ -283,6 +283,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
               name="config.useMetadataDescriptorUrl"
               label={t("useMetadataDescriptorUrl")}
               isDisabled={readOnly}
+              stringify
             />
             {useMetadataDescriptorUrl !== "true" && (
               <TextAreaControl


### PR DESCRIPTION
fixes: #31687
backport: #31717

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 3f6136c6487f715bee2badf3d686efd3520eac21)
