### PR TITLE
Prevent Unexpected RESTART_AUTHENTICATION_ERROR on iOS browsers

### DIFF
--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -29,7 +29,9 @@ export function checkCookiesAndSetTimer(loginRestartUrl) {
     );
   } else {
     // Redirect to the login restart URL. This can typically automatically login user due the SSO
-    location.href = loginRestartUrl;
+    if (getCookieByName("KC_RESTART")) {
+      location.href = loginRestartUrl;
+    }
   }
 }
 


### PR DESCRIPTION
## Issue

Closes https://github.com/keycloak/keycloak/issues/33071

Unexpected requests to `/realms/{realm_name}/login-actions/restart` are causing RESTART_AUTHENTICATION_ERROR. This error overrides the OIDC client state (particularly affecting Cloudflare Zero Trust service) and can trigger CODE_TO_TOKEN_ERROR, resulting in unexpected unauthenticated errors.

Note: The occurrence of CODE_TO_TOKEN_ERROR is inconsistent and depends on the timing of the request to `/realms/{realm_name}/login-actions/restart`.

## Root Cause

The `checkCookiesAndSetTimer` function in `themes/src/main/resources/theme/base/login/resources/js/authChecker.js` is not properly unloaded or cleared in the browser, leading to unexpected execution. This issue has been reproduced on iOS Safari and Google Chrome.

Comparison of network logs between environments where the problem does not occur (PC) and where it does (mobile) reveals an unexpected `/realms/teamv/login-actions/restart` request being sent.

## Tested Environment
- IdP: Keycloak 26.0.5 (docker image quay.io/keycloak/keycloak:26.0.5)
- OIDC Client: Cloudflare (ref: [Cloudflare One Identity Documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/generic-oidc/))

## Test Cases
The following test cases were conducted using Passkey authentication on the default theme UI, with requests analyzed through a local proxy.

### Test Case 1: Success (No error)
Environment:
- Ubuntu 22.04
- Google Chrome: Version 130.0.6723.91 (Official Build) (64-bit)

Normal authentication flow:
1. GET `/realms/{realm_name}/protocol/openid-connect/auth` (200 OK)
	- loads `checkCookiesAndSetTimer`
    - set KC_RESTART cookie
3. POST `/realms/{realm_name}/login-actions/authenticate` (input username) (200 OK)
	- loads `checkCookiesAndSetTimer` 
5. POST `/realms/{realm_name}/login-actions/authenticate` (input credentials) (302 Found)
    - unset KC_RESTART cookie
7. GET `/cdn-cgi/access/callback` (302 Found)
8. GET `/cdn-cgi/access/authorized` (302 Found)

### Test Case 2: Failure (RESTART_AUTHENTICATION_ERROR)
Environment:
- iOS 18.0.1
- Safari 17.4 (19618.1.15.11.12)

Flow with RESTART_AUTHENTICATION_ERROR:
1. GET `/realms/{realm_name}/protocol/openid-connect/auth` (200 OK)
	- loads `checkCookiesAndSetTimer`
    - set KC_RESTART cookie
3. POST `/realms/{realm_name}/login-actions/authenticate` (input username) (200 OK)
	- loads `checkCookiesAndSetTimer` 
5. POST `/realms/{realm_name}/login-actions/authenticate` (input credentials) (302 Found)
    - unset KC_RESTART cookie
7. GET `/cdn-cgi/access/callback` (302 Found)
8. GET `/cdn-cgi/access/authorized` (302 Found)
9. GET `/realms/{realm_name}/login-actions/restart` -> RESTART_AUTHENTICATION_ERROR

Web inspector analysis suggests that the timer unload code is not executed at the expected timing on iOS browsers:

```javascript
addEventListener("beforeunload", () => {
  if (timeout) {
    clearTimeout(timeout);
    timeout = undefined;
  }
});
```

It appears the root cause was the `beforeunload` event not functioning correctly in iOS browsers. While the documentation at https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event states that it's supported, in practice, it wasn't working as expected.

As a result, the restart request is invoked by the checkCookiesAndSetTimer function, even though the KC_RESTART cookie has already been cleared by valid authentication. This function/timer event is expected to be cleared after a valid authentication but does not in the case of access from iOS browsers.

### Proposed Solution

Add validation before redirect to prevent unintended restart requests, as there should be no case where `login-actions/restart` is called without the KC_RESTART cookie being set.

### Post-Fix Testing

Confirmed that the RESTART_AUTHENTICATION_ERROR no longer reproduces on iOS browsers after the fix.

### Relevant Code for `login-actions/restart` 
- Route definition of login-action/restart: [Urls.java#L178](https://github.com/keycloak/keycloak/blob/d2e19da64eb76176e70c84292d847d4876772855/services/src/main/java/org/keycloak/services/Urls.java#L178)
- `public static AuthenticationSessionModel restartSession`: [RestartLoginCookie.java#L142](https://github.com/keycloak/keycloak/blob/d2e19da64eb76176e70c84292d847d4876772855/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java#L142)
