### PR TITLE
Support for blocking concurrent requests when brute force is enabled (22)

### DIFF
--- a/docs/documentation/upgrading/topics/keycloak/changes-22_0_12.adoc
+++ b/docs/documentation/upgrading/topics/keycloak/changes-22_0_12.adoc
@@ -3,3 +3,14 @@
 When a client scope or the full realm are deleted the associated user consents should also be removed. A new index over the table `USER_CONSENT_CLIENT_SCOPE` has been added to increase the performance.
 
 Note that, if the table contains more than 300.000 entries, by default {project_name} skips the creation of the indexes during the automatic schema migration and logs the SQL statements to the console instead. The statements must be run manually in the DB after {project_name}'s startup. Check the link:{upgradingguide_link}[{upgradingguide_name}] for details on how to configure a different limit.
+
+= Concurrent login requests are blocked by default when brute force is enabled
+
+If an attacker launched many login attempts in parallel then the attacker could have more guesses at a password than the brute force protection configuration permits. This was due to the brute force check occurring before the brute force protector has locked the user. To prevent this race the Brute Force Protector now rejects all login attempts that occur while another login is in progress in the same server.
+
+If, for whatever reason, the new feature wants to be disabled there is a startup factory option:
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --spi-brute-force-protector-default-brute-force-detector-allow-concurrent-requests=true
+----

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.managers;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.keycloak.models.AbstractKeycloakTransaction;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtector {
+
+    // make this configurable?
+    private static final int DEFAULT_MAX_CONCURRENT_ATTEMPTS = 1000;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+    private final Map<String, String> loginAttempts = Collections.synchronizedMap(new LinkedHashMap(100, DEFAULT_LOAD_FACTOR) {
+        @Override
+        protected boolean removeEldestEntry(Entry eldest) {
+            return loginAttempts.size() > DEFAULT_MAX_CONCURRENT_ATTEMPTS;
+        }
+    });
+
+    DefaultBlockingBruteForceProtector(KeycloakSessionFactory factory) {
+        super(factory);
+    }
+
+    @Override
+    public boolean isPermanentlyLockedOut(KeycloakSession session, RealmModel realm, UserModel user) {
+        if (super.isPermanentlyLockedOut(session, realm, user)) {
+            return true;
+        }
+
+        if (!realm.isPermanentLockout()) return false;
+
+        return isLoginInProgress(session, user);
+    }
+
+    @Override
+    public boolean isTemporarilyDisabled(KeycloakSession session, RealmModel realm, UserModel user) {
+        if (super.isTemporarilyDisabled(session, realm, user)) {
+            return true;
+        }
+
+        return isLoginInProgress(session, user);
+    }
+
+    private boolean isLoginInProgress(KeycloakSession session, UserModel user) {
+        AuthenticationSessionModel authSession = session.getContext().getAuthenticationSession();
+
+        if (authSession == null) {
+            // not authenticating as there is no auth session bound to the session
+            return false;
+        }
+
+        if (isCurrentLoginAttempt(user)) {
+            return !tryEnlistBlockingTransaction(session, user);
+        }
+
+        return true;
+    }
+
+    // Return true if this thread successfully enlisted itself
+    private boolean tryEnlistBlockingTransaction(KeycloakSession session, UserModel user) {
+        String threadInProgress = loginAttempts.computeIfAbsent(user.getId(), k -> getThreadName());
+
+        // This means that this thread successfully added itself into the map. We can enlist transaction just in that case
+        if (threadInProgress.equals(getThreadName())) {
+            session.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
+                @Override
+                protected void commitImpl() {
+                    unblock();
+                }
+
+                @Override
+                protected void rollbackImpl() {
+                    unblock();
+                }
+
+                private void unblock() {
+                    loginAttempts.remove(user.getId());
+                }
+            });
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isCurrentLoginAttempt(UserModel user) {
+        return loginAttempts.getOrDefault(user.getId(), getThreadName()).equals(getThreadName());
+    }
+
+    private String getThreadName() {
+        return Thread.currentThread().getName();
+    }
+}

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -217,12 +217,10 @@ public class DefaultBruteForceProtector implements Runnable, BruteForceProtector
                             session.getTransactionManager().begin();
                             try {
                                 for (LoginEvent event : events) {
-                                    if (event instanceof FailedLogin) {
-                                        failure(session, event);
-                                    } else if (event instanceof SuccessfulLogin) {
-                                        success(session, event);
-                                    } else if (event instanceof ShutdownEvent) {
+                                    if (event instanceof ShutdownEvent) {
                                         run = false;
+                                    } else {
+                                        processLogin(session, event);
                                     }
                                 }
                             } catch (Exception e) {
@@ -297,6 +295,14 @@ public class DefaultBruteForceProtector implements Runnable, BruteForceProtector
         SuccessfulLogin event = new SuccessfulLogin(realm.getId(), user.getId(), clientConnection.getRemoteAddr());
         queue.offer(event);
         logger.trace("sent success event");
+    }
+
+    protected void processLogin(KeycloakSession session, LoginEvent event) {
+        if (event instanceof SuccessfulLogin) {
+            success(session, event);
+        } else {
+            failure(session, event);
+        }
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -17,9 +17,12 @@
 
 package org.keycloak.services.managers;
 
+import java.util.List;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -56,5 +59,17 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
     @Override
     public String getId() {
         return "default-brute-force-detector";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name("allowConcurrentRequests")
+                .type("boolean")
+                .helpText("If concurrent logins are allowed by the brute force protection.")
+                .defaultValue(false)
+                .add()
+                .build();
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -28,6 +28,8 @@ import org.keycloak.models.KeycloakSessionFactory;
 public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFactory {
     DefaultBruteForceProtector protector;
 
+    private boolean allowConcurrentRequests;
+
     @Override
     public BruteForceProtector create(KeycloakSession session) {
         return protector;
@@ -35,14 +37,14 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
 
     @Override
     public void init(Config.Scope config) {
-
+        // this can be a brute force setting?
+        this.allowConcurrentRequests = config.getBoolean("allowConcurrentRequests", Boolean.FALSE);
     }
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        protector = new DefaultBruteForceProtector(factory);
+        protector = allowConcurrentRequests ? new DefaultBruteForceProtector(factory) : new DefaultBlockingBruteForceProtector(factory);
         protector.start();
-
     }
 
     @Override


### PR DESCRIPTION
Closes #31726

Backport of PR #31728 into 22. Related issues found after the PR are also backported.
