### PR TITLE
fix: addresses consistency issues with property mapping

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/DisabledMappersInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/DisabledMappersInterceptor.java
@@ -81,6 +81,10 @@ public class DisabledMappersInterceptor implements ConfigSourceInterceptor {
     }
 
     public static void runWithDisabled(Runnable execution) {
+        if (!isEnabled()) {
+            execution.run();
+            return;
+        }
         try {
             disable();
             execution.run();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
@@ -160,6 +160,9 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
     }
 
     public <T> T runWithDisabled(Supplier<T> execution) {
+        if (!isEnabled()) {
+            return execution.get();
+        }
         try {
             disable();
             return execution.get();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -23,7 +23,6 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Priorities;
 import jakarta.annotation.Priority;
 import org.apache.commons.collections4.iterators.FilterIterator;
-import org.keycloak.common.util.StringPropertyReplacer;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
@@ -82,29 +81,6 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
         if (Boolean.TRUE.equals(disable.get())) {
             return context.proceed(name);
         }
-        ConfigValue value = PropertyMappers.getValue(context, name);
-
-        if (value == null || value.getValue() == null) {
-            return null;
-        }
-
-        if (!value.getValue().contains("${")) {
-            return value;
-        }
-
-        // Our mappers might have returned a value containing an expression ${...}.
-        // However, ExpressionConfigSourceInterceptor was already executed before (to expand e.g. env vars in config file).
-        // Hence, we need to manually resolve these expressions here. Not ideal, but there's no other way (at least I haven't found one).
-        return value.withValue(
-                StringPropertyReplacer.replaceProperties(value.getValue(),
-                        property -> {
-                            ConfigValue prop = context.proceed(property);
-
-                            if (prop == null) {
-                                return null;
-                            }
-
-                            return prop.getValue();
-                        }));
+        return PropertyMappers.getValue(context, name);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -2,12 +2,14 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.smallrye.config.ConfigSourceInterceptorContext;
-import io.smallrye.config.ConfigValue;
 import org.keycloak.config.DatabaseOptions;
+import org.keycloak.config.TransactionOptions;
 import org.keycloak.config.database.Database;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
+
+import java.util.Optional;
 
 final class DatabasePropertyMappers {
 
@@ -84,8 +86,8 @@ final class DatabasePropertyMappers {
     }
 
     private static String getXaOrNonXaDriver(String value, ConfigSourceInterceptorContext context) {
-        ConfigValue xaEnabledConfigValue = context.proceed("kc.transaction-xa-enabled");
-        boolean isXaEnabled = xaEnabledConfigValue != null && Boolean.parseBoolean(xaEnabledConfigValue.getValue());
+        Optional<String> xaEnabledConfigValue = Configuration.getOptionalKcValue(TransactionOptions.TRANSACTION_XA_ENABLED);
+        boolean isXaEnabled = xaEnabledConfigValue.map(Boolean::parseBoolean).orElse(false);
 
         return Database.getDriver(value, isXaEnabled).orElse(null);
     }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
@@ -27,6 +27,8 @@ import io.smallrye.config.ConfigValue.ConfigValueBuilder;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.keycloak.Config;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
@@ -96,6 +98,11 @@ public abstract class AbstractConfigurationTest {
             System.clearProperty(key);
         }
     }
+    
+    @AfterClass
+    public static void resetConfigruation() {
+        ConfigurationTest.createConfig(); // onAfter doesn't actually reset the config
+    }
 
     @After
     public void onAfter() {
@@ -124,7 +131,7 @@ public abstract class AbstractConfigurationTest {
         return Config.scope(scope);
     }
 
-    protected SmallRyeConfig createConfig() {
+    static protected SmallRyeConfig createConfig() {
         KeycloakConfigSourceProvider.reload();
         // older versions of quarkus implicitly picked up this config, now we
         // must set it manually

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -35,6 +35,7 @@ import io.smallrye.config.SmallRyeConfig;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Expressions;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.h2.Driver;
@@ -204,6 +205,14 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         SmallRyeConfig config = createConfig();
         assertEquals(MariaDBDialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:mariadb:aurora://foo/bar?a=1&b=2", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+    }
+    
+    @Test
+    public void testExpansionDisabled() {
+        ConfigArgsConfigSource.setCliArgs("--db=mysql");
+        SmallRyeConfig config = createConfig();
+        String value = Expressions.withoutExpansion(() -> config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+        assertEquals("jdbc:mysql://${kc.db-url-host:localhost}:${kc.db-url-port:3306}/${kc.db-url-database:keycloak}${kc.db-url-properties:}", value);
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.quarkus.runtime.configuration.test;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.common.Profile;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
@@ -48,6 +49,11 @@ import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvi
 import static org.keycloak.quarkus.runtime.configuration.test.ConfigurationTest.setSystemProperty;
 
 public class IgnoredArtifactsTest {
+    
+    @BeforeClass
+    public static void resetConfigruation() {
+        ConfigurationTest.createConfig(); // make sure we're dealing with a clean config
+    }
 
     @Test
     public void fipsDisabled() {


### PR DESCRIPTION
localized, and standardized, expression expansion
replaced context.proceed for kc and quarkus properties

We do still need to keep the context in the property mapping logic. Using Configuration.getValue for the import/export logic ends up with a recursive call due to the structuring of the hidden properties. 

Other cleanups:
- we shouldn't do unconditional expression expansion, and we should reuse the quarkus logic, not our own.
- we should prevent reentrant calls from toggling disabled flags on interceptors

closes: #33741 
- I'll update that issue with what was done here since this isn't really about the performance implications.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
