### PR TITLE
Check email with ignorecase when setting basic attributes in IdP

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1060,14 +1060,14 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     }
 
     private void setBasicUserAttributes(BrokeredIdentityContext context, UserModel federatedUser) {
-        setDiffAttrToConsumer(federatedUser.getEmail(), context.getEmail(), email -> setEmail(context, federatedUser, email));
-        setDiffAttrToConsumer(federatedUser.getFirstName(), context.getFirstName(), federatedUser::setFirstName);
-        setDiffAttrToConsumer(federatedUser.getLastName(), context.getLastName(), federatedUser::setLastName);
+        setDiffAttrToConsumer(federatedUser.getEmail(), context.getEmail(), email -> setEmail(context, federatedUser, email), true);
+        setDiffAttrToConsumer(federatedUser.getFirstName(), context.getFirstName(), federatedUser::setFirstName, false);
+        setDiffAttrToConsumer(federatedUser.getLastName(), context.getLastName(), federatedUser::setLastName, false);
     }
 
-    private void setDiffAttrToConsumer(String actualValue, String newValue, Consumer<String> consumer) {
+    private void setDiffAttrToConsumer(String actualValue, String newValue, Consumer<String> consumer, boolean ignoreCase) {
         String actualValueNotNull = Optional.ofNullable(actualValue).orElse("");
-        if (newValue != null && !newValue.equals(actualValueNotNull)) {
+        if (newValue != null && !(ignoreCase? newValue.equalsIgnoreCase(actualValueNotNull) : newValue.equals(actualValueNotNull))) {
             consumer.accept(newValue);
         }
     }


### PR DESCRIPTION
Closes #31848

Email is stored in keycloak in lowercase so just changing the `equals` for `equalsIgnoreCase` when comparing if email was changed in the IDP login. Previously the mail was detected as modified and the `emailVerified` property was also set to false if the IdP was not trusted. Test added.