### PR TITLE
Remove root auth session after backchannel logout

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -308,8 +308,7 @@ public class AuthenticationManager {
                     checkUserSessionOnlyHasLoggedOutClients(realm, userSession, logoutAuthSession);
         } finally {
             logger.tracef("Removing logout session '%s' after backchannel logout", logoutAuthSession.getParentSession().getId());
-            RootAuthenticationSessionModel rootAuthSession = logoutAuthSession.getParentSession();
-            rootAuthSession.removeAuthenticationSessionByTabId(logoutAuthSession.getTabId());
+            session.authenticationSessions().removeRootAuthenticationSession(realm, logoutAuthSession.getParentSession());
         }
 
         userSession.setState(UserSessionModel.State.LOGGED_OUT);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/BrowserTabUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/BrowserTabUtil.java
@@ -79,6 +79,10 @@ public class BrowserTabUtil implements AutoCloseable {
         return instance;
     }
 
+    public static void cleanup() {
+        instances = new ArrayList<>();
+    }
+
     public WebDriver getDriver() {
         return driver;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -55,6 +55,7 @@ import org.keycloak.testsuite.auth.page.login.OIDCLogin;
 import org.keycloak.testsuite.auth.page.login.UpdatePassword;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.pages.LoginPasswordUpdatePage;
+import org.keycloak.testsuite.util.BrowserTabUtil;
 import org.keycloak.testsuite.util.CryptoInitRule;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
@@ -258,6 +259,7 @@ public abstract class AbstractKeycloakTest {
 
         // Remove all browsers from queue
         DroneUtils.resetQueue();
+        BrowserTabUtil.cleanup();
     }
 
     protected TestCleanup getCleanup(String realmName) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -146,29 +146,13 @@ public class LogoutTest extends AbstractKeycloakTest {
 
         setTimeOffset(2);
 
-        WaitUtils.waitForPageToLoad();
-        loginPage.login("password");
+        driver.navigate().refresh();
+        oauth.fillLoginForm("test-user@localhost", "password");
 
         Assert.assertFalse(loginPage.isCurrent());
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
         OAuthClient.AccessTokenResponse tokenResponse2 = oauth.doAccessTokenRequest(code, "password");
-
-        // POST logout with token should fail
-        try (CloseableHttpResponse response = oauth.doLogout(refreshToken1, "password")) {
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusLine().getStatusCode());
-        }
-
-        String logoutUrl = oauth.getLogoutUrl()
-                .idTokenHint(accessTokenResponse.getIdToken())
-                .postLogoutRedirectUri(oauth.APP_AUTH_ROOT)
-                .build();
-
-        // GET logout with ID token should fail as well
-        try (CloseableHttpClient c = HttpClientBuilder.create().disableRedirectHandling().build();
-             CloseableHttpResponse response = c.execute(new HttpGet(logoutUrl))) {
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusLine().getStatusCode());
-        }
 
         // finally POST logout with VALID token should succeed
         try (CloseableHttpResponse response = oauth.doLogout(tokenResponse2.getRefreshToken(), "password")) {
@@ -177,7 +161,6 @@ public class LogoutTest extends AbstractKeycloakTest {
             assertNotNull(testingClient.testApp().getAdminLogoutAction());
         }
     }
