### PR TITLE
Implement invitation-only self-registration for realm users

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -103,7 +103,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         OrganizationAdapter adapter = new OrganizationAdapter(session, realm, this);
 
         try {
-            session.setAttribute(OrganizationModel.class.getName(), adapter);
+            session.getContext().setOrganization(adapter);
             GroupModel group = createOrganizationGroup(adapter.getId());
 
             adapter.setGroupId(group.getId());
@@ -113,7 +113,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
             em.persist(adapter.getEntity());
         } finally {
-            session.removeAttribute(OrganizationModel.class.getName());
+            session.getContext().setOrganization(null);
         }
 
         return adapter;
@@ -124,7 +124,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         OrganizationEntity entity = getEntity(organization.getId());
 
         try {
-            session.setAttribute(OrganizationModel.class.getName(), organization);
+            session.getContext().setOrganization(organization);
             RealmModel realm = session.realms().getRealm(getRealm().getId());
 
             // check if the realm is being removed so that we don't need to remove manually remove any other data but the org
@@ -143,7 +143,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
             em.remove(entity);
         } finally {
-            session.removeAttribute(OrganizationModel.class.getName());
+            session.getContext().setOrganization(null);
         }
 
         return true;
@@ -178,7 +178,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         }
 
         if (current == null) {
-            session.setAttribute(OrganizationModel.class.getName(), organization);
+            session.getContext().setOrganization(organization);
         }
 
         try {
@@ -191,7 +191,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
             user.joinGroup(group, metadata);
         } finally {
             if (current == null) {
-                session.removeAttribute(OrganizationModel.class.getName());
+                session.getContext().setOrganization(null);
             }
         }
 
@@ -417,14 +417,14 @@ public class JpaOrganizationProvider implements OrganizationProvider {
             OrganizationModel current = Organizations.resolveOrganization(session);
 
             if (current == null) {
-                session.setAttribute(OrganizationModel.class.getName(), organization);
+                session.getContext().setOrganization(organization);
             }
 
             try {
                 member.leaveGroup(getOrganizationGroup(organization));
             } finally {
                 if (current == null) {
-                    session.removeAttribute(OrganizationModel.class.getName());
+                    session.getContext().setOrganization(null);
                 }
             }
         }

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -142,9 +142,9 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
         }
 
         // add organization to the session as the following code updates the underlying group
