### PR TITLE
Don't fail on drop index IDX_US_SESS_ID_ON_CL_SESS (fixes #33780)

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -93,6 +93,12 @@
     </changeSet>
 
     <changeSet author="keycloak" id="26.0.0-32583-drop-redundant-index-on-client-session">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <and>
+                <dbms type="oracle"/>
+                <indexExists indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
+            </and>
+        </preConditions>
         <dropIndex indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
     </changeSet>
     

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -94,9 +94,7 @@
 
     <changeSet author="keycloak" id="26.0.0-32583-drop-redundant-index-on-client-session">
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
-            <and>
-                <indexExists indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
-            </and>
+            <indexExists indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
         </preConditions>
         <dropIndex indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
     </changeSet>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -95,7 +95,6 @@
     <changeSet author="keycloak" id="26.0.0-32583-drop-redundant-index-on-client-session">
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <and>
-                <dbms type="oracle"/>
                 <indexExists indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
             </and>
         </preConditions>


### PR DESCRIPTION
Closes #33780

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
This PR tries to fix the issue described in #33780 by using the same approach as in [jpa-changelog-24.0.2.xml](https://github.com/keycloak/keycloak/blob/main/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.2.xml#L25).

I wanted to test it by building Keycloak as described in [docs/building.md](https://github.com/keycloak/keycloak/blob/main/docs/building.md), but it failed due to other problems, see spoiler below.
<details>
<summary>mvnw failed with the following error (despite having JDK 21):</summary>

```bash
$ ./mvnw clean install
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project keycloak-common: Fatal error compiling: Fehler: Releaseversion 8 nicht unterstützt -> [Help 1]
$ ./mvnw -version
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /home/kevin/.m2/wrapper/dists/apache-maven-3.9.8/af622e91
Java version: 21.0.4, vendor: Ubuntu, runtime: /usr/lib/jvm/java-21-openjdk-amd64
Default locale: de_DE, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-45-generic", arch: "amd64", family: "unix"
```
</details>

Instead I've tested the changes by manually editing and replacing `META-INF/jpa-changelog-26.0.0.xml` in `/opt/keycloak/lib/lib/main/org.keycloak.keycloak-model-jpa-26.0.0.jar` (using `jar xf` and `jar uf`).

Migration was then successful and Keycloak started without problems.
<details>
<summary>Docker container logs:</summary>

```
keycloak     | 2024-10-10 15:35:04,277 ERROR [org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers] (main) Hostname v1 options [hostname-strict-backchannel, proxy] are still in use, please review your configuration
keycloak     | 2024-10-10 15:35:16,868 INFO  [org.keycloak.quarkus.runtime.storage.infinispan.CacheManagerFactory] (main) Starting Infinispan embedded cache manager
keycloak     | 2024-10-10 15:35:19,856 INFO  [org.infinispan.CONTAINER] (Thread-5) ISPN000556: Starting user marshaller 'org.infinispan.commons.marshall.ImmutableProtoStreamMarshaller'
keycloak     | 2024-10-10 15:35:21,352 WARN  [org.jgroups.stack.Configurator] (Thread-5) JGRP000014: ThreadPool.thread_dumps_threshold has been deprecated: ignored
keycloak     | 2024-10-10 15:35:21,363 INFO  [org.infinispan.CLUSTER] (Thread-5) ISPN000078: Starting JGroups channel `ISPN` with stack `udp`
keycloak     | 2024-10-10 15:35:21,451 INFO  [org.jgroups.JChannel] (Thread-5) local_addr: 8ced2657-1ec8-48b4-bfb6-b2f7c13e14e8, name: 6e8ff1c3a903-30763
keycloak     | 2024-10-10 15:35:21,456 WARN  [org.jgroups.protocols.UDP] (Thread-5) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB
keycloak     | 2024-10-10 15:35:21,457 WARN  [org.jgroups.protocols.UDP] (Thread-5) JGRP000015: the receive buffer of socket MulticastSocket was set to 20MB, but the OS only allocated 212.99KB
keycloak     | 2024-10-10 15:35:21,457 WARN  [org.jgroups.protocols.UDP] (Thread-5) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB
keycloak     | 2024-10-10 15:35:21,458 WARN  [org.jgroups.protocols.UDP] (Thread-5) JGRP000015: the receive buffer of socket MulticastSocket was set to 25MB, but the OS only allocated 212.99KB
keycloak     | 2024-10-10 15:35:21,465 INFO  [org.jgroups.protocols.FD_SOCK2] (Thread-5) server listening on *.28684
keycloak     | 2024-10-10 15:35:23,554 INFO  [org.jgroups.protocols.pbcast.GMS] (Thread-5) 6e8ff1c3a903-30763: no members discovered after 2003 ms: creating cluster as coordinator
keycloak     | 2024-10-10 15:35:23,563 INFO  [org.infinispan.CLUSTER] (Thread-5) ISPN000094: Received new cluster view for channel ISPN: [6e8ff1c3a903-30763|0] (1) [6e8ff1c3a903-30763]
keycloak     | 2024-10-10 15:35:24,052 INFO  [org.infinispan.CLUSTER] (Thread-5) ISPN000079: Channel `ISPN` local address is `6e8ff1c3a903-30763`, physical addresses are `[172.18.0.3:44220]`
keycloak     | 2024-10-10 15:35:25,453 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Node name: 6e8ff1c3a903-30763, Site name: null
keycloak     | 2024-10-10 15:35:30,767 INFO  [org.keycloak.quarkus.runtime.storage.database.liquibase.QuarkusJpaUpdaterProvider] (main) Updating database. Using changelog META-INF/jpa-changelog-master.xml
keycloak     | 
keycloak     | UPDATE SUMMARY
keycloak     | Run:                          3
keycloak     | Previously run:             141
keycloak     | Filtered out:                 0
keycloak     | -------------------------------
keycloak     | Total change sets:          144
keycloak     | 
keycloak     | 2024-10-10 15:35:33,255 WARN  [io.agroal.pool] (main) Datasource '<default>': JDBC resources leaked: 3 ResultSet(s) and 0 Statement(s)
keycloak     | 2024-10-10 15:35:33,256 WARN  [io.agroal.pool] (main) Datasource '<default>': JDBC resources leaked: 9 ResultSet(s) and 0 Statement(s)
keycloak     | 2024-10-10 15:35:34,664 INFO  [org.keycloak.storage.datastore.DefaultMigrationManager] (main) Migrating older model to 26.0.0
keycloak     | 2024-10-10 15:35:40,369 INFO  [org.keycloak.broker.provider.AbstractIdentityProviderMapper] (main) Registering class org.keycloak.broker.provider.mappersync.ConfigSyncEventListener
keycloak     | 2024-10-10 15:35:40,529 WARN  [io.agroal.pool] (main) Datasource '<default>': JDBC resources leaked: 3 ResultSet(s) and 0 Statement(s)
keycloak     | 2024-10-10 15:35:41,357 INFO  [io.quarkus] (main) Keycloak 26.0.0 on JVM (powered by Quarkus 3.15.1) started in 44.397s. Listening on: https://0.0.0.0:8443
keycloak     | 2024-10-10 15:35:41,358 INFO  [io.quarkus] (main) Profile prod activated. 
keycloak     | 2024-10-10 15:35:41,358 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, jdbc-postgresql, keycloak, narayana-jta, opentelemetry, reactive-routes, rest, rest-jackson, smallrye-context-propagation, vertx]
```
</details>