### PR TITLE
Fix and enable firefox-strict-cookies profile adapter tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     name: Adapter IT
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 100
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -161,7 +161,7 @@ jobs:
         run: |
           TESTS="org.keycloak.testsuite.adapter.**"
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Papp-server-wildfly -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Papp-server-wildfly -Dtest=$TESTS -Dapp.server.ssl.required=true -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()
@@ -179,6 +179,47 @@ jobs:
         uses: ./.github/actions/archive-surefire-reports
         with:
           job-id: adapter-integration-tests
+
+  adapter-integration-tests-strict-cookies:
+    name: Adapter IT Strict Cookies
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+
+      - name: Build adapter distributions
+        run: ./mvnw install -DskipTests -f distribution/pom.xml
+
+      - name: Build app servers
+        run: ./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
+
+      - name: Run adapter tests
+        run: |
+          TESTS="org.keycloak.testsuite.adapter.**"
+          echo "Tests: $TESTS"
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pfirefox-strict-cookies -Pauth-server-quarkus -Papp-server-wildfly -Dtest=$TESTS -Dapp.server.ssl.required=true "-Dwebdriver.gecko.driver=$GECKOWEBDRIVER/geckodriver" -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+
+      - name: Upload JVM Heapdumps
+        if: always()
+        uses: ./.github/actions/upload-heapdumps
+
+      - uses: ./.github/actions/upload-flaky-tests
+        name: Upload flaky tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          job-name: Base IT
+
+      - name: Surefire reports
+        if: always()
+        uses: ./.github/actions/archive-surefire-reports
+        with:
+          job-id: adapter-integration-tests-strict-cookies
 
   quarkus-unit-tests:
     name: Quarkus UT
@@ -1009,6 +1050,7 @@ jobs:
       - unit-tests
       - base-integration-tests
       - adapter-integration-tests
+      - adapter-integration-tests-strict-cookies
       - quarkus-unit-tests
       - quarkus-integration-tests
       - jdk-integration-tests

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -53,7 +53,7 @@
         <arquillian-infinispan-container.version>1.2.0.Beta3</arquillian-infinispan-container.version>
         <undertow.version>${undertow-jakarta.version}</undertow.version>
         <undertow-embedded.version>1.0.0.Final</undertow-embedded.version>
-        <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
+        <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <jakarta.persistence-legacy.version>2.2.3</jakarta.persistence-legacy.version>
         <smallrye.jandex.version>3.0.5</smallrye.jandex.version>
         <commons.validator.version>1.8.0</commons.validator.version>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.testsuite.arquillian;
 
-import java.io.File;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.arquillian.container.test.api.ContainerController;
@@ -30,13 +29,10 @@ import org.jboss.logging.Logger;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainers;
 import org.keycloak.testsuite.arquillian.containers.SelfManagedAppContainerLifecycle;
-import org.wildfly.extras.creaper.commands.web.AddConnector;
-import org.wildfly.extras.creaper.commands.web.AddConnectorSslConfig;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.ManagementClient;
 import org.wildfly.extras.creaper.core.online.CliException;
 import org.wildfly.extras.creaper.core.online.ManagementProtocol;
-import org.wildfly.extras.creaper.core.online.ModelNodeResult;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.OnlineOptions;
 import org.wildfly.extras.creaper.core.online.operations.Address;
@@ -44,6 +40,7 @@ import org.wildfly.extras.creaper.core.online.operations.OperationException;
 import org.wildfly.extras.creaper.core.online.operations.Operations;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -57,9 +54,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import static org.keycloak.testsuite.arquillian.ServerTestEnricherUtil.addHttpsListenerAppServer;
 import static org.keycloak.testsuite.arquillian.ServerTestEnricherUtil.reloadOrRestartTimeoutClient;
-import static org.keycloak.testsuite.arquillian.ServerTestEnricherUtil.removeHttpsListener;
 import static org.keycloak.testsuite.util.ServerURLs.getAppServerContextRoot;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
