### PR TITLE
Use default bootstrap service account client-id in testsuite PoC

### DIFF
--- a/test-poc/framework/src/main/java/org/keycloak/test/framework/config/Config.java
+++ b/test-poc/framework/src/main/java/org/keycloak/test/framework/config/Config.java
@@ -18,11 +18,11 @@ public class Config {
     }
 
     public static String getAdminClientId() {
-        return "kc-test-admin";
+        return "admin";
     }
 
     public static String getAdminClientSecret() {
-        return "kc-test-secret";
+        return "mysecret";
     }
 
     public static SmallRyeConfig initConfig() {


### PR DESCRIPTION
Signed-off-by: stianst <stianst@gmail.com>
