### PR TITLE
Honor baseUrl when generating client home url in admin-ui

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -1278,6 +1278,25 @@ describe("Clients test", () => {
     });
   });
 
+  describe("Generated home URLs for built-in clients", () => {
+    beforeEach(() => {
+      loginPage.logIn();
+      keycloakBefore();
+      commonPage.sidebar().goToRealm(realmName);
+      commonPage.sidebar().goToClients();
+    });
+
+    it("Check account-console Home URL", () => {
+      cy.findByTestId("client-home-url-account-console").contains("/account/");
+    });
+
+    it("Check security-admin-console Home URL", () => {
+      cy.findByTestId("client-home-url-security-admin-console").contains(
+        "/console/",
+      );
+    });
+  });
+
   describe("Accessibility tests for clients", () => {
     const clientId = "a11y-client";
 

--- a/js/apps/admin-ui/src/clients/ClientsSection.tsx
+++ b/js/apps/admin-ui/src/clients/ClientsSection.tsx
@@ -92,7 +92,12 @@ const ClientHomeLink = (client: ClientRepresentation) => {
     return "—";
   }
 
-  return <FormattedLink href={href} />;
+  return (
+    <FormattedLink
+      href={href}
+      data-testid={`client-home-url-${client.clientId}`}
+    />
+  );
 };
 
 const ToolbarItems = () => {

--- a/js/apps/admin-ui/src/utils/client-url.test.ts
+++ b/js/apps/admin-ui/src/utils/client-url.test.ts
@@ -17,17 +17,17 @@ describe("convertClientToUrl", () => {
   it("when root url constrains ${authAdminUrl}", () => {
     //given
     const rootUrl = "${authAdminUrl}";
-    const adminUrl = "/else";
+    const baseUrl = "/else";
 
     //when
     const result = convertClientToUrl(
-      { rootUrl, adminUrl },
+      { rootUrl, baseUrl },
       //@ts-ignore
       { adminBaseUrl: "/admin" },
     );
 
     //then
-    expect(result).toBe("/admin");
+    expect(result).toBe("/admin/else");
   });
 
   it("when root url constrains ${authBaseUrl}", () => {

--- a/js/apps/admin-ui/src/utils/client-url.ts
+++ b/js/apps/admin-ui/src/utils/client-url.ts
@@ -12,7 +12,10 @@ export const convertClientToUrl = (
   }
 
   if (rootUrl === "${authAdminUrl}") {
-    return rootUrl.replace(/\$\{(authAdminUrl)\}/, environment.adminBaseUrl);
+    return joinPath(
+      rootUrl.replace(/\$\{(authAdminUrl)\}/, environment.adminBaseUrl),
+      baseUrl || "",
+    );
   }
 
   if (rootUrl === "${authBaseUrl}") {


### PR DESCRIPTION
Previously, the baseUrl was not considered when ${authAdminUrl} was used in the URLs, e.g. for security-admin-console client.

Fixes #34015

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
