### PR TITLE
fix: remove hostname v1 handling from the operator

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -112,9 +112,7 @@ public class KeycloakDistConfigurator {
         optionMapper(keycloakCR -> keycloakCR.getSpec().getHostnameSpec())
                 .mapOption("hostname", HostnameSpec::getHostname)
                 .mapOption("hostname-admin", HostnameSpec::getAdmin)
-                .mapOption("hostname-admin-url", HostnameSpec::getAdminUrl)
                 .mapOption("hostname-strict", HostnameSpec::isStrict)
-                .mapOption("hostname-strict-backchannel", HostnameSpec::isStrictBackchannel)
                 .mapOption("hostname-backchannel-dynamic", HostnameSpec::isBackchannelDynamic);
     }
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/HostnameSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/HostnameSpec.java
@@ -27,20 +27,14 @@ import java.io.Serializable;
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class HostnameSpec implements Serializable {
 
-    @JsonPropertyDescription("Hostname for the Keycloak server. Applicable for Hostname v1 and v2.")
+    @JsonPropertyDescription("Hostname for the Keycloak server. Applicable for Hostname v2.")
     private String hostname;
 
-    @JsonPropertyDescription("The hostname for accessing the administration console. Applicable for Hostname v1 and v2.")
+    @JsonPropertyDescription("The hostname for accessing the administration console. Applicable for Hostname v2.")
     private String admin;
 
-    @JsonPropertyDescription("DEPRECATED. Sets the base URL for accessing the administration console, including scheme, host, port and path. Applicable for Hostname v1.")
-    private String adminUrl;
-
-    @JsonPropertyDescription("Disables dynamically resolving the hostname from request headers. Applicable for Hostname v1 and v2.")
+    @JsonPropertyDescription("Disables dynamically resolving the hostname from request headers. Applicable for Hostname v2.")
     private Boolean strict;
-
-    @JsonPropertyDescription("DEPRECATED. By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. Applicable for Hostname v1.")
-    private Boolean strictBackchannel;
 
     @JsonPropertyDescription("Enables dynamic resolving of backchannel URLs, including hostname, scheme, port and context path. Set to true if your application accesses Keycloak via a private network. Applicable for Hostname v2.")
     private Boolean backchannelDynamic;
@@ -61,28 +55,12 @@ public class HostnameSpec implements Serializable {
         this.admin = admin;
     }
 
-    public String getAdminUrl() {
-        return adminUrl;
-    }
-
-    public void setAdminUrl(String adminUrl) {
-        this.adminUrl = adminUrl;
-    }
-
     public Boolean isStrict() {
         return strict;
     }
 
     public void setStrict(Boolean strict) {
         this.strict = strict;
-    }
-
-    public Boolean isStrictBackchannel() {
-        return strictBackchannel;
-    }
-
-    public void setStrictBackchannel(Boolean strictBackchannel) {
-        this.strictBackchannel = strictBackchannel;
     }
 
     public Boolean isBackchannelDynamic() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -52,8 +52,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
         kc.getSpec().getHttpSpec().setTlsSecret(null);
         kc.getSpec().getHttpSpec().setHttpEnabled(true);
         var hostnameSpecBuilder = new HostnameSpecBuilder()
-                .withStrict(false)
-                .withStrictBackchannel(false);
+                .withStrict(false);
         if (isOpenShift) {
             kc.getSpec().setIngressSpec(new IngressSpecBuilder().withIngressClassName(KeycloakController.OPENSHIFT_DEFAULT).build());
         }
@@ -78,8 +77,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
     public void testIngressOnHTTPSAndProxySettings() {
         var kc = getTestKeycloakDeployment(false);
         var hostnameSpecBuilder = new HostnameSpecBuilder()
-                .withStrict(false)
-                .withStrictBackchannel(false);
+                .withStrict(false);
         if (isOpenShift) {
             kc.getSpec().setIngressSpec(new IngressSpecBuilder().withIngressClassName(KeycloakController.OPENSHIFT_DEFAULT).build());
         }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -123,9 +123,7 @@ public class CRSerializationTest {
 
         assertThat(hostnameSpec.getHostname(), is("my-hostname"));
         assertThat(hostnameSpec.getAdmin(), is("my-admin-hostname"));
-        assertThat(hostnameSpec.getAdminUrl(), is("https://www.my-admin-hostname.org:8448/something"));
         assertThat(hostnameSpec.isStrict(), is(true));
-        assertThat(hostnameSpec.isStrictBackchannel(), is(true));
 
         keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/empty-podtemplate-keycloak.yml"), Keycloak.class);
 
@@ -133,9 +131,7 @@ public class CRSerializationTest {
         assertThat(hostnameSpec, notNullValue());
         assertThat(hostnameSpec.getHostname(), is("example.com"));
         assertThat(hostnameSpec.getAdmin(), nullValue());
-        assertThat(hostnameSpec.getAdminUrl(), nullValue());
         assertThat(hostnameSpec.isStrict(), nullValue());
-        assertThat(hostnameSpec.isStrictBackchannel(), nullValue());
     }
 
     @Test

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -113,9 +113,7 @@ public class KeycloakDistConfiguratorTest {
     public void hostname() {
         final Map<String, String> expectedValues = Map.of(
                 "hostname", "my-hostname",
-                "hostname-admin-url", "https://www.my-admin-hostname.org:8448/something",
                 "hostname-strict", "true",
-                "hostname-strict-backchannel", "true",
                 "hostname-backchannel-dynamic", "true",
                 "hostname-admin", "my-admin-hostname"
         );

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -40,9 +40,7 @@ spec:
   hostname:
     hostname: my-hostname
     admin: my-admin-hostname
-    adminUrl: https://www.my-admin-hostname.org:8448/something
     strict: true
-    strictBackchannel: true
     backchannelDynamic: true
   cache:
     configMapFile:


### PR DESCRIPTION
closes: #32470

This is a draft of the most aggressive option, which is to completely remove hostname v1 fields from the cr. While this is a breaking change, it is allowable via an olm upgrade as long none of the Keycloaks on the cluster have these fields populated. This would be called out in the migration guide. Kubernetes itself takes this approach - deprecated fields are dropped from the same api version after a sufficient period of deprecation.

Other possible options:
- we can do nothing for now, for the user to use these fields they'd also have setting the features, which will result in the keycloak failing to start with an appropriate error message. This has the benefit(?) of allowing for users to use the newer operator with older custom images.
- we can add a v2 of the crd - however I'd say this change alone doesn't warrent this, and removal or leaving alone for now is far simpler.

cc @vmuzikar @mabartos 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
