### PR TITLE
Set service account flag to false by default in user search fallback

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/BruteForceUsersResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/BruteForceUsersResource.java
@@ -131,7 +131,7 @@ public class BruteForceUsersResource {
             attributes.putAll(searchAttributes);
 
             return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                    maxResults, true);
+                    maxResults, false);
         } else {
             return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
                     firstResult, maxResults, false);


### PR DESCRIPTION
Closes #34233 

Service account flag was defaulting to true in the fallback else clause of the `searchForUser` method, resulting in unintended behavior. The flag is now explicitly set to false by default in this clause, ensuring consistent handling of service accounts.

