### PR TITLE
Backport: Fix various issues holding up CI (22)

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ArtifactResolutionService.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ArtifactResolutionService.java
@@ -43,7 +43,7 @@ public class ArtifactResolutionService implements Provider<Source>, Runnable {
     private ArtifactResponseType artifactResponseType;
     private final String endpointAddress;
     private ArtifactResolveType lastArtifactResolve;
-    private boolean running = true;
+    private volatile boolean running = true;
 
     /**
      * Standard constructor

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
@@ -55,8 +55,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setResponseDocument(doc);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder response = builder.artifactMessage(camb).build().login().user(bburkeUser).build().getSamlResponse(SamlClient.Binding.POST);
                 assertThat(response.getSamlObject(), instanceOf(ResponseType.class));
@@ -90,8 +90,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setResponseDocument(doc);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder response = builder.artifactMessage(camb).build().login().user(bburkeUser).build().getSamlResponse(REDIRECT);
                 assertThat(response.getSamlObject(), instanceOf(ResponseType.class));
@@ -124,8 +124,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setResponseDocument(doc);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 String response = builder.artifactMessage(camb).build().executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
                 assertThat(response, containsString("Invalid Request"));
@@ -151,8 +151,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/").setEmptyArtifactResponse(SAML_CLIENT_ID_SALES_POST);
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 builder.artifactMessage(camb).build().execute(r -> {
                     assertThat(r, statusCodeIsHC(400));
@@ -180,8 +180,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/");
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder samlResponse = builder.authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
                         .login().user(bburkeUser).build()
@@ -220,8 +220,8 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
         ArtifactResolutionService ars = new ArtifactResolutionService("http://127.0.0.1:8082/");
         Thread arsThread = new Thread(ars);
         try {
-            arsThread.start();
             synchronized (ars) {
+                arsThread.start();
                 ars.wait();
                 SAMLDocumentHolder samlResponse = builder
                         .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST,


### PR DESCRIPTION
Closes #33064

PR: https://github.com/keycloak/keycloak/pull/33086
Commit: https://github.com/keycloak/keycloak/commit/42cde0cfdd6b75455ece5af0a2e6bc0ae1d11010
Target branch: https://github.com/keycloak/keycloak/tree/release/22.0

Fix for the saml hang in ArtifactBindingWithResolutionServiceTest. In upstream the PR fixed several things. Just the needed commit is backported.
