### PR TITLE
Set correct "typ" value "at+jwt" in OAuth 2 access token headers

### DIFF
--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -238,6 +238,8 @@ public class DefaultTokenManager implements TokenManager {
 
     private String type(TokenCategory category) {
         switch (category) {
+            case ACCESS:
+                return TokenUtil.TOKEN_TYPE_JWT_ACCESS_TOKEN;
             case LOGOUT:
                 return TokenUtil.TOKEN_TYPE_JWT_LOGOUT_TOKEN;
             default:

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -212,7 +212,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
         JWSHeader header = new JWSInput(response.getAccessToken()).getHeader();
         assertEquals("RS256", header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertEquals(expectedKid, header.getKeyId());
         assertNull(header.getContentType());
 
@@ -1420,7 +1420,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
         JWSHeader header = new JWSInput(response.getAccessToken()).getHeader();
         verifySignatureAlgorithm(header, expectedAccessAlg);
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertNull(header.getContentType());
 
         header = new JWSInput(response.getIdToken()).getHeader();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -213,7 +213,7 @@ public class LogoutTest extends AbstractKeycloakTest {
 
         JWSHeader header = new JWSInput(tokenResponse.getAccessToken()).getHeader();
         assertEquals(expectedAccessAlg, header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertNull(header.getContentType());
 
         header = new JWSInput(tokenResponse.getIdToken()).getHeader();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -88,18 +88,18 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     }
 
     @Test
-    
+
     public void accessTokenRequestWithoutPKCE() throws Exception {
     	// test case : success : A-1-1
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
-        
+
         String sessionId = loginEvent.getSessionId();
         String codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        
+
         expectSuccessfulResponseFromTokenEndpoint(codeId, sessionId, code);
     }
 
@@ -110,7 +110,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	String codeChallenge = generateS256CodeChallenge(codeVerifier);
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -121,7 +121,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
         oauth.codeVerifier(codeVerifier);
-        
+
         expectSuccessfulResponseFromTokenEndpoint(codeId, sessionId, code);
     }
 
@@ -132,7 +132,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	String codeChallenge = codeVerifier;
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -143,23 +143,23 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
         oauth.codeVerifier(codeVerifier);
-        
+
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        
+
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("PKCE verification failed: Code mismatch", response.getErrorDescription());
-        
+
         events.expectCodeToToken(codeId, sessionId).error(Errors.PKCE_VERIFICATION_FAILED).clearDetails().assertEvent();
     }
-    
+
     @Test
-    
+
     public void accessTokenRequestInPKCEValidPlainCodeChallengeMethod() throws Exception {
     	// test case : success : A-1-3
     	oauth.codeChallenge(".234567890-234567890~234567890_234567890123");
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -168,9 +168,9 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        
+
         oauth.codeVerifier(".234567890-234567890~234567890_234567890123");
-        
+
         expectSuccessfulResponseFromTokenEndpoint(codeId, sessionId, code);
     }
 
@@ -179,7 +179,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	// test case : failure : A-1-6
     	oauth.codeChallenge("1234567890123456789012345678901234567890123");
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -188,24 +188,24 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        
+
         oauth.codeVerifier("aZ_-.~1234567890123456789012345678901234567890123Za");
-        
+
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        
+
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("PKCE verification failed: Code mismatch", response.getErrorDescription());
-        
+
         events.expectCodeToToken(codeId, sessionId).error(Errors.PKCE_VERIFICATION_FAILED).clearDetails().assertEvent();
     }
-    
+
     @Test
-    
+
     public void accessTokenRequestInPKCEValidDefaultCodeChallengeMethod() throws Exception {
     	// test case : success : A-1-4
     	oauth.codeChallenge("1234567890123456789012345678901234567890123");
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -216,45 +216,45 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
         oauth.codeVerifier("1234567890123456789012345678901234567890123");
-        
+
         expectSuccessfulResponseFromTokenEndpoint(codeId, sessionId, code);
     }
-    
+
     @Test
     public void accessTokenRequestInPKCEWithoutCodeChallengeWithValidCodeChallengeMethod() throws Exception {
     	// test case : failure : A-1-7
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
         UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
+
         driver.navigate().to(b.build().toURL());
-    	
+
         OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
 
         Assert.assertTrue(errorResponse.isRedirected());
         Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
         Assert.assertEquals(errorResponse.getErrorDescription(), "Missing parameter: code_challenge");
-        
+
         events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
     }
-    
+
     @Test
     public void accessTokenRequestInPKCEInvalidUnderCodeChallengeWithS256CodeChallengeMethod() throws Exception {
     	// test case : failure : A-1-8
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
     	oauth.codeChallenge("ABCDEFGabcdefg1234567ABCDEFGabcdefg1234567"); // 42
         UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
+
         driver.navigate().to(b.build().toURL());
-    	
+
         OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
 
         Assert.assertTrue(errorResponse.isRedirected());
         Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
         Assert.assertEquals(errorResponse.getErrorDescription(), "Invalid parameter: code_challenge");
-        
+
         events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
     }
-    
+
     @Test
     public void accessTokenRequestInPKCEInvalidOverCodeChallengeWithPlainCodeChallengeMethod() throws Exception {
     	// test case : failure : A-1-9
@@ -262,18 +262,18 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	oauth.codeChallenge("3fRc92kac_keic8c7al-3ncbdoaie.DDeizlck3~3fRc92kac_keic8c7al-3ncbdoaie.DDeizlck3~3fRc92kac_keic8c7al-3ncbdoaie.DDeizlck3~123456789"); // 129
 
     	UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
+
         driver.navigate().to(b.build().toURL());
-    	
+
         OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
 
         Assert.assertTrue(errorResponse.isRedirected());
         Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
         Assert.assertEquals(errorResponse.getErrorDescription(), "Invalid parameter: code_challenge");
-        
+
         events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
     }
-    
+
     @Test
     public void accessTokenRequestInPKCEInvalidUnderCodeVerifierWithS256CodeChallengeMethod() throws Exception {
     	// test case : success : A-1-10
@@ -282,7 +282,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
 
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -293,16 +293,16 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
         oauth.codeVerifier(codeVerifier);
-        
+
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        
+
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("PKCE verification failed: Invalid code verifier", response.getErrorDescription());
-        
+
         events.expectCodeToToken(codeId, sessionId).error(Errors.INVALID_CODE_VERIFIER).clearDetails().assertEvent();
     }
-    
+
     @Test
     public void accessTokenRequestInPKCEInvalidOverCodeVerifierWithS256CodeChallengeMethod() throws Exception {
     	// test case : success : A-1-11
@@ -310,7 +310,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	String codeChallenge = generateS256CodeChallenge(codeVerifier);
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -321,13 +321,13 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
         oauth.codeVerifier(codeVerifier);
-        
+
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        
+
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("PKCE verification failed: Invalid code verifier", response.getErrorDescription());
-        
+
         events.expectCodeToToken(codeId, sessionId).error(Errors.INVALID_CODE_VERIFIER).clearDetails().assertEvent();
     }
 
@@ -338,7 +338,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	String codeChallenge = codeVerifier;
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -347,13 +347,13 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-       
+
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        
+
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("PKCE code verifier not specified", response.getErrorDescription());
-        
+
         events.expectCodeToToken(codeId, sessionId).error(Errors.CODE_VERIFIER_MISSING).clearDetails().assertEvent();
     }
 
@@ -364,17 +364,17 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	String codeChallenge = codeVerifier;
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
     	UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
+
         driver.navigate().to(b.build().toURL());
-    	
+
         OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
 
         Assert.assertTrue(errorResponse.isRedirected());
         Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
         Assert.assertEquals(errorResponse.getErrorDescription(), "Invalid parameter: code_challenge");
-        
+
         events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
     }
 
