### PR TITLE
Commit proto.lock files when creating release branch

### DIFF
--- a/.github/workflows/branch-create.yml
+++ b/.github/workflows/branch-create.yml
@@ -1,0 +1,25 @@
+name: Release Branch Create
+
+on:
+  create:
+    branches:
+      - 'release/**'
+
+jobs:
+  commit-proto-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Keycloak
+        uses: ./.github/actions/build-keycloak
+
+      - name: Commit unstaged proto.lock files to branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add **/proto.lock
+          git commit -s -m "Committing **/proto.lock changes"
+          git push origin ${{ github.ref_name }}


### PR DESCRIPTION

Closes #34147

@stianst This seemed like the simplest way for us to automatically commit proto.lock files when we create a new release branch from `main` as we can re-use the existing `build-keycloak` action. The downside is that the logic isn't contained with keycloak-rel. Let me know what you think, happy to add actions to keycloak-rel if you prefer.