### PR TITLE
Admin API with Lightweight access token and transient session

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -700,12 +700,9 @@ public abstract class AbstractKeycloakTest {
         Time.setOffset(offset);
         Map result = testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(offset)));
 
-        // force refreshing token after time offset has changed
-        try {
-            adminClient.tokenManager().refreshToken();
-        } catch (RuntimeException e) {
-            adminClient.tokenManager().grantToken();
-        }
+        // force getting new token after time offset has changed
+        adminClient.tokenManager().grantToken();
+
 
         return String.valueOf(result);
     }


### PR DESCRIPTION
Check in addition to the `sub` claim, if the `sid` is null and there are no realm roles or client roles in the token to cover the case of lightweight access token with transient session on the Admin Rest API.

Closes #32802
Closes #32896

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
