### PR TITLE
Ability to specify log category levels through separate options

### DIFF
--- a/docs/documentation/release_notes/topics/26_1_0.adoc
+++ b/docs/documentation/release_notes/topics/26_1_0.adoc
@@ -61,6 +61,12 @@ See the Javadoc for a detailed description.
 In this release, admin events might hold additional details about the context when the event is fired. When upgrading you should
 expect the database schema being updated to add a new column `DETAILS_JSON` to the `ADMIN_EVENT_ENTITY` table.
 
+= Individual options for category-specific log levels
+
+It is now possible to set category-specific log levels as individual `log-level-category` options.
+
+For more details, see the https://www.keycloak.org/server/logging#_configuring_levels_as_individual_options[Logging guide].
+
 = Infinispan default XML configuration location
 
 Previous releases ignored any change  to `conf/cache-ispn.xml` if the `--cache-config-file` option was not provided.

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -69,6 +69,25 @@ This example sets the following log levels:
 * The hibernate log level in general is set to debug.
 * To keep SQL abstract syntax trees from creating verbose log output, the specific subcategory `org.hibernate.hql.internal.ast` is set to info. As a result, the SQL abstract syntax trees are omitted instead of appearing at the `debug` level.
 
+==== Configuring levels as individual options
+When configuring category-specific log levels, you can also set the log levels as individual `log-level-<category>` options instead of using the `log-level` option for that.
+This is useful when you want to set the log levels for selected categories without overwriting the previously set `log-level` option.
+
+.Example
+If you start the server as:
+
+<@kc.start parameters="--log-level=\"INFO,org.hibernate:debug\""/>
+
+you can then set an environmental variable `KC_LOG_LEVEL_ORG_KEYCLOAK=trace` to change the log level for the `org.keycloak` category.
+
+The `log-level-<category>` options take precedence over `log-level`. This allows you to override what was set in the `log-level` option.
+For instance if you set `KC_LOG_LEVEL_ORG_HIBERNATE=trace` for the CLI example above, the  `org.hibernate` category will use the `trace` level instead of `debug`.
+
+Bear in mind that when using the environmental variables, the category name must be in uppercase and the dots must be replaced with underscores.
+When using other config sources, the category name must be specified "as is", for example:
+
+<@kc.start parameters="--log-level=\"INFO,org.hibernate:debug\" --log-level-org.keycloak=trace"/>
+
 == Enabling log handlers
 To enable log handlers, enter the following command:
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -60,6 +60,12 @@ public class LoggingOptions {
             .description("The log level of the root category or a comma-separated list of individual categories and their levels. For the root category, you don't need to specify a category.")
             .build();
 
+    public static final Option<Level> LOG_LEVEL_CATEGORY = new OptionBuilder<>("log-level-<category>", Level.class)
+            .category(OptionCategory.LOGGING)
+            .description("The log level of a category. Takes precedence over the 'log-level' option.")
+            .caseInsensitiveExpectedValues(true)
+            .build();
+
     public enum Output {
         DEFAULT,
         JSON;

--- a/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
@@ -2,9 +2,12 @@ package org.keycloak.config;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Option<T> {
+    public static final Pattern WILDCARD_PLACEHOLDER_PATTERN = Pattern.compile("<.+>");
 
     private final Class<T> type;
     private final String key;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -39,8 +39,6 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
     @Override
     public void run() {
         doBeforeRun();
-        HttpPropertyMappers.validateConfig();
-        HostnameV2PropertyMappers.validateConfig();
         validateConfig();
 
         if (isDevProfile()) {
@@ -54,6 +52,13 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
     
     protected void doBeforeRun() {
 
+    }
+
+    @Override
+    protected void validateConfig() {
+        super.validateConfig(); // we want to run the generic validation here first to check for unknown options
+        HttpPropertyMappers.validateConfig();
+        HostnameV2PropertyMappers.validateConfig();
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -129,6 +129,8 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
                 PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
                 if (mapper != null) {
+                    mapper = mapper.forKey(key);
+
                     String to = mapper.getTo();
 
                     if (to != null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
@@ -50,6 +50,8 @@ public class KcEnvConfigSource extends PropertiesConfigSource {
                 PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
                 if (mapper != null) {
+                    mapper = mapper.forEnvKey(key);
+
                     String to = mapper.getTo();
 
                     if (to != null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -22,12 +22,16 @@ import io.smallrye.config.ConfigValue;
 
 import io.smallrye.config.Priorities;
 import jakarta.annotation.Priority;
+import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.iterators.FilterIterator;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
+import org.keycloak.quarkus.runtime.configuration.mappers.WildcardPropertyMapper;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 
@@ -49,7 +53,8 @@ import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 @Priority(Priorities.APPLICATION - 10)
 public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
-    private static ThreadLocal<Boolean> disable = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> disable = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> disableAdditionalNames = new ThreadLocal<>();
 
     public static void disable() {
         disable.set(true);
@@ -73,7 +78,26 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
     @Override
     public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {
-        return filterRuntime(context.iterateNames());
+        // We need to iterate through names to get wildcard option names.
+        // Additionally, wildcardValuesTransformer might also trigger iterateNames.
+        // Hence we need to disable this to prevent infinite recursion.
+        // But we don't want to disable the whole interceptor, as wildcardValuesTransformer
+        // might still need mappers to work.
+        List<String> mappedWildcardNames = List.of();
+        if (!Boolean.TRUE.equals(disableAdditionalNames.get())) {
+            disableAdditionalNames.set(true);
+            try {
+                mappedWildcardNames = PropertyMappers.getWildcardMappers().stream()
+                        .map(WildcardPropertyMapper::getToWithWildcards)
+                        .flatMap(Set::stream)
+                        .toList();
+            } finally {
+                disableAdditionalNames.remove();
+            }
+        }
+
+        // this could be optimized by filtering the wildcard names in the stream above
+        return filterRuntime(IteratorUtils.chainedIterator(mappedWildcardNames.iterator(), context.iterateNames()));
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -17,6 +17,7 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import static java.util.Optional.ofNullable;
+import static org.keycloak.config.Option.WILDCARD_PLACEHOLDER_PATTERN;
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR_CHAR;
@@ -27,10 +28,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
@@ -38,23 +41,22 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.ConfigValue.ConfigValueBuilder;
 import io.smallrye.config.ExpressionConfigSourceInterceptor;
 import io.smallrye.config.Expressions;
-
 import org.keycloak.config.DeprecatedMetadata;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionCategory;
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.ShortErrorMessageHandler;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.KcEnvConfigSource;
 import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
-import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.utils.StringUtil;
 
 public class PropertyMapper<T> {
 
-    private final Option<T> option;
+    protected final Option<T> option;
     private final String to;
     private BooleanSupplier enabled;
     private String enabledWhen;
@@ -69,13 +71,21 @@ public class PropertyMapper<T> {
     private final String description;
     private final BooleanSupplier required;
     private final String requiredWhen;
+    private final String from;
+
+    PropertyMapper(PropertyMapper<T> mapper, String from, String to, BiFunction<String, ConfigSourceInterceptorContext, String> parentMapper) {
+        this(mapper.option, to, mapper.enabled, mapper.enabledWhen, mapper.mapper, mapper.mapFrom, parentMapper,
+                mapper.paramLabel, mapper.mask, mapper.validator, mapper.description, mapper.required,
+                mapper.requiredWhen, from);
+    }
 
     PropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen,
                    BiFunction<String, ConfigSourceInterceptorContext, String> mapper,
                    String mapFrom, BiFunction<String, ConfigSourceInterceptorContext, String> parentMapper,
                    String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator,
-                   String description, BooleanSupplier required, String requiredWhen) {
+                   String description, BooleanSupplier required, String requiredWhen, String from) {
         this.option = option;
+        this.from = from == null ? MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + this.option.getKey() : from;
         this.to = to == null ? getFrom() : to;
         this.enabled = enabled;
         this.enabledWhen = enabledWhen;
@@ -234,6 +244,14 @@ public class PropertyMapper<T> {
         return option.getDeprecatedMetadata();
     }
 
+    /**
+     * An option is considered a wildcard option if its key contains a wildcard placeholder (e.g. log-level-<category>).
+     * The placeholder must be denoted by the '<' and '>' characters.
+     */
+    public boolean hasWildcard() {
+        return false;
+    }
+
     private ConfigValue transformValue(String name, ConfigValue configValue, ConfigSourceInterceptorContext context, boolean parentValue) {
         String value = configValue.getValue();
         String mappedValue = value;
@@ -261,7 +279,7 @@ public class PropertyMapper<T> {
         }
 
         // by unsetting the ordinal this will not be seen as directly modified by the user
-        return configValue.from().withValue(mappedValue).withRawValue(value).withConfigSourceOrdinal(0).build();
+        return configValue.from().withName(name).withValue(mappedValue).withRawValue(value).withConfigSourceOrdinal(0).build();
     }
 
     private ConfigValue convertValue(ConfigValue configValue) {
@@ -270,6 +288,11 @@ public class PropertyMapper<T> {
         }
 
         return configValue.withValue(ofNullable(configValue.getValue()).map(String::trim).orElse(null));
+    }
+
+    @FunctionalInterface
+    public interface ValueMapper {
+        String map(String name, String value, ConfigSourceInterceptorContext context);
     }
 
     private final class ContextWrapper implements ConfigSourceInterceptorContext {
@@ -315,6 +338,8 @@ public class PropertyMapper<T> {
         private String description;
         private BooleanSupplier isRequired = () -> false;
         private String requiredWhen = "";
+        private Function<Set<String>, Set<String>> wildcardKeysTransformer;
+        private ValueMapper wildcardMapFrom;
 
         public Builder(Option<T> option) {
             this.option = option;
@@ -439,11 +464,30 @@ public class PropertyMapper<T> {
             return this;
         }
 
+        public Builder<T> wildcardKeysTransformer(Function<Set<String>, Set<String>> wildcardValuesTransformer) {
+            this.wildcardKeysTransformer = wildcardValuesTransformer;
+            return this;
+        }
+
+        public Builder<T> wildcardMapFrom(Option<?> mapFrom, ValueMapper function) {
+            this.mapFrom = mapFrom.getKey();
+            this.wildcardMapFrom = function;
+            return this;
+        }
+
         public PropertyMapper<T> build() {
             if (paramLabel == null && Boolean.class.equals(option.getType())) {
                 paramLabel = Boolean.TRUE + "|" + Boolean.FALSE;
             }
-            return new PropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen);
+            // The wildcard pattern (e.g. log-level-<category>) is matching only a-z, 0-0 and dots. For env vars, dots are replaced by underscores.
+            var fromWildcardMatcher = WILDCARD_PLACEHOLDER_PATTERN.matcher(option.getKey());
+            if (fromWildcardMatcher.find()) {
+                return new WildcardPropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, fromWildcardMatcher, wildcardKeysTransformer, wildcardMapFrom);
+            }
+            if (wildcardKeysTransformer != null || wildcardMapFrom != null) {
+                throw new AssertionError("Wildcard operations not expected with non-wildcard mapper");
+            }
+            return new PropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, null);
         }
     }
 
@@ -523,6 +567,34 @@ public class PropertyMapper<T> {
         }
         return String.format("'%s' in %s", getFrom(),
                 KeycloakConfigSourceProvider.getConfigSourceDisplayName(configValue.getConfigSourceName()));
+    }
+
+    /**
+     * Get all Keycloak config values for the mapper. A multivalued config option is a config option that
+     * has a wildcard in its name, e.g. log-level-<category>.
+     *
+     * @return a list of config values where the key is the resolved wildcard (e.g. category) and the value is the config value
+     */
+    public List<ConfigValue> getKcConfigValues() {
+        return List.of(Configuration.getConfigValue(getFrom()));
+    }
+
+    /**
+     * Returns a new PropertyMapper tailored for the given env var key.
+     * This is currently useful in {@link WildcardPropertyMapper} where "to" and "from" fields need to include a specific
+     * wildcard key.
+     */
+    public PropertyMapper<?> forEnvKey(String key) {
+        return this;
+    }
+
+    /**
+     * Returns a new PropertyMapper tailored for the given key.
+     * This is currently useful in {@link WildcardPropertyMapper} where "to" and "from" fields need to include a specific
+     * wildcard key.
+     */
+    public PropertyMapper<?> forKey(String key) {
+        return this;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -183,7 +183,7 @@ public class PropertyMapper<T> {
     }
 
     public String getFrom() {
-        return MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + this.option.getKey();
+        return from;
     }
 
     public String getDescription() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
@@ -1,0 +1,159 @@
+package org.keycloak.quarkus.runtime.configuration.mappers;
+
+import static org.keycloak.config.Option.WILDCARD_PLACEHOLDER_PATTERN;
+import static org.keycloak.quarkus.runtime.cli.Picocli.ARG_PREFIX;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.keycloak.config.Option;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+
+public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
+
+    private final Matcher fromWildcardMatcher;
+    private final Pattern fromWildcardPattern;
+    private final Pattern envVarNameWildcardPattern;
+    private Matcher toWildcardMatcher;
+    private Pattern toWildcardPattern;
+    private final Function<Set<String>, Set<String>> wildcardKeysTransformer;
+    private final ValueMapper wildcardMapFrom;
+
+    public WildcardPropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen,
+            BiFunction<String, ConfigSourceInterceptorContext, String> mapper,
+            String mapFrom, BiFunction<String, ConfigSourceInterceptorContext, String> parentMapper,
+            String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator,
+            String description, BooleanSupplier required, String requiredWhen, Matcher fromWildcardMatcher, Function<Set<String>, Set<String>> wildcardKeysTransformer, ValueMapper wildcardMapFrom) {
+        super(option, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, mask, validator, description, required, requiredWhen, null);
+        this.wildcardMapFrom = wildcardMapFrom;
+        this.fromWildcardMatcher = fromWildcardMatcher;
+        // Includes handling for both "--" prefix for CLI options and "kc." prefix
+        this.fromWildcardPattern = Pattern.compile("(?:" + ARG_PREFIX + "|kc\\.)" + fromWildcardMatcher.replaceFirst("([\\\\\\\\.a-zA-Z0-9]+)"));
+
+        // Not using toEnvVarFormat because it would process the whole string incl the <...> wildcard.
+        Matcher envVarMatcher = WILDCARD_PLACEHOLDER_PATTERN.matcher(option.getKey().toUpperCase().replace("-", "_"));
+        this.envVarNameWildcardPattern = Pattern.compile("KC_" + envVarMatcher.replaceFirst("([_A-Z0-9]+)"));
+
+        if (to != null) {
+            toWildcardMatcher = WILDCARD_PLACEHOLDER_PATTERN.matcher(to);
+            if (!toWildcardMatcher.find()) {
+                throw new IllegalArgumentException("Attempted to map a wildcard option to a non-wildcard option");
+            }
+
+            this.toWildcardPattern = Pattern.compile(toWildcardMatcher.replaceFirst("([\\\\\\\\.a-zA-Z0-9]+)"));
+        }
+
+        this.wildcardKeysTransformer = wildcardKeysTransformer;
+    }
+
+    @Override
+    public boolean hasWildcard() {
+        return true;
+    }
+
+    String getTo(String wildcardKey) {
+        return toWildcardMatcher.replaceFirst(wildcardKey);
+    }
+
+    String getFrom(String wildcardKey) {
+        return MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + fromWildcardMatcher.replaceFirst(wildcardKey);
+    }
+
+    @Override
+    public List<ConfigValue> getKcConfigValues() {
+        return this.getWildcardKeys().stream().map(v -> Configuration.getConfigValue(getFrom(v))).toList();
+    }
+
+    public Set<String> getWildcardKeys() {
+        // this is not optimal
+        // TODO find an efficient way to get all values that match the wildcard
+        Set<String> values = StreamSupport.stream(Configuration.getPropertyNames().spliterator(), false)
+                .map(n -> getMappedKey(n, true, false))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+
+        if (wildcardKeysTransformer != null) {
+            return wildcardKeysTransformer.apply(values);
+        }
+
+        return values;
+    }
+
+    /**
+     * Returns a mapped key for the given option name if a relevant mapping is available, or empty otherwise.
+     * Currently, it only attempts to extract the wildcard key from the given option name.
+     * E.g. for the option "log-level-<category>" and the option name "log-level-io.quarkus",
+     * the wildcard value would be "io.quarkus".
+     */
+    private Optional<String> getMappedKey(String originalKey, boolean tryFrom, boolean tryTo) {
+        if (tryFrom) {
+            Matcher matcher = fromWildcardPattern.matcher(originalKey);
+            if (matcher.matches()) {
+                return Optional.of(matcher.group(1));
+            }
+        }
+
+        if (tryTo && toWildcardPattern != null) {
+            Matcher matcher = toWildcardPattern.matcher(originalKey);
+            if (matcher.matches()) {
+                return Optional.of(matcher.group(1));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public Set<String> getToWithWildcards() {
+        if (toWildcardMatcher == null) {
+            return Set.of();
+        }
+
+        return getWildcardKeys().stream()
+                .map(v -> toWildcardMatcher.replaceFirst(v))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Checks if the given option name matches the wildcard pattern of this option.
+     * E.g. check if "log-level-io.quarkus" matches the wildcard pattern "log-level-<category>".
+     */
+    public boolean matchesWildcardOptionName(String name) {
+        return fromWildcardPattern.matcher(name).matches() || envVarNameWildcardPattern.matcher(name).matches()
+                || (toWildcardPattern != null && toWildcardPattern.matcher(name).matches());
+    }
+
+    @Override
+    public PropertyMapper<?> forEnvKey(String key) {
+        Matcher matcher = envVarNameWildcardPattern.matcher(key);
+        String value = matcher.group(1);
+        final String wildcardValue = value.toLowerCase().replace("_", "."); // we opiniotatedly convert env var names to CLI format with dots
+        return forWildcardValue(wildcardValue);
+    }
+
+    private PropertyMapper<?> forWildcardValue(final String wildcardValue) {
+        String to = getTo(wildcardValue);
+        String from = getFrom(wildcardValue);
+        return new PropertyMapper<T>(this, from, to, wildcardMapFrom == null ? null : (v, context) -> wildcardMapFrom.map(wildcardValue, v, context));
+    }
+
+    @Override
+    public PropertyMapper<?> forKey(String key) {
+        final String wildcardValue = getMappedKey(key, true, true).orElseThrow();
+        return forWildcardValue(wildcardValue);
+    }
+
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -386,4 +386,29 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(Integer.MAX_VALUE, nonRunningPicocli.exitCode); // "running" state
     }
 
+    @Test
+    public void wrongLevelForCategory() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-level-org.keycloak=wrong");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertTrue(nonRunningPicocli.getErrString().contains("Invalid log level: wrong. Possible values are: warn, trace, debug, error, fatal, info."));
+    }
+
+    @Test
+    public void wildcardLevelForCategory() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-level-org.keycloak=warn");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        var value = nonRunningPicocli.config.getConfigValue("quarkus.log.category.\"org.keycloak\".level");
+        assertEquals("quarkus.log.category.\"org.keycloak\".level", value.getName());
+        assertEquals("WARN", value.getValue());
+    }
+
+    @Test
+    public void wildcardLevelFromParent() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-level=org.keycloak:warn");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        var value = nonRunningPicocli.config.getConfigValue("quarkus.log.category.\"org.keycloak\".level");
+        assertEquals("quarkus.log.category.\"org.keycloak\".level", value.getName());
+        assertEquals("WARN", value.getValue());
+    }
+
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -532,4 +532,35 @@ public class ConfigurationTest extends AbstractConfigurationTest {
             assertEquals(Integer.toString(maxCount), config.getConfigValue(prop).getValue());
         }
     }
+
+    @Test
+    public void testWildcardCliOptionCanBeMappedToQuarkusOption() {
+        ConfigArgsConfigSource.setCliArgs("--log-level-org.keycloak=trace");
+        SmallRyeConfig config = createConfig();
+        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
+    }
+
+    @Test
+    public void testWildcardEnvVarOptionCanBeMappedToQuarkusOption() {
+        putEnvVar("KC_LOG_LEVEL_IO_QUARKUS", "trace");
+        SmallRyeConfig config = createConfig();
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
+    }
+
+    @Test
+    public void testWildcardOptionFromConfigFile() {
+        putEnvVar("SOME_CATEGORY_LOG_LEVEL", "debug");
+        SmallRyeConfig config = createConfig();
+        assertEquals("DEBUG", config.getConfigValue("quarkus.log.category.\"io.k8s\".level").getValue());
+    }
+
+    @Test
+    public void testWildcardPropertiesDontMatchEnvVarsFormat() {
+        SmallRyeConfig config = createConfig();
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+    }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
@@ -184,4 +184,26 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
                 "quarkus.log.file.level", "DEBUG"
         ));
     }
+
+    @Test
+    public void logLevelTakesPrecedenceOverCategoryLevel() {
+        ConfigArgsConfigSource.setCliArgs("--log-level=org.keycloak:error");
+        SmallRyeConfig config = createConfig();
+        assertEquals("INFO", config.getConfigValue("quarkus.log.level").getValue());
+        assertEquals("ERROR", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+
+        ConfigArgsConfigSource.setCliArgs("--log-level=org.keycloak:error", "--log-level-org.keycloak=trace");
+        config = createConfig();
+        assertEquals("INFO", config.getConfigValue("quarkus.log.level").getValue());
+        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+    }
+
+    @Test
+    public void unknownCategoryLevelIsResolvedFromRootLevel() {
+        ConfigArgsConfigSource.setCliArgs("--log-level=warn,org.keycloak:error", "--log-level-org.keycloak=trace");
+        SmallRyeConfig config = createConfig();
+        assertEquals("WARN", config.getConfigValue("quarkus.log.level").getValue());
+        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+        assertEquals("WARN", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
+    }
 }

--- a/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
@@ -1,6 +1,8 @@
 spi-hostname-default-frontend-url = ${keycloak.frontendUrl:http://filepropdefault.unittest}
 %user-profile.spi-hostname-default-frontend-url = http://filepropprofile.unittest
 log-level=${SOME_LOG_LEVEL:info}
+log-level-io.k8s=${SOME_CATEGORY_LOG_LEVEL}
+KC_LOG_LEVEL_IO_QUARKUS=trace
 config-keystore=src/test/resources/keystore
 config-keystore-password=secret
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -142,6 +142,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -167,6 +167,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -142,6 +142,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -167,6 +167,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -308,6 +308,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -368,6 +368,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -315,6 +315,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -369,6 +369,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -266,6 +266,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -320,6 +320,10 @@ Logging:
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
+--log-level-<category> <level>
+                     The log level of a category. Takes precedence over the 'log-level' option.
+                       Possible values are (case insensitive): off, fatal, error, warn, info,
+                       debug, trace, all.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.


### PR DESCRIPTION
Closes #34957

The majority of changes focus on adding the support for option names with wildcard, e.g. `log-level-<category>`.
* The wildcard can be placed anywhere in the name, e.g. if it's desired we could do something like `log-<category>-level`. 
* For env vars, the wildcard doesn't need any `_` escaping. E.g. `LOG_LEVEL_IO_QUARKUS=TRACE` gets mapped to `log-level-io.quarkus=TRACE`.
* Because of the ambiguity what `_` represents in the env var format, the wildcard does not support `-` symbols, only `a-z`, `0-9` and `.` are generally accepted. Env vars match only `A-Z`, `0-9` and `_`.

What's missing and is to be done in this PR:
- [x] Docs
- [x] Tests