### PR TITLE
More options to organization scope mapper including adding organization attributes to tokens

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3240,3 +3240,5 @@ sentInvitation=Sent invitation
 loggedInAsTempAdminUser=You are logged in as a temporary admin user. To harden security, create a permanent admin account and delete the temporary one.
 temporaryAdmin=Temporary admin user account. Ensure it is replaced with a permanent admin user account as soon as possible.
 temporaryService=Temporary admin service account. Ensure it is replaced with a permanent admin service account as soon as possible.
+addOrganizationAttributes.label=Add organization attributes
+addOrganizationAttributes.help=If enabled, the organization attributes will be available for each organization mapped to the token.

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -442,18 +442,17 @@ public class OIDCAttributeMapperHelper {
     }
 
     public static void addJsonTypeConfig(List<ProviderConfigProperty> configProperties) {
+        addJsonTypeConfig(configProperties, List.of("String", "long", "int", "boolean", "JSON"), null);
+    }
+
+    public static void addJsonTypeConfig(List<ProviderConfigProperty> configProperties, List<String> supportedTypes, String defaultValue) {
         ProviderConfigProperty property = new ProviderConfigProperty();
         property.setName(JSON_TYPE);
         property.setLabel(JSON_TYPE);
-        List<String> types = new ArrayList<>(5);
-        types.add("String");
-        types.add("long");
-        types.add("int");
-        types.add("boolean");
-        types.add("JSON");
         property.setType(ProviderConfigProperty.LIST_TYPE);
-        property.setOptions(types);
+        property.setOptions(supportedTypes);
         property.setHelpText(JSON_TYPE_TOOLTIP);
+        property.setDefaultValue(defaultValue);
         configProperties.add(property);
     }
 


### PR DESCRIPTION
Closes #31642

* Adds a setting to add organization attributes when mapping organizations to tokens
* Adds setting to map single or multiple organizations based on the `Multivalued`
* Adds setting to choose if the `organization` claim should be a list (string values) or a JSON object.
* By default, the `organization` claim will be a list of organization aliases.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
