### PR TITLE
Drop redundant index on client sessions

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -92,4 +92,8 @@
         <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate26_0_0_IdentityProviderAttributesMigration"/>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.0.0-32583-drop-redundant-index-on-client-session">
+        <dropIndex indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
I tested using example data and explain plains that the index is not used on MariaDB, PostgreSQL and OracleDB. Also got confirmation from @sschu that MSSQL will not need it. 

Closes #32583

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