@@ -385,7 +385,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	String codeChallenge = generateS256CodeChallenge(codeVerifier);
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
-    	
+
         oauth.doLogin("test-user@localhost", "password");
 
         EventRepresentation loginEvent = events.expectLogin().assertEvent();
@@ -396,13 +396,13 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
         oauth.codeVerifier(codeVerifier);
-        
+
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
-        
+
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("PKCE verification failed: Invalid code verifier", response.getErrorDescription());
-        
+
         events.expectCodeToToken(codeId, sessionId).error(Errors.INVALID_CODE_VERIFIER).clearDetails().assertEvent();
     }
 
@@ -431,7 +431,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
 
         events.expectCodeToToken(codeId, sessionId).error(Errors.INVALID_CODE_VERIFIER).clearDetails().assertEvent();
     }
-    
+
     private String generateS256CodeChallenge(String codeVerifier) throws Exception {
         MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update(codeVerifier.getBytes("ISO_8859_1"));
@@ -439,7 +439,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         String codeChallenge = Base64Url.encode(digestBytes);
         return codeChallenge;
     }
- 
+
     private void expectSuccessfulResponseFromTokenEndpoint(String codeId, String sessionId, String code)  throws Exception {
         OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
 
@@ -455,7 +455,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
 
         JWSHeader header = new JWSInput(response.getAccessToken()).getHeader();
         assertEquals("RS256", header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertEquals(expectedKid, header.getKeyId());
         assertNull(header.getContentType());
 
@@ -482,13 +482,13 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         assertTrue(token.getResourceAccess(oauth.getClientId()).isUserInRole("customer-user"));
 
         EventRepresentation event = events.expectCodeToToken(codeId, sessionId).assertEvent();
-        
+
         assertEquals(token.getId(), event.getDetails().get(Details.TOKEN_ID));
         assertEquals(oauth.parseRefreshToken(response.getRefreshToken()).getId(), event.getDetails().get(Details.REFRESH_TOKEN_ID));
         assertEquals(sessionId, token.getSessionState());
-        
+
         // make sure PKCE does not affect token refresh on Token Endpoint
-        
+
         String refreshTokenString = response.getRefreshToken();
         RefreshToken refreshToken = oauth.parseRefreshToken(refreshTokenString);
 
@@ -501,7 +501,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         setTimeOffset(2);
 
         OAuthClient.AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(refreshTokenString, "password");
-        
+
         AccessToken refreshedToken = oauth.verifyToken(refreshResponse.getAccessToken());
         RefreshToken refreshedRefreshToken = oauth.parseRefreshToken(refreshResponse.getRefreshToken());
 
@@ -601,7 +601,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
             setPkceActivationSettings("test-app", null);
         }
     }
