### PR TITLE
Disable SessionTimeoutsTest for old cross-site code

### DIFF
--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/KeycloakModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/KeycloakModelTest.java
@@ -545,7 +545,7 @@ public abstract class KeycloakModelTest {
         KeycloakModelUtils.runJobInTransaction(getFactory(), this::cleanEnvironment);
     }
 
-    protected <T> Stream<T> getParameters(Class<T> clazz) {
+    protected static <T> Stream<T> getParameters(Class<T> clazz) {
         return MODEL_PARAMETERS.stream().flatMap(mp -> mp.getParameters(clazz)).filter(Objects::nonNull);
     }
 

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/SessionTimeoutsTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/SessionTimeoutsTest.java
@@ -20,13 +20,17 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runners.MethodSorters;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.Retry;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
@@ -34,8 +38,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.session.UserSessionPersisterProvider;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
@@ -58,6 +62,14 @@ import org.keycloak.testsuite.model.infinispan.InfinispanTestUtil;
 @RequireProvider(UserProvider.class)
 @RequireProvider(RealmProvider.class)
 public class SessionTimeoutsTest extends KeycloakModelTest {
+
+    @ClassRule
+    public static final TestRule SKIPPED_PROFILES = (base, description) -> {
+        // Embedded caches with the Remote Store uses asynchronous code with event listeners, making the test failing randomly.
+        // It is a deprecated configuration for cross-site, so we skip the tests.
+        Assume.assumeFalse(InfinispanUtils.isEmbeddedInfinispan() && getParameters(HotRodServerRule.class).findFirst().isPresent());
+        return base;
+    };
 
     private String realmId;
 


### PR DESCRIPTION
The test is disabled for the embedded caches + remote store combination (old cross-site code) due to the async event processing.

Events can be handled after the test changes the time offset, causing the test to fail.

Fixes #31612

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
