### PR TITLE
Create a new logout session when initiating it for another client

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -231,7 +231,7 @@ public class LogoutEndpoint {
             }
         }
 
-        AuthenticationSessionModel logoutSession = AuthenticationManager.createOrJoinLogoutSession(session, realm, new AuthenticationSessionManager(session), null, true);
+        AuthenticationSessionModel logoutSession = AuthenticationManager.createOrJoinLogoutSession(session, realm, new AuthenticationSessionManager(session), null, true, true);
         session.getContext().setAuthenticationSession(logoutSession);
         if (uiLocales != null) {
             logoutSession.setClientNote(LocaleSelectorProvider.CLIENT_REQUEST_LOCALE, uiLocales);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -684,7 +684,13 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
     public void logoutWithClientIdAndWithoutIdTokenHint() {
         OAuthClient.AccessTokenResponse tokenResponse = loginUser();
 
-        String logoutUrl = oauth.getLogoutUrl().postLogoutRedirectUri(APP_REDIRECT_URI).clientId("test-app").state("somethingg").build();
+        // logout url with no parameters, client is the account app
+        String logoutUrl = oauth.getLogoutUrl().build();
+        driver.navigate().to(logoutUrl);
+        logoutConfirmPage.assertCurrent();
+
+        // change logout to our app with redirect uri
+        logoutUrl = oauth.getLogoutUrl().postLogoutRedirectUri(APP_REDIRECT_URI).clientId("test-app").state("somethingg").build();
         driver.navigate().to(logoutUrl);
 
         // Assert logout confirmation page as id_token_hint was not sent. Session still exists. Assert default language on logout page (English)


### PR DESCRIPTION
Closes #34207

The logout endpoint cannot be called twice with different clients. The PR adds a new method parameter that marks the logout is initiated now. If it's initiated the previous client session is not valid if the client is a different one. One test modified to cover the failing situation.