### PR TITLE
Check alias is unique for authenticator config when it is created

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -461,6 +461,10 @@ public class AuthenticationManagementResource {
 
                     if (config.getAlias() != null) {
                         config.setAlias(newName + " " + config.getAlias());
+                        if (configManager.getAuthenticatorConfigByAlias(realm, config.getAlias()) != null) {
+                            logger.warnf("Authentication execution configuration [%s] already exists", config.getAlias());
+                            throw new IllegalStateException("Authentication execution configuration " + config.getAlias() + " already exists.");
+                        }
                     }
 
                     AuthenticatorConfigModel newConfig = realm.addAuthenticatorConfig(config);
@@ -1025,24 +1029,41 @@ public class AuthenticationManagementResource {
     public Response newExecutionConfig(@Parameter(description = "Execution id") @PathParam("executionId") String execution, @Parameter(description = "JSON with new configuration") AuthenticatorConfigRepresentation json) {
         auth.realm().requireManageRealm();
 
+        if (json.getAlias() == null || json.getAlias().isEmpty()) {
+            throw ErrorResponse.exists("Failed to create authentication execution configuration with empty alias name");
+        }
+
         ReservedCharValidator.validate(json.getAlias());
 
         AuthenticationExecutionModel model = realm.getAuthenticationExecutionById(execution);
         if (model == null) {
             session.getTransactionManager().setRollbackOnly();
             throw new NotFoundException("Illegal execution");
+        }
 
+        // retrieve the previous configuration if assigned
+        AuthenticatorConfigModel prevConfig = null;
+        if (model.getAuthenticatorConfig() != null) {
+            prevConfig = realm.getAuthenticatorConfigById(model.getAuthenticatorConfig());
         }
+
+        AuthenticatorConfigModel otherConfig = realm.getAuthenticatorConfigByAlias(json.getAlias());
+        if (otherConfig != null && (prevConfig == null || !prevConfig.getId().equals(otherConfig.getId()))) {
+            throw ErrorResponse.exists("Authentication execution configuration " + json.getAlias() + " already exists");
+        }
+
+        // remove the previous config
+        if (prevConfig != null) {
+            realm.removeAuthenticatorConfig(prevConfig);
+        }
+
         AuthenticatorConfigModel config = RepresentationToModel.toModel(json);
-        if (config.getAlias() == null) {
-            throw ErrorResponse.error("Alias missing", Response.Status.BAD_REQUEST);
-        }
         config = realm.addAuthenticatorConfig(config);
         model.setAuthenticatorConfig(config.getId());
         realm.updateAuthenticatorExecution(model);
 
         json.setId(config.getId());
-        adminEvent.operation(OperationType.CREATE).resource(ResourceType.AUTH_EXECUTION).resourcePath(session.getContext().getUri()).representation(json).success();
+        adminEvent.operation(OperationType.CREATE).resource(ResourceType.AUTHENTICATOR_CONFIG).resourcePath(session.getContext().getUri()).representation(json).success();
         return Response.created(session.getContext().getUri().getAbsolutePathBuilder().path(config.getId()).build()).build();
     }
 
@@ -1528,6 +1549,14 @@ public class AuthenticationManagementResource {
     @Deprecated
     public Response createAuthenticatorConfig(@Parameter(description = "JSON describing new authenticator configuration") AuthenticatorConfigRepresentation rep) {
         auth.realm().requireManageRealm();
+
+        if (rep.getAlias() == null || rep.getAlias().isEmpty()) {
+            throw ErrorResponse.exists("Failed to create authentication execution configuration with empty alias name");
+        }
+
+        if (realm.getAuthenticatorConfigByAlias(rep.getAlias()) != null) {
+            throw ErrorResponse.exists("Authentication execution configuration " + rep.getAlias() + " already exists");
+        }
 
         ReservedCharValidator.validate(rep.getAlias());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -736,7 +736,7 @@ public class FlowTest extends AbstractAuthenticationTest {
 
         try (Response response = authMgmtResource.newExecutionConfig(executionWithConfig.getId(), executionConfig)) {
             getCleanup().addAuthenticationConfigId(ApiUtil.getCreatedId(response));
-            assertAdminEvents.assertEvent(testRealmId, OperationType.CREATE, AdminEventPaths.authAddExecutionConfigPath(executionWithConfig.getId()), executionConfig, ResourceType.AUTH_EXECUTION);
+            assertAdminEvents.assertEvent(testRealmId, OperationType.CREATE, AdminEventPaths.authAddExecutionConfigPath(executionWithConfig.getId()), executionConfig, ResourceType.AUTHENTICATOR_CONFIG);
         }
 
         String newFlowName = "Duplicated of " + DefaultAuthenticationFlows.BROWSER_FLOW;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthenticationMethodReferenceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthenticationMethodReferenceTest.java
@@ -395,7 +395,7 @@ public class AuthenticationMethodReferenceTest extends AbstractOIDCScopeTest{
         if (execution.getAuthenticationConfig() == null){
             // create config if it doesn't exist
             AuthenticatorConfigRepresentation config = new AuthenticatorConfigRepresentation();
-            config.setAlias("test");
+            config.setAlias(KeycloakModelUtils.generateId());
             config.setConfig(new HashMap<>(){{
                 put(AMR_VALUE_KEY, amrValue);
                 put(AMR_MAX_AGE_KEY, maxAge.toString());


### PR DESCRIPTION
Closes #31727

Checking for uniqueness of the alias in the authentication executor configuration. The PR does the same that we are already doing now for the flow alias. As the issue comments the export is using the alias so exports with duplicated aliases in the config cannot ensure what config assigns to the execution at import time.

As I commented in the issue, there is another option which is changing the export to use the ID (instead of the current alias, and using the alias as fallback to load previous export files). I'm not sure what solution is better, this one is better in terms of usability but the other is better in terms of compatibility (there can be automated scripts or procedures that can fail because they create duplicated alias for configs). If you prefer the other solution just let me know.

I'm also not changing the DB because upgrading would be a mess in current installations with duplicates (besides the flow alias has no unique constraint either). So it's just ensured at creation time with the possible race issues. We can add the constraint later when this code has been running for a long  time.
