### PR TITLE
Fix typo in v24 changelog: "longer" -> "no longer"

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-24_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-24_0_0.adoc
@@ -155,7 +155,7 @@ If you use a custom theme to change these templates, they will function as expec
 However, we recommend you to take a look at how to configure a link:{adminguide_link}#user-profile[{declarative user profile}] and possibly avoid
 changing the built-in templates by using all the capabilities provided by this feature.
 
-Also, the templates used by the `declarative-user-profile` feature to render the pages for the same flows are longer necessary and removed in this release:
+Also, the templates used by the `declarative-user-profile` feature to render the pages for the same flows are no longer necessary and removed in this release:
 
 * `update-user-profile.ftl`
 * `register-user-profile.ftl`


### PR DESCRIPTION
Closes #35229

The missing "no" makes this really confusing to read

@ahus1 pinging you as I've seen you approve similar docs typo fixes. 🙏 