### PR TITLE
Adding Minder & Stacklok usage

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -39,6 +39,7 @@ List of organization names below is based on information collected using Keycloa
 * ITROI Solutions
 * Kindly Ops, LLC
 * [Microcks](https://landscape.cncf.io/?selected=microcks)
+* [Minder](https://github.com/mindersec/minder)
 * msg systems ag
 * Netdava International
 * Ohio Supercomputer Center
@@ -50,6 +51,7 @@ List of organization names below is based on information collected using Keycloa
 * Quest Software
 * Research Industrial Software Engineering (RISE)
 * Sportsbet.com.au
+* [Stacklok](https://stacklok.com/)
 * Stack Labs
 * Storebrand
 * Synekus


### PR DESCRIPTION
Adds Minder (an OpenSSF project) and Stacklok (a commercial company which uses Keycloak with both Minder and other closed-source applications) to the Adopters list.
