### PR TITLE
Add LOGIN_WEBAUTHN as possible initial login page for locale bean

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -498,6 +498,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                     switch (page) {
                         case LOGIN:
                         case LOGIN_USERNAME:
+                        case LOGIN_WEBAUTHN:
                         case X509_CONFIRM:
                             b = UriBuilder.fromUri(Urls.realmLoginPage(baseUri, realm.getName()));
                             break;


### PR DESCRIPTION
Closes #33336

The webauthn page can be shown the first one when going to the auth endpoint, as it does not require any user (if passwordless). The locale is then set incorrectly to the `auth` instead of the `authorize` url. The PR just adds LOGIN_WEBAUTHN with LOGIN or LOGIN_USERNAME to force login url for the locale bean. I added no tests because this is already tested for the other pages and not doing anything special, but if you think it is needed just let me know.
