### PR TITLE
Support for selecting an organization when requesting the organization scope

### DIFF
--- a/docs/documentation/server_admin/topics/organizations/mapping-organization-claims.adoc
+++ b/docs/documentation/server_admin/topics/organizations/mapping-organization-claims.adoc
@@ -2,11 +2,9 @@
 
 =  Mapping organization claims
 [role="_abstract"]
-When authenticating in the context of an organization, the access token is automatically updated with specific claims
-about the organization where the user is a member.
-
 To map organization-specific claims into tokens, a client needs to request the *organization* scope when sending
-authorization requests to the server.
+authorization requests to the server. When authenticating in the context of an organization, clients can request the `organization` scope to map to tokens information
+about the organizations the user is a member.
 
 As a result, the token will contain a claim as follows:
 
@@ -19,5 +17,17 @@ As a result, the token will contain a claim as follows:
 The organization claim can be used by clients (for example, from ID Tokens) and resource servers (for example, from access tokens)
 to authorize access to protected resources based on the organization where the user is a member.
 
-The organization scope is a built-in optional client scope at the realm.  Therefore, this scope is added to any client created
+The `organization` scope is a built-in optional client scope at the realm.  Therefore, this scope is added to any client created
 in the realm, by default.
+
+The `organization` scope is requested using different formats:
+
+[cols="2*", options="header"]
+|===
+|Format
+|Description
+| `organization` | Maps to a single organization if the user is a member of a single organization.
+Otherwise, if a member of multiple organizations, the user will be prompted to select an organization when authenticating to the realm.
+| `organization:<alias>` | Maps to a single organization with the given alias.
+| `organization:*` | Maps to all organizations the user is a member of.
+|===

--- a/services/src/main/java/org/keycloak/email/freemarker/beans/ProfileBean.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/beans/ProfileBean.java
@@ -17,8 +17,11 @@
 package org.keycloak.email.freemarker.beans;
 
 import org.jboss.logging.Logger;
