### PR TITLE
Set client in context for dynamic scopes calculation

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -621,6 +621,7 @@ public class TokenManager {
         Set<ClientScopeModel> clientScopes;
 
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
+            session.getContext().setClient(client);
             clientScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, scopeParam)
                     .collect(Collectors.toSet());
         } else {


### PR DESCRIPTION
Closes #33684

If dynamic scopes, lightweight access tokens and client credentials are used at the same time there is a NPE because the client is not set in the context when calculating the scopes. Just setting the client before doing the calculation. Test added.