### PR TITLE
Gather better information about failures in Quarkus IT

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -138,7 +138,7 @@ public class StartCommandDistTest {
         cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");
         cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " show-config");
         cliResult.assertMessage("Next time you run the server, just run:");
-        cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " start --http-enabled=true --hostname-strict=false " + OPTIMIZED_BUILD_OPTION_LONG);
+        cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " start --http-enabled=true --hostname-strict=false --verbose " + OPTIMIZED_BUILD_OPTION_LONG);
         assertFalse(cliResult.getOutput().contains("--metrics-enabled"));
         cliResult.assertStarted();
     }

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.it.junit5.extension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -59,29 +58,31 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertStarted() {
-        assertFalse(getOutput().contains("The delayed handler's queue was overrun and log record(s) were lost (Did you forget to configure logging?)"), () -> "The standard Output:\n" + getOutput() + "should not contain a warning about log queue overrun.");
-        assertTrue(getOutput().contains("Listening on:"), () -> "The standard output:\n" + getOutput() + "does include \"Listening on:\"");
+        assertThat("The standard output should not contain a warning about log queue overrun.",
+                getOutput(), not(containsString("The delayed handler's queue was overrun and log record(s) were lost (Did you forget to configure logging?)")));
+        assertThat("The standard output does not include \"Listening on:\"",
+                getOutput(), containsString("Listening on:"));
         assertNotDevMode();
     }
 
     default void assertNotDevMode() {
-        assertFalse(getOutput().contains("Running the server in development mode."),
-                () -> "The standard output:\n" + getOutput() + "\ndoes include the Start Dev output");
+        assertThat("The standard output does include the Start Dev output",
+                getOutput(), not(containsString("Running the server in development mode.")));
     }
 
     default void assertStartedDevMode() {
-        assertTrue(getOutput().contains("Running the server in development mode."),
-                () -> "The standard output:\n" + getOutput() + "\ndoesn't include the Start Dev output");
+        assertThat("The standard output does not include the Start Dev output",
+                getOutput(), containsString("Running the server in development mode."));
     }
 
     default void assertError(String msg) {
-        assertTrue(getErrorOutput().contains(msg),
-                () -> "The Error Output:\n " + getErrorOutput() + "\ndoesn't contains " + msg);
+        assertThat("The error output does not contain: " + msg,
+                getErrorOutput(), containsString(msg));
     }
 
     default void assertNoError(String msg) {
-        assertFalse(getErrorOutput().contains(msg),
-                () -> "The Error Output:\n " + getErrorOutput() + "\n contains " + msg);
+        assertThat("The error output contains: " + msg,
+                getErrorOutput(), not(containsString(msg)));
     }
 
     default void assertMessage(String message) {
@@ -102,11 +103,7 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertNoBuild() {
-        assertFalse(getOutput().contains("Server configuration updated and persisted"));
-    }
-
-    default void assertBuildRuntimeMismatchWarning(String quarkusBuildtimePropKey) {
-        assertTrue(getOutput().contains(" - " + quarkusBuildtimePropKey + " is set to 'true' but it is build time fixed to 'false'. Did you change the property " + quarkusBuildtimePropKey + " after building the application?"));
+        assertNoMessage("Server configuration updated and persisted");
     }
 
     default boolean isClustered() {
@@ -148,6 +145,6 @@ public interface CLIResult extends LaunchResult {
 
     default void assertStringCount(String msg, int count) {
         Pattern pattern = Pattern.compile(msg);
-        assertEquals(count, pattern.matcher(getOutput()).results().count());
+        assertThat(pattern.matcher(getOutput()).results().count(), is(count));
     }
 }

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
@@ -18,6 +18,7 @@ import org.testcontainers.utility.LazyFuture;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,9 +105,15 @@ public final class DockerKeycloakDistribution implements KeycloakDistribution {
 
             keycloakContainer = getKeycloakContainer();
 
+            var allArgs = new ArrayList<>(arguments);
+
+            if (!allArgs.contains("--verbose")) {
+                allArgs.add("--verbose");
+            }
+
             keycloakContainer
                     .withLogConsumer(backupConsumer)
-                    .withCommand(arguments.toArray(new String[0]))
+                    .withCommand(allArgs.toArray(new String[0]))
                     .start();
             containerId = keycloakContainer.getContainerId();
 

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -111,7 +111,7 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         this.requestPort = requestPort;
         this.distPath = prepareDistribution();
     }
-    
+
     public CLIResult kcadm(String... arguments) throws IOException {
     	return kcadm(Arrays.asList(arguments));
     }
@@ -300,6 +300,10 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
 
         allArgs.add("-Dkc.home.dir=" + distPath + File.separator);
         allArgs.addAll(arguments);
+
+        if (!arguments.contains("--verbose")) {
+            allArgs.add("--verbose");
+        }
 
         return allArgs.toArray(String[]::new);
     }


### PR DESCRIPTION
During the investigation of the flakiness in https://github.com/keycloak/keycloak/issues/33224 test, I wasn't able to obtain more information and the exact cause of the failure. I had to do it manually and I think we can improve stuff here. 

What this PR is proposing:

- better error messages with better comparison in IDE (use `assertThat`)
- explicitly add `--verbose` flag to our Quarkus IT