### PR TITLE
Drop old tables for user and client sessions that are no longer used

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -95,5 +95,16 @@
     <changeSet author="keycloak" id="26.0.0-32583-drop-redundant-index-on-client-session">
         <dropIndex indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
     </changeSet>
+    
+    <changeSet id="26.0.0.32582-remove-tables-user-session-user-session-note-and-client-session" author="keycloak">
+        <dropTable tableName="CLIENT_SESSION_ROLE"/>
+        <dropTable tableName="CLIENT_SESSION_NOTE"/>
+        <dropTable tableName="CLIENT_SESSION_PROT_MAPPER"/>
+        <dropTable tableName="CLIENT_SESSION_AUTH_STATUS"/>
+        <dropTable tableName="CLIENT_USER_SESSION_NOTE"/>
+        <dropTable tableName="CLIENT_SESSION"/>
+        <dropTable tableName="USER_SESSION_NOTE"/>
+        <dropTable tableName="USER_SESSION"/>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Closes #32582

I tested that newly initialized database does not contain the tables and that migration from 25.0.2 -> 26.0.0 correctly removes the tables

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