- 
+
     @Test
     public void accessTokenRequestCodeChallengeMethodMismatchPkceEnforced() throws Exception {
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -973,7 +973,7 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
        if (accessToken != null) {
            header = new JWSInput(accessToken).getHeader();
            assertEquals(expectedAccessAlg, header.getAlgorithm().name());
-           assertEquals("JWT", header.getType());
+           assertEquals("at+jwt", header.getType());
            assertNull(header.getContentType());
        }
        if (refreshToken != null) {
@@ -1045,7 +1045,7 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         if (accessToken != null) {
             header = new JWSInput(accessToken).getHeader();
             assertEquals(expectedAccessAlg, header.getAlgorithm().name());
-            assertEquals("JWT", header.getType());
+            assertEquals("at+jwt", header.getType());
             assertNull(header.getContentType());
         }
         if (refreshToken != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -2099,7 +2099,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
 
         JWSHeader header = new JWSInput(tokenResponse.getAccessToken()).getHeader();
         assertEquals(expectedAccessAlg, header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertNull(header.getContentType());
 
         header = new JWSInput(tokenResponse.getIdToken()).getHeader();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
@@ -385,7 +385,7 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
         JWSHeader header = new JWSInput(response.getAccessToken()).getHeader();
 
         assertEquals(expectedAccessAlg, header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertNull(header.getContentType());
 
         header = new JWSInput(response.getRefreshToken()).getHeader();
@@ -553,7 +553,7 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
         // Check that count of authSessions is same as before authentication (as authentication session was removed)
         Assert.assertEquals(authSessionsBefore, getAuthenticationSessionsCount());
     }
-    
+
     @Test
     public void grantAccessTokenVerifyEmailInvalidPassword() throws Exception {
 
@@ -617,7 +617,7 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
                     .removeRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD.toString());
         }
     }
-    
+
     @Test
     public void grantAccessTokenExpiredPasswordInvalidPassword() throws Exception {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
@@ -470,7 +470,7 @@ public class ServiceAccountTest extends AbstractKeycloakTest {
 
         JWSHeader header = new JWSInput(response.getAccessToken()).getHeader();
         assertEquals(expectedAccessAlg, header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertNull(header.getContentType());
 
         header = new JWSInput(response.getRefreshToken()).getHeader();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
@@ -133,7 +133,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
             }
         }
     }
-    
+
     private void configTestRealmForTokenIntrospection(RealmRepresentation testRealm) {
         ClientRepresentation confApp = KeycloakModelUtils.createClient(testRealm, "confidential-cli");
         confApp.setSecret("secret1");
@@ -176,8 +176,8 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseMtlsHoKToken(true);
         clientResource.update(clientRep);
     }
-    
-    // Authorization Code Flow 
+
+    // Authorization Code Flow
     // Bind HoK Token
 
     @Test
@@ -199,7 +199,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         expectSuccessfulResponseFromTokenEndpoint(sessionId, codeId, response);
         verifyHoKTokenDefaultCertThumbPrint(response);
     }
-    
+
     @Test
     public void accessTokenRequestWithoutClientCertificate() throws Exception {
         oauth.doLogin("test-user@localhost", "password");
@@ -233,7 +233,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
 
         JWSHeader header = new JWSInput(response.getAccessToken()).getHeader();
         assertEquals("RS256", header.getAlgorithm().name());
-        assertEquals("JWT", header.getType());
+        assertEquals("at+jwt", header.getType());
         assertEquals(expectedKid, header.getKeyId());
         assertNull(header.getContentType());
 
@@ -395,7 +395,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
     private void expectSuccessfulResponseFromTokenEndpoint(AccessTokenResponse response, String sessionId, AccessToken token, RefreshToken refreshToken, EventRepresentation tokenEvent) {
         expectSuccessfulResponseFromTokenEndpoint(oauth, "test-user@localhost", response, sessionId, token, refreshToken, tokenEvent);
     }
-    
+
     private void expectSuccessfulResponseFromTokenEndpoint(OAuthClient oauth, String username, AccessTokenResponse response, String sessionId, AccessToken token, RefreshToken refreshToken, EventRepresentation tokenEvent) {
         AccessToken refreshedToken = oauth.verifyToken(response.getAccessToken());
         RefreshToken refreshedRefreshToken = oauth.parseRefreshToken(response.getRefreshToken());
@@ -567,7 +567,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
 
     // Hybrid Code Flow : response_type = code id_token
     // Bind HoK Token
-    
+
     @Test
     public void accessTokenRequestWithClientCertificateInHybridFlowWithCodeIDToken() throws Exception {
         String nonce = "ckw938gnspa93dj";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/AbstractOIDCResponseTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/AbstractOIDCResponseTypeTest.java
@@ -240,7 +240,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
         if (accessToken != null) {
             header = new JWSInput(accessToken).getHeader();
             verifySignatureAlgorithm(header, expectedAccessAlg);
-            assertEquals("JWT", header.getType());
+            assertEquals("at+jwt", header.getType());
             assertNull(header.getContentType());
         }
 


### PR DESCRIPTION
Set correct "typ" value "at+jwt" in OAuth 2 access token headers to comply with RFC 9068.

See https://datatracker.ietf.org/doc/html/rfc9068#section-2.1

I hope I have updated all relevant tests. Not all tests ran successfully locally, so I am not fully certain.

Closes #34146