### PR TITLE
Move deleteCookies to before for RecoveryAuthnCodesAuthenticatorTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -139,7 +139,9 @@ public final class WaitUtils {
                 wait.until(not(urlToBe(currentUrl)));
             }
             catch (TimeoutException e) {
-                break; // URL has not changed recently - ok, the URL is stable and page is current
+                if (driver.getPageSource() != null) {
+                    break; // URL has not changed recently - ok, the URL is stable and page is current
+                }
             }
             if (maxRedirects == 1) {
                 log.warn("URL seems unstable! (Some redirect are probably still in progress)");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractTestRealmKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractTestRealmKeycloakTest.java
@@ -17,10 +17,8 @@
 
 package org.keycloak.testsuite;
 
-import org.junit.After;
+import org.junit.Before;
 import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.common.ClientConnection;
-import org.keycloak.common.util.Resteasy;
 import org.keycloak.common.util.reflections.Reflections;
 import org.keycloak.events.Details;
 import org.keycloak.models.KeycloakSession;
@@ -78,8 +76,13 @@ public abstract class AbstractTestRealmKeycloakTest extends AbstractKeycloakTest
     }
 
 
-    // Logout user after test
-    @After
+    @Before
+    @Override
+    public void beforeAbstractKeycloakTest() throws Exception {
+        deleteCookies();
+        super.beforeAbstractKeycloakTest();
+    }
+
     public void deleteCookies() {
         deleteAllCookiesForRealm("test");
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -113,9 +113,9 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         testRealm.setBruteForceProtected(true);
         testRealm.setFailureFactor(failureFactor);
-        testRealm.setMaxDeltaTimeSeconds(20);
+        testRealm.setMaxDeltaTimeSeconds(60);
         testRealm.setMaxFailureWaitSeconds(100);
-        testRealm.setWaitIncrementSeconds(5);
+        testRealm.setWaitIncrementSeconds(20);
         testRealm.setOtpPolicyCodeReusable(true);
         //testRealm.setQuickLoginCheckMilliSeconds(0L);
 
@@ -132,9 +132,9 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             clearAllUserFailures();
             RealmRepresentation realm = adminClient.realm("test").toRepresentation();
             realm.setFailureFactor(failureFactor);
-            realm.setMaxDeltaTimeSeconds(20);
+            realm.setMaxDeltaTimeSeconds(60);
             realm.setMaxFailureWaitSeconds(100);
-            realm.setWaitIncrementSeconds(5);
+            realm.setWaitIncrementSeconds(20);
             realm.setOtpPolicyCodeReusable(true);
             adminClient.realm("test").update(realm);
         } catch (Exception e) {
@@ -492,7 +492,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         // KEYCLOAK-5420
         // Test to make sure that temporarily disabled doesn't increment failure count
-        testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(6)));
+        testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(21)));
         // should be unlocked now
         loginSuccess();
         clearUserFailures();
@@ -674,11 +674,11 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             loginInvalidPassword();
             loginInvalidPassword();
             expectTemporarilyDisabled();
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(6)));
+            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(21)));
 
             loginInvalidPassword();
             expectTemporarilyDisabled();
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(11)));
+            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(42)));
 
             loginInvalidPassword();
             expectPermanentlyDisabled();
@@ -703,7 +703,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             loginInvalidPassword();
             loginInvalidPassword();
             expectTemporarilyDisabled();
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(6)));
+            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(21)));
             UserRepresentation user = adminClient.realm("test").users().search("test-user@localhost", 0, 1).get(0);
             Map<String, Object> status = adminClient.realm("test").attackDetection().bruteForceUserStatus(user.getId());
             assertEquals(1, status.get("numTemporaryLockouts"));


### PR DESCRIPTION
Closes #26176

I was checking this issue for a long time the previous week. The flaky test only happens in firefox (see all failures in the issue) and not in chrome so I discarded a code issue in the test. I have detected that the issue seems to disappear if the `deleteCookies` is moved `before` instead of `after` the tests. Besides I have seen that some firefox issues are also generated because this [250ms wait](https://github.com/keycloak/keycloak/blob/25.0.6/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java#L137), it is too short for firefox from time to time. Nevertheless incrementing this wait means longer CI times, so I decided to check the `driver.getPageSource()` is not null (which seems to minimize the issue) to force a new wait instead of incrementing the wait time always. Finally I have increased the 5s timeout in `BruteForceTest` to 20s because it failed sporadically in my firefox tests. With these changes I could run the `forms` CI 50 times without issue in firefox. I this that this is not a definitive fix but at least the `forms` CI seems to be more stable after the changes.
