### PR TITLE
Fix errors when code, clientId, or tabId are null

### DIFF
--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -28,44 +28,15 @@ import jakarta.ws.rs.core.Response;
  */
 public class ErrorPageException extends WebApplicationException {
 
-    private final KeycloakSession session;
-    private final Response.Status status;
-    private final String errorMessage;
-    private final Object[] parameters;
-    private final AuthenticationSessionModel authSession;
-    private final Response response;
-
-    
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
-        super(errorMessage, status);
-        this.session = session;
-        this.status = status;
-        this.errorMessage = errorMessage;
-        this.parameters = parameters;
-        this.authSession = null;
-        this.response = null;
+        super(errorMessage, ErrorPage.error(session, null, status, errorMessage, parameters));
     }
-    
+
     public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, Response.Status status, String errorMessage, Object... parameters) {
-        this.session = session;
-        this.status = status;
-        this.errorMessage = errorMessage;
-        this.parameters = parameters;
-        this.authSession = authSession;
-        this.response = null;
+        super(errorMessage, ErrorPage.error(session, authSession, status, errorMessage, parameters));
     }
 
     public ErrorPageException(Response response) {
-        this.session = null;
-        this.status = null;
-        this.errorMessage = null;
-        this.parameters = null;
-        this.authSession = null;
-        this.response = response;
-    }
-
-    @Override
-    public Response getResponse() {
-        return response != null ? response : ErrorPage.error(session, authSession, status, errorMessage, parameters);
+        super((Throwable) null, response);
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -404,6 +404,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 }
                 return response;
             }
+        } catch (WebApplicationException e) {
+            return e.getResponse();
         } catch (IdentityBrokerException e) {
             return redirectToErrorPage(Response.Status.BAD_GATEWAY, Messages.COULD_NOT_SEND_AUTHENTICATION_REQUEST, e, providerAlias);
         } catch (Exception e) {


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/33232

Calling `parseSessionCode` inside the try-catch would result in `ErrorPageException` thrown by `redirectToErrorPage` being caught and re-reported, resulting in one log entry with `invalidRequestMessage` and another one with `unexpectedErrorHandlingRequestMessage`:
```
Sep 19, 2024 1:40:53 PM org.keycloak.services.resources.IdentityBrokerService fireErrorEvent
ERROR: invalidRequestMessage
Sep 19, 2024 1:40:53 PM org.keycloak.services.resources.IdentityBrokerService fireErrorEvent
ERROR: unexpectedErrorHandlingRequestMessage: org.keycloak.services.ErrorPageException: HTTP 500 Internal Server Error
```

Additionally, two of `ErrorPageException` constructors didn't pass the status to `super()`, resulting in the logger error message being "HTTP 500 Internal Server Error" even though the status was actually something else, like 400. I noticed that `ErrorPageException` can be simplified by just passing the response to `super()`, which is one way of fixing the problem.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
