### PR TITLE
Fix for Client secret is visable in Admin event representation when Credentials Reset action performed for the Client.

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
@@ -24,6 +24,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ComponentExportRepresentation;
 import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -59,6 +60,7 @@ public class StripSecretsUtils {
         REPRESENTATION_FORMATTER.put(ClientRepresentation.class, (session, o) -> StripSecretsUtils.stripClient((ClientRepresentation) o));
         REPRESENTATION_FORMATTER.put(IdentityProviderRepresentation.class, (session, o) -> StripSecretsUtils.stripBroker((IdentityProviderRepresentation) o));
         REPRESENTATION_FORMATTER.put(ComponentRepresentation.class, (session, o) -> StripSecretsUtils.stripComponent(session, (ComponentRepresentation) o));
+        REPRESENTATION_FORMATTER.put(CredentialRepresentation.class, (session, o) -> StripSecretsUtils.stripCredentials((CredentialRepresentation) o));
     }
 
     public static <T> T stripSecrets(KeycloakSession session, T representation) {
@@ -80,6 +82,11 @@ public class StripSecretsUtils {
              ? value
              : ComponentRepresentation.SECRET_VALUE
             );
+    }
+
+    protected static CredentialRepresentation stripCredentials(CredentialRepresentation rep) {
+        rep.setValue("**********");
+        return rep;
     }
 
     private static ComponentRepresentation stripComponent(KeycloakSession session, ComponentRepresentation rep) {

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/StripSecretsUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/StripSecretsUtilsTest.java
@@ -123,6 +123,16 @@ public class StripSecretsUtilsTest {
     }
 
     @Test
+    public void stripCredentials(){
+        CredentialRepresentation rep = new CredentialRepresentation();
+        rep.setId("test");
+        rep.setValue("secretValue");
+        StripSecretsUtils.stripCredentials(rep);
+        assertEquals("test", rep.getId());
+        assertEquals("**********", rep.getValue());
+    }
+
+    @Test
     public void stripComponent() {
         ComponentRepresentation rep = new ComponentRepresentation();
         rep.setId("componentId");

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -299,7 +299,7 @@ public class ClientResource {
 
             adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).representation(rep).success();
             session.removeAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED);
-
+            rep.setValue(secret);
             return rep;
         } catch (ClientPolicyException cpe) {
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(),


### PR DESCRIPTION
Closes #31892