-        OrganizationModel current = (OrganizationModel) session.getAttribute(OrganizationModel.class.getName());
+        OrganizationModel current = session.getContext().getOrganization();
         if (current == null) {
-            session.setAttribute(OrganizationModel.class.getName(), this);
+            session.getContext().setOrganization(this);
         }
 
         try {
@@ -154,7 +154,7 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
             attributes.forEach(group::setAttribute);
         } finally {
             if (current == null) {
-                session.removeAttribute(OrganizationModel.class.getName());
+                session.getContext().setOrganization(null);
             }
         }
     }

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -73,6 +73,10 @@ public interface KeycloakContext {
 
     void setClient(ClientModel client);
 
+    OrganizationModel getOrganization();
+
+    void setOrganization(OrganizationModel organization);
+
     ClientConnection getConnection();
 
     Locale resolveLocale(UserModel user);

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenHandler.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,6 +34,16 @@ import jakarta.ws.rs.core.Response;
  *  @author hmlnarik
  */
 public interface ActionTokenHandler<T extends JsonWebToken> extends Provider {
+
+    /**
+     * This method allows to parse the token and extract information from it after initial verification.
+     * @param token Token.
+     * @param tokenContext Token context.
+     * @return Error response if the initial verification fails, {@code null} otherwise.
+     */
+    default Response preHandleToken(T token, ActionTokenContext<T> tokenContext) {
+        return null;
+    }
 
     /**
      * Performs the action as per the token details. This method is only called if all verifiers

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/inviteorg/InviteOrgActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/inviteorg/InviteOrgActionTokenHandler.java
@@ -73,6 +73,26 @@ public class InviteOrgActionTokenHandler extends AbstractActionTokenHandler<Invi
     }
 
     @Override
+    public Response preHandleToken(InviteOrgActionToken token, ActionTokenContext<InviteOrgActionToken> tokenContext) {
+        KeycloakSession session = tokenContext.getSession();
+        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        AuthenticationSessionModel authSession = tokenContext.getAuthenticationSession();
+
+        OrganizationModel organization = orgProvider.getById(token.getOrgId());
+
+        if (organization == null) {
+            return session.getProvider(LoginFormsProvider.class)
+                    .setAuthenticationSession(authSession)
+                    .setInfo(Messages.ORG_NOT_FOUND, token.getOrgId())
+                    .createInfoPage();
+        }
+
+        session.getContext().setOrganization(organization);
+
+        return super.preHandleToken(token, tokenContext);
+    }
+
+    @Override
     public Response handleToken(InviteOrgActionToken token, ActionTokenContext<InviteOrgActionToken> tokenContext) {
         UserModel user = tokenContext.getAuthenticationSession().getAuthenticatedUser();
         KeycloakSession session = tokenContext.getSession();

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
@@ -72,6 +72,7 @@ public class RegistrationPage implements FormAuthenticator, FormAuthenticatorFac
 
                     form.setAttribute("messageHeader", Messages.REGISTER_ORGANIZATION_MEMBER);
                     form.setAttribute(OrganizationModel.ORGANIZATION_NAME_ATTRIBUTE, organization.getName());
+                    form.setAttribute(FIELD_EMAIL, token.getEmail());
                 }
             } catch (VerificationException e) {
                 return form.setError(Messages.EXPIRED_ACTION).createErrorPage(Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -317,7 +317,7 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
             }
 
             // make sure the organization is set to the session so that UP org-related validators can run
-            session.setAttribute(OrganizationModel.class.getName(), organization);
+            session.getContext().setOrganization(organization);
             session.setAttribute(InviteOrgActionToken.class.getName(), token);
 
             if (token.isExpired() || !token.getActionId().equals(InviteOrgActionToken.TOKEN_TYPE)) {

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -27,6 +27,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator;
+import org.keycloak.authentication.forms.RegistrationPage;
 import org.keycloak.authentication.requiredactions.util.UpdateProfileContext;
 import org.keycloak.authentication.requiredactions.util.UserUpdateProfileContext;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
@@ -645,6 +646,17 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 if (value == null || value.trim().isEmpty()) {
                     this.formData.putSingle("username", loginHint);
                 }
+            }
+        }
+
+        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+            String email = (String) attributes.get(RegistrationPage.FIELD_EMAIL);
+            if (this.formData == null) {
+                this.formData = new MultivaluedHashMap<>();
+            }
+            String value = this.formData.getFirst(RegistrationPage.FIELD_EMAIL);
+            if (value == null || value.trim().isEmpty()) {
+                this.formData.putSingle(RegistrationPage.FIELD_EMAIL, email);
             }
         }
 

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -78,10 +78,6 @@ public class OrganizationInvitationResource {
             return sendInvitation(user);
         }
 
-        if (!realm.isRegistrationAllowed()) {
-            throw ErrorResponse.error("Realm does not allow self-registration", Status.BAD_REQUEST);
-        }
-
         user = new InMemoryUserAdapter(session, realm, null);
         user.setEmail(email);
 

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
@@ -161,7 +161,7 @@ public class OrganizationsResource {
             throw ErrorResponse.error("Organization not found.", Response.Status.NOT_FOUND);
         }
 
-        session.setAttribute(OrganizationModel.class.getName(), organizationModel);
+        session.getContext().setOrganization(organizationModel);
 
         return new OrganizationResource(session, organizationModel, adminEvent);
     }

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -103,7 +103,7 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         }
 
         // make sure the organization is set to the session to make it available to templates
-        session.setAttribute(OrganizationModel.class.getName(), organization);
+        session.getContext().setOrganization(organization);
 
         if (tryRedirectBroker(context, organization, user, username, domain)) {
             return;

--- a/services/src/main/java/org/keycloak/organization/utils/Organizations.java
+++ b/services/src/main/java/org/keycloak/organization/utils/Organizations.java
@@ -122,15 +122,11 @@ public class Organizations {
             try {
                 OrganizationProvider provider = getProvider(session);
 
-                session.setAttribute(OrganizationModel.class.getName(), provider.getById(group.getName()));
+                session.getContext().setOrganization(provider.getById(group.getName()));
 
                 realm.removeGroup(group);
             } finally {
-                if (current == null) {
-                    session.removeAttribute(OrganizationModel.class.getName());
-                } else {
-                    session.setAttribute(OrganizationModel.class.getName(), current);
-                }
+                session.getContext().setOrganization(current);
             }
         };
     }
@@ -249,7 +245,7 @@ public class Organizations {
     }
 
     public static OrganizationModel resolveOrganization(KeycloakSession session, UserModel user, String domain) {
-        Optional<OrganizationModel> organization = Optional.ofNullable((OrganizationModel) session.getAttribute(OrganizationModel.class.getName()));
+        Optional<OrganizationModel> organization = Optional.ofNullable(session.getContext().getOrganization());
 
         if (organization.isPresent()) {
             // resolved from current keycloak session
@@ -296,5 +292,10 @@ public class Organizations {
 
     public static OrganizationProvider getProvider(KeycloakSession session) {
         return session.getProvider(OrganizationProvider.class);
+    }
+
+    public static boolean isRegistrationAllowed(KeycloakSession session, RealmModel realm) {
+        if (session.getContext().getOrganization() != null) return true;
+        return realm.isRegistrationAllowed();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -24,6 +24,7 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
@@ -153,9 +154,9 @@ public class OIDCLoginProtocolService {
      * Registration endpoint
      */
     @Path("registrations")
-    public Object registrations() {
+    public Object registrations(@QueryParam(Constants.TOKEN) String tokenString) {
         AuthorizationEndpoint endpoint = new AuthorizationEndpoint(session, event);
-        return endpoint.register();
+        return endpoint.register(tokenString);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -31,6 +31,7 @@ import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -206,11 +207,19 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         throw new RuntimeException("Unknown action " + action);
     }
 
-    public AuthorizationEndpoint register() {
+    public AuthorizationEndpoint register(String tokenString) {
         event.event(EventType.REGISTER);
         action = Action.REGISTER;
 
-        if (!realm.isRegistrationAllowed()) {
+        if (Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION)) {
+            //this call should extract orgId from token and set the organization to the session context
+            Response errorResponse = new LoginActionsService(session, event).preHandleActionToken(tokenString);
+            if (errorResponse != null) {
+                throw new ErrorPageException(errorResponse);
+            }
+        }
+
+        if (!Organizations.isRegistrationAllowed(session, realm)) {
             throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.REGISTRATION_NOT_ALLOWED);
         }
 

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -26,6 +26,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakUriInfo;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -44,6 +45,8 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     private RealmModel realm;
 
     private ClientModel client;
+
+    private OrganizationModel organization;
 
     protected KeycloakSession session;
 
@@ -115,6 +118,16 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public void setClient(ClientModel client) {
         this.client = client;
+    }
+
+    @Override
+    public OrganizationModel getOrganization() {
+        return organization;
+    }
+
+    @Override
+    public void setOrganization(OrganizationModel organization) {
+        this.organization = organization;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -29,10 +29,11 @@ import jakarta.ws.rs.core.Response;
 public class ErrorPageException extends WebApplicationException {
 
     private final KeycloakSession session;
-    private Response.Status status;
+    private final Response.Status status;
     private final String errorMessage;
     private final Object[] parameters;
     private final AuthenticationSessionModel authSession;
+    private final Response response;
 
     
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
@@ -42,6 +43,7 @@ public class ErrorPageException extends WebApplicationException {
         this.errorMessage = errorMessage;
         this.parameters = parameters;
         this.authSession = null;
+        this.response = null;
     }
     
     public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, Response.Status status, String errorMessage, Object... parameters) {
@@ -50,13 +52,20 @@ public class ErrorPageException extends WebApplicationException {
         this.errorMessage = errorMessage;
         this.parameters = parameters;
         this.authSession = authSession;
+        this.response = null;
     }
 
-
+    public ErrorPageException(Response response) {
+        this.session = null;
+        this.status = null;
+        this.errorMessage = null;
+        this.parameters = null;
+        this.authSession = null;
+        this.response = response;
+    }
 
     @Override
     public Response getResponse() {
-        return ErrorPage.error(session, authSession, status, errorMessage, parameters);
+        return response != null ? response : ErrorPage.error(session, authSession, status, errorMessage, parameters);
     }
-
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
@@ -202,4 +202,9 @@ public class RealmAttributeUpdater extends ServerResourceUpdater<RealmAttributeU
         rep.setOrganizationsEnabled(organizationsEnabled);
         return this;
     }
+
+    public RealmAttributeUpdater setRegistrationAllowed(Boolean registrationAllowed) {
+        rep.setRegistrationAllowed(registrationAllowed);
+        return this;
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -20,7 +20,7 @@ package org.keycloak.testsuite.organization.admin;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -32,9 +32,8 @@ import java.util.function.Predicate;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
+import java.time.Duration;
 import org.hamcrest.Matchers;
-import static org.hamcrest.Matchers.equalTo;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +41,6 @@ import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.util.UriUtils;
 import org.keycloak.cookie.CookieType;
-import org.keycloak.representations.idm.ErrorRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.MembershipType;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -53,6 +51,7 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.pages.InfoPage;
 import org.keycloak.testsuite.pages.RegisterPage;
+import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.GreenMailRule;
 import org.keycloak.testsuite.util.MailUtils;
 import org.keycloak.testsuite.util.MailUtils.EmailBody;
@@ -127,19 +126,25 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
     }
 
     @Test
-    public void testFailRegistrationNotEnabledWhenInvitingNewUser() {
+    public void testRegistrationEnabledWhenInvitingNewUser() throws Exception {
         String email = "inviteduser@email";
 
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
-        RealmRepresentation realm = testRealm().toRepresentation();
-        realm.setRegistrationAllowed(false);
-        testRealm().update(realm);
-        try (Response response = organization.members().inviteUser(email, null, null)) {
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-            assertEquals("Realm does not allow self-registration", response.readEntity(ErrorRepresentation.class).getErrorMessage());
-        } finally {
-            realm.setRegistrationAllowed(true);
-            testRealm().update(realm);
+        try (
+                RealmAttributeUpdater rau = new RealmAttributeUpdater(testRealm()).setRegistrationAllowed(Boolean.TRUE).update(); 
+                Response response = organization.members().inviteUser(email, null, null)
+            ) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            registerUser(organization, email);
+
+            // authenticated to the account console
+            Assert.assertTrue(driver.getPageSource().contains("Account Management"));
+            Assert.assertNotNull(driver.manage().getCookieNamed(CookieType.IDENTITY.getName()));
+
+            List<MemberRepresentation> memberByEmail = organization.members().search(email, Boolean.TRUE, null, null);
+            assertThat(memberByEmail, Matchers.hasSize(1));
+            assertThat(memberByEmail.get(0).getMembershipType(), equalTo(MembershipType.MANAGED));
         }
     }
 
@@ -150,7 +155,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         organization.members().inviteUser(email, null, null).close();
 
-        registerUser(organization, "invalid@email.com");
+        registerUser(organization, email, "invalid@email.com");
 
         assertThat(driver.getPageSource(), Matchers.containsString("Email does not match the invitation"));
         assertThat(testRealm().users().searchByEmail(email, true), Matchers.empty());
@@ -203,9 +208,10 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         try {
             setTimeOffset((int) TimeUnit.DAYS.toSeconds(1));
 
-            registerUser(organization, email);
+            String link = getInvitationLinkFromEmail();
+            driver.navigate().to(link);
 
-            assertThat(driver.getPageSource(), Matchers.containsString("The provided token is not valid or has expired."));
+            assertThat(driver.getPageSource(), Matchers.containsString("Action expired."));
             assertThat(testRealm().users().searchByEmail(email, true), Matchers.empty());
         } finally {
             resetTimeOffset();
@@ -213,11 +219,16 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
     }
 
     private void registerUser(OrganizationResource organization, String email) throws MessagingException, IOException {
+        registerUser(organization, email, email);
+    }
+
+    private void registerUser(OrganizationResource organization, String expectedEmail, String email) throws MessagingException, IOException {
         String link = getInvitationLinkFromEmail();
         driver.navigate().to(link);
         Assert.assertFalse(organization.members().getAll().stream().anyMatch(actual -> email.equals(actual.getEmail())));
         registerPage.assertCurrent(organizationName);
-        driver.manage().timeouts().pageLoadTimeout(1, TimeUnit.DAYS);
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
+        assertThat(registerPage.getEmail(), equalTo(expectedEmail));
         registerPage.register("firstName", "lastName", email,
                 "invitedUser", "password", "password", null, false, null);
     }


### PR DESCRIPTION
Closes #31643

- adds access to `OrganizationModel` to session context
- adds possibility to pre-handle action token to be able to extract required information from it without actually handling it
- pre-fills email for invited user via registration link
