### PR TITLE
Removed hard-coded LTR dir attribute in inputs in configure OTP template

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-config-totp.ftl
@@ -62,7 +62,6 @@
                 <div class="${properties.kcInputClass!} <#if messagesPerField.existsError('totp')>pf-m-error</#if>">
                     <input type="text" required id="totp" name="totp" autocomplete="off"
                            aria-invalid="<#if messagesPerField.existsError('totp')>true</#if>"
-                           dir="ltr"
                     />
 
                     <@field.errorIcon error=kcSanitize(messagesPerField.get('totp'))?no_esc/>
@@ -85,7 +84,6 @@
                 <div class="${properties.kcInputClass!}">
                     <input type="text" id="userLabel" name="userLabel" autocomplete="off"
                            aria-invalid="<#if messagesPerField.existsError('userLabel')>true</#if>"
-                           dir="ltr"
                     />
 
                     <@field.errorIcon error=kcSanitize(messagesPerField.get('userLabel'))?no_esc/>


### PR DESCRIPTION
This should be done in the html opening tag only (see issue #33642)

Closes #32844

Signed-off-by: Jon Haynes <senyahnoj@gmail.com>
(cherry picked from commit df3035883903782cda52776c6b49c2f4a444fd60)
