### PR TITLE
Refresh login page when root auth session changes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/cookie/CookieType.java
+++ b/server-spi-private/src/main/java/org/keycloak/cookie/CookieType.java
@@ -19,6 +19,11 @@ public final class CookieType {
             .defaultMaxAge(CookieMaxAge.SESSION)
             .build();
 
+    public static final CookieType AUTH_SESSION_ID_HASH = CookieType.create("KC_AUTH_SESSION_HASH")
+            .scope(CookieScope.INTERNAL_JS)
+            .defaultMaxAge(60)
+            .build();
+
     public static final CookieType AUTH_SESSION_ID = CookieType.create("AUTH_SESSION_ID")
             .scope(CookieScope.FEDERATION)
             .defaultMaxAge(CookieMaxAge.SESSION)

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationSessionBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationSessionBean.java
@@ -19,21 +19,33 @@
 
 package org.keycloak.forms.login.freemarker.model;
 
+import org.keycloak.crypto.JavaAlgorithm;
+import org.keycloak.jose.jws.crypto.HashUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public class AuthenticationSessionBean {
 
     private final String authSessionId;
+    private final String authSessionIdHash;
     private final String tabId;
 
     public AuthenticationSessionBean(String authSessionId, String tabId) {
         this.authSessionId = authSessionId;
+        this.authSessionIdHash = Base64.getEncoder().withoutPadding().encodeToString(HashUtils.hash(JavaAlgorithm.SHA256, authSessionId.getBytes(StandardCharsets.UTF_8)));
         this.tabId = tabId;
     }
 
     public String getAuthSessionId() {
         return authSessionId;
+    }
+
+    public String getAuthSessionIdHash() {
+        return authSessionIdHash;
     }
 
     public String getTabId() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/DefaultCookieProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/DefaultCookieProviderTest.java
@@ -70,6 +70,7 @@ public class DefaultCookieProviderTest extends AbstractKeycloakTest {
         Response response = testingInsecure.server("master").runWithResponse(session -> {
             CookieProvider cookies = session.getProvider(CookieProvider.class);
             cookies.set(CookieType.AUTH_SESSION_ID, "my-auth-session-id");
+            cookies.set(CookieType.AUTH_SESSION_ID_HASH, "my-kc-auth-session");
             cookies.set(CookieType.AUTH_RESTART, "my-auth-restart");
             cookies.set(CookieType.AUTH_DETACHED, "my-auth-detached", 222);
             cookies.set(CookieType.IDENTITY, "my-identity", 333);
@@ -78,8 +79,9 @@ public class DefaultCookieProviderTest extends AbstractKeycloakTest {
             cookies.set(CookieType.SESSION, "my-session", 444);
             cookies.set(CookieType.WELCOME_CSRF, "my-welcome-csrf");
         });
-        Assert.assertEquals(8, response.getCookies().size());
+        Assert.assertEquals(9, response.getCookies().size());
         assertCookie(response, "AUTH_SESSION_ID", "my-auth-session-id", "/auth/realms/master/", -1, false, true, "Lax", true);
+        assertCookie(response, "KC_AUTH_SESSION_HASH", "my-kc-auth-session", "/auth/realms/master/", 60, false, false, "Strict", true);
         assertCookie(response, "KC_RESTART", "my-auth-restart", "/auth/realms/master/", -1, false, true, "Lax", false);
         assertCookie(response, "KC_STATE_CHECKER", "my-auth-detached", "/auth/realms/master/", 222, false, true, "Strict", false);
         assertCookie(response, "KEYCLOAK_IDENTITY", "my-identity", "/auth/realms/master/", 333, false, true, "Lax", true);
@@ -183,6 +185,7 @@ public class DefaultCookieProviderTest extends AbstractKeycloakTest {
             response = testingClient.server("master").runWithResponse(session -> {
                 CookieProvider cookies = session.getProvider(CookieProvider.class);
                 cookies.set(CookieType.AUTH_SESSION_ID, "my-auth-session-id");
+                cookies.set(CookieType.AUTH_SESSION_ID_HASH, "my-kc-auth-session");
                 cookies.set(CookieType.AUTH_RESTART, "my-auth-restart");
                 cookies.set(CookieType.AUTH_DETACHED, "my-auth-detached", 222);
                 cookies.set(CookieType.IDENTITY, "my-identity", 333);
@@ -193,8 +196,9 @@ public class DefaultCookieProviderTest extends AbstractKeycloakTest {
             });
         }
 
-        Assert.assertEquals(8, response.getCookies().size());
+        Assert.assertEquals(9, response.getCookies().size());
         assertCookie(response, "AUTH_SESSION_ID", "my-auth-session-id", "/auth/realms/master/", -1, false, true, "Lax", true);
+        assertCookie(response, "KC_AUTH_SESSION_HASH", "my-kc-auth-session", "/auth/realms/master/", 60, false, false, "Strict", true);
         assertCookie(response, "KC_RESTART", "my-auth-restart", "/auth/realms/master/", -1, false, true, "Lax", false);
         assertCookie(response, "KC_STATE_CHECKER", "my-auth-detached", "/auth/realms/master/", 222, false, true, "Strict", false);
         assertCookie(response, "KEYCLOAK_IDENTITY", "my-identity", "/auth/realms/master/", 333, false, true, "Lax", true);

--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -1,4 +1,5 @@
 const CHECK_INTERVAL_MILLISECS = 2000;
+const AUTH_SESSION_TIMEOUT_MILLISECS = 1000;
 const initialSession = getSession();
 
 let timeout;
@@ -30,6 +31,19 @@ export function checkCookiesAndSetTimer(loginRestartUrl) {
     // Redirect to the login restart URL. This can typically automatically login user due the SSO
     location.href = loginRestartUrl;
   }
+}
+
+export function checkAuthSession(pageAuthSessionHash) {
+  setTimeout(() => {
+    const cookieAuthSessionHash = getKcAuthSessionHash();
+    if (cookieAuthSessionHash !== pageAuthSessionHash) {
+      location.reload();
+    }
+  }, AUTH_SESSION_TIMEOUT_MILLISECS);
+}
+
+function getKcAuthSessionHash() {
+  return getCookieByName("KC_AUTH_SESSION_HASH");
 }
 
 function getSession() {

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -50,6 +50,15 @@
           "${url.ssoLoginInOtherTabsUrl?no_esc}"
         );
     </script>
+    <#if authenticationSession??>
+        <script type="module">
+            import { checkAuthSession } from "${url.resourcesPath}/js/authChecker.js";
+
+            checkAuthSession(
+                "${authenticationSession.authSessionIdHash}"
+            );
+        </script>
+    </#if>
 </head>
 
 <body class="${properties.kcBodyClass!}">

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -92,6 +92,15 @@
             "${url.ssoLoginInOtherTabsUrl?no_esc}"
         );
     </script>
+    <#if authenticationSession??>
+        <script type="module">
+            import { checkAuthSession } from "${url.resourcesPath}/js/authChecker.js";
+
+            checkAuthSession(
+                "${authenticationSession.authSessionIdHash}"
+            );
+        </script>
+    </#if>
     <script>
       // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
       const isFirefox;


### PR DESCRIPTION
Closes #32658 

This PR fixes the issue of encountering the error message "Your login attempt timed out." when multiple login pages are opened simultaneously in the same browser and the login form is submitted in one of them. 

To address the issue, in the existing `authChecker.js`, 1 second after the login page is opened, the page is reloaded if the new `KC_AUTH_SESSION_HASH` has changed.

This issue fixed by this PR is different from the concurrent write issue for the RootAuthenticationSession, which is fixed by another PR: #33830.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
