### PR TITLE
fix: remove erroneous spi warnings

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -88,7 +88,8 @@ public class KeycloakMain implements QuarkusApplication {
 
             try {
                 PropertyMappers.sanitizeDisabledMappers();
-                Picocli.validateConfig(cliArgs, new Start());
+                PrintWriter outStream = new PrintWriter(System.out, true);
+                Picocli.validateConfig(cliArgs, new Start(), outStream);
             } catch (PropertyException | ProfileException e) {
                 handleUsageError(e.getMessage(), e.getCause());
                 return;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -34,6 +34,7 @@ public abstract class AbstractCommand {
 
     @Spec
     protected CommandSpec spec;
+    protected Picocli picocli;
 
     protected void executionError(CommandLine cmd, String message) {
         executionError(cmd, message, null);
@@ -65,13 +66,17 @@ public abstract class AbstractCommand {
     }
 
     protected void validateConfig() {
-        Picocli.validateConfig(ConfigArgsConfigSource.getAllCliArgs(), this);
+        Picocli.validateConfig(ConfigArgsConfigSource.getAllCliArgs(), this, spec.commandLine().getOut());
     }
 
     public abstract String getName();
 
     public CommandLine getCommandLine() {
         return spec.commandLine();
+    }
+    
+    public void setPicocli(Picocli picocli) {
+        this.picocli = picocli;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -25,7 +25,6 @@ import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.mappers.HostnameV2PropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
-import org.keycloak.url.HostnameV2ProviderFactory;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -38,8 +37,6 @@ import static org.keycloak.quarkus.runtime.configuration.Configuration.getRawPer
 public abstract class AbstractStartCommand extends AbstractCommand implements Runnable {
     public static final String OPTIMIZED_BUILD_OPTION_LONG = "--optimized";
     
-    private boolean skipStart;
-
     @Override
     public void run() {
         Environment.setParsedCommand(this);
@@ -52,10 +49,8 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
         if (ConfigArgsConfigSource.getAllCliArgs().contains(OPTIMIZED_BUILD_OPTION_LONG) && !wasBuildEverRun()) {
             executionError(spec.commandLine(), Messages.optimizedUsedForFirstStartup());
         }
-
-        if (!skipStart) {
-            KeycloakMain.start((ExecutionExceptionHandler) cmd.getExecutionExceptionHandler(), cmd.getErr(), cmd.getParseResult().originalArgs().toArray(new String[0]));
-        }
+        
+        picocli.start(cmd);
     }
 
     protected void doBeforeRun() {
@@ -76,8 +71,4 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
         return EnumSet.of(OptionCategory.IMPORT, OptionCategory.EXPORT);
     }
     
-    public void setSkipStart(boolean skipStart) {
-        this.skipStart = skipStart;
-    }
-
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -79,7 +79,7 @@ public final class Build extends AbstractCommand implements Runnable {
             configureBuildClassLoader();
 
             beforeReaugmentationOnWindows();
-            QuarkusEntryPoint.main();
+            picocli.build();
 
             if (!isDevProfile()) {
                 println(spec.commandLine(), "Server configuration updated and persisted. Run the following command to review the configuration:\n");
@@ -133,7 +133,7 @@ public final class Build extends AbstractCommand implements Runnable {
     private void cleanTempResources() {
         if (!LaunchMode.current().isDevOrTest()) {
             // only needed for dev/testing purposes
-            getHomePath().resolve("quarkus-artifact.properties").toFile().delete();
+            Optional.ofNullable(getHomePath()).ifPresent(path -> path.resolve("quarkus-artifact.properties").toFile().delete());
         }
     }
 


### PR DESCRIPTION
closes: #34057

Follow up to #33638 to make all sys out unit testable. There are a couple of changes for this:
- switch from using a logger to the picocli out for warnings. Usage of the logger was a little problematic in any case, and this makes sure that warnings are emitted the same way as other cli time output, including help. Some coloring was added for the WARNING: prefix, but can be tweaked / removed if anyone objects.
- rather than using a boolean flag, fully encapsulate quarkus callouts on the Picocli class and inject the instance when commands are created.

The changes to capture the out output means we could do the help tests in this manner as well.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
