### PR TITLE
Use sendKeys instead of click for the webauthn tests

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -24,6 +24,7 @@ import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -216,7 +217,7 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public void clickRegister() {
-        registerLink.click();
+        registerLink.sendKeys(Keys.ENTER);
         WaitUtils.waitForPageToLoad();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AbstractWebAuthnVirtualTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AbstractWebAuthnVirtualTest.java
@@ -227,6 +227,7 @@ public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycl
 
     protected void registerUser(String username, String password, String email, String authenticatorLabel, boolean shouldSuccess) {
         loginPage.open();
+        loginPage.assertCurrent();
         loginPage.clickRegister();
 
         waitForPageToLoad();


### PR DESCRIPTION
Closes #33362
Closes #33037
Closes #32548

I know it seems to be black magic but sometimes the `click` is not working and the `sendKeys` seems to work all the time. I reproduced it locally and in CI, in CI executing the UserVerificationRegisterTest 5x10 with the original `click` failed [here](https://github.com/rmartinc/keycloak/actions/runs/11139847164/job/30957540783) and using `sendKeys` it worked flawlessly the 50 times [here](https://github.com/rmartinc/keycloak/actions/runs/11140168521/job/30958586348). I saw that a `WaitUtils.waitForPageToLoad` was added yesterday (so someone else detected this part as troublesome) but it does not fix my issue, in my tests it is not needed with `sendKeys` but I'm maintaining it as it does no harm.
