### PR TITLE
Update KEYCLOAK_SESSION cookie to not have sessionId in plaintext

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
@@ -21,6 +21,7 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.HashException;
 import org.keycloak.crypto.JavaAlgorithm;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
@@ -72,6 +73,12 @@ public class HashUtils {
         byte[] hashInput = Arrays.copyOf(hash, hashLength);
 
         return Base64Url.encode(hashInput);
+    }
+
+    public static String sha256UrlEncodedHash(String input, Charset charset) {
+        byte[] inputBytes = input.getBytes(charset);
+        byte[] hashedOutput = hash(JavaAlgorithm.SHA256, inputBytes);
+        return Base64Url.encode(hashedOutput);
     }
 
 }

--- a/core/src/test/java/org/keycloak/HashTest.java
+++ b/core/src/test/java/org/keycloak/HashTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.jose.jws.crypto.HashUtils;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class HashTest {
+
+    @Test
+    public void testSha256Hash() throws Exception {
+        testSha256Hash("myCodeVerifier", StandardCharsets.ISO_8859_1, "rxrlnYFwTggx1TzJeKXupM_TAJia_vbHD35PIlq9tRg");
+        testSha256Hash("myCodeVerifier", StandardCharsets.UTF_8, "rxrlnYFwTggx1TzJeKXupM_TAJia_vbHD35PIlq9tRg");
+
+        testSha256Hash("Some1[^&*$#", StandardCharsets.ISO_8859_1, "lXO5GHk4DoCxiStRrpJgQ-cOnJQmJTb2gh3HJ3Ueq9U");
+        testSha256Hash("Some1[^&*$#", StandardCharsets.UTF_8, "lXO5GHk4DoCxiStRrpJgQ-cOnJQmJTb2gh3HJ3Ueq9U");
+
+        // This will differ between ISO-8851-1 and UTF8 due the special character
+        testSha256Hash("krák", StandardCharsets.ISO_8859_1, "XD3Gb_rLS49onF_rOsTWc7SLa27Vny8AHgmoEOmJx5s");
+        testSha256Hash("krák", StandardCharsets.UTF_8, "QKvM6HItSe5Yi0rQqQgIFhyKhQJCNr4H60eP3YgcjpU");
+    }
+
+    private void testSha256Hash(String codeVerifier, Charset charset, String expectedHash) {
+        String hash1 = HashUtils.sha256UrlEncodedHash(codeVerifier, charset);
+        Assert.assertEquals(hash1, expectedHash);
+    }
+}

--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -51,6 +51,12 @@ stack as a direct replacement.
 When developing extensions for {project_name}, developers can now specify dependencies between provider factories classes by implementing the method `dependsOn()` in the `ProviderFactory` interface.
 See the Javadoc for a detailed description.
 
