### PR TITLE
document syslog app-name

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -196,6 +196,13 @@ To enable logging using Syslog, add it to the list of activated log handlers as 
 
 <@kc.start parameters="--log=\"console,syslog\""/>
 
+=== Configuring the Syslog Application Name
+To set a different application name, add the `--log-syslog-app-name` option as follows:
+
+<@kc.start parameters="--log=\"console,syslog\" --log-syslog-app-name=kc-p-itadmins"/>
+
+If not set, the application name defaults to `keycloak`.
+
 === Configuring the Syslog endpoint
 
 To configure the endpoint(_host:port_) of your centralized logging system, enter the following command and substitute the values with your specific values:

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -145,7 +145,6 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .description("The app name used when formatting the message in RFC5424 format.")
             .defaultValue("keycloak")
-            .hidden()
             .build();
 
     public static final Option<String> LOG_SYSLOG_PROTOCOL = new OptionBuilder<>("log-syslog-protocol", String.class)

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -153,6 +153,9 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
 --log-syslog-endpoint <host:port>
                      The IP address and port of the syslog server. Default: localhost:514.
                        Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -153,6 +153,9 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
 --log-syslog-endpoint <host:port>
                      The IP address and port of the syslog server. Default: localhost:514.
                        Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -329,6 +329,9 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
 --log-syslog-endpoint <host:port>
                      The IP address and port of the syslog server. Default: localhost:514.
                        Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -330,6 +330,9 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
 --log-syslog-endpoint <host:port>
                      The IP address and port of the syslog server. Default: localhost:514.
                        Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -281,6 +281,9 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-syslog-app-name <name>
+                     The app name used when formatting the message in RFC5424 format. Default:
+                       keycloak. Available only when Syslog is activated.
 --log-syslog-endpoint <host:port>
                      The IP address and port of the syslog server. Default: localhost:514.
                        Available only when Syslog is activated.


### PR DESCRIPTION
Closes #32525

The app-name is often use in bigger environments to route the logs to the correct flow or file. The newly re-introduced syslog functionality does support this expected syslog configuration but it is not documented. I added it to the logging guide.

The app-name functionality works as expected and is needed in the efforts to replace the short-lived GELF support in Keycloak.
