### PR TITLE
Pre-download and cache Node.js and PNPM on CI

### DIFF
--- a/.github/actions/node-cache/action.yml
+++ b/.github/actions/node-cache/action.yml
@@ -8,14 +8,20 @@ runs:
       id: tooling-versions
       shell: bash
       run: |
-        echo "node=$(./mvnw help:evaluate -Dexpression=node.version -q -DforceStdout | cut -c 2-)" >> $GITHUB_OUTPUT
-        echo "pnpm=$(./mvnw help:evaluate -Dexpression=pnpm.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+        echo "node=$(cat pom.xml | grep '<node.version>' | cut -d '>' -f 2 | cut -d '<' -f 1 | cut -c 2-)" >> $GITHUB_OUTPUT
+        echo "pnpm=$(cat pom.xml | grep '<pnpm.version>' | cut -d '>' -f 2 | cut -d '<' -f 1 | cut -c 1-)" >> $GITHUB_OUTPUT
 
     # Downloading Node.js often fails due to network issues, therefore we cache the artifacts downloaded by the frontend plugin.
     - uses: actions/cache@v4
+      id: cache-binaries
       name: Cache Node.js and PNPM binaries
       with:
         path: |
           ~/.m2/repository/com/github/eirslett/node
           ~/.m2/repository/com/github/eirslett/pnpm
         key: ${{ runner.os }}-frontend-plugin-artifacts-${{ steps.tooling-versions.outputs.node }}-${{ steps.tooling-versions.outputs.pnpm }}
+
+    - name: Download Node.js and PNPM
+      if: steps.cache-binaries.outputs.cache-hit != 'true'
+      shell: bash
+      run: ./.github/scripts/download-node-tooling.sh ${{ steps.tooling-versions.outputs.node }} ${{ steps.tooling-versions.outputs.pnpm }}

--- a/.github/scripts/download-node-tooling.sh
+++ b/.github/scripts/download-node-tooling.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+
+abort() {
+  echo $1
+  exit 1
+}
+
+download_file() {
+    local url=$1
+    local target=$2
+
+    echo "Downloading $(basename "$url")..."
+    mkdir -p "$(dirname "$target")"
+    curl --silent --fail --show-error --retry 3 --retry-delay 30 --output "$target" "$url"
+}
+
+node_url() {
+    local version=$1
+    local platform=$2
+    local root_url="https://nodejs.org/dist/v$version"
+
+    if [ "$platform" == "windows" ]; then
+        echo "$root_url/win-x64/node.exe"
+    elif [ "$platform" == "linux" ]; then
+        echo "$root_url/node-v$version-linux-x64.tar.gz"
+    else
+        abort "Unsupported platform: $platform"
+    fi
+}
+
+pnpm_url() {
+    local version=$1
+
+    echo "https://registry.npmjs.org/pnpm/-/pnpm-$version.tgz"
+}
+
+main() {
+    local node_version=$1
+    local pnpm_version=$2
+
+    if [ "$node_version" == "" ] || [ "$pnpm_version" == "" ]; then
+        abort "Usage: download-node-tooling.sh <NODE_VERSION> <PNPM_VERSION>"
+    fi
+
+    local target_directory=~/.m2/repository/com/github/eirslett
+
+    download_file "$(node_url "$node_version" "linux")" "$target_directory/node/$node_version/node-$node_version-linux-x64.tar.gz"
+    download_file "$(node_url "$node_version" "windows")" "$target_directory/node/$node_version/node-$node_version-win-x64.exe"
+    download_file "$(pnpm_url "$pnpm_version")" "$target_directory/pnpm/$pnpm_version/pnpm-$pnpm_version.tar.gz"
+}
+
+main "$1" "$2"


### PR DESCRIPTION
Adds a step to the CI to pre-download Node.js and PNPM into the local Maven repository so that the `frontend-maven-plugin` does not download Node.js and PNPM itself. The result of this is then cached on GitHub to avoid re-downloading these files for every run, hopefully mitigating the network errors that are causing issues on CI.

Closes #31835

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
