### PR TITLE
Run all maven commands inside the ubi docker container

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -16,5 +16,23 @@ echo "Tests: $TESTS"
 export JAVA_HOME=/etc/alternatives/java_sdk_21
 set -o pipefail
 
+# Build adapter distributions
+./mvnw install -DskipTests -f distribution/pom.xml
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+# Build app servers
+./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+# Prepare Quarkus distribution with BCFIPS
+./mvnw install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 # Profile app-server-wildfly needs to be explicitly set for FIPS tests
 ./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dcom.redhat.fips=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,59 +704,49 @@ jobs:
         with:
           job-id: fips-unit-tests
 
-#  fips-integration-tests:
-#    name: FIPS IT
-#    needs: build
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 45
-#    strategy:
-#      matrix:
-#        mode: [non-strict, strict]
-#      fail-fast: false
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Fake fips
-#        run: |
-#          cd .github/fake_fips
-#          make
-#          sudo insmod fake_fips.ko
-#
-#      - id: integration-test-setup
-#        name: Integration test setup
-#        uses: ./.github/actions/integration-test-setup
-#        with:
-#          jdk-version: 21
-#
-#      - name: Build adapter distributions
-#        run: ./mvnw install -DskipTests -f distribution/pom.xml
-#
-#      - name: Build app servers
-#        run: ./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
-#
-#
-#      - name: Prepare Quarkus distribution with BCFIPS
-#        run: ./mvnw install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
-#
-#      - name: Run base tests
-#        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
-#
-#      - name: Upload JVM Heapdumps
-#        if: always()
-#        uses: ./.github/actions/upload-heapdumps
-#
-#      - uses: ./.github/actions/upload-flaky-tests
-#        name: Upload flaky tests
-#        env:
-#          GH_TOKEN: ${{ github.token }}
-#        with:
-#          job-name: FIPS IT
-#
-#      - name: Surefire reports
-#        if: always()
-#        uses: ./.github/actions/archive-surefire-reports
-#        with:
-#          job-id: fips-integration-tests-${{ matrix.mode }}
+  fips-integration-tests:
+    name: FIPS IT
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        mode: [non-strict, strict]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fake fips
+        run: |
+          cd .github/fake_fips
+          make
+          sudo insmod fake_fips.ko
+
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+        with:
+          jdk-version: 21
+
+      - name: Run base tests
+        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
+
+      - name: Upload JVM Heapdumps
+        if: always()
+        uses: ./.github/actions/upload-heapdumps
+
+      - uses: ./.github/actions/upload-flaky-tests
+        name: Upload flaky tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          job-name: FIPS IT
+
+      - name: Surefire reports
+        if: always()
+        uses: ./.github/actions/archive-surefire-reports
+        with:
+          job-id: fips-integration-tests-${{ matrix.mode }}
 
   forms-integration-tests:
     name: Forms IT
@@ -975,7 +965,7 @@ jobs:
       - store-model-tests
       - clustering-integration-tests
       - fips-unit-tests
-#      - fips-integration-tests
+      - fips-integration-tests
       - forms-integration-tests
       - webauthn-integration-tests
       - sssd-unit-tests


### PR DESCRIPTION
Closes #33881

The issue is that the openssl in the ubuntu image seems to check the `/proc/sys/crypto/fips_enabled` to configure things. Note that ubuntu also provides a fips mode (see [here](https://ubuntu.com/security/certifications/docs/fips)). So I suppose that now the ubuntu build for openssl3 is reading if fips is enabled and trying to load the fips library that is not there (because we are using a fake, no real ubuntu fips). The wget is using openssl that is failing. Moving all compilation inside the ubi container like in FIPS UT.
