### PR TITLE
Fix: admin GUI not working with 1000s of realms

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -140,6 +140,11 @@ The CLI command `kc.[sh|bat] import` now has placeholder replacement enabled. Pr
 
 If you wish to disable placeholder replacement for the `import` command, add the system property `-Dkeycloak.migration.replace-placeholders=false`
 
+= New Java API to search realms by name
+
+The `RealmProvider` Java API now contains a new method `Stream<RealmModel> getRealmsStream(String search)` which allows searching for a realm by name.
+While there is a default implementation which filters the stream after loading it from the provider, implementations are encouraged to provide this with more efficient implementation.
+
 = Keystore and trust store default format change
 
 {project_name} now determines the format of the keystore and trust store based on the file extension. If the file extension is `.p12`, `.pkcs12` or `.pfx`, the format is PKCS12. If the file extension is `.jks`, `.keystore` or `.truststore`, the format is JKS. If the file extension is `.pem`, `.crt` or `.key`, the format is PEM.

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -563,6 +563,12 @@ public class RealmCacheSession implements CacheRealmProvider {
         return getRealms(getRealmDelegate().getRealmsStream());
     }
 
+    @Override
+    public Stream<RealmModel> getRealmsStream(String search) {
+        // Retrieve realms from backend
+        return getRealms(getRealmDelegate().getRealmsStream(search));
+    }
+
     private Stream<RealmModel> getRealms(Stream<RealmModel> backendRealms) {
         // Return cache delegates to ensure cache invalidated during write operations
         return backendRealms.map(RealmModel::getId).map(this::getRealm);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -152,6 +152,16 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         return getRealms(query);
     }
 
+    @Override
+    public Stream<RealmModel> getRealmsStream(String search) {
+        if (search.trim().isEmpty()) {
+            return getRealmsStream();
+        }
+        TypedQuery<String> query = em.createNamedQuery("getRealmIdsWithNameContaining", String.class);
+        query.setParameter("search", search);
+        return getRealms(query);
+    }
+
     private Stream<RealmModel> getRealms(TypedQuery<String> query) {
         return closing(query.getResultStream().map(session.realms()::getRealm).filter(Objects::nonNull));
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -49,6 +49,7 @@ import java.util.Set;
 @Entity
 @NamedQueries({
         @NamedQuery(name="getAllRealmIds", query="select realm.id from RealmEntity realm"),
+        @NamedQuery(name="getRealmIdsWithNameContaining", query="select realm.id from RealmEntity realm where LOWER(realm.name) like CONCAT('%', LOWER(:search), '%')"),
         @NamedQuery(name="getRealmIdByName", query="select realm.id from RealmEntity realm where realm.name = :name"),
         @NamedQuery(name="getRealmIdsWithProviderType", query="select distinct c.realm.id from ComponentEntity c where c.providerType = :providerType"),
 })

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
@@ -55,9 +55,8 @@ public class UIRealmsResource {
                                                      @QueryParam("search") @DefaultValue("") String search) {
         final RealmsPermissionEvaluator eval = AdminPermissions.realms(session, auth.adminAuth());
 
-        return session.realms().getRealmsStream()
+        return session.realms().getRealmsStream(search)
                 .filter(realm -> eval.canView(realm) || eval.isAdmin(realm))
-                .filter(realm -> search.isEmpty() || realm.getName().toLowerCase().contains(search.trim().toLowerCase()))
                 .skip(first)
                 .limit(max)
                 .map((RealmModel realm) -> new RealmNameRepresentation(realm.getName(), realm.getDisplayName()));

--- a/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
@@ -65,6 +65,13 @@ public interface RealmProvider extends Provider {
     Stream<RealmModel> getRealmsStream();
 
     /**
+     * Returns realms as a stream filtered by search.
+     * @param search String to search for in realm names
+     * @return Stream of {@link RealmModel}. Never returns {@code null}.
+     */
+    Stream<RealmModel> getRealmsStream(String search);
+
+    /**
      * Returns stream of realms which has component with the given provider type.
      * @param type {@code Class<?>} Type of the provider.
      * @return Stream of {@link RealmModel}. Never returns {@code null}.
@@ -101,7 +108,7 @@ public interface RealmProvider extends Provider {
      * Removes all expired client initial accesses from all realms.
      */
     void removeExpiredClientInitialAccess();
-    
+
     default void decreaseRemainingCount(RealmModel realm, ClientInitialAccessModel clientInitialAccess) { // Separate provider method to ensure we decrease remainingCount atomically instead of doing classic update
         realm.decreaseRemainingCount(clientInitialAccess);
     }

--- a/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
@@ -69,7 +69,9 @@ public interface RealmProvider extends Provider {
      * @param search String to search for in realm names
      * @return Stream of {@link RealmModel}. Never returns {@code null}.
      */
-    Stream<RealmModel> getRealmsStream(String search);
+    default Stream<RealmModel> getRealmsStream(String search) {
+        return getRealmsStream().filter(realm -> search.isEmpty() || realm.getName().toLowerCase().contains(search.trim().toLowerCase()));
+    }
 
     /**
      * Returns stream of realms which has component with the given provider type.


### PR DESCRIPTION
Search by RealmName is done before loading all realms when filtering

Closes #31956

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
