### PR TITLE
Add support for marking a managed realm as dirty, making updates with rollback, and running cleanup tasks for a realm

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/test/framework/injection/ManagedTestResource.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/injection/ManagedTestResource.java
@@ -1,0 +1,17 @@
+package org.keycloak.test.framework.injection;
+
+public abstract class ManagedTestResource {
+
+    private boolean dirty = false;
+
+    public abstract void runCleanup();
+
+    boolean isDirty() {
+        return dirty;
+    }
+
+    public void dirty() {
+        this.dirty = true;
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/realm/ManagedRealm.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/realm/ManagedRealm.java
@@ -2,12 +2,15 @@ package org.keycloak.test.framework.realm;
 
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.test.framework.injection.ManagedTestResource;
 
-public class ManagedRealm {
+public class ManagedRealm extends ManagedTestResource {
 
     private final String baseUrl;
     private final RealmRepresentation createdRepresentation;
     private final RealmResource realmResource;
+
+    private ManagedRealmCleanup cleanup;
 
     public ManagedRealm(String baseUrl, RealmRepresentation createdRepresentation, RealmResource realmResource) {
         this.baseUrl = baseUrl;
@@ -25,6 +28,39 @@ public class ManagedRealm {
 
     public RealmResource admin() {
         return realmResource;
+    }
+
+    public void updateWithCleanup(RealmUpdate... updates) {
+        RealmRepresentation rep = admin().toRepresentation();
+        cleanup().resetToOriginalRepresentation(rep);
+
+        RealmConfigBuilder configBuilder = RealmConfigBuilder.update(rep);
+        for (RealmUpdate update : updates) {
+            configBuilder = update.update(configBuilder);
+        }
+
+        admin().update(configBuilder.build());
+    }
+
+    public ManagedRealmCleanup cleanup() {
+        if (cleanup == null) {
+            cleanup = new ManagedRealmCleanup();
+        }
+        return cleanup;
+    }
+
+    @Override
+    public void runCleanup() {
+        if (cleanup != null) {
+            cleanup.runCleanupTasks(realmResource);
+            cleanup = null;
+        }
+    }
+
+    public interface RealmUpdate {
+
+        RealmConfigBuilder update(RealmConfigBuilder realm);
+
     }
 
 }

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/realm/ManagedRealmCleanup.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/realm/ManagedRealmCleanup.java
@@ -1,0 +1,49 @@
+package org.keycloak.test.framework.realm;
+
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ManagedRealmCleanup {
+
+    private final List<RealmCleanup> cleanupTasks = new LinkedList<>();
+
+    public ManagedRealmCleanup add(RealmCleanup realmCleanup) {
+        this.cleanupTasks.add(realmCleanup);
+        return this;
+    }
+
+    public ManagedRealmCleanup deleteUsers() {
+        return add(r -> r.users().list().forEach(u -> r.users().delete(u.getId()).close()));
+    }
+
+    void resetToOriginalRepresentation(RealmRepresentation rep) {
+        if (cleanupTasks.stream().noneMatch(c -> c instanceof ResetRealm)) {
+            RealmRepresentation clone = RepresentationUtils.clone(rep);
+            cleanupTasks.add(new ResetRealm(clone));
+        }
+    }
+
+    void runCleanupTasks(RealmResource realm) {
+        cleanupTasks.forEach(t -> t.cleanup(realm));
+        cleanupTasks.clear();
+    }
+
+    public interface RealmCleanup {
+
+        void cleanup(RealmResource realm);
+
+    }
+
+    private record ResetRealm(RealmRepresentation rep) implements RealmCleanup {
+
+        @Override
+        public void cleanup(RealmResource realm) {
+            realm.update(rep);
+        }
+
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/realm/RealmConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/realm/RealmConfigBuilder.java
@@ -28,6 +28,11 @@ public class RealmConfigBuilder {
         return this;
     }
 
+    public RealmConfigBuilder registrationEmailAsUsername(boolean registrationEmailAsUsername) {
+        rep.setRegistrationEmailAsUsername(registrationEmailAsUsername);
+        return this;
+    }
+
     public RealmConfigBuilder roles(String... roleNames) {
         if (rep.getRoles() == null) {
             rep.setRoles(new RolesRepresentation());

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/realm/RepresentationUtils.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/realm/RepresentationUtils.java
@@ -1,0 +1,19 @@
+package org.keycloak.test.framework.realm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RepresentationUtils {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    @SuppressWarnings("unchecked")
+    public static <T> T clone(T t) {
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(t);
+            return (T) objectMapper.readValue(bytes, t.getClass());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/CleanupTest.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/CleanupTest.java
@@ -1,0 +1,75 @@
+package org.keycloak.test.examples;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.test.framework.annotations.InjectRealm;
+import org.keycloak.test.framework.annotations.KeycloakIntegrationTest;
+import org.keycloak.test.framework.realm.ManagedRealm;
+
+@KeycloakIntegrationTest
+public class CleanupTest {
+
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @Test
+    public void dirty() {
+        checkCleanState();
+
+        managedRealm.dirty();
+
+        UserRepresentation userRepresentation = new UserRepresentation();
+        userRepresentation.setEnabled(true);
+        userRepresentation.setUsername("foobar");
+        managedRealm.admin().users().create(userRepresentation);
+    }
+
+    @Test
+    public void cleanupTask() {
+        checkCleanState();
+
+        managedRealm.cleanup().add(r -> r.users().list().forEach(u -> r.users().delete(u.getId()).close()));
+
+        UserRepresentation userRepresentation = new UserRepresentation();
+        userRepresentation.setEnabled(true);
+        userRepresentation.setUsername("foobar");
+        managedRealm.admin().users().create(userRepresentation).close();
+    }
+
+    @Test
+    public void cleanupTaskReusableTasks() {
+        checkCleanState();
+
+        managedRealm.cleanup().deleteUsers();
+
+        UserRepresentation userRepresentation = new UserRepresentation();
+        userRepresentation.setEnabled(true);
+        userRepresentation.setUsername("foobar");
+        managedRealm.admin().users().create(userRepresentation).close();
+    }
+
+    @Test
+    public void test() {
+        checkCleanState();
+
+        managedRealm.updateWithCleanup(r -> r.registrationEmailAsUsername(true));
+
+        Assertions.assertTrue(managedRealm.admin().toRepresentation().isRegistrationEmailAsUsername());
+    }
+
+    @Test
+    public void test2() {
+        checkCleanState();
+
+        managedRealm.updateWithCleanup(r -> r.registrationEmailAsUsername(true));
+
+        Assertions.assertTrue(managedRealm.admin().toRepresentation().isRegistrationEmailAsUsername());
+    }
+
+    private void checkCleanState() {
+        Assertions.assertTrue(managedRealm.admin().users().list().isEmpty());
+        Assertions.assertFalse(managedRealm.admin().toRepresentation().isRegistrationEmailAsUsername());
+    }
+
+}


### PR DESCRIPTION
See #35035 for details, and [CleanupTest](https://github.com/keycloak/keycloak/pull/35037/files#diff-63a6536b14b020e23afb4fdfaec2dfca126bb657b318ee7fb12f4c604e74776b) for example on how this is used.

Only adding this for realms initially, we can add to client and users if needed later.

Closes #35035
