### PR TITLE
Require Keycloak JS configuration to be passed explicitly

### DIFF
--- a/js/libs/keycloak-js/lib/keycloak.d.ts
+++ b/js/libs/keycloak-js/lib/keycloak.d.ts
@@ -28,7 +28,7 @@ export interface KeycloakConfig {
 	/**
 	 * URL to the Keycloak server, for example: http://keycloak-server/auth
 	 */
-	url?: string;
+	url: string;
 	/**
 	 * Name of the realm, for example: 'myrealm'
 	 */
@@ -373,7 +373,7 @@ declare class Keycloak {
 	 * Creates a new Keycloak client instance.
 	 * @param config A configuration object or path to a JSON config file.
 	 */
-	constructor(config?: KeycloakConfig | string)
+	constructor(config: KeycloakConfig | string)
 
 	/**
 	 * Is true if the user is authenticated, false otherwise.

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JavascriptTestExecutor.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JavascriptTestExecutor.java
@@ -171,7 +171,7 @@ public class JavascriptTestExecutor {
         jsExecutor.executeScript("console.warn = event;");
 
         if (argumentsBuilder == null) {
-            jsExecutor.executeScript("window.keycloak = new Keycloak();");
+            jsExecutor.executeScript("window.keycloak = new Keycloak('./keycloak.json');");
         } else {
             String configArguments = argumentsBuilder.build();
             jsExecutor.executeScript("window.keycloak = new Keycloak(" + configArguments + ");");


### PR DESCRIPTION
Removes the ability for Keycloak to automatically find the `keycloak.json` configuration based on where `keycloak.js` is loaded from. This logic was relevant when Keycloak JS was loaded statically from the server, but this was removed under #33083.

Additionally this feature would essentially not work in bundled environments, as these don't load `keycloak.js` as an individual script.

Closes #32823

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
