### PR TITLE
Fix NPE in ConditionalOtpFormAuthenticator if no configuration

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticator.java
@@ -18,16 +18,19 @@
 package org.keycloak.authentication.authenticators.browser;
 
 import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.keycloak.authentication.authenticators.browser.ConditionalOtpFormAuthenticator.OtpDecision.ABSTAIN;
 import static org.keycloak.authentication.authenticators.browser.ConditionalOtpFormAuthenticator.OtpDecision.SHOW_OTP;
@@ -105,8 +108,8 @@ public class ConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-
-        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+        AuthenticatorConfigModel model = context.getAuthenticatorConfig();
+        Map<String, String> config = model != null? model.getConfig() : Collections.emptyMap();
 
         if (tryConcludeBasedOn(voteForUserOtpControlAttribute(context.getUser(), config), context)) {
             return;
@@ -284,30 +287,32 @@ public class ConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
 
     private boolean isOTPRequired(KeycloakSession session, RealmModel realm, UserModel user) {
         MultivaluedMap<String, String> requestHeaders = session.getContext().getRequestHeaders().getRequestHeaders();
-        return realm.getAuthenticatorConfigsStream().anyMatch(configModel -> {
-            if (tryConcludeBasedOn(voteForUserOtpControlAttribute(user, configModel.getConfig()))) {
+        List<Map<String,String>> configs = realm.getAuthenticatorConfigsStream().map(AuthenticatorConfigModel::getConfig)
+                .filter(this::containsConditionalOtpConfig)
+                .collect(Collectors.toList());
+        if (configs.isEmpty()) {
+            // no configuration at all means it is configured
+            return true;
+        }
+        return configs.stream().anyMatch(config -> {
+            if (tryConcludeBasedOn(voteForUserOtpControlAttribute(user, config))) {
                 return true;
             }
-            if (tryConcludeBasedOn(voteForUserRole(realm, user, configModel.getConfig()))) {
+            if (tryConcludeBasedOn(voteForUserRole(realm, user, config))) {
                 return true;
             }
-            if (tryConcludeBasedOn(voteForHttpHeaderMatchesPattern(requestHeaders, configModel.getConfig()))) {
+            if (tryConcludeBasedOn(voteForHttpHeaderMatchesPattern(requestHeaders, config))) {
                 return true;
             }
-            if (configModel.getConfig().get(DEFAULT_OTP_OUTCOME) != null
-                    && configModel.getConfig().get(DEFAULT_OTP_OUTCOME).equals(FORCE)
-                    && configModel.getConfig().size() <= 1) {
+            if (config.get(DEFAULT_OTP_OUTCOME) != null
+                    && config.get(DEFAULT_OTP_OUTCOME).equals(FORCE)
+                    && config.size() <= 1) {
                 return true;
             }
-            if (containsConditionalOtpConfig(configModel.getConfig())
-                && voteForUserOtpControlAttribute(user, configModel.getConfig()) == ABSTAIN
-                && voteForUserRole(realm, user, configModel.getConfig()) == ABSTAIN
-                && voteForHttpHeaderMatchesPattern(requestHeaders, configModel.getConfig()) == ABSTAIN
-                && (voteForDefaultFallback(configModel.getConfig()) == SHOW_OTP
-                    || voteForDefaultFallback(configModel.getConfig()) == ABSTAIN)) {
-                return true;
-            }
-            return false;
+            return voteForUserOtpControlAttribute(user, config) == ABSTAIN
+                && voteForUserRole(realm, user, config) == ABSTAIN
+                && voteForHttpHeaderMatchesPattern(requestHeaders, config) == ABSTAIN
+                && (voteForDefaultFallback(config) == SHOW_OTP || voteForDefaultFallback(config) == ABSTAIN);
         });
     }
 


### PR DESCRIPTION
Closes #34298

Just fixing the NPE in `ConditionalOtpFormAuthenticator` when the authenticator has no configuration. The `isOTPRequired` is a bit strange but I just followed the same idea and just return that it is needed if no configuration is found. Test added.
