### PR TITLE
[quarkus-next] Align dependency versions before build

### DIFF
--- a/.github/scripts/prepare-quarkus-next.sh
+++ b/.github/scripts/prepare-quarkus-next.sh
@@ -50,8 +50,7 @@ add_repository "pom.xml" "repository"
 add_repository "quarkus/pom.xml" "pluginRepository"
 add_repository "operator/pom.xml" "pluginRepository"
 
-./mvnw -B versions:set-property -Dproperty=quarkus.version -DnewVersion=999-SNAPSHOT
-./mvnw -B versions:set-property -Dproperty=quarkus.build.version -DnewVersion=999-SNAPSHOT
+./quarkus/scripts/set-quarkus-version.sh
 git commit -am "Set quarkus version to 999-SNAPSHOT"
 
 snapshot_version_hash=$(git log origin/quarkus-next --grep="Set quarkus version to 999-SNAPSHOT" --format="%H" -n 1)

--- a/quarkus/set-quarkus-version.sh
+++ b/quarkus/set-quarkus-version.sh
@@ -31,9 +31,15 @@ if [ "$1" == "--revert" ]; then
   exit
 fi
 
-DEFAULT_QUARKUS_VERSION="999.0.0-SNAPSHOT"
+SCRIPT_DIR=$(dirname "$0")
+DEFAULT_QUARKUS_VERSION="999-SNAPSHOT"
 QUARKUS_VERSION=${1:-"$DEFAULT_QUARKUS_VERSION"}
 QUARKUS_BRANCH="$QUARKUS_VERSION"
+
+EXCLUDED_DEPENDENCIES=(
+    "infinispan"
+    "jakarta.mail"
+)
 
 if [ "$QUARKUS_BRANCH" == "$DEFAULT_QUARKUS_VERSION" ]; then
     QUARKUS_BRANCH="main"
@@ -49,22 +55,30 @@ fi
 QUARKUS_BOM=$(curl -f -s "$QUARKUS_BOM_URL")
 
 echo "Setting Quarkus version: $QUARKUS_VERSION"
-$(mvn versions:set-property -f ../pom.xml -Dproperty=quarkus.version,quarkus.build.version -DnewVersion="$QUARKUS_VERSION" 1> /dev/null)
 
-DEPENDENCIES_LIST=$(grep -oP '(?<=\</).*(?=\.version\>)' ../pom.xml)
+$SCRIPT_DIR/../mvnw -B versions:set-property -f $SCRIPT_DIR/../pom.xml -Dproperty=quarkus.version -DnewVersion="$QUARKUS_VERSION" 1> /dev/null
+$SCRIPT_DIR/../mvnw -B versions:set-property -f $SCRIPT_DIR/../pom.xml -Dproperty=quarkus.build.version -DnewVersion="$QUARKUS_VERSION" 1> /dev/null
+
+DEPENDENCIES_LIST=$(grep -oP '(?<=\</).*(?=\.version\>)' "$SCRIPT_DIR/../pom.xml")
 
 echo "Changing dependencies: $DEPENDENCIES_LIST"
-$(mvn -f ./pom.xml versions:revert 1> /dev/null)
+$SCRIPT_DIR/../mvnw -f $SCRIPT_DIR/pom.xml versions:revert 1> /dev/null
 
 for dependency in $DEPENDENCIES_LIST; do
+    for excluded in "${EXCLUDED_DEPENDENCIES[@]}"; do
+        if [[ $dependency =~ $excluded ]]; then
+            echo "Skipping $dependency because it is listed as an excluded dependency"
+            continue 2
+        fi
+    done
     VERSION=$(grep -oP "(?<=<$dependency.version>).*(?=</$dependency.version)" <<< "$QUARKUS_BOM")
     if [ "$VERSION" == "" ]; then
         echo "Failed to resolve version for dependency '$dependency'"
-        continue;
+        continue
     fi
     echo "Setting $dependency to $VERSION"
-    mvn versions:set-property -f ../pom.xml -Dproperty="$dependency".version -DnewVersion="$VERSION" 1> /dev/null
-    mvn versions:set-property -f ./pom.xml -Dproperty="$dependency".version -DnewVersion="$VERSION" 1> /dev/null
+        $SCRIPT_DIR/../mvnw versions:set-property -f $SCRIPT_DIR/../pom.xml -Dproperty="$dependency".version -DnewVersion="$VERSION" 1> /dev/null
+        $SCRIPT_DIR/../mvnw versions:set-property -f $SCRIPT_DIR/pom.xml -Dproperty="$dependency".version -DnewVersion="$VERSION" 1> /dev/null
 done
 
 echo ""


### PR DESCRIPTION
More systematic approach to the [dependency issues](https://github.com/keycloak/keycloak/pull/32448) we recently encountered in the `quarkus-next` branch.

cc: @vmuzikar 
