### PR TITLE
Refactor JWT Token parsing in OIDCIdentityProvider (#34825)

### DIFF
--- a/core/src/main/java/org/keycloak/jose/JOSEHeader.java
+++ b/core/src/main/java/org/keycloak/jose/JOSEHeader.java
@@ -19,4 +19,6 @@ public interface JOSEHeader extends Serializable {
     String getRawAlgorithm();
 
     String getKeyId();
+
+    String getType();
 }


### PR DESCRIPTION
This PR splits up token parsing for userinfo responses and JWT tokens. This makes it easier for custom OIDCIdentityProvider implementations to customize the JWT parsing. 

It also exposes access to the token type in JOSEHeader.
I kept the original exception handling flow.

Fixes #34825

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
