### PR TITLE
update/fix-typo-repeated-to-a

### DIFF
--- a/js/apps/admin-ui/src/clients/add/__tests__/mock-serverinfo.json
+++ b/js/apps/admin-ui/src/clients/add/__tests__/mock-serverinfo.json
@@ -2070,7 +2070,7 @@
            "id":"saml-user-attribute-mapper",
            "name":"User Attribute",
            "category":"AttributeStatement Mapper",
-           "helpText":"Map a custom user attribute to a to a SAML attribute.",
+           "helpText":"Map a custom user attribute to a SAML attribute.",
            "priority":0,
            "properties":[
               {
@@ -6444,7 +6444,7 @@
         },
         {
            "id":"saml-user-attribute-mapper",
-           "helpText":"Map a custom user attribute to a to a SAML attribute.",
+           "helpText":"Map a custom user attribute to a SAML attribute.",
            "properties":[
               {
                  "name":"user.attribute",

--- a/js/apps/admin-ui/src/context/server-info/__tests__/mock.json
+++ b/js/apps/admin-ui/src/context/server-info/__tests__/mock.json
@@ -1411,7 +1411,7 @@
         "id": "saml-user-attribute-mapper",
         "name": "User Attribute",
         "category": "AttributeStatement Mapper",
-        "helpText": "Map a custom user attribute to a to a SAML attribute.",
+        "helpText": "Map a custom user attribute to a SAML attribute.",
         "priority": 0,
         "properties": [
           {
@@ -5789,7 +5789,7 @@
       },
       {
         "id": "saml-user-attribute-mapper",
-        "helpText": "Map a custom user attribute to a to a SAML attribute.",
+        "helpText": "Map a custom user attribute to a SAML attribute.",
         "properties": [
           {
             "name": "user.attribute",

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
@@ -81,7 +81,7 @@ public class UserAttributeStatementMapper extends AbstractSAMLProtocolMapper imp
 
     @Override
     public String getHelpText() {
-        return "Map a custom user attribute to a to a SAML attribute.";
+        return "Map a custom user attribute to a SAML attribute.";
     }
 
     @Override


### PR DESCRIPTION
- Corrected "Map a custom user attribute to a to a SAML attribute." by removing the repeated "to a".

Closes: https://github.com/keycloak/keycloak/issues/33603

Signed-off-by: Pedro Aguiar <contact@codespearhead.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
