### PR TITLE
SAML IdMapperUpdaterSessionListener should be added always and must implement HttpSessionIdListener interface

### DIFF
--- a/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/IdMapperUpdaterSessionListener.java
+++ b/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/IdMapperUpdaterSessionListener.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionAttributeListener;
 import jakarta.servlet.http.HttpSessionBindingEvent;
 import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionIdListener;
 import jakarta.servlet.http.HttpSessionListener;
 import org.jboss.logging.Logger;
 
@@ -31,7 +32,7 @@ import org.jboss.logging.Logger;
  *
  * @author hmlnarik
  */
-public class IdMapperUpdaterSessionListener implements HttpSessionListener, HttpSessionAttributeListener {
+public class IdMapperUpdaterSessionListener implements HttpSessionListener, HttpSessionAttributeListener, HttpSessionIdListener {
 
     private static final Logger LOG = Logger.getLogger(IdMapperUpdaterSessionListener.class);
 
@@ -54,6 +55,15 @@ public class IdMapperUpdaterSessionListener implements HttpSessionListener, Http
         LOG.debugf("Session destroyed");
         HttpSession session = hse.getSession();
         unmap(session.getId(), session.getAttribute(SamlSession.class.getName()));
+    }
+
+    @Override
+    public void sessionIdChanged(HttpSessionEvent hse, String oldSessionId) {
+        LOG.debugf("Session changed ID from %s", oldSessionId);
+        HttpSession session = hse.getSession();
+        Object value = session.getAttribute(SamlSession.class.getName());
+        unmap(oldSessionId, value);
+        map(session.getId(), value);
     }
 
     @Override

--- a/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/KeycloakConfigurationServletListener.java
+++ b/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/KeycloakConfigurationServletListener.java
@@ -156,13 +156,13 @@ public class KeycloakConfigurationServletListener implements ServletContextListe
     public void addTokenStoreUpdaters(ServletContext servletContext) {
         SessionIdMapperUpdater updater = this.idMapperUpdater;
 
+        servletContext.addListener(new IdMapperUpdaterSessionListener(idMapper));    // This takes care of HTTP sessions manipulated locally
+
         try {
             String idMapperSessionUpdaterClasses = servletContext.getInitParameter("keycloak.sessionIdMapperUpdater.classes");
             if (idMapperSessionUpdaterClasses == null) {
                 return;
             }
-
-            servletContext.addListener(new IdMapperUpdaterSessionListener(idMapper));    // This takes care of HTTP sessions manipulated locally
 
             updater = SessionIdMapperUpdater.DIRECT;
 

--- a/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/SendUsernameServlet.java
+++ b/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/SendUsernameServlet.java
@@ -23,7 +23,6 @@ import org.keycloak.adapters.saml.SamlAuthenticationError;
 import org.keycloak.adapters.saml.SamlPrincipal;
 import org.keycloak.adapters.saml.SamlSession;
 import org.keycloak.adapters.spi.AuthenticationError;
-import org.keycloak.saml.processing.core.saml.v2.constants.X500SAMLProfileConstants;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,8 +44,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -105,10 +102,18 @@ public class SendUsernameServlet {
     }
 
     @GET
+    @Path("change-session-id")
+    public Response changeSessionId() throws IOException {
+        System.out.println("In SendUsername Servlet changeSessionId()");
+        final String sessionId = httpServletRequest.changeSessionId();
+
+        return Response.ok(sessionId).header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_TYPE + ";charset=UTF-8").build();
+    }
+
+    @GET
     @Path("getAssertionFromDocument")
     public Response getAssertionFromDocument() throws IOException, TransformerException {
         sentPrincipal = httpServletRequest.getUserPrincipal();
-        DocumentBuilderFactory domFact = DocumentBuilderFactory.newInstance();
         Document doc = ((SamlPrincipal) sentPrincipal).getAssertionDocument();
         String xml = "";
         if (doc != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
@@ -1987,6 +1987,34 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         checkLoggedOut(salesPostSigEmailServletPage, testRealmSAMLPostLoginPage);
     }
 
+    @Test
+    public void testChangeSessionID() throws Exception {
+        // login in the employeeDom application
+        assertSuccessfulLogin(employeeDomServletPage, bburkeUser, testRealmSAMLPostLoginPage, "principal=bburke");
+        assertSuccessfullyLoggedIn(employeeDomServletPage, "principal=bburke");
+        String sessionId = driver.manage().getCookieNamed("JSESSIONID").getValue();
+
+        // retrieve the saml document
+        driver.navigate().to(employeeDomServletPage.getUriBuilder().clone().path("getAssertionFromDocument").build().toURL());
+        waitForPageToLoad();
+        String xml = getRawPageSource();
+        Assert.assertNotEquals("", xml);
+
+        // change the session id
+        driver.navigate().to(employeeDomServletPage.getUriBuilder().clone().path("change-session-id").build().toURL());
+        waitForPageToLoad();
+        Assert.assertNotEquals("SessionID has not been changed at login", sessionId, driver.manage().getCookieNamed("JSESSIONID").getValue());
+
+        // retrieve again the saml document and should be the same as login should be maintained
+        driver.navigate().to(employeeDomServletPage.getUriBuilder().clone().path("getAssertionFromDocument").build().toURL());
+        waitForPageToLoad();
+        Assert.assertEquals(xml, getRawPageSource());
+
+        // logout
+        employeeDomServletPage.logout();
+        checkLoggedOut(employeeDomServletPage, testRealmSAMLPostLoginPage);
+    }
+
     public static void printDocument(Source doc, OutputStream out) throws IOException, TransformerException {
         TransformerFactory tf = TransformerFactory.newInstance();
         Transformer transformer = tf.newTransformer();


### PR DESCRIPTION
Closes #32084

The PR just adds the `IdMapperUpdaterSessionListener` unconditionally and implements the jakartaee `HttpSessionIdListener` to manage session ID changes in the SAML elytron adapter. The old undertow implementation already did these two things. Test added. 