### PR TITLE
Possibility to separately specify log levels for log handlers - basic

### DIFF
--- a/docs/documentation/release_notes/topics/26_0_0.adoc
+++ b/docs/documentation/release_notes/topics/26_0_0.adoc
@@ -158,6 +158,13 @@ GELF support has been deprecated for a while now, and with this release it has b
 Other log handlers are available and fully supported to be used as a replacement of GELF, for example Syslog. For details
 see the https://www.keycloak.org/server/logging[Logging guide].
 
+= Specify different log levels for log handlers
+
+It is possible to specify log levels for all available log handlers, such as `console`, `file`, or `syslog`.
+The more fine-grained approach provides the ability to control logging over the whole application and be tailored to your needs.
+
+For more information, see the https://www.keycloak.org/server/logging[Logging guide].
+
 = All user sessions are persisted by default
 
 {project_name} 25 introduced the feature `persistent-user-sessions`. With this feature enabled all user sessions are persisted in the database as opposed to the previous behavior where only offline sessions were persisted.

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -9,15 +9,18 @@ title="Configuring logging"
 summary="Learn how to configure Logging"
 includedOptions="log log-*">
 
-{project_name} uses the JBoss Logging framework. The following is a high-level overview for the available log handlers:
+{project_name} uses the JBoss Logging framework.
+The following is a high-level overview for the available log handlers with the common parent log handler `root`:
 
-* root
-** console (_default_)
-** file
-** Syslog
+<@opts.expectedValues option="log"/>
 
 == Logging configuration
-Logging is done on a per-category basis in {project_name}. You can configure logging for the root log level or for more specific categories such as `org.hibernate` or `org.keycloak`. This {section} describes how to configure logging.
+
+Logging is done on a per-category basis in {project_name}.
+You can configure logging for the root log level or for more specific categories such as `org.hibernate` or `org.keycloak`.
+It is also possible to tailor log levels for each particular log handler.
+
+This {section} describes how to configure logging.
 
 === Log levels
 
@@ -71,14 +74,58 @@ To enable log handlers, enter the following command:
 
 <@kc.start parameters="--log=\"<handler1>,<handler2>\""/>
 
-The available handlers are
-<@profile.ifCommunity>
-`console`, `file`, `syslog`.
-</@profile.ifCommunity>
-<@profile.ifProduct>
-`console`, `file` and `syslog`.
-</@profile.ifProduct>
+The available handlers are:
+
+<@opts.expectedValues option="log"/>
+
 The more specific handler configuration mentioned below will only take effect when the handler is added to this comma-separated list.
+
+== Specify log level for each handler
+
+The `log-level` property specifies the global root log level and levels for selected categories.
+However, a more fine-grained approach for log levels is necessary to comply with the modern application requirements.
+
+To set log levels for particular handlers, properties in format `log-<handler>-level` (where `<handler>` is available log handler) were introduced.
+
+It means properties for log level settings look like this:
+
+* `log-console-level` - Console log handler
+* `log-file-level` - File log handler
+* `log-syslog-level` - Syslog log handler
+
+NOTE: The `log-<handler>-level` properties are available only when the particular log handlers are enabled.
+More information in log handlers settings below.
+
+Only log levels specified in <<Log levels>> section are accepted, and *must be in lowercase*.
+There is no support for specifying particular categories for log handlers yet.
+
+=== General principle
+
+It is necessary to understand that setting the log levels for each particular handler *does not override the root level* specified in the `log-level` property.
+Log handlers respect the root log level, which represents the maximal verbosity for the whole logging system.
+It means individual log handlers can be configured to be less verbose than the root logger, but not more.
+
+Specifically, when an arbitrary log level is defined for the handler, it does not mean the log records with the log level will be present in the output.
+In that case, the root `log-level` must also be assessed.
+Log handler levels provide the *restriction for the root log level*, and the default log level for log handlers is `all` - without any restriction.
+
+=== Examples
+
+.Example: `debug` for file handler, but `info` for console handler:
+<@kc.start parameters="--log=console,file --log-level=debug --log-console-level=info"/>
+
+The root log level is set to `debug`, so every log handler inherits the value - so does the file log handler.
+To hide `debug` records in the console, we need to set the minimal (least severe) level to `info` for the console handler.
+
+.Example: `warn` for all handlers, but `debug` for file handler:
+<@kc.start parameters="--log=console,file,syslog --log-level=debug --log-console-level=warn --log-syslog-level=warn"/>
+
+The root level must be set to the most verbose required level (`debug` in this case), and other log handlers must be amended accordingly.
+
+.Example: `info` for all handlers, but `debug`+`org.keycloak.events:trace` for Syslog handler:
+<@kc.start parameters="--log=console,file,syslog --log-level=debug,org.keycloak.events:trace, --log-syslog-level=trace --log-console-level=info --log-file-level=info"/>
+
+In order to see the `org.keycloak.events:trace`, the `trace` level must be set for the Syslog handler.
 
 == Console log handler
 The console log handler is enabled by default, providing unstructured log messages for the console.
