### PR TITLE
Remove online session for offline access in direct access grants and client credentials

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/sessions_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/sessions_test.spec.ts
@@ -86,14 +86,6 @@ describe("Sessions test", () => {
 
       listingPage.searchItem(clientId, false);
       sidebarPage.waitForPageLoad();
-      // Log out the associated online session of the user
-      commonPage
-        .tableUtils()
-        .checkRowItemExists(username)
-        .selectRowItemAction(username, "Sign out");
-
-      listingPage.searchItem(clientId, false);
-      sidebarPage.waitForPageLoad();
 
       // Now check that offline session exists (online one has been logged off above)
       // and that it is possible to revoke it

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -145,6 +145,10 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
         // Make refresh token generation optional, see KEYCLOAK-9551
         if (useRefreshToken) {
             responseBuilder = responseBuilder.generateRefreshToken();
+            if (TokenUtil.TOKEN_TYPE_OFFLINE.equals(responseBuilder.getRefreshToken().getType())) {
+                // for client credentials the online session can be removed
+                session.sessions().removeUserSession(realm, userSession);
+            }
         } else {
             responseBuilder.getAccessToken().setSessionId(null);
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
@@ -138,6 +138,10 @@ public class ResourceOwnerPasswordCredentialsGrantType extends OAuth2GrantTypeBa
         boolean useRefreshToken = clientConfig.isUseRefreshToken();
         if (useRefreshToken) {
             responseBuilder.generateRefreshToken();
+            if (TokenUtil.TOKEN_TYPE_OFFLINE.equals(responseBuilder.getRefreshToken().getType())) {
+                // for direct access grants the online session can be removed
+                session.sessions().removeUserSession(realm, userSession);
+            }
         }
 
         String scopeParam = clientSessionCtx.getClientSession().getNote(OAuth2Constants.SCOPE);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -1181,8 +1181,8 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
         assertThat(apps.keySet(), containsInAnyOrder("offline-client", "offline-client-without-base-url", "always-display-client", "direct-grant"));
 
-        assertClientRep(apps.get("offline-client"), "Offline Client", null, false, true, true, null, offlineClientAppUri);
-        assertClientRep(apps.get("offline-client-without-base-url"), "Offline Client Without Base URL", null, false, true, true, null, null);
+        assertClientRep(apps.get("offline-client"), "Offline Client", null, false, false, true, null, offlineClientAppUri);
+        assertClientRep(apps.get("offline-client-without-base-url"), "Offline Client Without Base URL", null, false, false, true, null, null);
     }
 
     @Test
@@ -1709,9 +1709,9 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(applications.isEmpty());
 
         Map<String, ClientRepresentation> apps = applications.stream().collect(Collectors.toMap(x -> x.getClientId(), x -> x));
-        assertThat(apps.keySet(), containsInAnyOrder("offline-client", "always-display-client", "direct-grant"));
+        assertThat(apps.keySet(), containsInAnyOrder("always-display-client", "direct-grant"));
 
-        assertClientRep(apps.get("offline-client"), "Offline Client", null, false, true, false, null, offlineClientAppUri);
+        assertNull(apps.get("offline-client"));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
@@ -204,7 +204,7 @@ public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
         boolean directTested = false;
         for (Map<String, String> entry : list) {
             if (entry.get("clientId").equals("hardcoded-client")) {
-                Assert.assertEquals("4", entry.get("active"));
+                Assert.assertEquals("2", entry.get("active"));
                 Assert.assertEquals("2", entry.get("offline"));
                 hardTested = true;
             } else if (entry.get("clientId").equals("test-app")) {
@@ -212,7 +212,7 @@ public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
                 Assert.assertEquals("0", entry.get("offline"));
                 testAppTested = true;
             } else if (entry.get("clientId").equals("direct-grant")) {
-                Assert.assertEquals("3", entry.get("active"));
+                Assert.assertEquals("1", entry.get("active"));
                 Assert.assertEquals("2", entry.get("offline"));
                 directTested = true;
             }
@@ -225,13 +225,13 @@ public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
             ClientModel hardcoded = realm.getClientByClientId("hardcoded-client");
             long activeUserSessions = session.sessions().getActiveUserSessions(realm, hardcoded);
             long offlineSessionsCount = session.sessions().getOfflineSessionsCount(realm, hardcoded);
-            Assert.assertEquals(4, activeUserSessions);
+            Assert.assertEquals(2, activeUserSessions);
             Assert.assertEquals(2, offlineSessionsCount);
 
             ClientModel direct = realm.getClientByClientId("direct-grant");
             activeUserSessions = session.sessions().getActiveUserSessions(realm, direct);
             offlineSessionsCount = session.sessions().getOfflineSessionsCount(realm, direct);
-            Assert.assertEquals(3, activeUserSessions);
+            Assert.assertEquals(1, activeUserSessions);
             Assert.assertEquals(2, offlineSessionsCount);
         });
     }


### PR DESCRIPTION
Closes #34000 

The online session is removed for client credentials and direct access grants if the request if a offline access. The removal is done in theirs respective grant implementations if the refresh token is set to offline. The `OfflineTokenTest` is modified to check the online session is not there after the request. Some other tests need some tweaks because they were counting sessions and the online is not there now.