### PR TITLE
Automatically retrieve configuration for authorization

### DIFF
--- a/docs/documentation/authorization_services/topics/enforcer-js-adapter.adoc
+++ b/docs/documentation/authorization_services/topics/enforcer-js-adapter.adoc
@@ -25,6 +25,10 @@ const keycloak = new Keycloak({
 });
 
 const authorization = new KeycloakAuthorization(keycloak);
+
+await keycloak.init();
+
+// Now you can use the authorization object to interact with the server.
 ----
 
 The `keycloak-js/authz` library provides two main features:

--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -9,3 +9,12 @@ Starting from this release, when `--cache-config-file` is not set, the default I
 The embedded `work` cache needs to be configured as a `replicated-cache` for cache invalidation to work as expected.
 
 Starting from this release, {project_name} check this at startup and will fail to start if it is not configured as such.
+
+= Deprecated APIs for JavaScript Authorization client
+
+The following APIs for the JavaScript Authorization client are deprecated and will be removed in the next major release:
+
+- The `ready` property on the `KeycloakAuthorization` instance.
+- The `init()` method on the `KeycloakAuthorization` instance.
+
+These APIs are no longer needed as initialization is done automatically on demand when calling methods on the `KeycloakAuthorization` instance. You can safely remove any code that depends on these APIs.

--- a/js/libs/keycloak-js/lib/keycloak-authz.d.ts
+++ b/js/libs/keycloak-js/lib/keycloak-authz.d.ts
@@ -102,7 +102,17 @@ declare class KeycloakAuthorization {
 	rpt: any;
 	config: { rpt_endpoint: string };
 
+	/**
+	 * Initializes the `KeycloakAuthorization` instance.
+	 * @deprecated Initialization now happens automatically, calling this method is no longer required.
+	 */
 	init(): void;
+
+	/**
+	 * A promise that resolves when the `KeycloakAuthorization` instance is initialized.
+	 * @deprecated Initialization now happens automatically, using this property is no longer required.
+	 */
+	ready: Promise<void>;
 
 	/**
 	 * This method enables client applications to better integrate with resource servers protected by a Keycloak


### PR DESCRIPTION
Modifies the JavaScript authorization client so that it retrieves its configuration lazily. Previously this would happen when a `KeycloakAuthorization` was constructed, which triggered asynchronous side-effects that could create race conditions when calling methods on the instance.

This change also means that the `ready` property and `.init()` method (which was called at time of construction) are no longer relevant. These APIs are now essentially a "no-op" and have been deprecated and slated for removal in the next major.


Closes #14562

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
