### PR TITLE
fix: removing erroneous warnings (#33977)

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -476,7 +476,7 @@ public class Picocli {
                         ignoredBuildTime.add(key);
                     }
                 }
-            } else if (!buildTimeOption) {
+            } else if (!options.includeRuntime && !buildTimeOption) {
                 ignoredRunTime.add(key);
             }
         }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -133,6 +133,7 @@ public class StartCommandDistTest {
     @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--metrics-enabled=true" })
     void testStartUsingAutoBuild(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
+        cliResult.assertNoMessage("ignored during build");
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
         cliResult.assertMessage("Updating the configuration and installing your custom providers, if any. Please wait.");
         cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");


### PR DESCRIPTION
closes: #33638

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit 795b90a8eb61b05d3539971130ee4b3696fe80f6)
