### PR TITLE
Fix credential_type in update/remove credential email template

### DIFF
--- a/services/src/main/java/org/keycloak/email/freemarker/beans/EventBean.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/beans/EventBean.java
@@ -58,6 +58,12 @@ public class EventBean {
         return details;
     }
 
+    public String getDetail(String name) {
+        return event.getDetails() != null
+                ? event.getDetails().get(name)
+                : null;
+    }
+
     public static class DetailBean {
 
         private Map.Entry<String, String> entry;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.testsuite.actions;
 
+import jakarta.mail.internet.MimeMessage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.After;
@@ -26,6 +29,7 @@ import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.cookie.CookieType;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
+import org.keycloak.events.email.EmailEventListenerProviderFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
@@ -35,7 +39,10 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.LoginPasswordUpdatePage;
+import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
+import org.keycloak.testsuite.updaters.UserAttributeUpdater;
 import org.keycloak.testsuite.util.GreenMailRule;
+import org.keycloak.testsuite.util.MailUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.SecondBrowser;
 import org.openqa.selenium.Cookie;
@@ -81,48 +88,66 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
 
     @Test
     public void resetPassword() throws Exception {
-        loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        try (RealmAttributeUpdater realmUpdater = new RealmAttributeUpdater(testRealm())
+                .addEventsListener(EmailEventListenerProviderFactory.ID)
+                .update();
+             UserAttributeUpdater userUpdater = new UserAttributeUpdater(ApiUtil.findUserByUsernameId(testRealm(), "test-user@localhost"))
+                .setEmailVerified(true)
+                .update()) {
 
-        events.expectLogin().assertEvent();
+            loginPage.open();
+            loginPage.login("test-user@localhost", "password");
 
-        doAIA();
+            events.expectLogin().assertEvent();
 
-        changePasswordPage.assertCurrent();
-        assertTrue(changePasswordPage.isCancelDisplayed());
+            doAIA();
 
-        Cookie authSessionCookie = driver.manage().getCookieNamed(CookieType.AUTH_SESSION_ID.getName());
-        String authSessionId = authSessionCookie.getValue().split("\\.")[0];
-        testingClient.server().run(session -> {
-            // ensure that our logic to detect the authentication session works as expected
-            RealmModel realm = session.realms().getRealm(TEST_REALM_NAME);
-            assertNotNull(session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId));
-        });
+            changePasswordPage.assertCurrent();
+            assertTrue(changePasswordPage.isCancelDisplayed());
 
-        changePasswordPage.changePassword("new-password", "new-password");
+            Cookie authSessionCookie = driver.manage().getCookieNamed(CookieType.AUTH_SESSION_ID.getName());
+            String authSessionId = authSessionCookie.getValue().split("\\.")[0];
+            testingClient.server().run(session -> {
+                // ensure that our logic to detect the authentication session works as expected
+                RealmModel realm = session.realms().getRealm(TEST_REALM_NAME);
+                assertNotNull(session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId));
+            });
 
-        testingClient.server().run(session -> {
-            // ensure that the authentication session has been terminated
-            RealmModel realm = session.realms().getRealm(TEST_REALM_NAME);
-            assertNull(session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId));
-        });
+            changePasswordPage.changePassword("new-password", "new-password");
 
-        events.expectRequiredAction(EventType.UPDATE_PASSWORD).assertEvent();
-        events.expectRequiredAction(EventType.UPDATE_CREDENTIAL).detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE).assertEvent();
+            testingClient.server().run(session -> {
+                // ensure that the authentication session has been terminated
+                RealmModel realm = session.realms().getRealm(TEST_REALM_NAME);
+                assertNull(session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId));
+            });
 
-        assertKcActionStatus(SUCCESS);
+            events.expectRequiredAction(EventType.UPDATE_PASSWORD).assertEvent();
+            events.expectRequiredAction(EventType.UPDATE_CREDENTIAL).detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE).assertEvent();
 
-        EventRepresentation loginEvent = events.expectLogin().assertEvent();
+            MimeMessage[] receivedMessages = greenMail.getReceivedMessages();
+            Assert.assertEquals(2, receivedMessages.length);
 
-        OAuthClient.AccessTokenResponse tokenResponse = sendTokenRequestAndGetResponse(loginEvent);
-        oauth.idTokenHint(tokenResponse.getIdToken()).openLogout();
+            Assert.assertEquals("Update password", receivedMessages[0].getSubject());
+            Assert.assertEquals("Update credential", receivedMessages[1].getSubject());
+            MatcherAssert.assertThat(MailUtils.getBody(receivedMessages[1]).getText(),
+                    Matchers.startsWith("Your password credential was changed"));
+            MatcherAssert.assertThat(MailUtils.getBody(receivedMessages[1]).getHtml(),
+                    Matchers.containsString("Your password credential was changed"));
 
-        events.expectLogout(loginEvent.getSessionId()).assertEvent();
+            assertKcActionStatus(SUCCESS);
 
-        loginPage.open();
-        loginPage.login("test-user@localhost", "new-password");
+            EventRepresentation loginEvent = events.expectLogin().assertEvent();
 
