### PR TITLE
Use note to detect the IDP verify email action is already done

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/IdpLinkEmailPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/IdpLinkEmailPage.java
@@ -28,8 +28,11 @@ public class IdpLinkEmailPage extends AbstractPage {
     @FindBy(id = "instruction1")
     private WebElement message;
 
-    @FindBy(linkText = "Click here")
+    @FindBy(xpath = "//p[@id='instruction2']/a[text() = 'Click here']")
     private WebElement resendEmailLink;
+
+    @FindBy(xpath = "//p[@id='instruction3']/a[text() = 'Click here']")
+    private WebElement continueLink;
 
     @Override
     public boolean isCurrent() {
@@ -47,5 +50,9 @@ public class IdpLinkEmailPage extends AbstractPage {
 
     public void resendEmail() {
         resendEmailLink.click();
+    }
+
+    public void continueLink() {
+        continueLink.click();
     }
 }


### PR DESCRIPTION
Closes #31563

If the IdP email verification for linking an account is done in another browser, the verification is detected as already done and login cannot continue. The current implementation detects it as already verified because the  session is transient (the verification is done in another browser) and has no action in it. The PR uses the VERIFY_ACCOUNT_IDP_USERNAME note instead of the action to check if this session (when not transient) or the other initiating session (when transient)  has already being marked by the note as executed.
