### PR TITLE
Change order of absolute path and normalize in the theme folder

### DIFF
--- a/services/src/main/java/org/keycloak/theme/ResourceLoader.java
+++ b/services/src/main/java/org/keycloak/theme/ResourceLoader.java
@@ -36,7 +36,7 @@ public class ResourceLoader {
         if (root == null || resource == null) {
             return null;
         }
-        Path rootPath = root.toPath().normalize().toAbsolutePath();
+        Path rootPath = root.toPath().toAbsolutePath().normalize();
         Path resourcePath = rootPath.resolve(resource).normalize().toAbsolutePath();
         if (resourcePath.startsWith(rootPath)) {
             return resourcePath.toFile();

--- a/services/src/test/java/org/keycloak/theme/ResourceLoaderTest.java
+++ b/services/src/test/java/org/keycloak/theme/ResourceLoaderTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class ResourceLoaderTest {
 
@@ -48,6 +49,10 @@ public class ResourceLoaderTest {
         assertFileAsStream(parent, DOUBLE + "myresource.css", false, false);
 
         assertFileAsStream(new File(tempDirectory.toFile(), "test/../resources/"), "myresource.css", true, true);
+
+        // relativize tmp folder to the current working directory, something like ../../../tmp/path
+        Path relativeParent = Paths.get(".").toAbsolutePath().relativize(parent.toPath());
+        assertFileAsStream(relativeParent.toFile(), "myresource.css", true, true);
     }
 
     private void assertResourceAsStream(String parent, String resource, boolean expectValid, boolean expectResourceToExist) throws IOException {


### PR DESCRIPTION
Closes #34028

The current order is `normalize().toAbsolutePath()` but it seems in macos the home folder of keycloak (the system property) is  `-Dkc.home.dir=./..`. This is because in macos the `readlink` has no `-f` option that canonicalize the path (check [kc.sh](https://github.com/keycloak/keycloak/blob/26.0.1/quarkus/dist/src/main/content/bin/kc.sh#L10) script). Therefore doing the `normalize()` first, the `./..` into is transformed into empty string ``, and then `themes` folder is incorrect (nothing is found). If we do in the reverse order (first absolute path and then normalize) the correct themes folder is found. Added a test that uses relative path to get the file.