### PR TITLE
fix: corrections to kc.bat for -D and --debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Run Quarkus integration Tests
         run: |
           declare -A PARAMS
-          PARAMS["win"]="-Dtest=StartCommandDistTest,StartDevCommandDistTest,BuildAndStartDistTest,ImportAtStartupDistTest"
+          PARAMS["win"]="-Dtest=JavaOptsScriptTest,StartCommandDistTest,StartDevCommandDistTest,BuildAndStartDistTest,ImportAtStartupDistTest"
           PARAMS["zip"]=""
           PARAMS["container"]="-Dkc.quarkus.tests.dist=docker"
           PARAMS["storage"]="-Ptest-database -Dtest=PostgreSQLDistTest,MariaDBDistTest#testSuccessful,MySQLDistTest#testSuccessful,DatabaseOptionsDistTest,JPAStoreDistTest,HotRodStoreDistTest,MixedStoreDistTest,TransactionConfigurationDistTest,ExternalInfinispanTest"

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -34,14 +34,12 @@ if "%KEY%" == "" (
 )
 if "%KEY%" == "--debug" (
   set DEBUG_MODE=true
-  set DEBUG_PORT_VAR=%2
-  if "%DEBUG_PORT_VAR%" == "" (
+  if 1%2 EQU +1%2 (
+     set DEBUG_PORT_VAR=%2
+     shift
+  ) else (
      set DEBUG_PORT_VAR=8787
   )
-  if "%DEBUG_SUSPEND_VAR%" == "" (
-     set DEBUG_SUSPEND_VAR=n
-  )
-  shift
   shift
   goto READ-ARGS
 )
@@ -50,22 +48,35 @@ if "%KEY%" == "start-dev" (
   shift
   goto READ-ARGS
 )
-if not "%KEY:~0,2%"=="--" if "%KEY:~0,2%"=="-D" (
-  set SERVER_OPTS=%SERVER_OPTS% %KEY%=%2
-  shift
+set "VALUE=%~2"
+set PROBABLY_VALUE=false
+if "%VALUE%" NEQ "" (
+    if "%VALUE:~0,1%" NEQ "-" (
+        if "%KEY:^==%"=="%KEY%" (
+            set PROBABLY_VALUE=true
+        )
+    )
 )
-if not "%KEY:~0,2%"=="--" if not "%KEY:~0,1%"=="-" (
-  set CONFIG_ARGS=%CONFIG_ARGS% %1
-)
-if not "%KEY:~0,2%"=="-D" (
-  if "%KEY:~0,1%"=="-" (
-      if "%~2"=="" (
-        set CONFIG_ARGS=%CONFIG_ARGS% %1
-      ) else (
-        set CONFIG_ARGS=%CONFIG_ARGS% %1 %2
-      )
-      shift
+if "%KEY:~0,2%"=="-D" (
+  if %PROBABLY_VALUE%==true (
+    set SERVER_OPTS=%SERVER_OPTS% %KEY%^=%VALUE%
+    shift
+  ) else (
+    set SERVER_OPTS=%SERVER_OPTS% %KEY%
   )
+  shift
+  goto READ-ARGS
+)
+if not "%KEY:~0,1%"=="-" (
+  set CONFIG_ARGS=%CONFIG_ARGS% %1
+  shift
+  goto READ-ARGS
+)
+if %PROBABLY_VALUE%==true (
+  set CONFIG_ARGS=%CONFIG_ARGS% %1 %2
+  shift
+) else (
+  set CONFIG_ARGS=%CONFIG_ARGS% %1
 )
 shift
 goto READ-ARGS
@@ -92,10 +103,11 @@ if not "x%JAVA_OPTS%" == "x" (
       set "JAVA_OPTS_KC_HEAP=-Xms64m -Xmx512m"
     )
 
-    set "JAVA_OPTS=!JAVA_OPTS! !JAVA_OPTS_KC_HEAP!"
   ) else (
     echo "JAVA_OPTS_KC_HEAP already set in environment; overriding default settings"
   )
+  
+  set "JAVA_OPTS=!JAVA_OPTS! !JAVA_OPTS_KC_HEAP!"
 )
 
 @REM See also https://github.com/wildfly/wildfly-core/blob/7e5624cf92ebe4b64a4793a8c0b2a340c0d6d363/core-feature-pack/common/src/main/resources/content/bin/common.sh#L57-L60
@@ -180,8 +192,8 @@ if not errorlevel == 1 (
 )
 
 if "%PRINT_ENV%" == "true" (
-  echo "Using JAVA_OPTS: !JAVA_OPTS!"
-  echo "Using JAVA_RUN_OPTS: !JAVA_RUN_OPTS!"
+  echo Using JAVA_OPTS: !JAVA_OPTS!
+  echo Using JAVA_RUN_OPTS: !JAVA_RUN_OPTS!
 )
 
 set START_SERVER=true

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
@@ -20,6 +20,7 @@ package org.keycloak.it.cli.dist;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.junit5.extension.WithEnvVars;
@@ -75,7 +76,7 @@ public class JavaOptsScriptTest {
         assertThat(output, not(containsString("-Xms128m")));
 
         assertThat(output, containsString("JAVA_OPTS already set in environment; overriding default settings"));
-        assertThat(output, containsString("Using JAVA_OPTS: -Xmx256m"));
+        assertThat(output, containsString(" -Xmx256m"));
     }
 
     @Test
@@ -84,7 +85,8 @@ public class JavaOptsScriptTest {
     void testJavaOpts(LaunchResult result) {
         String output = result.getOutput();
         assertThat(output, containsString("JAVA_OPTS already set in environment; overriding default settings"));
-        assertThat(output, containsString("Using JAVA_OPTS: -Dfoo=bar"));
+        assertThat(output, containsString(String.format("Using JAVA_OPTS: %s-Dfoo=bar",
+                OS.WINDOWS.isCurrentOs() ? "-Dprogram.name=kc.bat " : "")));
     }
 
     @Test
@@ -93,7 +95,8 @@ public class JavaOptsScriptTest {
     void testJavaOptsAppend(LaunchResult result) {
         String output = result.getOutput();
         assertThat(output, containsString("Appending additional Java properties to JAVA_OPTS"));
-        assertThat(output, matchesPattern("(?s).*Using JAVA_OPTS: " + DEFAULT_OPTS + " -Dfoo=bar\\n.*"));
+        assertThat(output, matchesPattern(String.format("(?s).*Using JAVA_OPTS: %s%s -Dfoo=bar\\r?\\n.*",
+                OS.WINDOWS.isCurrentOs() ? "-Dprogram.name=kc.bat " : "", DEFAULT_OPTS)));
     }
 
     @Test
@@ -103,7 +106,8 @@ public class JavaOptsScriptTest {
         String output = result.getOutput();
         assertThat(output, containsString("JAVA_ADD_OPENS already set in environment; overriding default settings"));
         assertThat(output, not(containsString("--add-opens")));
-        assertThat(output, matchesPattern("(?s).*Using JAVA_OPTS: " + DEFAULT_OPTS + " -Dfoo=bar.*"));
+        assertThat(output, matchesPattern(String.format("(?s).*Using JAVA_OPTS: %s%s -Dfoo=bar.*", 
+                OS.WINDOWS.isCurrentOs() ? "-Dprogram.name=kc.bat " : "", DEFAULT_OPTS)));
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -53,11 +53,12 @@ public class StartDevCommandDistTest {
     }
 
     @Test
-    @Launch({ "start-dev", "--debug" })
+    @Launch({ "start-dev", "--debug", "--features=passkeys:v1" })
     void testStartDevShouldStartTwoJVMs(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertMessageWasShownExactlyNumberOfTimes("Listening for transport dt_socket at address:", 2);
         cliResult.assertStartedDevMode();
+        cliResult.assertMessage("passkeys");
     }
 
     @Test


### PR DESCRIPTION
closes: #33970

The -D handling is a bit dicey as we're always assuming -Dx=y, the usage of of a boolean -Dx will inadvertantly consume the next parameter. I don't see good escaping options for this. @Pepo48 should we document this and / or is there a way to escape / preserve the = character in those parameters?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
