### PR TITLE
Script Support for Content Security Policy Header

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/headers/SecurityHeadersOptions.java
+++ b/server-spi-private/src/main/java/org/keycloak/headers/SecurityHeadersOptions.java
@@ -22,6 +22,10 @@ public interface SecurityHeadersOptions {
 
     SecurityHeadersOptions allowAnyFrameAncestor();
 
+    SecurityHeadersOptions addScriptSrc(String source);
+
+    SecurityHeadersOptions addStyleSrc(String source);
+
     SecurityHeadersOptions skipHeaders();
 
     SecurityHeadersOptions allowEmptyContentType();

--- a/server-spi-private/src/main/java/org/keycloak/models/ContentSecurityPolicyBuilder.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/ContentSecurityPolicyBuilder.java
@@ -25,10 +25,13 @@ public class ContentSecurityPolicyBuilder {
     public static final String DIRECTIVE_NAME_FRAME_SRC = "frame-src";
     public static final String DIRECTIVE_NAME_FRAME_ANCESTORS = "frame-ancestors";
     public static final String DIRECTIVE_NAME_OBJECT_SRC = "object-src";
+    public static final String DIRECTIVE_NAME_SCRIPT_SRC = "script-src";
+    public static final String DIRECTIVE_NAME_STYLE_SRC = "style-src";
 
     // constants for specific directive value keywords
     public static final String DIRECTIVE_VALUE_SELF = "'self'";
     public static final String DIRECTIVE_VALUE_NONE = "'none'";
+    public static final String DIRECTIVE_VALUE_ANY = "*";
 
     private final Map<String, String> directives = new LinkedHashMap<>();
 
@@ -36,7 +39,9 @@ public class ContentSecurityPolicyBuilder {
         return new ContentSecurityPolicyBuilder()
                 .add(DIRECTIVE_NAME_FRAME_SRC, DIRECTIVE_VALUE_SELF)
                 .add(DIRECTIVE_NAME_FRAME_ANCESTORS, DIRECTIVE_VALUE_SELF)
-                .add(DIRECTIVE_NAME_OBJECT_SRC, DIRECTIVE_VALUE_NONE);
+                .add(DIRECTIVE_NAME_OBJECT_SRC, DIRECTIVE_VALUE_NONE)
+                .add(DIRECTIVE_NAME_SCRIPT_SRC, DIRECTIVE_VALUE_ANY)
+                .add(DIRECTIVE_NAME_STYLE_SRC, DIRECTIVE_VALUE_ANY);
     }
 
     public static ContentSecurityPolicyBuilder create(String directives) {
@@ -71,6 +76,40 @@ public class ContentSecurityPolicyBuilder {
 
     public ContentSecurityPolicyBuilder addFrameAncestors(String frameancestors) {
         return add(DIRECTIVE_NAME_FRAME_ANCESTORS, frameancestors);
+    }
+
+    public boolean isDefaultScriptSrc() {
+        return DIRECTIVE_VALUE_ANY.equals(directives.get(DIRECTIVE_NAME_SCRIPT_SRC)) || !directives.containsKey(DIRECTIVE_NAME_SCRIPT_SRC);
+    }
+
+    public ContentSecurityPolicyBuilder scriptSrc(String scriptSrc) {
+        if (scriptSrc == null) {
+            directives.remove(DIRECTIVE_NAME_SCRIPT_SRC);
+        } else {
+            put(DIRECTIVE_NAME_SCRIPT_SRC, scriptSrc);
+        }
+        return this;
+    }
+
+    public ContentSecurityPolicyBuilder addScriptSrc(String scriptSrc) {
+        return add(DIRECTIVE_NAME_SCRIPT_SRC, scriptSrc);
+    }
+
+    public boolean isDefaultStyleSrc() {
+        return DIRECTIVE_VALUE_ANY.equals(directives.get(DIRECTIVE_NAME_STYLE_SRC)) || !directives.containsKey(DIRECTIVE_NAME_STYLE_SRC);
+    }
+
+    public ContentSecurityPolicyBuilder styleSrc(String styleSrc) {
+        if (styleSrc == null) {
+            directives.remove(DIRECTIVE_NAME_STYLE_SRC);
+        } else {
+            put(DIRECTIVE_NAME_STYLE_SRC, styleSrc);
+        }
+        return this;
+    }
+
+    public ContentSecurityPolicyBuilder addStyleSrc(String styleSrc) {
+        return add(DIRECTIVE_NAME_STYLE_SRC, styleSrc);
     }
 
     public String build() {

--- a/server-spi-private/src/test/java/org/keycloak/models/BrowserSecurityHeadersTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/BrowserSecurityHeadersTest.java
@@ -20,13 +20,15 @@ public class BrowserSecurityHeadersTest {
 
     @Test
     public void contentSecurityPolicyBuilderTest() {
-        assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().build());
-        assertEquals("frame-ancestors 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc(null).build());
-        assertEquals("frame-src 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameAncestors(null).build());
-        assertEquals("frame-src 'custom-frame-src'; frame-ancestors 'custom-frame-ancestors'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc("'custom-frame-src'").frameAncestors("'custom-frame-ancestors'").build());
-        assertEquals("frame-src localhost; frame-ancestors 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc("localhost").build());
-        assertEquals("frame-src 'self' localhost; frame-ancestors 'self'; object-src 'none';",
+        assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src *; style-src *;", ContentSecurityPolicyBuilder.create().build());
+        assertEquals("frame-ancestors 'self'; object-src 'none'; script-src *; style-src *;", ContentSecurityPolicyBuilder.create().frameSrc(null).build());
+        assertEquals("frame-src 'self'; object-src 'none'; script-src *; style-src *;", ContentSecurityPolicyBuilder.create().frameAncestors(null).build());
+        assertEquals("frame-src 'custom-frame-src'; frame-ancestors 'custom-frame-ancestors'; object-src 'none'; script-src *; style-src *;", ContentSecurityPolicyBuilder.create().frameSrc("'custom-frame-src'").frameAncestors("'custom-frame-ancestors'").build());
+        assertEquals("frame-src localhost; frame-ancestors 'self'; object-src 'none'; script-src *; style-src *;", ContentSecurityPolicyBuilder.create().frameSrc("localhost").build());
+        assertEquals("frame-src 'self' localhost; frame-ancestors 'self'; object-src 'none'; script-src *; style-src *;",
                 ContentSecurityPolicyBuilder.create().addFrameSrc("localhost").build());
+        assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src localhost; style-src *;", ContentSecurityPolicyBuilder.create().scriptSrc("localhost").build());
+        assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src *; style-src localhost;", ContentSecurityPolicyBuilder.create().styleSrc("localhost").build());
     }
 
     private void assertParsedDirectives(String directives) {

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -46,6 +46,7 @@ import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
 import org.keycloak.forms.login.freemarker.model.IdpReviewProfileBean;
 import org.keycloak.forms.login.freemarker.model.LoginBean;
 import org.keycloak.forms.login.freemarker.model.LogoutConfirmBean;
+import org.keycloak.forms.login.freemarker.model.NonceBean;
 import org.keycloak.forms.login.freemarker.model.OAuthGrantBean;
 import org.keycloak.forms.login.freemarker.model.OrganizationBean;
 import org.keycloak.forms.login.freemarker.model.ProfileBean;
@@ -560,6 +561,11 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
         if (authenticationSession != null && authenticationSession.getClientNote(Constants.KC_ACTION_EXECUTING) != null
                 && !Boolean.TRUE.toString().equals(authenticationSession.getClientNote(Constants.KC_ACTION_ENFORCED))) {
             attributes.put("isAppInitiatedAction", true);
+        }
+
+        // JAS: Insert nonces into CSP header and attributes.
+        if (session != null) {
+            attributes.put("nonce", new NonceBean(session));
         }
     }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/NonceBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/NonceBean.java
@@ -1,0 +1,31 @@
+package org.keycloak.forms.login.freemarker.model;
+
+import org.keycloak.headers.SecurityHeadersProvider;
+import org.keycloak.models.KeycloakSession;
+
+import java.util.UUID;
+
+public class NonceBean {
+    private final KeycloakSession session;
+
+    private final String scriptNonce;
+    private final String styleNonce;
+
+    public NonceBean(KeycloakSession session) {
+        this.session = session;
+
+        scriptNonce = UUID.randomUUID().toString();
+        session.getProvider(SecurityHeadersProvider.class).options().addScriptSrc("'nonce-" + scriptNonce + "'");
+
+        styleNonce = UUID.randomUUID().toString();
+        session.getProvider(SecurityHeadersProvider.class).options().addStyleSrc("'nonce-" + styleNonce + "'");
+    }
+
+    public String getScript() {
+        return scriptNonce;
+    }
+
+    public String getStyle() {
+        return styleNonce;
+    }
+}

--- a/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersOptions.java
+++ b/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersOptions.java
@@ -16,12 +16,17 @@
  */
 package org.keycloak.headers;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DefaultSecurityHeadersOptions implements SecurityHeadersOptions {
 
     private boolean skipHeaders;
     private boolean allowAnyFrameAncestor;
     private boolean allowEmptyContentType;
     private String allowedFrameSrc;
+    private final List<String> allowedScriptSrc = new ArrayList<String>();
+    private final List<String> allowedStyleSrc = new ArrayList<String>();
 
     public SecurityHeadersOptions allowFrameSrc(String source) {
         allowedFrameSrc = source;
@@ -31,6 +36,18 @@ public class DefaultSecurityHeadersOptions implements SecurityHeadersOptions {
     @Override
     public SecurityHeadersOptions allowAnyFrameAncestor() {
         allowAnyFrameAncestor = true;
+        return this;
+    }
+
+    @Override
+    public SecurityHeadersOptions addScriptSrc(String source) {
+        allowedScriptSrc.add(source);
+        return this;
+    }
+
+    @Override
+    public SecurityHeadersOptions addStyleSrc(String source) {
+        allowedStyleSrc.add(source);
         return this;
     }
 
@@ -47,6 +64,14 @@ public class DefaultSecurityHeadersOptions implements SecurityHeadersOptions {
 
     String getAllowedFrameSrc() {
         return allowedFrameSrc;
+    }
+
+    List<String> getAllowedScriptSrc() {
+        return allowedScriptSrc;
+    }
+
+    List<String> getAllowedStyleSrc() {
+        return allowedStyleSrc;
     }
 
     boolean isAllowAnyFrameAncestor() {

--- a/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersProvider.java
+++ b/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersProvider.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.keycloak.models.BrowserSecurityHeaders.CONTENT_SECURITY_POLICY;
@@ -121,6 +122,20 @@ public class DefaultSecurityHeadersProvider implements SecurityHeadersProvider {
                 String allowedFrameSrc = options.getAllowedFrameSrc();
                 if (allowedFrameSrc != null) {
                     csp.addFrameSrc(allowedFrameSrc);
+                }
+
+                List<String> allowedScriptSrc = options.getAllowedScriptSrc();
+                if (allowedScriptSrc != null && !csp.isDefaultScriptSrc()) {
+                    for (String stmt : allowedScriptSrc) {
+                        csp.addScriptSrc(stmt);
+                    }
+                }
+
+                List<String> allowedStyleSrc = options.getAllowedStyleSrc();
+                if (allowedStyleSrc != null && !csp.isDefaultStyleSrc()) {
+                    for (String stmt : allowedStyleSrc) {
+                        csp.addStyleSrc(stmt);
+                    }
                 }
 
                 headers.putSingle(CONTENT_SECURITY_POLICY.getHeaderName(), csp.build());

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
@@ -18,10 +18,12 @@
 package org.keycloak.protocol.oidc.utils;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.Encode;
 import org.keycloak.common.util.HtmlUtils;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.common.util.Time;
+import org.keycloak.headers.SecurityHeadersProvider;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
@@ -34,8 +36,12 @@ import org.keycloak.services.Urls;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -59,7 +65,7 @@ public abstract class OIDCRedirectUriBuilder {
         switch (responseMode) {
             case QUERY: return new QueryRedirectUriBuilder(uriBuilder);
             case FRAGMENT: return new FragmentRedirectUriBuilder(uriBuilder);
-            case FORM_POST: return new FormPostRedirectUriBuilder(uriBuilder);
+            case FORM_POST: return new FormPostRedirectUriBuilder(uriBuilder, session);
             case QUERY_JWT:
             case FRAGMENT_JWT:
             case FORM_POST_JWT:
@@ -137,10 +143,12 @@ public abstract class OIDCRedirectUriBuilder {
     // http://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html
     private static class FormPostRedirectUriBuilder extends OIDCRedirectUriBuilder {
 
+        private final KeycloakSession session;
         private Map<String, String> params = new HashMap<>();
 
-        protected FormPostRedirectUriBuilder(KeycloakUriBuilder uriBuilder) {
+        protected FormPostRedirectUriBuilder(KeycloakUriBuilder uriBuilder, KeycloakSession session) {
             super(uriBuilder);
+            this.session = session;
         }
 
         @Override
@@ -154,11 +162,13 @@ public abstract class OIDCRedirectUriBuilder {
             StringBuilder builder = new StringBuilder();
             URI redirectUri = uriBuilder.build();
 
-            builder.append("<HTML>");
+            builder.append("<!DOCTYPE html>");
+            builder.append("<html lang=\"en\">");
             builder.append("  <HEAD>");
+            builder.append("    <meta charset=\"utf-8\" />");
             builder.append("    <TITLE>OIDC Form_Post Response</TITLE>");
             builder.append("  </HEAD>");
-            builder.append("  <BODY Onload=\"document.forms[0].submit()\">");
+            builder.append("  <BODY>");
 
             builder.append("    <FORM METHOD=\"POST\" ACTION=\"")
                     .append(HtmlUtils.escapeAttribute(redirectUri.toString()))
@@ -173,10 +183,26 @@ public abstract class OIDCRedirectUriBuilder {
             }
 
             builder.append("      <NOSCRIPT>");
-            builder.append("        <P>JavaScript is disabled. We strongly recommend to enable it. Click the button below to continue .</P>");
+            builder.append("        <P>JavaScript is disabled. We strongly recommend to enable it. Click the button below to continue.</P>");
             builder.append("        <INPUT name=\"continue\" TYPE=\"SUBMIT\" VALUE=\"CONTINUE\" />");
             builder.append("      </NOSCRIPT>");
             builder.append("    </FORM>");
+
+            String javascript = "document.forms[0].submit();";
+
+            try {
+                MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+                byte[] hashed = sha256.digest(javascript.getBytes(StandardCharsets.UTF_8));
+                String scriptHash = Base64.encodeBytes(hashed);
+                String scriptSrc = "'sha256-" + scriptHash + "'";
+
+                session.getProvider(SecurityHeadersProvider.class).options().addScriptSrc(scriptSrc);
+            } catch (NoSuchAlgorithmException _e) {
+                // JAS: Do nothing.
+            }
+
+            builder.append("    <script>" + javascript + "</script>");
+
             builder.append("  </BODY>");
             builder.append("</HTML>");
 

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -6,7 +6,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password>
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                <form id="kc-form-login" action="${url.loginAction}" method="post">
                     <#if !usernameHidden??>
                         <div class="${properties.kcFormGroupClass!}">
                             <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
@@ -75,6 +75,7 @@
                           <input tabindex="7" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                       </div>
                 </form>
+                <script nonce="${nonce.script}">document.getElementById("kc-form-login").onsubmit = function () { document.querySelector("#kc-form-login input[name='login']").disabled = true; return true; };</script>
             </#if>
             </div>
         </div>


### PR DESCRIPTION
Extends the CSP builder to support script-src, extends the Security Headers Provider to permit the injection of script-src directives, and implements hash generation for the on-the-fly JavaScript used for browser history.

Adds nonce to Freemarker login templates.

Closes #32123

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
