### PR TITLE
Use clickLink for logout in webauthn

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LogoutConfirmPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LogoutConfirmPage.java
@@ -18,6 +18,7 @@
 
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -50,14 +51,14 @@ public class LogoutConfirmPage extends LanguageComboboxAwarePage {
     }
 
     public void confirmLogout() {
-        confirmLogoutButton.click();
+        UIUtils.clickLink(confirmLogoutButton);
     }
 
     public void confirmLogout(WebDriver driver) {
-        driver.findElement(By.cssSelector("input[type=\"submit\"]")).click();
+        UIUtils.clickLink(driver.findElement(By.cssSelector("input[type=\"submit\"]")));
     }
 
     public void clickBackToApplicationLink() {
-        backToApplicationLink.click();
+        UIUtils.clickLink(backToApplicationLink);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AbstractWebAuthnVirtualTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AbstractWebAuthnVirtualTest.java
@@ -71,6 +71,7 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.keycloak.testsuite.util.BrowserDriverUtil.isDriverFirefox;
 import static org.keycloak.testsuite.util.BrowserDriverUtil.isDriverInstanceOf;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
@@ -391,7 +392,7 @@ public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycl
             logoutConfirmPage.assertCurrent();
             logoutConfirmPage.confirmLogout();
             infoPage.assertCurrent();
-            waitForPageToLoad();
+            assertEquals("You are logged out", infoPage.getInfo());
         } catch (Exception e) {
             throw new RuntimeException("Cannot logout user", e);
         }


### PR DESCRIPTION
Closes #32923
Closes #32606
Closes #32605
Closes #32503

This fixes the tests for `WebAuthnTransportsTest` but maybe some more. The `logout` was also affected by the missed click issue. Just changing the direct `click` to the `clickLink` that performs the trick sending ENTER.
