### PR TITLE
Do not show internal details in KcUnrecognizedPropertyExceptionHandler

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KcUnrecognizedPropertyExceptionHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KcUnrecognizedPropertyExceptionHandler.java
@@ -41,9 +41,14 @@ public class KcUnrecognizedPropertyExceptionHandler implements ExceptionMapper<U
 
     /**
      * Return escaped original message
+     * @param exception Exception to map
+     * @return The response with the error
      */
     @Override
     public Response toResponse(UnrecognizedPropertyException exception) {
-        return KeycloakErrorHandler.getResponse(session, new BadRequestException(exception.getMessage()));
+        final String message = String.format("Invalid json representation for %s. Unrecognized field \"%s\" at line %s column %s.",
+                exception.getReferringClass().getSimpleName(), exception.getPropertyName(),
+                exception.getLocation().getLineNr(), exception.getLocation().getColumnNr());
+        return KeycloakErrorHandler.getResponse(session, new BadRequestException(message));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -97,6 +97,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1820,6 +1821,19 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
             realmRep.setAccountTheme(accountTheme);
             testRealm().update(realmRep);
         }
+    }
+
+    @Test
+    public void testUpdateProfileUnrecognizedPropertyInRepresentation() throws IOException {
+        final UserRepresentation user = getUser();
+        final Map<String,String> invalidRep = Map.of("id", user.getId(), "username", user.getUsername(), "invalid", "something");
+        SimpleHttp.Response response = SimpleHttpDefault.doPost(getAccountUrl(null), httpClient)
+                .auth(tokenUtil.getToken())
+                .json(invalidRep)
+                .asResponse();
+       assertEquals(400, response.getStatus());
+       final OAuth2ErrorRepresentation error = response.asJson(OAuth2ErrorRepresentation.class);
+       assertThat(error.getError(), containsString("Invalid json representation for UserRepresentation. Unrecognized field \"invalid\" at line"));
     }
 
     @EnableFeature(Profile.Feature.UPDATE_EMAIL)


### PR DESCRIPTION
Closes #29570

Just changing the `KcUnrecognizedPropertyExceptionHandler` to use a custom message instead of the default message in the exception. Don't know why but many people are complaining about it. They say that it's very detailed and that it can be a hardening issue. I don't see it as a risk, but it's generating so much noise that I have simplified the message giving some details to know the failed field/representation and the location (line/column). If you also want the path or change the message, please let me know.
