### PR TITLE
Use clickLink in delete credential page

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/DeleteCredentialPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/DeleteCredentialPage.java
@@ -20,6 +20,7 @@
 package org.keycloak.testsuite.pages;
 
 import org.junit.Assert;
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -37,15 +38,16 @@ public class DeleteCredentialPage extends AbstractPage {
     @FindBy(id = "kc-delete-text")
     private WebElement message;
 
+    @Override
     public boolean isCurrent() {
         return PageUtils.getPageTitle(driver).startsWith("Delete ");
     }
 
     public void confirm() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
     public void cancel() {
-        cancelButton.click();
+        UIUtils.clickLink(cancelButton);
     }
 
     public void assertCredentialInMessage(String expectedLabel) {


### PR DESCRIPTION
Closes #33505

Another flaky tests because of the `clickLink` issue in chrome. Now it's time for `DeleteCredentialPage.java`.
