### PR TITLE
JS password validation doesn't work as intended with uppercase and lowercase minimum requirements

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
@@ -11,7 +11,7 @@ const policies = {
   },
   upperCase: (policy, value) => {
     if (
-      value.split("").filter((char) => char !== char.toUpperCase()).length >
+      value.split("").filter((char) => char === char.toUpperCase() && char !== char.toLowerCase()).length <
       policy.value
     ) {
       return templateError(policy);
@@ -19,7 +19,7 @@ const policies = {
   },
   lowerCase: (policy, value) => {
     if (
-      value.split("").filter((char) => char !== char.toLowerCase()).length >
+      value.split("").filter((char) => char === char.toLowerCase() && char !== char.toUpperCase()).length <
       policy.value
     ) {
       return templateError(policy);


### PR DESCRIPTION
Closes #34151

Signed-off-by: SebastEnn <103125747+SebastEnn@users.noreply.github.com>