### PR TITLE
Add getResourcesCommonUrl method to URLBean

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
@@ -96,7 +96,7 @@ public class UrlBean {
     }
 
     public String getResourcesUrl() {
-        return getThemeRootUri().toString() + "/" + theme.getType().toString().toLowerCase() +"/" + theme.getName();
+        return getThemeRootUri().toString() + "/" + getResourcesPath();
     }
 
     public String getResourcesCommonUrl() {

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
@@ -99,6 +99,10 @@ public class UrlBean {
         return getThemeRootUri().toString() + "/" + theme.getType().toString().toLowerCase() +"/" + theme.getName();
     }
 
+    public String getResourcesCommonUrl() {
+        return getThemeRootUri().toString() + "/" + getResourcesCommonPath();
+    }
+
     public String getOauthAction() {
         if (this.actionuri != null) {
             return this.actionuri.getPath();


### PR DESCRIPTION
Fixes #33198

- Adds a single `getResourcesCommonUrl()` to obtain the full URL
- Small refactoring to obtain the resource path from method call