### PR TITLE
Fix: JS adapter cannot pass client_secret parameter when request token #32064

### DIFF
--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -784,6 +784,10 @@ function Keycloak (config) {
                 params += '&code_verifier=' + oauth.pkceCodeVerifier;
             }
 
+            if (config.credentials && config.credentials.secret) {
+                params += '&client_secret=' + config.credentials.secret;
+            }
+            
             req.withCredentials = true;
 
             req.onreadystatechange = function() {


### PR DESCRIPTION
JS adapter cannot pass client_secret parameter when request token #32064