### PR TITLE
Improve session polling to prevent accidental redirects

### DIFF
--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -91,7 +91,7 @@
                 <#if recaptchaRequired?? && !(recaptchaVisible!false)>
                     <script>
                         function onSubmitRecaptcha(token) {
-                            document.getElementById("kc-register-form").submit();
+                            document.getElementById("kc-register-form").requestSubmit();
                         }
                     </script>
                     <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">

--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -1,19 +1,24 @@
-const CHECK_INTERVAL_MILLISECS = 2000;
+const SESSION_POLLING_INTERVAL = 2000;
 const AUTH_SESSION_TIMEOUT_MILLISECS = 1000;
 const initialSession = getSession();
-
+const forms = Array.from(document.forms);
 let timeout;
 
-// Remove the timeout when unloading to avoid execution of the
-// checkCookiesAndSetTimer when the page is already submitted
-addEventListener("beforeunload", () => {
-  if (timeout) {
-    clearTimeout(timeout);
-    timeout = undefined;
-  }
-});
+// Stop polling for a session when a form is submitted to prevent unexpected redirects.
+// This is required as Safari does not support the 'beforeunload' event properly.
+// See: https://bugs.webkit.org/show_bug.cgi?id=219102
+forms.forEach((form) =>
+  form.addEventListener("submit", () => stopSessionPolling()),
+);
 
