### PR TITLE
Add check to ensure that no unstaged proto.lock files exist on PRs is…

### DIFF
--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -35,7 +35,7 @@ runs:
         # Ensure this plugin is built first to avoid warnings in the build
         ./mvnw install -Pdistribution -am -pl distribution/maven-plugins/licenses-processor
         # By using "dependency:resolve", it will download all dependencies used in later stages for running the tests
-        ./mvnw install dependency:resolve -V -e -DskipTests -DskipExamples -DexcludeGroupIds=org.keycloak -Dsilent=true
+        ./mvnw install dependency:resolve -V -e -DskipTests -DskipExamples -DexcludeGroupIds=org.keycloak -Dsilent=true -DcommitProtoLockChanges=true
 
     - id: compress-keycloak-maven-repository
       name: Compress Keycloak Maven artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Build Keycloak
         uses: ./.github/actions/build-keycloak
 
+      - name: Check for unstaged proto.lock files
+        if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release/')
+        run: git diff --name-only --exit-code -- "**/proto.lock"
+
   unit-tests:
     name: Base UT
     runs-on: ubuntu-latest


### PR DESCRIPTION

Closes #33566 

This also needs to be backported to `release/26.0`.

The Keycloak build is now always executed with the `-DcommitProtoLockChanges=true` so that the various `**/proto.lock` files are created/updated. We then fail the "build" job if there exists uncommitted changes to any `**/proto.lock` files. This will not impact the `main` branch as no `proto.lock` files should exist in the repository, however it will ensure that any changes to `proto.lock` files in the release branches must be committed in order for CI to continue.