### PR TITLE
Wait for welcome page to load as it might take a bit more time to load/redirect.

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -61,6 +61,7 @@ import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.TestCleanup;
 import org.keycloak.testsuite.util.TestEventsLogger;
+import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.WebDriver;
 
 import jakarta.ws.rs.NotFoundException;
@@ -279,6 +280,7 @@ public abstract class AbstractKeycloakTest {
             log.debug("updating admin password");
 
             welcomePage.navigateTo();
+            WaitUtils.waitForPageToLoad();
             if (!welcomePage.isPasswordSet()) {
                 welcomePage.setPassword("admin", "admin");
             }


### PR DESCRIPTION
Closes #28953

* Ideally we want to bootstrap the master user during startup but not sure if we want to change this now in favor of the new test framework.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
