### PR TITLE
Improve error message when wrong KC profile is set

### DIFF
--- a/common/src/main/java/org/keycloak/common/profile/PropertiesProfileConfigResolver.java
+++ b/common/src/main/java/org/keycloak/common/profile/PropertiesProfileConfigResolver.java
@@ -21,7 +21,15 @@ public class PropertiesProfileConfigResolver implements ProfileConfigResolver {
     @Override
     public Profile.ProfileName getProfileName() {
         String profile = getter.apply("keycloak.profile");
-        return profile != null ? Profile.ProfileName.valueOf(profile.toUpperCase()) : null;
+
+        if (profile != null) {
+            try {
+                return Profile.ProfileName.valueOf(profile.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new ProfileException(String.format("Invalid profile '%s' specified via 'keycloak.profile' property", profile));
+            }
+        }
+        return null;
     }
 
     @Override

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -85,11 +85,9 @@ public class ProfileTest {
         Properties properties = new Properties();
         properties.setProperty("keycloak.profile.feature.account_api", "disabled");
 
-        try {
-            Profile.configure(new PropertiesProfileConfigResolver(properties));
-        } catch (ProfileException e) {
-            Assert.assertEquals("Feature account3 depends on disabled feature account-api", e.getMessage());
-        }
+        Assert.assertEquals("Feature account3 depends on disabled feature account-api",
+                assertThrows(ProfileException.class,
+                        () -> Profile.configure(new PropertiesProfileConfigResolver(properties))).getMessage());
     }
 
     @Test
@@ -107,11 +105,19 @@ public class ProfileTest {
         Properties properties = new Properties();
         properties.setProperty("keycloak.profile.feature.account_api", "invalid");
 
-        try {
-            Profile.configure(new PropertiesProfileConfigResolver(properties));
-        } catch (ProfileException e) {
-            Assert.assertEquals("Invalid config value 'invalid' for feature key keycloak.profile.feature.account_api", e.getMessage());
-        }
+        Assert.assertEquals("Invalid config value 'invalid' for feature key keycloak.profile.feature.account_api",
+                assertThrows(ProfileException.class,
+                        () -> Profile.configure(new PropertiesProfileConfigResolver(properties))).getMessage());
+    }
+
+    @Test
+    public void wrongProfileInProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("keycloak.profile", "experimental");
+
+        Assert.assertEquals("Invalid profile 'experimental' specified via 'keycloak.profile' property",
+                assertThrows(ProfileException.class,
+                        () -> Profile.configure(new PropertiesProfileConfigResolver(properties))).getMessage());
     }
 
     @Test


### PR DESCRIPTION
- Closes #30454

@abstractj @shawkins Could you please check this small PR?

The error message during the startup looks like this now:
```
ERROR: Invalid profile 'experimental' specified via 'keycloak.profile' property
```