### PR TITLE
Issue when running tests from IDE on embedded undertow - org.jboss.th…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -184,13 +184,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- FIXME: Override in order to prevent NoClassDefFoundError: org/jboss/threads/AsyncFuture in ClientContainerController -->
-        <dependency>
-            <groupId>org.jboss.threads</groupId>
-            <artifactId>jboss-threads</artifactId>
-            <version>2.4.0.Final</version>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.0_spec</artifactId>
@@ -480,6 +473,12 @@
                     <scope>test</scope>
                     <version>${wildfly.core.version}</version>
                 </dependency>
+                <!-- FIXME: Override in order to prevent NoClassDefFoundError: org/jboss/threads/AsyncFuture in ClientContainerController -->
+                <dependency>
+                    <groupId>org.jboss.threads</groupId>
+                    <artifactId>jboss-threads</artifactId>
+                    <version>2.4.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>
@@ -517,6 +516,12 @@
                     <artifactId>wildfly-cli</artifactId>
                     <scope>test</scope>
                     <version>${wildfly.core.version}</version>
+                </dependency>
+                <!-- FIXME: Override in order to prevent NoClassDefFoundError: org/jboss/threads/AsyncFuture in ClientContainerController -->
+                <dependency>
+                    <groupId>org.jboss.threads</groupId>
+                    <artifactId>jboss-threads</artifactId>
+                    <version>2.4.0.Final</version>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
…reads.EnhancedQueueExecutor.setKeepAliveTime(java.time.Duration)

closes #33517

The jboss-threads dependency is overriden just for the adapter tests as the lower version is needed just when using `app-server-wildfly` or `app-server-eap8` profiles. The rest of the testsuite can then use the proper version of jboss-threads, which is required by the infinispan.
