### PR TITLE
Fix for trivy workflow issues

### DIFF
--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -19,17 +19,21 @@ jobs:
       fail-fast: false
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
+        uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: quay.io/keycloak/${{ matrix.container}}:nightly
+          image-ref: quay.io/keycloak/${{ matrix.container }}:nightly
           format: sarif
           output: trivy-results.sarif
           severity: MEDIUM,CRITICAL,HIGH
           ignore-unfixed: true
+          version: v0.57.1
           timeout: 15m
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
-          category: ${{ matrix.container}}
+          category: ${{ matrix.container }}


### PR DESCRIPTION
Closes #34440

Fixes for the trivy workflow. The main points are the following:

1. Upgrading the action version to last 0.28.0 version.
2. The issues with the downloads are solved using the db images from `public.ecr.aws` that are also published there by aqua security.
3. We need to use the last version of the trivy software `v0.57.1` because of this issue https://github.com/aquasecurity/trivy/issues/7911 with RH images.

With that I could run the workflow OK. See https://github.com/rmartinc/keycloak/actions/runs/11908379480/job/33183677705.