-        events.expectLogin().assertEvent();
+            OAuthClient.AccessTokenResponse tokenResponse = sendTokenRequestAndGetResponse(loginEvent);
+            oauth.idTokenHint(tokenResponse.getIdToken()).openLogout();
+
+            events.expectLogout(loginEvent.getSessionId()).assertEvent();
+
+            loginPage.open();
+            loginPage.login("test-user@localhost", "new-password");
+
+            events.expectLogin().assertEvent();
+        }
     }
 
     @Test

--- a/themes/src/main/resources/theme/base/email/html/event-remove_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/html/event-remove_credential.ftl
@@ -1,4 +1,9 @@
 <#import "template.ftl" as layout>
+<#list event.details as detail>
+    <#if detail.key == "credential_type">
+        <#assign credential_type = detail.value>
+    </#if>
+</#list>
 <@layout.emailLayout>
-${kcSanitize(msg("eventRemoveCredentialBodyHtml", event.details.credential_type!"unknown", event.date, event.ipAddress))?no_esc}
+${kcSanitize(msg("eventRemoveCredentialBodyHtml", credential_type!"unknown", event.date, event.ipAddress))?no_esc}
 </@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/html/event-remove_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/html/event-remove_credential.ftl
@@ -1,9 +1,4 @@
 <#import "template.ftl" as layout>
-<#list event.details as detail>
-    <#if detail.key == "credential_type">
-        <#assign credential_type = detail.value>
-    </#if>
-</#list>
 <@layout.emailLayout>
-${kcSanitize(msg("eventRemoveCredentialBodyHtml", credential_type!"unknown", event.date, event.ipAddress))?no_esc}
+${kcSanitize(msg("eventRemoveCredentialBodyHtml", event.getDetail("credential_type")!"unknown", event.date, event.ipAddress))?no_esc}
 </@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/html/event-update_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/html/event-update_credential.ftl
@@ -1,9 +1,4 @@
 <#import "template.ftl" as layout>
-<#list event.details as detail>
-    <#if detail.key == "credential_type">
-        <#assign credential_type = detail.value>
-    </#if>
-</#list>
 <@layout.emailLayout>
-${kcSanitize(msg("eventUpdateCredentialBodyHtml", credential_type!"unknown", event.date, event.ipAddress))?no_esc}
+${kcSanitize(msg("eventUpdateCredentialBodyHtml", event.getDetail("credential_type")!"unknown", event.date, event.ipAddress))?no_esc}
 </@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/html/event-update_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/html/event-update_credential.ftl
@@ -1,4 +1,9 @@
 <#import "template.ftl" as layout>
+<#list event.details as detail>
+    <#if detail.key == "credential_type">
+        <#assign credential_type = detail.value>
+    </#if>
+</#list>
 <@layout.emailLayout>
-${kcSanitize(msg("eventUpdateCredentialBodyHtml", event.details.credential_type!"unknown", event.date, event.ipAddress))?no_esc}
+${kcSanitize(msg("eventUpdateCredentialBodyHtml", credential_type!"unknown", event.date, event.ipAddress))?no_esc}
 </@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/text/event-remove_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-remove_credential.ftl
@@ -1,7 +1,2 @@
 <#ftl output_format="plainText">
-<#list event.details as detail>
-    <#if detail.key == "credential_type">
-        <#assign credential_type = detail.value>
-    </#if>
-</#list>
-${msg("eventRemoveCredentialBody", credential_type!"unknown", event.date, event.ipAddress)}
+${msg("eventRemoveCredentialBody", event.getDetail("credential_type")!"unknown", event.date, event.ipAddress)}

--- a/themes/src/main/resources/theme/base/email/text/event-remove_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-remove_credential.ftl
@@ -1,2 +1,7 @@
 <#ftl output_format="plainText">
-${msg("eventRemoveCredentialBody", event.details.credential_type!"unknown", event.date, event.ipAddress)}
+<#list event.details as detail>
+    <#if detail.key == "credential_type">
+        <#assign credential_type = detail.value>
+    </#if>
+</#list>
+${msg("eventRemoveCredentialBody", credential_type!"unknown", event.date, event.ipAddress)}

--- a/themes/src/main/resources/theme/base/email/text/event-update_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-update_credential.ftl
@@ -1,7 +1,2 @@
 <#ftl output_format="plainText">
-<#list event.details as detail>
-    <#if detail.key == "credential_type">
-        <#assign credential_type = detail.value>
-    </#if>
-</#list>
-${msg("eventUpdateCredentialBody", credential_type!"unknown", event.date, event.ipAddress)}
+${msg("eventUpdateCredentialBody", event.getDetail("credential_type")!"unknown", event.date, event.ipAddress)}

--- a/themes/src/main/resources/theme/base/email/text/event-update_credential.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-update_credential.ftl
@@ -1,2 +1,7 @@
 <#ftl output_format="plainText">
-${msg("eventUpdateCredentialBody", event.details.credential_type!"unknown", event.date, event.ipAddress)}
+<#list event.details as detail>
+    <#if detail.key == "credential_type">
+        <#assign credential_type = detail.value>
+    </#if>
+</#list>
+${msg("eventUpdateCredentialBody", credential_type!"unknown", event.date, event.ipAddress)}


### PR DESCRIPTION
Closes #34687

This fixes the broken update/remove credential email templates, as mentioned in #32685 

Background:
The `event.details` are transformed by the `ThemeBean` to a list of a key/value pairs, so a direct access with `event.details.credential_type` is not possible. We have to lookup the key `credential_type ` in the list, and display its value.