### PR TITLE
Add OAuth SIG meeting link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To write tests, refer to the [writing tests](docs/tests-development.md) guide.
 
 Before contributing to Keycloak, please read our [contributing guidelines](CONTRIBUTING.md). Participation in the Keycloak project is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
+Our [website](https://www.keycloak.org/community) lists the community meetings, you may find things to work on by joining them.
 
 ## Other Keycloak Projects
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To write tests, refer to the [writing tests](docs/tests-development.md) guide.
 
 Before contributing to Keycloak, please read our [contributing guidelines](CONTRIBUTING.md). Participation in the Keycloak project is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Our [website](https://www.keycloak.org/community) lists the community meetings, you may find things to work on by joining them.
+Joining a [community meeting](https://www.keycloak.org/community) is a great way to get involved and help shape the future of Keycloak.
 
 ## Other Keycloak Projects
 


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/32384

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
