### PR TITLE
update: fix typo "a email"

### DIFF
--- a/docs/documentation/server_development/topics/themes.adoc
+++ b/docs/documentation/server_development/topics/themes.adoc
@@ -260,7 +260,7 @@ An example for a custom `footer.ftl` may look like this:
 </#macro>
 ```
 
-==== Adding an image to a email theme
+==== Adding an image to an email theme
 
 To make images available to the theme add them to the `<THEME TYPE>/email/resources/img` directory of your theme. These can be used from within directly in HTML templates.
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -635,7 +635,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         idpRep.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
         testRealm().identityProviders().get(idpRep.getAlias()).update(idpRep);
 
-        // create a user to the provider realm using a email that does not share the same domain as the org
+        // create a user to the provider realm using an email that does not share the same domain as the org
         UserRepresentation user = UserBuilder.create()
                 .username("user")
                 .email("user@different.org")
@@ -660,7 +660,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         idpRep.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
         testRealm().identityProviders().get(idpRep.getAlias()).update(idpRep);
 
-        // create a user to the provider realm using a email that does not share the same domain as the org
+        // create a user to the provider realm using an email that does not share the same domain as the org
         UserRepresentation user = UserBuilder.create()
                 .username("user")
                 .email("user@different.org")


### PR DESCRIPTION
- "a email" becomes "an email".

Signed-off-by: Pedro Aguiar <contact@codespearhead.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
