### PR TITLE
fix: ensuring placeholders can be used with --import-realm (#33589)

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
-import org.keycloak.it.junit5.extension.WithEnvVars;
 import org.keycloak.it.utils.KeycloakDistribution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/quarkus/tests/integration/src/test/resources/quickstart-realm.json
+++ b/quarkus/tests/integration/src/test/resources/quickstart-realm.json
@@ -1,6 +1,6 @@
 {
     "realm": "quickstart-realm",
-    "enabled": true,
+    "enabled": ${TEST_REALM_ENABLED:true},
     "accessTokenLifespan": 60,
     "accessCodeLifespan": 60,
     "accessCodeLifespanUserAction": 300,

--- a/services/src/main/java/org/keycloak/exportimport/ExportImportManager.java
+++ b/services/src/main/java/org/keycloak/exportimport/ExportImportManager.java
@@ -95,6 +95,7 @@ public class ExportImportManager {
         if (dir == null) {
             throw new IllegalStateException("Import not enabled");
         }
+        ExportImportConfig.setReplacePlaceholders(true);
         
         return getStartupImportProviders(dir).map(Supplier::get).anyMatch(provider -> {
             try {


### PR DESCRIPTION
closes: #33578

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit cb3954fc7bfa5662a339d6bdf29ba9d74c96ff7b)
