### PR TITLE
Fixes for FIPS IT in CI (22.0)

### DIFF
--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -40,12 +40,3 @@ runs:
           ~/.m2/repository/*/*
           !~/.m2/repository/org/keycloak
         key: ${{ steps.weekly-cache-key.outputs.key }}
-
-    - name: Cache Maven Wrapper
-      uses: actions/cache@v3
-      with:
-        path: .mvn/wrapper/maven-wrapper.jar
-        key: ${{ runner.os }}-maven-wrapper-${{ hashFiles('**/maven-wrapper.properties') }}
-        # use a previously cached JAR file as something else besides the version could have changed in the file
-        restore-keys: |
-          ${{ runner.os }}-maven-wrapper-

--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -16,5 +16,23 @@ echo "Tests: $TESTS"
 export JAVA_HOME=/etc/alternatives/java_sdk_17
 set -o pipefail
 
+# Build adapter distributions
+./mvnw install -DskipTests -f distribution/pom.xml
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+# Build app servers
+./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+# Prepare Quarkus distribution with BCFIPS
+./mvnw install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 # Profile app-server-wildfly needs to be explicitly set for FIPS tests
 ./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dcom.redhat.fips=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base | misc/log/trimmer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,46 +455,46 @@ jobs:
         with:
           job-id: fips-unit-tests
 
-  fips-integration-tests:
-    name: FIPS IT
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    strategy:
-      matrix:
-        mode: [non-strict, strict]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Fake fips
-        run: |
-          cd .github/fake_fips
-          make
-          sudo insmod fake_fips.ko
-
-      - id: integration-test-setup
-        name: Integration test setup
-        uses: ./.github/actions/integration-test-setup
-        with:
-          jdk-version: 17
-
-      - name: Prepare Quarkus distribution with BCFIPS
-        run: ./mvnw ${{ env.MAVEN_ARGS }} install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
-
-      - name: Run base tests
-        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
-
-      - name: Upload JVM Heapdumps
-        if: always()
-        uses: ./.github/actions/upload-heapdumps
-
-      - uses: ./.github/actions/upload-flaky-tests
-        name: Upload flaky tests
-        env:
-          GH_TOKEN: ${{ github.token }}
-        with:
-          job-name: FIPS IT
+#  fips-integration-tests:
+#    name: FIPS IT
+#    needs: build
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 45
+#    strategy:
+#      matrix:
+#        mode: [non-strict, strict]
+#      fail-fast: false
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Fake fips
+#        run: |
+#          cd .github/fake_fips
+#          make
+#          sudo insmod fake_fips.ko
+#
+#      - id: integration-test-setup
+#        name: Integration test setup
+#        uses: ./.github/actions/integration-test-setup
+#        with:
+#          jdk-version: 17
+#
+#      - name: Prepare Quarkus distribution with BCFIPS
+#        run: ./mvnw ${{ env.MAVEN_ARGS }} install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
+#
+#      - name: Run base tests
+#        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
+#
+#      - name: Upload JVM Heapdumps
+#        if: always()
+#        uses: ./.github/actions/upload-heapdumps
+#
+#      - uses: ./.github/actions/upload-flaky-tests
+#        name: Upload flaky tests
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        with:
+#          job-name: FIPS IT
 
       - name: Surefire reports
         if: always()
@@ -719,7 +719,7 @@ jobs:
       - store-model-tests
       - clustering-integration-tests
       - fips-unit-tests
-      - fips-integration-tests
+#      - fips-integration-tests
       - account-console-integration-tests
       - forms-integration-tests
       - webauthn-integration-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,46 +455,39 @@ jobs:
         with:
           job-id: fips-unit-tests
 
-#  fips-integration-tests:
-#    name: FIPS IT
-#    needs: build
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 45
-#    strategy:
-#      matrix:
-#        mode: [non-strict, strict]
-#      fail-fast: false
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Fake fips
-#        run: |
-#          cd .github/fake_fips
-#          make
-#          sudo insmod fake_fips.ko
-#
-#      - id: integration-test-setup
-#        name: Integration test setup
-#        uses: ./.github/actions/integration-test-setup
-#        with:
-#          jdk-version: 17
-#
-#      - name: Prepare Quarkus distribution with BCFIPS
-#        run: ./mvnw ${{ env.MAVEN_ARGS }} install -e -pl testsuite/integration-arquillian/servers/auth-server/quarkus -Pauth-server-quarkus,auth-server-fips140-2
-#
-#      - name: Run base tests
-#        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
-#
-#      - name: Upload JVM Heapdumps
-#        if: always()
-#        uses: ./.github/actions/upload-heapdumps
-#
-#      - uses: ./.github/actions/upload-flaky-tests
-#        name: Upload flaky tests
-#        env:
-#          GH_TOKEN: ${{ github.token }}
-#        with:
-#          job-name: FIPS IT
+  fips-integration-tests:
+    name: FIPS IT
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        mode: [non-strict, strict]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fake fips
+        run: |
+          cd .github/fake_fips
+          make
+          sudo insmod fake_fips.ko
+
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+        with:
+          jdk-version: 17
+
+      - name: Run base tests
+        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
+
+      - uses: ./.github/actions/upload-flaky-tests
+        name: Upload flaky tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          job-name: FIPS IT
 
       - name: Surefire reports
         if: always()
@@ -719,7 +712,7 @@ jobs:
       - store-model-tests
       - clustering-integration-tests
       - fips-unit-tests
-#      - fips-integration-tests
+      - fips-integration-tests
       - account-console-integration-tests
       - forms-integration-tests
       - webauthn-integration-tests


### PR DESCRIPTION
Backport for the issue in FIPS IT. Two PRs:

Closes #33875
Closes #33881

PR 1: https://github.com/keycloak/keycloak/pull/33876
PR 2: https://github.com/keycloak/keycloak/pull/33893

Commit 1: 272d59be889e56c1933ae1681c29a3362de10396
Commit 2: 10aca5552314d6e5c9226f3c6d0107861c38c693 

As in 24 here are issues with cache maven wraper and it's removed in upstream (https://github.com/keycloak/keycloak/commit/e2e47f14dd4e502243bb5433005a95280cbb29fb) so I have removed that part too. Besides the upload dumps fails for the same reason (root permissions). I have removed that part too. We can also do a `chown` in the script but I prefer to main this backports simple.