### PR TITLE
fix: ensure the legacy admin username env can still be used

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -67,6 +67,13 @@ public class BuildAndStartDistTest {
         cliResult.assertBuild();
         cliResult.assertStarted();
     }
+    
+    @Test
+    @WithEnvVars({"KEYCLOAK_ADMIN", "oldadmin123", "KEYCLOAK_ADMIN_PASSWORD", "oldadmin123"})
+    @Launch({"start-dev"})
+    void testCreateLegacyAdmin(KeycloakDistribution dist, LaunchResult result) {
+        assertAdminCreation(dist, result, "oldadmin123", "oldadmin123", "oldadmin123");
+    }
 
     @Test
     @WithEnvVars({"KC_BOOTSTRAP_ADMIN_USERNAME", "admin123", "KC_BOOTSTRAP_ADMIN_PASSWORD", "admin123"})


### PR DESCRIPTION
closes: #32333

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
