### PR TITLE
Use sendKeys instead of click for the webauthn tests

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -24,6 +24,7 @@ import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -216,8 +217,7 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public void clickRegister() {
-        registerLink.click();
-        WaitUtils.waitForPageToLoad();
+        clickLink(registerLink);
     }
 
     public void clickSocial(String alias) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginTotpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginTotpPage.java
@@ -129,7 +129,7 @@ public class LoginTotpPage extends LanguageComboboxAwarePage {
     public void selectOtpCredential(String credentialName) {
         WebElement webElement = driver.findElement(
                 getXPathForLookupCardWithName(credentialName));
-        UIUtils.clickLink(webElement);
+        UIUtils.click(webElement);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -10,7 +10,6 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -69,11 +68,35 @@ public final class UIUtils {
         performOperationWithPageReload(() -> getCurrentDriver().navigate().refresh());
     }
 
+    /**
+     * The method executes click or sendKeys(Keys.ENTER) in the element.
+     * In the chrome driver click is emulated by pressing the ENTER key. Since
+     * the upgrade to chrome 128 some clicks are missed and that triggers CI
+     * failures. The method is intended to be used for buttons and links which
+     * accept clicking by pressing the ENTER key. If the element passed does
+     * not allow clicking using keys use the {@link #click(WebElement) click}
+     * method.
+     *
+     * @param element The element to click
+     */
     public static void clickLink(WebElement element) {
         WebDriver driver = getCurrentDriver();
 
         waitUntilElement(element).is().clickable();
 
+        performOperationWithPageReload(BrowserDriverUtil.isDriverChrome(driver)
+                ? () -> element.sendKeys(Keys.ENTER)
+                : element::click);
+    }
+
+    /**
+     * The method executes click in the element. This method always uses click and
+     * is not emulated by key pressing in chrome.
+     *
+     * @param element The element to click
+     */
+    public static void click(WebElement element) {
+        waitUntilElement(element).is().clickable();
         performOperationWithPageReload(element::click);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/fragments/AbstractHeader.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/fragments/AbstractHeader.java
@@ -20,7 +20,7 @@ package org.keycloak.testsuite.webauthn.pages.fragments;
 import org.openqa.selenium.WebElement;
 
 import static org.junit.Assert.assertEquals;
-import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.click;
 import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.UIUtils.isElementVisible;
 
@@ -49,7 +49,7 @@ public abstract class AbstractHeader extends AbstractFragmentWithMobileLayout {
 
     protected void clickToolsBtn(WebElement btn) {
         clickOptions();
-        clickLink(btn);
+        click(btn);
     }
 
     protected boolean isToolsBtnVisible(WebElement btn) {


### PR DESCRIPTION
Closes #33362
Closes #33037
Closes #32548

Draft for this because it's a bit strange. I have detected that the issue in `UserVerificationRegisterTest` is that `click` method sometimes does not work for the chrome driver. It's not a matter of waiting, you have to `click` again. I have detected that the method `sendKeys` works always. So I'm modifying the `clickLink` method to use the `sendKeys` for chrome. That is valid for links and buttons but not for selects, so another method `click` is created for selects (only used a few times in the CI). Maybe I'm too drastic so just asking what do you think about this.

I have executed 5x10 executions of the `UserVerificationRegisterTest` and with `click` it fails ([here](https://github.com/rmartinc/keycloak/actions/runs/11141588474), not even a single 10 run is achieved completely) and with `sendKeys` it never fails ([here](https://github.com/rmartinc/keycloak/actions/runs/11141821891/job/30963724174)). I don't know, as commented this is very weird, and related to CI infrastructure.

Other alternatives I see:

1. Just creating the new method for the `clickRegister` that is failing (although I suppose it can happen in more places).
2. Do not use the `sendKeys` but try to re-click if doesn't work. I have not tried this but I suppose it's possible, but I fear it would be again a solution only for the `clickRegister` (we have to call the new method one by one when we detect the issue).