### PR TITLE
Prefer usage of `StandardCharsets.UTF_8` over `"UTF-8"` charset reference

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
@@ -21,6 +21,7 @@ import static org.keycloak.adapters.saml.SamlPrincipal.DEFAULT_ROLE_ATTRIBUTE_NA
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -689,7 +690,7 @@ public abstract class AbstractSamlAuthenticationHandler implements SamlAuthentic
         try {
             //byte[] decodedSignature = RedirectBindingUtil.urlBase64Decode(signature);
             byte[] decodedSignature = Base64.decode(signature);
-            byte[] rawQueryBytes = rawQuery.getBytes("UTF-8");
+            byte[] rawQueryBytes = rawQuery.getBytes(StandardCharsets.UTF_8);
 
             SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.getFromXmlMethod(decodedAlgorithm);
 

--- a/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/ElytronHttpFacade.java
+++ b/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/ElytronHttpFacade.java
@@ -22,11 +22,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -226,11 +226,7 @@ class ElytronHttpFacade implements HttpFacade {
             @Override
             public String getURI() {
                 if (elyweb163Workaround) {
-                    try {
-                        return URLDecoder.decode(request.getRequestURI().toString(), "UTF-8");
-                    } catch (UnsupportedEncodingException e) {
-                        throw new RuntimeException("Failed to decode request URI", e);
-                    }
+                    return URLDecoder.decode(request.getRequestURI().toString(), StandardCharsets.UTF_8);
                 } else {
                     return request.getRequestURI().toString();
                 }
@@ -261,11 +257,7 @@ class ElytronHttpFacade implements HttpFacade {
                         for (String parameter : parameters) {
                             String[] keyValue = parameter.split("=", 2);
                             if (keyValue[0].equals(param)) {
-                                try {
-                                    return URLDecoder.decode(keyValue[1], "UTF-8");
-                                } catch (IOException e) {
-                                    throw new RuntimeException("Failed to decode request URI", e);
-                                }
+                                return URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
                             }
                         }
                     }

--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethod.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethod.java
@@ -17,7 +17,7 @@
  */
 package org.keycloak.authorization.client.util;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -184,11 +184,7 @@ public class HttpMethod<R> {
                         }
                     }
 
-                    try {
-                        builder.setEntity(new UrlEncodedFormEntity(formparams, "UTF-8"));
-                    } catch (UnsupportedEncodingException e) {
-                        throw new RuntimeException("Error creating form parameters");
-                    }
+                    builder.setEntity(new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8));
                 }
             }
         };

--- a/core/src/main/java/org/keycloak/TokenVerifier.java
+++ b/core/src/main/java/org/keycloak/TokenVerifier.java
@@ -32,6 +32,7 @@ import org.keycloak.util.TokenUtil;
 
 import javax.crypto.SecretKey;
 
