### PR TITLE
Fixed persisting translations for attribute groups and improved errors for empty translations on attribute/attribute groups save

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3281,3 +3281,4 @@ termsAndConditionsDeclined=You need to accept the Terms and Conditions to contin
 somethingWentWrong=Something went wrong
 somethingWentWrongDescription=Sorry, an unexpected error has occurred.
 tryAgain=Try again
+errorSavingTranslations=Error saving translations\: '{{error}}'

--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import type {
   UserProfileAttribute,
   UserProfileConfig,

--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-
 import type {
   UserProfileAttribute,
   UserProfileConfig,

--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type {
   UserProfileAttribute,
   UserProfileConfig,
@@ -31,7 +30,6 @@ import { AttributeAnnotations } from "./user-profile/attribute/AttributeAnnotati
 import { AttributeGeneralSettings } from "./user-profile/attribute/AttributeGeneralSettings";
 import { AttributePermission } from "./user-profile/attribute/AttributePermission";
 import { AttributeValidations } from "./user-profile/attribute/AttributeValidations";
-import { add } from "lodash-es";
 
 type TranslationForm = {
   locale: string;

--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
 import type {
   UserProfileAttribute,
   UserProfileConfig,
@@ -195,7 +197,6 @@ export default function NewAttributeSettings() {
               translations,
             )
               .filter(([key]) => key === formattedKey)
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
               .map(([_, value]) => ({
                 locale: selectedLocale,
                 value,
@@ -242,8 +243,6 @@ export default function NewAttributeSettings() {
         ),
       );
     },
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     () => {},
     [combinedLocales, realmName, form],
   );

--- a/js/apps/admin-ui/src/realm-settings/localization/RealmOverrides.tsx
+++ b/js/apps/admin-ui/src/realm-settings/localization/RealmOverrides.tsx
@@ -190,7 +190,7 @@ export const RealmOverrides = ({
   const options = [
     <SelectGroup label={t("defaultLocale")} key="group1">
       <SelectOption key={DEFAULT_LOCALE} value={DEFAULT_LOCALE}>
-        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.getDisplayName())}
+        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.getLocale())}
       </SelectOption>
     </SelectGroup>,
     <Divider key="divider" />,

--- a/js/apps/admin-ui/src/realm-settings/localization/RealmOverrides.tsx
+++ b/js/apps/admin-ui/src/realm-settings/localization/RealmOverrides.tsx
@@ -190,7 +190,7 @@ export const RealmOverrides = ({
   const options = [
     <SelectGroup label={t("defaultLocale")} key="group1">
       <SelectOption key={DEFAULT_LOCALE} value={DEFAULT_LOCALE}>
-        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.getLocale())}
+        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.getDisplayName())}
       </SelectOption>
     </SelectGroup>,
     <Divider key="divider" />,

--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
@@ -112,11 +112,11 @@ export default function AttributesGroupForm() {
   const [translationsData, setTranslationsData] = useState({
     displayHeader: {
       key: "",
-      translations: [] as { locale: string; value: string }[],
+      translations: [] as TranslationForm[],
     },
     displayDescription: {
       key: "",
-      translations: [] as { locale: string; value: string }[],
+      translations: [] as TranslationForm[],
     },
   });
 

--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
@@ -224,6 +224,7 @@ export default function AttributesGroupForm() {
 
       setTranslationsData(translationsDataNew);
     },
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     () => {},
     [combinedLocales, realmName, form],
@@ -252,7 +253,10 @@ export default function AttributesGroupForm() {
     };
 
     try {
-      if (translationsData.displayHeader?.translations.length > 0) {
+      if (
+        translationsData &&
+        translationsData.displayHeader.translations.length > 0
+      ) {
         for (const translation of translationsData.displayHeader.translations) {
           if (translation.locale && translation.value) {
             await addLocalization(
@@ -264,7 +268,10 @@ export default function AttributesGroupForm() {
         }
       }
 
-      if (translationsData.displayDescription?.translations.length > 0) {
+      if (
+        translationsData &&
+        translationsData.displayDescription.translations.length > 0
+      ) {
         for (const translation of translationsData.displayDescription
           .translations) {
           if (translation.locale && translation.value) {

--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import type { UserProfileGroup } from "@keycloak/keycloak-admin-client/lib/defs/userProfileMetadata";
 import {
   HelpItem,
@@ -224,8 +225,6 @@ export default function AttributesGroupForm() {
 
       setTranslationsData(translationsDataNew);
     },
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     () => {},
     [combinedLocales, realmName, form],
   );

--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AddTranslationsDialog.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AddTranslationsDialog.tsx
@@ -142,10 +142,13 @@ export const AddTranslationsDialog = ({
   useEffect(() => {
     combinedLocales.forEach((locale, rowIndex) => {
       setValue(`translations.${rowIndex}.locale`, locale);
+
+      const translationExists =
+        translations.translations[rowIndex] !== undefined;
       setValue(
         `translations.${rowIndex}.value`,
-        translations.translations.length > 0
-          ? translations.translations[rowIndex].value
+        translationExists
+          ? translations.translations[rowIndex]?.value
           : defaultTranslations[locale] || "",
       );
     });


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/33531

I have also found some use cases for improving the errors when saving attributes/attribute groups without translations or with empty translations and decided to address them in this PR as well.

Test cases
![Screenshot 2024-10-17 at 10 07 41](https://github.com/user-attachments/assets/96352aab-dc66-4348-99de-9e21dff28b1b)


