### PR TITLE
doc: Replaced dead link

### DIFF
--- a/docs/documentation/server_development/topics/themes-react.adoc
+++ b/docs/documentation/server_development/topics/themes-react.adoc
@@ -62,4 +62,4 @@ backend: {
 
 All "pages" are React components that can be used in your application.
 To see what components are available, see the [source](https://github.com/keycloak/keycloak/blob/main/js/apps/account-ui/src/index.ts).
-Or have a look at the [quick start](https://github.com/keycloak/keycloak-quickstarts/tree/main/extension/extend-admin-console-node) to see how to use them.
+Or have a look at the [quick start](https://github.com/keycloak/keycloak-quickstarts/tree/main/extension/extend-account-console-node) to see how to use them.


### PR DESCRIPTION
The [Keycloak server development documentation](https://www.keycloak.org/docs/26.0.1/server_development/#using-the-pages) contains a broken (dead) link to a quickstart template.

I replaced the dead link with a similar template, that is fitting in this context.

Old (broken link): https://github.com/keycloak/keycloak-quickstarts/tree/main/extension/extend-admin-console-node
New: https://github.com/keycloak/keycloak-quickstarts/tree/main/extension/extend-account-console-node

fixes: #34257
