### PR TITLE
Upgrade to proto-schema-compatibility-maven-plugin 5.0.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <!-- version number is needed for the proto-schema-compatibility-maven-plugin and needs to be in-sync with the version used in Infinispan -->
         <protostream.version>5.0.8.Final</protostream.version>
         <!-- protostream.plugin.version property can be replaced with protostream.version once protostream.version >= 5.0.10.Final -->
-        <protostream.plugin.version>5.0.10.Final</protostream.plugin.version>
+        <protostream.plugin.version>5.0.12.Final</protostream.plugin.version>
 
         <!--JAKARTA-->
         <jakarta.mail.version>2.1.1</jakarta.mail.version>


### PR DESCRIPTION
Closes #33711

@shawkins You can test this works as expected by removing any local `proto.lock` files and then building the `model/infinispan` module.