### PR TITLE
BACKPORT: Avoid NPE if realm configuration contains invalid required action configuration (#32649)

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AuthenticationManagementResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AuthenticationManagementResource.java
@@ -18,6 +18,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.admin.ui.rest.model.Authentication;
 import org.keycloak.admin.ui.rest.model.AuthenticationMapper;
@@ -37,6 +38,9 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluato
 
 
 public class AuthenticationManagementResource extends RoleMappingResource {
+
+    private static final Logger logger = Logger.getLogger(AuthenticationManagementResource.class);
+
     public AuthenticationManagementResource(KeycloakSession session, RealmModel realm, AdminPermissionEvaluator auth) {
         super(session, realm, auth);
     }
@@ -145,7 +149,12 @@ public class AuthenticationManagementResource extends RoleMappingResource {
         rep.setConfig(model.getConfig());
 
         RequiredActionFactory factory = (RequiredActionFactory)session.getKeycloakSessionFactory().getProviderFactory(RequiredActionProvider.class, model.getProviderId());
-        rep.setConfigurable(factory.isConfigurable());
+        if (factory != null) {
+            rep.setConfigurable(factory.isConfigurable());
+        } else {
+            logger.warnv("Detected RequiredAction with missing provider. realm={0}, alias={1}, providerId={2}",
+                    realm.getName(), model.getAlias(), model.getProviderId());
+        }
 
         return rep;
     }


### PR DESCRIPTION
* Avoid NPE if realm configuration contains invalid required action configuration

If users removed implementations or renamed the provider id of a required action, then the realm configuration might contain dangling references to required actions.
If we then try to find the RequiredActionFactory to determine the if the required action is configurable then NPE is thrown. This PR prevents the NPE with a guard clause.

Fixes #32624

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

* Log a warning if required action with missing provider is detected.

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

---------

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>
(cherry picked from commit d28adcb81bc41d8ddd2aae11eaafae8846c6f5be)
