### PR TITLE
Redirect to relative-path from the root path

### DIFF
--- a/docs/documentation/release_notes/topics/26_0_0.adoc
+++ b/docs/documentation/release_notes/topics/26_0_0.adoc
@@ -120,6 +120,15 @@ The support is in preview mode, and we would be happy to obtain any feedback.
 
 For more information, see the link:{tracingguide_link}[{tracingguide_name}] guide.
 
+= Automatic redirect from root to relative path
+
+User is automatically redirected to the path where {project_name} is hosted when the `http-relative-path` property is specified.
+It means when the relative path is set to `/auth`, and the user access `localhost:8080/`, the page is redirected to `localhost:8080/auth`.
+
+The same applies to the management interface when the `http-management-relative-path` or `http-relative-path` property is specified.
+
+It improves user experience as users no longer need to set the relative path to the URL explicitly.
+
 = Removal of legacy cookies
 
 Keycloak no longer sends `_LEGACY` cookies, which where introduced as a work-around to older browsers not supporting

--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -36,6 +36,15 @@ to perform any cleanup or custom processing when a realm, and their groups, are 
 The `GroupProvider` interface is also updated with a new `preRemove(RealmModel)` method to force implementations to properly
 handle the removal of groups when a realm is removed.
 
+= Automatic redirect from root to relative path
+
+User is automatically redirected to the path where {project_name} is hosted when the `http-relative-path` property is specified.
+It means when the relative path is set to `/auth`, and the user access `localhost:8080/`, the page is redirected to `localhost:8080/auth`.
+
+The same applies to the management interface when the `http-management-relative-path` or `http-relative-path` property is specified.
+
+It improves user experience as users no longer need to set the relative path to the URL explicitly.
+
 = Operator scheduling defaults
 
 Keycloak Pods will now have default affinities to prevent multiple instances from the same CR from being deployed on the same node, and all Pods from the same CR will prefer to be in the same zone to prevent stretch cache clusters.

--- a/docs/guides/migration/migrating-to-quarkus.adoc
+++ b/docs/guides/migration/migrating-to-quarkus.adoc
@@ -62,6 +62,9 @@ By default, the new Quarkus distribution removes `/auth` from the context-path. 
 bin/kc.[sh|bat] start-dev --http-relative-path /auth
 ----
 
+When the relative path is specified, it is still possible to be redirected from the root to the relative path.
+Specifically, when the user access `localhost:8080/`, the page is redirected to the `localhost:8080/auth`.
+
 == Migrating custom providers
 
 Similarly to the WildFly distribution custom providers are deployed to Keycloak by copying them to a deployment directory. In the new distribution you should copy your providers to the `providers` directory instead of `standalone/deployments`, which no longer exists. Additional dependencies are also copied to the `providers` directory.

--- a/docs/guides/server/management-interface.adoc
+++ b/docs/guides/server/management-interface.adoc
@@ -16,19 +16,25 @@ The most significant advantage might be seen in Kubernetes environments as the s
 The management interface is turned on when something is exposed on it.
 Management endpoints such as `/metrics` and `/health` are exposed on the default management port `9000` when metrics and health are enabled.
 The management interface provides a set of options and is fully configurable.
-In order to change the port for the management interface, you can use the {project_name} option `http-management-port`.
 
 NOTE: If management interface properties are not explicitly set, their values are automatically inherited from the default HTTP server.
 
+=== Port
+In order to change the port for the management interface, you can use the {project_name} option `http-management-port`.
+
+=== Relative path
 You can change the relative path of the management interface, as the prefix path for the management endpoints can be different.
 You can achieve it via the {project_name} option `http-management-relative-path`.
 
 For instance, if you set the CLI option `--http-management-relative-path=/management`, the metrics, and health endpoints will be accessed on the `/management/metrics` and `/management/health` paths.
 
+User is automatically *redirected* to the path where {project_name} is hosted when the relative path is specified.
+It means when the relative path is set to `/management`, and the user access `localhost:9000/`, the page is redirected to `localhost:9000/management`.
+
 NOTE: If you do not explicitly set the value for it, the value from the `http-relative-path` property is used. For instance,
 if you set the CLI option `--http-relative-path=/auth`, these endpoints are accessible on the `/auth/metrics` and `/auth/health` paths.
 
-== TLS support
+=== TLS support
 
 When the TLS is set for the default {project_name} server, the management interface will be accessible through HTTPS as well.
 The management interface can run only either on HTTP or HTTPS, not both as for the main server.
@@ -36,7 +42,7 @@ The management interface can run only either on HTTP or HTTPS, not both as for t
 Specific {project_name} management interface options with the prefix `https-management-*` were provided for setting different TLS parameters for the management HTTP server. Their function is similar to their counterparts for the main HTTP server, for details see <@links.server id="enabletls" />.
 When these options are not explicitly set, the TLS parameters are inherited from the default HTTP server.
 
-== Disable Management interface
+=== Disable Management interface
 
 The management interface is automatically turned off when nothing is exposed on it.
 Currently, only health checks and metrics are exposed on the management interface regardless.

--- a/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakPathConfigurationTest.java
+++ b/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakPathConfigurationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 class KeycloakPathConfigurationTest {
 
@@ -98,11 +99,16 @@ class KeycloakPathConfigurationTest {
     }
 
     @Test
-    void testRootUnavailable() {
+    void testRootRedirect() {
+        given().basePath("/").redirects().follow(false)
+                .when().get("")
+                .then()
+                .statusCode(302)
+                .header("Location", is("/auth"));
+
         given().basePath("/")
                 .when().get("")
                 .then()
-                // application root is configured to /auth, so we expect 404 on /
-                .statusCode(404);
+                .statusCode(200);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -80,6 +80,11 @@ public class KeycloakRecorder {
         Profile.init(profileName, features);
     }
 
+    // default handler for redirecting to specific path
+    public Handler<RoutingContext> getRedirectHandler(String redirectPath) {
+        return routingContext -> routingContext.redirect(redirectPath);
+    }
+
     // default handler for the management interface
     public Handler<RoutingContext> getManagementHandler() {
         return routingContext -> routingContext.response().end("Keycloak Management Interface");


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/32863

Even though there's a slight change in the behavior, I'd consider it rather beneficial for users. I think we don't need to provide any flag to not redirect (like system prop). WDYT?