### PR TITLE
[PERF] OpenTelemetry is initialized even when disabled

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -340,7 +340,7 @@ To use structured JSON log output instead, enter the following command:
 .Example Log Message
 [source, bash]
 ----
-2024-04-05T12:32:20.616+02:00 mabartos keycloak 2788276 io.quarkus - {"timestamp":"2024-04-05T12:32:20.616208533+02:00","sequence":9948,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus","level":"INFO","message":"Profile prod activated. ","threadName":"main","threadId":1,"mdc":{},"ndc":"","hostName":"host","processName":"QuarkusEntryPoint","processId":2788276}
+2024-04-05T12:32:20.616+02:00 host keycloak 2788276 io.quarkus - {"timestamp":"2024-04-05T12:32:20.616208533+02:00","sequence":9948,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus","level":"INFO","message":"Profile prod activated. ","threadName":"main","threadId":1,"mdc":{},"ndc":"","hostName":"host","processName":"QuarkusEntryPoint","processId":2788276}
 ----
 
 When using JSON output, colors are disabled and the format settings set by `--log-syslog-format` will not apply.
@@ -352,7 +352,7 @@ To use unstructured logging, enter the following command:
 .Example Log Message
 [source, bash]
 ----
-2024-04-05T12:31:38.473+02:00 mabartos keycloak 2787568 io.quarkus - 2024-04-05 12:31:38,473 INFO  [io.quarkus] (main) Profile prod activated.
+2024-04-05T12:31:38.473+02:00 host keycloak 2787568 io.quarkus - 2024-04-05 12:31:38,473 INFO  [io.quarkus] (main) Profile prod activated.
 ----
 
 As you can see, the timestamp is present twice, so you can amend it correspondingly via the `--log-syslog-format` property.

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
@@ -49,7 +49,7 @@ public class TracingPropertyMappers {
         return new PropertyMapper[]{
                 fromOption(TRACING_ENABLED)
                         .isEnabled(TracingPropertyMappers::isFeatureEnabled, OTEL_FEATURE_ENABLED_MSG)
-                        .to("quarkus.otel.traces.enabled")
+                        .to("quarkus.otel.enabled") // enable/disable whole OTel, tracing is enabled by default
                         .build(),
                 fromOption(TRACING_ENDPOINT)
                         .isEnabled(TracingPropertyMappers::isTracingEnabled, TRACING_ENABLED_MSG)

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/TracingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/TracingConfigurationTest.java
@@ -46,7 +46,7 @@ public class TracingConfigurationTest extends AbstractConfigurationTest {
         assertConfig("tracing-service-name", "keycloak");
 
         assertExternalConfig(Map.of(
-                "quarkus.otel.traces.enabled", "false",
+                "quarkus.otel.enabled", "false",
                 "quarkus.otel.service.name", "keycloak",
                 "quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost:4317",
                 "quarkus.otel.exporter.otlp.traces.protocol", "grpc",
@@ -96,7 +96,7 @@ public class TracingConfigurationTest extends AbstractConfigurationTest {
         ));
 
         assertExternalConfig(Map.of(
-                "quarkus.otel.traces.enabled", "true",
+                "quarkus.otel.enabled", "true",
                 "quarkus.otel.exporter.otlp.traces.endpoint", "http://something:4444",
                 "quarkus.otel.exporter.otlp.traces.protocol", "http/protobuf",
                 "quarkus.datasource.jdbc.telemetry", "false",
@@ -194,7 +194,7 @@ public class TracingConfigurationTest extends AbstractConfigurationTest {
         ));
 
         assertExternalConfig(Map.of(
-                "quarkus.otel.traces.enabled", "true",
+                "quarkus.otel.enabled", "true",
                 "quarkus.log." + loggerType.name() + ".format", expectedFormat
         ));
 
@@ -210,7 +210,7 @@ public class TracingConfigurationTest extends AbstractConfigurationTest {
         ));
 
         assertExternalConfig(Map.of(
-                "quarkus.otel.traces.enabled", "true",
+                "quarkus.otel.enabled", "true",
                 "quarkus.log." + loggerType.name() + ".format", "someFormat"
         ));
     }


### PR DESCRIPTION
Change host reference in logging guide

- Fixes #33948

No executions in `OpenTelemetryProcessor` anymore.