### PR TITLE
Add missing translation for webauthn-register action

### DIFF
--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -389,6 +389,7 @@ requiredAction.UPDATE_PROFILE=Update Profile
 requiredAction.VERIFY_EMAIL=Verify Email
 requiredAction.CONFIGURE_RECOVERY_AUTHN_CODES=Generate Recovery Codes
 requiredAction.webauthn-register-passwordless=Webauthn Register Passwordless
+requiredAction.webauthn-register=Webauthn Register
 
 invalidTokenRequiredActions=Required actions included in the link are not valid
 


### PR DESCRIPTION
Add English and german translations for `requiredAction.webauthn-register`.

Closes #32415
