### PR TITLE
fix: ensure that kc.config.args is omitted from show-config

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -29,15 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
-import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
@@ -52,8 +49,8 @@ import picocli.CommandLine.Parameters;
 public final class ShowConfig extends AbstractCommand implements Runnable {
 
     public static final String NAME = "show-config";
-    private static final List<String> ignoredPropertyKeys = List.of(
-            "kc.show.config", "kc.profile", "kc.quarkus-properties-enabled", "kc.home.dir");
+    private static final List<String> allowedSystemPropertyKeys = List.of(
+            "kc.version");
 
     @Parameters(
             paramLabel = "filter",
@@ -100,28 +97,6 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
                 .filter(ShowConfig::filterByGroup)
                 .collect(Collectors.groupingBy(ShowConfig::groupProperties, Collectors.toSet()));
 
-        StreamSupport.stream(getPropertyNames().spliterator(), false)
-                .filter(new Predicate<String>() {
-                    @Override
-                    public boolean test(String s) {
-                        ConfigValue configValue = getConfigValue(s);
-
-                        if (configValue == null) {
-                            return false;
-                        }
-
-                        return PersistedConfigSource.NAME.equals(configValue.getConfigSourceName());
-                    }
-                })
-                .filter(ShowConfig::filterByGroup)
-                .collect(Collectors.groupingBy(ShowConfig::groupProperties, Collectors.toSet()))
-                .forEach(new BiConsumer<String, Set<String>>() {
-                    @Override
-                    public void accept(String group, Set<String> propertyNames) {
-                        properties.computeIfAbsent(group, name -> new HashSet<>()).addAll(propertyNames);
-                    }
-                });
-
         return properties;
     }
 
@@ -144,7 +119,11 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
 
         PropertyMapper<?> mapper = PropertyMappers.getMapper(property);
 
-        if (mapper != null && mapper.isRunTime()) {
+        if (mapper == null) {
+            if (configValue.getSourceName().equals("SysPropConfigSource") && !allowedSystemPropertyKeys.contains(property)) {
+                return; // most system properties are internally used, and not relevant during show-config
+            }
+        } else if (mapper.isRunTime()) {
             value = getRuntimeProperty(property).orElse(value);
         }
 
@@ -154,10 +133,6 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
     }
 
     private static String groupProperties(String property) {
-        if (property.startsWith("%")) {
-            return "%";
-        }
-
         int endIndex = property.indexOf('.');
 
         if (endIndex == -1) {
@@ -168,10 +143,8 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
     }
 
     private static boolean filterByGroup(String property) {
-        return (property.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK)
-                || property.startsWith(MicroProfileConfigProvider.NS_QUARKUS)
-                || property.startsWith("%"))
-                && !ignoredPropertyKeys.contains(property);
+        return property.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX)
+                || property.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX);
     }
 
     @Override

--- a/quarkus/runtime/src/test/java/or/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/or/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -221,6 +221,17 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getErrString(), containsString("No trust store password provided"));
     }
+    
+    @Test
+    public void testShowConfigHidesSystemProperties() {
+        setSystemProperty("kc.something", "password", () -> {
+            NonRunningPicocli nonRunningPicocli = pseudoLaunch("show-config");
+            // the command line should now show up within the output
+            assertThat(nonRunningPicocli.getOutString(), not(containsString("show-config")));
+            // arbitrary kc system properties should not show up either
+            assertThat(nonRunningPicocli.getOutString(), not(containsString("kc.something")));
+        });
+    }
 
     @Test
     public void failSingleParamWithSpace() {


### PR DESCRIPTION
closes: #34460

Change the logic to be opt-in, rather than opt-out for system properties shown in show-config. It's not expected that users will directly use -Dkc.something=value, so it seems fine to ignore that case.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
