### PR TITLE
Add a PasswordPoliciesBean to the FreeMarker context.

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -48,6 +48,7 @@ import org.keycloak.forms.login.freemarker.model.LoginBean;
 import org.keycloak.forms.login.freemarker.model.LogoutConfirmBean;
 import org.keycloak.forms.login.freemarker.model.OAuthGrantBean;
 import org.keycloak.forms.login.freemarker.model.OrganizationBean;
+import org.keycloak.forms.login.freemarker.model.PasswordPoliciesBean;
 import org.keycloak.forms.login.freemarker.model.ProfileBean;
 import org.keycloak.forms.login.freemarker.model.RealmBean;
 import org.keycloak.forms.login.freemarker.model.RecoveryAuthnCodeInputLoginBean;
@@ -548,6 +549,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                     attributes.put("org", new OrganizationBean(organization, user));
                 }
             }
+            attributes.put("passwordPolicies", new PasswordPoliciesBean(realm.getPasswordPolicy()));
         }
         if (realm != null && user != null && session != null) {
             attributes.put("authenticatorConfigured", new AuthenticatorConfiguredMethod(realm, user, session));

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/PasswordPoliciesBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/PasswordPoliciesBean.java
@@ -1,0 +1,69 @@
+package org.keycloak.forms.login.freemarker.model;
+
+import org.keycloak.models.PasswordPolicy;
+
+public class PasswordPoliciesBean {
+  private final Integer length;
+  private final Integer maxLength;
+  private final Integer lowerCase;
+  private final Integer upperCase;
+  private final Integer specialChars;
+  private final Integer digits;
+  private final Integer passwordHistory;
+  private final Integer forceExpiredPasswordChange;
+  private final boolean notUsername;
+  private final boolean notEmail;
+
+  public PasswordPoliciesBean(PasswordPolicy policy) {
+    this.length = policy.getPolicyConfig("length");
+    this.maxLength = policy.getPolicyConfig("maxLength");
+    this.lowerCase = policy.getPolicyConfig("lowerCase");
+    this.upperCase = policy.getPolicyConfig("upperCase");
+    this.specialChars = policy.getPolicyConfig("specialChars");
+    this.digits = policy.getPolicyConfig("digits");
+    this.passwordHistory = policy.getPolicyConfig("passwordHistory");
+    this.forceExpiredPasswordChange = policy.getPolicyConfig("forceExpiredPasswordChange");
+    this.notUsername = policy.getPolicies().contains("notUsername");
+    this.notEmail = policy.getPolicies().contains("notEmail");
+  }
+
+  public Integer getLength() {
+    return length;
+  }
+
+  public Integer getMaxLength() {
+    return maxLength;
+  }
+
+  public Integer getLowerCase() {
+    return lowerCase;
+  }
+
+  public Integer getUpperCase() {
+    return upperCase;
+  }
+
+  public Integer getSpecialChars() {
+    return specialChars;
+  }
+
+  public Integer getDigits() {
+    return digits;
+  }
+
+  public Integer getPasswordHistory() {
+    return passwordHistory;
+  }
+
+  public Integer getForceExpiredPasswordChange() {
+    return forceExpiredPasswordChange;
+  }
+
+  public boolean isNotUsername() {
+    return notUsername;
+  }
+
+  public boolean isNotEmail() {
+    return notEmail;
+  }
+}


### PR DESCRIPTION
Closes #32553

- Add `services/src/main/java/org/keycloak/forms/login/freemarker/model/PasswordPoliciesBean.java`
- Update `services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java` `createCommonAttributes` method to add the bean with key `passwordPolicies`.