### PR TITLE
Differentiate error messages for incorrect credentials and account lock

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java
@@ -84,7 +84,7 @@ public class ValidateUsername extends AbstractDirectGrantAuthenticator {
             AuthenticatorUtils.dummyHash(context);
             context.getEvent().user(user);
             context.getEvent().error(bruteForceError);
-            Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid user credentials");
+            Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "User locked due to multiple failed login attempts");
             context.forceChallenge(challengeResponse);
             return;
         }


### PR DESCRIPTION
Now wrong credentials and account locked for too many attempts had the same error message. This commit changes the blocked user error message to make it unique.

Closes #34441

