### PR TITLE
Use short UUID for ldap components (#34815)

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/webauthn.adoc
+++ b/docs/documentation/server_admin/topics/authentication/webauthn.adoc
@@ -9,6 +9,11 @@
 WebAuthn's operations success depends on the user's WebAuthn supporting authenticator, browser, and platform. Make sure your authenticator, browser, and platform support the WebAuthn specification.
 ====
 
+[NOTE]
+====
+WebAuthn's specification uses a `user.id` to map a public key credential to a specific user account in the Relying Party. This user ID handle is an opaque byte sequence with a maximum size of 64 bytes. {project_name} passes the internal database ID to the registration, which in common users is an UUID of 36 characters. But, if the user is from a external user federation provider, the internal {project_name} ID is an link:{developerguide_link}#storage-ids[storage ID] in the form `f:<provider-id>:<user-id>` that can exceed the 64 byte limitation. Please take this into account and use short IDs for the federation provider component and for the users coming from that provider when combining the Storage SPI and WebAuthn.
+====
+
 ==== Setup
 
 The setup procedure of WebAuthn support for 2FA is the following:

--- a/docs/documentation/server_development/topics/user-storage/model-interfaces.adoc
+++ b/docs/documentation/server_development/topics/user-storage/model-interfaces.adoc
@@ -47,3 +47,18 @@ f:332a234e31234:wburke
 
 When the runtime does a lookup by id, the id is parsed to obtain the component id. The component id is used to locate the `UserStorageProvider` that was originally used to load the user. That provider is then passed the id. The provider again parses the id to obtain the external id and it will use to locate the user in external user storage.
 
+This format has the drawback that it can generate long IDs for the external storage users. This is specially important when combined with the link:{adminguide_link}#webauthn_server_administration_guide[WebAuthn authentication], which limits the user handle ID to 64 bytes. For that reason, if the storage users are going to use WebAuthn authentication, it is important to limit the full storage ID to 64 characters. The method `validateConfiguration` can be used to assign a short ID for the provider component on creation, giving some space to the user IDs within the 64 byte limitation.
+
+[source,java]
+----
+    @Override
+    void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel model)
+            throws ComponentValidationException
+    {
+        // ...
+        if (model.getId() == null) {
+            // On creation use short UUID of 22 chars, 40 chars left for the user ID
+            model.setId(KeycloakModelUtils.generateShortId());
+        }
+    }
+----

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -304,6 +304,11 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
         if (!userStorageModel.isImportEnabled() && cfg.getEditMode() == UserStorageProvider.EditMode.UNSYNCED) {
             throw new ComponentValidationException("ldapErrorCantEnableUnsyncedAndImportOff");
         }
+
+        if (config.getId() == null) {
+            // the ldap component is being created, use short id for ldap components
+            config.setId(KeycloakModelUtils.generateShortId());
+        }
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -71,6 +71,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -107,8 +108,46 @@ public final class KeycloakModelUtils {
     private KeycloakModelUtils() {
     }
 
+    /**
+     * Return an ID generated using the UUID java class.
+     * @return The ID using UUID.toString (36 chars)
+     */
     public static String generateId() {
         return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Return an ID generated using the UUID class but using base64 URL encoding
+     * with the two longs (msb+lsb).
+     * @return The ID getting msb and lsb from UUID and encoding them in
+     * base64 URL without padding (22 chars)
+     */
+    public static String generateShortId() {
+        return generateShortId(UUID.randomUUID());
+    }
+
+    /**
+     * Generates a short ID representation for the UUID. The representation is the
+     * base64 url encoding of the msb+lsb of the UUID.
+     * @param uuid The UUID to represent
+     * @return The string representation in 22 characters
+     */
+    public static String generateShortId(final UUID uuid) {
+        final byte[] bytes = new byte[2 * Long.BYTES];
+        // first the msb
+        long l = uuid.getMostSignificantBits();
+        for (int i = Long.BYTES - 1; i >= 0; i--) {
+            bytes[i] = (byte) (l & 0xff);
+            l >>= 8;
+        }
+        // second the lsb
+        l = uuid.getLeastSignificantBits();
+        for (int i = Long.BYTES - 1; i >= 0; i--) {
+            bytes[Long.BYTES + i] = (byte) (l & 0xff);
+            l >>= 8;
+        }
+        // encode in base64 URL no padding (22 chars)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
     public static PublicKey getPublicKey(String publicKeyPem) {

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/KeycloakModelUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/KeycloakModelUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.utils;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class KeycloakModelUtilsTest {
+
+    @Test
+    public void testGenerateId() {
+        final String id = KeycloakModelUtils.generateId();
+        Assert.assertEquals(36, id.length());
+        final String shortId = KeycloakModelUtils.generateShortId(UUID.fromString(id));
+        final UUID uuid = fromShortId(shortId);
+        Assert.assertEquals(id, uuid.toString());
+    }
+
+    @Test
+    public void testGenerateShortId() {
+        final String shortId = KeycloakModelUtils.generateShortId();
+        final UUID uuid = fromShortId(shortId);
+        Assert.assertEquals(shortId, KeycloakModelUtils.generateShortId(uuid));
+    }
+
+    private UUID fromShortId(String shortId) {
+        Assert.assertEquals(22, shortId.length());
+        final byte[] bytes = Base64.getUrlDecoder().decode(shortId);
+        Assert.assertEquals(Long.BYTES * 2, bytes.length);
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        final long msb = bb.getLong();
+        final long lsb = bb.getLong();
+        return new UUID(msb, lsb);
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/AbstractLDAPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/AbstractLDAPTest.java
@@ -25,6 +25,7 @@ import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
@@ -78,6 +79,7 @@ public abstract class AbstractLDAPTest extends AbstractTestRealmKeycloakTest {
     protected void createLDAPProvider() {
         Map<String, String> cfg = getLDAPRule().getConfig();
         ldapModelId = testingClient.testing().ldap(TEST_REALM_NAME).createLDAPProvider(cfg, isImportEnabled());
+        Assert.assertEquals("Short ID not used for ldap id", 22, ldapModelId.length());
         log.infof("LDAP Provider created");
     }
 


### PR DESCRIPTION
Closes #32143

Signed-off-by: rmartinc <rmartinc@redhat.com>
(cherry picked from commit ca1c10f7ba923349e7bb1643fb6f78115543c908)
