### PR TITLE
splitting the zip test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,11 +292,11 @@ jobs:
       - name: Run Quarkus integration Tests
         run: |
           declare -A PARAMS
-          PARAMS["win"]="-Dtest=JavaOptsScriptTest,StartCommandDistTest,StartDevCommandDistTest,BuildAndStartDistTest,ImportAtStartupDistTest"
+          PARAMS["win"]="-Dkc.quarkus.tests.groups=win"
           PARAMS["zip"]=""
           PARAMS["container"]="-Dkc.quarkus.tests.dist=docker"
-          PARAMS["storage"]="-Ptest-database -Dtest=PostgreSQLDistTest,MariaDBDistTest#testSuccessful,MySQLDistTest#testSuccessful,DatabaseOptionsDistTest,JPAStoreDistTest,HotRodStoreDistTest,MixedStoreDistTest,TransactionConfigurationDistTest,ExternalInfinispanTest"
-          PARAMS["smoke"]="-Dtest=ClusterConfigDistTest,CustomJpaEntityProviderDistTest,ExportDistTest,FeaturesDistTest,ImportAtStartupDistTest,ImportDistTest,JaxRsDistTest,TruststoreDistTest"
+          PARAMS["storage"]="-Ptest-database -Dkc.quarkus.tests.groups=storage"
+          PARAMS["smoke"]="-Dkc.quarkus.tests.groups=smoke"
 
           ./mvnw install -pl quarkus/tests/integration -am -DskipTests
           ./mvnw test -pl quarkus/tests/integration ${PARAMS["${{ matrix.suite }}"]} 2>&1 | misc/log/trimmer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        suite: [zip, container, storage, smoke]
+        suite: [zip-slow, zip-fast, container, storage, smoke]
         full-testsuite:
           - ${{ needs.conditional.outputs.ci-quarkus == 'true' }}
         # Win runs always as includes are evaluated after excludes
@@ -269,7 +269,9 @@ jobs:
         # Either run smoke tests, or full testsuite
         exclude:
           - full-testsuite: false
-            suite: zip
+            suite: zip-slow
+          - full-testsuite: false
+            suite: zip-fast
           - full-testsuite: false
             suite: container
           - full-testsuite: false
@@ -289,13 +291,16 @@ jobs:
 
       # Not sure why, but needs to re-build otherwise there's some failures starting up
       # Smoke tests should cover scenarios that could be broken by changes in other modules that quarkus
+      # test classes and even individual tests are included in the following suites by junit tags
+      # kc.quarkus.tests.groups acts as the tag filter
       - name: Run Quarkus integration Tests
         run: |
           declare -A PARAMS
           PARAMS["win"]="-Dkc.quarkus.tests.groups=win"
-          PARAMS["zip"]=""
+          PARAMS["zip-slow"]="-Dkc.quarkus.tests.groups=slow"
+          PARAMS["zip-fast"]='-Dkc.quarkus.tests.groups=!slow'
           PARAMS["container"]="-Dkc.quarkus.tests.dist=docker"
-          PARAMS["storage"]="-Ptest-database -Dkc.quarkus.tests.groups=storage"
+          PARAMS["storage"]="-Ptest-database"
           PARAMS["smoke"]="-Dkc.quarkus.tests.groups=smoke"
 
           ./mvnw install -pl quarkus/tests/integration -am -DskipTests

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -170,6 +170,9 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <properties>
+                <kc.quarkus.tests.groups>storage</kc.quarkus.tests.groups>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <kc.quarkus.tests.dist>raw</kc.quarkus.tests.dist>
+        <kc.quarkus.tests.groups>!invalid</kc.quarkus.tests.groups>
         <approvaltests.version>14.0.0</approvaltests.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     </properties>
@@ -124,6 +125,7 @@
                         <kc.quarkus.tests.dist>${kc.quarkus.tests.dist}</kc.quarkus.tests.dist>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>
