### PR TITLE
fix: makes the db setting require an explicit setting in prod

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -4,6 +4,10 @@ Previous releases ignored any change  to `conf/cache-ispn.xml` if the `--cache-c
 
 Starting from this release, when `--cache-config-file` is not set, the default Infinispan XML configuration file is `conf/cache-ispn.xml` as this is both the expected behavior and the implied behavior given the docs of the current and previous releases.
 
+= `db` option required for production
+
+The `db` option is now required for the `start` and `build` commands, and when not using the dev profile for non-server commands like `import`, `export`, or `bootstrap-admin`. This is to prevent the unintentional usage of the `dev-file` (H2) database in a production environment.
+
 = Embedded Infinispan: `work` cache must be replicated
 
 The embedded `work` cache needs to be configured as a `replicated-cache` for cache invalidation to work as expected.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -18,8 +18,7 @@ public class DatabaseOptions {
 
     public static final Option<String> DB = new OptionBuilder<>("db", String.class)
             .category(OptionCategory.DATABASE)
-            .description("The database vendor.")
-            .defaultValue("dev-file")
+            .description("The database vendor. In development mode the default value will be 'dev-file'.")
             .expectedValues(Database.getDatabaseAliases())
             .buildTime(true)
             .build();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -364,14 +365,8 @@ public class Picocli {
                     ConfigValue configValue = Configuration.getConfigValue(mapper.getFrom());
                     String configValueStr = configValue.getValue();
 
-                    // don't consider missing or anything below standard env properties
-                    if (configValueStr == null) {
-                        if (Environment.isRuntimeMode() && mapper.isEnabled() && mapper.isRequired()) {
-                            handleRequired(missingOption, mapper);
-                        }
-                        continue;
-                    }
-                    if (!isUserModifiable(configValue)) {
+                    // don't consider anything below standard env properties
+                    if (configValueStr != null && !isUserModifiable(configValue)) {
                         continue;
                     }
 
@@ -381,7 +376,7 @@ public class Picocli {
                         }
 
                         // only check build-time for a rebuild, we'll check the runtime later
-                        if (!mapper.isRunTime() || !isRebuild()) {
+                        if (configValueStr != null && (!mapper.isRunTime() || !isRebuild())) {
                             if (PropertyMapper.isCliOption(configValue)) {
                                 throw new KcUnmatchedArgumentException(abstractCommand.getCommandLine().orElseThrow(), List.of(mapper.getCliFormat()));
                             } else {
@@ -393,13 +388,22 @@ public class Picocli {
 
                     if (mapper.isBuildTime() && !options.includeBuildTime) {
                         String currentValue = getRawPersistedProperty(mapper.getFrom()).orElse(null);
-                        if (!configValueStr.equals(currentValue)) {
+                        if (!Objects.equals(configValueStr, currentValue)) {
                             ignoredBuildTime.add(mapper.getFrom());
                             continue;
                         }
                     }
                     if (mapper.isRunTime() && !options.includeRuntime) {
-                        ignoredRunTime.add(mapper.getFrom());
+                        if (configValueStr != null) {
+                            ignoredRunTime.add(mapper.getFrom());
+                        }
+                        continue;
+                    }
+
+                    if (configValueStr == null) {
+                        if (mapper.isRequired()) {
+                            handleRequired(missingOption, mapper);
+                        }
                         continue;
                     }
 
@@ -568,7 +572,7 @@ public class Picocli {
                 // only persist build options resolved from config sources and not default values
                 return;
             }
-            // since we're presisting all quarkus values, this may leak some runtime information - we don't want
+            // since we're persisting all quarkus values, this may leak some runtime information - we don't want
             // to capture expanded expressions that may be referencing environment variables
             String stringValue = value.getValue();
             if (quarkus && value.getRawValue() != null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -77,7 +77,10 @@ public final class Build extends AbstractCommand implements Runnable {
         exitWithErrorIfDevProfileIsSet();
 
         System.setProperty("quarkus.launch.rebuild", "true");
-        validateConfig();
+        PersistedConfigSource.getInstance().runWithDisabled(() -> {
+            validateConfig();
+            return null;
+        });
 
         println(spec.commandLine(), "Updating the configuration and installing your custom providers, if any. Please wait.");
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -2,6 +2,8 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.smallrye.config.ConfigSourceInterceptorContext;
+
+import org.keycloak.common.util.Environment;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.TransactionOptions;
 import org.keycloak.config.database.Database;
@@ -28,6 +30,7 @@ final class DatabasePropertyMappers {
                 fromOption(DatabaseOptions.DB)
                         .to("quarkus.datasource.db-kind")
                         .transformer(DatabasePropertyMappers::toDatabaseKind)
+                        .isRequired(() -> !Environment.isDevMode(), "The db option must be explicitly provided in a non-development profile")
                         .paramLabel("vendor")
                         .build(),
                 fromOption(DatabaseOptions.DB_URL)
@@ -114,7 +117,7 @@ final class DatabasePropertyMappers {
 
     private static boolean isDevModeDatabase(ConfigSourceInterceptorContext context) {
         String db = Configuration.getConfig().getConfigValue("kc.db").getValue();
-        return Database.getDatabaseKind(db).get().equals(DatabaseKind.H2);
+        return Database.getDatabaseKind(db).filter(DatabaseKind.H2::equals).isPresent();
     }
 
     private static String transformDialect(String db, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -1,5 +1,5 @@
 # Default and non-production grade database vendor
-db=dev-file
+%dev.db=dev-file
 
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.http-enabled=true

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -206,7 +206,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertEquals(MariaDBDialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:mariadb:aurora://foo/bar?a=1&b=2", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
     }
-    
+
     @Test
     public void testExpansionDisabled() {
         ConfigArgsConfigSource.setCliArgs("--db=mysql");
@@ -316,8 +316,8 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
         ConfigArgsConfigSource.setCliArgs("");
         config = createConfig();
-        assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
-        assertEquals("jdbc:h2:file:test-dir/data/h2/keycloakdb;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+        assertNull(config.getConfigValue("kc.db-dialect").getValue());
+        assertNull(config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty("kc.db-url-properties", "?test=test&test1=test1");
         ConfigArgsConfigSource.setCliArgs("--db=mariadb");
@@ -500,7 +500,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--https-certificates-reload-period=2h");
         assertEquals("2h", createConfig().getConfigValue("quarkus.http.ssl.certificate.reload-period").getValue());
     }
-    
+
     @Test
     public void testHttpsPaths() {
         ConfigArgsConfigSource.setCliArgs("--https-certificate-file=\\some\\file");
@@ -511,7 +511,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         }
         assertEquals(expected, createConfig().getConfigValue("quarkus.http.ssl.certificate.files").getValue());
     }
-    
+
     @Test
     public void testCacheMaxCount() {
         int maxCount = 500;
@@ -520,8 +520,9 @@ public class ConfigurationTest extends AbstractConfigurationTest {
               .collect(Collectors.toSet());
 
         StringBuilder sb = new StringBuilder();
-        for (String cache : maxCountCaches)
+        for (String cache : maxCountCaches) {
             sb.append(" --").append(CachingOptions.cacheMaxCountProperty(cache)).append("=").append(maxCount);
+        }
 
         String args = sb.toString();
         ConfigArgsConfigSource.setCliArgs(args.split(" "));

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
@@ -18,7 +18,6 @@
 package org.keycloak.quarkus.runtime.configuration.test;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.common.Profile;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
@@ -26,6 +25,7 @@ import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.MetricsOptions;
 import org.keycloak.config.Option;
+import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
 
@@ -46,14 +46,8 @@ import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_M
 import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_ORACLE;
 import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_POSTGRES;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.test.ConfigurationTest.setSystemProperty;
 
-public class IgnoredArtifactsTest {
-    
-    @BeforeClass
-    public static void resetConfigruation() {
-        ConfigurationTest.createConfig(); // make sure we're dealing with a clean config
-    }
+public class IgnoredArtifactsTest extends AbstractConfigurationTest {
 
     @Test
     public void fipsDisabled() {
@@ -113,6 +107,10 @@ public class IgnoredArtifactsTest {
 
     @Test
     public void multipleDatasources() {
+        // initialize the test with a default database
+        ConfigArgsConfigSource.setCliArgs("--db=dev-file");
+        createConfig();
+
         var defaultDS = Configuration.getOptionalValue("quarkus.datasource.db-kind");
         assertThat(defaultDS.isPresent(), is(true));
         assertThat(defaultDS.get(), is("h2"));

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -73,6 +73,7 @@
                     <finalName>keycloak</finalName>
                     <systemProperties>
                         <kc.home.dir>${kc.home.dir}</kc.home.dir>
+                        <kc.db>dev-file</kc.db>
                         <java.util.concurrent.ForkJoinPool.common.threadFactory>io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory</java.util.concurrent.ForkJoinPool.common.threadFactory>
                     </systemProperties>
                 </configuration>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BootstrapAdminDistTest {
 
     @Test
-    @Launch({ "bootstrap-admin", "user", "--no-prompt" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--no-prompt" })
     void failNoPassword(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("No password provided"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
@@ -44,14 +44,14 @@ public class BootstrapAdminDistTest {
 
     /**
     @Test
-    @Launch({ "bootstrap-admin", "user", "--expiration=tomorrow" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--expiration=tomorrow" })
     void failBadExpiration(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("Invalid value for option '--expiration': 'tomorrow' is not an int"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }*/
 
     @Test
-    @Launch({ "bootstrap-admin", "user", "--username=admin", "--password:env=MY_PASSWORD" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD" })
     void failEnvNotSet(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("Environment variable MY_PASSWORD not found"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
@@ -59,7 +59,7 @@ public class BootstrapAdminDistTest {
 
     @Test
     @WithEnvVars({"MY_PASSWORD", "admin123"})
-    @Launch({ "bootstrap-admin", "user", "--username=admin", "--password:env=MY_PASSWORD" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD" })
     void createAdmin(LaunchResult result) {
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
     }
@@ -72,14 +72,14 @@ public class BootstrapAdminDistTest {
     }
 
     @Test
-    @Launch({ "bootstrap-admin", "service", "--no-prompt" })
+    @Launch({ "bootstrap-admin", "service", "--db=dev-file", "--no-prompt" })
     void failServiceAccountNoSecret(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("No client secret provided"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }
 
     @Test
-    @Launch({ "bootstrap-admin", "service", "--client-id=admin", "--client-secret:env=MY_SECRET" })
+    @Launch({ "bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET" })
     void failServiceAccountEnvNotSet(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("Environment variable MY_SECRET not found"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
@@ -89,7 +89,7 @@ public class BootstrapAdminDistTest {
     @WithEnvVars({"MY_SECRET", "admin123"})
     void createAndUseSericeAccountAdmin(KeycloakDistribution dist) throws Exception {
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
-        CLIResult result = rawDist.run("bootstrap-admin", "service", "--client-id=admin", "--client-secret:env=MY_SECRET");
+        CLIResult result = rawDist.run("bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET");
 
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -46,7 +46,7 @@ public class BuildAndStartDistTest {
     void testBuildAndStart(KeycloakDistribution dist) {
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         // start using based on the build options set via CLI
-        CLIResult cliResult = rawDist.run("build");
+        CLIResult cliResult = rawDist.run("build", "--db=dev-file");
         cliResult.assertBuild();
         cliResult = rawDist.run("start", "--http-enabled=true", "--hostname-strict=false", OPTIMIZED_BUILD_OPTION_LONG);
         cliResult.assertNoBuild();
@@ -56,6 +56,7 @@ public class BuildAndStartDistTest {
         rawDist.setProperty("http-enabled", "true");
         rawDist.setProperty("hostname-strict", "false");
         rawDist.setProperty("http-relative-path", "/auth");
+        rawDist.setProperty("db", "dev-file");
         cliResult = rawDist.run("build");
         cliResult.assertBuild();
         cliResult = rawDist.run("start", OPTIMIZED_BUILD_OPTION_LONG);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -39,7 +39,7 @@ import java.nio.file.Paths;
 class BuildCommandDistTest {
 
     @Test
-    @Launch({ "build" })
+    @Launch({ "build", "--db=dev-file" })
     void resetConfig(CLIResult result) {
         assertTrue(result.getOutput().contains("Updating the configuration and installing your custom providers, if any. Please wait."),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -87,7 +87,7 @@ public class ClusterConfigDistTest {
 
     @Test
     @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
-    @Launch({ "start", "--log-level=info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--log-level=info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true", "--hostname-strict=false" })
     void testStartDefaultsToClustering(CLIResult result) {
         result.assertStarted();
         result.assertClusteredCache();
@@ -96,7 +96,7 @@ public class ClusterConfigDistTest {
 
     @Test
     @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell behaviour on Windows.")
-    @Launch({ "start", "--log-level=\"info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug\"","--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--log-level=\"info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug\"","--http-enabled=true", "--hostname-strict=false" })
     void testWinStartDefaultsToClustering(CLIResult result) {
         result.assertStarted();
         result.assertClusteredCache();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -25,7 +25,7 @@ import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.utils.KeycloakDistribution;
 
 @RawDistOnly(reason = "Containers are immutable")
-@DistributionTest
+@DistributionTest(defaultOptions = "--db=dev-file")
 @Tag(DistributionTest.SMOKE)
 public class ExportDistTest {
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -37,7 +37,7 @@ public class FeaturesDistTest {
 
     @Test
     public void testEnableOnBuild(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run(Build.NAME, "--features=preview");
+        CLIResult cliResult = dist.run(Build.NAME, "--db=dev-file", "--features=preview");
         cliResult.assertBuild();
         assertPreviewFeaturesEnabled(cliResult);
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -31,7 +31,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
-@DistributionTest(keepAlive = true, defaultOptions = { "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
+@DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
 @RawDistOnly(reason = "Containers are immutable")
 @Tag(DistributionTest.SLOW)
 public class FipsDistTest {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HostnameV2DistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HostnameV2DistTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RawDistOnly(reason = "Containers are immutable")
 public class HostnameV2DistTest {
     @Test
-    @Launch({"start", "--http-enabled=true"})
+    @Launch({"start", "--db=dev-file", "--http-enabled=true"})
     public void testServerFailsToStartWithoutHostnameSpecified(LaunchResult result) {
         assertThat(result.getErrorOutput(), containsString("ERROR: hostname is not configured; either configure hostname, or set hostname-strict to false"));
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
@@ -92,7 +92,7 @@ public class ImportAtStartupDistTest {
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromFileCreatedByExportAllRealms(KeycloakDistribution dist) throws IOException {
         dist.run("start-dev", "--import-realm");
-        dist.run("export", "--file=../data/import/realm.json");
+        dist.run("--profile=dev", "export", "--file=../data/import/realm.json");
 
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
@@ -107,7 +107,7 @@ public class ImportAtStartupDistTest {
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromFileCreatedByExportSingleRealm(KeycloakDistribution dist) throws IOException {
         dist.run("start-dev", "--import-realm");
-        dist.run("export", "--realm=quickstart-realm", "--file=../data/import/realm.json");
+        dist.run("--profile=dev", "export", "--realm=quickstart-realm", "--file=../data/import/realm.json");
 
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
@@ -123,7 +123,7 @@ public class ImportAtStartupDistTest {
         dist.run("start-dev", "--import-realm");
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("import").toAbsolutePath());
-        dist.run("export", "--dir=../data/import");
+        dist.run("--profile=dev", "export", "--dir=../data/import");
 
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
@@ -32,7 +32,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-@DistributionTest
+@DistributionTest(defaultOptions = "--db=dev-file")
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag(DistributionTest.SMOKE)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/IpStackDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/IpStackDistTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DistributionTest(keepAlive = true, defaultOptions = {"--http-enabled=true", "--hostname-strict=false"})
+@DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
 @RawDistOnly(reason = "Containers are immutable")
 public class IpStackDistTest {
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DistributionTest(keepAlive = true,
-        defaultOptions = {"--health-enabled=true", "--metrics-enabled=true"},
+        defaultOptions = {"--db=dev-file", "--health-enabled=true", "--metrics-enabled=true"},
         requestPort = 9000,
         containerExposedPorts = {9000, 8080, 9005})
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementHttpsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementHttpsDistTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 @DistributionTest(keepAlive = true,
         enableTls = true,
-        defaultOptions = {"--health-enabled=true", "--metrics-enabled=true"},
+        defaultOptions = {"--db=dev-file", "--health-enabled=true", "--metrics-enabled=true"},
         requestPort = 9000)
 @RawDistOnly(reason = "We do not test TLS in containers")
 public class ManagementHttpsDistTest {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
@@ -52,7 +52,7 @@ public class OptionsDistTest {
     @DryRun
     @Test
     @Order(2)
-    @Launch({"start", "--test=invalid"})
+    @Launch({"start", "--db=dev-file", "--test=invalid"})
     public void testServerDoesNotStartIfValidationFailDuringReAugStart(LaunchResult result) {
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Unknown option: '--test'")).count());
     }
@@ -60,7 +60,7 @@ public class OptionsDistTest {
     @DryRun
     @Test
     @Order(3)
-    @Launch({"start", "--log=console", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--log=console", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
     public void testServerDoesNotStartIfDisabledFileLogOption(LaunchResult result) {
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-level")).count());
@@ -69,7 +69,7 @@ public class OptionsDistTest {
     @DryRun
     @Test
     @Order(4)
-    @Launch({"start", "--log=file", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--log=file", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
     public void testServerStartIfEnabledFileLogOption(LaunchResult result) {
         assertEquals(0, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
     }
@@ -77,7 +77,7 @@ public class OptionsDistTest {
     @Test
     @Order(5)
     @WithEnvVars({"KC_LOG", "console", "KC_LOG_CONSOLE_COLOR", "true", "KC_LOG_FILE", "something-env", "KC_HTTP_ENABLED", "true", "KC_HOSTNAME_STRICT", "false"})
-    @Launch({"start"})
+    @Launch({"start", "--db=dev-file"})
     public void testSettingEnvVars(CLIResult cliResult) {
         cliResult.assertMessage("The following used run time options are UNAVAILABLE and will be ignored during build time:");
         cliResult.assertMessage("- log-file: Available only when File log handler is activated.");
@@ -91,7 +91,7 @@ public class OptionsDistTest {
     @RawDistOnly(reason = "Raw is enough and we avoid issues with including custom conf file in the container")
     public void testExpressionsInConfigFile(KeycloakDistribution distribution) {
         distribution.setEnvVar("MY_LOG_LEVEL", "warn");
-        CLIResult result = distribution.run(CONFIG_FILE_LONG_NAME + "=" + Paths.get("src/test/resources/OptionsDistTest/keycloak.conf").toAbsolutePath().normalize(), "start", "--http-enabled=true", "--hostname-strict=false");
+        CLIResult result = distribution.run(CONFIG_FILE_LONG_NAME + "=" + Paths.get("src/test/resources/OptionsDistTest/keycloak.conf").toAbsolutePath().normalize(), "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false");
         result.assertNoMessage("INFO [io.quarkus]");
         result.assertNoMessage("Listening on:");
 
@@ -103,7 +103,7 @@ public class OptionsDistTest {
 
     @Test
     @Order(7)
-    @Launch({"start", "--cache-embedded-mtls-enabled=true", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--cache-embedded-mtls-enabled=true", "--http-enabled=true", "--hostname-strict=false"})
     public void testCacheEmbeddedMtlsEnabled(LaunchResult result) {
         assertTrue(result.getOutputStream().stream().anyMatch(s -> s.contains("Property cache-embedded-mtls-key-store-file required but not specified")));
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
@@ -32,7 +32,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
 
-@DistributionTest(defaultOptions = {"--http-enabled=true", "--hostname-strict=false"})
+@DistributionTest(defaultOptions = {"--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(OrderAnnotation.class)
 public class QuarkusPropertiesAutoBuildDistTest {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -52,7 +52,7 @@ public class QuarkusPropertiesDistTest {
 
     @DryRun
     @Test
-    @Launch({"build"})
+    @Launch({"build", "--db=dev-file"})
     @Order(1)
     void testBuildWithPropertyFromQuarkusProperties(CLIResult cliResult) {
         cliResult.assertBuild();
@@ -60,21 +60,21 @@ public class QuarkusPropertiesDistTest {
 
     @Test
     @BeforeStartDistribution(QuarkusPropertiesDistTest.AddConsoleHandlerFromQuarkusProps.class)
-    @Launch({"start", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
     @Order(2)
     void testPropertyEnabledAtRuntime(CLIResult cliResult) {
         cliResult.assertMessage("Keycloak is the best");
     }
 
     @Test
-    @Launch({"-Dquarkus.log.handler.console.\"console-2\".enable=false", "start", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"-Dquarkus.log.handler.console.\"console-2\".enable=false", "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
     @Order(3)
     void testIgnoreQuarkusSystemPropertiesAtStart(CLIResult cliResult) {
         cliResult.assertMessage("Keycloak is the best");
     }
 
     @Test
-    @Launch({"-Dquarkus.log.handler.console.\"console-2\".enable=false", "build"})
+    @Launch({"-Dquarkus.log.handler.console.\"console-2\".enable=false", "build", "--db=dev-file"})
     @Order(4)
     void testIgnoreQuarkusSystemPropertyAtBuild(CLIResult cliResult) {
         cliResult.assertMessage("Keycloak is the best");
@@ -84,7 +84,7 @@ public class QuarkusPropertiesDistTest {
     @DryRun
     @Test
     @BeforeStartDistribution(UpdateConsoleHandlerFromKeycloakConf.class)
-    @Launch({"build"})
+    @Launch({"build", "--db=dev-file"})
     @Order(5)
     void testIgnoreQuarkusPropertyFromKeycloakConf(CLIResult cliResult) {
         cliResult.assertNoMessage("Keycloak is the best");
@@ -94,7 +94,7 @@ public class QuarkusPropertiesDistTest {
     @DryRun
     @Test
     @BeforeStartDistribution(UpdateConsoleHandlerFromQuarkusProps.class)
-    @Launch({"start", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
     @Order(6)
     @Disabled(value = "We don't properly differentiate between quarkus runtime and build time properties")
     void testRuntimePropFromQuarkusPropsIsAppliedWithoutRebuild(CLIResult cliResult) {
@@ -104,7 +104,7 @@ public class QuarkusPropertiesDistTest {
 
     @Test
     @BeforeStartDistribution(UpdateHibernateMetricsFromQuarkusProps.class)
-    @Launch({ "build", "--metrics-enabled=true" })
+    @Launch({ "build", "--db=dev-file", "--metrics-enabled=true" })
     @Order(7)
     void buildFirstWithUnknownQuarkusBuildProperty(CLIResult cliResult) {
         cliResult.assertBuild();
@@ -122,7 +122,7 @@ public class QuarkusPropertiesDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--config-keystore=../../../../src/test/resources/keystore" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false", "--config-keystore=../../../../src/test/resources/keystore" })
     @Order(9)
     void testMissingSmallRyeKeyStorePasswordProperty(CLIResult cliResult) {
         assertTrue(
@@ -135,7 +135,7 @@ public class QuarkusPropertiesDistTest {
 
     @Disabled("Ensuring config-keystore is used only at runtime removes proactive validation of the path when only the keystore is used")
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--config-keystore-password=secret" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false", "--config-keystore-password=secret" })
     @Order(10)
     void testMissingSmallRyeKeyStorePathProperty(CLIResult cliResult) {
         cliResult.assertBuild();
@@ -143,7 +143,7 @@ public class QuarkusPropertiesDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--config-keystore=/invalid/path",
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false", "--config-keystore=/invalid/path",
             "--config-keystore-password=secret" })
     @Order(11)
     void testInvalidSmallRyeKeyStorePathProperty(CLIResult cliResult) {
@@ -151,7 +151,7 @@ public class QuarkusPropertiesDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false",
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false",
             "--config-keystore=../../../../src/test/resources/keystore", "--config-keystore-password=secret" })
     @Order(12)
     void testSmallRyeKeyStoreConfigSource(CLIResult cliResult) {
@@ -163,7 +163,7 @@ public class QuarkusPropertiesDistTest {
     @Test
     @BeforeStartDistribution(ForceRebuild.class)
     @DisabledOnOs(value = { OS.WINDOWS }, disabledReason = "Windows uses a different path separator.")
-    @Launch({ "start", "--verbose", "--http-enabled=true", "--hostname-strict=false",
+    @Launch({ "start", "--verbose", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false",
             "--https-certificate-file=/tmp/kc/bin/../conf/server.crt.pem",
             "--https-certificate-key-file=/tmp/kc/bin/../conf/server.key.pem" })
     @Order(13)
@@ -174,7 +174,7 @@ public class QuarkusPropertiesDistTest {
     @Test
     @BeforeStartDistribution(ForceRebuild.class)
     @DisabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "Windows uses a different path separator.")
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false",
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false",
             "--https-certificate-file=C:\\tmp\\kc\\bin\\..\\conf/server.crt.pem",
             "--https-certificate-key-file=C:\\tmp\\kc\\bin\\..\\conf/server.key.pem" })
     @Order(14)
@@ -222,7 +222,7 @@ public class QuarkusPropertiesDistTest {
 
         @Override
         public void accept(KeycloakDistribution distribution) {
-            CLIResult buildResult = distribution.run("build");
+            CLIResult buildResult = distribution.run("build", "--db=dev-file");
             buildResult.assertBuild();
         }
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -29,7 +29,7 @@ public class ShowConfigCommandDistTest {
     void testShowConfigPicksUpRightConfigDependingOnCurrentMode(KeycloakDistribution distribution) {
         CLIResult initialResult = distribution.run("show-config");
         initialResult.assertMessage("Current Mode: production");
-        initialResult.assertMessage("kc.db =  dev-file");
+        initialResult.assertNoMessage("kc.db =  dev-file");
 
         distribution.run("start-dev");
 
@@ -37,7 +37,7 @@ public class ShowConfigCommandDistTest {
         devModeResult.assertMessage("Current Mode: development");
         devModeResult.assertMessage("kc.db =  dev-file");
 
-        distribution.run("build");
+        distribution.run("build", "--db=dev-file");
 
         CLIResult resetResult = distribution.run("show-config");
         resetResult.assertMessage("Current Mode: production");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -41,7 +41,7 @@ public class StartAutoBuildDistTest {
 
     @DryRun
     @Test
-    @Launch({ "--verbose", "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "--verbose", "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     @Order(1)
     void testStartAutoBuild(CLIResult cliResult) {
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
@@ -56,7 +56,7 @@ public class StartAutoBuildDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     @Order(2)
     void testShouldNotReAugIfConfigIsSame(CLIResult cliResult) {
         cliResult.assertNoBuild();
@@ -91,7 +91,7 @@ public class StartAutoBuildDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     @Order(6)
     void testReAugWhenNoOptionAfterBuild(CLIResult cliResult) {
         cliResult.assertBuild();
@@ -129,6 +129,7 @@ public class StartAutoBuildDistTest {
     @Order(9)
     void testShouldNotReAugStartDevIfConfigIsSame(CLIResult cliResult) {
         cliResult.assertNoMessage("Updating the configuration and installing your custom providers, if any. Please wait.");
+        cliResult.assertNoBuild();
         cliResult.assertStartedDevMode();
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -47,7 +47,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--hostname-strict=false" })
     void failNoTls(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("Key material not provided to setup HTTPS"),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
@@ -55,7 +55,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--spi-events-listener-jboss-logging-success-level" })
+    @Launch({ "start", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level" })
     void failSpiArgMissingValue(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("spi argument --spi-events-listener-jboss-logging-success-level requires a value"),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
@@ -63,7 +63,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "build", "--spi-events-listener-jboss-logging-success-level=debug" })
+    @Launch({ "build", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level=debug" })
     void warnSpiRuntimeAtBuildtime(CLIResult cliResult) {
         assertTrue(cliResult.getOutput().contains("The following run time options were found, but will be ignored during build time: kc.spi-events-listener-jboss-logging-success-level"),
                 () -> "The Output:\n" + cliResult.getOutput() + "doesn't contains the expected string.");
@@ -73,7 +73,7 @@ public class StartCommandDistTest {
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void errorSpiBuildtimeAtRuntime(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("build");
+        CLIResult cliResult = dist.run("build",  "--db=dev-file");
         cliResult.assertBuild();
 
         cliResult = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false", "--spi-events-listener-jboss-logging-enabled=false");
@@ -85,7 +85,7 @@ public class StartCommandDistTest {
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void noErrorSpiBuildtimeNotChanged(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("build");
+        CLIResult cliResult = dist.run("build", "--db=dev-file");
         cliResult.assertBuild();
 
         cliResult = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
@@ -94,14 +94,14 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "--profile=dev", "start" })
+    @Launch({ "--profile=dev", "start",  "--db=dev-file" })
     void failUsingDevProfile(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("ERROR: You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
     }
 
     @Test
-    @Launch({ "-v", "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "-v", "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     void testHttpEnabled(CLIResult cliResult) {
         cliResult.assertStarted();
     }
@@ -139,15 +139,25 @@ public class StartCommandDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true" })
     void failNoHostnameNotSet(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("ERROR: hostname is not configured; either configure hostname, or set hostname-strict to false"),
                 () -> "The Output:\n" + cliResult.getOutput() + "doesn't contains the expected string.");
     }
 
+    @RawDistOnly(reason = "Containers are immutable")
+    void testFastStartOptimized(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("build", "--db=dev-file");
+        cliResult.assertBuild();
+        dist.setEnvVar("KC_HOSTNAME", "localhost");
+        dist.setEnvVar("KC_HTTP_ENABLED", "true");
+        cliResult = dist.run("start", "--optimized");
+        cliResult.assertStarted();
+    }
+
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--metrics-enabled=true" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false", "--metrics-enabled=true" })
     void testStartUsingAutoBuild(CLIResult cliResult) {
         cliResult.assertNoMessage("ignored during build");
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
@@ -169,7 +179,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--cache-remote-host=localhost", "--hostname-strict=false", "--cache-remote-tls-enabled=false", "--transaction-xa-enabled=true" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--cache-remote-host=localhost", "--hostname-strict=false", "--cache-remote-tls-enabled=false", "--transaction-xa-enabled=true" })
     void testStartNoWarningOnDisabledRuntimeOption(CLIResult cliResult) {
         cliResult.assertNoMessage("cache-remote-tls-enabled: Available only when remote host is set");
     }
@@ -177,7 +187,7 @@ public class StartCommandDistTest {
     @DryRun
     @Test
     @WithEnvVars({"KC_LOG", "invalid"})
-    @Launch({ "start", "--http-enabled=false", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=false", "--hostname-strict=false" })
     void testStartUsingOptimizedInvalidEnvOption(CLIResult cliResult) {
         cliResult.assertError("Invalid value for option 'KC_LOG': invalid. Expected values are: console, file, syslog");
     }
@@ -188,7 +198,7 @@ public class StartCommandDistTest {
     void testWarningWhenOverridingBuildOptionsDuringStart(KeycloakDistribution dist) {
         CLIResult cliResult = dist.run("build", "--db=postgres", "--features=preview");
         cliResult.assertBuild();
-        cliResult = dist.run("start", "--hostname=localhost", "--http-enabled=true");
+        cliResult = dist.run("start", "--db=dev-file", "--hostname=localhost", "--http-enabled=true");
         cliResult.assertMessage("The previous optimized build will be overridden with the following build options:");
         cliResult.assertMessage("- db=postgres > db=dev-file"); // back to the default value
         cliResult.assertMessage("- features=preview > features=<unset>"); // no default value, the <unset> is shown
@@ -200,7 +210,7 @@ public class StartCommandDistTest {
         cliResult.assertNoMessage("The previous optimized build will be overridden with the following build options:");
         assertTrue(cliResult.getErrorOutput().isBlank());
         dist.run("build", "--db=postgres");
-        cliResult = dist.run("start", "--hostname=localhost", "--http-enabled=true");
+        cliResult = dist.run("start", "--db=dev-file", "--hostname=localhost", "--http-enabled=true");
         cliResult.assertMessage("- db=postgres > db=dev-file");
         cliResult.assertNoMessage("- features=preview > features=<unset>");
         assertTrue(cliResult.getErrorOutput().isBlank());
@@ -224,7 +234,7 @@ public class StartCommandDistTest {
         CLIResult cliResult = dist.run("start-dev");
         cliResult.assertStartedDevMode();
 
-        cliResult = dist.run("start", "--http-enabled", "true", "--hostname-strict", "false");
+        cliResult = dist.run("start", "--db=dev-file", "--http-enabled", "true", "--hostname-strict", "false");
         cliResult.assertNotDevMode();
         assertTrue(cliResult.getErrorOutput().isBlank());
     }
@@ -233,7 +243,7 @@ public class StartCommandDistTest {
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void testErrorWhenOverridingNonCliBuildOptionsDuringStart(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("build", "--features=preview");
+        CLIResult cliResult = dist.run("build", "--db=dev-file", "--features=preview");
         cliResult.assertBuild();
         dist.setEnvVar("KC_DB", "postgres");
         cliResult = dist.run("start", "--optimized", "--hostname=localhost", "--http-enabled=true");
@@ -242,7 +252,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({CONFIG_FILE_LONG_NAME + "=src/test/resources/non-existing.conf", "start"})
+    @Launch({CONFIG_FILE_LONG_NAME + "=src/test/resources/non-existing.conf", "start", "--db=dev-file"})
     void testInvalidConfigFileOption(CLIResult cliResult) {
         cliResult.assertError("File specified via '--config-file' or '-cf' option does not exist.");
         cliResult.assertError(String.format("Try '%s --help' for more information on the available options.", KeycloakDistribution.SCRIPT_CMD));
@@ -253,17 +263,17 @@ public class StartCommandDistTest {
     void testRuntimeValuesAreNotCaptured(KeycloakDistribution dist) {
         // confirm that the invalid value prevents startup - if this passes, then we need to use a different
         // spi provider
-        CLIResult cliResult = dist.run("start", "--spi-events-listener-jboss-logging-success-level=invalid", "--http-enabled", "true", "--hostname-strict", "false");
+        CLIResult cliResult = dist.run("start", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level=invalid", "--http-enabled", "true", "--hostname-strict", "false");
         cliResult.assertError("Failed to start quarkus");
 
         // if there was no auto-build use an explicit build to potentially capture the runtime default
         if (!cliResult.getOutput().contains("Server configuration updated and persisted")) {
-            cliResult = dist.run("build", "--spi-events-listener-jboss-logging-success-level=invalid");
+            cliResult = dist.run("build", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level=invalid");
             cliResult.assertBuild();
         }
 
         // the invalid value should not be the default
-        cliResult = dist.run("start", "--http-enabled", "true", "--hostname-strict", "false");
+        cliResult = dist.run("start", "--db=dev-file", "--http-enabled", "true", "--hostname-strict", "false");
         cliResult.assertNoBuild();
         cliResult.assertStarted();
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -66,7 +66,7 @@ public class StartDevCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "build", "--debug" })
+    @Launch({ "build", "--debug", "--db=dev-file" })
     void testBuildMustNotRunTwoJVMs(CLIResult cliResult) {
         cliResult.assertMessageWasShownExactlyNumberOfTimes("Listening for transport dt_socket at address:", 1);
         cliResult.assertBuild();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TracingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TracingDistTest.java
@@ -85,7 +85,7 @@ public class TracingDistTest {
 
     @Test
     @Order(5)
-    @Launch({"build", "--tracing-enabled=true", "--features=opentelemetry"})
+    @Launch({"build", "--db=dev-file", "--tracing-enabled=true", "--features=opentelemetry"})
     void buildTracingEnabled(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TruststoreDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TruststoreDistTest.java
@@ -58,7 +58,7 @@ public class TruststoreDistTest {
         dist.copyOrReplaceFileFromClasspath("/self-signed.p12", Path.of("conf", "self-signed.p12"));
         Path keyStore = rawDist.getDistPath().resolve("conf").resolve("self-signed.p12").toAbsolutePath();
 
-        rawDist.run("--verbose", "start", "--http-enabled=true", "--hostname=mykeycloak.org",
+        rawDist.run("--verbose", "start", "--db=dev-file", "--http-enabled=true", "--hostname=mykeycloak.org",
                 "--truststore-paths=" + paths, "--https-client-auth=required", "--https-key-store-file=" + keyStore);
 
         given().trustStore(TruststoreDistTest.class.getResource("/self-signed-truststore.p12").getPath(), TruststoreBuilder.DUMMY_PASSWORD)
@@ -77,7 +77,7 @@ public class TruststoreDistTest {
         dist.copyOrReplaceFileFromClasspath("/self-signed.p12", Path.of("conf", "self-signed.p12"));
         Path keyStore = rawDist.getDistPath().resolve("conf").resolve("self-signed.p12").toAbsolutePath();
 
-        rawDist.run("--verbose", "start", "--http-enabled=true", "--hostname=mykeycloak.org",
+        rawDist.run("--verbose", "start", "--db=dev-file", "--http-enabled=true", "--hostname=mykeycloak.org",
                 "--https-client-auth=required", "--https-key-store-file=" + keyStore);
 
         given().trustStore(TruststoreDistTest.class.getResource("/self-signed-truststore.p12").getPath(), TruststoreBuilder.DUMMY_PASSWORD)

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
@@ -19,8 +19,10 @@ Options:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -79,8 +79,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -105,8 +105,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -86,8 +86,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -106,8 +106,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In development mode the default value will be 'dev-file'.
+                       Possible values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle,
+                       postgres. Required when The db option must be explicitly provided in a
+                       non-development profile.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -269,7 +269,7 @@
                 <executions>
                     <execution>
                         <id>ant-generate-default</id>
-                        <phase>generate-resources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
Also various cleanups related to the configuration - there is some tech debt, and a few things that are probably wrong. Some of this could be separated from the pr, but we do need to change how we detect auto-builds are needed to understand the absense of the db option. See also #33902

I had initially tried to go the direction of mapping the the database from the profile property - but that revealed some additional compleity that is needed to handle that case (so that the other values mapped from db could work). So instead this uses a delayed default value, which looks at the profile.

These changes also bring up what is dev vs prod means with the non-server commands.  As it stands the changes will force users to specify --db on import, export, etc. just like start if --optimized is not specified. The alternative to this behavior is to default to the persisted db instead - but only if what's persisted is in the prod profile.

WDYT? @mabartos @vmuzikar @pedroigor 

closes: #23805

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
