### PR TITLE
Upgrade to Quarkus 3.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.15.1</quarkus.version>
-        <quarkus.build.version>3.15.1</quarkus.build.version>
+        <quarkus.version>3.15.2</quarkus.version>
+        <quarkus.build.version>3.15.2</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -43,34 +43,6 @@
         <module>tests</module>
     </modules>
 
-    <!-- Remove once Quarkus Micrometer extension uses Micrometer 1.13.5-->
-    <!-- See https://github.com/keycloak/keycloak/issues/33469 -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-core</artifactId>
-                <version>1.13.5</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-commons</artifactId>
-                <version>1.13.5</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-observation</artifactId>
-                <version>1.13.5</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
-                <version>1.13.5</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-    <!-- Remove until here  -->
-
     <repositories>
         <repository>
             <id>central</id>

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.services.resources.account;
 
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.logging.Logger;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
@@ -95,6 +98,16 @@ public class AccountLoader {
             throw new NotFoundException();
         }
     }
+
+    // Remove once Quarkus is upgraded to 3.15.3, or reconsidered to use this approach
+    // See https://github.com/keycloak/keycloak/issues/36009
+    @OPTIONS
+    @Path("{any:.*}")
+    @Operation(hidden = true)
+    public Response preFlight() {
+        return new CorsPreflightService().preflight();
+    }
+    // remove until here
 
     @Path("{version : v\\d[0-9a-zA-Z_\\-]*}")
     @Produces(MediaType.APPLICATION_JSON)

--- a/tests/base/src/test/java/org/keycloak/test/admin/AdminPreflightTest.java
+++ b/tests/base/src/test/java/org/keycloak/test/admin/AdminPreflightTest.java
@@ -26,7 +26,16 @@ public class AdminPreflightTest {
 
     @Test
     public void testPreflight() throws IOException {
-        HttpOptions options = new HttpOptions(keycloakUrls.getAdminBuilder().path("/realms/master/users").build());
+        testPreflightForAdminPath("/realms/master/users");
+    }
+
+    @Test
+    public void testPreflightServerInfo() throws IOException {
+        testPreflightForAdminPath("/serverinfo");
+    }
+
+    private void testPreflightForAdminPath(String path) throws IOException {
+        HttpOptions options = new HttpOptions(keycloakUrls.getAdminBuilder().path(path).build());
         options.setHeader("Origin", "http://test");
 
         HttpResponse response = client.execute(options);


### PR DESCRIPTION
- Closes #35077
- Closes #33469
- Fixes #36009 

## Micrometer
The proper Micrometer version(1.13.5) is used:

```
> mvn dependency:tree | grep io.micrometer
[INFO] |  \- io.micrometer:micrometer-core:jar:1.13.5:compile
[INFO] |     +- io.micrometer:micrometer-commons:jar:1.13.5:compile
[INFO] |     +- io.micrometer:micrometer-observation:jar:1.13.5:compile
[INFO] |  \- io.micrometer:micrometer-registry-prometheus-simpleclient:jar:1.13.5:compile
[INFO] |  +- io.micrometer:micrometer-core:jar:1.13.5:compile
[INFO] |  |  +- io.micrometer:micrometer-commons:jar:1.13.5:compile
[INFO] |  |  +- io.micrometer:micrometer-observation:jar:1.13.5:compile
[INFO] |  \- io.micrometer:micrometer-registry-prometheus-simpleclient:jar:1.13.5:compile
[INFO] |  |  \- io.micrometer:micrometer-core:jar:1.13.5:compile
[INFO] |  |     +- io.micrometer:micrometer-commons:jar:1.13.5:compile
[INFO] |  |     +- io.micrometer:micrometer-observation:jar:1.13.5:compile
[INFO] |  |  \- io.micrometer:micrometer-registry-prometheus-simpleclient:jar:1.13.5:compile
[INFO] |  |  +- io.micrometer:micrometer-core:jar:1.13.5:compile
[INFO] |  |  |  +- io.micrometer:micrometer-commons:jar:1.13.5:compile
[INFO] |  |  |  +- io.micrometer:micrometer-observation:jar:1.13.5:compile
[INFO] |  |  \- io.micrometer:micrometer-registry-prometheus-simpleclient:jar:1.13.5:compile
[INFO] |  |  \- io.micrometer:micrometer-core:jar:1.13.5:compile
[INFO] |  |     +- io.micrometer:micrometer-commons:jar:1.13.5:compile
[INFO] |  |     \- io.micrometer:micrometer-observation:jar:1.13.5:compile
[INFO] |  |  \- io.micrometer:micrometer-registry-prometheus-simpleclient:jar:1.13.5:compile
[INFO] |  |  +- io.micrometer:micrometer-registry-prometheus:jar:1.13.5:compile
[INFO] |  |  |  \- io.micrometer:micrometer-core:jar:1.13.5:test
[INFO] |  |  |     +- io.micrometer:micrometer-commons:jar:1.13.5:test
[INFO] |  |  |     \- io.micrometer:micrometer-observation:jar:1.13.5:test
[INFO] |  |  |  \- io.micrometer:micrometer-registry-prometheus-simpleclient:jar:1.13.5:test
[INFO] |  |  |  +- io.micrometer:micrometer-registry-prometheus:jar:1.13.5:test

```

## CORS changes
For Quarkus 3.15.2, some changes around `@HEAD`, and `@OPTIONS` handling for sub-resources were made[1]. We are more interested in the `@OPTIONS` HTTP method that is used in preflight requests. When a sub-resource does not contain REST handler for `@OPTIONS`, a default response with default fields like 'Access-Control-Allow-Methods' is returned. However, in some places, we managed the `@OPTIONS` in a method redirecting to the subresource, so RESTEasy was not able to discover it.

In that case, different headers (from the new default response) were provided, that do not allow some methods hidden in sub-sub-resources.

It is a breaking change introduced in Quarkus 3.15.2 and addressed by: https://github.com/quarkusio/quarkus/issues/45173


[1] https://github.com/quarkusio/quarkus/pull/43440