### PR TITLE
Binding brokering OIDC user sessions with the issuer of the ID Token to avoid looking up sessions by iterating over all brokers in a realm

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProviderConfig.java
@@ -32,6 +32,7 @@ public class OIDCIdentityProviderConfig extends OAuth2IdentityProviderConfig {
     public static final String USE_JWKS_URL = "useJwksUrl";
     public static final String VALIDATE_SIGNATURE = "validateSignature";
     public static final String IS_ACCESS_TOKEN_JWT = "isAccessTokenJWT";
+    public static final String ISSUER = "issuer";
 
     public OIDCIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
         super(identityProviderModel);
@@ -49,10 +50,10 @@ public class OIDCIdentityProviderConfig extends OAuth2IdentityProviderConfig {
     }
 
     public String getIssuer() {
-        return getConfig().get("issuer");
+        return getConfig().get(ISSUER);
     }
     public void setIssuer(String issuer) {
-        getConfig().put("issuer", issuer);
+        getConfig().put(ISSUER, issuer);
     }
     public String getLogoutUrl() {
         return getConfig().get("logoutUrl");

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -554,7 +554,7 @@ public class LogoutEndpoint {
                     Response.Status.BAD_REQUEST);
         }
 
-        LogoutTokenValidationCode validationCode = tokenManager.verifyLogoutToken(session, realm, encodedLogoutToken);
+        LogoutTokenValidationCode validationCode = tokenManager.verifyLogoutToken(session, encodedLogoutToken);
         if (!validationCode.equals(LogoutTokenValidationCode.VALIDATION_SUCCESS)) {
             String errorMessage = validationCode.getErrorMessage();
             event.detail(Details.REASON, errorMessage);
@@ -565,8 +565,7 @@ public class LogoutEndpoint {
 
         LogoutToken logoutToken = tokenManager.toLogoutToken(encodedLogoutToken).get();
 
-        Stream<String> identityProviderAliases = tokenManager.getValidOIDCIdentityProvidersForBackchannelLogout(realm,
-                session, encodedLogoutToken, logoutToken)
+        Stream<String> identityProviderAliases = tokenManager.getValidOIDCIdentityProvidersForBackchannelLogout(session, encodedLogoutToken, logoutToken)
                 .map(idp -> idp.getConfig().getAlias());
 
         boolean logoutOfflineSessions = Boolean.parseBoolean(logoutToken.getEvents()


### PR DESCRIPTION
Closes #32091

* Instead of binding user sessions originating from authenticating to an OIDC broker using the broker alias, it will use the `iss` (issuer) of the ID Token.
* By using the issuer, we can avoid iterating over all the brokers available from a realm when processing backchannel logout requests because looking up a session will be based on the issuer of the logout token and the `sid` or `sub` claims from this token.
* As a result, any session from the same `issuer` and a give `sid` or `sub` will be destroyed.
* This is a follow-up after fixing the backchannel logout tests as per https://github.com/keycloak/keycloak/pull/32497