### PR TITLE
Add client certificate lookup for Envoy proxy

### DIFF
--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -203,6 +203,9 @@ The server supports some of the most commons TLS termination proxies such as:
 
 |rfc9440
 |Proxies that are compliant to link:https://datatracker.ietf.org/doc/rfc9440/[RFC 9440]
+
+|Envoy
+|envoy
 |===
 
 To configure how client certificates are retrieved from the requests you need to:
@@ -289,6 +292,11 @@ Traefik sends the client certificate and any intermediate CA certificates as PEM
 The `traefik` provider parses all certificates from this header.
 
 Other than possibly changing the `certificate-chain-length`, you do not need to configure additional options for the `traefik` provider.
+
+=== Configuring the Envoy provider
+
+The Envoy provider will automatically retrieve the client certificate and optional certificate chain from the `x-forwarded-client-cert` header.
+You do not need to configure additional options for the `envoy` provider.
 
 [[graceful-http-shutdown]]
 == Graceful HTTP shutdown

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -204,8 +204,8 @@ The server supports some of the most commons TLS termination proxies such as:
 |rfc9440
 |Proxies that are compliant to link:https://datatracker.ietf.org/doc/rfc9440/[RFC 9440]
 
-|Envoy
 |envoy
+|Envoy
 |===
 
 To configure how client certificates are retrieved from the requests you need to:
@@ -227,7 +227,7 @@ Common options for configuring providers are:
 
 |ssl-client-cert
 | The name of the header holding the client certificate
-| all but `traefik`, optional for `rfc9440`
+| all but `traefik` and `envoy`, optional for `rfc9440`
 
 |ssl-cert-chain-prefix
 | The prefix of the headers holding additional certificates in the chain and used to retrieve individual
@@ -237,7 +237,7 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 
 |certificate-chain-length
 | The maximum length of the certificate chain beyond the client certificate
-| all (defaults to 1)
+| all but `envoy` (defaults to 1)
 
 |===
 

