### PR TITLE
Upgrade H2 to 2.3.232

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <bouncycastle.bctls-fips.version>1.0.19</bouncycastle.bctls-fips.version>
 
         <dom4j.version>2.1.3</dom4j.version>
-        <h2.version>2.2.224</h2.version>
+        <h2.version>2.3.232</h2.version>
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
         <hibernate.c3p0.version>6.2.13.Final</hibernate.c3p0.version>
         <infinispan.version>15.0.8.Final</infinispan.version>


### PR DESCRIPTION
* this will prevent Keycloak CI failures in quarkus-next

Closes: #32298
