### PR TITLE
fix: adding a server guide on installation location / layout

### DIFF
--- a/docs/guides/server/directory-structure.adoc
+++ b/docs/guides/server/directory-structure.adoc
@@ -1,0 +1,31 @@
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
+
+<@tmpl.guide
+title="Directory Structure"
+summary="Understand the purpose of the directories under the installation root"
+includedOptions="">
+
+== Installation Locations
+
+If you are installing from a zip file then by default there will be an install root directory of `{archivebasename}-{version}`, which can be created anywhere you choose on your filesystem.
+
+`/opt/keycloak` is the root install location for the server in all containerized usage shown for {project_name} including <@links.server id="containers"/>, <@links.gettingstarted id="getting-started-docker"/>, <@links.gettingstarted id="getting-started-podman"/>, <@links.gettingstarted id="getting-started-kubernetes"/>, and <@links.gettingstarted id="getting-started-openshift"/>.
+
+NOTE: in the rest of documentation relative paths are understood to be relative to the install root - e.g. `conf/file.xml` means `<install root>/conf/file.xml`
+
+== Directory Structure
+
+Under the {project_name} install root there exists a number of folders:
+
+* *bin/* - contains all the shell scripts for the server, including `kc.sh|bat`, `kcadm.sh|bat`, and `kcreg.sh|bat`
+** *client/* - used internally
+* *conf/* - directory used for configuration files, including `keycloak.conf` - see <@links.server id="configuration"/>. Many options for specifying a configuration file expect paths relative to this directory. 
+** *truststores/* - default path used by the `truststore-paths` option - see <@links.server id="keycloak-truststore"/> 
+* *data/* - directory for the server to store runtime information, such as transaction logs 
+** *logs/* - default directory for file logging - see <@links.server id="logging"/>
+* *lib/* - used internally
+* *providers/* - directory for user provided dependencies - see <@links.server id="configuration-provider"/> for extending the server and <@links.server id="db"/> for an example of add a JDBC driver. 
+* *themes/* - directory for customizations to the Admin Console - see https://www.keycloak.org/docs/latest/server_development/#_themes[Developing Themes]
+
+</@tmpl.guide>

--- a/docs/guides/server/pinned-guides
+++ b/docs/guides/server/pinned-guides
@@ -1,6 +1,7 @@
 configuration
 configuration-production
 bootstrap-admin-recovery
+directory-structure
 containers
 enabletls
 hostname

--- a/quarkus/dist/src/main/README.md
+++ b/quarkus/dist/src/main/README.md
@@ -1,6 +1,8 @@
 Keycloak
 ========
 
+To understand the contents of your Keycloak installation, see the [directory structure guide](https://www.keycloak.org/server/directory-structure).
+
 To get help configuring Keycloak via the CLI, run:
 
 on Linux/Unix:


### PR DESCRIPTION
closes: #32110

Calls out more clearly the usage of /opt/keycloak and provides an overview of what our directory structure looks like.

There's a note about the relative paths - I think a separate issue is needed if we want to change all existing relative paths to read as <install root>/path instead.

The README.md in our root directory could also be updated to have a link to this guide.

WDYT? @andymunro @vmuzikar @mabartos 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
