### PR TITLE
Fix flaky UserSessionPersisterProviderTest

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -32,6 +32,7 @@ import org.keycloak.models.session.PersistentClientSessionModel;
 import org.keycloak.models.session.PersistentUserSessionAdapter;
 import org.keycloak.models.session.PersistentUserSessionModel;
 import org.keycloak.models.session.UserSessionPersisterProvider;
+import org.keycloak.models.utils.SessionExpirationUtils;
 import org.keycloak.models.utils.SessionTimeoutHelper;
 import org.keycloak.storage.StorageId;
 
@@ -269,9 +270,9 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
     private int calculateOldestSessionTime(RealmModel realm, boolean offline) {
         if (offline) {
-            return Time.currentTime() - realm.getOfflineSessionIdleTimeout();
+            return Time.currentTime() - SessionExpirationUtils.getOfflineSessionIdleTimeout(realm);
         } else {
-            return Time.currentTime() - Math.max(realm.getSsoSessionIdleTimeout(), realm.getSsoSessionIdleTimeoutRememberMe());
+            return Time.currentTime() - Math.max(SessionExpirationUtils.getSsoSessionIdleTimeout(realm), realm.getSsoSessionIdleTimeoutRememberMe());
         }
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
@@ -185,7 +185,7 @@ public class SessionExpirationUtils {
         return lifespan;
     }
 
-    private static int getSsoSessionIdleTimeout(RealmModel realm) {
+    public static int getSsoSessionIdleTimeout(RealmModel realm) {
         int idle = realm.getSsoSessionIdleTimeout();
         if (idle <= 0) {
             idle = Constants.DEFAULT_SESSION_IDLE_TIMEOUT;
@@ -193,7 +193,7 @@ public class SessionExpirationUtils {
         return idle;
     }
 
-    private static int getOfflineSessionIdleTimeout(RealmModel realm) {
+    public static int getOfflineSessionIdleTimeout(RealmModel realm) {
         int idle = realm.getOfflineSessionIdleTimeout();
         if (idle <= 0) {
             idle = Constants.DEFAULT_OFFLINE_SESSION_IDLE_TIMEOUT;

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
@@ -30,9 +30,11 @@ import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionPr
 import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionSpi;
 import org.keycloak.connections.jpa.updater.liquibase.lock.LiquibaseDBLockProviderFactory;
 import org.keycloak.events.jpa.JpaEventStoreProviderFactory;
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.migration.MigrationProviderFactory;
 import org.keycloak.migration.MigrationSpi;
 import org.keycloak.models.IdentityProviderStorageSpi;
+import org.keycloak.models.UserSessionSpi;
 import org.keycloak.models.dblock.DBLockSpi;
 import org.keycloak.models.jpa.JpaClientProviderFactory;
 import org.keycloak.models.jpa.JpaClientScopeProviderFactory;
@@ -138,5 +140,13 @@ public class Jpa extends KeycloakModelParameters {
           .spi("deploymentState").defaultProvider("jpa")
           .spi("dblock").defaultProvider("jpa")
         ;
+// Use this for running model tests with Postgres database
+//        cf.spi("connectionsJpa")
+//                .provider("default")
+//                .config("url", "jdbc:postgresql://localhost:5432/keycloakDB")
+//                .config("user", "keycloak")
+//                .config("password", "pass")
+//                .config("driver", "org.postgresql.Driver");
+//
     }
 }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import org.keycloak.models.Constants;
@@ -83,6 +84,8 @@ public class UserSessionPersisterProviderTest extends KeycloakModelTest {
     public void createEnvironment(KeycloakSession s) {
         RealmModel realm = createRealm(s, "test");
         s.getContext().setRealm(realm);
+        realm.setSsoSessionMaxLifespan(Constants.DEFAULT_SESSION_MAX_LIFESPAN);
+        realm.setSsoSessionIdleTimeout(Constants.DEFAULT_SESSION_IDLE_TIMEOUT);
         realm.setOfflineSessionIdleTimeout(Constants.DEFAULT_OFFLINE_SESSION_IDLE_TIMEOUT);
         realm.setOfflineSessionMaxLifespan(Constants.DEFAULT_OFFLINE_SESSION_MAX_LIFESPAN);
         realm.setDefaultRole(s.roles().addRealmRole(realm, Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + realm.getName()));
@@ -281,6 +284,7 @@ public class UserSessionPersisterProviderTest extends KeycloakModelTest {
             RealmModel fooRealm = session.realms().getRealmByName("foo");
             session.getContext().setRealm(fooRealm);
             UserSessionModel userSession = session.sessions().getUserSession(fooRealm, userSessionID.get());
+            assertNotNull(userSession);
             persistUserSession(session, userSession, true);
         });
 


### PR DESCRIPTION
Closes #32892

This was introduced with this change: #32273 

The addition of the condition on lastSessionRefresh sometimes excluded the correct session from the query result because the test did not set maxLifespan and therefore sessions were searched with the current time as lastSessionRefresh which sometimes failed.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
