### PR TITLE
Remove retry in LoginPage.resetPassword due the more universal fix ex…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -19,16 +19,13 @@ package org.keycloak.testsuite.pages;
 
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Assert;
-import org.keycloak.common.util.Retry;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.support.FindBy;
 
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
@@ -237,14 +234,7 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public void resetPassword() {
-        // Since Chrome 128, the user can be still kept on the "Login page" after click to "Forget Password" link. Clicking the "Forget Password" link another
-        // time usually helps. Limit to 4 attempts for now.
-        Retry.execute(() -> {
-            clickLink(resetPasswordLink);
-            if (driver instanceof ChromeDriver) {
-                Assert.assertEquals("Forgot Your Password?", PageUtils.getPageTitle(driver));
-            }
-        }, 4, 0);
+        clickLink(resetPasswordLink);
     }
 
     public void setRememberMe(boolean enable) {


### PR DESCRIPTION
…ists in UIUtils.clickLink

closes #33492

Removing the previously added hack as the more universal approach is in the `UIUtils.clickLink` . The `ResetPasswordTest` (which was the original reason why the hack was added in #32710 ) passed 20 times in my local CI branch - https://github.com/mposolda/keycloak/actions/runs/11178061979/job/31075213201 .