+                    <groups>${kc.quarkus.tests.groups}</groups>
                 </configuration>
             </plugin>
             <plugin>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -20,6 +20,7 @@ package org.keycloak.it.cli.dist;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -37,6 +38,7 @@ import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTI
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(OrderAnnotation.class)
+@Tag(DistributionTest.WIN)
 public class BuildAndStartDistTest {
 
     @DryRun

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -42,6 +42,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 @RawDistOnly(reason = "Not possible to mount files using docker.")
 @Storage(defaultLocalCache = false)
 @Tag(DistributionTest.SMOKE)
+@Tag(DistributionTest.SLOW)
 public class ClusterConfigDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.function.Consumer;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -40,6 +41,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 @DistributionTest(reInstall = DistributionTest.ReInstall.BEFORE_TEST)
 @RawDistOnly(reason = "Not possible to mount files using docker.")
 @Storage(defaultLocalCache = false)
+@Tag(DistributionTest.SMOKE)
 public class ClusterConfigDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.it.cli.dist;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -29,6 +30,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SMOKE)
 public class CustomJpaEntityProviderDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.it.cli.dist;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -25,6 +26,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 
 @RawDistOnly(reason = "Containers are immutable")
 @DistributionTest
+@Tag(DistributionTest.SMOKE)
 public class ExportDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -4,6 +4,7 @@ import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -28,6 +29,7 @@ import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTI
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag(DistributionTest.SMOKE)
 public class FeaturesDistTest {
 
     private static final String PREVIEW_FEATURES_EXPECTED_LOG = "Preview features enabled: " + Arrays.stream(Profile.Feature.values())

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -18,6 +18,8 @@
 package org.keycloak.it.cli.dist;
 
 import java.nio.file.Path;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.crypto.fips.KeycloakFipsSecurityProvider;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -31,6 +33,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest(keepAlive = true, defaultOptions = { "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
 @RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SLOW)
 public class FipsDistTest {
 
     private static final String BCFIPS_VERSION = "BCFIPS version 2.0";

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
@@ -18,6 +18,8 @@
 package org.keycloak.it.cli.dist;
 
 import io.quarkus.test.junit.main.Launch;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.utils.KeycloakDistribution;
@@ -34,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 @DistributionTest(keepAlive = true,
         requestPort = 9000,
         containerExposedPorts = {8080, 9000})
+@Tag(DistributionTest.SLOW)
 public class HealthDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
@@ -41,6 +41,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 @RawDistOnly(reason = "Containers are immutable")
 @Tag(DistributionTest.WIN)
 @Tag(DistributionTest.SMOKE)
+@Tag(DistributionTest.SLOW)
 public class ImportAtStartupDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
@@ -17,11 +17,12 @@
 
 package org.keycloak.it.cli.dist;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -32,15 +33,14 @@ import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.WIN)
+@Tag(DistributionTest.SMOKE)
 public class ImportAtStartupDistTest {
 
     @Test
@@ -50,17 +50,17 @@ public class ImportAtStartupDistTest {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertMessage("Realm 'quickstart-realm' imported");
     }
-    
+
     @Test
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testMultipleImport(KeycloakDistribution dist) throws IOException {
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         Path dir = rawDist.getDistPath().resolve("data").resolve("import");
-        
+
         // add another realm
         Files.write(dir.resolve("realm2.json"), Files.readAllLines(dir.resolve("realm.json")).stream()
                 .map(s -> s.replace("quickstart-realm", "other-realm")).toList());
-        
+
         CLIResult cliResult = dist.run("start-dev", "--import-realm");
         cliResult.assertMessage("Realm 'quickstart-realm' imported");
         cliResult.assertMessage("Realm 'other-realm' imported");
@@ -135,7 +135,7 @@ public class ImportAtStartupDistTest {
         result.assertMessage("Realm 'quickstart-realm' imported");
         result.assertNoMessage("Not importing realm master from file");
     }
-    
+
     public static class CreateRealmConfigurationFile implements Consumer<KeycloakDistribution> {
 
         @Override

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -34,25 +35,26 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag(DistributionTest.SMOKE)
 public class ImportDistTest {
 
     @Test
     void testImport(KeycloakDistribution dist) throws IOException {
         CLIResult cliResult = dist.run("build");
-        
+
         File dir = new File("target");
 
         cliResult = dist.run("export", "--realm=master", "--dir=" + dir.getAbsolutePath());
         cliResult.assertMessage("Export of realm 'master' requested.");
         cliResult.assertMessage("Export finished successfully");
-        
+
         // add a placeholder into the realm
         ObjectMapper mapper = new ObjectMapper();
         File file = new File(dir, "master-realm.json");
         ObjectNode node = (ObjectNode)mapper.readTree(file);
         node.put("enabled", "${REALM_ENABLED}");
         mapper.writer().writeValue(file, node);
-        
+
         dist.setEnvVar("REALM_ENABLED", "true");
         cliResult = dist.run("import", "--dir=" + dir.getAbsolutePath());
         cliResult.assertMessage("Realm 'master' imported");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
@@ -19,6 +19,8 @@ package org.keycloak.it.cli.dist;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -33,6 +35,7 @@ import static org.hamcrest.Matchers.matchesPattern;
 @DistributionTest
 @RawDistOnly(reason = "No need to test script again on container")
 @WithEnvVars({"PRINT_ENV", "true"})
+@Tag(DistributionTest.WIN)
 public class JavaOptsScriptTest {
 
     private static final String DEFAULT_OPTS = "(?:-\\S+ )*-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Dfile.encoding=UTF-8(?: -\\S+)*";
@@ -106,7 +109,7 @@ public class JavaOptsScriptTest {
         String output = result.getOutput();
         assertThat(output, containsString("JAVA_ADD_OPENS already set in environment; overriding default settings"));
         assertThat(output, not(containsString("--add-opens")));
-        assertThat(output, matchesPattern(String.format("(?s).*Using JAVA_OPTS: %s%s -Dfoo=bar.*", 
+        assertThat(output, matchesPattern(String.format("(?s).*Using JAVA_OPTS: %s%s -Dfoo=bar.*",
                 OS.WINDOWS.isCurrentOs() ? "-Dprogram.name=kc.bat " : "", DEFAULT_OPTS)));
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JaxRsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JaxRsDistTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.it.cli.dist;
 
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.jaxrs.filter.TestFilterTestProvider;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DistributionTest(keepAlive = true)
 @RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SMOKE)
 public class JaxRsDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.config.LoggingOptions;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -47,6 +48,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest
 @RawDistOnly(reason = "Too verbose for docker and enough to check raw dist")
+@Tag(DistributionTest.SLOW)
 public class LoggingDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
@@ -20,6 +20,7 @@ import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
         requestPort = 9000,
         containerExposedPorts = {9000, 8080, 9005})
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag(DistributionTest.SLOW)
 public class ManagementDistTest {
 
     @Test
@@ -171,7 +173,9 @@ public class ManagementDistTest {
         cliResult.assertMessage("Management interface listening on http://localhost:9000");
 
         // If running in container, we cannot access the localhost due to network host settings
-        if (DistributionType.isContainerDist()) return;
+        if (DistributionType.isContainerDist()) {
+            return;
+        }
 
         when().get("/").then()
                 .statusCode(200)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/MetricsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/MetricsDistTest.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.utils.KeycloakDistribution;
@@ -36,6 +38,7 @@ import io.quarkus.test.junit.main.Launch;
 @DistributionTest(keepAlive = true,
         requestPort = 9000,
         containerExposedPorts = {8080, 9000})
+@Tag(DistributionTest.SLOW)
 public class MetricsDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -27,6 +27,7 @@ import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_LONG_NAM
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -42,6 +43,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 @WithEnvVars({"KC_CACHE", "local"}) // avoid flakey port conflicts
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DistributionTest
+@Tag(DistributionTest.WIN)
 public class StartCommandDistTest {
 
     @DryRun

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -20,6 +20,7 @@ package org.keycloak.it.cli.dist;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -39,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag(DistributionTest.WIN)
 public class StartDevCommandDistTest {
 
     @DryRun

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TruststoreDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TruststoreDistTest.java
@@ -21,6 +21,7 @@ import io.restassured.RestAssured;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
@@ -36,6 +37,7 @@ import static io.restassured.RestAssured.given;
 
 @DistributionTest(keepAlive = true)
 @RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SMOKE)
 public class TruststoreDistTest {
 
     @BeforeAll

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
@@ -19,9 +19,11 @@ package org.keycloak.it.storage.database;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
 
 import io.quarkus.test.junit.main.Launch;
@@ -30,9 +32,10 @@ import io.quarkus.test.junit.main.LaunchResult;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public abstract class BasicDatabaseTest {
 
+    @Tag(DistributionTest.STORAGE)
     @Test
     @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
-    void testSuccessful(LaunchResult result) {
+    protected void testSuccessful(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStarted();
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
@@ -19,11 +19,9 @@ package org.keycloak.it.storage.database;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
-import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
 
 import io.quarkus.test.junit.main.Launch;
@@ -32,7 +30,6 @@ import io.quarkus.test.junit.main.LaunchResult;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public abstract class BasicDatabaseTest {
 
-    @Tag(DistributionTest.STORAGE)
     @Test
     @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
     protected void testSuccessful(LaunchResult result) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/ExternalInfinispanTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/ExternalInfinispanTest.java
@@ -19,6 +19,8 @@ package org.keycloak.it.storage.database;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.util.Retry;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
@@ -31,6 +33,7 @@ import static io.restassured.RestAssured.when;
 
 @DistributionTest(keepAlive = true)
 @WithExternalInfinispan
+@Tag(DistributionTest.STORAGE)
 public class ExternalInfinispanTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatabaseOptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatabaseOptionsDistTest.java
@@ -19,6 +19,8 @@ package org.keycloak.it.storage.database.dist;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -27,6 +29,7 @@ import org.keycloak.it.junit5.extension.WithEnvVars;
 
 @DistributionTest
 @WithDatabase(alias = "postgres")
+@Tag(DistributionTest.STORAGE)
 public class DatabaseOptionsDistTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MariaDBDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MariaDBDistTest.java
@@ -17,12 +17,26 @@
 
 package org.keycloak.it.storage.database.dist;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.WithDatabase;
 import org.keycloak.it.storage.database.MariaDBTest;
+import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest(removeBuildOptionsAfterBuild = true)
 @WithDatabase(alias = "mariadb")
 public class MariaDBDistTest extends MariaDBTest {
+
+    @Override
+    @Tag(DistributionTest.STORAGE)
+    @Test
+    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
+    protected void testSuccessful(LaunchResult result) {
+        super.testSuccessful(result);
+    }
 
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MySQLDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MySQLDistTest.java
@@ -1,10 +1,24 @@
 package org.keycloak.it.storage.database.dist;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.WithDatabase;
 import org.keycloak.it.storage.database.MySQLTest;
+import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest(removeBuildOptionsAfterBuild = true)
 @WithDatabase(alias = "mysql")
 public class MySQLDistTest extends MySQLTest {
+
+    @Override
+    @Tag(DistributionTest.STORAGE)
+    @Test
+    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
+    protected void testSuccessful(LaunchResult result) {
+        super.testSuccessful(result);
+    }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/PostgreSQLDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/PostgreSQLDistTest.java
@@ -20,6 +20,7 @@ package org.keycloak.it.storage.database.dist;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -31,6 +32,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest(removeBuildOptionsAfterBuild = true)
 @WithDatabase(alias = "postgres")
+@Tag(DistributionTest.STORAGE)
 public class PostgreSQLDistTest extends PostgreSQLTest {
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/TransactionConfigurationDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/TransactionConfigurationDistTest.java
@@ -2,6 +2,8 @@ package org.keycloak.it.storage.database.dist;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -9,6 +11,7 @@ import org.keycloak.it.junit5.extension.WithDatabase;
 
 @DistributionTest
 @WithDatabase(alias = "mssql")
+@Tag(DistributionTest.STORAGE)
 public class TransactionConfigurationDistTest {
 
     @Test

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLITest.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLITest.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Target(ElementType.TYPE)

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DistributionTest.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DistributionTest.java
@@ -21,12 +21,17 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Target(ElementType.TYPE)
 @ExtendWith({ CLITestExtension.class })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DistributionTest {
+
+    public static final String WIN = "win";
+    public static final String STORAGE = "storage";
+    public static final String SMOKE = "smoke";
 
     boolean debug() default false;
     /**

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DistributionTest.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/DistributionTest.java
@@ -32,6 +32,7 @@ public @interface DistributionTest {
     public static final String WIN = "win";
     public static final String STORAGE = "storage";
     public static final String SMOKE = "smoke";
+    public static final String SLOW = "slow";
 
     boolean debug() default false;
     /**


### PR DESCRIPTION
splits the zip tests into those that run quickly and slowly. Also uses tags to control what is run.

closes: #34927

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
