### PR TITLE
Allow OIDCIdentityProvider implementations to override isTokenTypeSupported (#34695)

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -892,7 +892,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
 
     }
 
-    protected static boolean isTokenTypeSupported(JsonWebToken parsedToken) {
+    protected boolean isTokenTypeSupported(JsonWebToken parsedToken) {
         return SUPPORTED_TOKEN_TYPES.contains(parsedToken.getType());
     }
 


### PR DESCRIPTION

Fixes #34695

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
