### PR TITLE
Allow brute force to have http request/response and send emails

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/services/managers/BruteForceProtector.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/managers/BruteForceProtector.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.managers;
 
+import jakarta.ws.rs.core.UriInfo;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -30,9 +31,9 @@ import org.keycloak.provider.Provider;
 public interface BruteForceProtector extends Provider {
     String DISABLED_BY_PERMANENT_LOCKOUT = "permanentLockout";
 
-    void failedLogin(RealmModel realm, UserModel user, ClientConnection clientConnection);
+    void failedLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo);
 
-    void successfulLogin(RealmModel realm, UserModel user, ClientConnection clientConnection);
+    void successfulLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo);
 
     boolean isTemporarilyDisabled(KeycloakSession session, RealmModel realm, UserModel user);
 

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -720,7 +720,7 @@ public class AuthenticationProcessor {
         if (realm.isBruteForceProtected()) {
             UserModel user = AuthenticationManager.lookupUserForBruteForceLog(session, realm, authenticationSession);
             if (user != null) {
-                getBruteForceProtector().failedLogin(realm, user, connection);
+                getBruteForceProtector().failedLogin(realm, user, connection, session.getContext().getHttpRequest().getUri());
             }
         }
     }

--- a/services/src/main/java/org/keycloak/events/email/EmailEventListenerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/events/email/EmailEventListenerProviderFactory.java
@@ -54,6 +54,14 @@ public class EmailEventListenerProviderFactory implements EventListenerProviderF
         return new EmailEventListenerProvider(session, includedEvents);
     }
 
