### PR TITLE
Update upgrade guide docs 25.0.0 cache options

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -258,7 +258,7 @@ The old behavior to preload offline sessions at startup is now removed after it 
 
 = Specify `cache` options at runtime
 
-Options `cache`, `cache-stack`, and `cache-config-file` are no longer build options, and they can be specified only during runtime.
+Options `cache`, `cache-stack`, and `cache-config-file` are no longer build options, and they can be specified only during runtime (the corresponding runtime entries are: `KC_CACHE`, `KC_CACHE_STACK`, `KC_CACHE_CONFIG_FILE`. If you don't provide at least the following entries `KC_CACHE` and `KC_CACHE_CONFIG_FILE` it will fall-back to the default caching mechanism `udp` and completely ignores you're caching settings).
 This eliminates the need to execute the build phase and rebuild your image due to them.
 Be aware that they will not be recognized during the `build` phase, so you need to remove them.
 

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -82,8 +82,8 @@ For more details and more comprehensive scenarios, see https://www.keycloak.org/
 
 == `security-admin-console` Client Redirect URIs
 
-The handling of the `${authAdminUrl}` has changed in hostname v1. Previously with hostname v1 the admin URL was resolved dynamically from the request if the `hostname-admin` or `hostname-admin-url` options were not set. With hostname v2 the admin URL will default instead to the frontend URL. 
-If the `hostname` option is set and `hostname-strict` is true, this change will prevent redirect URIs with alternative hostnames from working for Clients using the Root URL `${authAdminUrl}`. 
+The handling of the `${authAdminUrl}` has changed in hostname v1. Previously with hostname v1 the admin URL was resolved dynamically from the request if the `hostname-admin` or `hostname-admin-url` options were not set. With hostname v2 the admin URL will default instead to the frontend URL.
+If the `hostname` option is set and `hostname-strict` is true, this change will prevent redirect URIs with alternative hostnames from working for Clients using the Root URL `${authAdminUrl}`.
 You should consider using the `hostname-admin` option instead of the redirect URIs to allow a single alternative hostname. Alternative hostname redirects should be removed as the `security-admin-console` Client only needs the default redirect URI of `/admin/master/console/*` with Root URL of `${authAdminUrl}`.
 
 = Persistent user sessions
@@ -258,9 +258,10 @@ The old behavior to preload offline sessions at startup is now removed after it 
 
 = Specify `cache` options at runtime
 
-Options `cache`, `cache-stack`, and `cache-config-file` are no longer build options, and they can be specified only during runtime (the corresponding runtime entries are: `KC_CACHE`, `KC_CACHE_STACK`, `KC_CACHE_CONFIG_FILE`. If you don't provide at least the following entries `KC_CACHE` and `KC_CACHE_CONFIG_FILE` it will fall-back to the default caching mechanism `udp` and completely ignores you're caching settings).
+Options `cache`, `cache-stack`, and `cache-config-file` are no longer build options, and they can be specified only during runtime.
 This eliminates the need to execute the build phase and rebuild your image due to them.
-Be aware that they will not be recognized during the `build` phase, so you need to remove them.
+Be aware that they will not be recognized during the `build` phase, so you need to remove them from the `build` phase and add them to the `runtime` phase.
+If you do not add your current caching options to the `runtime` phase, {project_name} will fall back to the default caching settings.
 
 = kcadm and kcreg changes
 


### PR DESCRIPTION
Update upgrade guide docs 25.0.0 cache options section to a better understanding what actually needs to be changed. This is based on the discussion on: https://github.com/keycloak/keycloak/discussions/28271#discussioncomment-11265473

Closes #34987