### PR TITLE
Re-try login to account for firefox CI

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
@@ -107,6 +107,7 @@ public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest imple
         createTestUserWithAdminClient(false);
 
         signingInPage.navigateTo();
+        waitForPageToLoad();
         loginToAccount();
         signingInPage.assertCurrent();
     }
@@ -158,6 +159,10 @@ public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest imple
     }
 
     protected void loginToAccount() {
+        if (!loginPage.isCurrent()) {
+            signingInPage.navigateTo();
+            waitForPageToLoad();
+        }
         loginPage.assertCurrent();
         loginPage.form().login(testUser);
         waitForPageToLoad();


### PR DESCRIPTION
Closes #30994

There are some failures in the firefox webauthn that cannot reproduce locally with firefox. So just adding a new try for the account login in the webauthn for firefox.
