### PR TITLE
set login-otp autocomplete="one-time-code"

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-otp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-otp.ftl
@@ -29,7 +29,7 @@
                 </div>
 
             <div class="${properties.kcInputWrapperClass!}">
-                <input id="otp" name="otp" autocomplete="off" type="text" class="${properties.kcInputClass!}"
+                <input id="otp" name="otp" autocomplete="one-time-code" type="text" class="${properties.kcInputClass!}"
                        autofocus aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>"
                        dir="ltr" />
 


### PR DESCRIPTION
Set  `autocomplete="one-time-code"` instead of `"off"` in `login-otp.ftl`

closes keycloak/keycloak#32579