### PR TITLE
fix: consolidating local ip checks

### DIFF
--- a/common/src/test/java/org/keycloak/common/enums/SslRequiredTest.java
+++ b/common/src/test/java/org/keycloak/common/enums/SslRequiredTest.java
@@ -1,0 +1,20 @@
+package org.keycloak.common.enums;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class SslRequiredTest {
+
+    @Test
+    public void sslRequiredExternalTest() throws IOException {
+        assertFalse(SslRequired.EXTERNAL.isRequired("127.0.0.1"));
+        assertTrue(SslRequired.EXTERNAL.isRequired((String)null));
+        assertTrue(SslRequired.EXTERNAL.isRequired(""));
+        assertTrue(SslRequired.EXTERNAL.isRequired("0.0.0.0"));
+    }
+
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusClientConnection.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusClientConnection.java
@@ -31,7 +31,7 @@ public final class QuarkusClientConnection implements ClientConnection {
 
     @Override
     public String getRemoteAddr() {
-        return request.remoteAddress().host();
+        return request.remoteAddress().hostAddress();
     }
 
     @Override
@@ -46,7 +46,7 @@ public final class QuarkusClientConnection implements ClientConnection {
 
     @Override
     public String getLocalAddr() {
-        return request.localAddress().host();
+        return request.localAddress().hostAddress();
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -50,13 +50,12 @@ import org.keycloak.theme.Theme;
 import org.keycloak.theme.freemarker.FreeMarkerProvider;
 import org.keycloak.urls.UrlType;
 import org.keycloak.utils.MediaType;
+import org.keycloak.utils.SecureContextResolver;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -264,25 +263,17 @@ public class WelcomeResource {
     }
 
     private boolean isLocal() {
-        try {
-            ClientConnection clientConnection = session.getContext().getConnection();
-            InetAddress remoteInetAddress = InetAddress.getByName(clientConnection.getRemoteAddr());
-            InetAddress localInetAddress = InetAddress.getByName(clientConnection.getLocalAddr());
-            HttpRequest request = session.getContext().getHttpRequest();
-            HttpHeaders headers = request.getHttpHeaders();
-            String xForwardedFor = headers.getHeaderString("X-Forwarded-For");
-            logger.debugf("Checking WelcomePage. Remote address: %s, Local address: %s, X-Forwarded-For header: %s", remoteInetAddress.toString(), localInetAddress.toString(), xForwardedFor);
+        ClientConnection clientConnection = session.getContext().getConnection();
+        String remoteAddress = clientConnection.getRemoteAddr();
+        String localAddress = clientConnection.getLocalAddr();
+        HttpRequest request = session.getContext().getHttpRequest();
+        HttpHeaders headers = request.getHttpHeaders();
+        String xForwardedFor = headers.getHeaderString("X-Forwarded-For");
+        String forwarded = headers.getHeaderString("Forwarded");
+        logger.debugf("Checking WelcomePage. Remote address: %s, Local address: %s, X-Forwarded-For header: %s, Forwarded header: %s", remoteAddress.toString(), localAddress.toString(), xForwardedFor, forwarded);
 
-            // Access through AJP protocol (loadbalancer) may cause that remoteAddress is "127.0.0.1".
-            // So consider that welcome page accessed locally just if it was accessed really through "localhost" URL and without loadbalancer (x-forwarded-for header is empty).
-            return isLocalAddress(remoteInetAddress) && isLocalAddress(localInetAddress) && xForwardedFor == null;
-        } catch (UnknownHostException e) {
-            throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    private boolean isLocalAddress(InetAddress inetAddress) {
-        return inetAddress.isAnyLocalAddress() || inetAddress.isLoopbackAddress();
+        // Consider that welcome page accessed locally just if it was accessed really through "localhost" URL and without loadbalancer (x-forwarded-for and forwarded header is empty).
+        return xForwardedFor == null && forwarded == null && SecureContextResolver.isLocalAddress(remoteAddress) && SecureContextResolver.isLocalAddress(localAddress);
     }
 
     private String setCsrfCookie() {

--- a/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
+++ b/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
@@ -57,13 +57,7 @@ public class SecureContextResolver {
             return false;
         }
 
-        // The host matches a CIDR notation of ::1/128
-        if (host.equals("[::1]") || host.equals("[0000:0000:0000:0000:0000:0000:0000:0001]")) {
-            return true;
-        }
-
-        // The host matches a CIDR notation of 127.0.0.0/8
-        if (LOCALHOST_IPV4.matcher(host).matches()) {
+        if (isLocalAddress(host)) {
             return true;
         }
 
@@ -72,5 +66,24 @@ public class SecureContextResolver {
         }
 
         return host.endsWith(".localhost") || host.endsWith(".localhost.");
+    }
+
+    /**
+     * Test whether the given address is the localhost
+     * @param address
+     * @return false if the address is not localhost or not an address value
+     */
+    public static boolean isLocalAddress(String address) {
+        // The host matches a CIDR notation of ::1/128
+        if (address.equals("[::1]") || address.equals("[0000:0000:0000:0000:0000:0000:0000:0001]")) {
+            return true;
+        }
+
+        // The host matches a CIDR notation of 127.0.0.0/8
+        if (LOCALHOST_IPV4.matcher(address).matches()) {
+            return true;
+        }
+        
+        return false;
     }
 }

--- a/services/src/test/java/org/keycloak/utils/SecureContextResolverTest.java
+++ b/services/src/test/java/org/keycloak/utils/SecureContextResolverTest.java
@@ -47,6 +47,7 @@ public class SecureContextResolverTest {
         assertSecureContext("http://[::2]", false);
         assertSecureContext("http://[2001:0000:130F:0000:0000:09C0:876A:130B]", false);
         assertSecureContext("http://::1", false);
+        assertSecureContext("http://[FE80:0000:130F:0000:0000:09C0:876A:130B]", false);
     }
 
     @Test


### PR DESCRIPTION
closes: #33484

As it turns out there's not a lot that should be consolidated between SslRequired and SecureContextResolver. The WelcomeResource should use SecureContextResolver - a check for the Forwarded header was added there as well.

The only other differences proposed here 
- to not accept 0.0.0.0 as local for the welcome check nor for SslRequired
- To have QuarkusClientConnection return the hostAddress for the remoteAddress. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
