### PR TITLE
Attempt to run snapshot Keycloak server against production DB should …

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProvider.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProvider.java
@@ -274,7 +274,7 @@ public class DefaultDatastoreProvider implements DatastoreProvider, StoreManager
     }
 
     public MigrationManager getMigrationManager() {
-        return new DefaultMigrationManager(session);
+        return new DefaultMigrationManager(session, factory.isAllowMigrateExistingDatabaseToSnapshot());
     }
 
 }

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProviderFactory.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProviderFactory.java
@@ -27,6 +27,8 @@ import org.keycloak.migration.MigrationModelManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.utils.PostMigrationEvent;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.provider.ProviderEvent;
 import org.keycloak.provider.ProviderEventListener;
 import org.keycloak.services.scheduled.ClearExpiredAdminEvents;
@@ -47,10 +49,13 @@ public class DefaultDatastoreProviderFactory implements DatastoreProviderFactory
 
     private static final String PROVIDER_ID = "legacy";
 
+    public static final String ALLOW_MIGRATE_EXISTING_DB_TO_SNAPSHOT_OPTION = "allowMigrateExistingDatabaseToSnapshot";
+
     private static final Logger logger = Logger.getLogger(DefaultDatastoreProviderFactory.class);
 
     private long clientStorageProviderTimeout;
     private long roleStorageProviderTimeout;
+    private boolean allowMigrateExistingDatabaseToSnapshot;
     private Runnable onClose;
 
     @Override
@@ -62,6 +67,7 @@ public class DefaultDatastoreProviderFactory implements DatastoreProviderFactory
     public void init(Scope config) {
         clientStorageProviderTimeout = Config.scope("client").getLong("storageProviderTimeout", 3000L);
         roleStorageProviderTimeout = Config.scope("role").getLong("storageProviderTimeout", 3000L);
+        allowMigrateExistingDatabaseToSnapshot = config.getBoolean(ALLOW_MIGRATE_EXISTING_DB_TO_SNAPSHOT_OPTION, false);
     }
 
     @Override
