### PR TITLE
Reload page when selecting a realm to force updating user permissions

### DIFF
--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -213,6 +213,7 @@ export const RealmSelector = () => {
                     navigate(toDashboard({ realm: realm.name }));
                     setOpen(false);
                     setSearch("");
+                    window.location.reload();
                   }}
                 >
                   <RealmText


### PR DESCRIPTION
Closes #31638

* Not yet fixing the error page when login in to the master realm (or any other realm the user hasn't access). We could think about a better page/message asking the user to select another realm
* When selecting the realm, the page is reloaded to make sure permissions are properly set and the user can access the other realms he has access to

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
