### PR TITLE
fix: resolve attributes on organization #34256

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
@@ -701,6 +701,11 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
         }
 
         @Override
+        public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroup) {
+            return getGroupsStream();
+        }
+
+        @Override
         public Stream<GroupModel> getGroupsStream() {
             Stream<GroupModel> ldapGroupMappings = getLDAPGroupMappingsConverted();
             if (config.getMode() == LDAPGroupMapperMode.LDAP_ONLY) {
@@ -708,7 +713,7 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
                 return ldapGroupMappings;
             } else {
                 // Merge mappings from both DB and LDAP
-                return Stream.concat(ldapGroupMappings, super.getGroupsStream());
+                return Stream.concat(ldapGroupMappings, super.getGroupsStream(true));
             }
         }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -417,6 +417,20 @@ public class UserAdapter implements CachedUserModel {
 
     @Override
     public Stream<GroupModel> getGroupsStream() {
+        return getGroupsStream(false);
+    }
+
+    @Override
+    public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups) {
+        Stream<GroupModel> result = getGroupModelStream();
+        if(withOrganizationGroups) {
+            return result.sorted(Comparator.comparing(GroupModel::getName));
+        } else {
+            return result.filter(g -> Type.REALM.equals(g.getType())).sorted(Comparator.comparing(GroupModel::getName));
+        }
+    }
+
+    private Stream<GroupModel> getGroupModelStream() {
         Stream<GroupModel> result = Stream.empty();
 
         if (updated != null) {
@@ -442,8 +456,7 @@ public class UserAdapter implements CachedUserModel {
                 result = groups.stream();
             }
         }
-
-        return result.filter(g -> Type.REALM.equals(g.getType())).sorted(Comparator.comparing(GroupModel::getName));
+        return result;
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -407,7 +407,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
     }
 
     @Override
-    public Stream<GroupModel> getGroupsStream() {
+    public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups) {
         return getGroupsStream(null, null, null);
     }
 

--- a/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -127,8 +127,12 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     @Override
-    public Stream<GroupModel> getGroupsStream() {
-        return getGroups().stream();
+    public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups) {
+        if(withOrganizationGroups) {
+            return getGroups().stream();
+        } else {
+            return getGroups().stream().filter(g -> !g.getType().equals(GroupModel.Type.ORGANIZATION));
+        }
     }
 
     @Override

--- a/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -126,7 +126,7 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
      *
      */
     @Override
-    public Stream<GroupModel> getGroupsStream() {
+    public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups) {
         Stream<GroupModel> groups = getFederatedStorage().getGroupsStream(realm, this.getId());
         if (appendDefaultGroups()) groups = Stream.concat(groups, realm.getDefaultGroupsStream());
         return Stream.concat(groups, getGroupsInternal().stream());

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -631,7 +631,7 @@ public final class KeycloakModelUtils {
             }
             aggrValues.addAll(values);
         }
-        Stream<Collection<String>> attributes = user.getGroupsStream()
+        Stream<Collection<String>> attributes = user.getGroupsStream(true)
                 .map(group -> resolveAttribute(group, name, aggregateAttrs))
                 .filter(attr -> !attr.isEmpty());
 

--- a/server-spi-private/src/main/java/org/keycloak/storage/adapter/AbstractInMemoryUserAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/adapter/AbstractInMemoryUserAdapter.java
@@ -206,12 +206,15 @@ public abstract class AbstractInMemoryUserAdapter extends UserModelDefaultMethod
     public void setEmailVerified(boolean verified) {
         checkReadonly();
         this.emailVerified = verified;
-
     }
 
     @Override
-    public Stream<GroupModel> getGroupsStream() {
-        return groupIds.stream().map(realm::getGroupById);
+    public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups) {
+        if(withOrganizationGroups) {
+            return groupIds.stream().map(realm::getGroupById);
+        } else {
+            return groupIds.stream().map(realm::getGroupById).filter(g -> !g.getType().equals(GroupModel.Type.ORGANIZATION));
+        }
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -162,7 +162,16 @@ public interface UserModel extends RoleMapperModel {
      *
      * @return a non-null {@link Stream} of groups.
      */
-    Stream<GroupModel> getGroupsStream();
+    default Stream<GroupModel> getGroupsStream() {
+        return getGroupsStream(true);
+    }
+
+    /**
+     * Obtains the groups associated with the user allowing to filter out Organization Groups.
+     *
+     * @return a non-null {@link Stream} of groups.
+     */
+    Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups);
 
     /**
      * Returns a paginated stream of groups within this realm with search in the name

--- a/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
@@ -218,12 +218,12 @@ public class UserModelDelegate implements UserModel {
     public UserModel getDelegate() {
         return delegate;
     }
-    
+
     @Override
     public Long getCreatedTimestamp(){
         return delegate.getCreatedTimestamp();
     }
-    
+
     @Override
     public void setCreatedTimestamp(Long timestamp){
         delegate.setCreatedTimestamp(timestamp);
@@ -232,6 +232,11 @@ public class UserModelDelegate implements UserModel {
     @Override
     public Stream<GroupModel> getGroupsStream() {
         return delegate.getGroupsStream();
+    }
+
+    @Override
+    public Stream<GroupModel> getGroupsStream(boolean withOrganizationGroups) {
+        return delegate.getGroupsStream(withOrganizationGroups);
     }
 
     @Override


### PR DESCRIPTION
This PR is a fix to issue #34256 .

User attribute resolution should aggregate attributes from organization also.
Without this PR, organization attributes are completely ignored on user attribute resolution.