### PR TITLE
Add acr scope to all clients for those migrating from older than Keyc…

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo18_0_0.java
+++ b/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo18_0_0.java
@@ -22,8 +22,10 @@ import org.jboss.logging.Logger;
 import org.keycloak.common.Profile;
 import org.keycloak.migration.MigrationProvider;
 import org.keycloak.migration.ModelVersion;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.RealmRepresentation;
 
 /**
@@ -56,8 +58,14 @@ public class MigrateTo18_0_0 implements Migration {
         if (Profile.isFeatureEnabled(Profile.Feature.STEP_UP_AUTHENTICATION)) {
             MigrationProvider migrationProvider = session.getProvider(MigrationProvider.class);
 
-            // create 'acr' default client scope in the realm.
-            migrationProvider.addOIDCAcrClientScope(realm);
+            ClientScopeModel acrScope = KeycloakModelUtils.getClientScopeByName(realm, "acr");
+            if (acrScope == null) {
+                // create 'acr' default client scope in the realm.
+                acrScope = migrationProvider.addOIDCAcrClientScope(realm);
+
+                //add acr scope to all existing OIDC clients
+                session.clients().addClientScopeToAllClients(realm, acrScope, true);
+            }
         }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/migration/MigrationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/MigrationProvider.java
@@ -76,7 +76,7 @@ public interface MigrationProvider extends Provider {
      * @param realm
      * @return created or already existing client scope 'acr'
      */
-    void addOIDCAcrClientScope(RealmModel realm);
+    ClientScopeModel addOIDCAcrClientScope(RealmModel realm);
 
     /**
      * Add 'basic' client scope or return it if already exists

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -393,7 +393,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     }
 
 
-    public void addAcrClientScope(RealmModel newRealm) {
+    public ClientScopeModel addAcrClientScope(RealmModel newRealm) {
         if (Profile.isFeatureEnabled(Profile.Feature.STEP_UP_AUTHENTICATION)) {
             ClientScopeModel acrScope = KeycloakModelUtils.getClientScopeByName(newRealm, ACR_SCOPE);
             if (acrScope == null) {
@@ -411,8 +411,10 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             } else {
                 logger.debugf("Client scope '%s' already exists in realm '%s'. Skip creating it.", ACR_SCOPE, newRealm.getName());
             }
+            return acrScope;
         } else {
             logger.debugf("Skip creating client scope '%s' in the realm '%s' due the step-up authentication feature is disabled.", ACR_SCOPE, newRealm.getName());
+            return null;
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/migration/DefaultMigrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/migration/DefaultMigrationProvider.java
@@ -103,8 +103,8 @@ public class DefaultMigrationProvider implements MigrationProvider {
     }
 
     @Override
-    public void addOIDCAcrClientScope(RealmModel realm) {
-        getOIDCLoginProtocolFactory().addAcrClientScope(realm);
+    public ClientScopeModel addOIDCAcrClientScope(RealmModel realm) {
+        return getOIDCLoginProtocolFactory().addAcrClientScope(realm);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
@@ -119,7 +119,7 @@ public class AccountCredentialResource {
         public String getCategory() {
             return category;
         }
-        
+
         public String getType() {
             return type;
         }
@@ -302,6 +302,9 @@ public class AccountCredentialResource {
     @Deprecated
     public void removeCredential(final @PathParam("credentialId") String credentialId) {
         auth.require(AccountRoles.MANAGE_ACCOUNT);
+        logger.warnf("Using deprecated endpoint of Account REST service for removing credential of user '%s' in the realm '%s'. It is recommended to use application initiated actions (AIA) for removing credentials",
+                user.getUsername(),
+                realm.getName());
         CredentialModel credential = CredentialDeleteHelper.removeCredential(session, user, credentialId, this::getCurrentAuthenticatedLevel);
 
         if (credential != null && OTPCredentialModel.TYPE.equals(credential.getType())) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
@@ -441,6 +441,7 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
 
         assertThat(defaultClientScopes, Matchers.hasItems(
                 OIDCLoginProtocolFactory.BASIC_SCOPE,
+                OIDCLoginProtocolFactory.ACR_SCOPE,
                 OAuth2Constants.SCOPE_PROFILE,
                 OAuth2Constants.SCOPE_EMAIL
         ));
@@ -1189,9 +1190,9 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
     protected void testDefaultRoles(RealmResource realm) {
         String realmName = realm.toRepresentation().getRealm().toLowerCase();
         assertThat(realm.roles().get("default-roles-" + realmName).getRoleComposites().stream()
-                .map(RoleRepresentation::getName).collect(Collectors.toSet()), 
+                .map(RoleRepresentation::getName).collect(Collectors.toSet()),
             allOf(
-                hasItem(realmName + "-test-realm-role"), 
+                hasItem(realmName + "-test-realm-role"),
                 hasItem(realmName + "-test-client-role"))
             );
     }
@@ -1217,7 +1218,7 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
 
         realm.clients().findByClientId("migration-saml-client")
           .forEach(clientRepresentation -> {
-                assertThat(clientRepresentation.getAttributes(), hasEntry("extremely_long_attribute", 
+                assertThat(clientRepresentation.getAttributes(), hasEntry("extremely_long_attribute",
                       "     00000     00010     00020     00030     00040     00050     00060     00070     00080     00090"
                     + "     00100     00110     00120     00130     00140     00150     00160     00170     00180     00190"
                     + "     00200     00210     00220     00230     00240     00250     00260     00270     00280     00290"

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-19.0.3.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-19.0.3.json
@@ -643,7 +643,7 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "web-origins", "roles", "profile", "email" ],
+    "defaultClientScopes" : [ "acr", "web-origins", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
     "id" : "c11d03ac-b4b0-4581-995c-cc9c2f868b17",

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-24.0.4.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/migration-test/migration-realm-24.0.4.json
@@ -2875,7 +2875,7 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "web-origins", "roles", "profile", "email" ],
+    "defaultClientScopes" : [ "acr", "web-origins", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
     "id" : "c11d03ac-b4b0-4581-995c-cc9c2f868b17",


### PR DESCRIPTION
…loak 18

closes #31107

- Adding the `acr` client scope to all clients migrating from older than Keycloak 18

- Not updating those migrating from Keycloak 18 or newer as it is not possible to reliably detect if they removed `acr` client scope on purpose from their clients

- Added small warning in `AccountCredentialResource.removeCredential` that endpoint is deprecated and people should rather use AIA