@@ -158,6 +205,13 @@ Colored console log output for unstructured logs is disabled by default. Colors 
 
 <@kc.start parameters="--log-console-color=<false|true>"/>
 
+=== Configuring the console log level
+Log level for console log handler can be specified by `--log-console-level` property as follows:
+
+<@kc.start parameters="--log-console-level=warn"/>
+
+For more information, see the section <<Specify log level for each handler>> above.
+
 == File logging
 As an alternative to logging to the console, you can use unstructured logging to a file.
 
@@ -187,6 +241,13 @@ To configure a different logging format for the file log handler, enter the foll
 
 See <<Configuring the console log format>> for more information and a table of the available pattern configuration.
 
+=== Configuring the file log level
+Log level for file log handler can be specified by `--log-file-level` property as follows:
+
+<@kc.start parameters="--log-file-level=warn"/>
+
+For more information, see the section <<Specify log level for each handler>> above.
+
 == Centralized logging using Syslog
 
 {project_name} provides the ability to send logs to a remote Syslog server.
@@ -212,6 +273,13 @@ To configure the endpoint(_host:port_) of your centralized logging system, enter
 
 When the Syslog handler is enabled, the host is using `localhost` as host value.
 The Default port is `514`.
+
+=== Configuring the Syslog log level
+Log level for Syslog log handler can be specified by `--log-syslog-level` property as follows:
+
+<@kc.start parameters="--log-syslog-level=warn"/>
+
+For more information, see the section <<Specify log level for each handler>> above.
 
 === Configuring the Syslog protocol
 Syslog uses TCP as the default protocol for communication.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -77,6 +77,14 @@ public class LoggingOptions {
             .description("Set the log output to JSON or default (plain) unstructured logging.")
             .build();
 
+    public static final Option<Level> LOG_CONSOLE_LEVEL = new OptionBuilder<>("log-console-level", Level.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(Level.ALL)
+            .description("Set the log level for the console handler. It specifies the minimal allowed level for logs shown in the output. "
+                    + "It respects levels specified in the 'log-level' option, which creates a minimal log level bar for log records. "
+                    + "For more information, check the Logging guide.")
+            .build();
+
     public static final Option<String> LOG_CONSOLE_FORMAT = new OptionBuilder<>("log-console-format", String.class)
             .category(OptionCategory.LOGGING)
             .description("The format of unstructured console log entries. If the format has spaces in it, escape the value using \"<format>\".")
@@ -112,6 +120,14 @@ public class LoggingOptions {
             .defaultValue(new File(DEFAULT_LOG_PATH))
             .build();
 
+    public static final Option<Level> LOG_FILE_LEVEL = new OptionBuilder<>("log-file-level", Level.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(Level.ALL)
+            .description("Set the log level for the file handler. It specifies the minimal allowed level for logs shown in the output. "
+                    + "It respects levels specified in the 'log-level' option, which creates a minimal log level bar for log records. "
+                    + "For more information, check the Logging guide.")
+            .build();
+
     public static final Option<String> LOG_FILE_FORMAT = new OptionBuilder<>("log-file-format", String.class)
             .category(OptionCategory.LOGGING)
             .description("Set a format specific to file log entries.")
@@ -140,6 +156,14 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .description("Set the IP address and port of the Syslog server.")
             .defaultValue("localhost:514")
+            .build();
+
+    public static final Option<Level> LOG_SYSLOG_LEVEL = new OptionBuilder<>("log-syslog-level", Level.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(Level.ALL)
+            .description("Set the log level for the Syslog handler. It specifies the minimal allowed level for logs shown in the output. "
+                    + "It respects levels specified in the 'log-level' option, which creates a minimal log level bar for log records. "
+                    + "For more information, check the Logging guide.")
             .build();
 
     public static final Option<String> LOG_SYSLOG_TYPE = new OptionBuilder<>("log-syslog-type", String.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -80,8 +80,8 @@ public class LoggingOptions {
     public static final Option<Level> LOG_CONSOLE_LEVEL = new OptionBuilder<>("log-console-level", Level.class)
             .category(OptionCategory.LOGGING)
             .defaultValue(Level.ALL)
-            .description("Set the log level for the console handler. It specifies the minimal allowed level for logs shown in the output. "
-                    + "It respects levels specified in the 'log-level' option, which creates a minimal log level bar for log records. "
+            .description("Set the log level for the console handler. It specifies the most verbose log level for logs shown in the output. "
+                    + "It respects levels specified in the 'log-level' option, which represents the maximal verbosity for the whole logging system. "
                     + "For more information, check the Logging guide.")
             .build();
 
@@ -123,8 +123,8 @@ public class LoggingOptions {
     public static final Option<Level> LOG_FILE_LEVEL = new OptionBuilder<>("log-file-level", Level.class)
             .category(OptionCategory.LOGGING)
             .defaultValue(Level.ALL)
-            .description("Set the log level for the file handler. It specifies the minimal allowed level for logs shown in the output. "
-                    + "It respects levels specified in the 'log-level' option, which creates a minimal log level bar for log records. "
+            .description("Set the log level for the file handler. It specifies the most verbose log level for logs shown in the output. "
+                    + "It respects levels specified in the 'log-level' option, which represents the maximal verbosity for the whole logging system. "
                     + "For more information, check the Logging guide.")
             .build();
 
@@ -161,8 +161,8 @@ public class LoggingOptions {
     public static final Option<Level> LOG_SYSLOG_LEVEL = new OptionBuilder<>("log-syslog-level", Level.class)
             .category(OptionCategory.LOGGING)
             .defaultValue(Level.ALL)
-            .description("Set the log level for the Syslog handler. It specifies the minimal allowed level for logs shown in the output. "
-                    + "It respects levels specified in the 'log-level' option, which creates a minimal log level bar for log records. "
+            .description("Set the log level for the Syslog handler. It specifies the most verbose log level for logs shown in the output. "
+                    + "It respects levels specified in the 'log-level' option, which represents the maximal verbosity for the whole logging system. "
                     + "For more information, check the Logging guide.")
             .build();
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -42,6 +42,11 @@ public final class LoggingPropertyMappers {
                         .paramLabel("output")
                         .transformer(LoggingPropertyMappers::resolveLogOutput)
                         .build(),
+                fromOption(LoggingOptions.LOG_CONSOLE_LEVEL)
+                        .isEnabled(LoggingPropertyMappers::isConsoleEnabled, CONSOLE_ENABLED_MSG)
+                        .to("quarkus.log.console.level")
+                        .paramLabel("level")
+                        .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_FORMAT)
                         .isEnabled(LoggingPropertyMappers::isConsoleEnabled, CONSOLE_ENABLED_MSG)
                         .to("quarkus.log.console.format")
@@ -72,6 +77,11 @@ public final class LoggingPropertyMappers {
                         .to("quarkus.log.file.path")
                         .paramLabel("file")
                         .transformer(LoggingPropertyMappers::resolveFileLogLocation)
+                        .build(),
+                fromOption(LoggingOptions.LOG_FILE_LEVEL)
+                        .isEnabled(LoggingPropertyMappers::isFileEnabled, FILE_ENABLED_MSG)
+                        .to("quarkus.log.file.level")
+                        .paramLabel("level")
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE_FORMAT)
                         .isEnabled(LoggingPropertyMappers::isFileEnabled, FILE_ENABLED_MSG)
@@ -106,6 +116,11 @@ public final class LoggingPropertyMappers {
                         .isEnabled(LoggingPropertyMappers::isSyslogEnabled, SYSLOG_ENABLED_MSG)
                         .to("quarkus.log.syslog.endpoint")
                         .paramLabel("host:port")
+                        .build(),
+                fromOption(LoggingOptions.LOG_SYSLOG_LEVEL)
+                        .isEnabled(LoggingPropertyMappers::isSyslogEnabled, SYSLOG_ENABLED_MSG)
+                        .to("quarkus.log.syslog.level")
+                        .paramLabel("level")
                         .build(),
                 fromOption(LoggingOptions.LOG_SYSLOG_APP_NAME)
                         .isEnabled(LoggingPropertyMappers::isSyslogEnabled, SYSLOG_ENABLED_MSG)

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -64,7 +64,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void testKeycloakConfPlaceholder() {
-        assertEquals("warn", createConfig().getRawValue("kc.log-level"));
+        assertEquals("info", createConfig().getRawValue("kc.log-level"));
         putEnvVar("SOME_LOG_LEVEL", "debug");
         assertEquals("debug", createConfig().getRawValue("kc.log-level"));
     }
@@ -476,7 +476,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         ConfigValue secret = config.getConfigValue("my.secret");
         assertEquals("secret", secret.getValue());
     }
-    
+
     @Test
     public void testReloadPeriod() {
         ConfigArgsConfigSource.setCliArgs("");

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
@@ -158,4 +158,30 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
         assertConfig("log-syslog-max-length", "512");
         assertExternalConfig("quarkus.log.syslog.max-length", "512");
     }
+
+    @Test
+    public void logLevelsHandlers() {
+        putEnvVars(Map.of(
+                "KC_LOG_LEVEL", "debug",
+                "KC_LOG_CONSOLE_LEVEL", "info",
+                "KC_LOG_SYSLOG_LEVEL", "trace",
+                "KC_LOG_FILE_LEVEL", "debug"
+        ));
+
+        initConfig();
+
+        assertConfig(Map.of(
+                "log-level", "debug",
+                "log-console-level", "info",
+                "log-syslog-level", "trace",
+                "log-file-level", "debug"
+        ));
+
+        assertExternalConfig(Map.of(
+                "quarkus.log.level", "DEBUG",
+                "quarkus.log.console.level", "info",
+                "quarkus.log.syslog.level", "trace",
+                "quarkus.log.file.level", "debug"
+        ));
+    }
 }

--- a/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
@@ -1,6 +1,6 @@
 spi-hostname-default-frontend-url = ${keycloak.frontendUrl:http://filepropdefault.unittest}
 %user-profile.spi-hostname-default-frontend-url = http://filepropprofile.unittest
-log-level=${SOME_LOG_LEVEL:warn}
+log-level=${SOME_LOG_LEVEL:info}
 config-keystore=src/test/resources/keystore
 config-keystore-password=secret
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
@@ -58,7 +58,7 @@ public class OptionsDistTest {
     @Launch({"start", "--log=console", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
     public void testServerDoesNotStartIfDisabledFileLogOption(LaunchResult result) {
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
-        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-console-output, --log-console-format, --log-console-color")).count());
+        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-level")).count());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class OptionsDistTest {
     @Launch({"start-dev", "--log=console", "--log-file-output=json"})
     public void testServerDoesNotStartDevIfDisabledFileLogOption(LaunchResult result) {
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
-        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-console-output, --log-console-format, --log-console-color")).count());
+        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-level")).count());
     }
 
     @Test
@@ -119,6 +119,6 @@ public class OptionsDistTest {
     public void testServerStartDevIfEnabledFileLogOption(LaunchResult result) {
         assertEquals(0, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-console-color'. Available only when Console log handler is activated")).count());
-        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-file, --log-file-format, --log-file-output, --log-level")).count());
+        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-file, --log-file-level, --log-file-format, --log-file-output, --log-level")).count());
     }
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -128,12 +128,12 @@ Logging:
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -127,6 +127,13 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -132,12 +132,12 @@ Logging:
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -153,12 +153,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
 --log-file-level <level>
-                     Set the log level for the file handler. It specifies the minimal allowed level
-                       for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when File log handler is activated.
+                     Set the log level for the file handler. It specifies the most verbose log
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -181,12 +181,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
 --log-syslog-level <level>
-                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                     Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Syslog is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -131,6 +131,13 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -145,6 +152,13 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-level <level>
+                     Set the log level for the file handler. It specifies the minimal allowed level
+                       for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -166,6 +180,13 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-level <level>
+                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -128,12 +128,12 @@ Logging:
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -127,6 +127,13 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -132,12 +132,12 @@ Logging:
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -153,12 +153,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
 --log-file-level <level>
-                     Set the log level for the file handler. It specifies the minimal allowed level
-                       for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when File log handler is activated.
+                     Set the log level for the file handler. It specifies the most verbose log
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -181,12 +181,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
 --log-syslog-level <level>
-                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                     Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Syslog is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -131,6 +131,13 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -145,6 +152,13 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-level <level>
+                     Set the log level for the file handler. It specifies the minimal allowed level
+                       for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -166,6 +180,13 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-level <level>
+                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -273,6 +273,13 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -274,12 +274,12 @@ Logging:
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -313,12 +313,12 @@ Logging:
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -334,12 +334,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
 --log-file-level <level>
-                     Set the log level for the file handler. It specifies the minimal allowed level
-                       for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when File log handler is activated.
+                     Set the log level for the file handler. It specifies the most verbose log
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -362,12 +362,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
 --log-syslog-level <level>
-                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                     Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Syslog is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -312,6 +312,13 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -326,6 +333,13 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-level <level>
+                     Set the log level for the file handler. It specifies the minimal allowed level
+                       for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -347,6 +361,13 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-level <level>
+                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -274,6 +274,13 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -275,12 +275,12 @@ Logging:
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -313,6 +313,13 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -327,6 +334,13 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-level <level>
+                     Set the log level for the file handler. It specifies the minimal allowed level
+                       for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -348,6 +362,13 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-level <level>
+                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -314,12 +314,12 @@ Logging:
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -335,12 +335,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
 --log-file-level <level>
-                     Set the log level for the file handler. It specifies the minimal allowed level
-                       for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when File log handler is activated.
+                     Set the log level for the file handler. It specifies the most verbose log
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -363,12 +363,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
 --log-syslog-level <level>
-                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                     Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Syslog is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -226,12 +226,12 @@ Logging:
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -225,6 +225,13 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -264,6 +264,13 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-level <level>
+                     Set the log level for the console handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -278,6 +285,13 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-level <level>
+                     Set the log level for the file handler. It specifies the minimal allowed level
+                       for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -299,6 +313,13 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-level <level>
+                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which creates a minimal log level bar for log records.
+                       For more information, check the Logging guide. Possible values are: off,
+                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
+                       when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -265,12 +265,12 @@ Logging:
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
 --log-console-level <level>
-                     Set the log level for the console handler. It specifies the minimal allowed
+                     Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Console log handler is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Console log handler is activated.
 --log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when Console log
@@ -286,12 +286,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
 --log-file-level <level>
-                     Set the log level for the file handler. It specifies the minimal allowed level
-                       for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when File log handler is activated.
+                     Set the log level for the file handler. It specifies the most verbose log
+                       level for logs shown in the output. It respects levels specified in the
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when File log handler is activated.
 --log-file-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default. Available only when File log
@@ -314,12 +314,12 @@ Logging:
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
 --log-syslog-level <level>
-                     Set the log level for the Syslog handler. It specifies the minimal allowed
+                     Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
-                       'log-level' option, which creates a minimal log level bar for log records.
-                       For more information, check the Logging guide. Possible values are: off,
-                       fatal, error, warn, info, debug, trace, all. Default: all. Available only
-                       when Syslog is activated.
+                       'log-level' option, which represents the maximal verbosity for the whole
+                       logging system. For more information, check the Logging guide. Possible
+                       values are: off, fatal, error, warn, info, debug, trace, all. Default: all.
+                       Available only when Syslog is activated.
 --log-syslog-max-length <max-length>
                      Set the maximum length, in bytes, of the message allowed to be sent. The
                        length includes the header and the message. If not set, the default value is


### PR DESCRIPTION
- Closes #32619

Descoped version of https://github.com/keycloak/keycloak/pull/32620, with slightly different logic around log levels - based on the current JBoss log manager/Quarkus implementation. 

The logic around log levels for handlers might not be very intuitive, and the docs in the Quarkus [Logging configuration guide](https://quarkus.io/guides/logging) do not touch more details as well.





