### PR TITLE
fix: expose bootstrap-admin-* options

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/BootstrapAdminOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/BootstrapAdminOptions.java
@@ -6,7 +6,7 @@ public class BootstrapAdminOptions {
     public static final String DEFAULT_TEMP_ADMIN_SERVICE = DEFAULT_TEMP_ADMIN_USERNAME;
     public static final int DEFAULT_TEMP_ADMIN_EXPIRATION = 120;
     private static final String USED_ONLY_WHEN = " Used only when the master realm is created.";
-    private static final String NON_CLI = " Use a non-CLI configration option for this option if possible.";
+    private static final String NON_CLI = " Use a non-CLI configuration option for this option if possible.";
 
     public static final Option<String> PASSWORD = new OptionBuilder<>("bootstrap-admin-password", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/BootstrapAdminOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/BootstrapAdminOptions.java
@@ -1,35 +1,39 @@
 package org.keycloak.config;
 
 public class BootstrapAdminOptions {
+    
+    public static final String DEFAULT_TEMP_ADMIN_USERNAME = "temp-admin";
+    public static final String DEFAULT_TEMP_ADMIN_SERVICE = DEFAULT_TEMP_ADMIN_USERNAME;
+    public static final int DEFAULT_TEMP_ADMIN_EXPIRATION = 120;
+    private static final String USED_ONLY_WHEN = " Used only when the master realm is created.";
+    private static final String NON_CLI = " Use a non-CLI configration option for this option if possible.";
 
     public static final Option<String> PASSWORD = new OptionBuilder<>("bootstrap-admin-password", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Bootstrap admin password")
-            .hidden()
+            .description("Temporary bootstrap admin password." + USED_ONLY_WHEN + NON_CLI)
             .build();
 
     public static final Option<String> USERNAME = new OptionBuilder<>("bootstrap-admin-username", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Username of the bootstrap admin")
-            .hidden()
+            .description("Temporary bootstrap admin username." + USED_ONLY_WHEN)
+            .defaultValue(DEFAULT_TEMP_ADMIN_USERNAME)
             .build();
 
     public static final Option<Integer> EXPIRATION = new OptionBuilder<>("bootstrap-admin-expiration", Integer.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Time in minutes for the bootstrap admin user to expire.")
+            .description("Time in minutes for the bootstrap admin user to expire." + USED_ONLY_WHEN)
             .hidden()
             .build();
 
     public static final Option<String> CLIENT_ID = new OptionBuilder<>("bootstrap-admin-client-id", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Client id for the admin service")
-            .hidden()
+            .description("Client id for the temporary bootstrap admin service account." + USED_ONLY_WHEN)
+            .defaultValue(DEFAULT_TEMP_ADMIN_SERVICE)
             .build();
 
     public static final Option<String> CLIENT_SECRET = new OptionBuilder<>("bootstrap-admin-client-secret", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Client secret for the admin service")
-            .hidden()
+            .description("Client secret for the temporary bootstrap admin service account." + USED_ONLY_WHEN + NON_CLI)
             .build();
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminService.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminService.java
@@ -18,11 +18,11 @@
 package org.keycloak.quarkus.runtime.cli.command;
 
 import org.keycloak.common.util.IoUtils;
+import org.keycloak.config.BootstrapAdminOptions;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.integration.jaxrs.QuarkusKeycloakApplication;
-import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
 
 import picocli.CommandLine.ArgGroup;
@@ -38,7 +38,7 @@ public class BootstrapAdminService extends AbstractNonServerCommand {
 
     static class ClientIdOptions {
         @Option(names = { "--client-id" }, description = "Client id, defaults to "
-                + ApplianceBootstrap.DEFAULT_TEMP_ADMIN_SERVICE)
+                + BootstrapAdminOptions.DEFAULT_TEMP_ADMIN_SERVICE)
         String clientId;
 
         @Option(names = { "--client-id:env" }, description = "Environment variable name for the client id")
@@ -69,7 +69,7 @@ public class BootstrapAdminService extends AbstractNonServerCommand {
                 clientId = clientIdOptions.clientId;
             }
         } else if (!bootstrap.noPrompt) {
-            clientId = IoUtils.readLineFromConsole("client id", ApplianceBootstrap.DEFAULT_TEMP_ADMIN_SERVICE);
+            clientId = IoUtils.readLineFromConsole("client id", BootstrapAdminOptions.DEFAULT_TEMP_ADMIN_SERVICE);
         }
 
         if (clientSecretEnv == null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminUser.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminUser.java
@@ -18,11 +18,11 @@
 package org.keycloak.quarkus.runtime.cli.command;
 
 import org.keycloak.common.util.IoUtils;
+import org.keycloak.config.BootstrapAdminOptions;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.integration.jaxrs.QuarkusKeycloakApplication;
-import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
 
 import picocli.CommandLine.ArgGroup;
@@ -38,7 +38,7 @@ public class BootstrapAdminUser extends AbstractNonServerCommand {
 
     static class UsernameOptions {
         @Option(names = { "--username" }, description = "Username of admin user, defaults to "
-                + ApplianceBootstrap.DEFAULT_TEMP_ADMIN_USERNAME)
+                + BootstrapAdminOptions.DEFAULT_TEMP_ADMIN_USERNAME)
         String username;
 
         @Option(names = { "--username:env" }, description = "Environment variable name for the admin username")
@@ -69,7 +69,7 @@ public class BootstrapAdminUser extends AbstractNonServerCommand {
                 username = usernameOptions.username;
             }
         } else if (!bootstrap.noPrompt) {
-            username = IoUtils.readLineFromConsole("username", ApplianceBootstrap.DEFAULT_TEMP_ADMIN_USERNAME);
+            username = IoUtils.readLineFromConsole("username", BootstrapAdminOptions.DEFAULT_TEMP_ADMIN_USERNAME);
         }
 
         if (passwordEnv == null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
@@ -18,6 +18,7 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import org.keycloak.config.BootstrapAdminOptions;
+import org.keycloak.quarkus.runtime.cli.PropertyException;
 
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
@@ -30,25 +31,36 @@ public final class BootstrapAdminPropertyMappers {
     private BootstrapAdminPropertyMappers() {
     }
 
+    // We prefer validators here to isEnabled so that the options show up in help
     public static PropertyMapper<?>[] getMappers() {
         return new PropertyMapper[]{
                 fromOption(BootstrapAdminOptions.USERNAME)
                         .paramLabel("username")
-                        .isEnabled(BootstrapAdminPropertyMappers::isPasswordSet, PASSWORD_SET)
+                        .validator((mapper, value) -> {
+                            if (!isPasswordSet()) {
+                                throw new PropertyException(mapper.getOption().getKey() + " available only when " + PASSWORD_SET);
+                            }
+                        })
                         .build(),
                 fromOption(BootstrapAdminOptions.PASSWORD)
                         .paramLabel("password")
+                        .isMasked(true)
                         .build(),
-                fromOption(BootstrapAdminOptions.EXPIRATION)
+                /*fromOption(BootstrapAdminOptions.EXPIRATION)
                         .paramLabel("expiration")
                         .isEnabled(BootstrapAdminPropertyMappers::isPasswordSet, PASSWORD_SET)
-                        .build(),
+                        .build(),*/
                 fromOption(BootstrapAdminOptions.CLIENT_ID)
                         .paramLabel("client id")
-                        .isEnabled(BootstrapAdminPropertyMappers::isClientSecretSet, CLIENT_SECRET_SET)
+                        .validator((mapper, value) -> {
+                            if (!isClientSecretSet()) {
+                                throw new PropertyException(mapper.getOption().getKey() + " available only when " + CLIENT_SECRET_SET);
+                            }
+                        })
                         .build(),
                 fromOption(BootstrapAdminOptions.CLIENT_SECRET)
                         .paramLabel("client secret")
+                        .isMasked(true)
                         .build(),
         };
     }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -165,11 +165,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -157,3 +157,19 @@ Export:
                      Set the number of users per file. It is used only if 'users' is set to
                        'different_files'. Increasing this number leads to exponentially increasing
                        export times. Default: 50.
+
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -269,11 +269,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -261,3 +261,19 @@ Export:
                      Set the number of users per file. It is used only if 'users' is set to
                        'different_files'. Increasing this number leads to exponentially increasing
                        export times. Default: 50.
+
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -151,3 +151,19 @@ Import:
 --override <true|false>
                      Set if existing data should be overwritten. If set to false, data will be
                        ignored. Default: true.
+
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -159,11 +159,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -263,11 +263,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -255,3 +255,19 @@ Import:
 --override <true|false>
                      Set if existing data should be overwritten. If set to false, data will be
                        ignored. Default: true.
+
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -292,6 +292,22 @@ Security:
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
 
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.
+
 Do NOT start the server using this command when deploying to production.
 
 Use 'kc.sh start-dev --help-all' to list all available options, including build

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -299,11 +299,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -468,6 +468,22 @@ Security:
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
 
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.
+
 Do NOT start the server using this command when deploying to production.
 
 Use 'kc.sh start-dev --help-all' to list all available options, including build

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -475,11 +475,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -300,11 +300,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -293,6 +293,22 @@ Security:
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
 
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.
+
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the
 '--optimized' option:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -469,6 +469,22 @@ Security:
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
 
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.
+
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the
 '--optimized' option:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -476,11 +476,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -235,6 +235,22 @@ Truststore:
                      List of pkcs12 (p12 or pfx file extensions), PEM files, or directories
                        containing those files that will be used as a system truststore.
 
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.
+
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the
 '--optimized' option:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -242,11 +242,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -401,6 +401,22 @@ Truststore:
                      List of pkcs12 (p12 or pfx file extensions), PEM files, or directories
                        containing those files that will be used as a system truststore.
 
+Bootstrap Admin:
+
+--bootstrap-admin-client-id <client id>
+                     Client id for the temporary bootstrap admin service account. Used only when
+                       the master realm is created. Default: temp-admin.
+--bootstrap-admin-client-secret <client secret>
+                     Client secret for the temporary bootstrap admin service account. Used only
+                       when the master realm is created. Use a non-CLI configration option for this
+                       option if possible.
+--bootstrap-admin-password <password>
+                     Temporary bootstrap admin password. Used only when the master realm is
+                       created. Use a non-CLI configration option for this option if possible.
+--bootstrap-admin-username <username>
+                     Temporary bootstrap admin username. Used only when the master realm is
+                       created. Default: temp-admin.
+
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the
 '--optimized' option:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -408,11 +408,11 @@ Bootstrap Admin:
                        the master realm is created. Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
                      Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configration option for this
-                       option if possible.
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible.
 --bootstrap-admin-password <password>
                      Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configration option for this option if possible.
+                       created. Use a non-CLI configuration option for this option if possible.
 --bootstrap-admin-username <username>
                      Temporary bootstrap admin username. Used only when the master realm is
                        created. Default: temp-admin.

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -246,7 +246,10 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-storage-private</artifactId>
         </dependency>
-
+        <dependency>
+        	<groupId>org.keycloak</groupId>
+        	<artifactId>keycloak-config-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -19,6 +19,7 @@ package org.keycloak.services.managers;
 import org.keycloak.Config;
 import org.keycloak.common.Version;
 import org.keycloak.common.enums.SslRequired;
+import org.keycloak.config.BootstrapAdminOptions;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
@@ -42,10 +43,6 @@ import org.keycloak.utils.StringUtil;
  * @version $Revision: 1 $
  */
 public class ApplianceBootstrap {
-
-    public static final String DEFAULT_TEMP_ADMIN_USERNAME = "temp-admin";
-    public static final String DEFAULT_TEMP_ADMIN_SERVICE = "temp-admin";
-    public static final int DEFAULT_TEMP_ADMIN_EXPIRATION = 120;
 
     private final KeycloakSession session;
 
@@ -125,7 +122,7 @@ public class ApplianceBootstrap {
         RealmModel realm = session.realms().getRealmByName(Config.getAdminRealm());
         session.getContext().setRealm(realm);
 
-        username = StringUtil.isBlank(username) ? DEFAULT_TEMP_ADMIN_USERNAME : username;
+        username = StringUtil.isBlank(username) ? BootstrapAdminOptions.DEFAULT_TEMP_ADMIN_USERNAME : username;
         //expriationMinutes = expriationMinutes == null ? DEFAULT_TEMP_ADMIN_EXPIRATION : expriationMinutes;
 
         if (initialUser && session.users().getUsersCount(realm) > 0) {
@@ -164,7 +161,7 @@ public class ApplianceBootstrap {
         RealmModel realm = session.realms().getRealmByName(Config.getAdminRealm());
         session.getContext().setRealm(realm);
 
-        clientId = StringUtil.isBlank(clientId) ? DEFAULT_TEMP_ADMIN_SERVICE : clientId;
+        clientId = StringUtil.isBlank(clientId) ? BootstrapAdminOptions.DEFAULT_TEMP_ADMIN_SERVICE : clientId;
         //expriationMinutes = expriationMinutes == null ? DEFAULT_TEMP_ADMIN_EXPIRATION : expriationMinutes;
 
         ClientRepresentation adminClient = new ClientRepresentation();


### PR DESCRIPTION
closes: #32176

@mabartos @vmuzikar not sure if it's necessary, but this introduces validators that are somewhat like the enabled logic - we could expand on that if it seems like a good idea with a new builder signature and ideally an automatic update to the description.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
