### PR TITLE
Mitigate Unexpected RESTART_AUTHENTICATION_ERROR on iOS Browsers

### DIFF
--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -1,15 +1,20 @@
 const CHECK_INTERVAL_MILLISECS = 2000;
+const DELAY_REDIRECT_MILLISECS = 2000;
 const AUTH_SESSION_TIMEOUT_MILLISECS = 1000;
 const initialSession = getSession();
 
 let timeout;
-
-// Remove the timeout when unloading to avoid execution of the
+let redirect;
+// Remove the timeout and redirect when unloading to avoid execution of the
 // checkCookiesAndSetTimer when the page is already submitted
 addEventListener("beforeunload", () => {
   if (timeout) {
     clearTimeout(timeout);
     timeout = undefined;
+  }
+  if (redirect) {
+    clearTimeout(redirect);
+    redirect = undefined;
   }
 });
 
@@ -29,7 +34,11 @@ export function checkCookiesAndSetTimer(loginRestartUrl) {
     );
   } else {
     // Redirect to the login restart URL. This can typically automatically login user due the SSO
-    location.href = loginRestartUrl;
+    redirect = setTimeout(
+      () => {
+        location.href = loginRestartUrl;
+      }, DELAY_REDIRECT_MILLISECS
+    );
   }
 }
 


### PR DESCRIPTION
@jonkoops 

I have found another approach to mitigate the RESTART_AUTHENTICATION_ERROR in iOS browsers, so I opened this PR.

### Issue

Closes #33071

### Summary of Changes

This PR introduces a 2000ms delay in the checkCookieAndSetTimer function to address authentication errors on iOS browsers. This fix make amends for the unreliable beforeunload event in iOS browsers, which can cause RESTART_AUTHENTICATION_ERROR.

### Key points

- Adds a 2000ms delay before redirect triggered by `checkCookieAndSetTimer`
- Provides a temporal window, enabling the browser to dispose of the entire context, including the timeout event, before proceeding with the redirect when beforeunload event doesn't work.

I have confirmed that on my iPhone and iPad using Safari/Chrome with Keycloak 26.0.5, errors do not occur unless there are significant network speed issues or loading delays. However, it's important to note that this is only a mitigation for the unreliable beforeunload event, so it cannot completely eliminate the issue.

### Related PR
PR #34709