### PR TITLE
Support for Content Security Policy Header

### DIFF
--- a/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/index.ftl
+++ b/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/index.ftl
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="${properties.description!'The Account Console is a web-based interface for managing your account.'}">
     <title>${properties.title!'Account Management'}</title>
-    <style>
+    <style nonce="${nonce.style!}">
       body {
         margin: 0;
       }
@@ -48,7 +48,7 @@
         padding-top: 32px;
       }
     </style>
-    <script type="importmap">
+    <script type="importmap" nonce="${nonce.script}">
       {
         "imports": {
           "react": "${resourceCommonUrl}/vendor/react/react.production.min.js",
@@ -58,14 +58,14 @@
       }
     </script>
     <#if devServerUrl?has_content>
-      <script type="module">
+      <script type="module" nonce="${nonce.script}">
         import { injectIntoGlobalHook } from "${devServerUrl}/@react-refresh";
 
         injectIntoGlobalHook(window);
         window.$RefreshReg$ = () => {};
         window.$RefreshSig$ = () => (type) => type;
       </script>
-      <script type="module">
+      <script type="module" nonce="${nonce.script}">
         import { inject } from "${devServerUrl}/@vite-plugin-checker-runtime";
 
         inject({
@@ -116,7 +116,7 @@
       </main>
     </div>
     <noscript>JavaScript is required to use the Account Console.</noscript>
-    <script id="environment" type="application/json">
+    <script id="environment" type="application/json" nonce="${nonce.script}">
       {
         "serverBaseUrl": "${serverBaseUrl}",
         "authUrl": "${authUrl}",

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/index.ftl
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/index.ftl
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="${properties.description!'The Keycloak Administration Console is a web-based interface for managing Keycloak.'}">
     <title>${properties.title!'Keycloak Administration Console'}</title>
-    <style>
+    <style nonce="${nonce.style!}">
       body {
         margin: 0;
       }
@@ -48,7 +48,7 @@
         padding-top: 32px;
       }
     </style>
-    <script type="importmap">
+    <script type="importmap" nonce="${nonce.script}">
       {
         "imports": {
           "react": "${resourceCommonUrl}/vendor/react/react.production.min.js",
@@ -58,14 +58,14 @@
       }
     </script>
     <#if devServerUrl?has_content>
-      <script type="module">
+      <script type="module" nonce="${nonce.script}">
         import { injectIntoGlobalHook } from "${devServerUrl}/@react-refresh";
 
         injectIntoGlobalHook(window);
         window.$RefreshReg$ = () => {};
         window.$RefreshSig$ = () => (type) => type;
       </script>
-      <script type="module">
+      <script type="module" nonce="${nonce.script}">
         import { inject } from "${devServerUrl}/@vite-plugin-checker-runtime";
 
         inject({
@@ -116,7 +116,7 @@
       </main>
     </div>
     <noscript>JavaScript is required to use the Administration Console.</noscript>
-    <script id="environment" type="application/json">
+    <script id="environment" type="application/json" nonce="${nonce.script}">
       {
         "serverBaseUrl": "${serverBaseUrl}",
         "adminBaseUrl": "${adminBaseUrl}",

--- a/server-spi-private/src/main/java/org/keycloak/headers/SecurityHeadersOptions.java
+++ b/server-spi-private/src/main/java/org/keycloak/headers/SecurityHeadersOptions.java
@@ -18,9 +18,15 @@ package org.keycloak.headers;
 
 public interface SecurityHeadersOptions {
 
+    SecurityHeadersOptions addFormAction(String action);
+
     SecurityHeadersOptions allowFrameSrc(String source);
 
     SecurityHeadersOptions allowAnyFrameAncestor();
+
+    SecurityHeadersOptions addScriptSrc(String source);
+
+    SecurityHeadersOptions addStyleSrc(String source);
 
     SecurityHeadersOptions skipHeaders();
 

--- a/server-spi-private/src/main/java/org/keycloak/models/ContentSecurityPolicyBuilder.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/ContentSecurityPolicyBuilder.java
@@ -22,25 +22,38 @@ import java.util.Map;
 public class ContentSecurityPolicyBuilder {
 
     // constants for directive names used in the class
+    public static final String DIRECTIVE_NAME_FORM_ACTION = "form-action";
     public static final String DIRECTIVE_NAME_FRAME_SRC = "frame-src";
     public static final String DIRECTIVE_NAME_FRAME_ANCESTORS = "frame-ancestors";
     public static final String DIRECTIVE_NAME_OBJECT_SRC = "object-src";
+    public static final String DIRECTIVE_NAME_SCRIPT_SRC = "script-src";
+    public static final String DIRECTIVE_NAME_STYLE_SRC = "style-src";
 
     // constants for specific directive value keywords
     public static final String DIRECTIVE_VALUE_SELF = "'self'";
     public static final String DIRECTIVE_VALUE_NONE = "'none'";
+    public static final String DIRECTIVE_VALUE_UNSAFE_INLINE = "'unsafe-inline'";
 
     private final Map<String, String> directives = new LinkedHashMap<>();
 
     public static ContentSecurityPolicyBuilder create() {
         return new ContentSecurityPolicyBuilder()
+                .add(DIRECTIVE_NAME_FORM_ACTION, DIRECTIVE_VALUE_SELF)
                 .add(DIRECTIVE_NAME_FRAME_SRC, DIRECTIVE_VALUE_SELF)
                 .add(DIRECTIVE_NAME_FRAME_ANCESTORS, DIRECTIVE_VALUE_SELF)
-                .add(DIRECTIVE_NAME_OBJECT_SRC, DIRECTIVE_VALUE_NONE);
+                .add(DIRECTIVE_NAME_OBJECT_SRC, DIRECTIVE_VALUE_NONE)
+                .add(DIRECTIVE_NAME_SCRIPT_SRC, DIRECTIVE_VALUE_SELF)
+                .add(DIRECTIVE_NAME_SCRIPT_SRC, DIRECTIVE_VALUE_UNSAFE_INLINE)
+                .add(DIRECTIVE_NAME_STYLE_SRC, DIRECTIVE_VALUE_SELF)
+                .add(DIRECTIVE_NAME_STYLE_SRC, DIRECTIVE_VALUE_UNSAFE_INLINE);
     }
 
     public static ContentSecurityPolicyBuilder create(String directives) {
         return new ContentSecurityPolicyBuilder().parse(directives);
+    }
+
+    public ContentSecurityPolicyBuilder addFormAction(String formAction) {
+        return add(DIRECTIVE_NAME_FORM_ACTION, formAction);
     }
 
     public ContentSecurityPolicyBuilder frameSrc(String frameSrc) {
@@ -71,6 +84,48 @@ public class ContentSecurityPolicyBuilder {
 
     public ContentSecurityPolicyBuilder addFrameAncestors(String frameancestors) {
         return add(DIRECTIVE_NAME_FRAME_ANCESTORS, frameancestors);
+    }
+
+    public ContentSecurityPolicyBuilder scriptSrc(String scriptSrc) {
+        if (scriptSrc == null) {
+            directives.remove(DIRECTIVE_NAME_SCRIPT_SRC);
+        } else {
+            put(DIRECTIVE_NAME_SCRIPT_SRC, scriptSrc);
+        }
+        return this;
+    }
+
+    public ContentSecurityPolicyBuilder addScriptSrc(String scriptSrc) {
+        boolean nonceOrHash = scriptSrc.trim().startsWith("'nonce-") || scriptSrc.trim().startsWith("'hash-");
+        boolean isDefault = "'self' 'unsafe-inline'".equals(directives.get(DIRECTIVE_NAME_SCRIPT_SRC));
+
+        // JAS: Do not add a nonce or hash if 'unsafe-inline' is defined.
+        if (isDefault && nonceOrHash) {
+            return this;
+        }
+
+        return add(DIRECTIVE_NAME_SCRIPT_SRC, scriptSrc);
+    }
+
+    public ContentSecurityPolicyBuilder styleSrc(String styleSrc) {
+        if (styleSrc == null) {
+            directives.remove(DIRECTIVE_NAME_STYLE_SRC);
+        } else {
+            put(DIRECTIVE_NAME_STYLE_SRC, styleSrc);
+        }
+        return this;
+    }
+
+    public ContentSecurityPolicyBuilder addStyleSrc(String styleSrc) {
+        boolean nonceOrHash = styleSrc.trim().startsWith("'nonce-") || styleSrc.trim().startsWith("'hash-");
+        boolean isDefault = "'self' 'unsafe-inline'".equals(directives.get(DIRECTIVE_NAME_STYLE_SRC));
+
+        // JAS: Do not add a nonce or hash if 'unsafe-inline' is defined.
+        if (isDefault && nonceOrHash) {
+            return this;
+        }
+
+        return add(DIRECTIVE_NAME_STYLE_SRC, styleSrc);
     }
 
     public String build() {

--- a/server-spi-private/src/test/java/org/keycloak/models/BrowserSecurityHeadersTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/BrowserSecurityHeadersTest.java
@@ -20,13 +20,21 @@ public class BrowserSecurityHeadersTest {
 
     @Test
     public void contentSecurityPolicyBuilderTest() {
-        assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().build());
-        assertEquals("frame-ancestors 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc(null).build());
-        assertEquals("frame-src 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameAncestors(null).build());
-        assertEquals("frame-src 'custom-frame-src'; frame-ancestors 'custom-frame-ancestors'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc("'custom-frame-src'").frameAncestors("'custom-frame-ancestors'").build());
-        assertEquals("frame-src localhost; frame-ancestors 'self'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc("localhost").build());
-        assertEquals("frame-src 'self' localhost; frame-ancestors 'self'; object-src 'none';",
-                ContentSecurityPolicyBuilder.create().addFrameSrc("localhost").build());
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().build());
+        assertEquals("form-action 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().frameSrc(null).build());
+        assertEquals("form-action 'self'; frame-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().frameAncestors(null).build());
+        assertEquals("form-action 'self'; frame-src 'custom-frame-src'; frame-ancestors 'custom-frame-ancestors'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().frameSrc("'custom-frame-src'").frameAncestors("'custom-frame-ancestors'").build());
+        assertEquals("form-action 'self'; frame-src localhost; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().frameSrc("localhost").build());
+        assertEquals("form-action 'self'; frame-src 'self' localhost; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().addFrameSrc("localhost").build());
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src localhost; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().scriptSrc("localhost").build());
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src localhost;", ContentSecurityPolicyBuilder.create().styleSrc("localhost").build());
+
+        // Adding a nonce or hash to 'unsafe-inline' should have no effect.
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().addScriptSrc("'nonce-46cc8f91-509f-4f80-ba93-943431630d46'").build());
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().addStyleSrc("'nonce-46cc8f91-509f-4f80-ba93-943431630d46'").build());
+
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' https://github.com; style-src 'self' 'unsafe-inline';", ContentSecurityPolicyBuilder.create().scriptSrc("'self'").addScriptSrc("https://github.com").build());
+        assertEquals("form-action 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' https://github.com;", ContentSecurityPolicyBuilder.create().styleSrc("'self'").addStyleSrc("https://github.com").build());
     }
 
     private void assertParsedDirectives(String directives) {

--- a/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersOptions.java
+++ b/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersOptions.java
@@ -16,12 +16,18 @@
  */
 package org.keycloak.headers;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DefaultSecurityHeadersOptions implements SecurityHeadersOptions {
 
     private boolean skipHeaders;
     private boolean allowAnyFrameAncestor;
     private boolean allowEmptyContentType;
     private String allowedFrameSrc;
+    private final List<String> allowedFormAction = new ArrayList<String>();
+    private final List<String> allowedScriptSrc = new ArrayList<String>();
+    private final List<String> allowedStyleSrc = new ArrayList<String>();
 
     public SecurityHeadersOptions allowFrameSrc(String source) {
         allowedFrameSrc = source;
@@ -29,8 +35,26 @@ public class DefaultSecurityHeadersOptions implements SecurityHeadersOptions {
     }
 
     @Override
+    public SecurityHeadersOptions addFormAction(String action) {
+        allowedFormAction.add(action);
+        return this;
+    }
+
+    @Override
     public SecurityHeadersOptions allowAnyFrameAncestor() {
         allowAnyFrameAncestor = true;
+        return this;
+    }
+
+    @Override
+    public SecurityHeadersOptions addScriptSrc(String source) {
+        allowedScriptSrc.add(source);
+        return this;
+    }
+
+    @Override
+    public SecurityHeadersOptions addStyleSrc(String source) {
+        allowedStyleSrc.add(source);
         return this;
     }
 
@@ -45,8 +69,20 @@ public class DefaultSecurityHeadersOptions implements SecurityHeadersOptions {
         return this;
     }
 
+    List<String> getAllowedFormAction() {
+        return allowedFormAction;
+    }
+
     String getAllowedFrameSrc() {
         return allowedFrameSrc;
+    }
+
+    List<String> getAllowedScriptSrc() {
+        return allowedScriptSrc;
+    }
+
+    List<String> getAllowedStyleSrc() {
+        return allowedStyleSrc;
     }
 
     boolean isAllowAnyFrameAncestor() {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -30,6 +30,7 @@ import org.keycloak.services.validation.Validation;
 import org.keycloak.theme.FreeMarkerException;
 import org.keycloak.theme.Theme;
 import org.keycloak.theme.beans.MessageFormatterMethod;
+import org.keycloak.theme.beans.NonceBean;
 import org.keycloak.theme.freemarker.FreeMarkerProvider;
 import org.keycloak.urls.UrlType;
 import org.keycloak.util.JsonSerialization;
@@ -186,6 +187,9 @@ public class AccountConsole implements AccountResourceProvider {
             map.put("entryScript", entryScript);
             map.put("entryImports", entryImports);
         }
+
+        // JAS: Insert nonces into CSP header and attributes.
+        map.put("nonce", new NonceBean(session));
 
         FreeMarkerProvider freeMarkerUtil = session.getProvider(FreeMarkerProvider.class);
         String result = freeMarkerUtil.processTemplate(map, "index.ftl", theme);

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -54,6 +54,7 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.util.ViteManifest;
 import org.keycloak.theme.FreeMarkerException;
 import org.keycloak.theme.Theme;
+import org.keycloak.theme.beans.NonceBean;
 import org.keycloak.theme.freemarker.FreeMarkerProvider;
 import org.keycloak.urls.UrlType;
 import org.keycloak.utils.MediaType;
@@ -383,6 +384,9 @@ public class AdminConsole {
                 map.put("entryScript", entryScript);
                 map.put("entryImports", entryImports);
             }
+
+            // JAS: Insert nonces into CSP header and attributes.
+            map.put("nonce", new NonceBean(session));
 
             final var freeMarkerUtil = session.getProvider(FreeMarkerProvider.class);
             final var result = freeMarkerUtil.processTemplate(map, "index.ftl", theme);

--- a/services/src/main/java/org/keycloak/theme/beans/NonceBean.java
+++ b/services/src/main/java/org/keycloak/theme/beans/NonceBean.java
@@ -1,0 +1,30 @@
+package org.keycloak.theme.beans;
+
+import org.keycloak.headers.SecurityHeadersProvider;
+import org.keycloak.models.KeycloakSession;
+
+import java.util.UUID;
+
+/**
+ * @author James Shuriff
+ */
+public class NonceBean {
+    private final String scriptNonce;
+    private final String styleNonce;
+
+    public NonceBean(KeycloakSession session) {
+        scriptNonce = UUID.randomUUID().toString();
+        session.getProvider(SecurityHeadersProvider.class).options().addScriptSrc("'nonce-" + scriptNonce + "'");
+
+        styleNonce = UUID.randomUUID().toString();
+        session.getProvider(SecurityHeadersProvider.class).options().addStyleSrc("'nonce-" + styleNonce + "'");
+    }
+
+    public String getScript() {
+        return scriptNonce;
+    }
+
+    public String getStyle() {
+        return styleNonce;
+    }
+}

--- a/services/src/main/java/org/keycloak/theme/freemarker/DefaultFreeMarkerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/theme/freemarker/DefaultFreeMarkerProviderFactory.java
@@ -23,7 +23,7 @@ public class DefaultFreeMarkerProviderFactory implements FreeMarkerProviderFacto
                         cache = new ConcurrentHashMap<>();
                     }
                     kcSanitizeMethod = new KeycloakSanitizerMethod();
-                    provider = new DefaultFreeMarkerProvider(cache, kcSanitizeMethod);
+                    provider = new DefaultFreeMarkerProvider(cache, kcSanitizeMethod, session);
                 }
             }
         }

--- a/services/src/main/java/org/keycloak/theme/freemarker/FreeMarkerProvider.java
+++ b/services/src/main/java/org/keycloak/theme/freemarker/FreeMarkerProvider.java
@@ -4,8 +4,10 @@ import org.keycloak.provider.Provider;
 import org.keycloak.theme.FreeMarkerException;
 import org.keycloak.theme.Theme;
 
+import java.util.Map;
+
 public interface FreeMarkerProvider extends Provider {
 
-    public String processTemplate(Object data, String templateName, Theme theme) throws FreeMarkerException;
+    public String processTemplate(Map<String, Object> attributes, String templateName, Theme theme) throws FreeMarkerException;
 
 }

--- a/services/src/main/java/org/keycloak/utils/ReplacingInputStream.java
+++ b/services/src/main/java/org/keycloak/utils/ReplacingInputStream.java
@@ -1,0 +1,208 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Inbot
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.keycloak.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * Simple FilterInputStream that can replace occurrences of bytes with something
+ * else.
+ */
+public class ReplacingInputStream extends FilterInputStream {
+
+    // while matching, this is where the bytes go.
+    final int[] buf;
+    private int matchedIndex;
+    private int unbufferIndex;
+    private int replacedIndex;
+
+    private final byte[] pattern;
+    private final byte[] replacement;
+    private State state = State.NOT_MATCHED;
+
+    // simple state machine for keeping track of what we are doing
+    private enum State {
+        NOT_MATCHED, MATCHING, REPLACING, UNBUFFER
+    }
+
+    /**
+     * Replace occurrences of pattern in the input. Note: input is assumed to be
+     * UTF-8 encoded. If not the case use byte[] based pattern and replacement.
+     *
+     * @param in          input
+     * @param pattern     pattern to replace.
+     * @param replacement the replacement or null
+     */
+    public ReplacingInputStream(InputStream in, String pattern, String replacement) {
+        this(in, pattern.getBytes(UTF_8), replacement == null ? null : replacement.getBytes(UTF_8));
+    }
+
+    /**
+     * Replace occurrences of pattern in the input.
+     * <p>
+     *
+     * If you want to normalize line endings DOS/MAC (\n\r | \r) to UNIX (\n), you
+     * can call the following:<br>
+     * {@code new ReplacingInputStream(new ReplacingInputStream(is, "\n\r", "\n"), "\r", "\n")}
+     *
+     * @param in          input
+     * @param pattern     pattern to replace
+     * @param replacement the replacement or null
+     */
+    public ReplacingInputStream(InputStream in, byte[] pattern, byte[] replacement) {
+        super(in);
+        if (pattern == null || pattern.length == 0) {
+            throw new IllegalArgumentException("pattern length should be > 0");
+        }
+        this.pattern = pattern;
+        this.replacement = replacement;
+        // we will never match more than the pattern length
+        buf = new int[pattern.length];
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        // copy of parent logic; we need to call our own read() instead of super.read(),
+        // which delegates instead of calling our read
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int c = read();
+        if (c == -1) {
+            return -1;
+        }
+        b[off] = (byte) c;
+
+        int i = 1;
+        for (; i < len; i++) {
+            c = read();
+            if (c == -1) {
+                break;
+            }
+            b[off + i] = (byte) c;
+        }
+        return i;
+
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        // call our own read
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read() throws IOException {
+        // use a simple state machine to figure out what we are doing
+        int next;
+        switch (state) {
+        default:
+        case NOT_MATCHED:
+            // we are not currently matching, replacing, or unbuffering
+            next = super.read();
+            if (pattern[0] != next) {
+                return next;
+            }
+
+            // clear whatever was there
+            Arrays.fill(buf, 0);
+            // make sure we start at 0
+            matchedIndex = 0;
+
+            buf[matchedIndex++] = next;
+            if (pattern.length == 1) {
+                // edge-case when the pattern length is 1 we go straight to replacing
+                state = State.REPLACING;
+                // reset replace counter
+                replacedIndex = 0;
+            } else {
+                // pattern of length 1
+                state = State.MATCHING;
+            }
+            // recurse to continue matching
+            return read();
+
+        case MATCHING:
+            // the previous bytes matched part of the pattern
+            next = super.read();
+            if (pattern[matchedIndex] == next) {
+                buf[matchedIndex++] = next;
+                if (matchedIndex == pattern.length) {
+                    // we've found a full match!
+                    if (replacement == null || replacement.length == 0) {
+                        // the replacement is empty, go straight to NOT_MATCHED
+                        state = State.NOT_MATCHED;
+                        matchedIndex = 0;
+                    } else {
+                        // start replacing
+                        state = State.REPLACING;
+                        replacedIndex = 0;
+                    }
+                }
+            } else {
+                // mismatch -> unbuffer
+                buf[matchedIndex++] = next;
+                state = State.UNBUFFER;
+                unbufferIndex = 0;
+            }
+            return read();
+
+        case REPLACING:
+            // we've fully matched the pattern and are returning bytes from the replacement
+            next = replacement[replacedIndex++];
+            if (replacedIndex == replacement.length) {
+                state = State.NOT_MATCHED;
+                replacedIndex = 0;
+            }
+            return next;
+
+        case UNBUFFER:
+            // we partially matched the pattern before encountering a non matching byte
+            // we need to serve up the buffered bytes before we go back to NOT_MATCHED
+            next = buf[unbufferIndex++];
+            if (unbufferIndex == matchedIndex) {
+                state = State.NOT_MATCHED;
+                matchedIndex = 0;
+            }
+            return next;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return state.name() + " " + matchedIndex + " " + replacedIndex + " " + unbufferIndex;
+    }
+
+}

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/3p-cookies-step1.html
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/3p-cookies-step1.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
   </head>
   <body>
-    <script type="module">
+    <script type="module" nonce="$NONCE_SCRIPT">
       checkStorageAccess();
       
       async function checkStorageAccess() {

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/3p-cookies-step2.html
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/3p-cookies-step2.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
   </head>
   <body>
-    <script type="module">
+    <script type="module" nonce="$NONCE_SCRIPT">
       // Check if the previously placed cookies exist to detect support for 3rd-party access.
       const hasAccess = document.cookie.includes("KEYCLOAK_3P_COOKIE");
 

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.html
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
   </head>
   <body>
-    <script type="module">
+    <script type="module" nonce="$NONCE_SCRIPT">
       window.addEventListener("message", onMessage);
 
       async function onMessage(event) {

--- a/themes/src/main/resources/theme/base/login/frontchannel-logout.ftl
+++ b/themes/src/main/resources/theme/base/login/frontchannel-logout.ftl
@@ -1,7 +1,7 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout; section>
     <#if section = "header">
-        <script>
+        <script nonce="${nonce.script}">
             document.title =  "${msg("frontchannel-logout.title")}";
         </script>
         ${msg("frontchannel-logout.title")}
@@ -16,7 +16,7 @@
         </#list>
         </ul>
         <#if logout.logoutRedirectUri?has_content>
-            <script>
+            <script nonce="${nonce.script}">
                 function readystatechange(event) {
                     if (document.readyState=='complete') {
                         window.location.replace('${logout.logoutRedirectUri}');

--- a/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
@@ -70,7 +70,7 @@
             <div id="kc-form">
                 <div id="kc-form-wrapper">
                     <#if realm.password>
-                        <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" style="display:none">
+                        <form id="kc-form-login" action="${url.loginAction}" method="post" style="display:none">
                             <#if !usernameHidden??>
                                 <div class="${properties.kcFormGroupClass!}">
                                     <label for="username" class="${properties.kcLabelClass!}">${msg("passkey-autofill-select")}</label>
@@ -91,7 +91,7 @@
                         </form>
                     </#if>
                     <div id="kc-form-passkey-button" class="${properties.kcFormButtonsClass!}" style="display:none">
-                        <input id="authenticateWebAuthnButton" type="button" onclick="doAuthenticate([], "${rpId}", "${challenge}", ${isUserIdentified}, ${createTimeout}, "${userVerification}", "${msg("passkey-unsupported-browser-text")?no_esc}")" autofocus="autofocus"
+                        <input id="authenticateWebAuthnButton" type="button" autofocus="autofocus"
                             value="${kcSanitize(msg("passkey-doAuthenticate"))}"
                             class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"/>
                     </div>
@@ -104,7 +104,7 @@
             </div>
         </div>
 
-        <script type="module">
+        <script type="module" nonce="${nonce.script}">
             import { authenticateByWebAuthn } from "${url.resourcesPath}/js/webauthnAuthenticate.js";
             import { initAuthenticate } from "${url.resourcesPath}/js/passkeysConditionalAuth.js";
 
@@ -131,6 +131,10 @@
             };
 
             document.addEventListener("DOMContentLoaded", (event) => initAuthenticate(args));
+        </script>
+
+        <script nonce="${nonce.script}">
+            document.querySelectorAll("#authenticateWebAuthnButton")[0].onclick = () => doAuthenticate([], "${rpId}", "${challenge}", ${isUserIdentified}, ${createTimeout}, "${userVerification}", "${msg("passkey-unsupported-browser-text")?no_esc}");
         </script>
 
     <#elseif section = "info">

--- a/themes/src/main/resources/theme/base/login/login-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-password.ftl
@@ -5,18 +5,18 @@
     <#elseif section = "form">
         <div id="kc-form">
             <div id="kc-form-wrapper">
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
-                      method="post">
+                <form id="kc-form-login" action="${url.loginAction}" method="post">
+                    <input type="hidden" name="username" autocomplete="username" value="${auth.attemptedUsername}" />
                     <div class="${properties.kcFormGroupClass!} no-bottom-margin">
                         <hr/>
                         <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
                         <div class="${properties.kcInputGroup!}" dir="ltr">
                             <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password"
-                                   type="password" autocomplete="on" autofocus
+                                   type="password" autocomplete="current-password" autofocus
                                    aria-invalid="<#if messagesPerField.existsError('password')>true</#if>"
                             />
                             <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button" aria-label="${msg('showPassword')}"
-                                    aria-controls="password"  data-password-toggle
+                                    aria-controls="password" data-password-toggle
                                     data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}" data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}"
                                     data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
                                 <i class="${properties.kcFormPasswordVisibilityIconShow!}" aria-hidden="true"></i>
@@ -44,6 +44,14 @@
                         <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                     </div>
                 </form>
+                <script nonce="${nonce.script}">
+                    document.getElementById("kc-form-login").onsubmit = () => {
+                        document.querySelector("#kc-form-login input[name='username']").disabled = true;
+                        document.querySelector("#kc-form-login input[name='login']").disabled = true;
+
+                        return true;
+                    };
+                </script>
             </div>
         </div>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>

--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
@@ -71,7 +71,7 @@
         </#if>
     </form>
 
-    <script>
+    <script nonce="${nonce.script}">
         /* copy recovery codes  */
         function copyRecoveryCodes() {
             var tmpTextarea = document.createElement("textarea");

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -6,8 +6,7 @@
         <div id="kc-form">
             <div id="kc-form-wrapper">
                 <#if realm.password>
-                    <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
-                          method="post">
+                    <form id="kc-form-login" action="${url.loginAction}" method="post">
                         <#if !usernameHidden??>
                             <div class="${properties.kcFormGroupClass!}">
                                 <label for="username"
@@ -52,6 +51,7 @@
                                    name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                         </div>
                     </form>
+                    <script nonce="${nonce.script}">document.getElementById("kc-form-login").onsubmit = () => { document.querySelector("#kc-form-login input[name='login']").disabled = true; return true; };</script>
                 </#if>
             </div>
         </div>

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -6,7 +6,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password>
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                <form id="kc-form-login" action="${url.loginAction}" method="post">
                     <#if !usernameHidden??>
                         <div class="${properties.kcFormGroupClass!}">
                             <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
@@ -23,6 +23,8 @@
                             </#if>
 
                         </div>
+                    <#else>
+                        <input name="username" value="${(login.username!'')}" type="hidden" autocomplete="username" />
                     </#if>
 
                     <div class="${properties.kcFormGroupClass!}">
@@ -75,6 +77,17 @@
                           <input tabindex="7" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                       </div>
                 </form>
+                <script nonce="${nonce.script}">
+                    document.getElementById("kc-form-login").onsubmit = () => {
+                        document.querySelector("#kc-form-login input[name='login']").disabled = true;
+
+                        <#if usernameHidden??>
+                            document.querySelector("#kc-form-login input[name='username']").disabled = true;
+                        </#if>
+
+                        return true;
+                    };
+                </script>
             </#if>
             </div>
         </div>

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -89,7 +89,7 @@
                 </div>
 
                 <#if recaptchaRequired?? && !(recaptchaVisible!false)>
-                    <script>
+                    <script nonce="${nonce.script}">
                         function onSubmitRecaptcha(token) {
                             document.getElementById("kc-register-form").submit();
                         }

--- a/themes/src/main/resources/theme/base/login/saml-post-form.ftl
+++ b/themes/src/main/resources/theme/base/login/saml-post-form.ftl
@@ -3,7 +3,7 @@
     <#if section = "header">
         ${msg("saml.post-form.title")}
     <#elseif section = "form">
-        <script>window.onload = function() {document.forms[0].submit()};</script>
+        <script nonce="${nonce.script}">window.onload = () => document.forms[0].submit();</script>
         <p>${msg("saml.post-form.message")}</p>
         <form name="saml-post-binding" method="post" action="${samlPost.url}">
             <#if samlPost.SAMLRequest??>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -27,10 +27,10 @@
     </#if>
     <#if properties.scripts?has_content>
         <#list properties.scripts?split(' ') as script>
-            <script src="${url.resourcesPath}/${script}" type="text/javascript"></script>
+            <script src="${url.resourcesPath}/${script}"></script>
         </#list>
     </#if>
-    <script type="importmap">
+    <script type="importmap" nonce="${nonce.script}">
         {
             "imports": {
                 "rfc4648": "${url.resourcesCommonPath}/vendor/rfc4648/rfc4648.js"
@@ -40,10 +40,10 @@
     <script src="${url.resourcesPath}/js/menu-button-links.js" type="module"></script>
     <#if scripts??>
         <#list scripts as script>
-            <script src="${script}" type="text/javascript"></script>
+            <script src="${script}"></script>
         </#list>
     </#if>
-    <script type="module">
+    <script type="module" nonce="${nonce.script}">
         import { checkCookiesAndSetTimer } from "${url.resourcesPath}/js/authChecker.js";
 
         checkCookiesAndSetTimer(
@@ -147,8 +147,13 @@
               <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post">
                   <div class="${properties.kcFormGroupClass!}">
                       <input type="hidden" name="tryAnotherWay" value="on"/>
-                      <a href="#" id="try-another-way"
-                         onclick="document.forms['kc-select-try-another-way-form'].submit();return false;">${msg("doTryAnotherWay")}</a>
+                      <a href="#" id="try-another-way">${msg("doTryAnotherWay")}</a>
+                      <script nonce="${nonce.script}">
+                          document.getElementById("try-another-way").onclick = () => {
+                              document.forms['kc-select-try-another-way-form'].submit();
+                              return false;
+                          };
+                      </script>
                   </div>
               </form>
           </#if>

--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -76,10 +76,10 @@
             </div>
         </div>
 
-    <script type="module">
+    <script type="module" nonce="${nonce.script}">
         import { authenticateByWebAuthn } from "${url.resourcesPath}/js/webauthnAuthenticate.js";
         const authButton = document.getElementById('authenticateWebAuthnButton');
-        authButton.addEventListener("click", function() {
+        authButton.addEventListener("click", () => {
             const input = {
                 isUserIdentified : ${isUserIdentified},
                 challenge : '${challenge}',

--- a/themes/src/main/resources/theme/base/login/webauthn-error.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-error.ftl
@@ -4,24 +4,24 @@
         ${kcSanitize(msg("webauthn-error-title"))?no_esc}
     <#elseif section = "form">
 
-        <script type="text/javascript">
-            refreshPage = () => {
-                document.getElementById('isSetRetry').value = 'retry';
-                document.getElementById('executionValue').value = '${execution}';
-                document.getElementById('kc-error-credential-form').submit();
-            }
-        </script>
-
         <form id="kc-error-credential-form" class="${properties.kcFormClass!}" action="${url.loginAction}"
               method="post">
             <input type="hidden" id="executionValue" name="authenticationExecution"/>
             <input type="hidden" id="isSetRetry" name="isSetRetry"/>
         </form>
 
-        <input tabindex="4" onclick="refreshPage()" type="button"
+        <input tabindex="4" type="button"
                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                name="try-again" id="kc-try-again" value="${kcSanitize(msg("doTryAgain"))?no_esc}"
         />
+
+        <script nonce="${nonce.script}">
+            document.getElementById("kc-try-again").onclick = () => {
+                document.getElementById('isSetRetry').value = 'retry';
+                document.getElementById('executionValue').value = '${execution}';
+                document.getElementById('kc-error-credential-form').submit();
+            };
+        </script>
 
         <#if isAppInitiatedAction??>
             <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-webauthn-settings-form" method="post">

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -21,10 +21,10 @@
             </div>
         </form>
 
-        <script type="module">
+        <script type="module" nonce="${nonce.script}">
             import { registerByWebAuthn } from "${url.resourcesPath}/js/webauthnRegister.js";
             const registerButton = document.getElementById('registerWebAuthn');
-            registerButton.addEventListener("click", function() {
+            registerButton.addEventListener("click", () => {
                 const input = {
                     challenge : '${challenge}',
                     userid : '${userid}',

--- a/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
@@ -7,7 +7,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password>
-                <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" novalidate="novalidate">
+                <form id="kc-form-login" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post" novalidate="novalidate">
                     <#if !usernameHidden??>
                         <#assign label>
                             <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
@@ -28,6 +28,7 @@
                         <input tabindex="4" class="pf-v5-c-button pf-m-primary pf-m-block" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                     </div>
                 </form>
+                <script nonce="${nonce.script}">document.getElementById("kc-form-login").onsubmit = function () { document.querySelector("#kc-form-login input[name='login']").disabled = true; return true; };</script>
             </#if>
             </div>
         </div>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -24,7 +24,7 @@
             <link href="${url.resourcesPath}/${style}" rel="stylesheet" />
         </#list>
     </#if>
-    <script type="importmap">
+    <script type="importmap" nonce="${nonce.script}">
         {
             "imports": {
                 "rfc4648": "${url.resourcesCommonPath}/vendor/rfc4648/rfc4648.js"
@@ -41,7 +41,7 @@
             <script src="${script}" type="text/javascript"></script>
         </#list>
     </#if>
-    <script type="module">
+    <script type="module" nonce="${nonce.script}">
         import { checkCookiesAndSetTimer } from "${url.resourcesPath}/js/authChecker.js";
 
         checkCookiesAndSetTimer(


### PR DESCRIPTION
Extends the CSP builder to support script-src and style-src, extends the Security Headers Provider to permit the injection of script-src and style-src directives, and implements hash generation for the on-the-fly JavaScript used for browser history and OIDC form redirect.

Adds script-src and style-src nonce support to Freemarker login templates with new NonceBean.

Closes #32123

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
