### PR TITLE
enable autocomplete for Username Form

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -17,7 +17,7 @@
                                        aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
                                        class="${properties.kcInputClass!}" name="username"
                                        value="${(login.username!'')}"
-                                       type="text" autofocus autocomplete="off"
+                                       type="text" autofocus autocomplete="username"
                                        dir="ltr"/>
 
                                 <#if messagesPerField.existsError('username')>


### PR DESCRIPTION
Enable autocomplete for Username Form

This allows browsers and password managers to suggest a username.

Closes https://github.com/keycloak/keycloak/issues/34091