### PR TITLE
Sort the IDPs in the admin console admin and organization tables by alias (#32999)

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/IdentityProvidersSection.tsx
+++ b/js/apps/admin-ui/src/identity-providers/IdentityProvidersSection.tsx
@@ -109,7 +109,7 @@ export default function IdentityProvidersSection() {
       params.search = search;
     }
     const providers = await adminClient.identityProviders.find(params);
-    return sortBy(providers, ["config.guiOrder", "alias"]);
+    return sortBy(providers, "alias");
   };
 
   const navigateToCreate = (providerId: string) =>

--- a/js/apps/admin-ui/src/organizations/IdentityProviders.tsx
+++ b/js/apps/admin-ui/src/organizations/IdentityProviders.tsx
@@ -6,6 +6,7 @@ import {
   Switch,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { sortBy } from "lodash-es";
 import { BellIcon } from "@patternfly/react-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -85,8 +86,12 @@ export const IdentityProviders = () => {
     [],
   );
 
-  const loader = () =>
-    adminClient.organizations.listIdentityProviders({ orgId: orgId! });
+  const loader = async () => {
+    const providers = await adminClient.organizations.listIdentityProviders({
+      orgId: orgId!,
+    });
+    return sortBy(providers, "alias");
+  };
 
   const [toggleUnlinkDialog, UnlinkConfirm] = useConfirmDialog({
     titleKey: "identityProviderUnlink",


### PR DESCRIPTION
- prevent issues when ordering by guiOrder due to pagination of results

Closes #32669

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit 6503d202ac9994a5ea6dafc0f800b1a5f1fd8e76)
