### PR TITLE
Add ECDH-ES encyption algorithms to the java keystore key provider

### DIFF
--- a/docs/documentation/release_notes/topics/26_0_0.adoc
+++ b/docs/documentation/release_notes/topics/26_0_0.adoc
@@ -103,3 +103,11 @@ no longer holds the list of identity providers. However, they are still availabl
 when exporting a realm.
 
 For information on how to migrate, see the link:{upgradingguide_link}[{upgradingguide_name}].
+
+= Adding support for ECDH-ES encryption key management algorithms
+
+Now {project_name} allows configuring ECDH-ES, ECDH-ES+A128KW, ECDH-ES+A192KW or ECDH-ES+A256KW as the encryption key management algorithm for clients. The Key Agreement with Elliptic Curve Diffie-Hellman Ephemeral Static (ECDH-ES) specification introduces three new header parameters for the JWT: `epk`, `apu` and `apv`. Currently {project_name} implementation only manages the compulsory `epk` while the other two (which are optional) are never added to the header. For more information about those algorithms please refer to the link:https://datatracker.ietf.org/doc/html/rfc7518#section-4.6[JSON Web Algorithms (JWA)].
+
+ifeval::[{project_community}==true]
+Many thanks to https://github.com/justin-tay[Justin Tay] for the contribution.
+endif::[]

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
@@ -107,6 +107,8 @@ public class JavaKeystoreKeyProvider implements KeyProvider {
                     loadRSAKey(keyStore, keyAlias, KeyUse.ENC);
                 case Algorithm.ES256, Algorithm.ES384, Algorithm.ES512 ->
                     loadECKey(keyStore, keyAlias, KeyUse.SIG);
+                case Algorithm.ECDH_ES, Algorithm.ECDH_ES_A128KW, Algorithm.ECDH_ES_A192KW, Algorithm.ECDH_ES_A256KW ->
+                    loadECKey(keyStore, keyAlias, KeyUse.ENC);
                 case Algorithm.EdDSA ->
                     loadEdDSAKey(keyStore, keyAlias, KeyUse.SIG);
                 case Algorithm.AES ->

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
@@ -123,7 +123,8 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
                         List.of(Algorithm.ES256, Algorithm.ES384, Algorithm.ES512),
                         Attributes.HS_ALGORITHM_PROPERTY.getOptions(),
                         Attributes.RS_ALGORITHM_PROPERTY.getOptions(),
-                        Attributes.RS_ENC_ALGORITHM_PROPERTY.getOptions())
+                        Attributes.RS_ENC_ALGORITHM_PROPERTY.getOptions(),
+                        GeneratedEcdhKeyProviderFactory.ECDH_ALGORITHM_PROPERTY.getOptions())
                 .flatMap(Collection::stream)
                 .toList();
         return new ProviderConfigProperty(Attributes.RS_ALGORITHM_PROPERTY.getName(), Attributes.RS_ALGORITHM_PROPERTY.getLabel(),


### PR DESCRIPTION
Closes #32023

Adding new ECDH-ES algs to the java keystore key provider. I'm using this PR to also announce in the release notes that ECDH-ES encryption key management algorithms are supported now.
