### PR TITLE
Allow updating the username when registration as email is enabled during LDAP updates

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -187,6 +187,9 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                             UserModel.USERNAME);
                 }
             } else if (usernameChanged) {
+                if (realm.isRegistrationEmailAsUsername() && username.equals(user.getEmail())) {
+                    return;
+                }
                 throw new ModelException("Cannot change username if the realm is not configured to allow edit the usernames");
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserProfileTest.java
@@ -37,6 +37,7 @@ import org.keycloak.component.PrioritizedComponentModel;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserProfileAttributeMetadata;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPAttribute;
@@ -394,6 +395,43 @@ public class LDAPUserProfileTest extends AbstractLDAPTest {
         loginPage.open();
         loginPage.login(upperCaseUsername.toLowerCase(), "Password1");
         appPage.assertCurrent();
+    }
+
+    @Test
+    public void testUpdateEmailWhenEmailAsUsernameEnabledAndEditUsernameDisabled() {
+        String username = "johnkeycloak";
+        UserResource johnResource = ApiUtil.findUserByUsernameId(testRealm(), username);
+        UserRepresentation john = johnResource.toRepresentation(true);
+        String email = "john@email.org";
+        assertUser(john, username, email, "John", "Doe", "1234");
+
+        // enable email as username
+        RealmRepresentation realm = testRealm().toRepresentation();
+        boolean initialEditUserNameAllowed = realm.isEditUsernameAllowed();
+        boolean initialEmailUsernameEnabled = realm.isRegistrationEmailAsUsername();
+        realm.setEditUsernameAllowed(false);
+        realm.setRegistrationEmailAsUsername(true);
+        testRealm().update(realm);
+
+        // update the user to force updating the username as the email
+        john.setEmail("john@newemail.org");
+        johnResource.update(john);
+        john = johnResource.toRepresentation(true);
+        assertUser(john, "john@newemail.org", "john@newemail.org", "John", "Doe", "1234");
+        getCleanup().addCleanup(() -> {
+            try {
+                realm.setEditUsernameAllowed(initialEditUserNameAllowed);
+                realm.setRegistrationEmailAsUsername(initialEmailUsernameEnabled);
+                testRealm().update(realm);
+                UserRepresentation user = johnResource.toRepresentation(true);
+                user.setUsername(username);
+                user.setEmail(email);
+                johnResource.update(user);
+            } finally {
+                testRealm().update(realm);
+            }
+
+        });
     }
 
     private void setLDAPReadOnly() {


### PR DESCRIPTION
Closes #34560

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
