### PR TITLE
[Backport] Implement pagination for getLDAPRoleMappings (#34043)

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -42,6 +42,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.reflection.Property;
 import org.keycloak.models.utils.reflection.PropertyCriteria;
 import org.keycloak.models.utils.reflection.PropertyQueries;
+import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.Condition;
@@ -288,6 +289,18 @@ public class LDAPUtils {
      */
     public static List<LDAPObject> loadAllLDAPObjects(LDAPQuery ldapQuery, LDAPStorageProvider ldapProvider) {
         LDAPConfig ldapConfig = ldapProvider.getLdapIdentityStore().getConfig();
+        return loadAllLDAPObjects(ldapQuery, ldapConfig);
+    }
+
+    /**
+     * Load all LDAP objects corresponding to given query. We will load them paginated, so we allow to bypass the limitation of 1000
+     * maximum loaded objects in single query in MSAD
+     *
+     * @param ldapQuery LDAP query to be used. The caller should close it after calling this method
+     * @param ldapConfig
+     * @return
+     */
+    public static List<LDAPObject> loadAllLDAPObjects(LDAPQuery ldapQuery, LDAPConfig ldapConfig) {
         boolean pagination = ldapConfig.isPagination();
         if (pagination) {
             // For now reuse globally configured batch size in LDAP provider page

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/UserRolesRetrieveStrategy.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/UserRolesRetrieveStrategy.java
@@ -62,7 +62,8 @@ public interface UserRolesRetrieveStrategy {
 
                 Condition membershipCondition = getMembershipCondition(membershipAttr, userMembership);
                 ldapQuery.addWhereCondition(membershipCondition);
-                return ldapQuery.getResultList();
+
+                return LDAPUtils.loadAllLDAPObjects(ldapQuery, ldapConfig);
             }
         }
 


### PR DESCRIPTION
* Implement pagination for getLDAPRoleMappings

On Active Directory, allow to retrieve more groups than the MaxPageSize (default to 1000). Without this patch, we need to increase the MaxPageSize which does not really scale. Implemented only for the LoadRolesByMember startegy.

Closes #34042

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
