### PR TITLE
Reuse a single DB instance across all tests in the store-integration-…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,7 +599,12 @@ jobs:
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh database`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Pdb-${{ matrix.db }} "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} \
+            -Pauth-server-quarkus -Pdb-${{ matrix.db }} \
+            "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" \
+            -Dtest=$TESTS \
+            -Ddocker.keepRunning \
+            -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Run cluster JDBC_PING2 UDP smoke test
         run: |
@@ -609,6 +614,8 @@ jobs:
             -Dtest=RealmInvalidationClusterTest \
             -Dsession.cache.owners=2 \
             -Dauth.server.quarkus.cluster.stack=jdbc-ping-udp \
+            -Ddocker.database.skip=true \
+            -Dauth.server.db.host=localhost \
             -pl testsuite/integration-arquillian/tests/base \
             2>&1 | misc/log/trimmer.sh
 
@@ -620,6 +627,8 @@ jobs:
             -Dtest=RealmInvalidationClusterTest \
             -Dsession.cache.owners=2 \
             -Dauth.server.quarkus.cluster.stack=jdbc-ping \
+            -Ddocker.database.skip=true \
+            -Dauth.server.db.host=localhost \
             -pl testsuite/integration-arquillian/tests/base \
             2>&1 | misc/log/trimmer.sh
 


### PR DESCRIPTION
Closes #34339 

@stianst This reduces the oracle job execution time from 68 to 42mins.