### PR TITLE
Add the nonce attribute when the client session context is recreated (25)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -1118,8 +1118,12 @@ public class TokenManager {
             String scope = oldRefreshToken.getScope();
             Object reuseId = oldRefreshToken.getOtherClaims().get(Constants.REUSE_ID);
             boolean offlineTokenRequested = Arrays.asList(scope.split(" ")).contains(OAuth2Constants.OFFLINE_ACCESS) ;
-            if (offlineTokenRequested)
+            if (offlineTokenRequested) {
                 clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, scope, session);
+                if (oldRefreshToken.getNonce() != null) {
+                    clientSessionCtx.setAttribute(OIDCLoginProtocol.NONCE_PARAM, oldRefreshToken.getNonce());
+                }
+            }
             generateRefreshToken(offlineTokenRequested);
             if (realm.isRevokeRefreshToken()) {
                 refreshToken.getOtherClaims().put(Constants.REUSE_ID, reuseId);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ArtifactResolutionService.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ArtifactResolutionService.java
@@ -43,7 +43,7 @@ public class ArtifactResolutionService implements Provider<Source>, Runnable {
     private ArtifactResponseType artifactResponseType;
     private final String endpointAddress;
     private ArtifactResolveType lastArtifactResolve;
-    private boolean running = true;
+    private volatile boolean running = true;
 
     /**
      * Standard constructor

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
@@ -55,8 +55,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setResponseDocument(doc);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder response = builder.artifactMessage(camb).build().login().user(bburkeUser).build().getSamlResponse(SamlClient.Binding.POST);
                 assertThat(response.getSamlObject(), instanceOf(ResponseType.class));
@@ -90,8 +90,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setResponseDocument(doc);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder response = builder.artifactMessage(camb).build().login().user(bburkeUser).build().getSamlResponse(REDIRECT);
                 assertThat(response.getSamlObject(), instanceOf(ResponseType.class));
@@ -124,8 +124,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setResponseDocument(doc);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 String response = builder.artifactMessage(camb).build().executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
                 assertThat(response, containsString("Invalid Request"));
@@ -151,8 +151,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setEmptyArtifactResponse(SAML_CLIENT_ID_SALES_POST);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 builder.artifactMessage(camb).build().execute(r -> {
                     assertThat(r, statusCodeIsHC(400));
@@ -180,8 +180,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/");
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder samlResponse = builder.authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
                         .login().user(bburkeUser).build()
@@ -220,8 +220,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/");
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder samlResponse = builder
                         .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST,


### PR DESCRIPTION
Closes #33355

PR:             https://github.com/keycloak/keycloak/pull/33422
Commit:         https://github.com/keycloak/keycloak/commit/6e471a84773a6952a8cb3d87efcb5d61ac643ecd
PR branch:      backport-33422-25.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/25.0


Signed-off-by: rmartinc <rmartinc@redhat.com>
Co-authored-by: Tomas Kralik <tomas.kralik@pbktechnology.cz>
(cherry picked from commit 6e471a84773a6952a8cb3d87efcb5d61ac643ecd)
