### PR TITLE
fix: deprecate various aspects of SslRequired

### DIFF
--- a/common/src/main/java/org/keycloak/common/enums/SslRequired.java
+++ b/common/src/main/java/org/keycloak/common/enums/SslRequired.java
@@ -27,7 +27,9 @@ import java.net.UnknownHostException;
  */
 public enum SslRequired {
 
+    @Deprecated
     ALL,
+    @Deprecated
     EXTERNAL,
     NONE;
 

--- a/common/src/main/java/org/keycloak/common/util/UriUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/UriUtils.java
@@ -123,6 +123,8 @@ public class UriUtils {
             throw new IllegalArgumentException("Invalid protocol/scheme for url [" + name + "]");
         }
 
+        // TODO: as we transition to NONE / removal of SslRequired this check either needs to
+        // consider http settings (which aren't immediately available here) or just go away
         if (!"https".equals(protocol) && sslRequired.isRequired(parsed.getHost())) {
             throw new IllegalArgumentException("The url [" + name + "] requires secure connections");
         }

--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -1,0 +1,6 @@
+= SslRequired deprecations
+
+`SslRequired.EXTERNAL`, `SslRequired.ALL` have been deprecated. 
+New realms will default to `SslRequired.NONE` meaning that you must explicitly set `SslRequired.EXTERNAL` to enable the legacy behavior. 
+Moving forward if you want `SslRequired.EXTERNAL` behavior, then your proxy should only allow https access, and if you want `SslRequired.ALL` behavior, you should not enable http.
+To align with this you should change your existing realms to `SslRequired.NONE`.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -1,6 +1,10 @@
 [[migration-changes]]
 == Migration Changes
 
+=== Migrating to 26.1.0
+
+include::changes-26_1_0.adoc[leveloffset=3]
+
 === Migrating to 26.0.0
 
 include::changes-26_0_0.adoc[leveloffset=3]

--- a/docs/guides/server/hostname.adoc
+++ b/docs/guides/server/hostname.adoc
@@ -40,15 +40,16 @@ In this manner, your applications, referred to as clients, can connect with {pro
 
 == Using edge TLS termination
 
-As you can observe, the HTTPS protocol is the default choice, adhering to {project_name}'s commitment to security best practices. However, {project_name} also provides the flexibility for users to opt for HTTP if necessary. This can be achieved simply by specifying the HTTP listener, consult the <@links.server id="enabletls"/> for details. With an edge TLS-termination proxy you can start the server as follows:
+As you can observe, the HTTPS protocol is the default choice, adhering to {project_name}'s commitment to security best practices. However, {project_name} also provides the flexibility for users to opt for HTTP if necessary. This can be achieved by specifying `http-enabled`. 
+With an edge TLS-termination proxy you can start the server as follows:
 
 <@kc.start parameters="--hostname https://my.keycloak.org --http-enabled true"/>
 
-The result of this configuration is that you can continue to access {project_name} at `https://my.keycloak.org` via HTTPS, while the proxy interacts with the instance using HTTP and port `8080`.
+The result of this configuration is that you can continue to access {project_name} at `https://my.keycloak.org` via HTTPS, while the proxy interacts with the instance using HTTP and port `8080`. For more details refer to the <@links.server id="reverseproxy"/> guide and the following section "Using a reverse proxy".
 
 == Using a reverse proxy
 
-When a proxy is forwarding http or reencrypted TLS requests, the `proxy-headers` option should be set. Depending on the hostname settings, some or all of the URL, may be dynamically determined.
+When a proxy is forwarding http or reencrypted TLS requests, the `proxy-headers` option should be set. For more details refer to the <@links.server id="reverseproxy"/> guide. Depending on the hostname settings, some or all of the URL, may be dynamically determined.
 
 WARNING: If either `forwarded` or `xforwarded` is selected, make sure your reverse proxy properly sets and overwrites the `Forwarded` or `X-Forwarded-*` headers respectively. To set these headers, consult the documentation for your reverse proxy. Misconfiguration will leave {project_name} exposed to security vulnerabilities.
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -10,7 +10,7 @@ public class HttpOptions {
 
     public static final Option<Boolean> HTTP_ENABLED = new OptionBuilder<>("http-enabled", Boolean.class)
             .category(OptionCategory.HTTP)
-            .description("Enables the HTTP listener.")
+            .description("Enables the HTTP listener. Only for production usage if you restricted external access, such as with a TLS termination proxy")
             .defaultValue(Boolean.FALSE)
             .build();
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -159,7 +159,8 @@ Hostname v2:
 HTTP(S):
 
 --http-enabled <true|false>
-                     Enables the HTTP listener. Default: false.
+                     Enables the HTTP listener. Only for production usage if you restricted
+                       external access, such as with a TLS termination proxy Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -185,7 +185,8 @@ Hostname v2:
 HTTP(S):
 
 --http-enabled <true|false>
-                     Enables the HTTP listener. Default: false.
+                     Enables the HTTP listener. Only for production usage if you restricted
+                       external access, such as with a TLS termination proxy Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -160,7 +160,8 @@ Hostname v2:
 HTTP(S):
 
 --http-enabled <true|false>
-                     Enables the HTTP listener. Default: false.
+                     Enables the HTTP listener. Only for production usage if you restricted
+                       external access, such as with a TLS termination proxy Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -186,7 +186,8 @@ Hostname v2:
 HTTP(S):
 
 --http-enabled <true|false>
-                     Enables the HTTP listener. Default: false.
+                     Enables the HTTP listener. Only for production usage if you restricted
+                       external access, such as with a TLS termination proxy Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -145,7 +145,8 @@ Hostname v2:
 HTTP(S):
 
 --http-enabled <true|false>
-                     Enables the HTTP listener. Default: false.
+                     Enables the HTTP listener. Only for production usage if you restricted
+                       external access, such as with a TLS termination proxy Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -171,7 +171,8 @@ Hostname v2:
 HTTP(S):
 
 --http-enabled <true|false>
-                     Enables the HTTP listener. Default: false.
+                     Enables the HTTP listener. Only for production usage if you restricted
+                       external access, such as with a TLS termination proxy Default: false.
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -92,7 +92,7 @@ public class ApplianceBootstrap {
         realm.setAccessCodeLifespan(60);
         realm.setAccessCodeLifespanUserAction(300);
         realm.setAccessCodeLifespanLogin(1800);
-        realm.setSslRequired(SslRequired.EXTERNAL);
+        realm.setSslRequired(SslRequired.NONE);
         realm.setRegistrationAllowed(false);
         realm.setRegistrationEmailAsUsername(false);
 

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -259,7 +259,7 @@ public class RealmManager {
         realm.setQuickLoginCheckMilliSeconds(1000);
         realm.setMaxDeltaTimeSeconds(60 * 60 * 12); // 12 hours
         realm.setFailureFactor(30);
-        realm.setSslRequired(SslRequired.EXTERNAL);
+        realm.setSslRequired(SslRequired.NONE);
         realm.setOTPPolicy(OTPPolicy.DEFAULT_POLICY);
         realm.setLoginWithEmailAllowed(true);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -34,6 +34,7 @@ import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.RealmsResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.utils.TimeBasedOTP;
@@ -473,11 +474,14 @@ public abstract class AbstractKeycloakTest {
     public void importRealm(RealmRepresentation realm) {
         if (modifyRealmForSSL()) {
             if (AUTH_SERVER_SSL_REQUIRED) {
+                realm.setSslRequired(SslRequired.EXTERNAL.name());
                 log.debugf("Modifying %s for SSL", realm.getId());
-                for (ClientRepresentation cr : realm.getClients()) {
-                    modifyMainUrls(cr);
-                    modifyRedirectUrls(cr);
-                    modifySamlAttributes(cr);
+                if (realm.getClients() != null) {
+                    for (ClientRepresentation cr : realm.getClients()) {
+                        modifyMainUrls(cr);
+                        modifyRedirectUrls(cr);
+                        modifySamlAttributes(cr);
+                    }
                 }
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -219,7 +219,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
 
     @Test
     public void failCreateInvalidUrl() throws Exception {
-        try (AutoCloseable c = new RealmAttributeUpdater(realmsResouce().realm("test"))
+        try (AutoCloseable c = new RealmAttributeUpdater(realmsResouce().realm(REALM_NAME))
                 .updateWith(r -> r.setSslRequired(SslRequired.ALL.name()))
                 .update()
         ) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AdapterInstallationConfigTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AdapterInstallationConfigTest.java
@@ -38,6 +38,11 @@ public class AdapterInstallationConfigTest extends AbstractClientRegistrationTes
     private ClientRepresentation client;
     private ClientRepresentation client2;
     private ClientRepresentation clientPublic;
+    
+    @Override
+    protected boolean modifyRealmForSSL() {
+        return true;
+    }
 
     @Before
     @Override


### PR DESCRIPTION
closes: #31914

This deprecates ALL and EXTERNAL. It leaves the public get/setSslRequired undeprecated for now. 

As long as we agree that users should either not be enabled http or using a proxy to limit access, then the only thing we're loosing here is some of the validation the checkUrl logic. That could made better, but we'll need to have access to the relevant Configuration options there - a comment was added in the code, but I didn't attempt to change the logic.

This also does not do any cleanup in tests around SslRequired.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
