### PR TITLE
Adding retry when clicking on rememberMe checkbox on the loginPage du…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.keycloak.common.util.Retry;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -247,10 +248,7 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public void setRememberMe(boolean enable) {
-        boolean current = rememberMe.isSelected();
-        if (current != enable) {
-            rememberMe.click();
-        }
+        UIUtils.switchCheckbox(rememberMe, enable);
     }
 
     public boolean isRememberMeChecked() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -1,6 +1,8 @@
 package org.keycloak.testsuite.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.keycloak.common.util.Retry;
 import org.keycloak.testsuite.page.AbstractPatternFlyAlert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -98,6 +100,28 @@ public final class UIUtils {
     public static void click(WebElement element) {
         waitUntilElement(element).is().clickable();
         performOperationWithPageReload(element::click);
+    }
+
+    /**
+     * The method switches the checkbox to the expected state.
+     *
+     * It looks that since chrome 128, the single click sometimes does
+     * not work (See also similar issue {@link #clickLink(WebElement)}, so it is possible repeated multiple times until it reach
+     * the desired state
+     *
+     * @param checkbox Checkbox element to enable or disable
+     * @param enable If true, the checkbox should be switched to enabled (checked). If false, the checkbox should be switched to disabled (unchecked)
+     */
+    public static void switchCheckbox(WebElement checkbox, boolean enable) {
+        int maxAttempts = 4;
+
+        Retry.execute(() -> {
+            boolean current = checkbox.isSelected();
+            if (current != enable) {
+                UIUtils.click(checkbox);
+                Assert.assertNotEquals("Checkbox " + checkbox + " is still in the state " + current + " after click.", current, checkbox.isSelected());
+            }
+        }, maxAttempts, 0);
     }
 
     /**


### PR DESCRIPTION
…ring tests

closes #32476
closes #32677
closes #32767
closes #33132
closes #32550

This is again problem with Chrome 128. After click to checkbox like "rememberMe" on login page, the click is sometimes not taken into account and should be repeated. This helps to fix all flaky tests of `LoginTest` . It passed 20 times in a row with Chrome in my branch - https://github.com/mposolda/keycloak/actions/runs/11176736792/job/31070953971
