### PR TITLE
Align google social `hd` param helptext with single-value constraint

### DIFF
--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
@@ -66,7 +66,7 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
                 .label("Hosted Domain")
                 .helpText("Set 'hd' query parameter when logging in with Google. Google will list accounts only for this " +
                         "domain. Keycloak validates that the returned identity token has a claim for this domain. When '*' " +
-                        "is entered, any hosted account can be used. Comma ',' separated list of domains is supported.")
+                        "is entered, any hosted account can be used. Must be a single domain or '*'.")
                 .type(ProviderConfigProperty.STRING_TYPE).add()
                 .property().name("userIp")
                 .label("Use userIp param")


### PR DESCRIPTION
This PR takes as given the fact that a comma-separated list of domains supplied to Keycloak's `hd` configuration for Google social IdPs doesn't work. Google doesn't advertise support for a multi-valued parameter but it is still _possible_ as far as I know that the issue is a fixable one on Keycloak's side, and in theory it ought to work. This PR assumes it can't work, and fixes the help text for that configuration parameter.

Closes #29712
