### PR TITLE
fix: using local cache for distribution tests to avoid port conflicts

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -32,6 +32,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
+@WithEnvVars({"KC_CACHE", "local"}) // avoid flakey port conflicts
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(OrderAnnotation.class)
@@ -67,7 +68,7 @@ public class BuildAndStartDistTest {
         cliResult.assertBuild();
         cliResult.assertStarted();
     }
-    
+
     @Test
     @WithEnvVars({"KEYCLOAK_ADMIN", "oldadmin123", "KEYCLOAK_ADMIN_PASSWORD", "oldadmin123"})
     @Launch({"start-dev"})

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -40,6 +40,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@WithEnvVars({"KC_CACHE", "local"}) // avoid flakey port conflicts
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DistributionTest
 public class StartCommandDistTest {
@@ -76,7 +77,7 @@ public class StartCommandDistTest {
         result = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false", "--spi-events-listener-jboss-logging-enabled=false");
         result.assertError("The following build time options have values that differ from what is persisted - the new values will NOT be used until another build is run: kc.spi-events-listener-jboss-logging-enabled");
     }
-    
+
     @WithEnvVars({"KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_ENABLED", "false"})
     @Test
     @RawDistOnly(reason = "Containers are immutable")


### PR DESCRIPTION
closes: #34844

This may not completely disable the cluster caching until the env changes from #34272 are incorporated.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
