### PR TITLE
Allow URIs without a hostname in KeycloakUriBuilder

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -458,13 +458,15 @@ public class KeycloakUriBuilder {
             buffer.append(ssp);
         } else if (userInfo != null || host != null || port != -1) {
             buffer.append("//");
-            if (userInfo != null)
+            if (userInfo != null) {
+                if (host == null || host.isEmpty()) throw new RuntimeException("empty host name, but userInfo supplied");
                 replaceUserInfoParameter(paramMap, fromEncodedMap, isTemplate, userInfo, buffer).append("@");
+            }
             if (host != null) {
-                if ("".equals(host)) throw new RuntimeException("empty host name");
                 replaceParameter(paramMap, fromEncodedMap, isTemplate, host, buffer, encodeSlash);
             }
             if (port != -1 && (preserveDefaultPort || !(("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443)))) {
+                if (host == null || host.isEmpty()) throw new RuntimeException("empty host name, but port supplied");
                 buffer.append(":").append(Integer.toString(port));
             }
         } else if (authority != null) {

--- a/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
+++ b/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
@@ -92,4 +92,10 @@ public class KeycloakUriBuilderTest {
         Assert.assertEquals("https://user-info%E2%82%AC@localhost:8443", KeycloakUriBuilder.fromUri(
                 "https://user-info€@localhost:8443", false).buildAsString());
     }
+
+    @Test
+    public void testEmptyHostname() {
+        Assert.assertEquals("app.immich:///oauth-callback", KeycloakUriBuilder.fromUri(
+                "app.immich:///oauth-callback").buildAsString());
+    }
 }


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

While according to the [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3), empty hostnames / authority sections are allowed, the KeycloakUriBuilder did not allow these. These lead to issues with redirect uris without a Hostname, for example `immich.app:///oauth-redirect`. This PR allows URIs without a hostname.

This PR fixes #32623