### PR TITLE
Ensure latest dependencies are installed before running pre-commit hook

### DIFF
--- a/js/.husky/pre-commit
+++ b/js/.husky/pre-commit
@@ -17,4 +17,13 @@ if ! [ -x "$(command -v pnpm)" ]; then
   exit 0;
 fi
 
+echo "Running pre-commit hook…";
+
+# Ensure latest dependencies are installed, and exit if unable to install.
+pnpm install --reporter=silent || {
+  echo "Unable to install dependencies, skipping pre-commit hook.";
+  exit 0;
+}
+
+# Run lint-staged.
 pnpm exec lint-staged


### PR DESCRIPTION
Adds a step to the pre-commit hook that explicitly installs the latest dependencies to prevent an inconsistent state of the `node_modules`. This should prevent issues where the pre-commit script runs into unexpected issues when switching between branches.