### PR TITLE
Identity provider should not be hidden from login page when the a user goes back from the reset credentials page

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -30,6 +30,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import static org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUser.RESET_CREDENTIAL_USER_CHOSEN;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -58,6 +60,7 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
         MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
         String loginHint = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM);
 
+        clearUserIfComingFromResetPassword(context);
         String rememberMeUsername = AuthenticationManager.getRememberMeUsername(context.getSession());
 
         if (context.getUser() != null) {
@@ -78,6 +81,12 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
         }
         Response challengeResponse = challenge(context, formData);
         context.challenge(challengeResponse);
+    }
+
+    private void clearUserIfComingFromResetPassword(AuthenticationFlowContext context) {
+        if ("true".equals(context.getAuthenticationSession().getAuthNote(RESET_CREDENTIAL_USER_CHOSEN))) {
+            context.clearUser();
+        }
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
@@ -50,6 +50,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
     private static final Logger logger = Logger.getLogger(ResetCredentialChooseUser.class);
 
     public static final String PROVIDER_ID = "reset-credentials-choose-user";
+    public static final String RESET_CREDENTIAL_USER_CHOSEN = "RESET_CREDENTIAL_USER_CHOSEN";
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
@@ -104,7 +105,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
         }
 
         username = username.trim();
-        
+
         RealmModel realm = context.getRealm();
         UserModel user = context.getSession().users().getUserByUsername(realm, username);
         if (user == null && realm.isLoginWithEmailAllowed() && username.contains("@")) {
@@ -126,6 +127,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
                     .user(user).error(Errors.USER_DISABLED);
             context.clearUser();
         } else {
+            context.getAuthenticationSession().setAuthNote(RESET_CREDENTIAL_USER_CHOSEN, "true");
             context.setUser(user);
         }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -188,10 +188,10 @@ public class IdentityProviderBean {
                         .map(FederatedIdentityModel::getIdentityProvider)
                         .collect(Collectors.toSet());
 
-                if (!federatedIdentities.isEmpty() || organizationsDisabled(realm))
+                if (!federatedIdentities.isEmpty() || organizationsDisabled(realm)) {
                     // if orgs are enabled, we don't want to return an empty set - we want the organization IDPs to be shown if those are available.
                     result = new HashSet<>(federatedIdentities);
-
+                }
             }
         }
         return result;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -130,7 +130,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
                 .removeDetail(Details.EMAIL)
                 .user((String) null).error("username_in_use").assertEvent();
     }
- 
+
     @Test
     public void registerExistingEmailForbidden() {
         loginPage.open();
@@ -154,7 +154,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
                 .removeDetail(Details.EMAIL)
                 .user((String) null).error("email_in_use").assertEvent();
     }
- 
+
     @Test
     public void registerExistingEmailAllowed() throws IOException {
         try (RealmAttributeUpdater rau = setDuplicateEmailsAllowed(true).update()) {
@@ -849,6 +849,35 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
     public void testRegisterShouldFailBeforeUserCreationWhenUserIsInContext() {
         loginPage.open();
         loginPage.clickRegister();
+        String registrationUrl = driver.getCurrentUrl();
+
+        registerPage.clickBackToLogin();
+        loginPage.assertCurrent(testRealm().toRepresentation().getRealm());
+
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+        resetPasswordPage.changePassword("test-user@localhost");
+
+        events.clear();
+
+        driver.navigate().to(registrationUrl);
+
+        errorPage.assertCurrent();
+        Assert.assertEquals("Action expired. Please continue with login now.", errorPage.getError());
+
+        events.expectRegister("registerUserMissingTermsAcceptance", "registerUserMissingTermsAcceptance@email")
+                .removeDetail(Details.USERNAME)
+                .removeDetail(Details.EMAIL)
+                .removeDetail(Details.REGISTER_METHOD)
+                .detail(Details.EXISTING_USER, "test-user@localhost")
+                .detail(Details.AUTHENTICATION_ERROR_DETAIL, Errors.DIFFERENT_USER_AUTHENTICATING)
+                .error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+    }
+
+    @Test
+    public void testLoginPageClearsUserFromContextIfUserNavigatesBackFromResetPassword() {
+        loginPage.open();
+        loginPage.clickRegister();
         registerPage.clickBackToLogin();
         loginPage.assertCurrent(testRealm().toRepresentation().getRealm());
 
@@ -861,16 +890,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         events.clear();
         driver.navigate().back();
 
-        errorPage.assertCurrent();
-        Assert.assertEquals("Action expired. Please continue with login now.", errorPage.getError());
-
-        events.expectRegister("registerUserMissingTermsAcceptance", "registerUserMissingTermsAcceptance@email")
-                .removeDetail(Details.USERNAME)
-                .removeDetail(Details.EMAIL)
-                .removeDetail(Details.REGISTER_METHOD)
-                .detail(Details.EXISTING_USER, "test-user@localhost")
-                .detail(Details.AUTHENTICATION_ERROR_DETAIL, Errors.DIFFERENT_USER_AUTHENTICATING)
-                .error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        registerPage.assertCurrent();
     }
 
     protected RealmAttributeUpdater configureRealmRegistrationEmailAsUsername(final boolean value) {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Closes #33204.

Breaks only one test, `RegisterTest::testRegisterShouldFailBeforeUserCreationWhenUserIsInContext`, which was added in #23064 (issue #21514) - that test covers basically the same bug (also reported by me). In the previous bug the steps to reproduce was:
 - go to reset credentials, and pick a valid username
 - then go back, and try to register -> the fix was to check and raise an error during the registration if the user was set in the `ResetCredentialChooseUser`

The current issue (#33204) I'm having in short is:
 - go to reset credentials, and pick a valid username
 - then go back to the login page -> the social logins, which doesn't linked to the picked account, will be hidden from the login. You don't even need to pass the authentication to find out what social sites the user has linked to their account.

My current fix checks whether a user has been set in the context during an attempted (and cancelled) reset credential flow - and if it has been set, then we clear them from the context when loading the login page.

If I modify the failing test (also written by me), would you be willing to merge this?  Probably I need to:
 - modify the failing test
 - add a new, slightly modified `RegisterTest::testRegisterShouldFailBeforeUserCreationWhenUserIsInContext` one where the login page is skipped entirely

cc @ahus1 @sguilhen @mposolda who was involved in the test which fails currently.