+import org.keycloak.forms.login.freemarker.model.OrganizationBean;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.userprofile.UserProfileProvider;
@@ -26,6 +29,7 @@ import org.keycloak.userprofile.UserProfileProvider;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -36,10 +40,13 @@ public class ProfileBean {
     private static final Logger logger = Logger.getLogger(ProfileBean.class);
 
     private UserModel user;
+    private final KeycloakSession session;
     private final Map<String, String> attributes = new HashMap<>();
+    private List<OrganizationBean> organizations;
 
     public ProfileBean(UserModel user, KeycloakSession session) {
         this.user = user;
+        this.session = session;
 
         if (user.getAttributes() != null) {
             //TODO: there is no need to set only a single value for attributes but changing this might break existing
@@ -79,5 +86,14 @@ public class ProfileBean {
 
     public Map<String, String> getAttributes() {
         return attributes;
+    }
+
+    public List<OrganizationBean> getOrganizations() {
+        if (organizations == null) {
+            organizations = session.getProvider(OrganizationProvider.class).getByMember(user)
+                    .map(o -> new OrganizationBean(o, user))
+                    .toList();
+        }
+        return organizations;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -397,7 +397,9 @@ public class TokenManager {
         //if scope parameter is not null, remove every scope that is not part of scope parameter
         if (scopeParameter != null && ! scopeParameter.isEmpty()) {
             Set<String> scopeParamScopes = Arrays.stream(scopeParameter.split(" ")).collect(Collectors.toSet());
-            oldTokenScope = Arrays.stream(oldTokenScope.split(" ")).filter(sc -> scopeParamScopes.contains(sc))
+            oldTokenScope = Arrays.stream(oldTokenScope.split(" "))
+                    .map(transformScopes(scopeParamScopes))
+                    .filter(Objects::nonNull)
                     .collect(Collectors.joining(" "));
         }
 
@@ -437,6 +439,21 @@ public class TokenManager {
         }
 
         return responseBuilder;
+    }
+
+    private Function<String, String> transformScopes(Set<String> requestedScopes) {
+        return scope -> {
+            if (requestedScopes.contains(scope)) {
+                return scope;
+            }
+
+            if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+                OrganizationScope oldScope = OrganizationScope.valueOfScope(scope);
+                return oldScope == null ? null : oldScope.resolveName(requestedScopes, scope);
+            }
+
+            return null;
+        };
     }
 
     private void validateTokenReuseForRefresh(KeycloakSession session, RealmModel realm, RefreshToken refreshToken,

--- a/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
+++ b/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
@@ -75,6 +75,7 @@ public class DefaultClientSessionContext implements ClientSessionContext {
         this.requestedScopes = requestedScopes;
         this.clientSession = clientSession;
         this.session = session;
+        this.session.setAttribute(ClientSessionContext.class.getName(), this);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SelectOrganizationPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SelectOrganizationPage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.pages;
+
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.keycloak.testsuite.util.DroneUtils;
+import org.keycloak.testsuite.util.OAuthClient;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class SelectOrganizationPage extends LanguageComboboxAwarePage {
+
+    @ArquillianResource
+    protected OAuthClient oauth;
+
+    @FindBy(xpath = "//html")
+    protected WebElement htmlRoot;
+
+    @Override
+    public boolean isCurrent() {
+        try {
+            return !driver.findElements(By.id("kc-user-organizations")).isEmpty();
+        } catch (NoSuchElementException ignore) {}
+
+        return false;
+    }
+
+    @Override
+    public void open() {
+        throw new UnsupportedOperationException();
+    }
+
+    public void assertCurrent(String realm) {
+        String name = getClass().getSimpleName();
+        Assert.assertTrue("Expected " + name + " but was " + DroneUtils.getCurrentDriver().getTitle() + " (" + DroneUtils.getCurrentDriver().getCurrentUrl() + ")",
+                isCurrent(realm));
+    }
+
+    public void selectOrganization(String alias) {
+        WebElement socialButton = findOrganizationButton(alias);
+        clickLink(socialButton);
+    }
+
+    public boolean isOrganizationButtonPresent(String alias) {
+        String id = "organization-" + alias;
+        return !DroneUtils.getCurrentDriver().findElements(By.id(id)).isEmpty();
+    }
+
+    private WebElement findOrganizationButton(String alias) {
+        String id = "organization-" + alias;
+        return DroneUtils.getCurrentDriver().findElement(By.id(id));
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
@@ -54,6 +54,7 @@ import org.keycloak.testsuite.organization.broker.BrokerConfigurationWrapper;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.IdpConfirmLinkPage;
 import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.pages.SelectOrganizationPage;
 import org.keycloak.testsuite.pages.UpdateAccountInformationPage;
 import org.keycloak.testsuite.util.TestCleanup;
 
@@ -70,6 +71,9 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
 
     @Page
     protected LoginPage loginPage;
+
+    @Page
+    protected SelectOrganizationPage selectOrganizationPage;
 
     @Page
     protected IdpConfirmLinkPage idpConfirmLinkPage;

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -523,3 +523,4 @@ error-invalid-multivalued-size=Attribute {0} must have at least {1} and at most 
 organization.confirm-membership.title=You are about to join organization ${kc.org.name}
 organization.confirm-membership=By clicking on the link below, you will become a member of the {0} organization:
 organization.member.register.title=Create an account to join the ${kc.org.name} organization
+organization.select=Select an organization to proceed:

--- a/themes/src/main/resources/theme/base/login/select-organization.ftl
+++ b/themes/src/main/resources/theme/base/login/select-organization.ftl
@@ -1,0 +1,23 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <#if section = "form">
+        <form action="${url.loginAction}" class="form-vertical" method="post">
+            <div id="kc-user-organizations" class="${properties.kcFormGroupClass!}">
+                <h2>${msg("organization.select")}</h2>
+
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if user.organizations?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
+                    <#list user.organizations as organization>
+                        <li>
+                            <a id="organization-${organization.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if user.organizations?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                               type="button" onclick="document.forms[0]['kc.org'].value = '${organization.alias}'; document.forms[0].submit()">
+                                <span class="${properties.kcFormSocialAccountNameClass!}">${organization.name!}</span>
+                            </a>
+                        </li>
+                    </#list>
+                </ul>
+            </div>
+            <input type="hidden" name="kc.org"/>
+        </form>
+    </#if>
+
+</@layout.registrationLayout>


### PR DESCRIPTION
* Introduces a new step during authentication to force users to select an organization when authenticating to a realm. This is changing the current semantics of the `organization` scope given that it won't return all the organizations the user is a member anymore. Please take a look at the updates to the documentation for more details.
* Support for refreshing tokens using the `organization` scope and make sure clients can not request more organization than what was previously granted when the refresh token was issued.

Closes #31438

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