+= Updated format of KEYCLOAK_SESSION cookie
+
+The format of `KEYCLOAK_SESSION` cookie was slightly updated to not contain any private data in plain text. Until now, the format of the cookie was `realmName/userId/userSessionId`. Now the cookie
+contains user session ID, which is hashed by SHA-256 and URL encoded. This can affect you just in case when implementing your own providers and relying on the format of internal {project_name}
+cookies.
+
 = Removal of robots.txt file
 
 The `robots.txt` file, previously included by default, is now removed. The default `robots.txt` file blocked all crawling, which prevented the `noindex`/`nofollow` directives from being followed. The desired default behaviour is for {project_name} pages to not show up in search engine results and this is accomplished by the existing `X-Robots-Tag` header, which is set to `none` by default. The value of this header can be overidden per-realm if a different behaviour is needed.

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/IframeUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/IframeUtil.java
@@ -25,9 +25,15 @@ import org.keycloak.services.util.CacheControlUtil;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
+import java.util.function.Supplier;
 
 public class IframeUtil {
+
     public static Response returnIframeFromResources(String fileName, String version, KeycloakSession session) {
+        return returnIframe(version, session, () -> IframeUtil.class.getResourceAsStream(fileName));
+    }
+
+    public static Response returnIframe(String version, KeycloakSession session, Supplier<Object> responseEntityProvider) {
         CacheControl cacheControl;
         if (version != null) {
             if (!version.equals(Version.RESOURCES_VERSION)) {
@@ -38,7 +44,7 @@ public class IframeUtil {
             cacheControl = CacheControlUtil.noCache();
         }
 
-        InputStream resource = IframeUtil.class.getResourceAsStream(fileName);
+        Object resource = responseEntityProvider.get();
         if (resource != null) {
             session.getProvider(SecurityHeadersProvider.class).options().allowAnyFrameAncestor();
             return Response.ok(resource).cacheControl(cacheControl).build();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
@@ -23,6 +23,9 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.utils.WebOriginsUtils;
+import org.keycloak.services.Urls;
+import org.keycloak.urls.UrlType;
+import org.keycloak.utils.FreemarkerUtils;
 import org.keycloak.utils.MediaType;
 
 import jakarta.ws.rs.GET;
@@ -31,9 +34,10 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
-import java.util.Set;
+import org.keycloak.utils.SecureContextResolver;
 
-import static org.keycloak.protocol.oidc.endpoints.IframeUtil.returnIframeFromResources;
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -51,7 +55,20 @@ public class LoginStatusIframeEndpoint {
     @GET
     @Produces(MediaType.TEXT_HTML_UTF_8)
     public Response getLoginStatusIframe(@QueryParam("version") String version) {
-        return returnIframeFromResources("login-status-iframe.html", version, session);
+        final var map = new HashMap<String, Object>();
+        final var isSecureContext = SecureContextResolver.isSecureContext(session);
+        final var adminBaseUri = session.getContext().getUri(UrlType.ADMIN).getBaseUri();
+        map.put("isSecureContext", isSecureContext);
+        map.put("resourceCommonUrl", Urls.themeRoot(adminBaseUri).getPath() + "/common/keycloak");
+
+        return IframeUtil.returnIframe(version, session, () -> {
+            try {
+                return FreemarkerUtils.loadTemplateFromClasspath(map, "login-status-iframe.ftl", getClass());
+            } catch (Exception e) {
+                logger.error("Failure when loading login-status-iframe.ftl", e);
+                return null;
+            }
+        });
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
@@ -57,9 +57,9 @@ public class LoginStatusIframeEndpoint {
     public Response getLoginStatusIframe(@QueryParam("version") String version) {
         final var map = new HashMap<String, Object>();
         final var isSecureContext = SecureContextResolver.isSecureContext(session);
-        final var adminBaseUri = session.getContext().getUri(UrlType.ADMIN).getBaseUri();
+        final var serverBaseUri = session.getContext().getUri(UrlType.FRONTEND).getBaseUri();
         map.put("isSecureContext", isSecureContext);
-        map.put("resourceCommonUrl", Urls.themeRoot(adminBaseUri).getPath() + "/common/keycloak");
+        map.put("resourceCommonUrl", Urls.themeRoot(serverBaseUri).getPath() + "/common/keycloak");
 
         return IframeUtil.returnIframe(version, session, () -> {
             try {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -432,7 +432,7 @@ public class LogoutEndpoint {
             return initiateBrowserLogout(userSession);
         } else if (userSession != null) {
             // identity cookie is missing but there's valid id_token_hint which matches session cookie => continue with browser logout
-            if (userSessionIdFromIdToken.equals(AuthenticationManager.getSessionIdFromSessionCookie(session))) {
+            if (AuthenticationManager.compareSessionIdWithSessionCookie(session, userSessionIdFromIdToken)) {
                 return initiateBrowserLogout(userSession);
             }
             // check if the user session is not logging out or already logged out

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/PkceUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/PkceUtils.java
@@ -5,15 +5,16 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.crypto.HashException;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
+import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.services.cors.Cors;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,11 +46,8 @@ public class PkceUtils {
     }
 
     // https://tools.ietf.org/html/rfc7636#section-4.6
-    public static String generateS256CodeChallenge(String codeVerifier) throws Exception {
-        MessageDigest md = MessageDigest.getInstance("SHA-256");
-        md.update(codeVerifier.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] digestBytes = md.digest();
-        return Base64Url.encode(digestBytes);
+    public static String generateS256CodeChallenge(String codeVerifier) throws HashException {
+        return HashUtils.sha256UrlEncodedHash(codeVerifier, StandardCharsets.ISO_8859_1);
     }
 
     public static boolean validateCodeChallenge(String verifier, String codeChallenge, String codeChallengeMethod) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -960,9 +960,7 @@ public class AuthenticationManager {
      * @return true if sessionId matches with the session from KEYCLOAK_SESSION_COOKIE
      */
     public static boolean compareSessionIdWithSessionCookie(KeycloakSession session, String sessionId) {
-        if (sessionId == null) {
-            throw new IllegalArgumentException("Not expected to provide null sessionId");
-        }
+        Objects.requireNonNull(sessionId, "Session id cannot be null");
 
         String cookie = session.getProvider(CookieProvider.class).get(CookieType.SESSION);
         if (cookie == null || cookie.isEmpty()) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -804,9 +804,7 @@ public class AuthenticationManager {
     }
 
     public static void createLoginCookie(KeycloakSession keycloakSession, RealmModel realm, UserModel user, UserSessionModel session, UriInfo uriInfo, ClientConnection connection) {
-        if (session == null) {
-            throw new IllegalArgumentException("User session cannot be null");
-        }
+        assert session != null : "User session cannot be null";
         String issuer = Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName());
         IdentityCookieToken identityCookieToken = createIdentityToken(keycloakSession, realm, user, session, issuer);
         String encoded = keycloakSession.tokens().encode(identityCookieToken);

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -804,7 +804,7 @@ public class AuthenticationManager {
     }
 
     public static void createLoginCookie(KeycloakSession keycloakSession, RealmModel realm, UserModel user, UserSessionModel session, UriInfo uriInfo, ClientConnection connection) {
-        assert session != null : "User session cannot be null";
+        Objects.requireNonNull(session, "User session cannot be null");
         String issuer = Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName());
         IdentityCookieToken identityCookieToken = createIdentityToken(keycloakSession, realm, user, session, issuer);
         String encoded = keycloakSession.tokens().encode(identityCookieToken);

--- a/services/src/main/java/org/keycloak/utils/FreemarkerUtils.java
+++ b/services/src/main/java/org/keycloak/utils/FreemarkerUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.utils;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Map;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class FreemarkerUtils {
+
+    /**
+     * Load the template from classpath
+     *
+     * @param contextMap map with the attributes passed to freemarker
+     * @param templateFile Name of the file, which is supposed to be available on classpath
+     * @param clazz Class, which should be in same package as the template
+     * @return template from classpath
+     */
+    public static String loadTemplateFromClasspath(Map<String, Object> contextMap, String templateFile, Class<?> clazz) throws TemplateException, IOException {
+        Configuration freemarkerConfig = new Configuration(Configuration.VERSION_2_3_32);
+        freemarkerConfig.setClassForTemplateLoading(clazz, "");
+        Template freemarkerTemplate = freemarkerConfig.getTemplate(templateFile);
+
+        Writer out = new StringWriter();
+        freemarkerTemplate.process(contextMap, out);
+        return out.toString();
+    }
+}

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.ftl
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.ftl
@@ -52,7 +52,7 @@
             preventAdditionalRequests = true;
           }
 
-          const url = new URL(window.location.origin + window.location.pathname + "/init");
+          const url = new URL(location.origin + location.pathname + "/init");
 
           url.searchParams.set("client_id", clientId);
           url.searchParams.set("origin", origin);

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.ftl
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.ftl
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
   </head>
   <body>
+    <#if !isSecureContext>
+      <script type="module" src="${resourceCommonUrl}/vendor/web-crypto-shim/web-crypto-shim.js"></script>
+    </#if>
     <script type="module">
       window.addEventListener("message", onMessage);
 
@@ -49,7 +52,7 @@
             preventAdditionalRequests = true;
           }
 
-          const url = new URL(`${location.origin}${location.pathname}/init`);
+          const url = new URL(window.location.origin + window.location.pathname + "/init");
 
           url.searchParams.set("client_id", clientId);
           url.searchParams.set("origin", origin);

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.html
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.html
@@ -72,6 +72,10 @@
 
         // If the client and origin from the event match the verified ones from the server, signal if the cookie has changed.
         if (clientId === init.clientId && origin === init.origin) {
+          const hashedSessionId = await hashString(sessionState);
+          if (hashedSessionId === cookie) return "unchanged";
+
+          // Backwards compatibility with versions older than 26.1
           const [, , cookieSessionState] = cookie.split("/");
           return sessionState === cookieSessionState ? "unchanged" : "changed";
         }
@@ -120,6 +124,42 @@
         }
         return null;
       }
+
+      /**
+       * @param {ArrayBuffer} bytes
+       * @see https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+       */
+      function bytesToBase64(bytes) {
+        const binString = String.fromCodePoint(...bytes);
+        return btoa(binString);
+      }
+
+      /**
+        * @param {string} message
+        * @see https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#basic_example
+        */
+      async function sha256Digest(message) {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(message);
+
+        if (typeof crypto === "undefined" || typeof crypto.subtle === "undefined") {
+          throw new Error("Web Crypto API is not available.");
+        }
+
+        return await crypto.subtle.digest("SHA-256", data);
+      }
+
+      async function hashString(str) {
+        // hash codeVerifier, then encode as url-safe base64 without padding
+        const hashBytes = new Uint8Array(await sha256Digest(str));
+        const encodedHash = bytesToBase64(hashBytes)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/\=/g, '');
+
+        return encodedHash;
+      }
+
     </script>
   </body>
 </html>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -267,9 +267,11 @@ public class UserStorageTest extends AbstractAuthTest {
 
         Cookie sameSiteSessionCookie = driver.manage().getCookieNamed(CookieType.SESSION.getName());
 
+        Assert.assertNotNull(sameSiteSessionCookie);
+        Assert.assertNotNull(sameSiteSessionCookie.getValue());
         String cookieValue = sameSiteSessionCookie.getValue();
         assertThat(cookieValue.contains("spécial"), is(false));
-        assertThat(cookieValue.contains("sp%C3%A9cial"), is(true));
+        assertThat(cookieValue.contains("sp%C3%A9cial"), is(false));
 
         AccountHelper.logout(testRealmResource(), "spécial");
     }


### PR DESCRIPTION
closes #34026

- Updated `KEYCLOAK_SESSION` state cookie to not have sessionId in plain-text. More details described in the #34026

- This handles also the backwards compatibility, so the migration from previous versions works as expected. After migration from previous version, user is not logged-out. The verification in `login-status-iframe.html` as well as in `AuthenticationManager.compareSessionIdWithSessionCookie` also takes the old format of the cookie into account.
