### PR TITLE
Hide the 'Delete' button in the account console when DeleteCredential…

### DIFF
--- a/js/apps/account-ui/src/account-security/SigningIn.tsx
+++ b/js/apps/account-ui/src/account-security/SigningIn.tsx
@@ -207,7 +207,7 @@ export const SigningIn = () => {
                               aria-label={t("updateCredAriaLabel")}
                               aria-labelledby={`cred-${meta.credential.id}`}
                             >
-                              {container.removeable ? (
+                              {container.removeable && (
                                 <Button
                                   variant="danger"
                                   data-testrole="remove"
@@ -221,12 +221,12 @@ export const SigningIn = () => {
                                 >
                                   {t("delete")}
                                 </Button>
-                              ) : (
+                              )}
+                              {container.updateAction && (
                                 <Button
                                   variant="secondary"
                                   onClick={() => {
-                                    if (container.updateAction)
-                                      login({ action: container.updateAction });
+                                    login({ action: container.updateAction });
                                   }}
                                   data-testrole="update"
                                 >

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialTypeMetadata.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialTypeMetadata.java
@@ -244,6 +244,9 @@ public class CredentialTypeMetadata implements Comparable<CredentialTypeMetadata
             if (instance.createAction != null && instance.updateAction != null) {
                 throw new IllegalStateException("Both createAction and updateAction are not null when building CredentialTypeMetadata for the credential type '" + instance.type);
             }
+            if (!verifyRequiredAction(session, "delete_credential")) {
+                instance.removeable = false;
+            }
 
             return instance;
         }


### PR DESCRIPTION
…Action is disabled or unavailable

closes #30204

 - Make sure that `removeable` returned in `CredentialTypeMetadata` is false when the `Delete Credential` required action is disabled or unavailable

- Hide the `delete` button in the account UI (The old behaviour was, that when the action `removeable=false` was set, the `Delete` button was not shown, which was OK. However in that case, the `Update` button was always shown. This did not makes sense as some action may be not-removeable and not-updateable at the same time).
