### PR TITLE
Fix flaky test for concurrent client creation on H2 database

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrencyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrencyTest.java
@@ -35,12 +35,14 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.model.StoreProvider;
 import org.keycloak.testsuite.util.UserBuilder;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import org.junit.Ignore;
 
@@ -163,11 +165,18 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
 
             c = realm.clients().get(id).toRepresentation();
             assertNotNull(c);
-            assertTrue("Client " + name + " not found in client list",
-              realm.clients().findAll().stream()
-                .map(ClientRepresentation::getClientId)
-                .filter(Objects::nonNull)
-                .anyMatch(name::equals));
+
+            int findAttempts = 1;
+            if (StoreProvider.getCurrentProvider().equals(StoreProvider.DEFAULT)) {
+                findAttempts = 5;
+            }
+            boolean clientFound = IntStream.range(0, findAttempts)
+                    .anyMatch(i -> realm.clients().findAll().stream()
+                            .map(ClientRepresentation::getClientId)
+                            .filter(Objects::nonNull)
+                            .anyMatch(name::equals));
+
+            assertTrue("Client " + name + " not found in client list after " + findAttempts + " attempts", clientFound);
         }
     }
 
@@ -193,11 +202,18 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
 
             c = client.toRepresentation();
             assertNotNull(c);
-            assertTrue("Client " + name + " not found in client list",
-              clients.findAll().stream()
-                .map(ClientRepresentation::getClientId)
-                .filter(Objects::nonNull)
-                .anyMatch(name::equals));
+
+            int findAttempts = 1;
+            if (StoreProvider.getCurrentProvider().equals(StoreProvider.DEFAULT)) {
+                findAttempts = 5;
+            }
+            boolean clientFound = IntStream.range(0, findAttempts)
+                    .anyMatch(i -> clients.findAll().stream()
+                            .map(ClientRepresentation::getClientId)
+                            .filter(Objects::nonNull)
+                            .anyMatch(name::equals));
+
+            assertTrue("Client " + name + " not found in client list after " + findAttempts + " attempts", clientFound);
 
             client.remove();
             try {


### PR DESCRIPTION
Closes #29290
Closes #31091
Closes #29289

The test seems to fail only when using H2 database. I tested with postgresql, mysql and oracle without being able to reproduce the issue. I increased the number of attempts to 5 for the assertion on the existence of the client in the results of `realm.clients().findAll() `in case the client is missing.
