### PR TITLE
[Backport] Do not show domain match message in the identity-first login when no login hint is provided

### DIFF
--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -111,7 +111,7 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         }
 
         if (user == null) {
-            unknownUserChallenge(context, organization, realm);
+            unknownUserChallenge(context, organization, realm, domain != null);
             return;
         }
 
@@ -241,7 +241,7 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         return user;
     }
 
-    private void unknownUserChallenge(AuthenticationFlowContext context, OrganizationModel organization, RealmModel realm) {
+    private void unknownUserChallenge(AuthenticationFlowContext context, OrganizationModel organization, RealmModel realm, boolean domainMatch) {
         // the user does not exist and is authenticating in the scope of the organization, show the identity-first login page and the
         // public organization brokers for selection
         LoginFormsProvider form = context.form()
@@ -267,7 +267,10 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
                     return attributes;
                 });
 
-        form.addError(new FormMessage("Your email domain matches the " + organization.getName() + " organization but you don't have an account yet."));
+        if (domainMatch) {
+            form.addError(new FormMessage("Your email domain matches the " + organization.getName() + " organization but you don't have an account yet."));
+        }
+
         context.challenge(form.createLoginUsername());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -141,6 +141,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         org.keycloak.testsuite.Assert.assertFalse(loginPage.isPasswordInputPresent());
         org.keycloak.testsuite.Assert.assertTrue(loginPage.isSocialButtonPresent(orgA.getAlias() + "-identity-provider"));
         org.keycloak.testsuite.Assert.assertFalse(loginPage.isSocialButtonPresent(orgB.getAlias() + "-identity-provider"));
+        assertFalse(driver.getPageSource().contains("Your email domain matches"));
 
         // identity-first login will respect the organization provided in the scope even though the user email maps to a different organization
         oauth.clientId("broker-app");


### PR DESCRIPTION
Closes #34069

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
