### PR TITLE
OTEL: Dynamic service name for tracing in K8s environment

### DIFF
--- a/docs/guides/server/tracing.adoc
+++ b/docs/guides/server/tracing.adoc
@@ -118,4 +118,18 @@ External callers can manipulate trace headers, parent spans can be injected, and
 Proper HTTP headers (especially `tracestate`) filtering and adequate measures of caller trust would need to be assessed.
 
 For more information, see the https://www.w3.org/TR/trace-context/#security-considerations[W3C Trace context] document.
+
+== Tracing in Kubernetes environment
+When the tracing is enabled when using the {project_name} Operator, certain information about the deployment is propagated to the underlying containers.
+
+NOTE: There is no support for tracing configuration in {project_name} CR yet, so the `additionalValues` can be used for demonstrating purposes by adding the `tracing-enabled` property.
+
+You can filter out the required traces in your tracing backend based on their tags:
+
+* `service.name` - {project_name} deployment name
+* `k8s.namespace.name` - Namespace
+* `host.name` - Pod name
+
+{project_name} Operator automatically sets the `KC_TRACING_SERVICE_NAME` and `KC_TRACING_RESOURCE_ATTRIBUTES` environment variables for each {project_name} container included in pods it manages.
+
 </@tmpl.guide>

--- a/docs/guides/server/tracing.adoc
+++ b/docs/guides/server/tracing.adoc
@@ -122,7 +122,7 @@ For more information, see the https://www.w3.org/TR/trace-context/#security-cons
 == Tracing in Kubernetes environment
 When the tracing is enabled when using the {project_name} Operator, certain information about the deployment is propagated to the underlying containers.
 
-NOTE: There is no support for tracing configuration in {project_name} CR yet, so the `additionalValues` can be used for demonstrating purposes by adding the `tracing-enabled` property.
+NOTE: There is no support for tracing configuration in {project_name} CR yet, so the `additionalOptions` can be used to the `tracing-enabled` property and other tracing options.
 
 You can filter out the required traces in your tracing backend based on their tags:
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -17,7 +17,9 @@
 
 package org.keycloak.operator.testsuite.integration;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
@@ -41,12 +43,14 @@ import org.keycloak.operator.testsuite.utils.K8sUtils;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.keycloak.operator.controllers.KeycloakDeploymentDependentResource.KC_TRACING_SERVICE_NAME;
 
 @QuarkusTest
 public class ClusteringTest extends BaseOperatorTest {
@@ -87,6 +91,33 @@ public class ClusteringTest extends BaseOperatorTest {
         checkInstanceCount(1, Secret.class, kc, kc1);
         checkInstanceCount(1, Ingress.class, kc, kc1);
         checkInstanceCount(2, Service.class, kc, kc1);
+
+        // Tracing assertions
+        var pods = k8sclient
+                .pods()
+                .inNamespace(namespace)
+                .withLabels(Constants.DEFAULT_LABELS)
+                .list()
+                .getItems();
+
+        assertThat(pods.size()).isEqualTo(2);
+
+        Function<Pod, String> getTracingServiceName = (pod) -> pod.getSpec().getContainers().get(0).getEnv().stream()
+                .filter(f -> f.getName().equals(KC_TRACING_SERVICE_NAME)).findAny().map(EnvVar::getValue).orElse(null);
+
+        var kc1Pod = pods.stream().filter(f -> f.getMetadata().getName().startsWith("another-example-")).findAny().orElse(null);
+        assertThat(kc1Pod).isNotNull();
+
+        var tracingServiceName1 = getTracingServiceName.apply(kc1Pod);
+        assertThat(tracingServiceName1).isNotNull();
+        assertThat(tracingServiceName1).isEqualTo("another-example");
+
+        var kcPod = pods.stream().filter(f -> !f.equals(kc1Pod)).findAny().orElse(null);
+        assertThat(kcPod).isNotNull();
+
+        var tracingServiceName2 = getTracingServiceName.apply(kcPod);
+        assertThat(tracingServiceName2).isNotNull();
+        assertThat(tracingServiceName2).isEqualTo("example-kc");
 
         // ensure they don't see each other's pods
         assertThat(k8sclient.resource(kc).scale().getStatus().getReplicas()).isEqualTo(1);


### PR DESCRIPTION
Closes #32095 

k9s: env vars
![image](https://github.com/user-attachments/assets/5f48b36a-4b5b-4c7b-959f-1921123152b9)

Pod log:
```
resource=Resource{schemaUrl=null, attributes={host.name="example-kc-0", k8s.namespace.name="keycloak-test-14b6b809-0814-4255-a910-f34b1684e965", service.name="example-kc", ...
```

It could be good to provide some test cases by analyzing the pod log and the used service name - but not sure how. @vmuzikar @shawkins Is it possible to achieve it somehow?
