### PR TITLE
[Backport] Fixing action token lifespan information in the invitation email

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -111,7 +111,7 @@ public class OrganizationInvitationResource {
             session.getProvider(EmailTemplateProvider.class)
                     .setRealm(realm)
                     .setUser(user)
-                    .sendOrgInviteEmail(organization, link, TimeUnit.SECONDS.toMinutes(tokenExpiration));
+                    .sendOrgInviteEmail(organization, link, TimeUnit.SECONDS.toMinutes(getActionTokenLifespan()));
         } catch (EmailException e) {
             ServicesLogger.LOGGER.failedToSendEmail(e);
             throw ErrorResponse.error("Failed to send invite email", Status.INTERNAL_SERVER_ERROR);
@@ -123,7 +123,11 @@ public class OrganizationInvitationResource {
     }
 
     private int getTokenExpiration() {
-        return Time.currentTime() + realm.getActionTokenGeneratedByAdminLifespan();
+        return Time.currentTime() + getActionTokenLifespan();
+    }
+
+    private int getActionTokenLifespan() {
+        return realm.getActionTokenGeneratedByAdminLifespan();
     }
 
     private String createInvitationLink(UserModel user) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -196,7 +196,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
 
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         try (
-                RealmAttributeUpdater rau = new RealmAttributeUpdater(testRealm()).setRegistrationAllowed(Boolean.TRUE).update(); 
+                RealmAttributeUpdater rau = new RealmAttributeUpdater(testRealm()).setRegistrationAllowed(Boolean.TRUE).update();
                 Response response = organization.members().inviteUser(email, null, null)
             ) {
             assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
@@ -256,6 +256,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         assertThat(text, Matchers.containsString(("You were invited to join the " + organizationName + " organization. Click the link below to join. </p>")));
         assertThat(text, Matchers.containsString(("<a href=\"" + link + "\" rel=\"nofollow\">Link to join the organization</a></p>")));
         assertThat(text, Matchers.containsString(("Link to join the organization")));
+        assertThat(text, Matchers.containsString(("This link will expire within 12 hours")));
         assertThat(text, Matchers.containsString(("<p>If you dont want to join the organization, just ignore this message.</p>")));
 
         String orgToken = UriUtils.parseQueryParameters(link, false).values().stream().map(strings -> strings.get(0)).findFirst().orElse(null);


### PR DESCRIPTION
Closes #34049

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
