### PR TITLE
Disable trim_trailing_whitespace in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,11 @@
 root = true
 
-[{*.java,*.js,*.tsx,*.adoc}]
+[{*.js,*.tsx,*.adoc}]
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.java]
+insert_final_newline = true
 # Don't use class imports with an asterisk ('*') in IntelliJ
 ij_java_use_single_class_imports = true
 ij_java_class_count_to_use_import_on_demand = 999


### PR DESCRIPTION
Currently, the trim_trailing_whitespace setting is enabled for *.java files which leads to a lot of noise when doing simple changes in a PR. This makes it harder to see the essence of the PR.

Fixes #34755

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
