### PR TITLE
Support for blocking concurrent requests when brute force is enabled (25)

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-25_0_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_3.adoc
@@ -1,0 +1,10 @@
+= Concurrent login requests are blocked by default when brute force is enabled
+
+If an attacker launched many login attempts in parallel then the attacker could have more guesses at a password than the brute force protection configuration permits. This was due to the brute force check occurring before the brute force protector has locked the user. To prevent this race the Brute Force Protector now rejects all login attempts that occur while another login is in progress in the same server.
+
+If, for whatever reason, the new feature wants to be disabled there is a startup factory option:
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --spi-brute-force-protector-default-brute-force-detector-allow-concurrent-requests=true
+----

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -1,6 +1,10 @@
 [[migration-changes]]
 == Migration Changes
 
+=== Migrating to 25.0.3
+
+include::changes-25_0_3.adoc[leveloffset=3]
+
 === Migrating to 25.0.2
 
 include::changes-25_0_2.adoc[leveloffset=3]

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -20,7 +20,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.keycloak.common.ClientConnection;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -33,6 +35,7 @@ public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtect
     // make this configurable?
     private static final int DEFAULT_MAX_CONCURRENT_ATTEMPTS = 1000;
     private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+    private static final String OFF_THREAD_STARTED = "#brute_force_started";
 
     private final Map<String, String> loginAttempts = Collections.synchronizedMap(new LinkedHashMap<>(100, DEFAULT_LOAD_FACTOR) {
         @Override
@@ -73,46 +76,80 @@ public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtect
             return false;
         }
 
-        if (isCurrentLoginAttempt(user)) {
-            return !tryEnlistBlockingTransaction(session, user);
-        }
-
-        return true;
+        return !tryEnlistBlockingTransactionOrSameThread(session, user);
     }
 
-    // Return true if this thread successfully enlisted itself
-    private boolean tryEnlistBlockingTransaction(KeycloakSession session, UserModel user) {
-        String threadInProgress = loginAttempts.computeIfAbsent(user.getId(), k -> getThreadName());
+    // Return true if this thread successfully enlisted itself or it was already done by the same thread
+    private boolean tryEnlistBlockingTransactionOrSameThread(KeycloakSession session, UserModel user) {
+        AtomicBoolean inserted = new AtomicBoolean(false);
+        String threadInProgress = loginAttempts.computeIfAbsent(user.getId(), k -> {
+            inserted.set(true);
+            return getThreadName();
+        });
 
         // This means that this thread successfully added itself into the map. We can enlist transaction just in that case
-        if (threadInProgress.equals(getThreadName())) {
+        if (inserted.get()) {
             session.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
                 @Override
                 protected void commitImpl() {
-                    unblock();
+                    // remove or wait the brute force thread to finish
+                    loginAttempts.computeIfPresent(user.getId(), (k, v) -> v.endsWith(OFF_THREAD_STARTED)? "" : null);
                 }
 
                 @Override
                 protected void rollbackImpl() {
-                    unblock();
-                }
-
-                private void unblock() {
+                    // remove on rollback
                     loginAttempts.remove(user.getId());
                 }
             });
 
             return true;
         } else {
-            return false;
+            return isCurrentThread(threadInProgress);
         }
     }
 
