### PR TITLE
Removed hard-coded LTR dir attributes from form elements

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -58,7 +58,6 @@
                 <div class="${properties.kcInputWrapperClass!}">
                     <input type="text" id="totp" name="totp" autocomplete="off" class="${properties.kcInputClass!}"
                            aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>"
-                           dir="ltr"
                     />
 
                     <#if messagesPerField.existsError('totp')>
@@ -79,7 +78,7 @@
 
                 <div class="${properties.kcInputWrapperClass!}">
                     <input type="text" class="${properties.kcInputClass!}" id="userLabel" name="userLabel" autocomplete="off"
-                           aria-invalid="<#if messagesPerField.existsError('userLabel')>true</#if>" dir="ltr"
+                           aria-invalid="<#if messagesPerField.existsError('userLabel')>true</#if>"
                     />
 
                     <#if messagesPerField.existsError('userLabel')>

--- a/themes/src/main/resources/theme/base/login/login-oauth2-device-verify-user-code.ftl
+++ b/themes/src/main/resources/theme/base/login/login-oauth2-device-verify-user-code.ftl
@@ -10,7 +10,7 @@
                 </div>
 
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input id="device-user-code" name="device_user_code" autocomplete="off" type="text" class="${properties.kcInputClass!}" autofocus dir="ltr" />
+                    <input id="device-user-code" name="device_user_code" autocomplete="off" type="text" class="${properties.kcInputClass!}" autofocus />
                 </div>
             </div>
 

--- a/themes/src/main/resources/theme/base/login/login-otp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-otp.ftl
@@ -30,8 +30,7 @@
 
             <div class="${properties.kcInputWrapperClass!}">
                 <input id="otp" name="otp" autocomplete="one-time-code" type="text" class="${properties.kcInputClass!}"
-                       autofocus aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>"
-                       dir="ltr" />
+                       autofocus aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>" />
 
                 <#if messagesPerField.existsError('totp')>
                     <span id="input-error-otp-code" class="${properties.kcInputErrorMessageClass!}"

--- a/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
@@ -79,8 +79,7 @@
                                         class="${properties.kcInputClass!}" name="username"
                                         value="${(login.username!'')}"
                                         autocomplete="username webauthn"
-                                        type="text" autofocus autocomplete="off"
-                                        dir="ltr"/>
+                                        type="text" autofocus autocomplete="off" />
                                     <#if messagesPerField.existsError('username')>
                                         <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
                                             ${kcSanitize(messagesPerField.get('username'))?no_esc}

--- a/themes/src/main/resources/theme/base/login/login-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-password.ftl
@@ -10,7 +10,7 @@
                     <div class="${properties.kcFormGroupClass!} no-bottom-margin">
                         <hr/>
                         <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
-                        <div class="${properties.kcInputGroup!}" dir="ltr">
+                        <div class="${properties.kcInputGroup!}">
                             <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password"
                                    type="password" autocomplete="on" autofocus
                                    aria-invalid="<#if messagesPerField.existsError('password')>true</#if>"

--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-input.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-input.ftl
@@ -17,8 +17,7 @@
                            autocomplete="off"
                            type="text"
                            class="${properties.kcInputClass!}"
-                           autofocus
-                           dir="ltr"/>
+                           autofocus />
 
                     <#if messagesPerField.existsError('recoveryCodeInput')>
                         <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">

--- a/themes/src/main/resources/theme/base/login/login-reset-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-reset-password.ftl
@@ -9,7 +9,7 @@
                     <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus value="${(auth.attemptedUsername!'')}" aria-invalid="<#if messagesPerField.existsError('username')>true</#if>" dir="ltr"/>
+                    <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus value="${(auth.attemptedUsername!'')}" aria-invalid="<#if messagesPerField.existsError('username')>true</#if>" />
                     <#if messagesPerField.existsError('username')>
                         <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
                                     ${kcSanitize(messagesPerField.get('username'))?no_esc}

--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -10,7 +10,7 @@
                     <label for="password-new" class="${properties.kcLabelClass!}">${msg("passwordNew")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <div class="${properties.kcInputGroup!}" dir="ltr">
+                    <div class="${properties.kcInputGroup!}">
                         <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}"
                                autofocus autocomplete="new-password"
                                aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
@@ -36,7 +36,7 @@
                     <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <div class="${properties.kcInputGroup!}" dir="ltr">
+                    <div class="${properties.kcInputGroup!}">
                         <input type="password" id="password-confirm" name="password-confirm"
                                class="${properties.kcInputClass!}"
                                autocomplete="new-password"

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -17,8 +17,7 @@
                                        aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
                                        class="${properties.kcInputClass!}" name="username"
                                        value="${(login.username!'')}"
-                                       type="text" autofocus autocomplete="off"
-                                       dir="ltr"/>
+                                       type="text" autofocus autocomplete="off" />
 
                                 <#if messagesPerField.existsError('username')>
                                     <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -13,7 +13,6 @@
 
                             <input tabindex="2" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="username"
                                    aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
-                                   dir="ltr"
                             />
 
                             <#if messagesPerField.existsError('username','password')>
@@ -28,7 +27,7 @@
                     <div class="${properties.kcFormGroupClass!}">
                         <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
 
-                        <div class="${properties.kcInputGroup!}" dir="ltr">
+                        <div class="${properties.kcInputGroup!}">
                             <input tabindex="3" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="current-password"
                                    aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                             />

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -20,7 +20,7 @@
                                 <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label> *
                             </div>
                             <div class="${properties.kcInputWrapperClass!}">
-                                <div class="${properties.kcInputGroup!}" dir="ltr">
+                                <div class="${properties.kcInputGroup!}">
                                     <input type="password" id="password" class="${properties.kcInputClass!}" name="password"
                                            autocomplete="new-password"
                                            aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
@@ -47,7 +47,7 @@
                                        class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label> *
                             </div>
                             <div class="${properties.kcInputWrapperClass!}">
-                                <div class="${properties.kcInputGroup!}" dir="ltr">
+                                <div class="${properties.kcInputGroup!}">
                                     <input type="password" id="password-confirm" class="${properties.kcInputClass!}"
                                            name="password-confirm" autocomplete="new-password"
                                            aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-config-totp.ftl
@@ -62,7 +62,6 @@
                 <div class="${properties.kcInputClass!} <#if messagesPerField.existsError('totp')>pf-m-error</#if>">
                     <input type="text" required id="totp" name="totp" autocomplete="off"
                            aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>"
-                           dir="ltr"
                     />
 
                     <@field.errorIcon error=kcSanitize(messagesPerField.get('totp'))?no_esc/>
@@ -85,7 +84,6 @@
                 <div class="${properties.kcInputClass!}">
                     <input type="text" id="userLabel" name="userLabel" autocomplete="off"
                            aria-invalid="<#if messagesPerField.existsError('userLabel')>true</#if>"
-                           dir="ltr"
                     />
 
                     <@field.errorIcon error=kcSanitize(messagesPerField.get('userLabel'))?no_esc/>


### PR DESCRIPTION
Directionality is set in the html opening tag only (in base/login/template.ftl)

See also related issue #33642 which is to fix directionality in keycloak.v2/login/template.ftl

Closes #32844

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
