### PR TITLE
Fail to start if work cache is not replicated

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -4,6 +4,8 @@ Previous releases ignored any change  to `conf/cache-ispn.xml` if the `--cache-c
 
 Starting from this release, when `--cache-config-file` is not set, the default Infinispan XML configuration file is `conf/cache-ispn.xml` as this is both the expected behavior and the implied behavior given the docs of the current and previous releases.
 
-= Embedded Infinispan: `work` cache must be replicated.
+= Embedded Infinispan: `work` cache must be replicated
 
-The `work` cache needs to be configured as a `replicated-cache` and {project_name} will not start if it is not configured as such.
+The embedded `work` cache needs to be configured as a `replicated-cache` for cache invalidation to work as expected.
+
+Starting from this release, {project_name} check this at startup and will fail to start if it is not configured as such.

--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -3,3 +3,7 @@
 Previous releases ignored any change  to `conf/cache-ispn.xml` if the `--cache-config-file` option was not provided.
 
 Starting from this release, when `--cache-config-file` is not set, the default Infinispan XML configuration file is `conf/cache-ispn.xml` as this is both the expected behavior and the implied behavior given the docs of the current and previous releases.
+
+= Embedded Infinispan: `work` cache must be replicated.
+
+The `work` cache needs to be configured as a `replicated-cache` and {project_name} will not start if it is not configured as such.

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -371,7 +371,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                 workBuilder.simpleCache(false);
                 workBuilder.clustering().cacheMode(async ? CacheMode.REPL_ASYNC : CacheMode.REPL_SYNC);
             }
-            defineClusteredCache(cacheManager, WORK_CACHE_NAME, builder.build());
+            defineClusteredCache(cacheManager, WORK_CACHE_NAME, workBuilder.build());
         }
 
         return cacheManager;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheManagerFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheManagerFactory.java
@@ -527,7 +527,7 @@ public class CacheManagerFactory {
         }
         var cacheMode = cacheBuilder.clustering().cacheMode();
         if (!cacheMode.isReplicated()) {
-            throw new RuntimeException("Unable to start Keycloak. '%s' cache should be replicated but is %s".formatted(WORK_CACHE_NAME, cacheMode.friendlyCacheModeString().toLowerCase()));
+            throw new RuntimeException("Unable to start Keycloak. '%s' cache must be replicated but is %s".formatted(WORK_CACHE_NAME, cacheMode.friendlyCacheModeString().toLowerCase()));
         }
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheManagerFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheManagerFactory.java
@@ -87,6 +87,7 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.L
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.USER_SESSION_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.WORK_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.skipSessionsCacheIfRequired;
 import static org.wildfly.security.sasl.util.SaslMechanismInformation.Names.SCRAM_SHA_512;
 
@@ -314,6 +315,7 @@ public class CacheManagerFactory {
             }
             configureCacheMaxCount(builder, CachingOptions.CLUSTERED_MAX_COUNT_CACHES);
             configureSessionsCaches(builder);
+            validateWorkCacheConfiguration(builder);
         }
         configureCacheMaxCount(builder, CachingOptions.LOCAL_MAX_COUNT_CACHES);
         checkForRemoteStores(builder);
@@ -511,6 +513,21 @@ public class CacheManagerFactory {
                         .memory()
                         .maxCount(maxCount)
                   );
+        }
+    }
+
+    private static void validateWorkCacheConfiguration(ConfigurationBuilderHolder builder) {
+        var cacheBuilder  = builder.getNamedConfigurationBuilders().get(WORK_CACHE_NAME);
+        if (cacheBuilder == null) {
+            throw new RuntimeException("Unable to start Keycloak. '%s' cache is missing".formatted(WORK_CACHE_NAME));
+        }
+        if (builder.getGlobalConfigurationBuilder().cacheContainer().transport().getTransport() == null) {
+            // non-clustered, Keycloak started in dev mode?
+            return;
+        }
+        var cacheMode = cacheBuilder.clustering().cacheMode();
+        if (!cacheMode.isReplicated()) {
+            throw new RuntimeException("Unable to start Keycloak. '%s' cache should be replicated but is %s".formatted(WORK_CACHE_NAME, cacheMode.friendlyCacheModeString().toLowerCase()));
         }
     }
 


### PR DESCRIPTION
Keycloak will now fail to start if the work cache is replicated. Listeners require the data to be local.

Closes #33702

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
