### PR TITLE
Add support for refresh tokens with non-JWT payload

### DIFF
--- a/js/libs/keycloak-js/lib/keycloak.js
+++ b/js/libs/keycloak-js/lib/keycloak.js
@@ -175,6 +175,12 @@ function Keycloak (config) {
             } else {
                 kc.messageReceiveTimeout = 10000;
             }
+
+            if (typeof initOptions.jwtRefreshToken === 'boolean') {
+                kc.jwtRefreshToken = initOptions.jwtRefreshToken;
+            } else {
+                kc.jwtRefreshToken = initOptions.jwtRefreshToken;
+            }
         }
 
         if (!kc.responseMode) {
@@ -955,7 +961,9 @@ function Keycloak (config) {
 
         if (refreshToken) {
             kc.refreshToken = refreshToken;
-            kc.refreshTokenParsed = decodeToken(refreshToken);
+            if (kc.jwtRefreshToken === true) {
+              kc.refreshTokenParsed = decodeToken(refreshToken);
+            }
         } else {
             delete kc.refreshToken;
             delete kc.refreshTokenParsed;

--- a/js/libs/keycloak-js/lib/keycloak.js
+++ b/js/libs/keycloak-js/lib/keycloak.js
@@ -179,7 +179,7 @@ function Keycloak (config) {
             if (typeof initOptions.jwtRefreshToken === 'boolean') {
                 kc.jwtRefreshToken = initOptions.jwtRefreshToken;
             } else {
-                kc.jwtRefreshToken = initOptions.jwtRefreshToken;
+                kc.jwtRefreshToken = true;
             }
         }
 


### PR DESCRIPTION
Previously Keycloak assumes refresh token has JWT payload and tries to parse it, throwing an error and breaking login flow. This revision adds an init option "jwtRefreshToken", when set to false refresh token is not parsed as JWT.

Closes #33568


