### PR TITLE
Not possible to import realm with newest Java admin-client against Ke…

### DIFF
--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/JacksonProvider.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/JacksonProvider.java
@@ -1,6 +1,20 @@
 package org.keycloak.admin.client;
 
+import javax.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 
 public class JacksonProvider extends ResteasyJackson2Provider {
+
+    @Override
+    public ObjectMapper locateMapper(Class<?> type, MediaType mediaType) {
+        ObjectMapper objectMapper = super.locateMapper(type, mediaType);
+
+        // Same like JSONSerialization class. Makes it possible to use admin-client against older versions of Keycloak server where the properties on representations might be different
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        
+        return objectMapper;
+    }
 }


### PR DESCRIPTION
…ycloak 24

closes #32035


The `objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);` is already using by Keycloak helper class `JsonSerialization`, but for some reason was not used in the admin client.

Some more context in the parent issue #32025 . Until now, the admin-client serialized objects with having `null` values sent over the network. For example something like:
```
ClientRepresentation clientRep = new ClientRepresentation();
clientRep.setClientId("foo");
```
was serialized into JSON like:
```
{
  "clientId": "foo",
  "name": null,
  ... null for all other properties of client representation

```

And then sent over the network to Keycloak server. This meant unnecessary overhead for sending values over the network, but also makes it impossible to test with older versions of Keycloak as for example when testing admin-client of Keycloak 25 with KEycloak server 24, then every property added in the Keycloak 25 or later will break the parsing on Keycloak server 24 or earlier because of "UnrecognizedProperty" error.

There is no automated test in this PR as this is not tested in keycloak main repository, but will be tested in `keycloak-client` repository, which contains tests for keycloak admin-client with older versions of Keycloak (like Keycloak 24). Related issue #32036 
