### PR TITLE
Upgrade to Quarkus 3.14.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.14.2</quarkus.version>
-        <quarkus.build.version>3.14.2</quarkus.build.version>
+        <quarkus.version>3.14.4</quarkus.version>
+        <quarkus.build.version>3.14.4</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 
@@ -92,7 +92,7 @@
         <bouncycastle.bctls-fips.version>1.0.19</bouncycastle.bctls-fips.version>
 
         <dom4j.version>2.1.3</dom4j.version>
-        <h2.version>2.3.232</h2.version>
+        <h2.version>2.3.230</h2.version>
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
         <hibernate.c3p0.version>6.2.13.Final</hibernate.c3p0.version>
         <infinispan.version>15.0.8.Final</infinispan.version>


### PR DESCRIPTION
Closes #32970
Closes #32784

Quarkus [downgraded](https://github.com/quarkusio/quarkus/commit/cc815f2f60b91d87bae751e08007c1ad7c2e88b3) H2 for now. The actual H2 issue is tracked at:  https://github.com/h2database/h2database/issues/4123.

~~We could also keep #32785 open to track our "incompatibility" with 2.3.232 on Keycloak side too. WDYT?~~
Decoupled this from #32785.