### PR TITLE
BACKPORT: no longer disable when resource is pre selected (#34702)

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/ResourcesPolicySelect.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ResourcesPolicySelect.tsx
@@ -266,7 +266,6 @@ export const ResourcesPolicySelect = ({
             }}
             isOpen={open}
             aria-label={t(name)}
-            isDisabled={!!preSelected}
             validated={errors[name] ? "error" : "default"}
             typeAheadAriaLabel={t(name)}
             chipGroupComponent={toChipGroupItems(field)}


### PR DESCRIPTION
as you can add more resources

fixes: #34678
backport #34702

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 90d8c4df207a811bffd03bd85f053cb28f576f12)
