### PR TITLE
fix: adding back the exclusion of the args to show config

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -53,7 +53,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
 
     public static final String NAME = "show-config";
     private static final List<String> ignoredPropertyKeys = List.of(
-            "kc.show.config", "kc.profile", "kc.quarkus-properties-enabled", "kc.home.dir");
+            "kc.config.args", "kc.show.config", "kc.profile", "kc.quarkus-properties-enabled", "kc.home.dir");
 
     @Parameters(
             paramLabel = "filter",


### PR DESCRIPTION
closes: #34155

The upstream fix may be different. Having system properties as an undocumented backdoor into the configuration creates some additional concerns that we may want to more systemically address.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
