### PR TITLE
Only use cookie detection iframe for non-OIDC configurations

### DIFF
--- a/js/libs/keycloak-js/lib/keycloak.js
+++ b/js/libs/keycloak-js/lib/keycloak.js
@@ -1241,7 +1241,7 @@ function Keycloak (config) {
     function check3pCookiesSupported() {
         var promise = createPromise();
 
-        if (loginIframe.enable || kc.silentCheckSsoRedirectUri) {
+        if ((loginIframe.enable || kc.silentCheckSsoRedirectUri) && typeof kc.endpoints.thirdPartyCookiesIframe === 'function') {
             var iframe = document.createElement('iframe');
             iframe.setAttribute('src', kc.endpoints.thirdPartyCookiesIframe());
             iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin');


### PR DESCRIPTION
Disables third-party cookie detection for configurations passed to Keycloak JS that use generic OpenID Connect.

Closes #20287

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
