### PR TITLE
fix: add a warning log if a deprecated admin env variable is used

### DIFF
--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -475,5 +475,9 @@ public interface ServicesLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id=109, value="Failed to add client '%s' to realm '%s': client with client ID exists")
     void addClientFailedClientExists(String clientId, String realm);
+    
+    @LogMessage(level = WARN)
+    @Message(id=110, value="Environment variable '%s' is deprecated, use '%s' instead")
+    void usingDeprecatedEnvironmentVariable(String deprecated, String supported);
 
 }


### PR DESCRIPTION
closes: #31491

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
