### PR TITLE
Deprecate cloud stacks

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -41,6 +41,11 @@ To enable the previous behavior, choose the transport stack `udp`.
 
 The {project_name} Operator will continue to configure `kubernetes` as a transport stack.
 
+= Deprecated transport stacks for distributed caches
+
+The `azure`, `ec2` and `google` transport stacks have been deprecated. Users should use the TCP based `jdbc-ping`
+stack as a direct replacement.
+
 = Defining dependencies between provider factories
 
 When developing extensions for {project_name}, developers can now specify dependencies between provider factories classes by implementing the method `dependsOn()` in the `ProviderFactory` interface.

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -246,6 +246,10 @@ The following table shows transport stacks that are available using the `--cache
 |===
 
 === Additional transport stacks
+
+IMPORTANT: The following stacks are deprecated. We recommend that you utilise the `jdbc-ping` stack in such environments
+as it does not require additional configuration or dependencies.
+
 The following table shows transport stacks that are supported by {project_name}, but need some extra steps to work.
 Note that _none_  of these stacks are Kubernetes / OpenShift stacks, so no need exists to enable the `google` stack if you want to run {project_name} on top of the Google Kubernetes engine.
 In that case, use the `kubernetes` stack.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/CachingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/CachingOptions.java
@@ -1,6 +1,9 @@
 package org.keycloak.config;
 
 import java.io.File;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.base.CaseFormat;
 
@@ -64,6 +67,7 @@ public class CachingOptions {
             .expectedValues(false)
             .description("Define the default stack to use for cluster communication and node discovery.")
             .defaultValue(Stack.jdbc_ping_udp)
+            .deprecatedValues(Stream.of(Stack.azure, Stack.ec2, Stack.google).map(Object::toString).collect(Collectors.toSet()), "Use 'jdbc-ping' instead")
             .build();
 
     public static final Option<File> CACHE_CONFIG_FILE = new OptionBuilder<>(CACHE_CONFIG_FILE_PROPERTY, File.class)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheManagerFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheManagerFactory.java
@@ -391,13 +391,16 @@ public class CacheManagerFactory {
         String transportStack = Configuration.getRawValue("kc.cache-stack");
         if (transportStack != null && !transportStack.isBlank() && !isJdbcPingStack(transportStack)) {
             transportConfig.defaultTransport().stack(transportStack);
+            warnDeprecatedCloudStack(transportStack);
             return;
         }
 
         var stackXmlAttribute = transportConfig.defaultTransport().attributes().attribute(STACK);
         // If the user has explicitly defined a transport stack that is not jdbc-ping or jdbc-ping-udp, return
-        if (stackXmlAttribute.isModified() && !isJdbcPingStack(stackXmlAttribute.get()))
+        if (stackXmlAttribute.isModified() && !isJdbcPingStack(stackXmlAttribute.get())) {
+            warnDeprecatedCloudStack(stackXmlAttribute.get());
             return;
+        }
 
         var stackName = transportStack != null ?
               transportStack :
@@ -426,6 +429,15 @@ public class CacheManagerFactory {
         Supplier<DataSource> dataSourceSupplier = Arc.container().select(AgroalDataSource.class)::get;
         transportConfig.addProperty(JGroupsTransport.DATA_SOURCE, dataSourceSupplier);
         transportConfig.defaultTransport().stack(stackName);
+    }
+
+    private void warnDeprecatedCloudStack(String stackName) {
+        switch (stackName) {
+            case "azure":
+            case "ec2":
+            case "google":
+                logger.warnf("Stack '%s' is deprecated. We recommend to use 'jdbc-ping' instead", stackName);
+        }
     }
 
     private boolean isJdbcPingStack(String stackName) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -59,6 +59,12 @@ public class ClusterConfigDistTest {
     }
 
     @Test
+    @Launch({ "start-dev", "--cache=ispn", "--cache-stack=azure" })
+    void warnDeprecatedCloudStack(LaunchResult result) {
+        assertTrue(result.getOutput().contains("Stack 'azure' is deprecated. We recommend to use 'jdbc-ping' instead"));
+    }
+
+    @Test
     @Launch({ "start-dev", "--cache-config-file=invalid" })
     void failInvalidClusterConfig(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("ERROR: Could not load cluster configuration file"));

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -97,9 +97,9 @@ Cache:
                        host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2,
-                       azure, google, or a custom one. Default: jdbc-ping-udp. Available only when
-                       'cache' type is set to 'ispn'.
+                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2
+                       (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Default: jdbc-ping-udp. Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -72,9 +72,9 @@ Cache:
                        as well and the related configuration in XML file should not be present.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2,
-                       azure, google, or a custom one. Default: jdbc-ping-udp. Available only when
-                       'cache' type is set to 'ispn'.
+                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2
+                       (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Default: jdbc-ping-udp. Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -98,9 +98,9 @@ Cache:
                        host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2,
-                       azure, google, or a custom one. Default: jdbc-ping-udp. Available only when
-                       'cache' type is set to 'ispn'.
+                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2
+                       (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Default: jdbc-ping-udp. Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -72,9 +72,9 @@ Cache:
                        as well and the related configuration in XML file should not be present.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2,
-                       azure, google, or a custom one. Default: jdbc-ping-udp. Available only when
-                       'cache' type is set to 'ispn'.
+                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2
+                       (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Default: jdbc-ping-udp. Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -98,9 +98,9 @@ Cache:
                        host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2,
-                       azure, google, or a custom one. Default: jdbc-ping-udp. Available only when
-                       'cache' type is set to 'ispn'.
+                       Possible values are: tcp, udp, jdbc-ping, jdbc-ping-udp, kubernetes, ec2
+                       (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Default: jdbc-ping-udp. Available only when 'cache' type is set to 'ispn'.
 
 Config:
 


### PR DESCRIPTION
Closes #34253

@ahus1 With regards to listing deprecated options. I don't think it make sense to create a new deprecated Feature purely to indicate that 3 option values are now deprecated. Instead we can use the existing `DeprecatedMetadata` field of the various `Option` instances to programmatically retrieve deprecated options. 