### PR TITLE
Calculating the correct Expected Destination Path for SAML IDP-initiated SSO flow.

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -814,7 +814,7 @@ public class SAMLEndpoint {
 
         private String getExpectedDestination(String providerAlias, String clientId) {
             if(clientId != null) {
-                return session.getContext().getUri().getAbsolutePath().toString();
+                return Urls.identityProviderAuthnResponse(session.getContext().getUri().getBaseUri(), providerAlias, realm.getName(), clientId).toString();
             }
             return Urls.identityProviderAuthnResponse(session.getContext().getUri().getBaseUri(), providerAlias, realm.getName()).toString();
         }

--- a/services/src/main/java/org/keycloak/services/Urls.java
+++ b/services/src/main/java/org/keycloak/services/Urls.java
@@ -18,6 +18,7 @@ package org.keycloak.services;
 
 import org.keycloak.common.Version;
 import org.keycloak.models.Constants;
+import org.keycloak.broker.saml.SAMLEndpoint;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.endpoints.LogoutEndpoint;
@@ -51,6 +52,13 @@ public class Urls {
         return realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
                 .path(IdentityBrokerService.class, "getEndpoint")
                 .build(realmName, providerAlias);
+    }
+
+    public static URI identityProviderAuthnResponse(URI baseUri, String providerAlias, String realmName, String client_id) {
+        return realmBase(baseUri).path(RealmsResource.class, "getBrokerService")
+                .path(IdentityBrokerService.class, "getEndpoint")
+                .path(SAMLEndpoint.class, "redirectBindingIdpInitiated")
+                .build(realmName, providerAlias, client_id);
     }
 
     public static URI identityProviderAuthnRequest(URI baseUri, String providerAlias, String realmName, String accessCode, String clientId, String tabId, String clientData, String loginHint) {


### PR DESCRIPTION
fixes https://github.com/keycloak/keycloak/issues/32622

The expected Destination Path needs to properly point to the client that is created for IDP-initiated SSO flow. This is especially an issue when Keycloak is behind a reverse proxy that terminates TLS.

No Tests are impacted with this change.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