@@ -82,12 +88,30 @@ public class DefaultDatastoreProviderFactory implements DatastoreProviderFactory
         return PROVIDER_ID;
     }
 
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(ALLOW_MIGRATE_EXISTING_DB_TO_SNAPSHOT_OPTION)
+                .type("boolean")
+                .helpText("By default, it is not allowed to run the snapshot/development server against the database, which was previously migrated to some officially released server version. As an attempt of doing this " +
+                        "indicates that you are trying to run development server against production database, which can result in a loss or corruption of data. If it is really intended, you can use this option, which will allow to use " +
+                        "nightly/development server against production database when explicitly switch to true. This option is recommended just in the development environments and should be never used in the production!")
+                .defaultValue(false)
+                .add()
+                .build();
+    }
+
     public long getClientStorageProviderTimeout() {
         return clientStorageProviderTimeout;
     }
 
     public long getRoleStorageProviderTimeout() {
         return roleStorageProviderTimeout;
+    }
+
+    boolean isAllowMigrateExistingDatabaseToSnapshot() {
+        return allowMigrateExistingDatabaseToSnapshot;
     }
 
     @Override

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProviderFactory.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProviderFactory.java
@@ -95,7 +95,7 @@ public class DefaultDatastoreProviderFactory implements DatastoreProviderFactory
                 .name(ALLOW_MIGRATE_EXISTING_DB_TO_SNAPSHOT_OPTION)
                 .type("boolean")
                 .helpText("By default, it is not allowed to run the snapshot/development server against the database, which was previously migrated to some officially released server version. As an attempt of doing this " +
-                        "indicates that you are trying to run development server against production database, which can result in a loss or corruption of data. If it is really intended, you can use this option, which will allow to use " +
+                        "indicates that you are trying to run development server against production database, which can result in a loss or corruption of data, and also does not allow upgrading. If it is really intended, you can use this option, which will allow to use " +
                         "nightly/development server against production database when explicitly switch to true. This option is recommended just in the development environments and should be never used in the production!")
                 .defaultValue(false)
                 .add()

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultMigrationManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultMigrationManager.java
@@ -143,8 +143,8 @@ public class DefaultMigrationManager implements MigrationManager {
 
         if (SNAPSHOT_VERSION.equals(currentVersion) && databaseVersion != null && databaseVersion.lessThan(SNAPSHOT_VERSION) && !allowMigrateExistingDatabaseToSnapshot) {
             throw new ModelException("Incorrect state of migration. You are trying to run nightly server version '" + currentVersion + "' against a database, which was previously migrated to version '" + databaseVersion +
-                    ". This indicates that you are trying to run development server version against production database, which can result in a loss or corruption of data. If it is intended, " +
-                    "use the option allow-migrate-existing-database-to-snapshot of datastore provider when starting the server and explicitly set it to true.");
+                    "'. This indicates that you are trying to run development server version against production database, which can result in a loss or corruption of data, and also does not allow upgrading. If it is intended, " +
+                    "use the option spi-datastore-legacy-allow-migrate-existing-database-to-snapshot of the datastore provider when starting the server and explicitly set it to true.");
         }
         if (databaseVersion == null || databaseVersion.lessThan(latestUpdate)) {
             for (Migration m : migrations) {

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultMigrationManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultMigrationManager.java
@@ -124,9 +124,11 @@ public class DefaultMigrationManager implements MigrationManager {
     };
 
     private final KeycloakSession session;
+    private final boolean allowMigrateExistingDatabaseToSnapshot;
 
-    public DefaultMigrationManager(KeycloakSession session) {
+    public DefaultMigrationManager(KeycloakSession session, boolean allowMigrateExistingDatabaseToSnapshot) {
         this.session = session;
+        this.allowMigrateExistingDatabaseToSnapshot = allowMigrateExistingDatabaseToSnapshot;
     }
 
     @Override
@@ -139,6 +141,11 @@ public class DefaultMigrationManager implements MigrationManager {
         ModelVersion latestUpdate = migrations[migrations.length-1].getVersion();
         ModelVersion databaseVersion = model.getStoredVersion() != null ? new ModelVersion(model.getStoredVersion()) : null;
 
+        if (SNAPSHOT_VERSION.equals(currentVersion) && databaseVersion != null && databaseVersion.lessThan(SNAPSHOT_VERSION) && !allowMigrateExistingDatabaseToSnapshot) {
+            throw new ModelException("Incorrect state of migration. You are trying to run nightly server version '" + currentVersion + "' against a database, which was previously migrated to version '" + databaseVersion +
+                    ". This indicates that you are trying to run development server version against production database, which can result in a loss or corruption of data. If it is intended, " +
+                    "use the option allow-migrate-existing-database-to-snapshot of datastore provider when starting the server and explicitly set it to true.");
+        }
         if (databaseVersion == null || databaseVersion.lessThan(latestUpdate)) {
             for (Migration m : migrations) {
                 if (databaseVersion == null || databaseVersion.lessThan(m.getVersion())) {
@@ -170,7 +177,7 @@ public class DefaultMigrationManager implements MigrationManager {
     public static final ModelVersion RHSSO_VERSION_7_2_KEYCLOAK_VERSION = new ModelVersion("3.4.3");
     public static final ModelVersion RHSSO_VERSION_7_3_KEYCLOAK_VERSION = new ModelVersion("4.8.3");
     public static final ModelVersion RHSSO_VERSION_7_4_KEYCLOAK_VERSION = new ModelVersion("9.0.3");
-    public static final ModelVersion SNAPSHOT_VERSION = new ModelVersion("999.0.0-SNAPSHOT");
+    public static final ModelVersion SNAPSHOT_VERSION = new ModelVersion(Constants.SNAPSHOT_VERSION);
 
     private static final Map<Pattern, ModelVersion> PATTERN_MATCHER = new LinkedHashMap<>();
     static {

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -140,6 +140,8 @@ public final class Constants {
      */
     public static final String STORAGE_BATCH_SIZE = "org.keycloak.storage.batch_size";
 
+    public static final String SNAPSHOT_VERSION = "999.0.0-SNAPSHOT";
+
     // Client Polices Realm Attributes Keys
     public static final String CLIENT_PROFILES = "client-policies.profiles";
     public static final String CLIENT_POLICIES = "client-policies.policies";

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -235,12 +235,12 @@ public class AuthServerTestEnricher {
                     .filter(c -> c.getQualifier().startsWith("cache-server-"))
                     .sorted((a, b) -> a.getQualifier().compareTo(b.getQualifier()))
                     .forEach(containerInfo -> {
-                        
+
                         log.info(String.format("cache container: %s", containerInfo.getQualifier()));
-                        
+
                         int prefixSize = containerInfo.getQualifier().lastIndexOf("-") + 1;
                         int dcIndex = Integer.parseInt(containerInfo.getQualifier().substring(prefixSize)) - 1;
-                        
+
                         suiteContext.addCacheServerInfo(dcIndex, containerInfo);
                     });
 
@@ -294,6 +294,8 @@ public class AuthServerTestEnricher {
         }
 
         if (START_MIGRATION_CONTAINER) {
+            suiteContext.getMigrationContext().setRunningMigrationTest(true);
+
             // init migratedAuthServerInfo
             for (ContainerInfo container : suiteContext.getContainers()) {
                 // migrated auth server
@@ -375,7 +377,7 @@ public class AuthServerTestEnricher {
 
     public void startAuthContainer(@Observes(precedence = 0) StartSuiteContainers event) {
         // this property can be used to skip start of auth-server before suite
-        // it might be useful for running some specific tests locally, e.g. when running standalone ZeroDowtime*Test 
+        // it might be useful for running some specific tests locally, e.g. when running standalone ZeroDowtime*Test
         if (Boolean.getBoolean("keycloak.testsuite.skip.start.auth.server")) {
             log.debug("Skipping the start of auth server before suite");
             return;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/SuiteContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/SuiteContext.java
@@ -182,6 +182,10 @@ public final class SuiteContext {
         return authServerBackendsInfo.size() > 1;
     }
 
+    /**
+     * @return true during migration test, but just right before and during old container running. It returns false during lifecycle of new container running
+     * and during migration test itself. Use {@link #getMigrationContext().isRunningMigrationTest()} if want to check if we are in the context of migration (including lifecycle of the new container)
+     */
     public boolean isAuthServerMigrationEnabled() {
         return migratedAuthServerInfo != null;
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -172,6 +172,10 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
             commands.add("--http-management-port=" + configuration.getManagementPort());
         }
 
+        if (suiteContext.get().getMigrationContext().isRunningMigrationTest()) {
+            commands.add("--spi-datastore-legacy-allow-migrate-existing-database-to-snapshot=true");
+        }
+
         if (configuration.getRoute() != null) {
             commands.add("-Djboss.node.name=" + configuration.getRoute());
         }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/migration/MigrationContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/migration/MigrationContext.java
@@ -36,6 +36,18 @@ public class MigrationContext {
 
     public static final Logger logger = Logger.getLogger(MigrationContext.class);
 
+    private boolean runningMigrationTest = false;
+
+    /**
+     * @return true if testsuite is running migration test. This returns true during whole lifecycle of migration test (Including running of the old container as well as running the new container)
+     */
+    public boolean isRunningMigrationTest() {
+        return runningMigrationTest;
+    }
+
+    public void setRunningMigrationTest(boolean runningMigrationTest) {
+        this.runningMigrationTest = runningMigrationTest;
+    }
 
     public String loadOfflineToken() throws Exception {
         String file = getOfflineTokenLocation();


### PR DESCRIPTION
…fail during migration

closes #30364

- By default, it is not allowed to run Keycloak snapshot/nightly version against the database, which was previously migrated to some released Keycloak server. As this indicates that there is an attempt to run development server against production database.

- Introduced the option `allowMigrateExistingDatabaseToSnapshot` on datastore provider to override that in case people know what they are doing. Also documented that option by implementing `DefaultDatastoreProviderFactory.getConfigMetadata()` . Not 100% sure if the option should be documented or not as it is only for the development purposes, so if you think otherwise, I can remove documenting that.

- Added that option when running `MigrationTest` as during migration, we are testing the migration of the DB from some released server version to latest snapshot

- Added the scenario in `MigrationDeniedTest` (this is not real integration test, but allows to test the scenario to some extent similarly like the other already existing disabled scenario when production scenario is executed against SNAPSHOT database)
