### PR TITLE
Fix to check correctly that the service account scope is assigned

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -449,8 +449,6 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                     ServiceAccountConstants.CLIENT_ADDRESS, "String",
                     true, true, true));
 
-            newRealm.addDefaultClientScope(serviceAccountScope, true);
-
             logger.debugf("Client scope '%s' created in the realm '%s'.", ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE, newRealm.getName());
         } else {
             logger.debugf("Client scope '%s' already exists in realm '%s'. Skip creating it.", ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE, newRealm.getName());

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -24,6 +24,7 @@ import org.jboss.logging.Logger;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -83,7 +84,8 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
         UserModel clientUser = session.users().getServiceAccount(client);
         ClientScopeModel serviceAccountScope = KeycloakModelUtils.getClientScopeByName(client.getRealm(), ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE);
 
-        if (clientUser == null || (serviceAccountScope != null && !client.getClientScopes(true).containsKey(serviceAccountScope.getId()))) {
+        if (clientUser == null || (!Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && serviceAccountScope != null
+                && !client.getClientScopes(true).containsKey(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE))) {
             // May need to handle bootstrap here as well
             logger.debugf("Service account user for client '%s' not found or default protocol mapper for service account not found. Creating now", client.getClientId());
             new ClientManager(new RealmManager(session)).enableServiceAccount(client);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -24,16 +24,13 @@ import org.jboss.logging.Logger;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
-import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
-import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessTokenResponse;
@@ -44,8 +41,6 @@ import org.keycloak.services.clientpolicy.context.ServiceAccountTokenRequestCont
 import org.keycloak.services.clientpolicy.context.ServiceAccountTokenResponseContext;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
-import org.keycloak.services.managers.ClientManager;
-import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -82,14 +77,11 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
         }
 
         UserModel clientUser = session.users().getServiceAccount(client);
-        ClientScopeModel serviceAccountScope = KeycloakModelUtils.getClientScopeByName(client.getRealm(), ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE);
-
-        if (clientUser == null || (!Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && serviceAccountScope != null
-                && !client.getClientScopes(true).containsKey(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE))) {
-            // May need to handle bootstrap here as well
-            logger.debugf("Service account user for client '%s' not found or default protocol mapper for service account not found. Creating now", client.getClientId());
-            new ClientManager(new RealmManager(session)).enableServiceAccount(client);
-            clientUser = session.users().getServiceAccount(client);
+        if (clientUser == null) {
+            event.detail(Details.REASON, "The associated service account for the client does not exist");
+            event.error(Errors.USER_NOT_FOUND);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                    "The associated service account for the client does not exist", Response.Status.UNAUTHORIZED);
         }
 
         String clientUsername = clientUser.getUsername();

--- a/services/src/main/java/org/keycloak/services/managers/ClientManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ClientManager.java
@@ -190,6 +190,10 @@ public class ClientManager {
         ClientScopeModel serviceAccountScope = KeycloakModelUtils.getClientScopeByName(client.getRealm(), ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE);
 
         if (serviceAccountScope != null) {
+            if (client.getClientScopes(false).containsKey(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE)) {
+                // if it's assigned as optional just remove it to assign it as default
+                client.removeClientScope(serviceAccountScope);
+            }
             client.addClientScope(serviceAccountScope, true);
         } else {
             logger.tracef("Service account scope not added to client %s because it does not exist", client.getClientId());

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -28,6 +28,7 @@ import org.keycloak.authorization.admin.AuthorizationService;
 import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
+import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Errors;
 import org.keycloak.events.admin.OperationType;
@@ -806,12 +807,13 @@ public class ClientResource {
 
     private void updateClientFromRep(ClientRepresentation rep, ClientModel client, KeycloakSession session) throws ModelDuplicateException {
         UserModel serviceAccount = this.session.users().getServiceAccount(client);
+        boolean serviceAccountScopeAssigned = client.getClientScopes(true).containsKey(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE);
         if (Boolean.TRUE.equals(rep.isServiceAccountsEnabled())) {
-            if (serviceAccount == null) {
+            if (serviceAccount == null || !serviceAccountScopeAssigned) {
                 new ClientManager(new RealmManager(session)).enableServiceAccount(client);
             }
         } else if (Boolean.FALSE.equals(rep.isServiceAccountsEnabled()) || !client.isServiceAccountsEnabled()) {
-            if (serviceAccount != null) {
+            if (serviceAccount != null || serviceAccountScopeAssigned) {
                 new ClientManager(new RealmManager(session)).disableServiceAccount(client);
             }
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -190,11 +190,7 @@ public class ClientsResource {
             ClientModel clientModel = ClientManager.createClient(session, realm, rep);
 
             if (TRUE.equals(rep.isServiceAccountsEnabled())) {
-                UserModel serviceAccount = session.users().getServiceAccount(clientModel);
-
-                if (serviceAccount == null) {
-                    new ClientManager(new RealmManager(session)).enableServiceAccount(clientModel);
-                }
+                new ClientManager(new RealmManager(session)).enableServiceAccount(clientModel);
             }
 
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), clientModel.getId()).representation(rep).success();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ServiceAccountClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ServiceAccountClientTest.java
@@ -27,6 +27,7 @@ import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.OAuthClient;
 
@@ -97,5 +98,11 @@ public class ServiceAccountClientTest extends AbstractClientTest {
         Assert.assertEquals("service-account-client", accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ID));
         Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_HOST));
         Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ADDRESS));
+
+        // remove the service account and client credentials should fail
+        UserRepresentation serviceAccountUser = client.getServiceAccountUser();
+        testRealmResource().users().delete(serviceAccountUser.getId());
+        response = oauth.doClientCredentialsGrantAccessTokenRequest("password");
+        Assert.assertEquals("invalid_request", response.getError());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ServiceAccountClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ServiceAccountClientTest.java
@@ -20,12 +20,14 @@ package org.keycloak.testsuite.admin.client;
 import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.OAuthClient;
 
 /**
@@ -37,6 +39,9 @@ public class ServiceAccountClientTest extends AbstractClientTest {
 
     @Test
     public void testServiceAccountEnableDisable() throws Exception {
+        ClientScopeRepresentation serviceAccountScope = ApiUtil.findClientScopeByName(
+                testRealmResource(), ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE).toRepresentation();
+
         // Create a client with service account enabled
         ClientRepresentation clientRep = new ClientRepresentation();
         clientRep.setClientId("service-account-client");
@@ -55,27 +60,42 @@ public class ServiceAccountClientTest extends AbstractClientTest {
         oauth.clientId("service-account-client");
         OAuthClient.AccessTokenResponse response = oauth.doClientCredentialsGrantAccessTokenRequest("password");
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
-        org.junit.Assert.assertEquals("service-account-client", accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ID));
-        org.junit.Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_HOST));
-        org.junit.Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ADDRESS));
+        Assert.assertEquals("service-account-client", accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ID));
+        Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_HOST));
+        Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ADDRESS));
 
         // update the client to remove service account
         clientRep.setServiceAccountsEnabled(Boolean.FALSE);
         client.update(clientRep);
         MatcherAssert.assertThat(client.getDefaultClientScopes().stream().map(ClientScopeRepresentation::getName).collect(Collectors.toList()),
-                Matchers.not(Matchers.hasItem("service_account")));
+                Matchers.not(Matchers.hasItem(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE)));
         response = oauth.doClientCredentialsGrantAccessTokenRequest("password");
-        org.junit.Assert.assertEquals("unauthorized_client", response.getError());
+        Assert.assertEquals("unauthorized_client", response.getError());
 
         // re-enable sevice accounts
         clientRep.setServiceAccountsEnabled(Boolean.TRUE);
         client.update(clientRep);
         MatcherAssert.assertThat(client.getDefaultClientScopes().stream().map(ClientScopeRepresentation::getName).collect(Collectors.toList()),
-                Matchers.hasItem("service_account"));
+                Matchers.hasItem(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE));
         response = oauth.doClientCredentialsGrantAccessTokenRequest("password");
         accessToken = oauth.verifyToken(response.getAccessToken());
-        org.junit.Assert.assertEquals("service-account-client", accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ID));
-        org.junit.Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_HOST));
-        org.junit.Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ADDRESS));
+        Assert.assertEquals("service-account-client", accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ID));
+        Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_HOST));
+        Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ADDRESS));
+
+        // assign the scope as optional
+        client.removeDefaultClientScope(serviceAccountScope.getId());
+        client.addOptionalClientScope(serviceAccountScope.getId());
+
+        // re-enable service accounts, should assign the scope again as default
+        clientRep.setServiceAccountsEnabled(Boolean.TRUE);
+        client.update(clientRep);
+        MatcherAssert.assertThat(client.getDefaultClientScopes().stream().map(ClientScopeRepresentation::getName).collect(Collectors.toList()),
+                Matchers.hasItem(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE));
+        response = oauth.doClientCredentialsGrantAccessTokenRequest("password");
+        accessToken = oauth.verifyToken(response.getAccessToken());
+        Assert.assertEquals("service-account-client", accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ID));
+        Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_HOST));
+        Assert.assertNotNull(accessToken.getOtherClaims().get(ServiceAccountConstants.CLIENT_ADDRESS));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -45,6 +45,8 @@ import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
+import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.testsuite.AbstractKeycloakTest;
@@ -54,8 +56,10 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
+import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.util.BasicAuthHelper;
+import org.keycloak.util.JsonSerialization;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
@@ -76,9 +80,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_ID;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_USERNAME;
-import org.keycloak.testsuite.util.AdminClientUtil;
-import org.keycloak.util.JsonSerialization;
-
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -230,6 +231,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         serviceAccount.setSecret("secret");
         serviceAccount.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         serviceAccount.setFullScopeAllowed(false);
+        new ClientManager(new RealmManager(session)).enableServiceAccount(serviceAccount);
 
         // permission for client to client exchange to "target" client
         ClientPolicyRepresentation clientRep = new ClientPolicyRepresentation();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -545,7 +545,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             oauth.scope(optionalScope);
             OAuthClient.AccessTokenResponse response1 = oauth.doGrantAccessTokenRequest("password", "test-user@localhost", "password");
             RefreshToken refreshToken1 = oauth.parseRefreshToken(response1.getRefreshToken());
-            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile address phone service_account",  refreshToken1.getScope());
+            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile address phone",  refreshToken1.getScope());
 
             setTimeOffset(2);
 
@@ -556,7 +556,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             AbstractOIDCScopeTest.assertScopes("openid email phone profile",  response2.getScope());
             RefreshToken refreshToken2 = oauth.parseRefreshToken(response2.getRefreshToken());
             assertNotNull(refreshToken2);
-            AbstractOIDCScopeTest.assertScopes("openid acr roles phone address email profile basic web-origins service_account",  refreshToken2.getScope());
+            AbstractOIDCScopeTest.assertScopes("openid acr roles phone address email profile basic web-origins",  refreshToken2.getScope());
 
         } finally {
             setTimeOffset(0);
@@ -574,7 +574,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
 
             OAuthClient.AccessTokenResponse response1 = oauth.doAccessTokenRequest(code, "password");
             RefreshToken refreshToken1 = oauth.parseRefreshToken(response1.getRefreshToken());
-            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile service_account",  refreshToken1.getScope());
+            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile",  refreshToken1.getScope());
 
             setTimeOffset(2);
 
@@ -608,7 +608,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
 
             AbstractOIDCScopeTest.assertScopes("openid email profile",  accessToken.getScope());
-            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile service_account",  refreshToken.getScope());
+            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile",  refreshToken.getScope());
 
             Assert.assertNotNull(accessToken.getRealmAccess());
             Assert.assertNotNull(accessToken.getResourceAccess());
@@ -621,7 +621,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
 
             AbstractOIDCScopeTest.assertScopes("openid email profile",  accessToken.getScope());
-            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile service_account",  refreshToken.getScope());
+            AbstractOIDCScopeTest.assertScopes("openid basic email roles web-origins acr profile",  refreshToken.getScope());
 
             Assert.assertNotNull(accessToken.getRealmAccess());
             Assert.assertNotNull(accessToken.getResourceAccess());


### PR DESCRIPTION
Closes #34875

The on the fly check to see if the service_account scope was assigned to the client was not OK (the key is the name and not the id! Sorry!). The scope is also change from default to none, so it's assigned only via service accounts enabled attribute. I think it's better this way.
