### PR TITLE
Fix broken JavaScript adapter tests when running in cross-origin context

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -187,6 +187,10 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
             commands.add("--log-level=" + System.getProperty("auth.server.quarkus.log-level"));
         }
 
+        if (System.getProperty("auth.server.host") != null) {
+            commands.add("-Dauth.server.host=" + System.getProperty("auth.server.host"));
+        }
+
         commands.addAll(getAdditionalBuildArgs());
 
         commands = configureArgs(commands);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -282,7 +282,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .init(iframeInterval)
                 .wait(2000, (driver1, output, events) -> { // iframe is initialized after ~1 second, 2 seconds is just to be sure
                     assertAdapterIsLoggedIn(driver1, output, events);
-                    final String logMsg = "3rd party cookies aren't supported by this browser.";
+                    final String logMsg = "Your browser is blocking access to 3rd-party cookies, this means:";
                     if (SuiteContext.BROWSER_STRICT_COOKIES) {
                         // this is here not really to test the log but also to make sure the browser is configured properly
                         // and cookies were blocked


### PR DESCRIPTION
Closes #23732

Signed-off-by: Jon Koops <jonkoops@gmail.com>
Signed-off-by: rmartinc <rmartinc@redhat.com>
Co-auhored-by: rmartinc <rmartinc@redhat.com>
(cherry picked from commit 82ad09b649fcd89b2ba7e6f5b4b312353965d879)
