### PR TITLE
Fix amr test

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthenticationMethodReferenceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthenticationMethodReferenceTest.java
@@ -288,13 +288,13 @@ public class AuthenticationMethodReferenceTest extends AbstractOIDCScopeTest{
      */
     @Test
     public void testAmrPastMaxAge() {
-        setAmr("browser", "auth-username-password-form", "password", 0);
+        setAmr("browser", "auth-username-password-form", "password", 10);
 
         List<String> expectedAmrs = new ArrayList<>();
         authenticatePassword("test-user", PASSWORD);
 
-        // server time forward by 60 seconds to ensure max age is exceeded
-        setTimeOffset(60);
+        // server time forward by 20 seconds to ensure max age is exceeded
+        setTimeOffset(20);
 
         Tokens tokens = assertLogin(passwordUserId);
 


### PR DESCRIPTION
Closes #26117

Sometimes the 60 second time offset exceeded the default Client Login Timeout (1 min) by 1 ms.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
