### PR TITLE
Lightweight access tokens for Admin REST API

### DIFF
--- a/docs/documentation/release_notes/topics/26_0_0.adoc
+++ b/docs/documentation/release_notes/topics/26_0_0.adoc
@@ -168,3 +168,7 @@ For information on how to upgrade, see the link:{upgradingguide_link}[{upgrading
 There are now generalized events for updating (`UPDATE_CREDENTIAL`) and removing (`REMOVE_CREDENTIAL`) a credential. The credential type is described in the `credential_type` attribute of the events. The new event types are supported by the Email Event Listener.
 
 The following event types are now deprecated and will be removed in a future version: `UPDATE_PASSWORD`, `UPDATE_PASSWORD_ERROR`, `UPDATE_TOTP`, `UPDATE_TOTP_ERROR`, `REMOVE_TOTP`, `REMOVE_TOTP_ERROR`
+
+= Lightweight access tokens for Admin REST API
+
+Lightweight access tokens can now be used on the admin REST API. The `security-admin-console` and `admin-cli` clients are now using lightweight access tokens by default, so “Always Use Lightweight Access Token” and “Full Scope Allowed” are now enabled on these two clients. However, the behavior in the admin console should effectively remain the same. Be cautious if you have made changes to these two clients and if you are using them for other purposes.

--- a/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo26_0_0.java
+++ b/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo26_0_0.java
@@ -21,7 +21,10 @@ package org.keycloak.migration.migrators;
 import java.lang.invoke.MethodHandles;
 
 import org.jboss.logging.Logger;
+import org.keycloak.Config;
 import org.keycloak.migration.ModelVersion;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionProvider;
@@ -55,6 +58,12 @@ public class MigrateTo26_0_0 implements Migration {
     }
 
     private void migrateRealm(KeycloakSession session, RealmModel realm) {
+        ClientModel adminConsoleClient = realm.getClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID);
+        adminConsoleClient.setFullScopeAllowed(true);
+        adminConsoleClient.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, String.valueOf(true));
+        ClientModel adminCliClient = realm.getClientByClientId(Constants.ADMIN_CLI_CLIENT_ID);
+        adminCliClient.setFullScopeAllowed(true);
+        adminCliClient.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, String.valueOf(true));
     }
 }
 

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -131,7 +131,7 @@ public class KeycloakIdentity implements Identity {
             if (userSession == null) {
                 userSession = sessions.getOfflineUserSession(realm, token.getSessionState());
             }
-            
+
             if (userSession == null) {
                 throw new RuntimeException("No active session associated with the token");
             }
@@ -176,15 +176,22 @@ public class KeycloakIdentity implements Identity {
     }
 
     public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession) {
+        this(accessToken, keycloakSession, keycloakSession.getContext().getRealm());
+    }
+
+    public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession, RealmModel realm) {
         if (accessToken == null) {
             throw new ErrorResponseException("invalid_bearer_token", "Could not obtain bearer access_token from request.", Status.FORBIDDEN);
         }
         if (keycloakSession == null) {
             throw new ErrorResponseException("no_keycloak_session", "No keycloak session", Status.FORBIDDEN);
         }
+        if (realm == null) {
+            throw new ErrorResponseException("no_keycloak_session", "No realm set", Status.FORBIDDEN);
+        }
         this.accessToken = accessToken;
         this.keycloakSession = keycloakSession;
-        this.realm = keycloakSession.getContext().getRealm();
+        this.realm = realm;
 
         Map<String, Collection<String>> attributes = new HashMap<>();
 

--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
@@ -25,14 +25,19 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.AdminRoles;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientInitialAccessModel;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserSessionProvider;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -43,11 +48,16 @@ import org.keycloak.services.clientpolicy.context.DynamicClientViewContext;
 import org.keycloak.services.clientregistration.policy.ClientRegistrationPolicyException;
 import org.keycloak.services.clientregistration.policy.ClientRegistrationPolicyManager;
 import org.keycloak.services.clientregistration.policy.RegistrationAuth;
+import org.keycloak.services.util.DefaultClientSessionContext;
 import org.keycloak.util.TokenUtil;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import org.keycloak.utils.RoleResolveUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -283,13 +293,36 @@ public class ClientRegistrationAuth {
 
     private boolean hasRole(String... roles) {
         try {
-            if (jwt.getIssuedFor().equals(Constants.ADMIN_CLI_CLIENT_ID)
-                    || jwt.getIssuedFor().equals(Constants.ADMIN_CONSOLE_CLIENT_ID)) {
-                return hasRoleInModel(roles);
 
-            } else {
-                return hasRoleInToken(roles);
+            //support for lightweight access token
+            if (jwt.getSubject() == null) {
+                String sid = (String) jwt.getOtherClaims().get("sid");
+                if (sid != null) {
+                    final String issuedFor = jwt.getIssuedFor();
+                    UserSessionProvider sessions = session.sessions();
+                    UserSessionModel userSession = sessions.getUserSession(realm, sid);
+                    if (userSession == null) {
+                        userSession = sessions.getOfflineUserSession(realm, sid);
+                    }
+
+                    //get client session
+                    ClientModel client = realm.getClientByClientId(issuedFor);
+                    AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+
+                    //set realm roles
+                    ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, (String) jwt.getOtherClaims().get("scope"), session);
+                    Map<String, AccessToken.Access> resourceAccess = RoleResolveUtil.getAllResolvedClientRoles(session, clientSessionCtx);
+
+                    Map<String, Map<String, List<String>>> resourceAccessMap = new HashMap<>();
+                    resourceAccess.forEach((key, access) ->
+                            resourceAccessMap.put(key, Map.of("roles", new ArrayList<>(access.getRoles())))
+                    );
+                    jwt.setSubject(userSession.getUser().getId());
+                    jwt.getOtherClaims().put("resource_access", resourceAccessMap);
+                }
             }
+            return hasRoleInToken(roles);
+
         } catch (Throwable t) {
             return false;
         }

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -188,11 +188,12 @@ public class RealmManager {
 
         adminConsole.setEnabled(true);
         adminConsole.setAlwaysDisplayInConsole(false);
+        adminConsole.setFullScopeAllowed(true);
         adminConsole.setPublicClient(true);
-        adminConsole.setFullScopeAllowed(false);
         adminConsole.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
         adminConsole.setAttribute(OIDCConfigAttributes.PKCE_CODE_CHALLENGE_METHOD, "S256");
+        adminConsole.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, "true");
     }
 
     protected void setupAdminConsoleLocaleMapper(RealmModel realm) {
@@ -214,10 +215,11 @@ public class RealmManager {
             adminCli.setName("${client_" + Constants.ADMIN_CLI_CLIENT_ID + "}");
             adminCli.setEnabled(true);
             adminCli.setAlwaysDisplayInConsole(false);
-            adminCli.setFullScopeAllowed(false);
+            adminCli.setFullScopeAllowed(true);
             adminCli.setStandardFlowEnabled(false);
             adminCli.setDirectAccessGrantsEnabled(true);
             adminCli.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+            adminCli.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, "true");
         }
 
     }
@@ -644,7 +646,7 @@ public class RealmManager {
     }
 
     private String determineDefaultRoleName(RealmRepresentation rep) {
-        String defaultRoleName = Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + rep.getRealm().toLowerCase(); 
+        String defaultRoleName = Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + rep.getRealm().toLowerCase();
         if (! hasRealmRole(rep, defaultRoleName)) {
             return defaultRoleName;
         } else {
@@ -778,7 +780,7 @@ public class RealmManager {
                 ClientModel clientModel = Optional.ofNullable(client.getId())
                         .map(realmModel::getClientById)
                         .orElseGet(() -> realmModel.getClientByClientId(client.getClientId()));
-                
+
                 if (clientModel == null) {
                     throw new RuntimeException("Cannot find provided client by dir import.");
                 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -30,21 +30,35 @@ import org.keycloak.authorization.permission.ResourcePermission;
 import org.keycloak.authorization.policy.evaluation.EvaluationContext;
 import org.keycloak.common.Profile;
 import org.keycloak.models.AdminRoles;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.utils.RoleUtils;
+import org.keycloak.protocol.oidc.AccessTokenIntrospectionProvider;
+import org.keycloak.protocol.oidc.AccessTokenIntrospectionProviderFactory;
+import org.keycloak.protocol.oidc.TokenIntrospectionProvider;
+import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.ws.rs.ForbiddenException;
+import org.keycloak.services.util.DefaultClientSessionContext;
+import org.keycloak.utils.RoleResolveUtil;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -98,17 +112,28 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
 
     private void initIdentity(KeycloakSession session, AdminAuth auth) {
         final String issuedFor = auth.getToken().getIssuedFor();
-
-        if (Constants.ADMIN_CLI_CLIENT_ID.equals(issuedFor) || Constants.ADMIN_CONSOLE_CLIENT_ID.equals(issuedFor)) {
-            this.identity = new UserModelIdentity(auth.getRealm(), auth.getUser());
-        } else {
-            ClientModel client  = session.clients().getClientByClientId(auth.getRealm(), issuedFor);
-            if (client != null && Boolean.parseBoolean(client.getAttribute(Constants.SECURITY_ADMIN_CONSOLE_ATTR))) {
-                this.identity = new UserModelIdentity(auth.getRealm(), auth.getUser());
-            } else {
-                this.identity = new KeycloakIdentity(auth.getToken(), session);
+        AccessToken accessToken = auth.getToken();
+        //support for lightweight access token
+        if (auth.getToken().getSubject() == null) {
+            //get user session
+            UserSessionProvider sessions = session.sessions();
+            UserSessionModel userSession = sessions.getUserSession(adminsRealm, auth.getToken().getSessionId());
+            if (userSession == null) {
+                userSession = sessions.getOfflineUserSession(adminsRealm, auth.getToken().getSessionId());
             }
+
+            //get client session
+            ClientModel client = adminsRealm.getClientByClientId(issuedFor);
+            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+
+            //set realm roles
+            ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, auth.getToken().getScope(), session);
+            AccessToken.Access realmAccess = RoleResolveUtil.getResolvedRealmRoles(session, clientSessionCtx, false);
+            Map<String, AccessToken.Access> clientAccess = RoleResolveUtil.getAllResolvedClientRoles(session, clientSessionCtx);
+            accessToken.setRealmAccess(realmAccess);
+            accessToken.setResourceAccess(clientAccess);
         }
+        this.identity = new KeycloakIdentity(accessToken, session, adminsRealm);
     }
 
     MgmtPermissions(KeycloakSession session, RealmModel adminsRealm, UserModel admin) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -40,17 +40,11 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
-import org.keycloak.models.utils.RoleUtils;
-import org.keycloak.protocol.oidc.AccessTokenIntrospectionProvider;
-import org.keycloak.protocol.oidc.AccessTokenIntrospectionProviderFactory;
-import org.keycloak.protocol.oidc.TokenIntrospectionProvider;
-import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -122,16 +116,18 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
                 userSession = sessions.getOfflineUserSession(adminsRealm, auth.getToken().getSessionId());
             }
 
-            //get client session
-            ClientModel client = adminsRealm.getClientByClientId(issuedFor);
-            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+            if (userSession != null) {
+                //get client session
+                ClientModel client = adminsRealm.getClientByClientId(issuedFor);
+                AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
 
-            //set realm roles
-            ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, auth.getToken().getScope(), session);
-            AccessToken.Access realmAccess = RoleResolveUtil.getResolvedRealmRoles(session, clientSessionCtx, false);
-            Map<String, AccessToken.Access> clientAccess = RoleResolveUtil.getAllResolvedClientRoles(session, clientSessionCtx);
-            accessToken.setRealmAccess(realmAccess);
-            accessToken.setResourceAccess(clientAccess);
+                //set realm roles
+                ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, auth.getToken().getScope(), session);
+                AccessToken.Access realmAccess = RoleResolveUtil.getResolvedRealmRoles(session, clientSessionCtx, false);
+                Map<String, AccessToken.Access> clientAccess = RoleResolveUtil.getAllResolvedClientRoles(session, clientSessionCtx);
+                accessToken.setRealmAccess(realmAccess);
+                accessToken.setResourceAccess(clientAccess);
+            }
         }
         this.identity = new KeycloakIdentity(accessToken, session, adminsRealm);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
@@ -434,6 +434,10 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
         if (testIdentityProviderConfigMigration) {
             testIdentityProviderConfigMigration(migrationRealm2);
         }
+        testLightweightClientAndFullScopeAllowed(masterRealm, Constants.ADMIN_CONSOLE_CLIENT_ID);
+        testLightweightClientAndFullScopeAllowed(masterRealm, Constants.ADMIN_CLI_CLIENT_ID);
+        testLightweightClientAndFullScopeAllowed(migrationRealm, Constants.ADMIN_CONSOLE_CLIENT_ID);
+        testLightweightClientAndFullScopeAllowed(migrationRealm, Constants.ADMIN_CLI_CLIENT_ID);
     }
 
     private void testClientContainsExpectedClientScopes() {
@@ -1350,5 +1354,11 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
         // gitlab identity provider should have it's hideOnLoginPage attribute migrated from the config to the provider itself.
         assertThat(rep.isHideOnLogin(), is(true));
         assertThat(rep.getConfig().containsKey(IdentityProviderModel.LEGACY_HIDE_ON_LOGIN_ATTR), is(false));
+    }
+
+    private void testLightweightClientAndFullScopeAllowed(RealmResource realm, String clientId) {
+        ClientRepresentation clientRepresentation = realm.clients().findByClientId(clientId).get(0);
+        assertTrue(clientRepresentation.isFullScopeAllowed());
+        assertTrue(Boolean.parseBoolean(clientRepresentation.getAttributes().get(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED)));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AssertAdminEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AssertAdminEvents.java
@@ -204,7 +204,9 @@ public class AssertAdminEvents implements TestRule {
 
             AuthDetailsRepresentation actualAuth = actual.getAuthDetails();
             Assert.assertEquals(expectedAuth.getRealmId(), actualAuth.getRealmId());
-            Assert.assertEquals(expectedAuth.getUserId(), actualAuth.getUserId());
+            if(expectedAuth.getUserId() != null) {
+                Assert.assertEquals(expectedAuth.getUserId(), actualAuth.getUserId());
+            }
             if (expectedAuth.getClientId() != null) {
                 Assert.assertEquals(expectedAuth.getClientId(), actualAuth.getClientId());
             }


### PR DESCRIPTION
Closes #31513

Changes introduced by this PR to support lightweight access tokens for the admin REST APIs:

- In `MgmtPermissions.initIdentity()`, the presence of the `sub` field in the token is evaluated to check if the access token is lightweight. If the `sub` is missing, the user session is retrieved, and the realm roles and client roles are resolved. All client roles of the user are resolved not just a subset. See the performance analysis for details.

- The workaround for the `security-admin-console` and `admin-cli` clients has been removed. To remove the workaround that was present both in `MgmtPermissions.initIdentity()` and in `ClientRegistrationAuth`, a migration was necessary to enable _the use of lightweight access tokens_ and to enable the _full scope allowed_ for these clients. Enabling the full scope allowed is needed to resolve the client roles of the various realm clients in the master realm.

- A normal audience check for the admin REST APIs is not possible due to the `admin-fine-grained-authz` feature. With this feature enabled, the permissions to invoke the admin APIs can be granted based on client policies. Should we check the audience only in the case of this feature disabled or feature enabled and negative permission evaluation?

**Performance Analysis:**
I conducted manual tests with the admin console, preloading 500 realms, and using both the admin user and a user with roles in 5 realms. With a non-lightweight token and with a different client than `security-admin-console` and `admin-cli`, the behavior remains the same.

However, when using a lightweight token, it's necessary to resolve the user's roles, and this operation can be more expensive. Resolving the realm roles or client roles using `RoleResolveUtil.getResolvedRealmRoles()`, `RoleResolveUtil.getResolvedClientRoles()` or `RoleResolveUtil.getAllResolvedRealmRoles()` first loads all the user's roles into cache with the `RoleResolveUtil.getAndCacheResolvedRoles()` method which based on the tests can cause a delay the first time it is invoked. The slowdown is noticeable only in the `/serverinfo` call which for the first time loads the user's roles in about 1.2 seconds (the same call with the previous behavior takes about 300ms). After this first load, the times  of all other requests are in line with the previous behavior, or even better.

One idea to optimize the loading of roles could be to add a query with a join between `USER_ROLE_MAPPING` and `KEYCLOAK_ROLE` to obtain only the list of roles for a client and a user or only realm roles for a user. However, this would require a greater impact on the classes and methods currently used to resolve roles.

Alternatively, we could maintain the workaround and introduce only the changes from the first point when using lightweight access tokens for other clients.