--- a/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookup.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.x509;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+import java.util.StringTokenizer;
+
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.http.HttpRequest;
+
+public class EnvoyProxySslClientCertificateLookup implements X509ClientCertificateLookup {
+
+    protected final static String XFCC_HEADER = "x-forwarded-client-cert";
+    protected final static String XFCC_HEADER_CERT_KEY = "Cert";
+    protected final static String XFCC_HEADER_CHAIN_KEY = "Chain";
+
+    @Override
+    public void close() {
+    }
+
+
+    /**
+     * Extracts the client certificate chain from the HTTP request forwarded by Envoy.
+     *
+     * Envoy encodes the client certificate and the certificate chain in the  header in following format:
+     *
+     *   x-forwarded-client-cert: key1="url encoded value 1";key2="url encoded value 2";...
+     *
+     * Following keys are supported by this implementation:
+     *
+     * 1. Cert - The entire client certificate in URL encoded PEM format.
+     * 2. Chain - The entire client certificate chain (including the leaf certificate) in URL encoded PEM format.
+     *
+     * For Envoy documentation, see
+     * https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
+     *
+     * @param httpRequest The HTTP request forwarded by Envoy.
+     * @return The client certificate chain extracted from the HTTP request.
+     */
+    @Override
+    public X509Certificate[] getCertificateChain(HttpRequest httpRequest) throws GeneralSecurityException {
+        String xfcc = httpRequest.getHttpHeaders().getRequestHeaders().getFirst(XFCC_HEADER);
+        if (xfcc == null) {
+            return null;
+        }
+
+        X509Certificate[] certs = null;
+
+        StringTokenizer st = new StringTokenizer(xfcc, ";");
+        while (st.hasMoreTokens()) {
+            String token = st.nextToken();
+            int index = token.indexOf("=");
+            if (index != -1) {
+                String key = token.substring(0, index).trim();
+                String value = token.substring(index + 1).trim();
+
+                if (key.equals(XFCC_HEADER_CHAIN_KEY)) {
+                    // Chain contains the entire chain including the leaf certificate so we can stop processing the header.
+                    certs = PemUtils.decodeCertificates(decodeValue(value));
+                    break;
+                } else if (key.equals(XFCC_HEADER_CERT_KEY)) {
+                    // Cert contains only the leaf certificate. We need to continue processing the header in case Chain is present.
+                    certs = PemUtils.decodeCertificates(decodeValue(value));
+                }
+           }
+        }
+
+        return certs;
+    }
+
+    private String decodeValue(String value) {
+        // Remove enclosing quotes if present.
+        if (value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookup.java
@@ -72,23 +72,29 @@ public class EnvoyProxySslClientCertificateLookup implements X509ClientCertifica
 
         X509Certificate[] certs = null;
 
-        StringTokenizer st = new StringTokenizer(xfcc, ";");
-        while (st.hasMoreTokens()) {
-            String token = st.nextToken();
-            int index = token.indexOf("=");
-            if (index != -1) {
-                String key = token.substring(0, index).trim();
-                String value = token.substring(index + 1).trim();
+        try {
+            StringTokenizer st = new StringTokenizer(xfcc, ";");
+            while (st.hasMoreTokens()) {
+                String token = st.nextToken();
+                int index = token.indexOf("=");
+                if (index != -1) {
+                    String key = token.substring(0, index).trim();
+                    String value = token.substring(index + 1).trim();
 
-                if (key.equals(XFCC_HEADER_CHAIN_KEY)) {
-                    // Chain contains the entire chain including the leaf certificate so we can stop processing the header.
-                    certs = PemUtils.decodeCertificates(decodeValue(value));
-                    break;
-                } else if (key.equals(XFCC_HEADER_CERT_KEY)) {
-                    // Cert contains only the leaf certificate. We need to continue processing the header in case Chain is present.
-                    certs = PemUtils.decodeCertificates(decodeValue(value));
+                    if (key.equals(XFCC_HEADER_CHAIN_KEY)) {
+                        // Chain contains the entire chain including the leaf certificate so we can stop processing the header.
+                        certs = PemUtils.decodeCertificates(decodeValue(value));
+                        break;
+                    } else if (key.equals(XFCC_HEADER_CERT_KEY)) {
+                        // Cert contains only the leaf certificate. We need to continue processing the header in case Chain is present.
+                        certs = PemUtils.decodeCertificates(decodeValue(value));
+                    }
                 }
-           }
+            }
+        } catch (Exception e) {
+            logger.warnv("Failed to extract client certificate from x-forwarded-client-cert header: {0}",
+                    e.getMessage());
+            throw new SecurityException("Failed to extract client certificate from x-forwarded-client-cert header", e);
         }
 
         return certs;

--- a/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookup.java
@@ -25,7 +25,11 @@ import java.util.StringTokenizer;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.http.HttpRequest;
 
+import org.jboss.logging.Logger;
+
 public class EnvoyProxySslClientCertificateLookup implements X509ClientCertificateLookup {
+
+    private static final Logger logger = Logger.getLogger(EnvoyProxySslClientCertificateLookup.class);
 
     protected final static String XFCC_HEADER = "x-forwarded-client-cert";
     protected final static String XFCC_HEADER_CERT_KEY = "Cert";
@@ -56,6 +60,11 @@ public class EnvoyProxySslClientCertificateLookup implements X509ClientCertifica
      */
     @Override
     public X509Certificate[] getCertificateChain(HttpRequest httpRequest) throws GeneralSecurityException {
+        if (!httpRequest.isProxyTrusted()) {
+            logger.warnv("HTTP header \"{0}\" is not trusted", XFCC_HEADER);
+            return null;
+        }
+
         String xfcc = httpRequest.getHttpHeaders().getRequestHeaders().getFirst(XFCC_HEADER);
         if (xfcc == null) {
             return null;

--- a/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupFactory.java
+++ b/services/src/main/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.x509;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class EnvoyProxySslClientCertificateLookupFactory implements X509ClientCertificateLookupFactory {
+
+    private final static String PROVIDER = "envoy";
+
+    @Override
+    public X509ClientCertificateLookup create(KeycloakSession session) {
+        return new EnvoyProxySslClientCertificateLookup();
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.x509.X509ClientCertificateLookupFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.x509.X509ClientCertificateLookupFactory
@@ -22,3 +22,4 @@ org.keycloak.services.x509.ApacheProxySslClientCertificateLookupFactory
 org.keycloak.services.x509.NginxProxySslClientCertificateLookupFactory
 org.keycloak.services.x509.Rfc9440ClientCertificateLookupFactory
 org.keycloak.services.x509.TraefikProxySslClientCertificateLookupFactory
+org.keycloak.services.x509.EnvoyProxySslClientCertificateLookupFactory

--- a/services/src/test/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupTest.java
+++ b/services/src/test/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.x509;
+
+import org.keycloak.http.HttpRequest;
+import org.keycloak.rule.CryptoInitRule;
+import org.keycloak.services.resteasy.HttpRequestImpl;
+
+import java.security.cert.X509Certificate;
+
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class EnvoyProxySslClientCertificateLookupTest {
+
+    private static EnvoyProxySslClientCertificateLookup envoyLookup = null;
+
+    @ClassRule
+    public static CryptoInitRule cryptoInitRule = new CryptoInitRule();
+
+
+    @BeforeClass
+    public static void setup() {
+        envoyLookup = new EnvoyProxySslClientCertificateLookup();
+    }
+
+    @Test
+    public void testCertificate() throws Exception {
+        // Verify that XFCC Cert is used when only Cert is present.
+
+        String chain = "Hash=a3d0d47ddd0db8c93ea787ef2fb025ddb64f24e6a808a55e73349486e0a890be;Cert=\"-----BEGIN%20CERTIFICATE-----%0AMIIBVTCB%2FKADAgECAggX9bbmjJbJVjAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1j%0AbGllbnQtc3ViLWNhMB4XDTI0MDkxNjExNDUzM1oXDTI1MDkxNjExNDUzM1owFTET%0AMBEGA1UEAxMKeDUwOWNsaWVudDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJIk%0A8XcabnGpwh2tDYlrKzQ1Z2X8SNrtBo4RypOfv7Vw2dFxMqab%2F%2FnPJZafCWkO6odO%0Ao1AVYK8hv8arz2FrLtGjMzAxMA4GA1UdDwEB%2FwQEAwIFoDAfBgNVHSMEGDAWgBQk%0A4w6%2F09dXWDgQXI%2FeySP%2BJ8IruTAKBggqhkjOPQQDAgNIADBFAiEAmIsEIqyRvFWr%0A5PDbbcOK6aOVKxUkCDUE9O27ITgTURgCICl1Hju0kFnDrTNpXHABg5dmWQ%2BD6y2L%0A7LDd0viM2OVJ%0A-----END%20CERTIFICATE-----%0A\"";
+
+        HttpRequest request = new HttpRequestImpl(
+                MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", chain));
+
+        X509Certificate[] certs = envoyLookup.getCertificateChain(request);
+        Assert.assertNotNull(certs);
+        Assert.assertEquals(1, certs.length);
+        Assert.assertEquals("CN=x509client", certs[0].getSubjectX500Principal().getName());
+    }
+
+    @Test
+    public void testChain() throws Exception {
+        // Verify that XFCC Chain is used when only Chain is present.
+
+        String chain = "Hash=a3d0d47ddd0db8c93ea787ef2fb025ddb64f24e6a808a55e73349486e0a890be;Chain=\"-----BEGIN%20CERTIFICATE-----%0AMIIBVTCB%2FKADAgECAggX9bbmjJbJVjAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1j%0AbGllbnQtc3ViLWNhMB4XDTI0MDkxNjExNDUzM1oXDTI1MDkxNjExNDUzM1owFTET%0AMBEGA1UEAxMKeDUwOWNsaWVudDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJIk%0A8XcabnGpwh2tDYlrKzQ1Z2X8SNrtBo4RypOfv7Vw2dFxMqab%2F%2FnPJZafCWkO6odO%0Ao1AVYK8hv8arz2FrLtGjMzAxMA4GA1UdDwEB%2FwQEAwIFoDAfBgNVHSMEGDAWgBQk%0A4w6%2F09dXWDgQXI%2FeySP%2BJ8IruTAKBggqhkjOPQQDAgNIADBFAiEAmIsEIqyRvFWr%0A5PDbbcOK6aOVKxUkCDUE9O27ITgTURgCICl1Hju0kFnDrTNpXHABg5dmWQ%2BD6y2L%0A7LDd0viM2OVJ%0A-----END%20CERTIFICATE-----%0A-----BEGIN%20CERTIFICATE-----%0AMIIBhTCCASugAwIBAgIIF%2FW25oyTeEowCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ%0AY2xpZW50LWNhMB4XDTI0MDkxNjExNDUzM1oXDTI1MDkxNjExNDUzM1owGDEWMBQG%0AA1UEAxMNY2xpZW50LXN1Yi1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABG5K%0A2RWk6GVSgVlIccGNfRt3Iubpr6rz5j%2FbEpuB02G9LW3sg7x3uKfLQL4hNnpyJooR%0AhMuo%2FtPCaBFGAUCiYzqjYzBhMA4GA1UdDwEB%2FwQEAwIBBjAPBgNVHRMBAf8EBTAD%0AAQH%2FMB0GA1UdDgQWBBQk4w6%2F09dXWDgQXI%2FeySP%2BJ8IruTAfBgNVHSMEGDAWgBQZ%0Aa6PCs%2BstKIy2mwuHcKzkKtzBvjAKBggqhkjOPQQDAgNIADBFAiEA69pKJ%2FZ25TN6%0AINr8rutOQCC0Lczo23KijbTQrF4USmECIFb8RrXYV34rxmTaSWH37fqmvsYEo3mp%0AmJ5bu1L%2BL9Zo%0A-----END%20CERTIFICATE-----%0A\"";
+
+        HttpRequest request = new HttpRequestImpl(
+                MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", chain));
+        X509Certificate[] certs = envoyLookup.getCertificateChain(request);
+
+        Assert.assertNotNull(certs);
+        Assert.assertEquals(2, certs.length);
+        Assert.assertEquals("CN=x509client", certs[0].getSubjectX500Principal().getName());
+        Assert.assertEquals("CN=client-sub-ca", certs[1].getSubjectX500Principal().getName());
+    }
+
+
+    @Test
+    public void testCertificateAndChain() throws Exception {
+        // Verify that XFCC Chain is used when both Cert and Chain are present.
+
+        String certAndChain = "Hash=a3d0d47ddd0db8c93ea787ef2fb025ddb64f24e6a808a55e73349486e0a890be;Cert=\"-----BEGIN%20CERTIFICATE-----%0AMIIBVTCB%2FKADAgECAggX9bbmjJbJVjAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1j%0AbGllbnQtc3ViLWNhMB4XDTI0MDkxNjExNDUzM1oXDTI1MDkxNjExNDUzM1owFTET%0AMBEGA1UEAxMKeDUwOWNsaWVudDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJIk%0A8XcabnGpwh2tDYlrKzQ1Z2X8SNrtBo4RypOfv7Vw2dFxMqab%2F%2FnPJZafCWkO6odO%0Ao1AVYK8hv8arz2FrLtGjMzAxMA4GA1UdDwEB%2FwQEAwIFoDAfBgNVHSMEGDAWgBQk%0A4w6%2F09dXWDgQXI%2FeySP%2BJ8IruTAKBggqhkjOPQQDAgNIADBFAiEAmIsEIqyRvFWr%0A5PDbbcOK6aOVKxUkCDUE9O27ITgTURgCICl1Hju0kFnDrTNpXHABg5dmWQ%2BD6y2L%0A7LDd0viM2OVJ%0A-----END%20CERTIFICATE-----%0A\";Chain=\"-----BEGIN%20CERTIFICATE-----%0AMIIBVTCB%2FKADAgECAggX9bbmjJbJVjAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1j%0AbGllbnQtc3ViLWNhMB4XDTI0MDkxNjExNDUzM1oXDTI1MDkxNjExNDUzM1owFTET%0AMBEGA1UEAxMKeDUwOWNsaWVudDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJIk%0A8XcabnGpwh2tDYlrKzQ1Z2X8SNrtBo4RypOfv7Vw2dFxMqab%2F%2FnPJZafCWkO6odO%0Ao1AVYK8hv8arz2FrLtGjMzAxMA4GA1UdDwEB%2FwQEAwIFoDAfBgNVHSMEGDAWgBQk%0A4w6%2F09dXWDgQXI%2FeySP%2BJ8IruTAKBggqhkjOPQQDAgNIADBFAiEAmIsEIqyRvFWr%0A5PDbbcOK6aOVKxUkCDUE9O27ITgTURgCICl1Hju0kFnDrTNpXHABg5dmWQ%2BD6y2L%0A7LDd0viM2OVJ%0A-----END%20CERTIFICATE-----%0A-----BEGIN%20CERTIFICATE-----%0AMIIBhTCCASugAwIBAgIIF%2FW25oyTeEowCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ%0AY2xpZW50LWNhMB4XDTI0MDkxNjExNDUzM1oXDTI1MDkxNjExNDUzM1owGDEWMBQG%0AA1UEAxMNY2xpZW50LXN1Yi1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABG5K%0A2RWk6GVSgVlIccGNfRt3Iubpr6rz5j%2FbEpuB02G9LW3sg7x3uKfLQL4hNnpyJooR%0AhMuo%2FtPCaBFGAUCiYzqjYzBhMA4GA1UdDwEB%2FwQEAwIBBjAPBgNVHRMBAf8EBTAD%0AAQH%2FMB0GA1UdDgQWBBQk4w6%2F09dXWDgQXI%2FeySP%2BJ8IruTAfBgNVHSMEGDAWgBQZ%0Aa6PCs%2BstKIy2mwuHcKzkKtzBvjAKBggqhkjOPQQDAgNIADBFAiEA69pKJ%2FZ25TN6%0AINr8rutOQCC0Lczo23KijbTQrF4USmECIFb8RrXYV34rxmTaSWH37fqmvsYEo3mp%0AmJ5bu1L%2BL9Zo%0A-----END%20CERTIFICATE-----%0A\"";
+
+        HttpRequest request = new HttpRequestImpl(
+                MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", certAndChain));
+        X509Certificate[] certs = envoyLookup.getCertificateChain(request);
+
+        Assert.assertNotNull(certs);
+        Assert.assertEquals(2, certs.length);
+        Assert.assertEquals("CN=x509client", certs[0].getSubjectX500Principal().getName());
+        Assert.assertEquals("CN=client-sub-ca", certs[1].getSubjectX500Principal().getName());
+    }
+
+
+    @Test
+    public void testNoCertificate() throws Exception {
+        // No XFCC header.
+        Assert.assertNull(envoyLookup.getCertificateChain(new HttpRequestImpl(
+                MockHttpRequest.create("GET", "http://foo/bar"))));
+
+        // No Cert or Chain value in XFCC header.
+        Assert.assertNull(envoyLookup.getCertificateChain(new HttpRequestImpl(
+            MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", "foobar"))));
+    }
+
+}

--- a/services/src/test/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupTest.java
+++ b/services/src/test/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupTest.java
@@ -98,7 +98,30 @@ public class EnvoyProxySslClientCertificateLookupTest {
 
         // No Cert or Chain value in XFCC header.
         Assert.assertNull(envoyLookup.getCertificateChain(new HttpRequestImpl(
-            MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", "foobar"))));
+                MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", "foobar"))));
     }
 
+    @Test(expected = SecurityException.class)
+    public void testCorruptedXfccInvalidCert() throws Exception {
+        envoyLookup.getCertificateChain(new HttpRequestImpl(
+                MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert", "Cert=\"foobar\"")));
+    }
+
+    @Test(expected = SecurityException.class)
+    public void testCorruptedXfccInvalidChain() throws Exception {
+        envoyLookup.getCertificateChain(new HttpRequestImpl(MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert",
+                "Hash=1234;Chain=\"foobar\"")));
+    }
+
+    @Test(expected = SecurityException.class)
+    public void testCorruptedXfccNoEndQuote() throws Exception {
+        envoyLookup.getCertificateChain(new HttpRequestImpl(MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert",
+                "Hash=1234;Cert=\"no end quote")));
+    }
+
+    @Test(expected = SecurityException.class)
+    public void testCorruptedXfccNoStartQuote() throws Exception {
+        envoyLookup.getCertificateChain(new HttpRequestImpl(MockHttpRequest.create("GET", "http://foo/bar").header("x-forwarded-client-cert",
+                "Hash=1234;Cert=no start quote\"")));
+    }
 }

--- a/services/src/test/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupTest.java
+++ b/services/src/test/java/org/keycloak/services/x509/EnvoyProxySslClientCertificateLookupTest.java
@@ -16,11 +16,11 @@
  */
 package org.keycloak.services.x509;
 
+import java.security.cert.X509Certificate;
+
 import org.keycloak.http.HttpRequest;
 import org.keycloak.rule.CryptoInitRule;
 import org.keycloak.services.resteasy.HttpRequestImpl;
-
-import java.security.cert.X509Certificate;
 
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.junit.Assert;


### PR DESCRIPTION
This update introduces the ability to lookup X509 client certificates from Envoy's `x-forwarded-client-cert` header (XFCC), using either `Cert` or `Chain` parameters ([doc link](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert)).

Fixes #33160 

**Motivation**

Built-in support for X509 client certificate lookup from Envoy is a valuable addition to Keycloak, as Envoy is widely adopted, particularly within the Kubernetes ecosystem. It serves as the core ingress proxy for projects like Istio, Contour, and others.

**Testing** 

Since there don't appear to be existing tests for X509 client certificate lookups, ~this PR does not include automated tests~. However, I have conducted manual testing with both Istio and Contour, see [notes here](https://gist.github.com/tsaarni/37911f2fe569c060b4debb66ed0f7533).

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
