### PR TITLE
Unified case in Dockerfile Example

### DIFF
--- a/docs/guides/server/containers.adoc
+++ b/docs/guides/server/containers.adoc
@@ -29,7 +29,7 @@ The following `Containerfile` creates a pre-configured {project_name} image that
 .Containerfile:
 [source,dockerfile,subs="attributes+"]
 ----
-FROM quay.io/keycloak/keycloak:{containerlabel} as builder
+FROM quay.io/keycloak/keycloak:{containerlabel} AS builder
 
 # Enable health and metrics support
 ENV KC_HEALTH_ENABLED=true


### PR DESCRIPTION
This prevents a warning on build-time.
https://docs.docker.com/reference/build-checks/from-as-casing/

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
