### PR TITLE
Fix: Add 'scope' parameter to the refresh external token request

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -265,9 +265,13 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     }
 
     protected SimpleHttp getRefreshTokenRequest(KeycloakSession session, String refreshToken, String clientId, String clientSecret) {
+        String idpScopes = getConfig().getConfig().get("defaultScope");
+
         SimpleHttp refreshTokenRequest = SimpleHttp.doPost(getConfig().getTokenUrl(), session)
                 .param(OAUTH2_GRANT_TYPE_REFRESH_TOKEN, refreshToken)
-                .param(OAUTH2_PARAMETER_GRANT_TYPE, OAUTH2_GRANT_TYPE_REFRESH_TOKEN);
+                .param(OAUTH2_PARAMETER_GRANT_TYPE, OAUTH2_GRANT_TYPE_REFRESH_TOKEN)
+                .param(OAUTH2_PARAMETER_SCOPE, idpScopes);
+
         return authenticateTokenRequest(refreshTokenRequest);
     }
 


### PR DESCRIPTION
The scopes for the request are taken from the 'defaultScope' attribute set in the identity provider itself.

Closes #32361
