### PR TITLE
Only show organization section in account UI of enabled

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -164,7 +164,7 @@ public class AccountConsole implements AccountResourceProvider {
         map.put("deleteAccountAllowed", deleteAccountAllowed);
 
         map.put("isViewGroupsEnabled", isViewGroupsEnabled);
-        map.put("isViewOrganizationsEnabled", Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION));
+        map.put("isViewOrganizationsEnabled", realm.isOrganizationsEnabled());
         map.put("isOid4VciEnabled", Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI));
 
         map.put("updateEmailFeatureEnabled", Profile.isFeatureEnabled(Profile.Feature.UPDATE_EMAIL));


### PR DESCRIPTION
We now only show organization section in account ui if org support is enabled for realm.

Checking for realm.isOrganizationsEnabled() is enough here because if true, it implies that the server has configured the feature.

Fixes #33735