### PR TITLE
Temporarily override micrometer dependencies

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -43,6 +43,34 @@
         <module>tests</module>
     </modules>
 
+    <!-- Remove once Quarkus Micrometer extension uses Micrometer 1.13.5-->
+    <!-- See https://github.com/keycloak/keycloak/issues/33469 -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>1.13.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-commons</artifactId>
+                <version>1.13.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-observation</artifactId>
+                <version>1.13.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+                <version>1.13.5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <!-- Remove until here  -->
+
     <repositories>
         <repository>
             <id>central</id>


### PR DESCRIPTION
- Closes #33468
- Fixes #33246
- Fixes #33224

Temporarily override micrometer dependencies, if there's no quick Quarkus LTS patch release.

Distribution contains the new versions of the Micrometer:

Main JARs:
```
> cd keycloak/quarkus/dist/target/keycloak-999.0.0-SNAPSHOT/lib/lib/main
> ls | grep micrometer
io.micrometer.micrometer-commons-1.13.5.jar
io.micrometer.micrometer-core-1.13.5.jar
io.micrometer.micrometer-observation-1.13.5.jar
io.micrometer.micrometer-registry-prometheus-simpleclient-1.13.5.jar
io.quarkus.quarkus-micrometer-3.15.1.jar
io.quarkus.quarkus-micrometer-registry-prometheus-3.15.1.jar
```

Deployment JARs:
```
> cd keycloak/quarkus/dist/target/keycloak-999.0.0-SNAPSHOT/lib/lib/deployment
> ls | grep micrometer
io.quarkus.quarkus-micrometer-deployment-3.15.1.jar
io.quarkus.quarkus-micrometer-registry-prometheus-deployment-3.15.1.jar
```


