### PR TITLE
fix: encapsulating where static import/export state is set/used

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
@@ -20,6 +20,8 @@ package org.keycloak.quarkus.runtime.cli.command;
 import static org.keycloak.quarkus.runtime.cli.Picocli.NO_PARAM_LABEL;
 
 import java.io.File;
+
+import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.quarkus.runtime.Environment;
 
 import picocli.CommandLine;
@@ -39,7 +41,7 @@ public final class ImportRealmMixin {
         File importDir = Environment.getHomePath().resolve("data").resolve("import").toFile();
 
         if (importDir.exists()) {
-            System.setProperty("keycloak.import", importDir.getAbsolutePath());
+            ExportImportConfig.setDir(importDir.getAbsolutePath());
         }
     }
 }

--- a/services/src/main/java/org/keycloak/exportimport/ExportImportConfig.java
+++ b/services/src/main/java/org/keycloak/exportimport/ExportImportConfig.java
@@ -18,6 +18,8 @@
 package org.keycloak.exportimport;
 
 import java.io.Closeable;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -59,6 +61,18 @@ public class ExportImportConfig {
     public static String getAction() {
         return System.getProperty(ACTION);
     }
+    
+    public static String getStrategy() {
+        return System.getProperty(STRATEGY);
+    }
+    
+    public static String setStrategy(Strategy strategy) {
+        return System.setProperty(STRATEGY, strategy.toString());
+    }
+    
+    public static Optional<String> getDir() {
+        return Optional.ofNullable(System.getProperty(DIR));
+    }
 
     public static Closeable setAction(String exportImportAction) {
         System.setProperty(ACTION, exportImportAction);
@@ -91,5 +105,10 @@ public class ExportImportConfig {
 
     public static void setReplacePlaceholders(boolean replacePlaceholders) {
         System.setProperty(REPLACE_PLACEHOLDERS, String.valueOf(replacePlaceholders));
+    }
+    
+    public static void reset() {
+        Stream.of(FILE, DIR, ACTION, STRATEGY, REPLACE_PLACEHOLDERS)
+                .forEach(prop -> System.getProperties().remove(prop));
     }
 }

--- a/services/src/main/java/org/keycloak/exportimport/ExportImportManager.java
+++ b/services/src/main/java/org/keycloak/exportimport/ExportImportManager.java
@@ -73,37 +73,36 @@ public class ExportImportManager {
             if (importProvider == null) {
                 throw new RuntimeException("Import provider '" + providerId + "' not found");
             }
+        } else if (ExportImportConfig.getDir().isPresent()) { // import at startup
+            ExportImportConfig.setStrategy(Strategy.IGNORE_EXISTING);
+            ExportImportConfig.setReplacePlaceholders(true);
+            // enables logging of what is imported
+            ExportImportConfig.setAction(ExportImportConfig.ACTION_IMPORT);
         }
-    }
-
-    public boolean isRunImport() {
-        return importProvider != null;
     }
 
     public boolean isImportMasterIncluded() {
-        if (!isRunImport()) {
-            throw new IllegalStateException("Import not enabled");
+        if (importProvider != null) {
+            try {
+                return importProvider.isMasterRealmExported();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return isImportMasterIncludedAtStartup();
         }
-        try {
-            return importProvider.isMasterRealmExported();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        
     }
     
-    public boolean isImportMasterIncludedAtStartup(String dir) {
-        if (dir == null) {
-            throw new IllegalStateException("Import not enabled");
-        }
-        ExportImportConfig.setReplacePlaceholders(true);
-        
-        return getStartupImportProviders(dir).map(Supplier::get).anyMatch(provider -> {
-            try {
-                return provider.isMasterRealmExported();
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to run import", e);
-            }
-        });
+    boolean isImportMasterIncludedAtStartup() {
+        return getStartupImportProviders().map(Supplier::get)
+                .anyMatch(provider -> {
+                    try {
+                        return provider.isMasterRealmExported();
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to run import", e);
+                    }
+                });
     }
 
     public boolean isRunExport() {
@@ -111,22 +110,19 @@ public class ExportImportManager {
     }
 
     public void runImport() {
-        try {
-            importProvider.importModel();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to run import", e);
+        if (importProvider != null) {
+            try {
+                importProvider.importModel();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to run import", e);
+            }
+        } else {
+            runImportAtStartup();
         }
     }
     
-    public void runImportAtStartup(String dir) throws IOException {
-        System.setProperty(ExportImportConfig.STRATEGY, Strategy.IGNORE_EXISTING.toString());
-        ExportImportConfig.setReplacePlaceholders(true);
-        // enables logging of what is imported
-        ExportImportConfig.setAction(ExportImportConfig.ACTION_IMPORT);
-        
-        // TODO: ideally the static setting above should be unset after this is run 
-        
-        getStartupImportProviders(dir).map(Supplier::get).forEach(ip -> {
+    public void runImportAtStartup() {
+        getStartupImportProviders().map(Supplier::get).forEach(ip -> {
             try {
                 ip.importModel();
             } catch (IOException e) {
@@ -135,17 +131,20 @@ public class ExportImportManager {
         });
     }
 
-    private Stream<Supplier<ImportProvider>> getStartupImportProviders(String dir) {
+    private Stream<Supplier<ImportProvider>> getStartupImportProviders() {
+        var dirProp = ExportImportConfig.getDir();
+        if (dirProp.isEmpty()) {
+            return Stream.empty();
+        }
+        String dir = dirProp.get();
+        
         Stream<ProviderFactory> factories = sessionFactory.getProviderFactoriesStream(ImportProvider.class);
 
         return factories.flatMap(factory -> {
             String providerId = factory.getId();
 
             if ("dir".equals(providerId)) {
-                Supplier<ImportProvider> func = () -> {
-                    ExportImportConfig.setDir(dir);
-                    return session.getProvider(ImportProvider.class, providerId);
-                };
+                Supplier<ImportProvider> func = () -> session.getProvider(ImportProvider.class, providerId);
                 return Stream.of(func);
             }
             if ("singleFile".equals(providerId)) {

--- a/services/src/test/java/org/keycloak/exportimport/ExportImportManagerTest.java
+++ b/services/src/test/java/org/keycloak/exportimport/ExportImportManagerTest.java
@@ -1,0 +1,79 @@
+package org.keycloak.exportimport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.Provider;
+import org.keycloak.services.DefaultKeycloakContext;
+import org.keycloak.services.DefaultKeycloakSession;
+
+public class ExportImportManagerTest {
+    
+    @After
+    public void reset() {
+        ExportImportConfig.reset();
+    }
+    
+    @Test
+    public void testImportOnStartup() {
+        ExportImportConfig.setDir("/some/dir");
+        new ExportImportManager(new DefaultKeycloakSession(null) {
+
+            @Override
+            protected DefaultKeycloakContext createKeycloakContext(KeycloakSession session) {
+                return null;
+            }
+            
+        });
+        assertEquals(ExportImportConfig.ACTION_IMPORT, ExportImportConfig.getAction());
+        assertEquals(Strategy.IGNORE_EXISTING.toString(), ExportImportConfig.getStrategy());
+        assertTrue(ExportImportConfig.isReplacePlaceholders());
+    }
+    
+    @Test
+    public void testImport() {
+        ExportImportConfig.setAction(ExportImportConfig.ACTION_IMPORT);
+        new ExportImportManager(new DefaultKeycloakSession(null) {
+
+            @Override
+            protected DefaultKeycloakContext createKeycloakContext(KeycloakSession session) {
+                return null;
+            }
+            
+            @Override
+            public <T extends Provider> T getProvider(Class<T> clazz, String id) {
+                return (T) new ImportProvider() {
+                    
+                    @Override
+                    public void close() {
+                        
+                    }
+                    
+                    @Override
+                    public boolean isMasterRealmExported() throws IOException {
+                        return false;
+                    }
+                    
+                    @Override
+                    public void importModel() throws IOException {
+                        
+                    }
+                };
+            }
+            
+        });
+        assertEquals(ExportImportConfig.ACTION_IMPORT, ExportImportConfig.getAction());
+        assertNull(ExportImportConfig.getStrategy());
+        // we're now setting this in the Quarkus logic, it's left as false in the ExportImportManager
+        // for arquillian, or other legacy usage
+        assertFalse(ExportImportConfig.isReplacePlaceholders());
+    }
+
+}


### PR DESCRIPTION
closes: #33596

Encapsulated the startup behavior under the ExportImportManager and got rid of the keycloak.import system property. 

If we want to take this a step further, it would be nice to reset the static state in some way after import, but I haven't tried to do that here.

cc @mabartos  

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
