### PR TITLE
Fix incorrect filter in docker protocol

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -144,8 +144,11 @@ public class ProtocolMapperUtils {
                         .filter(Objects::nonNull)
                         .filter(filter);
 
-        return Stream.concat(protocolMapperStream, DPoPUtil.getTransientProtocolMapper())
-                .sorted(Comparator.comparing(ProtocolMapperUtils::compare));
+        if (OIDCLoginProtocol.LOGIN_PROTOCOL.equals(ctx.getClientSession().getClient().getProtocol())) {
+            protocolMapperStream = Stream.concat(protocolMapperStream, DPoPUtil.getTransientProtocolMapper());
+        }
+
+        return protocolMapperStream.sorted(Comparator.comparing(ProtocolMapperUtils::compare));
     }
 
     public static int compare(Entry<ProtocolMapperModel, ProtocolMapper> entry) {

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2Protocol.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2Protocol.java
@@ -113,7 +113,6 @@ public class DockerAuthV2Protocol implements LoginProtocol {
         AtomicReference<DockerResponseToken> finalResponseToken = new AtomicReference<>(responseToken);
         ProtocolMapperUtils.getSortedProtocolMappers(session, clientSessionCtx, mapper ->
                     mapper.getValue() instanceof DockerAuthV2AttributeMapper && ((DockerAuthV2AttributeMapper) mapper.getValue()).appliesTo(finalResponseToken.get()))
-                .filter(mapper -> mapper instanceof DockerAuthV2AttributeMapper)
                 .forEach(mapper -> finalResponseToken.set(((DockerAuthV2AttributeMapper) mapper.getValue())
                             .transformDockerResponseToken(finalResponseToken.get(), mapper.getKey(), session, userSession, clientSession)));
         responseToken = finalResponseToken.get();


### PR DESCRIPTION
Closes #33776

There was an error adding the DPoP transient mapper. A line was added to filter it for the docker protocol but the `instanceof` was not OK (it was set to `mapper` when it should be to `mapper.getValue()`). But the PR is changing the utils to only add the transient mapper if the client is OIDC (adding it to a saml or docker client makes no sense). The docker test is improved to pull a little image from `docker.io` and push it to the keycloak protected registry. This way after the login the permissions are also tested.
