### PR TITLE
Allow certificate with duplicate principals in truststore.

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/truststore/TruststoreProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/truststore/TruststoreProvider.java
@@ -22,6 +22,7 @@ import org.keycloak.provider.Provider;
 
 import java.security.cert.X509Certificate;
 import java.security.KeyStore;
+import java.util.List;
 import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 import javax.security.auth.x500.X500Principal;
@@ -40,10 +41,10 @@ public interface TruststoreProvider extends Provider {
     /**
      * @return root certificates from the configured truststore as a map where the key is the X500Principal of the corresponding X509Certificate
      */
-    Map<X500Principal, X509Certificate> getRootCertificates();
+    Map<X500Principal, List<X509Certificate>> getRootCertificates();
 
     /**
      * @return intermediate certificates from the configured truststore as a map where the key is the X500Principal of the corresponding X509Certificate
      */
-    Map<X500Principal, X509Certificate> getIntermediateCertificates();
+    Map<X500Principal, List<X509Certificate>> getIntermediateCertificates();
 }

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
@@ -10,6 +10,7 @@ import org.keycloak.truststore.TruststoreProviderFactory;
 import java.security.cert.X509Certificate;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * The factory and the corresponding providers extract a client certificate
@@ -84,8 +85,11 @@ public class NginxProxySslClientCertificateLookupFactory extends AbstractClientC
             TruststoreProvider provider = truststoreFactory.create(kcSession);
 
             if (provider != null && provider.getTruststore() != null) {
-                trustedRootCerts.addAll(provider.getRootCertificates().values());
-                intermediateCerts.addAll(provider.getIntermediateCertificates().values());
+                Set<X509Certificate> rootCertificates = provider.getRootCertificates().entrySet().stream().flatMap(t -> t.getValue().stream()).collect(Collectors.toSet());
+                Set<X509Certificate> intermediateCertficiates = provider.getIntermediateCertificates().entrySet().stream().flatMap(t -> t.getValue().stream()).collect(Collectors.toSet());
+
+                trustedRootCerts.addAll(rootCertificates);
+                intermediateCerts.addAll(intermediateCertficiates);
                 logger.debug("Keycloak truststore loaded for NGINX x509cert-lookup provider.");
 
                 isTruststoreLoaded = true;

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProvider.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProvider.java
@@ -21,6 +21,7 @@ import org.keycloak.common.enums.HostnameVerificationPolicy;
 
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 import javax.security.auth.x500.X500Principal;
@@ -33,10 +34,10 @@ public class FileTruststoreProvider implements TruststoreProvider {
     private final HostnameVerificationPolicy policy;
     private final SSLSocketFactory sslSocketFactory;
     private final KeyStore truststore;
-    private final Map<X500Principal, X509Certificate> rootCertificates;
-    private final Map<X500Principal, X509Certificate> intermediateCertificates;
+    private final Map<X500Principal, List<X509Certificate>> rootCertificates;
+    private final Map<X500Principal, List<X509Certificate>> intermediateCertificates;
 
-    public FileTruststoreProvider(KeyStore truststore, HostnameVerificationPolicy policy, Map<X500Principal, X509Certificate> rootCertificates, Map<X500Principal, X509Certificate> intermediateCertificates) {
+    public FileTruststoreProvider(KeyStore truststore, HostnameVerificationPolicy policy, Map<X500Principal, List<X509Certificate>> rootCertificates,Map<X500Principal, List<X509Certificate>> intermediateCertificates) {
         this.policy = policy;
         this.truststore = truststore;
         this.rootCertificates = rootCertificates;
@@ -62,12 +63,12 @@ public class FileTruststoreProvider implements TruststoreProvider {
     }
 
     @Override
-    public Map<X500Principal, X509Certificate> getRootCertificates() {
+    public Map<X500Principal, List<X509Certificate>> getRootCertificates() {
         return rootCertificates;
     }
 
     @Override
-    public Map<X500Principal, X509Certificate> getIntermediateCertificates() {
+    public Map<X500Principal, List<X509Certificate>> getIntermediateCertificates() {
         return intermediateCertificates;
     }
 

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
@@ -37,6 +37,7 @@ import java.security.SignatureException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -176,8 +177,8 @@ public class FileTruststoreProviderFactory implements TruststoreProviderFactory 
 
     private static class TruststoreCertificatesLoader {
 
-        private Map<X500Principal, X509Certificate> trustedRootCerts = new HashMap<>();
-        private Map<X500Principal, X509Certificate> intermediateCerts = new HashMap<>();
+        private Map<X500Principal, List<X509Certificate>> trustedRootCerts = new HashMap<>();
+        private Map<X500Principal, List<X509Certificate>> intermediateCerts = new HashMap<>();
 
 
         public TruststoreCertificatesLoader(KeyStore truststore) {
@@ -213,11 +214,21 @@ public class FileTruststoreProviderFactory implements TruststoreProviderFactory 
                     X509Certificate cax509cert = (X509Certificate) certificate;
                     if (isSelfSigned(cax509cert)) {
                         X500Principal principal = cax509cert.getSubjectX500Principal();
-                        trustedRootCerts.put(principal, cax509cert);
+                        List<X509Certificate> certs = trustedRootCerts.get(principal);
+                        if (certs == null) {
+                            certs = new ArrayList<>();
+                            trustedRootCerts.put(principal, certs);
+                        }
+                        certs.add(cax509cert);
                         log.debug("Trusted root CA found in truststore : alias : " + alias + " | Subject DN : " + principal);
                     } else {
                         X500Principal principal = cax509cert.getSubjectX500Principal();
-                        intermediateCerts.put(principal, cax509cert);
+                        List<X509Certificate> certs = intermediateCerts.get(principal);
+                        if (certs == null) {
+                            certs = new ArrayList<>();
+                            intermediateCerts.put(principal, certs);
+                        }
+                        certs.add(cax509cert);
                         log.debug("Intermediate CA found in truststore : alias : " + alias + " | Subject DN : " + principal);
                     }
                 } else


### PR DESCRIPTION
The previous implementation uses principal as a key for a hashmap. This change uses the certificate alias as the key. Alias is guaranteed to be unique vice the principal name which is only unique in combination with the public key.

Closes #33125
