### PR TITLE
Fix ResetPasswordTest on chrome 128

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -19,12 +19,14 @@ package org.keycloak.testsuite.pages;
 
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Assert;
+import org.keycloak.common.util.Retry;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.support.FindBy;
 
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
@@ -233,7 +235,14 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public void resetPassword() {
-        clickLink(resetPasswordLink);
+        // Since Chrome 128, the user can be still kept on the "Login page" after click to "Forget Password" link. Clicking the "Forget Password" link another
+        // time usually helps. Limit to 4 attempts for now.
+        Retry.execute(() -> {
+            clickLink(resetPasswordLink);
+            if (driver instanceof ChromeDriver) {
+                Assert.assertEquals("Forgot Your Password?", PageUtils.getPageTitle(driver));
+            }
+        }, 4, 0);
     }
 
     public void setRememberMe(boolean enable) {


### PR DESCRIPTION
closes #32514
closes #32478
closes #32477
closes #32678
closes #32542
closes #32678
closes #32541

@miquelsi @wojnarfilip Are you able to review please?

I was not able to reproduce locally with Chrome 126 + ChromeDriver 125 and tests always passed. After upgrade to Chrome 128 and chromeDriver 128, I was able to reproduce flakiness locally. So it looks that chrome+chromeDriver upgrade caused this on GH actions, which is probably why this test started to fail just recently.

After this change, I am not able to see any flakiness locally, so I think this fix will help on GH actions as well.

This should help with all the `ResetPasswordTest` failures and flakiness. It looks that chrome update to 128 happened around 29th August on GH actions as this is when the issues started to be reported. If there are multiple links where this strange behaviour happens, we can possibly consider moving "retry" somewhere to the framework (maybe `UIUtils.clickLink`) instead of handling just this single link.