### PR TITLE
Check "Always use lightweight access token" is enabled on the client for Admin REST APIs

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -112,7 +112,8 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
         AccessToken accessToken = auth.getToken();
         ClientModel client = adminsRealm.getClientByClientId(issuedFor);
         //support for lightweight access token and transient session
-        if (accessToken.getSubject() == null || (accessToken.getSessionId() == null && accessToken.getResourceAccess().isEmpty() && accessToken.getRealmAccess() == null)) {
+        boolean isAlwaysUseLightweightAccessToken = Boolean.parseBoolean(client.getAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED));
+        if (isAlwaysUseLightweightAccessToken || accessToken.getSubject() == null || (accessToken.getSessionId() == null && accessToken.getResourceAccess().isEmpty() && accessToken.getRealmAccess() == null)) {
             //get user session
             EventBuilder event = new EventBuilder(adminsRealm, session);
             event.event(EventType.INTROSPECT_TOKEN);


### PR DESCRIPTION
Closes #34944

Added a check to verify if "Always use lightweight access token" is enabled on the client, to cover cases where the admin APIs are invoked with a lightweight token containing the sub claim."

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