+    public void addIncludedEvents(EventType... types) {
+        includedEvents.addAll(Arrays.asList(types));
+    }
+
+    public void removeIncludedEvents(EventType... types) {
+        includedEvents.removeAll(Arrays.asList(types));
+    }
+
     @Override
     public void init(Config.Scope config) {
         String[] include = config.getArray("include-events");

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1615,7 +1615,7 @@ public class AuthenticationManager {
             UserModel user = lookupUserForBruteForceLog(session, realm, authSession);
             if (user != null) {
                 BruteForceProtector bruteForceProtector = session.getProvider(BruteForceProtector.class);
-                bruteForceProtector.successfulLogin(realm, user, session.getContext().getConnection());
+                bruteForceProtector.successfulLogin(realm, user, session.getContext().getConnection(), session.getContext().getHttpRequest().getUri());
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.services.managers;
 
+import jakarta.ws.rs.core.UriInfo;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -133,10 +134,10 @@ public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtect
     }
 
     @Override
-    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, boolean success) {
+    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success) {
         // mark the off-thread is started for this request
         loginAttempts.computeIfPresent(user.getId(), (k, v) -> v + OFF_THREAD_STARTED);
-        super.processLogin(realm, user, clientConnection, success);
+        super.processLogin(realm, user, clientConnection, uriInfo, success);
     }
 
     @Override

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -41,6 +41,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.cookie.CookieProvider;
 import org.keycloak.cookie.CookieType;
 import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventQuery;
 import org.keycloak.events.EventStoreProvider;
 import org.keycloak.events.EventType;
@@ -48,6 +49,7 @@ import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.AuthDetails;
 import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.email.EmailEventListenerProviderFactory;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.AuthenticationFlowModel;
@@ -1194,5 +1196,27 @@ public class TestingResourceProvider implements RealmResourceProvider {
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("No authenticatedClientSession found."));
         return PreAuthorizedCodeGrantType.getPreAuthorizedCode(session, ascm, expiration);
+    }
+
+    @POST
+    @Path("/email-event-litener-provide/add-events")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void addEventsToEmailEventListenerProvider(List<EventType> events) {
+        if (events != null && !events.isEmpty()) {
+            EmailEventListenerProviderFactory prov = (EmailEventListenerProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(EventListenerProvider.class, EmailEventListenerProviderFactory.ID);
+            prov.addIncludedEvents(events.toArray(EventType[]::new));
+        }
+    }
+
+    @POST
+    @Path("/email-event-litener-provide/remove-events")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void removeEventsToEmailEventListenerProvider(List<EventType> events) {
+        if (events != null && !events.isEmpty()) {
+            EmailEventListenerProviderFactory prov = (EmailEventListenerProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(EventListenerProvider.class, EmailEventListenerProviderFactory.ID);
+            prov.removeIncludedEvents(events.toArray(EventType[]::new));
+        }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
@@ -20,6 +20,7 @@ package org.keycloak.testsuite.client.resources;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.common.Profile;
 import org.keycloak.common.enums.HostnameVerificationPolicy;
+import org.keycloak.events.EventType;
 import org.keycloak.representations.idm.AdminEventRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
@@ -470,4 +471,22 @@ public interface TestingResource {
     @GET
     @Path("/pre-authorized-code")
     String getPreAuthorizedCode(@QueryParam("realm") final String realmName, @QueryParam("userSessionId") final String userSessionId, @QueryParam("clientId") final String clientId, @QueryParam("expiration") final int expiration);
+
+    /**
+     * Adds the following types to the email event listener included list.
+     * @param events The events to be included
+     */
+    @POST
+    @Path("/email-event-litener-provide/add-events")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void addEventsToEmailEventListenerProvider(List<EventType> events);
+
+    /**
+     * Removes the following types from the email event listener included list.
+     * @param events The events to be removed
+     */
+    @POST
+    @Path("/email-event-litener-provide/remove-events")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void removeEventsToEmailEventListenerProvider(List<EventType> events);
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
@@ -3,6 +3,7 @@ package org.keycloak.testsuite.updaters;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -91,6 +92,23 @@ public class RealmAttributeUpdater extends ServerResourceUpdater<RealmAttributeU
 
     public RealmAttributeUpdater setEditUserNameAllowed(Boolean value) {
         rep.setEditUsernameAllowed(value);
+        return this;
+    }
+
+    public RealmAttributeUpdater setPermanentLockout(Boolean value) {
+        rep.setPermanentLockout(value);
+        return this;
+    }
+
+    public RealmAttributeUpdater setEventsListeners(List<String> eventListanets) {
+        rep.setEventsListeners(eventListanets);
+        return this;
+    }
+
+    public RealmAttributeUpdater addEventsListener(String value) {
+        List<String> list = new ArrayList<>(rep.getEventsListeners());
+        list.add(value);
+        rep.setEventsListeners(list);
         return this;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -83,7 +83,11 @@ public class AssertEvents implements TestRule {
     }
 
     public EventRepresentation poll() {
-        EventRepresentation event = fetchNextEvent();
+        return poll(0);
+    }
+
+    public EventRepresentation poll(int seconds) {
+        EventRepresentation event = fetchNextEvent(seconds);
         Assert.assertNotNull("Event expected", event);
 
         return event;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -27,6 +27,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
+import org.keycloak.events.email.EmailEventListenerProviderFactory;
 import org.keycloak.executors.ExecutorsProvider;
 import org.keycloak.models.Constants;
 import org.keycloak.models.UserModel;
@@ -46,12 +47,14 @@ import org.keycloak.testsuite.pages.LoginPasswordResetPage;
 import org.keycloak.testsuite.pages.LoginPasswordUpdatePage;
 import org.keycloak.testsuite.pages.LoginTotpPage;
 import org.keycloak.testsuite.pages.RegisterPage;
+import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.GreenMailRule;
 import org.keycloak.testsuite.util.MailUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmRepUtil;
 import org.keycloak.testsuite.util.UserBuilder;
 
+import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 
 import java.net.MalformedURLException;
@@ -106,7 +109,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
         UserRepresentation user = RealmRepUtil.findUser(testRealm, "test-user@localhost");
-        UserBuilder.edit(user).totpSecret("totpSecret");
+        UserBuilder.edit(user).totpSecret("totpSecret").emailVerified(true);
 
         testRealm.setBruteForceProtected(true);
         testRealm.setFailureFactor(failureFactor);
@@ -553,15 +556,21 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         assertUserDisabledEvent(Errors.INVALID_AUTHENTICATION_SESSION);
     }
 
-    @Test
-    public void testPermanentLockout() {
-        RealmRepresentation realm = testRealm().toRepresentation();
-        try {
-            // arrange
-            realm.setPermanentLockout(true);
-            realm.setQuickLoginCheckMilliSeconds(0L);
-            testRealm().update(realm);
+    private void checkEmailPresent(String subject) {
+        Assert.assertFalse("No email with subject: " + subject, Arrays.stream(greenMail.getReceivedMessages()).filter(m -> {
+            try {
+                return subject.equals(m.getSubject());
+            } catch (MessagingException ex) {
+                return false;
+            }
+        }).findAny().isEmpty());
+    }
 
+    @Test
+    public void testPermanentLockout() throws Exception {
+        testingClient.testing().addEventsToEmailEventListenerProvider(Collections.singletonList(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT));
+        try (RealmAttributeUpdater updater = new RealmAttributeUpdater(testRealm()).setPermanentLockout(true)
+                .addEventsListener(EmailEventListenerProviderFactory.ID).update()) {
             // act
             loginInvalidPassword("test-user@localhost");
             loginInvalidPassword("test-user@localhost", false);
@@ -569,9 +578,11 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             // As of now, there are two events: USER_DISABLED_BY_PERMANENT_LOCKOUT and LOGIN_ERROR but Order is not
             // guarantee though since the brute force detector is running separately "in its own thread" named
             // "Brute Force Protector".
-            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll());
+            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll(5));
             assertIsContained(events.expect(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT).client((String) null).detail(Details.REASON, "brute_force_attack detected"), actualEvents);
             assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
+
+            checkEmailPresent("User disabled by permament lockout");
 
             // assert
             expectPermanentlyDisabled();
@@ -584,9 +595,8 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             updateUser(user);
             assertUserDisabledReason(null);
         } finally {
-            realm.setPermanentLockout(false);
-            testRealm().update(realm);
-            UserRepresentation user = adminClient.realm("test").users().search("test-user@localhost", 0, 1).get(0);
+            testingClient.testing().removeEventsToEmailEventListenerProvider(Collections.singletonList(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT));
+            UserRepresentation user = testRealm().users().search("test-user@localhost", 0, 1).get(0);
             user.setEnabled(true);
             updateUser(user);
         }
@@ -612,7 +622,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             // As of now, there are two events: USER_DISABLED_BY_PERMANENT_LOCKOUT and LOGIN_ERROR but Order is not
             // guarantee though since the brute force detector is running separately "in its own thread" named
             // "Brute Force Protector".
-            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll());
+            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll(5));
             assertIsContained(events.expect(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT).client((String) null).detail(Details.REASON, "brute_force_attack detected"), actualEvents);
             assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
 
@@ -637,12 +647,20 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void testTemporaryLockout() throws Exception {
-        loginInvalidPassword("test-user@localhost");
-        loginInvalidPassword("test-user@localhost", false);
+        testingClient.testing().addEventsToEmailEventListenerProvider(Collections.singletonList(EventType.USER_DISABLED_BY_TEMPORARY_LOCKOUT));
+        try (RealmAttributeUpdater updater = new RealmAttributeUpdater(testRealm())
+                .addEventsListener(EmailEventListenerProviderFactory.ID).update()) {
+            loginInvalidPassword("test-user@localhost");
+            loginInvalidPassword("test-user@localhost", false);
 
-        List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll());
-        assertIsContained(events.expect(EventType.USER_DISABLED_BY_TEMPORARY_LOCKOUT).client((String) null).detail(Details.REASON, "brute_force_attack detected"), actualEvents);
-        assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
+            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll(5));
+            assertIsContained(events.expect(EventType.USER_DISABLED_BY_TEMPORARY_LOCKOUT).client((String) null).detail(Details.REASON, "brute_force_attack detected"), actualEvents);
+            assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
+
+            checkEmailPresent("User disabled by temporary lockout");
+        } finally {
+            testingClient.testing().removeEventsToEmailEventListenerProvider(Collections.singletonList(EventType.USER_DISABLED_BY_TEMPORARY_LOCKOUT));
+        }
     }
 
     @Test

--- a/themes/src/main/resources/theme/base/email/html/event-user_disabled_by_permanent_lockout.ftl
+++ b/themes/src/main/resources/theme/base/email/html/event-user_disabled_by_permanent_lockout.ftl
@@ -1,0 +1,4 @@
+<#import "template.ftl" as layout>
+<@layout.emailLayout>
+${kcSanitize(msg("eventUserDisabledByPermanentLockoutHtml", event.date))?no_esc}
+</@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/html/event-user_disabled_by_temporary_lockout.ftl
+++ b/themes/src/main/resources/theme/base/email/html/event-user_disabled_by_temporary_lockout.ftl
@@ -1,0 +1,4 @@
+<#import "template.ftl" as layout>
+<@layout.emailLayout>
+${kcSanitize(msg("eventUserDisabledByTemporaryLockoutHtml", event.date))?no_esc}
+</@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/email/messages/messages_en.properties
@@ -39,6 +39,12 @@ eventUpdateCredentialBodyHtml=<p>Your {0} credential was changed on {1} from {2}
 eventRemoveCredentialSubject=Remove credential
 eventRemoveCredentialBody=Credential {0} was removed from your account on {1} from {2}. If this was not you, please contact an administrator.
 eventRemoveCredentialBodyHtml=<p>Credential {0} was removed from your account on {1} from {2}. If this was not you, please contact an administrator.</p>
+eventUserDisabledByTemporaryLockoutSubject=User disabled by temporary lockout
+eventUserDisabledByTemporaryLockoutBody=Your user has been disabled temporarily because of multiple failed attemps on {0}. Please contact an administrator if needed.
+eventUserDisabledByTemporaryLockoutHtml=<p>Your user has been disabled temporarily because of multiple failed attemps on {0}. Please contact an administrator if needed.</p>
+eventUserDisabledByPermanentLockoutSubject=User disabled by permament lockout
+eventUserDisabledByPermanentLockoutBody=Your user has been disabled permanently because of multiple failed attemps on {0}. Please contact an administrator.
+eventUserDisabledByPermanentLockoutHtml=<p>Your user has been disabled permanently because of multiple failed attemps on {0}. Please contact an administrator.</p>
 
 requiredAction.CONFIGURE_TOTP=Configure OTP
 requiredAction.TERMS_AND_CONDITIONS=Terms and Conditions

--- a/themes/src/main/resources/theme/base/email/text/event-user_disabled_by_permanent_lockout.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-user_disabled_by_permanent_lockout.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventUserDisabledByPermanentLockoutBody", event.date)}

--- a/themes/src/main/resources/theme/base/email/text/event-user_disabled_by_temporary_lockout.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-user_disabled_by_temporary_lockout.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventUserDisabledByTemporaryLockoutBody", event.date)}


### PR DESCRIPTION
Closes #29542

@douglaspalmer I have been waiting all the brute force modifications to be merged to work on this. The idea the brute-force now adds some http request/response to fake the initial request. I'm just adding the UriInfo (initial url of the request). So the working is limited but you can send emails and normal things. I wanted to send the PR because I assigned this to keycloak 26 long ago. If we have no time for 26 just move the issue to the next release.
