### PR TITLE
Use current flow instead of browser to get highest LoA from prev auth

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/CookieAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/CookieAuthenticator.java
@@ -22,6 +22,7 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.authenticators.util.AcrStore;
 import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
+import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -65,7 +66,8 @@ public class CookieAuthenticator implements Authenticator {
             } else if(AuthenticatorUtil.isForkedFlow(authSession)){
                 context.attempted();
             } else {
-                int previouslyAuthenticatedLevel = acrStore.getHighestAuthenticatedLevelFromPreviousAuthentication();
+                String topLevelFlowId = context.getTopLevelFlow().getId();
+                int previouslyAuthenticatedLevel = acrStore.getHighestAuthenticatedLevelFromPreviousAuthentication(topLevelFlowId);
                 AuthenticatorUtils.updateCompletedExecutions(context.getAuthenticationSession(), authResult.getSession(), context.getExecution().getId());
 
                 if (acrStore.getRequestedLevelOfAuthentication(context.getTopLevelFlow()) > previouslyAuthenticatedLevel) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/util/AcrStore.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/util/AcrStore.java
@@ -207,7 +207,7 @@ public class AcrStore {
     /**
      * @return highest authenticated level from previous authentication, which is still valid (not yet expired)
      */
-    public int getHighestAuthenticatedLevelFromPreviousAuthentication() {
+    public int getHighestAuthenticatedLevelFromPreviousAuthentication(String flowId) {
         // No map found. User was not yet authenticated in this session
         Map<Integer, Integer> levels = getCurrentAuthenticatedLevelsMap();
         if (levels == null || levels.isEmpty()) return NO_LOA;
@@ -216,7 +216,7 @@ public class AcrStore {
         int maxLevel = Constants.MINIMUM_LOA;
         int currentTime = Time.currentTime();
 
-        Map<Integer, Integer> configuredMaxAges = LoAUtil.getLoaMaxAgesConfiguredInRealmBrowserFlow(authSession.getRealm());
+        Map<Integer, Integer> configuredMaxAges = LoAUtil.getLoaMaxAgesConfiguredInRealmFlow(authSession.getRealm(), flowId);
         levels = new TreeMap<>(levels);
 
         for (Map.Entry<Integer, Integer> entry : levels.entrySet()) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/util/LoAUtil.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/util/LoAUtil.java
@@ -86,7 +86,16 @@ public class LoAUtil {
      * @return All LoA numbers configured in the conditions in the realm browser flow. Key is level, Value is maxAge for particular level
      */
     public static Map<Integer, Integer> getLoaMaxAgesConfiguredInRealmBrowserFlow(RealmModel realm) {
-        List<AuthenticationExecutionModel> loaConditions = AuthenticatorUtil.getExecutionsByType(realm, realm.getBrowserFlow().getId(), ConditionalLoaAuthenticatorFactory.PROVIDER_ID);
+      return getLoaMaxAgesConfiguredInRealmFlow(realm, realm.getBrowserFlow().getId());
+    }
+
+    /**
+     * @param realm
+     * @param flowId
+     * @return All LoA numbers configured in the conditions in the realm flow @{param flowId}. Key is level, Vaue is maxAge for particular level
+     */
+    public static Map<Integer, Integer> getLoaMaxAgesConfiguredInRealmFlow(RealmModel realm, String flowId) {
+        List<AuthenticationExecutionModel> loaConditions = AuthenticatorUtil.getExecutionsByType(realm, flowId, ConditionalLoaAuthenticatorFactory.PROVIDER_ID);
         if (loaConditions.isEmpty()) {
             // Default values used when step-up conditions not used in the browser authentication flow.
             // This is used for backwards compatibility and in case when step-up is not configured in the authentication flow (returning 1 in case of "normal" authentication, 0 for SSO authentication)


### PR DESCRIPTION
closes #12919 

Addressing issue #12919. This is a recreation of the closed PR #19310, which addresses the maintainer's original comments.