### PR TITLE
Support RAR for client credentials grant type via protocol mapper

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -80,6 +80,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
     public static final String LOGIN_PROTOCOL = "openid-connect";
     public static final String STATE_PARAM = "state";
     public static final String SCOPE_PARAM = "scope";
+    public static final String AUTHORIZATION_DETAILS_PARAM = "authorization_details";
     public static final String CODE_PARAM = "code";
     public static final String RESPONSE_TYPE_PARAM = "response_type";
     public static final String GRANT_TYPE_PARAM = "grant_type";

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -106,6 +106,7 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
         authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
         authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scope);
+        setAuthorizationDetailsNoteIfIncluded(authSession);
 
         // persisting of userSession by default
         UserSessionModel.SessionPersistenceState sessionPersistenceState = UserSessionModel.SessionPersistenceState.PERSISTENT;
@@ -192,4 +193,14 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
         return EventType.CLIENT_LOGIN;
     }
 
+    /**
+     * Setting a client note with authorization_details to support custom protocol mappers using RAR (Rich Authorization Request)
+     * until RAR is fully implemented.
+     */
+    private void setAuthorizationDetailsNoteIfIncluded(AuthenticationSessionModel authSession) {
+        String authorizationDetails = formParams.getFirst(OIDCLoginProtocol.AUTHORIZATION_DETAILS_PARAM);
+        if (authorizationDetails != null) {
+            authSession.setClientNote(OIDCLoginProtocol.AUTHORIZATION_DETAILS_PARAM, authorizationDetails);
+        }
+    }
 }


### PR DESCRIPTION
Support RAR (Rich Authorization Request) for ClientCredentialsGrantType via protocol mapper until RAR is fully implemented.

Set authorization_details in a client note in ClientCredentialsGrantType so it can be accessed from a protocol mapper.

Closes #32488