+import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -432,7 +433,7 @@ public class TokenVerifier<T extends JsonWebToken> {
     public void verifySignature() throws VerificationException {
         if (this.verifier != null) {
             try {
-                if (!verifier.verify(jws.getEncodedSignatureInput().getBytes("UTF-8"), jws.getSignature())) {
+                if (!verifier.verify(jws.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), jws.getSignature())) {
                     throw new TokenSignatureInvalidException(token, "Invalid token signature");
                 }
             } catch (Exception e) {

--- a/core/src/main/java/org/keycloak/sdjwt/SdJws.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJws.java
@@ -17,6 +17,7 @@
 package org.keycloak.sdjwt;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -86,7 +87,7 @@ public abstract class SdJws {
     public void verifySignature(SignatureVerifierContext verifier) throws VerificationException {
         Objects.requireNonNull(verifier, "verifier must not be null");
         try {
-            if (!verifier.verify(jwsInput.getEncodedSignatureInput().getBytes("UTF-8"), jwsInput.getSignature())) {
+            if (!verifier.verify(jwsInput.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), jwsInput.getSignature())) {
                 throw new VerificationException("Invalid jws signature");
             }
         } catch (Exception e) {

--- a/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
+++ b/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
@@ -20,6 +20,7 @@ package org.keycloak.util;
 import org.keycloak.common.util.Base64;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -64,10 +65,14 @@ public class BasicAuthHelper {
     public static abstract class RFC6749 {
 
         public static String createHeader(String username, String password) {
-            return BasicAuthHelper.createHeader(
-                URLEncoder.encode(username, StandardCharsets.UTF_8),
-                URLEncoder.encode(password, StandardCharsets.UTF_8)
-            );
+            try {
+                return BasicAuthHelper.createHeader(
+                    URLEncoder.encode(username, "UTF-8"),
+                    URLEncoder.encode(password, "UTF-8")
+                );
+            } catch (UnsupportedEncodingException e) {
+                return null;
+            }
         }
 
         public static String[] parseHeader(String header) {
@@ -76,10 +81,14 @@ public class BasicAuthHelper {
                 return null;
             }
 
-            return new String[]{
-                URLDecoder.decode(val[0], StandardCharsets.UTF_8),
-                URLDecoder.decode(val[1], StandardCharsets.UTF_8)
-            };
+            try {
+                return new String[]{
+                    URLDecoder.decode(val[0], "UTF-8"),
+                    URLDecoder.decode(val[1], "UTF-8")
+                };
+            } catch (UnsupportedEncodingException e) {
+                return null;
+            }
         }
     }
 }

--- a/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
+++ b/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
@@ -20,7 +20,6 @@ package org.keycloak.util;
 import org.keycloak.common.util.Base64;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -65,14 +64,10 @@ public class BasicAuthHelper {
     public static abstract class RFC6749 {
 
         public static String createHeader(String username, String password) {
-            try {
-                return BasicAuthHelper.createHeader(
-                    URLEncoder.encode(username, "UTF-8"),
-                    URLEncoder.encode(password, "UTF-8")
-                );
-            } catch (UnsupportedEncodingException e) {
-                return null;
-            }
+            return BasicAuthHelper.createHeader(
+                URLEncoder.encode(username, StandardCharsets.UTF_8),
+                URLEncoder.encode(password, StandardCharsets.UTF_8)
+            );
         }
 
         public static String[] parseHeader(String header) {
@@ -81,14 +76,10 @@ public class BasicAuthHelper {
                 return null;
             }
 
-            try {
-                return new String[]{
-                    URLDecoder.decode(val[0], "UTF-8"),
-                    URLDecoder.decode(val[1], "UTF-8")
-                };
-            } catch (UnsupportedEncodingException e) {
-                return null;
-            }
+            return new String[]{
+                URLDecoder.decode(val[0], StandardCharsets.UTF_8),
+                URLDecoder.decode(val[1], StandardCharsets.UTF_8)
+            };
         }
     }
 }

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronUserIdentityExtractorProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronUserIdentityExtractorProvider.java
@@ -16,7 +16,7 @@
  */
 package org.keycloak.crypto.elytron;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
@@ -143,7 +143,7 @@ public class ElytronUserIdentityExtractorProvider  extends UserIdentityExtractor
                                             while(!Character.isLetterOrDigit(sb[0])) {
                                                 sb = Arrays.copyOfRange(sb, 1, sb.length);
                                             }
-                                            subjectName = new String(sb, "UTF-8");
+                                            subjectName = new String(sb, StandardCharsets.UTF_8);
                                             upnOidFound = true;
                                         }
                                         break;
@@ -176,7 +176,7 @@ public class ElytronUserIdentityExtractorProvider  extends UserIdentityExtractor
                     }
                     
                 }
-            } catch (CertificateParsingException | UnsupportedEncodingException e) {
+            } catch (CertificateParsingException e) {
                 log.error("Failed to parse Subject Name:",e);
             }
             

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/messages/Message.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/messages/Message.java
@@ -21,9 +21,9 @@ import org.freedesktop.dbus.utils.LoggingHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -609,13 +609,7 @@ public class Message {
                     payload = _data.toString();
                 }
 
-                byte[] payloadbytes = null;
-                try {
-                    payloadbytes = payload.getBytes("UTF-8");
-                } catch (UnsupportedEncodingException _ex) {
-                    logger.debug("System does not support UTF-8 encoding", _ex);
-                    throw new DBusException("System does not support UTF-8 encoding");
-                }
+                byte[] payloadbytes = payload.getBytes(StandardCharsets.UTF_8);
                 logger.trace("Appending String of length {}", payloadbytes.length);
                 appendint(payloadbytes.length, 4);
                 appendBytes(payloadbytes);
@@ -1055,12 +1049,7 @@ public class Message {
             case ArgumentType.STRING:
                 int length = (int) demarshallint(_dataBuf, _offsets[OFFSET_DATA], 4);
                 _offsets[OFFSET_DATA] += 4;
-                try {
-                    rv = new String(_dataBuf, _offsets[OFFSET_DATA], length, "UTF-8");
-                } catch (UnsupportedEncodingException _ex) {
-                    logger.debug("System does not support UTF-8 encoding", _ex);
-                    throw new DBusException("System does not support UTF-8 encoding");
-                }
+                rv = new String(_dataBuf, _offsets[OFFSET_DATA], length, StandardCharsets.UTF_8);
                 _offsets[OFFSET_DATA] += length + 1;
                 break;
             case ArgumentType.OBJECT_PATH:

--- a/federation/sssd/src/main/java/org/freedesktop/dbus/utils/XmlUtil.java
+++ b/federation/sssd/src/main/java/org/freedesktop/dbus/utils/XmlUtil.java
@@ -12,7 +12,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -219,8 +218,8 @@ public final class XmlUtil {
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
 
             transformer.transform(new DOMSource(_docOrNode),
-                 new StreamResult(new OutputStreamWriter(_outStream, "UTF-8")));
-        } catch (UnsupportedEncodingException | TransformerException _ex) {
+                 new StreamResult(new OutputStreamWriter(_outStream, StandardCharsets.UTF_8)));
+        } catch (TransformerException _ex) {
             throw new IOException("Could not print Document or Node.", _ex);
         }
 

--- a/model/storage-services/src/main/java/org/keycloak/exportimport/AbstractFileBasedImportProvider.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/AbstractFileBasedImportProvider.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Optional;
 import org.keycloak.common.util.StringPropertyReplacer;

--- a/model/storage-services/src/main/java/org/keycloak/exportimport/AbstractFileBasedImportProvider.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/AbstractFileBasedImportProvider.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Optional;
 import org.keycloak.common.util.StringPropertyReplacer;
@@ -39,7 +40,7 @@ public abstract class AbstractFileBasedImportProvider implements ImportProvider 
 
     protected InputStream parseFile(File importFile) throws IOException {
         if (ExportImportConfig.isReplacePlaceholders()) {
-            String raw = new String(Files.readAllBytes(importFile.toPath()), "UTF-8");
+            String raw = Files.readString(importFile.toPath());
             String parsed = replaceProperties(raw, ENV_VAR_PROPERTY_RESOLVER);
             return new ByteArrayInputStream(parsed.getBytes());
         }

--- a/server-spi-private/src/test/java/org/keycloak/broker/provider/util/SimpleHttpTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/broker/provider/util/SimpleHttpTest.java
@@ -120,7 +120,7 @@ public final class SimpleHttpTest {
 
         @Test
         public void requestWithEncodingParam() throws IOException {
-            String expectedResponse = "dummy=" + URLEncoder.encode(value, "UTF-8");
+            String expectedResponse = "dummy=" + URLEncoder.encode(value, StandardCharsets.UTF_8);
             HttpClientMock client = new HttpClientMock();
             if (expectedResponse.getBytes(StandardCharsets.UTF_8).length < 1024) {
                 SimpleHttp.Response response = SimpleHttp.doPost("", client, 1024).param("dummy", value).asResponse();

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
@@ -18,6 +18,7 @@
 package org.keycloak.authentication.forms;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,7 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
         formparams.add(new BasicNameValuePair("remoteip", context.getConnection().getRemoteAddr()));
 
         try {
-            UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, "UTF-8");
+            UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8);
             post.setEntity(form);
             try (CloseableHttpResponse response = httpClient.execute(post)) {
                 InputStream content = response.getEntity().getContent();

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -53,7 +53,6 @@ import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Duration;

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -274,7 +274,7 @@ public class DefaultTokenManager implements TokenManager {
         String encryptionKekId = keyWrapper.getKid();
         try {
             encryptedToken = TokenUtil.jweKeyEncryptionEncode(encryptionKek, encodedToken.getBytes(StandardCharsets.UTF_8), algAlgorithm, encAlgorithm, encryptionKekId, jweAlgorithmProvider, jweEncryptionProvider);
-        } catch (JWEException | UnsupportedEncodingException e) {
+        } catch (JWEException e) {
             throw new RuntimeException(e);
         }
         return encryptedToken;

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -54,6 +54,7 @@ import org.keycloak.util.TokenUtil;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Duration;
 import java.util.Comparator;
@@ -106,7 +107,7 @@ public class DefaultTokenManager implements TokenManager {
                 kid = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, signatureAlgorithm).getKid();
             }
 
-            boolean valid = signatureProvider.verifier(kid).verify(jws.getEncodedSignatureInput().getBytes("UTF-8"), jws.getSignature());
+            boolean valid = signatureProvider.verifier(kid).verify(jws.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), jws.getSignature());
             return valid ? jws.readJsonContent(clazz) : null;
         } catch (Exception e) {
             logger.debug("Failed to decode token", e);
@@ -181,7 +182,7 @@ public class DefaultTokenManager implements TokenManager {
                 return null;
             }
 
-            boolean valid = signatureProvider.verifier(client, jws).verify(jws.getEncodedSignatureInput().getBytes("UTF-8"), jws.getSignature());
+            boolean valid = signatureProvider.verifier(client, jws).verify(jws.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), jws.getSignature());
             return valid ? jws.readJsonContent(clazz) : null;
         } catch (Exception e) {
             logger.debug("Failed to decode token", e);
@@ -272,7 +273,7 @@ public class DefaultTokenManager implements TokenManager {
         Key encryptionKek = keyWrapper.getPublicKey();
         String encryptionKekId = keyWrapper.getKid();
         try {
-            encryptedToken = TokenUtil.jweKeyEncryptionEncode(encryptionKek, encodedToken.getBytes("UTF-8"), algAlgorithm, encAlgorithm, encryptionKekId, jweAlgorithmProvider, jweEncryptionProvider);
+            encryptedToken = TokenUtil.jweKeyEncryptionEncode(encryptionKek, encodedToken.getBytes(StandardCharsets.UTF_8), algAlgorithm, encAlgorithm, encryptionKekId, jweAlgorithmProvider, jweEncryptionProvider);
         } catch (JWEException | UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -77,7 +77,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Map;
 
@@ -346,9 +346,9 @@ public class UserInfoEndpoint {
         Key encryptionKek = keyWrapper.getPublicKey();
         String encryptionKekId = keyWrapper.getKid();
         try {
-            encryptedToken = TokenUtil.jweKeyEncryptionEncode(encryptionKek, content.getBytes("UTF-8"), algAlgorithm,
+            encryptedToken = TokenUtil.jweKeyEncryptionEncode(encryptionKek, content.getBytes(StandardCharsets.UTF_8), algAlgorithm,
                     encAlgorithm, encryptionKekId, jweAlgorithmProvider, jweEncryptionProvider, jweContentType);
-        } catch (JWEException | UnsupportedEncodingException e) {
+        } catch (JWEException e) {
             throw new RuntimeException(e);
         }
         return encryptedToken;

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/channel/CIBAAuthenticationRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/channel/CIBAAuthenticationRequest.java
@@ -19,7 +19,7 @@ package org.keycloak.protocol.oidc.grants.ciba.channel;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.crypto.Algorithm;
@@ -64,8 +64,8 @@ public class CIBAAuthenticationRequest extends JsonWebToken {
 
         try {
             byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(aesKey, hmacKey, jwe);
-            jwe = new String(contentBytes, "UTF-8");
-        } catch (JWEException | UnsupportedEncodingException e) {
+            jwe = new String(contentBytes, StandardCharsets.UTF_8);
+        } catch (JWEException e) {
             throw new RuntimeException("Error decoding auth_req_id.", e);
         }
 
@@ -159,8 +159,8 @@ public class CIBAAuthenticationRequest extends JsonWebToken {
             SecretKey aesKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, Algorithm.AES).getSecretKey();
             SecretKey hmacKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, Constants.INTERNAL_SIGNATURE_ALGORITHM).getSecretKey();
 
-            return TokenUtil.jweDirectEncode(aesKey, hmacKey, encodedJwt.getBytes("UTF-8"));
-        } catch (JWEException | UnsupportedEncodingException e) {
+            return TokenUtil.jweDirectEncode(aesKey, hmacKey, encodedJwt.getBytes(StandardCharsets.UTF_8));
+        } catch (JWEException e) {
             throw new RuntimeException("Error encoding auth_req_id.", e);
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/SHA256PairwiseSubMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/SHA256PairwiseSubMapper.java
@@ -12,6 +12,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -27,7 +28,7 @@ public class SHA256PairwiseSubMapper extends AbstractPairwiseSubMapper {
     private final Charset charset;
 
     public SHA256PairwiseSubMapper() {
-        charset = Charset.forName("UTF-8");
+        charset = StandardCharsets.UTF_8;
     }
 
     public static ProtocolMapperRepresentation createPairwiseMapper(String sectorIdentifierUri, String salt) {
@@ -75,7 +76,7 @@ public class SHA256PairwiseSubMapper extends AbstractPairwiseSubMapper {
             throw new IllegalStateException("Salt not available on mappingModel. Please update protocol mapper");
         }
 
-        Charset charset = Charset.forName("UTF-8");
+        Charset charset = StandardCharsets.UTF_8;
         byte[] salt = saltStr.getBytes(charset);
         String pairwiseSub = generateSub(sectorIdentifier, localSub, salt);
         logger.tracef("local sub = '%s', pairwise sub = '%s'", localSub, pairwiseSub);

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -100,6 +100,7 @@ import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPMessage;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.ArrayList;
@@ -859,7 +860,7 @@ public class SamlProtocol implements LoginProtocol {
                 formparams.add(new BasicNameValuePair("BACK_CHANNEL_LOGOUT", "BACK_CHANNEL_LOGOUT")); // for Picketlink
                 // todo remove
                 // this
-                UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, "UTF-8");
+                UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8);
                 HttpPost post = new HttpPost(logoutUrl);
                 post.setEntity(form);
                 try (CloseableHttpResponse response = httpClient.execute(post)) {

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolUtils.java
@@ -20,6 +20,7 @@ package org.keycloak.protocol.saml;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -172,7 +173,7 @@ public class SamlProtocolUtils {
             String decodedAlgorithm = RedirectBindingUtil.urlDecode(encodedParams.getFirst(GeneralConstants.SAML_SIG_ALG_REQUEST_KEY));
             SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.getFromXmlMethod(decodedAlgorithm);
             if (!RedirectBindingSignatureUtil.validateRedirectBindingSignature(signatureAlgorithm,
-                    rawQuery.getBytes("UTF-8"), decodedSignature, locator, keyId)) {
+                    rawQuery.getBytes(StandardCharsets.UTF_8), decodedSignature, locator, keyId)) {
                 throw new VerificationException("Invalid query param signature");
             }
         } catch (Exception e) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -97,7 +97,6 @@ import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -830,11 +829,7 @@ public class AuthenticationManager {
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
         // remember me cookie should be persistent (hardcoded to 365 days for now)
         //NewCookie cookie = new NewCookie(KEYCLOAK_REMEMBER_ME, "true", path, null, null, realm.getCentralLoginLifespan(), secureOnly);// todo httponly , true);
-        try {
-            session.getProvider(CookieProvider.class).set(CookieType.LOGIN_HINT, "username:" + URLEncoder.encode(username, "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Failed to urlencode", e);
-        }
+        session.getProvider(CookieProvider.class).set(CookieType.LOGIN_HINT, "username:" + URLEncoder.encode(username, StandardCharsets.UTF_8));
     }
 
     public static String getRememberMeUsername(KeycloakSession session) {
@@ -843,11 +838,7 @@ public class AuthenticationManager {
             if (value != null) {
                 String[] s = value.split(":");
                 if (s[0].equals("username") && s.length == 2) {
-                    try {
-                        return URLDecoder.decode(s[1], "UTF-8");
-                    } catch (UnsupportedEncodingException e) {
-                        throw new RuntimeException("Failed to urldecode", e);
-                    }
+                    return URLDecoder.decode(s[1], StandardCharsets.UTF_8);
                 }
             }
         }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -47,6 +47,7 @@ import org.keycloak.utils.StringUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -164,7 +165,7 @@ public class AccountConsole implements AccountResourceProvider {
         map.put("theme", (Function<String, String>) file -> {
             try {
                 final InputStream resource = theme.getResourceAsStream(file);
-                return new Scanner(resource, "UTF-8").useDelimiter("\\A").next();
+                return new Scanner(resource, StandardCharsets.UTF_8).useDelimiter("\\A").next();
             } catch (IOException e) {
                 throw new RuntimeException("could not load file", e);
             }

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookup.java
@@ -1,6 +1,6 @@
 package org.keycloak.services.x509;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
@@ -108,11 +108,7 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
             log.warn("End user TLS Certificate is NULL! ");
             return null;
         }
-        try {
-            pem = java.net.URLDecoder.decode(pem, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            log.error("Cannot URL decode the end user TLS Certificate : " + pem,e);
-        }
+        pem = java.net.URLDecoder.decode(pem, StandardCharsets.UTF_8);
 
         if (pem.startsWith(PemUtils.BEGIN_CERT)) {
             pem = removeBeginEnd(pem);

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxyTrustedClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxyTrustedClientCertificateLookup.java
@@ -5,7 +5,7 @@ import org.keycloak.http.HttpRequest;
 import org.keycloak.common.util.PemException;
 import org.keycloak.common.util.PemUtils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 
@@ -67,11 +67,8 @@ public class NginxProxyTrustedClientCertificateLookup extends AbstractClientCert
             log.warn("End user TLS Certificate is NULL! ");
             return null;
         }
-        try {
-            pem = java.net.URLDecoder.decode(pem, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            log.error("Cannot URL decode the end user TLS Certificate : " + pem,e);
-        }
+        pem = java.net.URLDecoder.decode(pem, StandardCharsets.UTF_8);
+
 
         return PemUtils.decodeCertificate(pem);
     }

--- a/services/src/main/java/org/keycloak/social/stackoverflow/StackoverflowIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/stackoverflow/StackoverflowIdentityProvider.java
@@ -28,11 +28,10 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakSession;
 
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 /**
@@ -118,7 +117,7 @@ public class StackoverflowIdentityProvider extends AbstractOAuth2IdentityProvide
 					}
 					String[] pe = path.split("/");
 					if (pe.length >= 3) {
-						return URLDecoder.decode(pe[2], "UTF-8");
+						return URLDecoder.decode(pe[2], StandardCharsets.UTF_8);
 					} else {
 						log.warn("Stackoverflow profile URL path is without third part: " + profileURL);
 					}

--- a/services/src/main/java/org/keycloak/userprofile/config/UPConfigUtils.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPConfigUtils.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,7 +91,7 @@ public class UPConfigUtils {
      * @throws IOException if JSON configuration can't be loaded (eg due to JSON format errors etc)
      */
     public static UPConfig parseConfig(String rawConfig) throws IOException {
-        return readConfig(new ByteArrayInputStream(rawConfig.getBytes("UTF-8")));
+        return readConfig(new ByteArrayInputStream(rawConfig.getBytes(StandardCharsets.UTF_8)));
     }
 
     /**

--- a/services/src/test/java/org/keycloak/social/openshift/OpenshiftV4IdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/social/openshift/OpenshiftV4IdentityProviderTest.java
@@ -1,7 +1,6 @@
 package org.keycloak.social.openshift;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;

--- a/services/src/test/java/org/keycloak/social/openshift/OpenshiftV4IdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/social/openshift/OpenshiftV4IdentityProviderTest.java
@@ -13,6 +13,7 @@ import org.keycloak.models.KeycloakSession;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public class OpenshiftV4IdentityProviderTest {
     @Before
     public void before() throws Exception {
         oauthMetadataFile = OpenshiftV4IdentityProviderTest.class.getResource(TEST_OAUTH_METADATA_FILE);
-        authMetadata = IOUtils.toString(oauthMetadataFile, Charsets.toCharset("UTF-8"));
+        authMetadata = IOUtils.toString(oauthMetadataFile, StandardCharsets.UTF_8);
 
         ObjectMapper objectMapper = new ObjectMapper();
         oauthMetadataMap = objectMapper.readValue(authMetadata, HashMap.class);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/migration/MigrationContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/migration/MigrationContext.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.jboss.logging.Logger;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/migration/MigrationContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/migration/MigrationContext.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
@@ -54,7 +55,7 @@ public class MigrationContext {
         logger.infof("Reading previously saved offline token from the file: %s", file);
 
         try (FileInputStream fis = new FileInputStream(file)) {
-            String offlineToken = StreamUtil.readString(fis, Charset.forName("UTF-8"));
+            String offlineToken = StreamUtil.readString(fis, StandardCharsets.UTF_8);
             logger.infof("Successfully read offline token: %s", offlineToken);
             File f = new File(file);
             f.delete();

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -88,11 +88,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -542,13 +540,7 @@ public class OAuthClient {
         parameters.add(new BasicNameValuePair("token", tokenToIntrospect));
         parameters.add(new BasicNameValuePair("token_type_hint", tokenType));
 
-        UrlEncodedFormEntity formEntity;
-
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
 
         post.setEntity(formEntity);
 
@@ -639,12 +631,7 @@ public class OAuthClient {
                         .forEach(paramName -> parameters.add(new BasicNameValuePair(paramName, customParameters.get(paramName))));
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AccessTokenResponse(client.execute(post));
@@ -694,12 +681,7 @@ public class OAuthClient {
                 parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scope));
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AccessTokenResponse(client.execute(post));
@@ -725,12 +707,7 @@ public class OAuthClient {
 
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AccessTokenResponse(client.execute(post));
@@ -766,12 +743,7 @@ public class OAuthClient {
                 parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scopeParam));
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AccessTokenResponse(client.execute(post));
@@ -785,12 +757,7 @@ public class OAuthClient {
             List<NameValuePair> parameters = new LinkedList<>();
             parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
             parameters.add(new BasicNameValuePair("code", preAuthorizedCode));
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AccessTokenResponse(client.execute(post));
@@ -836,12 +803,7 @@ public class OAuthClient {
                 }
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AuthenticationRequestAcknowledgement(client.execute(post));
@@ -881,12 +843,7 @@ public class OAuthClient {
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CIBA_GRANT_TYPE));
         parameters.add(new BasicNameValuePair(AUTH_REQ_ID, authReqId));
 
-        UrlEncodedFormEntity formEntity;
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         return new AccessTokenResponse(client.execute(post));
@@ -919,12 +876,7 @@ public class OAuthClient {
             post.addHeader("Origin", origin);
         }
 
-        UrlEncodedFormEntity formEntity;
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         return client.execute(post);
@@ -945,12 +897,7 @@ public class OAuthClient {
             parameters.add(new BasicNameValuePair(OAuth2Constants.LOGOUT_TOKEN, logoutToken));
         }
 
-        UrlEncodedFormEntity formEntity;
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         return client.execute(post);
@@ -991,12 +938,7 @@ public class OAuthClient {
             post.addHeader(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
         }
 
-        UrlEncodedFormEntity formEntity;
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         return client.execute(post);
@@ -1045,12 +987,7 @@ public class OAuthClient {
             post.addHeader(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
         }
 
-        UrlEncodedFormEntity formEntity;
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         try {
@@ -1090,12 +1027,7 @@ public class OAuthClient {
                 parameters.add(new BasicNameValuePair(OAuth2Constants.CODE_CHALLENGE_METHOD, codeChallengeMethod));
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new DeviceAuthorizationResponse(client.execute(post));
@@ -1124,12 +1056,7 @@ public class OAuthClient {
                 parameters.add(new BasicNameValuePair(OAuth2Constants.CODE_VERIFIER, codeVerifier));
             }
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new AccessTokenResponse(client.execute(post));
@@ -1301,7 +1228,7 @@ public class OAuthClient {
                     Assert.fail("Invalid content type. Status: " + statusCode + ", contentType: " + contentType);
                 }
 
-                String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                 Map responseJson = JsonSerialization.readValue(s, Map.class);
                 if (statusCode == 201) {
                     requestUri = (String) responseJson.get("request_uri");
@@ -1453,7 +1380,7 @@ public class OAuthClient {
         Map<String, String> m = new HashMap<>();
 
         String fragment = getCurrentUri().getRawFragment();
-        List<NameValuePair> pairs = (fragment == null || fragment.isEmpty()) ? Collections.emptyList() : URLEncodedUtils.parse(fragment, Charset.forName("UTF-8"));
+        List<NameValuePair> pairs = (fragment == null || fragment.isEmpty()) ? Collections.emptyList() : URLEncodedUtils.parse(fragment, StandardCharsets.UTF_8);
 
         for (NameValuePair p : pairs) {
             m.put(p.getName(), p.getValue());
@@ -1809,7 +1736,7 @@ public class OAuthClient {
             this.claims = null;
         } else {
             try {
-                this.claims = URLEncoder.encode(JsonSerialization.writeValueAsString(claims), "UTF-8");
+                this.claims = URLEncoder.encode(JsonSerialization.writeValueAsString(claims), StandardCharsets.UTF_8);
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }
@@ -1999,7 +1926,7 @@ public class OAuthClient {
                     Assert.fail("Invalid content type. Status: " + statusCode + ", contentType: " + contentType);
                 }
 
-                String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                 Map responseJson = JsonSerialization.readValue(s, Map.class);
                 if (statusCode == 200) {
                     authReqId = (String) responseJson.get("auth_req_id");
@@ -2301,7 +2228,7 @@ public class OAuthClient {
                     Assert.fail("Invalid content type. Status: " + statusCode + ", contentType: " + contentType);
                 }
 
-                String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                 Map responseJson = JsonSerialization.readValue(s, Map.class);
 
                 if (statusCode == 200) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClient.java
@@ -79,7 +79,6 @@ import jakarta.xml.ws.soap.SOAPFaultException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -148,7 +147,7 @@ public class SamlClient {
             @Override
             public SAMLDocumentHolder extractResponse(CloseableHttpResponse response, String realmPublicKey) throws IOException {
                 assertThat(response, statusCodeIsHC(Response.Status.OK));
-                String responsePage = EntityUtils.toString(response.getEntity(), "UTF-8");
+                String responsePage = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 response.close();
                 return extractSamlResponseFromForm(responsePage);
             }
@@ -176,7 +175,7 @@ public class SamlClient {
             @Override
             public String extractRelayState(CloseableHttpResponse response) throws IOException {
                 assertThat(response, statusCodeIsHC(Response.Status.OK));
-                String responsePage = EntityUtils.toString(response.getEntity(), "UTF-8");
+                String responsePage = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 response.close();
                 return extractSamlRelayStateFromForm(responsePage);
             }
@@ -227,14 +226,7 @@ public class SamlClient {
                     parameters.add(new BasicNameValuePair(RELAY_STATE, relayState));
                 }
 
-                UrlEncodedFormEntity formEntity;
-
-                try {
-                    formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
-
+                UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
                 post.setEntity(formEntity);
 
                 return post;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/Timer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/Timer.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -133,8 +134,8 @@ public class Timer {
             }
             OutputStream stream = new BufferedOutputStream(new FileOutputStream(f));
             for (Long duration : stats.get(op)) {
-                IOUtils.write(duration.toString(), stream, "UTF-8");
-                IOUtils.write("\n", stream, "UTF-8");
+                IOUtils.write(duration.toString(), stream, StandardCharsets.UTF_8);
+                IOUtils.write("\n", stream, StandardCharsets.UTF_8);
             }
             stream.flush();
             IOUtils.closeQuietly(stream);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/TokenSignatureUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/TokenSignatureUtil.java
@@ -17,6 +17,7 @@
 package org.keycloak.testsuite.util;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -95,7 +96,7 @@ public class TokenSignatureUtil {
         JWSInput jws = new JWSInput(token);
         Signature verifier = getSignature(sigAlgName);
         verifier.initVerify(publicKey);
-        verifier.update(jws.getEncodedSignatureInput().getBytes("UTF-8"));
+        verifier.update(jws.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8));
         return verifier.verify(jws.getSignature());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/CreateArtifactMessageStepBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/CreateArtifactMessageStepBuilder.java
@@ -19,9 +19,9 @@ import org.keycloak.testsuite.util.SamlClient;
 import org.keycloak.testsuite.util.SamlClientBuilder;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -67,12 +67,7 @@ public class CreateArtifactMessageStepBuilder implements SamlClient.Step {
         parameters.add(new BasicNameValuePair(GeneralConstants.SAML_ARTIFACT_KEY, lastArtifact));
         LOG.infof("Sending POST request with artifact %s", lastArtifact);
 
-        UrlEncodedFormEntity formEntity;
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         return post;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/HandleArtifactStepBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/HandleArtifactStepBuilder.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.List;
@@ -218,7 +219,7 @@ public class HandleArtifactStepBuilder extends SamlDocumentStepBuilder<ArtifactR
         
         if (currentResponse.getFirstHeader("location") != null) {
             String location = currentResponse.getFirstHeader("location").getValue();
-            List<NameValuePair> params = URLEncodedUtils.parse(URI.create(location), Charset.forName("UTF-8"));
+            List<NameValuePair> params = URLEncodedUtils.parse(URI.create(location), StandardCharsets.UTF_8);
             for (NameValuePair param : params) {
                 if (GeneralConstants.SAML_ARTIFACT_KEY.equals(param.getName())) {
                     String artifact = param.getValue();

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/LoginBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/LoginBuilder.java
@@ -20,8 +20,8 @@ import org.keycloak.testsuite.util.SamlClientBuilder;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.Users;
 import org.keycloak.testsuite.util.SamlClient.Step;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -66,7 +66,7 @@ public class LoginBuilder implements Step {
             return null;    // skip this step
         } else {
             assertThat(currentResponse, statusCodeIsHC(Response.Status.OK));
-            String loginPageText = EntityUtils.toString(currentResponse.getEntity(), "UTF-8");
+            String loginPageText = EntityUtils.toString(currentResponse.getEntity(), StandardCharsets.UTF_8);
             assertThat(loginPageText, containsString("login"));
 
             return handleLoginPage(loginPageText, currentURI);
@@ -150,12 +150,7 @@ public class LoginBuilder implements Step {
             if (isPost) {
                 HttpPost res = new HttpPost(action);
 
-                UrlEncodedFormEntity formEntity;
-                try {
-                    formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
+                UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
                 res.setEntity(formEntity);
 
                 return res;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/RequiredConsentBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/RequiredConsentBuilder.java
@@ -19,11 +19,10 @@ package org.keycloak.testsuite.util.saml;
 import org.keycloak.testsuite.util.SamlClient.Step;
 import org.keycloak.testsuite.util.SamlClientBuilder;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
@@ -59,7 +58,7 @@ public class RequiredConsentBuilder implements Step {
     @Override
     public HttpUriRequest perform(CloseableHttpClient client, URI currentURI, CloseableHttpResponse currentResponse, HttpClientContext context) throws Exception {
         assertThat(currentResponse, statusCodeIsHC(Response.Status.OK));
-        String consentPageText = EntityUtils.toString(currentResponse.getEntity(), "UTF-8");
+        String consentPageText = EntityUtils.toString(currentResponse.getEntity(), StandardCharsets.UTF_8);
         assertThat(consentPageText, containsString("consent"));
         assertThat(consentPageText, containsString("My Roles")); // Corresponding to role_list default SAML client scope
 
@@ -107,12 +106,7 @@ public class RequiredConsentBuilder implements Step {
             if (isPost) {
                 HttpPost res = new HttpPost(currentURI.resolve(action));
 
-                UrlEncodedFormEntity formEntity;
-                try {
-                    formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
+                UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
                 res.setEntity(formEntity);
 
                 return res;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/UpdateProfileBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/UpdateProfileBuilder.java
@@ -18,8 +18,8 @@ package org.keycloak.testsuite.util.saml;
 
 import org.keycloak.testsuite.util.SamlClientBuilder;
 import org.keycloak.testsuite.util.SamlClient.Step;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -63,7 +63,7 @@ public class UpdateProfileBuilder implements Step {
     @Override
     public HttpUriRequest perform(CloseableHttpClient client, URI currentURI, CloseableHttpResponse currentResponse, HttpClientContext context) throws Exception {
         assertThat(currentResponse, statusCodeIsHC(Response.Status.OK));
-        String loginPageText = EntityUtils.toString(currentResponse.getEntity(), "UTF-8");
+        String loginPageText = EntityUtils.toString(currentResponse.getEntity(), StandardCharsets.UTF_8);
         assertThat(loginPageText, containsString("Update Account Information"));
 
         return handleUpdateProfile(loginPageText, currentURI);
@@ -122,12 +122,7 @@ public class UpdateProfileBuilder implements Step {
             if (isPost) {
                 HttpPost res = new HttpPost(action);
 
-                UrlEncodedFormEntity formEntity;
-                try {
-                    formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
+                UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
                 res.setEntity(formEntity);
 
                 return res;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractServletsAdapterTest.java
@@ -32,6 +32,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
@@ -79,11 +80,11 @@ public abstract class AbstractServletsAdapterTest extends AbstractAdapterTest {
 
         String webXMLContent;
         try {
-            webXMLContent = IOUtils.toString(webXML.openStream(), Charset.forName("UTF-8"))
+            webXMLContent = IOUtils.toString(webXML.openStream(), StandardCharsets.UTF_8)
                     .replace("%CONTEXT_PATH%", name);
 
             if (clockSkewSec != null) {
-                String keycloakSamlXMLContent = IOUtils.toString(keycloakSAMLConfig.openStream(), Charset.forName("UTF-8"))
+                String keycloakSamlXMLContent = IOUtils.toString(keycloakSAMLConfig.openStream(), StandardCharsets.UTF_8)
                     .replace("%CLOCK_SKEW%", "${allowed.clock.skew:" + String.valueOf(clockSkewSec) + "}");
                 deployment.addAsWebInfResource(new StringAsset(keycloakSamlXMLContent), "keycloak-saml.xml");
             } else {
@@ -123,7 +124,7 @@ public abstract class AbstractServletsAdapterTest extends AbstractAdapterTest {
 
         String webXMLContent;
         try {
-            webXMLContent = IOUtils.toString(webXML.openStream(), Charset.forName("UTF-8"))
+            webXMLContent = IOUtils.toString(webXML.openStream(), StandardCharsets.UTF_8)
                     .replace("%CONTEXT_PATH%", name);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractServletsAdapterTest.java
@@ -31,7 +31,6 @@ import org.keycloak.testsuite.utils.io.IOUtil;
 import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
@@ -41,6 +41,7 @@ import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
@@ -2038,7 +2039,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
 
         transformer.transform(doc,
-                new StreamResult(new OutputStreamWriter(out, "UTF-8")));
+                new StreamResult(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
     }
 
     private URI getAuthServerSamlEndpoint(String realm) throws IllegalArgumentException, UriBuilderException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SamlXMLAttacksTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SamlXMLAttacksTest.java
@@ -15,8 +15,8 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.saml.AbstractSamlTest;
 import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -66,12 +66,7 @@ public class SamlXMLAttacksTest extends AbstractSamlTest {
                 String encoded = PostBindingUtil.base64Encode(bombDoctype + samlAuthnRequest);
                 parameters.add(new BasicNameValuePair(GeneralConstants.SAML_REQUEST_KEY, encoded));
 
-                UrlEncodedFormEntity formEntity;
-                try {
-                    formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
+                UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
 
                 post.setEntity(formEntity);
 
@@ -101,13 +96,7 @@ public class SamlXMLAttacksTest extends AbstractSamlTest {
             String encoded = PostBindingUtil.base64Encode(s);
             parameters.add(new BasicNameValuePair(GeneralConstants.SAML_REQUEST_KEY, encoded));
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
-
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             try (CloseableHttpResponse response = client.execute(post)) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -47,7 +47,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -48,6 +48,7 @@ import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -671,7 +672,7 @@ public class FlowTest extends AbstractAuthenticationTest {
         } catch (InternalServerErrorException isee) {
             try (Response response = isee.getResponse()) {
                 assertEquals(500, response.getStatus());
-                assertFalse(StreamUtil.readString((InputStream) response.getEntity(), Charset.forName("UTF-8")).toLowerCase().contains("exception"));
+                assertFalse(StreamUtil.readString((InputStream) response.getEntity(), StandardCharsets.UTF_8).toLowerCase().contains("exception"));
             }
         } catch (Exception e) {
             fail("Unexpected exception");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientDescriptionConverterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientDescriptionConverterTest.java
@@ -21,6 +21,8 @@ import org.keycloak.testsuite.AbstractAuthTest;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -34,7 +36,7 @@ public class ClientDescriptionConverterTest extends AbstractAuthTest {
     @Test
     public void testOrganizationDetailsMetadata() throws IOException {
         try (InputStream is = ClientDescriptionConverterTest.class.getResourceAsStream("KEYCLOAK-4040-sharefile-metadata.xml")) {
-            String data = IOUtils.toString(is, "UTF-8");
+            String data = IOUtils.toString(is, StandardCharsets.UTF_8);
             testRealmResource().convertClientDescription(data);
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
@@ -316,12 +316,7 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
         if (isPost) {
             HttpPost req = new HttpPost(action);
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(paramList, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(paramList, StandardCharsets.UTF_8);
             req.setEntity(formEntity);
 
             return req;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerTestTools.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerTestTools.java
@@ -11,9 +11,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -101,14 +101,7 @@ public class BrokerTestTools {
     }
 
     public static String encodeUrl(String url) {
-        String result;
-        try {
-            result = URLEncoder.encode(url, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            result = url;
-        }
-
-        return result;
+        return URLEncoder.encode(url, StandardCharsets.UTF_8);
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFrontendUrlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFrontendUrlTest.java
@@ -5,8 +5,8 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -72,11 +72,7 @@ public final class KcOidcBrokerFrontendUrlTest extends AbstractBrokerTest {
         log.debug("Logging in");
 
         // make sure the frontend url is used to build the redirect uri when redirecting to the broker
-        try {
-            assertTrue(driver.getCurrentUrl().contains("redirect_uri=" + URLEncoder.encode(proxy.getUrl(), "UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        assertTrue(driver.getCurrentUrl().contains("redirect_uri=" + URLEncoder.encode(proxy.getUrl(), StandardCharsets.UTF_8)));
 
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
         waitForPage(driver, "AUTH_RESPONSE", true);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerFrontendUrlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerFrontendUrlTest.java
@@ -21,10 +21,10 @@ import org.keycloak.testsuite.util.SamlClient;
 import org.keycloak.testsuite.util.SamlClientBuilder;
 
 import jakarta.ws.rs.core.Response;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -133,11 +133,7 @@ public final class KcSamlBrokerFrontendUrlTest extends AbstractBrokerTest {
         log.debug("Logging in");
 
         // make sure the frontend url is used to build the redirect uri when redirecting to the broker
-        try {
-            assertThat(driver.getCurrentUrl(), containsString("client_id=" + URLEncoder.encode(proxy.getUrl(), "UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        assertThat(driver.getCurrentUrl(), containsString("client_id=" + URLEncoder.encode(proxy.getUrl(), StandardCharsets.UTF_8)));
 
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
         waitForPage(driver, "AUTH_RESPONSE", true);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
         try {
             String template = StreamUtil.readString(is, Charset.defaultCharset());
             String realmString = StringPropertyReplacer.replaceProperties(template, properties);
-            return IOUtil.loadRealm(new ByteArrayInputStream(realmString.getBytes("UTF-8")));
+            return IOUtil.loadRealm(new ByteArrayInputStream(realmString.getBytes(StandardCharsets.UTF_8)));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractFAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractFAPITest.java
@@ -20,6 +20,7 @@ package org.keycloak.testsuite.client;
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -221,7 +222,7 @@ public abstract class AbstractFAPITest extends AbstractClientPoliciesTest {
         CloseableHttpClient client = httpClientSupplier.get();
         try {
             HttpPost post = new HttpPost(requestUrl);
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
             return client.execute(post);
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.client;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
@@ -375,7 +376,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
         CloseableHttpClient client = new DefaultHttpClient();
         try {
             HttpPost post = new HttpPost(requestUrl);
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
             return client.execute(post);
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -38,6 +38,7 @@ import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureClientA
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.MessageDigest;
@@ -573,7 +574,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         CloseableHttpClient client = new DefaultHttpClient();
         try {
             HttpPost post = new HttpPost(requestUrl);
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
             return client.execute(post);
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SamlClientPoliciesExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SamlClientPoliciesExecutorTest.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -298,7 +299,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
                 .build()
                 .executeAndTransform(response -> {
                     Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusLine().getStatusCode());
-                    MatcherAssert.assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"),
+                    MatcherAssert.assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
                             Matchers.containsString("Invalid Request"));
                     return null;
                 });
@@ -328,7 +329,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
                 .build()
                 .executeAndTransform(response -> {
                     Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusLine().getStatusCode());
-                    MatcherAssert.assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"),
+                    MatcherAssert.assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
                             Matchers.containsString("Invalid Request"));
                     return null;
                 });

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -80,7 +81,7 @@ public class UncaughtErrorPageTest extends AbstractKeycloakTest {
         assertEquals(500, response.getStatus());
 
         InputStream is = (InputStream) response.getEntity();
-        String responseString = StreamUtil.readString(is, Charset.forName("UTF-8"));
+        String responseString = StreamUtil.readString(is, StandardCharsets.UTF_8);
 
         Assert.assertTrue(responseString.contains("An internal server error has occurred"));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
@@ -191,23 +191,17 @@ public class RestartCookieTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testRestartCookieBackwardsCompatible_Keycloak25() throws IOException {
         String oldRestartCookie = testingClient.server().fetchString((KeycloakSession session) -> {
-            try {
-                String cookieVal = OLD_RESTART_COOKIE_JSON.replace("\n", "").replace(" ", "");
-                RealmModel realm = session.realms().getRealmByName("test");
+            String cookieVal = OLD_RESTART_COOKIE_JSON.replace("\n", "").replace(" ", "");
+            RealmModel realm = session.realms().getRealmByName("test");
 
-                KeyManager.ActiveHmacKey activeKey = session.keys().getActiveHmacKey(realm);
+            KeyManager.ActiveHmacKey activeKey = session.keys().getActiveHmacKey(realm);
 
-                String encodedToken = new JWSBuilder()
-                        .kid(activeKey.getKid())
-                        .content(cookieVal.getBytes(StandardCharsets.UTF_8))
-                        .hmac256(activeKey.getSecretKey());
+            String encodedToken = new JWSBuilder()
+                    .kid(activeKey.getKid())
+                    .content(cookieVal.getBytes(StandardCharsets.UTF_8))
+                    .hmac256(activeKey.getSecretKey());
 
-                return encodedToken;
-
-
-            } catch (IOException ioe) {
-                throw new RuntimeException(ioe);
-            }
+            return encodedToken;
         });
 
         oauth.openLoginForm();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
@@ -199,7 +199,7 @@ public class RestartCookieTest extends AbstractTestRealmKeycloakTest {
 
                 String encodedToken = new JWSBuilder()
                         .kid(activeKey.getKid())
-                        .content(cookieVal.getBytes("UTF-8"))
+                        .content(cookieVal.getBytes(StandardCharsets.UTF_8))
                         .hmac256(activeKey.getSecretKey());
 
                 return encodedToken;
@@ -229,24 +229,18 @@ public class RestartCookieTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testRestartCookieBackwardsCompatible_Keycloak19() throws IOException {
         String oldRestartCookie = testingClient.server().fetchString((KeycloakSession session) -> {
-            try {
-                String cookieVal = OLD_RESTART_COOKIE_JSON.replace("\n", "").replace(" ", "");
-                RealmModel realm = session.realms().getRealmByName("test");
+            String cookieVal = OLD_RESTART_COOKIE_JSON.replace("\n", "").replace(" ", "");
+            RealmModel realm = session.realms().getRealmByName("test");
 
-                KeyManager.ActiveHmacKey activeKey = session.keys().getActiveHmacKey(realm);
+            KeyManager.ActiveHmacKey activeKey = session.keys().getActiveHmacKey(realm);
 
-                // There was no KID in the token in Keycloak 1.9.8
-                String encodedToken = new JWSBuilder()
-                        //.kid(activeKey.getKid())
-                        .content(cookieVal.getBytes("UTF-8"))
-                        .hmac256(activeKey.getSecretKey());
+            // There was no KID in the token in Keycloak 1.9.8
+            String encodedToken = new JWSBuilder()
+                    //.kid(activeKey.getKid())
+                    .content(cookieVal.getBytes(StandardCharsets.UTF_8))
+                    .hmac256(activeKey.getSecretKey());
 
-                return encodedToken;
-
-
-            } catch (IOException ioe) {
-                throw new RuntimeException(ioe);
-            }
+            return encodedToken;
         });
 
         oauth.openLoginForm();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AbstractClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AbstractClientAuthSignedJWTTest.java
@@ -27,6 +27,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -719,7 +720,7 @@ public abstract class AbstractClientAuthSignedJWTTest extends AbstractKeycloakTe
         CloseableHttpClient client = new DefaultHttpClient();
         try {
             HttpPost post = new HttpPost(requestUrl);
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
             return client.execute(post);
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -102,6 +102,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1024,7 +1025,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, oauth.getClientId()));
             post.setHeader("Authorization", "Negotiate something-which-will-be-ignored");
 
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(client.execute(post));
@@ -1474,7 +1475,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
             String authorization = BasicAuthHelper.createHeader(OAuth2Constants.CLIENT_ID, "password");
             post.setHeader("Authorization", authorization);
 
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(client.execute(post));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthPostMethodTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthPostMethodTest.java
@@ -36,7 +36,7 @@ import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AbstractAdminTest;
 import org.keycloak.testsuite.util.OAuthClient;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -103,12 +103,7 @@ public class ClientAuthPostMethodTest extends AbstractKeycloakTest {
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_SECRET, clientSecret));
 
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
@@ -17,6 +17,7 @@
 package org.keycloak.testsuite.oauth;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -383,7 +384,7 @@ public class ClientAuthSecretSignedJWTTest extends AbstractKeycloakTest {
         CloseableHttpClient client = new DefaultHttpClient();
         try {
             HttpPost post = new HttpPost(requestUrl);
-            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
             return client.execute(post);
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeSAML2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeSAML2Test.java
@@ -70,6 +70,8 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Collections;
@@ -249,7 +251,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, response.getIssuedTokenType());
@@ -279,7 +281,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "legal", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, response.getIssuedTokenType());
@@ -328,7 +330,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response = oauth.doTokenExchange(TEST, accessToken, SAML_ENCRYPTED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, response.getIssuedTokenType());
@@ -376,7 +378,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_AND_ENCRYPTED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, response.getIssuedTokenType());
@@ -422,7 +424,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response = oauth.doTokenExchange(TEST, accessToken, SAML_UNSIGNED_AND_UNENCRYPTED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, response.getIssuedTokenType());
@@ -469,7 +471,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, response.getIssuedTokenType());
@@ -547,7 +549,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             response.close();
 
             String exchangedTokenString = accessTokenResponse.getToken();
-            String assertionXML = new String(Base64Url.decode(exchangedTokenString), "UTF-8");
+            String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
 
             // Verify issued_token_type
             Assert.assertEquals(OAuth2Constants.SAML2_TOKEN_TYPE, accessTokenResponse.getOtherClaims().get(OAuth2Constants.ISSUED_TOKEN_TYPE));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LoginStatusIframeEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LoginStatusIframeEndpointTest.java
@@ -48,6 +48,7 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -68,7 +69,7 @@ public class LoginStatusIframeEndpointTest extends AbstractKeycloakTest {
         CookieStore cookieStore = new BasicCookieStore();
 
         try (CloseableHttpClient client = HttpClients.custom().setDefaultCookieStore(cookieStore).build()) {
-            String redirectUri = URLEncoder.encode(suiteContext.getAuthServerInfo().getContextRoot() + "/auth/admin/master/console", "UTF-8");
+            String redirectUri = URLEncoder.encode(suiteContext.getAuthServerInfo().getContextRoot() + "/auth/admin/master/console", StandardCharsets.UTF_8);
 
             PkceGenerator pkce = new PkceGenerator();
 
@@ -77,7 +78,7 @@ public class LoginStatusIframeEndpointTest extends AbstractKeycloakTest {
                             "&redirect_uri=" + redirectUri + "&scope=openid&code_challenge_method=S256&code_challenge=" + pkce.getCodeChallenge());
 
             CloseableHttpResponse response = client.execute(get);
-            String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+            String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             response.close();
 
             String action = ActionURIUtils.getActionURIFromPageSource(s);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
@@ -69,10 +69,9 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.keycloak.util.BasicAuthHelper;
 import org.openqa.selenium.Cookie;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.LinkedList;
-
-import java.io.UnsupportedEncodingException;
 
 /**
  * @author <a href="mailto:h2-wada@nri.co.jp">Hiroyuki Wada</a>
@@ -1091,12 +1090,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
             parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, "profile"));
             parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, "foo"));
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             return new OAuthClient.DeviceAuthorizationResponse(client.execute(post));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
@@ -39,6 +39,7 @@ import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.UserBuilder;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -87,7 +88,7 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
         HttpPost post = new HttpPost(getTokenEndpoint());
         List<NameValuePair> parameters = new LinkedList<>();
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         OAuthClient.AccessTokenResponse accessTokenResponse = new OAuthClient.AccessTokenResponse(httpClient.execute(post));
@@ -99,7 +100,7 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
         List<NameValuePair> parameters = new LinkedList<>();
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
         parameters.add(new BasicNameValuePair("pre-authorized_code", preAuthorizedCode));
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         return new OAuthClient.AccessTokenResponse(httpClient.execute(post));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
@@ -68,7 +68,7 @@ import org.keycloak.testsuite.util.UserManager;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -753,12 +753,7 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
             HttpPost post = new HttpPost(oauth.getResourceOwnerPasswordCredentialGrantUrl());
             List<NameValuePair> parameters = new LinkedList<>();
             parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, "unsupported_grant_type"));
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
             OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(client.execute(post));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -67,7 +67,7 @@ import org.keycloak.util.TokenUtil;
 import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.utils.MediaType;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -663,14 +663,7 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
         parameters.add(new BasicNameValuePair("token", "foo"));
         parameters.add(new BasicNameValuePair("token_type_hint", "access_token"));
 
-        UrlEncodedFormEntity formEntity;
-
-        try {
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         post.setEntity(formEntity);
 
         try (CloseableHttpResponse response = HttpClientBuilder.create().build().execute(post)) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -355,12 +355,7 @@ public class TokenRevocationTest extends AbstractKeycloakTest {
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, oauth.getClientId()));
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_SECRET, clientSecret));
 
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
             post.setEntity(formEntity);
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -372,7 +372,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         List<NameValuePair> parameters = new LinkedList<>();
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
         parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, credentialsOffer.getGrants().getPreAuthorizedCode().getPreAuthorizedCode()));
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         postPreAuthorizedCode.setEntity(formEntity);
         OAuthClient.AccessTokenResponse accessTokenResponse = new OAuthClient.AccessTokenResponse(httpClient.execute(postPreAuthorizedCode));
         assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -157,7 +157,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
         List<NameValuePair> parameters = new LinkedList<>();
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
         parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, credentialsOffer.getGrants().getPreAuthorizedCode().getPreAuthorizedCode()));
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         postPreAuthorizedCode.setEntity(formEntity);
         OAuthClient.AccessTokenResponse accessTokenResponse = new OAuthClient.AccessTokenResponse(httpClient.execute(postPreAuthorizedCode));
         assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthorizationTokenEncryptionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthorizationTokenEncryptionTest.java
@@ -50,9 +50,9 @@ import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.util.Map;
 
@@ -199,7 +199,7 @@ public class AuthorizationTokenEncryptionTest extends AbstractTestRealmKeycloakT
             JWEAlgorithmProvider algorithmProvider = getJweAlgorithmProvider(algAlgorithm);
             JWEEncryptionProvider encryptionProvider = getJweEncryptionProvider(encAlgorithm);
             byte[] decodedString = TokenUtil.jweKeyEncryptionVerifyAndDecode(decryptionKEK, jweStr, algorithmProvider, encryptionProvider);
-            String authorizationTokenString = new String(decodedString, "UTF-8");
+            String authorizationTokenString = new String(decodedString, StandardCharsets.UTF_8);
 
             // a nested JWT (signed and encrypted JWT) needs to set "JWT" to its JOSE Header's "cty" field
             JWEHeader jweHeader = (JWEHeader) getHeader(parts[0]);
@@ -210,7 +210,7 @@ public class AuthorizationTokenEncryptionTest extends AbstractTestRealmKeycloakT
             Assert.assertEquals("test-app", authorizationToken.getAudience()[0]);
             Assert.assertEquals("OpenIdConnect.AuthenticationProperties=2302984sdlk", authorizationToken.getOtherClaims().get("state"));
             Assert.assertNotNull(authorizationToken.getOtherClaims().get("code"));
-        } catch (JWEException | UnsupportedEncodingException e) {
+        } catch (JWEException e) {
             Assert.fail();
         } finally {
             clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdTokenEncryptionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdTokenEncryptionTest.java
@@ -58,7 +58,7 @@ import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.util.List;
 import java.util.Map;
@@ -235,13 +235,13 @@ public class IdTokenEncryptionTest extends AbstractTestRealmKeycloakTest {
             JWEAlgorithmProvider algorithmProvider = getJweAlgorithmProvider(algAlgorithm);
             JWEEncryptionProvider encryptionProvider = getJweEncryptionProvider(encAlgorithm);
             byte[] decodedString = TokenUtil.jweKeyEncryptionVerifyAndDecode(decryptionKEK, jweStr, algorithmProvider, encryptionProvider);
-            String idTokenString = new String(decodedString, "UTF-8");
+            String idTokenString = new String(decodedString, StandardCharsets.UTF_8);
 
             // verify JWS
             IDToken idToken = oauth.verifyIDToken(idTokenString);
             Assert.assertEquals("test-user@localhost", idToken.getPreferredUsername());
             Assert.assertEquals("test-app", idToken.getIssuedFor());
-        } catch (JWEException | UnsupportedEncodingException e) {
+        } catch (JWEException e) {
             Assert.fail();
         } finally {
             clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -94,6 +94,7 @@ import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Collection;
@@ -401,7 +402,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
             JWEEncryptionProvider encryptionProvider = encAlgorithm != null ? getJweEncryptionProvider(encAlgorithm) :
                     getJweEncryptionProvider(JWEConstants.A128CBC_HS256);
             byte[] decodedString = TokenUtil.jweKeyEncryptionVerifyAndDecode(decryptionKEK, encryptedResponse, algorithmProvider, encryptionProvider);
-            String jwePayload = new String(decodedString, "UTF-8");
+            String jwePayload = new String(decodedString, StandardCharsets.UTF_8);
 
             UserInfo userInfo = null;
             // verify JWS

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BasicSamlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BasicSamlTest.java
@@ -25,6 +25,7 @@ import org.keycloak.testsuite.util.SamlClient.Step;
 import org.keycloak.testsuite.util.SamlClientBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.Signature;
 import java.util.Collections;
 import java.util.List;
@@ -138,7 +139,7 @@ public class BasicSamlTest extends AbstractSamlTest {
         try (CloseableHttpClient client = HttpClientBuilder.create().setRedirectStrategy(new RedirectStrategyWithSwitchableFollowRedirect()).build();
           CloseableHttpResponse response = client.execute(post)) {
             assertThat(response, statusCodeIsHC(Response.Status.OK));
-            assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"), containsString("login"));
+            assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), containsString("login"));
         }
     }
 
@@ -152,7 +153,7 @@ public class BasicSamlTest extends AbstractSamlTest {
         try (CloseableHttpClient client = HttpClientBuilder.create().setRedirectStrategy(new RedirectStrategyWithSwitchableFollowRedirect()).build();
           CloseableHttpResponse response = client.execute(post)) {
             assertThat(response, statusCodeIsHC(Response.Status.OK));
-            assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"), containsString("login"));
+            assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), containsString("login"));
         }
     }
 
@@ -195,7 +196,7 @@ public class BasicSamlTest extends AbstractSamlTest {
         try (CloseableHttpClient client = HttpClientBuilder.create().setRedirectStrategy(new RedirectStrategyWithSwitchableFollowRedirect()).build();
           CloseableHttpResponse response = client.execute(post)) {
             assertThat(response, statusCodeIsHC(expectedHttpCode));
-            assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"), pageTextMatcher);
+            assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), pageTextMatcher);
         }
     }
 
@@ -341,7 +342,7 @@ public class BasicSamlTest extends AbstractSamlTest {
                     .build()
                     .executeAndTransform(response -> {
                         assertThat(response, statusCodeIsHC(Status.BAD_REQUEST));
-                        return EntityUtils.toString(response.getEntity(), "UTF-8");
+                        return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                     });
             assertThat(page, containsString("Invalid redirect uri"));
         }
@@ -359,7 +360,7 @@ public class BasicSamlTest extends AbstractSamlTest {
                     .login().user(bburkeUser).build()
                     .executeAndTransform(response -> {
                         assertThat(response, statusCodeIsHC(Response.Status.OK));
-                        String responsePage = EntityUtils.toString(response.getEntity(), "UTF-8");
+                        String responsePage = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                         return SamlClient.extractFormFromPostResponse(responsePage)
                                 .attributes().asList().stream()
                                 .filter(a -> "action".equalsIgnoreCase(a.getKey()))

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ConcurrentAuthnRequestTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ConcurrentAuthnRequestTest.java
@@ -31,6 +31,7 @@ import org.keycloak.testsuite.utils.io.IOUtil;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -97,7 +98,7 @@ public class ConcurrentAuthnRequestTest extends AbstractSamlTest {
             HttpClientContext context = HttpClientContext.create();
             response = client.execute(post, context);
 
-            String loginPageText = EntityUtils.toString(response.getEntity(), "UTF-8");
+            String loginPageText = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             response.close();
 
             HttpUriRequest loginRequest = LoginBuilder.handleLoginPage(user, loginPageText);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlClientTest.java
@@ -23,6 +23,7 @@ import org.w3c.dom.Document;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -48,7 +49,7 @@ public class SamlClientTest extends AbstractSamlTest {
             HttpUriRequest post = SamlClient.Binding.POST.createSamlUnsignedRequest(samlEndpoint, null, samlRequest);
             CloseableHttpResponse response = sendPost(post, client);
             Assert.assertEquals(response.getStatusLine().getStatusCode(), 400);
-            String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+            String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             assertThat(s, Matchers.containsString("Wrong client protocol."));
 
             response.close();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlReverseProxyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlReverseProxyTest.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Document;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import static org.hamcrest.Matchers.containsString;
@@ -135,7 +136,7 @@ public class SamlReverseProxyTest extends AbstractSamlTest {
                 setRedirectStrategy(new SamlClient.RedirectStrategyWithSwitchableFollowRedirect()).build();
              CloseableHttpResponse response = client.execute(post)) {
             assertThat(response, statusCodeIsHC(expectedHttpCode));
-            assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"), pageTextMatcher);
+            assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), pageTextMatcher);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TestEventsLogger.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TestEventsLogger.java
@@ -26,6 +26,7 @@ import org.openqa.selenium.WebDriver;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -76,7 +77,7 @@ public class TestEventsLogger extends RunListener {
             if (driver != null && driver.getPageSource() != null) {
                 String pageSourceLocation = System.getProperty("page.source.location", "target/failed-tests/page-source/");
                 FileUtils.writeStringToFile(new File(pageSourceLocation + d.getTestClass().getSimpleName() + "/" + d.getMethodName() + ".html"), 
-                        driver.getPageSource(), Charset.forName("UTF-8"));
+                        driver.getPageSource(), StandardCharsets.UTF_8);
             }
         } catch (IllegalStateException ex) {
             Logger.getLogger(TestEventsLogger.class).warn(ex.getMessage());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TestEventsLogger.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TestEventsLogger.java
@@ -25,7 +25,6 @@ import org.openqa.selenium.WebDriver;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**


### PR DESCRIPTION
Used StandardCharsets.UTF_8 instead of "UTF-8" whenever possible. This reduces some warnings, simplifies the code and is more readable.

Fixes #35080

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