@@ -214,37 +209,21 @@ public class AppServerTestEnricher {
         Administration administration = new Administration(client);
         Operations operations = new Operations(client);
 
-        boolean isElytronConfigured = false;
-        try {
-            // check if the eap is configured to use elytron
-            ModelNodeResult result = operations.readAttribute(Address.subsystem("undertow")
-                    .and("server", "default-server").and("https-listener", "https"), "ssl-context");
-            if (!result.isFailed() && result.hasDefinedValue()) {
-                isElytronConfigured = true;
-            }
-        } catch (IOException e) {
-            log.debug("Error reading 'ssl-context' attribute in undertow, assuming not elytron", e);
-        }
-
-        if (isElytronConfigured && !operations.exists(Address.subsystem("elytron").and("server-ssl-context", "KCSslContext"))) {
+        if (!operations.exists(Address.subsystem("elytron").and("server-ssl-context", "KCSslContext"))) {
             client.execute("/subsystem=elytron/key-store=KCKeyStore:add(path=adapter.jks,relative-to=jboss.server.config.dir,credential-reference={clear-text=secret},type=JKS)");
             client.execute("/subsystem=elytron/key-manager=KCKeyManager:add(key-store=KCKeyStore,credential-reference={clear-text=secret,algorithm=PKIX})");
             client.execute("/subsystem=elytron/key-store=KCTrustStore:add(relative-to=jboss.server.config.dir,path=keycloak.truststore,credential-reference={clear-text=secret},type=JKS)");
             client.execute("/subsystem=elytron/trust-manager=KCTrustManager:add(key-store=KCTrustStore)");
             client.execute("/subsystem=elytron/server-ssl-context=KCSslContext:add(key-manager=KCKeyManager,trust-manager=KCTrustManager)");
-            client.execute("/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=KCSslContext)");
-        } else if (!operations.exists(Address.coreService("management").and("security-realm", "UndertowRealm"))) {
-            client.execute("/core-service=management/security-realm=UndertowRealm:add()");
-            client.execute("/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-relative-to=jboss.server.config.dir,keystore-password=secret,keystore-path=adapter.jks");
+            if (operations.exists(Address.subsystem("undertow").and("server", "default-server").and("https-listener", "https"))) {
+                client.execute("/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=KCSslContext)");
+            } else {
+                client.execute("/subsystem=undertow/server=default-server/https-listener=https:add(socket-binding=https, enable-http2=true, ssl-context=KCSslContext)");
+            }
         }
 
         client.execute("/system-property=javax.net.ssl.trustStore:add(value=${jboss.server.config.dir}/keycloak.truststore)");
         client.execute("/system-property=javax.net.ssl.trustStorePassword:add(value=secret)");
-
-        if (!isElytronConfigured) {
-            removeHttpsListener(client, administration);
-            addHttpsListenerAppServer(client);
-        }
 
         reloadOrRestartTimeoutClient(administration);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/samesite/undertow-handlers.conf
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/samesite/undertow-handlers.conf
@@ -1,0 +1,1 @@
+samesite-cookie(mode=None, cookie-pattern=JSESSIONID)


### PR DESCRIPTION
Closes #34853

The PR adds a CI job to run the adapter tests with the profile `firefox-strict-cookies`. Main changes:

1. Re-adding the file `undertow-handlers.conf` that was removed when the adapters cleanup. This adds an undertow rule to add `SameSite=None` to the apps session cookies (it also adds `secure` which is a problem).
2. As the undertow rule adds `secure` the apache client used for saml testing does not work for http. I decided to run the adapter tests using https. I did this for the old adapter job and this new strict one. I think it's better if we test using https.
3. In order to enable the https listener a small refactor was done. The new wildfly versions only accept the elytron configuration. So I have removed the undertow part and only the elytron setup remains. Besides the `creaper` library should be upgraded for the new version.
4. The test `testImpersonationForSaml` does not work for firefox. There is an error adding the cookies in the browser. I think that it's a security problem and it works for the rest of browser so I just assumed this test.

@miquelsi Check if you want to run the adapter tests with strict cookies this way. Maybe you have another idea about integrating these tests.
