### PR TITLE
Make createWebAuthnRegistrationManager protected to allow cutomizations in subclasses

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -296,7 +296,13 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         }
     }
 
-    private WebAuthnRegistrationManager createWebAuthnRegistrationManager() {
+    /**
+     * Create WebAuthnRegistrationManager instance
+     * Can be overridden in subclasses to customize the used attestation validators
+     *
+     * @return webauthn4j WebAuthnRegistrationManager instance
+     */
+    protected WebAuthnRegistrationManager createWebAuthnRegistrationManager() {
         return new WebAuthnRegistrationManager(
                 Arrays.asList(
                         new NoneAttestationStatementValidator(),


### PR DESCRIPTION
Allows to easier customize WebAuthn Registration, for example if attestation data should only be collected but not validated.

closes #33678

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