-    private boolean isCurrentLoginAttempt(UserModel user) {
-        return loginAttempts.getOrDefault(user.getId(), getThreadName()).equals(getThreadName());
+    private boolean isCurrentThread(String name) {
+        return name.equals(getThreadName()) || name.equals(getThreadName() + OFF_THREAD_STARTED);
     }
 
     private String getThreadName() {
         return Thread.currentThread().getName();
+    }
+
+    private void enlistRemoval(KeycloakSession session, String userId) {
+        session.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
+            @Override
+            protected void commitImpl() {
+                // remove or wait the main thread to finish
+                loginAttempts.computeIfPresent(userId, (k, v) -> v.isEmpty()? null : v.substring(0, v.length() - OFF_THREAD_STARTED.length()));
+            }
+
+            @Override
+            protected void rollbackImpl() {
+                loginAttempts.remove(userId);
+            }
+        });
+    }
+
+    @Override
+    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, boolean success) {
+        // mark the off-thread is started for this request
+        loginAttempts.computeIfPresent(user.getId(), (k, v) -> v + OFF_THREAD_STARTED);
+        super.processLogin(realm, user, clientConnection, success);
+    }
+
+    @Override
+    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime) {
+        // remove the user from concurrent login attemps once it's processed
+        enlistRemoval(session, userId);
+        super.failure(session, realm, userId, remoteAddr, failureTime);
+    }
+
+    @Override
+    protected void success(KeycloakSession session, RealmModel realm, String userId) {
+        // remove the user from concurrent login attemps once it's processed
+        enlistRemoval(session, userId);
+        super.success(session, realm, userId);
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.managers;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.keycloak.models.AbstractKeycloakTransaction;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtector {
+
+    // make this configurable?
+    private static final int DEFAULT_MAX_CONCURRENT_ATTEMPTS = 1000;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+    private final Map<String, String> loginAttempts = Collections.synchronizedMap(new LinkedHashMap<>(100, DEFAULT_LOAD_FACTOR) {
+        @Override
+        protected boolean removeEldestEntry(Entry<String, String> eldest) {
+            return loginAttempts.size() > DEFAULT_MAX_CONCURRENT_ATTEMPTS;
+        }
+    });
+
+    DefaultBlockingBruteForceProtector(KeycloakSessionFactory factory) {
+        super(factory);
+    }
+
+    @Override
+    public boolean isPermanentlyLockedOut(KeycloakSession session, RealmModel realm, UserModel user) {
+        if (super.isPermanentlyLockedOut(session, realm, user)) {
+            return true;
+        }
+
+        if (!realm.isPermanentLockout()) return false;
+
+        return isLoginInProgress(session, user);
+    }
+
+    @Override
+    public boolean isTemporarilyDisabled(KeycloakSession session, RealmModel realm, UserModel user) {
+        if (super.isTemporarilyDisabled(session, realm, user)) {
+            return true;
+        }
+
+        return isLoginInProgress(session, user);
+    }
+
+    private boolean isLoginInProgress(KeycloakSession session, UserModel user) {
+        AuthenticationSessionModel authSession = session.getContext().getAuthenticationSession();
+
+        if (authSession == null) {
+            // not authenticating as there is no auth session bound to the session
+            return false;
+        }
+
+        if (isCurrentLoginAttempt(user)) {
+            return !tryEnlistBlockingTransaction(session, user);
+        }
+
+        return true;
+    }
+
+    // Return true if this thread successfully enlisted itself
+    private boolean tryEnlistBlockingTransaction(KeycloakSession session, UserModel user) {
+        String threadInProgress = loginAttempts.computeIfAbsent(user.getId(), k -> getThreadName());
+
+        // This means that this thread successfully added itself into the map. We can enlist transaction just in that case
+        if (threadInProgress.equals(getThreadName())) {
+            session.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
+                @Override
+                protected void commitImpl() {
+                    unblock();
+                }
+
+                @Override
+                protected void rollbackImpl() {
+                    unblock();
+                }
+
+                private void unblock() {
+                    loginAttempts.remove(user.getId());
+                }
+            });
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isCurrentLoginAttempt(UserModel user) {
+        return loginAttempts.getOrDefault(user.getId(), getThreadName()).equals(getThreadName());
+    }
+
+    private String getThreadName() {
+        return Thread.currentThread().getName();
+    }
+}

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -180,10 +180,11 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
         logger.trace("sent success event");
     }
 
-    private void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, boolean success) {
-        KeycloakSession session = factory.create();
-        ExecutorsProvider provider = session.getProvider(ExecutorsProvider.class);
-        ExecutorService executor = provider.getExecutor("bruteforce");
+    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, boolean success) {
+        ExecutorService executor = KeycloakModelUtils.runJobInTransactionWithResult(factory, session -> {
+            ExecutorsProvider provider = session.getProvider(ExecutorsProvider.class);
+            return provider.getExecutor("bruteforce");
+        });
         executor.execute(() -> KeycloakModelUtils.runJobInTransaction(factory, s -> {
             if (success) {
                 success(s, realm, user.getId());

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -17,9 +17,12 @@
 
 package org.keycloak.services.managers;
 
+import java.util.List;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -54,5 +57,17 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
     @Override
     public String getId() {
         return "default-brute-force-detector";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name("allowConcurrentRequests")
+                .type("boolean")
+                .helpText("If concurrent logins are allowed by the brute force protection.")
+                .defaultValue(false)
+                .add()
+                .build();
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -28,6 +28,8 @@ import org.keycloak.models.KeycloakSessionFactory;
 public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFactory {
     DefaultBruteForceProtector protector;
 
+    private boolean allowConcurrentRequests;
+
     @Override
     public BruteForceProtector create(KeycloakSession session) {
         return protector;
@@ -35,12 +37,13 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
 
     @Override
     public void init(Config.Scope config) {
-
+        // this can be a brute force setting?
+        this.allowConcurrentRequests = config.getBoolean("allowConcurrentRequests", Boolean.FALSE);
     }
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        protector = new DefaultBruteForceProtector(factory);
+        protector = allowConcurrentRequests ? new DefaultBruteForceProtector(factory) : new DefaultBlockingBruteForceProtector(factory);
     }
 
     @Override


### PR DESCRIPTION
Closes #31726

Backport of PR #31728 into 25. Related issues found after the PR are also backported.
