### PR TITLE
Fix(admin-ui): key status filtering issue in KeysListTab

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/keys/KeysListTab.tsx
@@ -14,7 +14,7 @@ import {
 } from "@patternfly/react-core";
 import { FilterIcon } from "@patternfly/react-icons";
 import { cellWidth } from "@patternfly/react-table";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useAdminClient } from "../../admin-client";
@@ -30,6 +30,7 @@ import { toKeysTab } from "../routes/KeysTab";
 import "../realm-settings-section.css";
 
 const FILTER_OPTIONS = ["ACTIVE", "PASSIVE", "DISABLED"] as const;
+
 type FilterType = (typeof FILTER_OPTIONS)[number];
 
 type KeyData = KeyMetadataRepresentation & {
@@ -94,8 +95,14 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
 
   const { realm } = useRealm();
 
-  const [keyData, setKeyData] = useState<KeyData[]>();
-  const [filteredKeyData, setFilteredKeyData] = useState<KeyData[]>();
+  const [keyData, setKeyData] = useState<KeyData[]>([]);
+
+  const [filter, setFilter] = useState<string>(FILTER_OPTIONS[0]);
+
+  const filteredKeyData = useMemo(
+    () => keyData?.filter(({ status }) => status === filter),
+    [keyData, filter],
+  );
 
   useFetch(
     async () => {
@@ -139,19 +146,11 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
       <KeycloakDataTable
         isNotCompact
         className="kc-keys-list"
-        loader={filteredKeyData || keyData}
+        loader={filteredKeyData}
         ariaLabelKey="keysList"
         searchPlaceholderKey="searchKey"
         searchTypeComponent={
-          <SelectFilter
-            onFilter={(filterType) =>
-              setFilteredKeyData(
-                filterType !== FILTER_OPTIONS[0]
-                  ? keyData!.filter(({ status }) => status === filterType)
-                  : undefined,
-              )
-            }
-          />
+          <SelectFilter onFilter={(filterType) => setFilter(filterType)} />
         }
         columns={[
           {


### PR DESCRIPTION
## Issue Overview:  

Support customer reports that keys with 'Active' set to 'off' still appear in the Active keys list in the Admin console under Realms settings -> Keys -> Keys list. The root cause was identified as the filtering logic, which does not apply status-based filtering for the first item in FILTER_OPTIONS ('ACTIVE'). This commit corrects the filtering logic to properly exclude keys based on the 'Active' status selection.

## Solution 

This PR refactors the filtering logic in `KeysListTab.tsx` to ensure that only keys matching the selected status appear in the list. Specifically, it uses `useMemo` to cache and apply the correct filter based on the current selection, so that keys with an "Inactive" status are no longer shown in the Active keys list.

## How to Test It

### Steps to Reproduce the Bug (without the PR)

1. Set up the latest stable version of **Keycloak (26.0.4).**
2. Open a terminal and generate a new key with the following command:

```bash
keytool -genkeypair -alias <alias> -keyalg RSA -keysize 2048 -validity 365 -keystore <key-name>.jks
```

3. In the Keycloak Admin Console, go to **Realms settings -> Keys -> Add Provider** and add the generated key.

4. Set the key's Active status to "off".

5. Observe the bug: The key still appears in  **Realms settings -> Keys ->  keys list**, even though its status is set to inactive.


### Steps to Verify the Fix (with the PR applied)

1. Repeat steps 3-4 above to add a new key with the "Active" status set to "off."

2. Verify that the key does not appear in the Active keys list under Keys list.


Closes #34675