### PR TITLE
Resolve disabled options even at fast startup

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -79,6 +79,8 @@ public class KeycloakMain implements QuarkusApplication {
                 return;
             }
 
+            Environment.setParsedCommand(new Start());
+
             try {
                 PropertyMappers.sanitizeDisabledMappers();
                 Picocli.validateConfig(cliArgs, new Start());


### PR DESCRIPTION
Closes #30380

Disabled mappers were not resolved (sanitized in terms of our code wording) on fast startup (`--optimized` flag + no CLI args). I assume the removed condition was there just for optimization. @mabartos Can you please confirm as you are the author of this code?

Unfortunately, there is no good way to test that. If we don't want to rely on Hostname v1 ([which is going away very soon](https://github.com/keycloak/keycloak/issues/27731)) as reported in the original issue, we have no other options that take some effect when value is provided even though the option is supposed to be disabled. For instance, any of the disabled logging options don't take any effect (no validations are performed) when their respective log handler is disabled.