### PR TITLE
Avoid DB error when sessionId is passed in the incorrect format

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Event.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Event.java
@@ -107,7 +107,7 @@ public class Event {
     }
 
     public void setSessionId(String sessionId) {
-        this.sessionId = sessionId;
+        this.sessionId = maxLength(sessionId, 255);
     }
 
     public String getIpAddress() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventStoreProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventStoreProviderTest.java
@@ -246,6 +246,9 @@ public class EventStoreProviderTest extends AbstractEventsTest {
         testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, StringUtils.repeat(realmId, 100), "clientId", "userId", "127.0.0.1", "error"));
         testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, realmId, "clientId", StringUtils.repeat("userId", 100), "127.0.0.1", "error"));
 
+        EventRepresentation event = create(System.currentTimeMillis() - 30000, EventType.LOGIN, realmId, "clientId", "userId", "127.0.0.1", "error");
+        event.setSessionId(StringUtils.repeat("sessionId", 100));
+        testing().onEvent(event);
     }
 
     @Test


### PR DESCRIPTION
closes #34304

This fixes the `DB overflow` for the sessionId column as it is possible that this column can be manually set by the users if they are incorrectly using Keycloak. Example of incorrect usage is in the comment https://github.com/keycloak/keycloak/issues/34304#issuecomment-2473405487 .

We already have similar checks for other columns like `realmId`, `clientId`, `userId` . The `sessionId` was missing for some reason. I did not updated columns `type`, `error` and `ip_address` as those cannot be "manipulated" by the user (at least did not found any way how to do it).