### PR TITLE
Prevent multiple logout confirmation actions

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -339,7 +339,7 @@ public class LogoutEndpoint {
 
         SessionCodeChecks checks = new LogoutSessionCodeChecks(realm, session.getContext().getUri(), request, clientConnection, session, event, code, clientId, tabId);
         checks.initialVerify();
-        if (!checks.verifyActiveAndValidAction(AuthenticationSessionModel.Action.LOGGING_OUT.name(), ClientSessionCode.ActionType.USER) || !checks.isActionRequest() || !formData.containsKey("confirmLogout")) {
+        if (!checks.verifyActiveAndValidAction(AuthenticationSessionModel.Action.LOGGING_OUT.name(), ClientSessionCode.ActionType.USER) || !checks.isActionRequest()) {
             AuthenticationSessionModel logoutSession = checks.getAuthenticationSession();
             String errorMessage = "Failed verification during logout.";
             logger.debugf( "%s logoutSessionId=%s, clientId=%s, tabId=%s",

--- a/themes/src/main/resources/theme/base/login/logout-confirm.ftl
+++ b/themes/src/main/resources/theme/base/login/logout-confirm.ftl
@@ -6,7 +6,7 @@
         <div id="kc-logout-confirm" class="content-area">
             <p class="instruction">${msg("logoutConfirmHeader")}</p>
 
-            <form class="form-actions" action="${url.logoutConfirmAction}" method="POST">
+            <form class="form-actions" action="${url.logoutConfirmAction}" onsubmit="confirmLogout.disabled = true; return true;" method="POST">
                 <input type="hidden" name="session_code" value="${logoutConfirm.code}">
                 <div class="${properties.kcFormGroupClass!}">
                     <div id="kc-form-options">


### PR DESCRIPTION
closes #32435

This is inspired by the fix https://github.com/keycloak/keycloak/commit/986540ab34ee11c7f6ce421e93fe5808a1bc14f6 from few years ago, which we have for the login form ( `login.ftl` ).

I am not sure if we want some more generic approach as it is possible that this approach happens on more forms, but not sure...
