### PR TITLE
Fix error handling for duplicate group names and CSS selector update

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/group_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/group_test.spec.ts
@@ -34,6 +34,11 @@ describe("Group test", () => {
   let users: { id: string; username: string }[] = [];
   const username = "test-user";
 
+  const duplicatedGroupErrorMessage = {
+    mainGroup: "Could not create group Top level group named '",
+    childGroup: "Could not create group Sibling group named '",
+  };
+
   before(async () => {
     users = await Promise.all(
       range(5).map((index) => {
@@ -98,7 +103,10 @@ describe("Group test", () => {
         .assertNoGroupsInThisRealmEmptyStateMessageExist(false)
         .createGroup(groupName, false)
         .createGroup(groupName, false)
-        .assertNotificationCouldNotCreateGroupWithDuplicatedName(groupName);
+        .assertNotificationCouldNotCreateGroupWithDuplicatedName(
+          groupName,
+          duplicatedGroupErrorMessage.mainGroup,
+        );
       groupModal.closeModal();
       groupPage.searchGroup(groupName).assertGroupItemsEqual(1);
     });
@@ -267,11 +275,12 @@ describe("Group test", () => {
     });
 
     // https://github.com/keycloak/keycloak-admin-ui/issues/2726
-    it.skip("Fail to create group with duplicated name", () => {
+    it("Fail to create group with duplicated name", () => {
       childGroupsTab
         .createGroup(predefinedGroups[2], false)
         .assertNotificationCouldNotCreateGroupWithDuplicatedName(
           predefinedGroups[2],
+          duplicatedGroupErrorMessage.childGroup,
         );
     });
 

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/ListingPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/ListingPage.ts
@@ -33,7 +33,7 @@ export default class ListingPage extends CommonElements {
   #deleteUserButton = "delete-user-btn";
   #emptyListImg = '[role="tabpanel"]:not([hidden]) [data-testid="empty-state"]';
   #emptyState = "empty-state";
-  #itemRowDrpDwn = ".pf-v5-c-table__action button";
+  #itemRowDrpDwn = ".pf-v5-c-menu-toggle";
   #itemRowSelect = "[data-testid='cell-dropdown']";
   #itemRowSelectItem = ".pf-v5-c-menu__item";
   #itemCheckbox = ".pf-v5-c-table__check";

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/ListingPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/ListingPage.ts
@@ -33,7 +33,7 @@ export default class ListingPage extends CommonElements {
   #deleteUserButton = "delete-user-btn";
   #emptyListImg = '[role="tabpanel"]:not([hidden]) [data-testid="empty-state"]';
   #emptyState = "empty-state";
-  #itemRowDrpDwn = ".pf-v5-c-menu-toggle";
+  #itemRowDrpDwn = ".pf-v5-c-table__action button";
   #itemRowSelect = "[data-testid='cell-dropdown']";
   #itemRowSelectItem = ".pf-v5-c-menu__item";
   #itemCheckbox = ".pf-v5-c-table__check";

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/groups/GroupPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/groups/GroupPage.ts
@@ -201,11 +201,12 @@ export default class GroupPage extends PageObject {
     return this;
   }
 
-  assertNotificationCouldNotCreateGroupWithDuplicatedName(groupName: string) {
+  assertNotificationCouldNotCreateGroupWithDuplicatedName(
+    groupName: string,
+    errorMessage: string,
+  ) {
     masthead.checkNotificationMessage(
-      "Could not create group Top level group named '" +
-        groupName +
-        "' already exists.",
+      errorMessage + groupName + "' already exists.",
     );
     return this;
   }


### PR DESCRIPTION
CI was failing because of the error handling for duplicate group names. This PR fixes the error handling and updates the CSS selector for the group name input field.

## How to test it : 

Once you have a Keycloack UP run : 

```bash 
pnpm cypress run --spec "cypress/e2e/group_test.spec.ts"
```

You should see this result:

![duplicatedGroup](https://github.com/user-attachments/assets/8544c1f5-5d73-412e-8f6a-7561a7c0a5cf)


Closes #34605

