### PR TITLE
Make documentation more clear that keycloak javascript adapter and node.js adapter are OIDC

### DIFF
--- a/docs/guides/securing-apps/javascript-adapter.adoc
+++ b/docs/guides/securing-apps/javascript-adapter.adoc
@@ -7,6 +7,7 @@ priority=30
 summary="Client-side JavaScript library that can be used to secure web applications.">
 
 {project_name} comes with a client-side JavaScript library called `keycloak-js` that can be used to secure web applications. The adapter also comes with built-in support for Cordova applications.
+The adapter uses OpenID Connect protocol under the covers. You can take a look <<_oidc_available_endpoints, at this section>> for the more generic informations about OpenID Connect endpoints and capabilities.
 
 == Installation
 

--- a/docs/guides/securing-apps/nodejs-adapter.adoc
+++ b/docs/guides/securing-apps/nodejs-adapter.adoc
@@ -7,6 +7,7 @@ priority=40
 summary="Node.js adapter to protect server-side JavaScript apps">
 
 {project_name} provides a Node.js adapter built on top of https://github.com/senchalabs/connect[Connect] to protect server-side JavaScript apps - the goal was to be flexible enough to integrate with frameworks like https://expressjs.com/[Express.js].
+The adapter uses OpenID Connect protocol under the covers. You can take a look <<_oidc_available_endpoints, at this section>> for the more generic informations about OpenID Connect endpoints and capabilities.
 
 ifeval::[{project_community}==true]
 The library can be downloaded directly from https://www.npmjs.com/package/keycloak-connect[ {project_name} organization] and the source is available at

--- a/docs/guides/securing-apps/partials/oidc/available-endpoints.adoc
+++ b/docs/guides/securing-apps/partials/oidc/available-endpoints.adoc
@@ -1,3 +1,5 @@
+
+[[_oidc_available_endpoints]]
 == Available Endpoints
 
 As a fully-compliant OpenID Connect Provider implementation, {project_name} exposes a set of endpoints that applications


### PR DESCRIPTION
closes #34570

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit d80cb010ff087401569ec9c6dd544e0e6f0e5683)
