### PR TITLE
Support for using user provider as credential store

### DIFF
--- a/model/storage/src/main/java/org/keycloak/credential/DisabledCredentialStore.java
+++ b/model/storage/src/main/java/org/keycloak/credential/DisabledCredentialStore.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022. Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.credential;
+
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.ReadOnlyException;
+
+import java.util.stream.Stream;
+
+/**
+ * Credential store used as a substitute for disabled user storage providers.
+ *
+ * @author Michal Růžička
+ */
+public class DisabledCredentialStore implements UserCredentialStore {
+
+    public static final DisabledCredentialStore INSTANCE = new DisabledCredentialStore();
+
+    @Override
+    public void updateCredential(RealmModel realm, UserModel user, CredentialModel cred) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public CredentialModel createCredential(RealmModel realm, UserModel user, CredentialModel cred) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public boolean removeStoredCredential(RealmModel realm, UserModel user, String id) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public CredentialModel getStoredCredentialById(RealmModel realm, UserModel user, String id) {
+        return null;
+    }
+
+    @Override
+    public Stream<CredentialModel> getStoredCredentialsStream(RealmModel realm, UserModel user) {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<CredentialModel> getStoredCredentialsByTypeStream(RealmModel realm, UserModel user, String type) {
+        return Stream.empty();
+    }
+
+    @Override
+    public CredentialModel getStoredCredentialByNameAndType(RealmModel realm, UserModel user, String name, String type) {
+        return null;
+    }
+
+    @Override
+    public boolean moveCredentialTo(RealmModel realm, UserModel user, String id, String newPreviousCredentialId) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private ReadOnlyException readOnlyException() {
+        return new ReadOnlyException("user is disabled");
+    }
+
+}

--- a/model/storage/src/main/java/org/keycloak/credential/UserCredentialManager.java
+++ b/model/storage/src/main/java/org/keycloak/credential/UserCredentialManager.java
@@ -101,45 +101,45 @@ public class UserCredentialManager extends AbstractStorageManager<UserStoragePro
     @Override
     public void updateStoredCredential(CredentialModel cred) {
         throwExceptionIfInvalidUser(user);
-        getStoreForUser(user).updateCredential(realm, user, cred);
+        getStoreForUser().updateCredential(realm, user, cred);
     }
 
     @Override
     public CredentialModel createStoredCredential(CredentialModel cred) {
         throwExceptionIfInvalidUser(user);
-        return getStoreForUser(user).createCredential(realm, user, cred);
+        return getStoreForUser().createCredential(realm, user, cred);
     }
 
     @Override
     public boolean removeStoredCredentialById(String id) {
         throwExceptionIfInvalidUser(user);
-        return getStoreForUser(user).removeStoredCredential(realm, user, id);
+        return getStoreForUser().removeStoredCredential(realm, user, id);
     }
 
     @Override
     public CredentialModel getStoredCredentialById(String id) {
-        return getStoreForUser(user).getStoredCredentialById(realm, user, id);
+        return getStoreForUser().getStoredCredentialById(realm, user, id);
     }
 
     @Override
     public Stream<CredentialModel> getStoredCredentialsStream() {
-        return getStoreForUser(user).getStoredCredentialsStream(realm, user);
+        return getStoreForUser().getStoredCredentialsStream(realm, user);
     }
 
     @Override
     public Stream<CredentialModel> getStoredCredentialsByTypeStream(String type) {
-        return getStoreForUser(user).getStoredCredentialsByTypeStream(realm, user, type);
+        return getStoreForUser().getStoredCredentialsByTypeStream(realm, user, type);
     }
 
     @Override
     public CredentialModel getStoredCredentialByNameAndType(String name, String type) {
-        return getStoreForUser(user).getStoredCredentialByNameAndType(realm, user, name, type);
+        return getStoreForUser().getStoredCredentialByNameAndType(realm, user, name, type);
     }
 
     @Override
     public boolean moveStoredCredentialTo(String id, String newPreviousCredentialId) {
         throwExceptionIfInvalidUser(user);
-        return getStoreForUser(user).moveCredentialTo(realm, user, id, newPreviousCredentialId);
+        return getStoreForUser().moveCredentialTo(realm, user, id, newPreviousCredentialId);
     }
 
     @Override
@@ -217,7 +217,7 @@ public class UserCredentialManager extends AbstractStorageManager<UserStoragePro
         throwExceptionIfInvalidUser(user);
         return session.getKeycloakSessionFactory()
                 .getProviderFactoriesStream(CredentialProvider.class)
-                .map(f -> session.getProvider(CredentialProvider.class, f.getId()))
+                .map(f -> (CredentialProvider<?>) session.getProvider(CredentialProvider.class, f.getId()))
                 .filter(provider -> Objects.equals(provider.getType(), model.getType()))
                 .map(cp -> cp.createCredential(realm, user, cp.getCredentialFromModel(model)))
                 .findFirst()
@@ -268,13 +268,22 @@ public class UserCredentialManager extends AbstractStorageManager<UserStoragePro
         }
     }
 
-    private UserCredentialStore getStoreForUser(UserModel user) {
-        StoreManagers p = (StoreManagers) session.getProvider(DatastoreProvider.class);
-        if (StorageId.isLocalStorage(user.getId())) {
-            return (UserCredentialStore) p.userLocalStorage();
-        } else {
-            return (UserCredentialStore) p.userFederatedStorage();
+    private UserCredentialStore getStoreForUser() {
+        String providerId = user.getFederationLink();
+        if (providerId != null) {
+            UserStorageProviderModel model = getStorageProviderModel(realm, providerId);
+            if (model == null || !model.isEnabled()) return DisabledCredentialStore.INSTANCE;
+
+            UserCredentialStore store = getStorageProviderInstance(model, UserCredentialStore.class);
+            if (store != null) return store;
         }
+
+        StoreManagers storeManagers = (StoreManagers) session.getProvider(DatastoreProvider.class);
+        return (UserCredentialStore) (
+            StorageId.isLocalStorage(user.getId())
+                ? storeManagers.userLocalStorage()
+                : storeManagers.userFederatedStorage()
+        );
     }
 
 }


### PR DESCRIPTION
This PR adds the option to use a `UserStorageProvider` as a credential manager by implementing the `UserCredentialStore` interface as suggested in #33285.