### PR TITLE
Add ProviderConfigProperty types for numeric values (#29511)

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/IntComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/IntComponent.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from "react-i18next";
+import { TextControl } from "@keycloak/keycloak-ui-shared";
+
+import { convertToName } from "./DynamicComponents";
+import { NumberComponentProps } from "./components";
+
+export const IntComponent = ({
+  name,
+  label,
+  helpText,
+  ...props
+}: NumberComponentProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <TextControl
+      name={convertToName(name!)}
+      type="number"
+      pattern="\d*"
+      label={t(label!)}
+      labelIcon={t(helpText!)}
+      data-testid={name}
+      {...props}
+    />
+  );
+};

--- a/js/apps/admin-ui/src/components/dynamic/NumberComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/NumberComponent.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from "react-i18next";
+import { TextControl } from "@keycloak/keycloak-ui-shared";
+
+import { convertToName } from "./DynamicComponents";
+import { NumberComponentProps } from "./components";
+
+export const NumberComponent = ({
+  name,
+  label,
+  helpText,
+  ...props
+}: NumberComponentProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <TextControl
+      name={convertToName(name!)}
+      type="number"
+      label={t(label!)}
+      labelIcon={t(helpText!)}
+      data-testid={name}
+      {...props}
+    />
+  );
+};

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -33,7 +33,7 @@ export type NumberComponentProps = ComponentProps & {
 type ComponentType =
   | "String"
   | "Text"
-  | "int"
+  | "Integer"
   | "Number"
   | "boolean"
   | "List"
@@ -55,7 +55,7 @@ export const COMPONENTS: {
   String: StringComponent,
   Text: TextComponent,
   boolean: BooleanComponent,
-  int: IntComponent,
+  Integer: IntComponent,
   Number: NumberComponent,
   List: ListComponent,
   Role: RoleComponent,

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -16,6 +16,8 @@ import { StringComponent } from "./StringComponent";
 import { TextComponent } from "./TextComponent";
 import { UrlComponent } from "./UrlComponent";
 import { UserProfileAttributeListComponent } from "./UserProfileAttributeListComponent";
+import { IntComponent } from "./IntComponent";
+import { NumberComponent } from "./NumberComponent";
 
 export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
   isDisabled?: boolean;
@@ -23,9 +25,16 @@ export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
   stringify?: boolean;
 };
 
+export type NumberComponentProps = ComponentProps & {
+  min?: number;
+  max?: number;
+};
+
 type ComponentType =
   | "String"
   | "Text"
+  | "int"
+  | "Number"
   | "boolean"
   | "List"
   | "Role"
@@ -46,6 +55,8 @@ export const COMPONENTS: {
   String: StringComponent,
   Text: TextComponent,
   boolean: BooleanComponent,
+  int: IntComponent,
+  Number: NumberComponent,
   List: ListComponent,
   Role: RoleComponent,
   Script: ScriptComponent,

--- a/js/libs/keycloak-admin-client/src/defs/authenticatorConfigInfoRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/authenticatorConfigInfoRepresentation.ts
@@ -17,4 +17,5 @@ export interface ConfigPropertyRepresentation {
   options?: string[];
   secret?: boolean;
   required?: boolean;
+  placeholder?: string;
 }

--- a/js/libs/ui-shared/src/controls/TextControl.tsx
+++ b/js/libs/ui-shared/src/controls/TextControl.tsx
@@ -27,6 +27,7 @@ export type TextControlProps<
     isDisabled?: boolean;
     helperText?: string;
     "data-testid"?: string;
+    type?: string;
   };
 
 export const TextControl = <

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -28,6 +28,17 @@ import java.util.List;
  */
 public class ProviderConfigProperty {
     public static final String BOOLEAN_TYPE="boolean";
+
+    /**
+     * Integral Value
+     */
+    public static final String INT_TYPE="int";
+
+    /**
+     * Arbitrary number, e.g. integral, floating-point.
+     */
+    public static final String NUMBER_TYPE="Number";
+
     public static final String STRING_TYPE="String";
 
     /**

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -32,7 +32,7 @@ public class ProviderConfigProperty {
     /**
      * Integral Value
      */
-    public static final String INT_TYPE="int";
+    public static final String INTEGER_TYPE="Integer";
 
     /**
      * Arbitrary number, e.g. integral, floating-point.


### PR DESCRIPTION
This adds int and Number (integral and floating-point numbers) types to the supported types in ProviderConfigProperty.

Also introduced NumberComponentProps to allow setting min, max values in custom pages.

Fixes #29511

Supersedes #29512
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
