### PR TITLE
Implement pagination for getLDAPRoleMappings

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -42,6 +42,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.reflection.Property;
 import org.keycloak.models.utils.reflection.PropertyCriteria;
 import org.keycloak.models.utils.reflection.PropertyQueries;
+import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.Condition;
@@ -288,6 +289,18 @@ public class LDAPUtils {
      */
     public static List<LDAPObject> loadAllLDAPObjects(LDAPQuery ldapQuery, LDAPStorageProvider ldapProvider) {
         LDAPConfig ldapConfig = ldapProvider.getLdapIdentityStore().getConfig();
+        return loadAllLDAPObjects(ldapQuery, ldapConfig);
+    }
+
+    /**
+     * Load all LDAP objects corresponding to given query. We will load them paginated, so we allow to bypass the limitation of 1000
+     * maximum loaded objects in single query in MSAD
+     *
+     * @param ldapQuery LDAP query to be used. The caller should close it after calling this method
+     * @param ldapConfig
+     * @return
+     */
+    public static List<LDAPObject> loadAllLDAPObjects(LDAPQuery ldapQuery, LDAPConfig ldapConfig) {
         boolean pagination = ldapConfig.isPagination();
         if (pagination) {
             // For now reuse globally configured batch size in LDAP provider page

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/UserRolesRetrieveStrategy.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/UserRolesRetrieveStrategy.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.storage.ldap.mappers.membership;
 
-import org.jboss.logging.Logger;
+
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.LDAPUtils;
@@ -52,11 +52,8 @@ public interface UserRolesRetrieveStrategy {
      */
     class LoadRolesByMember implements UserRolesRetrieveStrategy {
 
-        private static final Logger log = Logger.getLogger(LDAPUtils.class);
-
         @Override
         public List<LDAPObject> getLDAPRoleMappings(CommonLDAPGroupMapper roleOrGroupMapper, LDAPObject ldapUser, LDAPConfig ldapConfig) {
-
             try (LDAPQuery ldapQuery = roleOrGroupMapper.createLDAPGroupQuery()) {
                 String membershipAttr = roleOrGroupMapper.getConfig().getMembershipLdapAttribute();
 
@@ -66,26 +63,7 @@ public interface UserRolesRetrieveStrategy {
                 Condition membershipCondition = getMembershipCondition(membershipAttr, userMembership);
                 ldapQuery.addWhereCondition(membershipCondition);
 
-                boolean pagination = ldapConfig.isPagination();
-                if (pagination) {
-                    // For now reuse globally configured batch size in LDAP provider page
-                    int pageSize = ldapConfig.getBatchSizeForSync();
-
-                    List<LDAPObject> result = new LinkedList<>();
-                    boolean nextPage = true;
-
-                    while (nextPage) {
-                        ldapQuery.setLimit(pageSize);
-                        final List<LDAPObject> currentPageGroups = ldapQuery.getResultList();
-                        result.addAll(currentPageGroups);
-                        nextPage = ldapQuery.getPaginationContext().hasNextPage();
-                    }
-
-                    return result;
-                } else {
-                    // LDAP pagination not available. Do everything in single transaction
-                    return ldapQuery.getResultList();
-                }
+                return LDAPUtils.loadAllLDAPObjects(ldapQuery, ldapConfig);
             }
         }
 


### PR DESCRIPTION
Closes #34042

On Active Directory, allow to retrieve more groups than the MaxPageSize (default to 1000). Without this patch, we need to increase the MaxPageSize which does not really scale. Implemented only for the LoadRolesByMember startegy.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