-export function checkCookiesAndSetTimer(loginRestartUrl) {
+// Stop polling for a session when the page is unloaded to prevent unexpected redirects.
+globalThis.addEventListener("beforeunload", () => stopSessionPolling());
+
+/**
+ * Starts polling to check if a new session was started in another context (e.g. a tab or window), and redirects to the specified URL if a session is detected.
+ * @param {string} redirectUrl - The URL to redirect to if a new session is detected.
+ */
+export function startSessionPolling(redirectUrl) {
   if (initialSession) {
     // We started with a session, so there is nothing to do, exit.
     return;
@@ -22,21 +27,35 @@ export function checkCookiesAndSetTimer(loginRestartUrl) {
   const session = getSession();
 
   if (!session) {
-    // The session is not present, check again later.
+    // No new session detected, check again later.
     timeout = setTimeout(
-      () => checkCookiesAndSetTimer(loginRestartUrl),
-      CHECK_INTERVAL_MILLISECS,
+      () => startSessionPolling(redirectUrl),
+      SESSION_POLLING_INTERVAL,
     );
   } else {
-    // Redirect to the login restart URL. This can typically automatically login user due the SSO
-    location.href = loginRestartUrl;
+    // A new session was detected, redirect to the specified URL and stop polling.
+    location.href = redirectUrl;
+    stopSessionPolling();
+  }
+}
+
+/**
+ * Stops polling the session.
+ */
+function stopSessionPolling() {
+  if (timeout) {
+    clearTimeout(timeout);
+    timeout = undefined;
   }
 }
 
 export function checkAuthSession(pageAuthSessionHash) {
   setTimeout(() => {
     const cookieAuthSessionHash = getKcAuthSessionHash();
-    if (cookieAuthSessionHash && cookieAuthSessionHash !== pageAuthSessionHash) {
+    if (
+      cookieAuthSessionHash &&
+      cookieAuthSessionHash !== pageAuthSessionHash
+    ) {
       location.reload();
     }
   }, AUTH_SESSION_TIMEOUT_MILLISECS);

--- a/themes/src/main/resources/theme/base/login/resources/js/webauthnAuthenticate.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/webauthnAuthenticate.js
@@ -73,10 +73,10 @@ export function returnSuccess(result) {
     if (result.response.userHandle) {
         document.getElementById("userHandle").value = base64url.stringify(new Uint8Array(result.response.userHandle), { pad: false });
     }
-    document.getElementById("webauth").submit();
+    document.getElementById("webauth").requestSubmit();
 }
 
 export function returnFailure(err) {
     document.getElementById("error").value = err;
-    document.getElementById("webauth").submit();
+    document.getElementById("webauth").requestSubmit();
 }

--- a/themes/src/main/resources/theme/base/login/resources/js/webauthnRegister.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/webauthnRegister.js
@@ -131,10 +131,10 @@ function returnSuccess(result, initLabel, initLabelPrompt) {
     }
     document.getElementById("authenticatorLabel").value = labelResult;
 
-    document.getElementById("register").submit();
+    document.getElementById("register").requestSubmit();
 }
 
 function returnFailure(err) {
     document.getElementById("error").value = err;
-    document.getElementById("register").submit();
+    document.getElementById("register").requestSubmit();
 }

--- a/themes/src/main/resources/theme/base/login/saml-post-form.ftl
+++ b/themes/src/main/resources/theme/base/login/saml-post-form.ftl
@@ -3,7 +3,7 @@
     <#if section = "header">
         ${msg("saml.post-form.title")}
     <#elseif section = "form">
-        <script>window.onload = function() {document.forms[0].submit()};</script>
+        <script>window.onload = function() {document.forms[0].requestSubmit()};</script>
         <p>${msg("saml.post-form.message")}</p>
         <form name="saml-post-binding" method="post" action="${samlPost.url}">
             <#if samlPost.SAMLRequest??>

--- a/themes/src/main/resources/theme/base/login/select-organization.ftl
+++ b/themes/src/main/resources/theme/base/login/select-organization.ftl
@@ -9,7 +9,7 @@
                     <#list user.organizations as organization>
                         <li>
                             <a id="organization-${organization.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if user.organizations?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                               type="button" onclick="document.forms[0]['kc.org'].value = '${organization.alias}'; document.forms[0].submit()">
+                               type="button" onclick="document.forms[0]['kc.org'].value = '${organization.alias}'; document.forms[0].requestSubmit()">
                                 <span class="${properties.kcFormSocialAccountNameClass!}">${organization.name!}</span>
                             </a>
                         </li>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -44,9 +44,9 @@
         </#list>
     </#if>
     <script type="module">
-        import { checkCookiesAndSetTimer } from "${url.resourcesPath}/js/authChecker.js";
+        import { startSessionPolling } from "${url.resourcesPath}/js/authChecker.js";
 
-        checkCookiesAndSetTimer(
+        startSessionPolling(
           "${url.ssoLoginInOtherTabsUrl?no_esc}"
         );
     </script>
@@ -157,7 +157,7 @@
                   <div class="${properties.kcFormGroupClass!}">
                       <input type="hidden" name="tryAnotherWay" value="on"/>
                       <a href="#" id="try-another-way"
-                         onclick="document.forms['kc-select-try-another-way-form'].submit();return false;">${msg("doTryAnotherWay")}</a>
+                         onclick="document.forms['kc-select-try-another-way-form'].requestSubmit();return false;">${msg("doTryAnotherWay")}</a>
                   </div>
               </form>
           </#if>

--- a/themes/src/main/resources/theme/base/login/webauthn-error.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-error.ftl
@@ -8,7 +8,7 @@
             refreshPage = () => {
                 document.getElementById('isSetRetry').value = 'retry';
                 document.getElementById('executionValue').value = '${execution}';
-                document.getElementById('kc-error-credential-form').submit();
+                document.getElementById('kc-error-credential-form').requestSubmit();
             }
         </script>
 

--- a/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
@@ -14,7 +14,7 @@
                 <form id="kc-select-credential-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
                     <input type="hidden" name="authenticationExecution" value="${authenticationSelection.authExecId}">
                 </form>
-                <div class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].submit()">
+                <div class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].requestSubmit()">
                     <div class="pf-v5-c-data-list__item-content">
                         <div class="${properties.kcSelectAuthListItemIconClass!}">
                             <i class="${properties['${authenticationSelection.iconCssClass}']!authenticationSelection.iconCssClass} ${properties.kcSelectAuthListItemIconPropertyClass!}"></i>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -86,9 +86,9 @@
     </#if>
     <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
     <script type="module">
-        import { checkCookiesAndSetTimer } from "${url.resourcesPath}/js/authChecker.js";
+        import { startSessionPolling } from "${url.resourcesPath}/js/authChecker.js";
 
-        checkCookiesAndSetTimer(
+        startSessionPolling(
             "${url.ssoLoginInOtherTabsUrl?no_esc}"
         );
     </script>
@@ -207,7 +207,7 @@
         <#if auth?has_content && auth.showTryAnotherWayLink()>
           <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post" novalidate="novalidate">
               <input type="hidden" name="tryAnotherWay" value="on"/>
-              <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].submit()"
+              <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].requestSubmit()"
                   class="${properties.kcButtonSecondaryClass} ${properties.kcButtonBlockClass} ${properties.kcMarginTopClass}">
                     ${kcSanitize(msg("doTryAnotherWay"))?no_esc}
               </a>


### PR DESCRIPTION
Improves the session polling in the login flow used to detect user sign-ins from other contexts (e.g. another tab or window). This fixes an issue where a user experiences a redirect to another page when submitting the login form, causing an unexpected re-start  authentication error.

This change also cleans up the code a little by renaming some functions to be more appropriate with their purpose, as well as adding additional comments to explain various parts of the code.

Closes #33071

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