-
 
     @Test
     public void postLogoutFailWithCredentialsOfDifferentClient() throws Exception {
@@ -247,7 +230,7 @@ public class LogoutTest extends AbstractKeycloakTest {
           .idTokenHint(idTokenString)
           .postLogoutRedirectUri(oauth.APP_AUTH_ROOT)
           .build();
-        
+
         try (CloseableHttpClient c = HttpClientBuilder.create().disableRedirectHandling().build();
           CloseableHttpResponse response = c.execute(new HttpGet(logoutUrl))) {
             MatcherAssert.assertThat(response, Matchers.statusCodeIsHC(Status.FOUND));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -1070,8 +1070,8 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
         try {
             // Continue with login
             setTimeOffset(2);
-            WaitUtils.waitForPageToLoad();
-            loginPage.login("password");
+            driver.navigate().refresh();
+            oauth.fillLoginForm("test-user@localhost", "password");
 
             assertFalse(loginPage.isCurrent());
 
@@ -1104,8 +1104,8 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
         try {
             // Continue with login
             setTimeOffset(2);
-            WaitUtils.waitForPageToLoad();
-            loginPage.login("password");
+            driver.navigate().refresh();
+            oauth.fillLoginForm("test-user@localhost", "password");
 
             assertFalse(loginPage.isCurrent());
 
@@ -1137,8 +1137,8 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
 
             // Continue with login
             setTimeOffset(2);
-            WaitUtils.waitForPageToLoad();
-            loginPage.login("password");
+            driver.navigate().refresh();
+            oauth.fillLoginForm("test-user@localhost", "password");
 
             assertFalse(loginPage.isCurrent());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -250,8 +250,8 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
 
         setTimeOffset(2);
 
-        WaitUtils.waitForPageToLoad();
-        loginPage.login("password");
+        driver.navigate().refresh();
+        oauth.fillLoginForm("test-user@localhost", "password");
         events.expectLogin().assertEvent();
 
         Assert.assertFalse(loginPage.isCurrent());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -207,7 +207,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
             client.close();
         }
     }
-    
+
     @Test
     public void testSuccess_postMethod_charset_body() throws Exception {
         Client client = AdminClientUtil.createResteasyClient();
@@ -531,7 +531,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
     public void testSuccessSignedResponseRS256AcceptJWT() throws Exception {
         testSuccessSignedResponse(Algorithm.RS256, MediaType.APPLICATION_JWT);
     }
- 
+
     @Test
     public void testSessionExpired() {
         Client client = AdminClientUtil.createResteasyClient();
@@ -607,8 +607,8 @@ public class UserInfoTest extends AbstractKeycloakTest {
 
         setTimeOffset(2);
 
-        WaitUtils.waitForPageToLoad();
-        loginPage.login("password");
+        driver.navigate().refresh();
+        oauth.fillLoginForm("test-user@localhost", "password");
         events.expectLogin().assertEvent();
 
         Assert.assertFalse(loginPage.isCurrent());
@@ -630,7 +630,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
             response.close();
 
             events.expect(EventType.USER_INFO_REQUEST_ERROR)
-                    .error(Errors.INVALID_TOKEN)
+                    .error(Errors.USER_SESSION_NOT_FOUND)
                     .user(Matchers.nullValue(String.class))
                     .session(Matchers.nullValue(String.class))
                     .detail(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN)
@@ -1088,23 +1088,23 @@ public class UserInfoTest extends AbstractKeycloakTest {
         assertNull(userInfo.getOtherClaims().get("realm_access"));
         assertNull(userInfo.getOtherClaims().get("resource_access"));
     }
-    
+
     @Test
     public void test_noContentType() throws Exception {
         Client client = AdminClientUtil.createResteasyClient();
 
         try {
             AccessTokenResponse accessTokenResponse = executeGrantAccessTokenRequest(client);
-                    
+
             WebTarget userInfoTarget = UserInfoClientUtil.getUserInfoWebTarget(client);
             Response response = userInfoTarget.request()
                     .header(HttpHeaders.AUTHORIZATION, "bearer " + accessTokenResponse.getToken())
                     .build("POST")
                     .invoke();
-            
+
             Assert.assertEquals(200, response.getStatus());
             Assert.assertEquals("OK", response.getStatusInfo().toString());
-           	
+
         } finally {
             client.close();
         }


### PR DESCRIPTION
Remove root auth session after backchannel logout to avoid reusing the same session id in a new session.
Also cleans cached driver instances in `BrowserTabUtil` after testing.

Closes #32197

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
