### PR TITLE
Avoid creating unnecessary exception when accessing methods starting with `is`

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -29,6 +29,7 @@ import org.keycloak.services.util.DPoPUtil;
 import java.lang.reflect.Method;
 import java.util.AbstractMap;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -87,24 +88,36 @@ public class ProtocolMapperUtils {
     // Script mapper goes last, so it can access the roles in the token
     public static final int PRIORITY_SCRIPT_MAPPER = 50;
 
+    private static final HashMap<String, Method> ACCESSORS = new HashMap<>();
+
+    // This caches known methods to avoid generating unnecessary failed lookups and exception at runtime which are expensive
+    static {
+        for (Method method : UserModel.class.getMethods()) {
+            String propertyName;
+            if (method.getName().startsWith("is") && method.getParameterCount() == 0) {
+                propertyName = method.getName().substring(2);
+            } else if (method.getName().startsWith("get") && method.getParameterCount() == 0) {
+                propertyName = method.getName().substring(3);
+            } else {
+                continue;
+            }
+            propertyName = Character.toLowerCase(propertyName.charAt(0)) + propertyName.substring(1);
+            ACCESSORS.put(propertyName, method);
+        }
+    }
+
     public static String getUserModelValue(UserModel user, String propertyName) {
+        Method m = ACCESSORS.get(propertyName);
+        if (m == null) {
+            return null;
+        }
 
-        String methodName = "get" + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
         try {
-            Method method = UserModel.class.getMethod(methodName);
-            Object val = method.invoke(user);
+            Object val = m.invoke(user);
             if (val != null) return val.toString();
         } catch (Exception ignore) {
-
         }
-        methodName = "is" + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
-        try {
-            Method method = UserModel.class.getMethod(methodName);
-            Object val = method.invoke(user);
-            if (val != null) return val.toString();
-        } catch (Exception ignore) {
 
-        }
         return null;
     }
 

--- a/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.UserModelDelegate;
+
+/**
+ * @author Alexander Schwartz
+ */
+public class ProtocolMapperUtilsTest {
+
+    @Test
+    public void getUserModelValue() {
+        UserModel useModel = new UserModelDelegate(null) {
+            @Override
+            public String getUsername() {
+                return "theo";
+            }
+
+            @Override
+            public boolean isEmailVerified() {
+                return true;
+            }
+        };
+
+        Assert.assertEquals("theo", ProtocolMapperUtils.getUserModelValue(useModel, "username"));
+        Assert.assertEquals("true", ProtocolMapperUtils.getUserModelValue(useModel, "emailVerified"));
+        Assert.assertNull(ProtocolMapperUtils.getUserModelValue(useModel, "unknown"));
+    }
+}


### PR DESCRIPTION
Closes #34850

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
