### PR TITLE
Upgrade 24 to 25 fails because db jpa changes drop nonexisting indexes.

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-25.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-25.0.0.xml
@@ -41,10 +41,28 @@
             <column name="LAST_SESSION_REFRESH" />
         </createIndex>
     </changeSet>
-    <changeSet author="keycloak" id="25.0.0-28265-index-cleanup">
+    <changeSet author="keycloak" id="25.0.0-28265-index-cleanup-uss-createdon">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_CREATEDON" />
+        </preConditions>
         <dropIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_CREATEDON" />
+    </changeSet>
+    <changeSet author="keycloak" id="25.0.0-28265-index-cleanup-uss-preload">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_PRELOAD" />
+        </preConditions>
         <dropIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_PRELOAD" />
+    </changeSet>
+    <changeSet author="keycloak" id="25.0.0-28265-index-cleanup-uss-by-usersess">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USERSESS" />
+        </preConditions>
         <dropIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USERSESS" />
+    </changeSet>
+    <changeSet author="keycloak" id="25.0.0-28265-index-cleanup-css-preload">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_PRELOAD" />
+        </preConditions>
         <dropIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_PRELOAD" />
     </changeSet>
     <changeSet author="keycloak" id="25.0.0-28265-index-2-mysql">


### PR DESCRIPTION
Closes #34899

(cherry picked from commit ebd411b93d03f3f77faff0b923689d8307acc2db)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
