### PR TITLE
Requested grant_types inconsistent with created grant_types for OpenI…

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -110,7 +110,7 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
                 session.realms().decreaseRemainingCount(realm, initialAccessModel);
             }
 
-            client.setDirectAccessGrantsEnabled(false);
+            client.setDirectAccessGrantsEnabled(clientModel.isDirectAccessGrantsEnabled());
 
             Stream<String> defaultRolesNames = getDefaultRolesStream(clientModel);
             if (defaultRolesNames != null) {

--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
@@ -17,7 +17,6 @@
 package org.keycloak.services.clientregistration.oidc;
 
 import org.jboss.logging.Logger;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSecretConstants;
@@ -27,9 +26,7 @@ import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
-import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
-import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.protocol.oidc.mappers.AbstractPairwiseSubMapper;
 import org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper;
 import org.keycloak.protocol.oidc.mappers.SHA256PairwiseSubMapper;
@@ -84,15 +81,6 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
 
         try {
             ClientRepresentation client = DescriptionConverter.toInternal(session, clientOIDC);
-            List<String> grantTypes = clientOIDC.getGrantTypes();
-
-            if (grantTypes != null && grantTypes.contains(OAuth2Constants.UMA_GRANT_TYPE)) {
-                client.setAuthorizationServicesEnabled(true);
-            }
-
-            if (!(grantTypes == null || grantTypes.contains(OAuth2Constants.REFRESH_TOKEN))) {
-                OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setUseRefreshToken(false);
-            }
 
             OIDCClientRegistrationContext oidcContext = new OIDCClientRegistrationContext(session, client, this, clientOIDC);
             client = create(oidcContext);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationResponseTypesAndGrantsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationResponseTypesAndGrantsTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.testsuite.client;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.client.registration.Auth;
+import org.keycloak.client.registration.ClientRegistrationException;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
+import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
+import org.keycloak.representations.idm.ClientInitialAccessPresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.testsuite.Assert;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_CODE;
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.keycloak.OAuth2Constants.DEVICE_CODE_GRANT_TYPE;
+import static org.keycloak.OAuth2Constants.IMPLICIT;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+import static org.keycloak.OAuth2Constants.REFRESH_TOKEN;
+import static org.keycloak.models.OAuth2DeviceConfig.OAUTH2_DEVICE_AUTHORIZATION_GRANT_ENABLED;
+import static org.keycloak.protocol.oidc.utils.OIDCResponseType.CODE;
+import static org.keycloak.protocol.oidc.utils.OIDCResponseType.ID_TOKEN;
+import static org.keycloak.protocol.oidc.utils.OIDCResponseType.NONE;
+
+/**
+ * Test of OIDC client registration with various combinations of parameters "response_types" and "grant_types"
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class OIDCClientRegistrationResponseTypesAndGrantsTest extends AbstractClientRegistrationTest {
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+
+        ClientInitialAccessPresentation token = adminClient.realm(REALM_NAME).clientInitialAccess().create(new ClientInitialAccessCreatePresentation(0, 10));
+        reg.auth(Auth.token(token));
+    }
+
+    private OIDCClientRepresentation createRep(List<String> responseTypes, List<String> grantTypes) {
+        OIDCClientRepresentation client = new OIDCClientRepresentation();
+        client.setClientName("RegistrationAccessTokenTest");
+        client.setClientUri("http://root");
+        client.setRedirectUris(Collections.singletonList("http://redirect"));
+        client.setResponseTypes(responseTypes);
+        client.setGrantTypes(grantTypes);
+        return client;
+    }
+
+    // OIDC mentions "code" as default response_type if ommitted. Type "none" used as well for backwards compatibility and lack of dedicated config.
+    // Refresh token enabled as well for backwards compatibility.
+    @Test
+    public void testClientWithoutResponseTypesAndGrantTypes() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, null);
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE), List.of(AUTHORIZATION_CODE, REFRESH_TOKEN));
+
+        assertKeycloakClient(response, true, false, false, false, true, false);
+    }
+
+    @Test
+    public void testResponseTypeCodeWithoutGrantTypes() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(List.of(CODE), null);
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE), List.of(AUTHORIZATION_CODE, REFRESH_TOKEN));
+
+        assertKeycloakClient(response, true, false, false, false, true, false);
+    }
+
+    // Limitation of Keycloak switches (Standard flow, Implicit flow) means that enabling any hybrid grant type enables also implicit flow.
+    // This is also backwards compatibile behaviour
+    @Test
+    public void testResponseTypeCodeIDTokenWithoutGrantTypes() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(List.of(CODE, ID_TOKEN), null);
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE, ID_TOKEN, "id_token token", "code id_token", "code token", "code id_token token"),
+                List.of(AUTHORIZATION_CODE, IMPLICIT, REFRESH_TOKEN));
+
+        assertKeycloakClient(response, true, true, false, false, true, false);
+    }
+
+    @Test
+    public void testWithoutResponseTypeClientCredentialsGrant() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, List.of(CLIENT_CREDENTIALS));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, Collections.emptyList(),
+                List.of(CLIENT_CREDENTIALS));
+
+        assertKeycloakClient(response, false, false, false, true, false, false);
+    }
+
+    @Test
+    public void testWithoutResponseTypePasswordGrant() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, List.of(PASSWORD));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, Collections.emptyList(),
+                List.of(PASSWORD));
+
+        assertKeycloakClient(response, false, false, true, false, false, false);
+    }
+
+    @Test
+    public void testWithoutResponseTypePasswordClientCredentialsRefreshTokensGrants() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, List.of(PASSWORD, CLIENT_CREDENTIALS, REFRESH_TOKEN));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, Collections.emptyList(),
+                List.of(PASSWORD, CLIENT_CREDENTIALS, REFRESH_TOKEN));
+
+        assertKeycloakClient(response, false, false, true, true, true, false);
+    }
+
+    @Test
+    public void testClientWithoutRefreshToken() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, List.of(AUTHORIZATION_CODE));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE), List.of(AUTHORIZATION_CODE));
+
+        assertKeycloakClient(response, true, false, false, false, false, false);
+    }
+
+    @Test
+    public void testClientWithRefreshToken() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, List.of(AUTHORIZATION_CODE, REFRESH_TOKEN));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE), List.of(AUTHORIZATION_CODE, REFRESH_TOKEN));
+
+        assertKeycloakClient(response, true, false, false, false, true, false);
+    }
+
+    @Test
+    public void testNoResponseTypesWithDeviceGrant() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(null, List.of(DEVICE_CODE_GRANT_TYPE));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, Collections.emptyList(), List.of(DEVICE_CODE_GRANT_TYPE));
+
+        assertKeycloakClient(response, false, false, false, false, false, true);
+    }
+
+    @Test
+    public void testCodeResponseTypeWithMoreGrants() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(List.of(CODE), List.of(AUTHORIZATION_CODE, REFRESH_TOKEN, PASSWORD, CLIENT_CREDENTIALS));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE), List.of(AUTHORIZATION_CODE, REFRESH_TOKEN, PASSWORD, CLIENT_CREDENTIALS));
+
+        assertKeycloakClient(response, true, false, true, true, true, false);
+    }
+
+    // Grant type "authorization_code" added automatically because of response_type "code" .
+    // If provided response_types are not 100% aligned with provided grant_types, we can in theory reject the request based on https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+    // and the note "The following table lists the correspondence between response_type values that the Client will use and grant_type values that MUST be included in the registered grant_types list"
+    // Not doing it for backwards compatibility for now
+    @Test
+    public void testCodeResponseTypeWithIncompatibleGrants() throws Exception {
+        OIDCClientRepresentation clientRep = createRep(List.of(CODE), List.of(REFRESH_TOKEN, PASSWORD, CLIENT_CREDENTIALS));
+
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+
+        assertOIDCResponse(response, List.of(CODE, NONE), List.of(AUTHORIZATION_CODE, REFRESH_TOKEN, PASSWORD, CLIENT_CREDENTIALS));
+
+        assertKeycloakClient(response, true, false, true, true, true, false);
+    }
+
+    private void assertOIDCResponse(OIDCClientRepresentation response, List<String> expectedResponseTypes, List<String> expectedGrantTypes) {
+        assertOIDCResponseImpl(response, expectedResponseTypes, expectedGrantTypes);
+
+        // Test subsequent "get" request returns the same as response from initial "create" request
+        try {
+            reg.auth(Auth.token(response));
+            OIDCClientRepresentation rep = reg.oidc().get(response.getClientId());
+            assertOIDCResponseImpl(rep, expectedResponseTypes, expectedGrantTypes);
+        } catch (ClientRegistrationException cre) {
+            throw new AssertionError(cre);
+        }
+    }
+
+    private void assertOIDCResponseImpl(OIDCClientRepresentation response, List<String> expectedResponseTypes, List<String> expectedGrantTypes) {
+        MatcherAssert.assertThat("Incompatible response_types", response.getResponseTypes(), containsInAnyOrder(expectedResponseTypes.toArray()));
+        MatcherAssert.assertThat("Incompatible grant_Types", response.getGrantTypes(), containsInAnyOrder(expectedGrantTypes.toArray()));
+    }
+
+    private void assertKeycloakClient(OIDCClientRepresentation response,
+                                             boolean expectedStandardFlow,
+                                             boolean expectedImplicitFlow,
+                                             boolean expectedDirectGrantFlow,
+                                             boolean expectedServiceAccountsFlow,
+                                             boolean expectedRefreshToken,
+                                             boolean expectedDeviceGrant) {
+        ClientRepresentation kcClient = getClient(response.getClientId());
+        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
+        Assert.assertEquals("Expected standard flow: " + expectedStandardFlow + " did not match.", expectedStandardFlow, kcClient.isStandardFlowEnabled());
+        Assert.assertEquals("Expected implicit flow: " + expectedImplicitFlow + " did not match.", expectedImplicitFlow, kcClient.isImplicitFlowEnabled());
+        Assert.assertEquals("Expected direct grant flow: " + expectedDirectGrantFlow + " did not match.", expectedDirectGrantFlow, kcClient.isDirectAccessGrantsEnabled());
+        Assert.assertEquals("Expected service accounts flow: " + expectedServiceAccountsFlow + " did not match.", expectedServiceAccountsFlow, kcClient.isServiceAccountsEnabled());
+        Assert.assertEquals("Expected refresh: " + expectedRefreshToken + " did not match.", expectedRefreshToken, config.isUseRefreshToken());
+        Assert.assertFalse("Don't expect refresh token for client credentials grant enabled", config.isUseRefreshTokenForClientCredentialsGrant());
+        boolean deviceEnabled = kcClient.getAttributes() != null && Boolean.parseBoolean(kcClient.getAttributes().get(OAUTH2_DEVICE_AUTHORIZATION_GRANT_ENABLED));
+        Assert.assertEquals("Expected device: " + expectedDeviceGrant + " did not match.", expectedDeviceGrant, deviceEnabled);
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -843,51 +843,6 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
     }
 
     @Test
-    public void testClientWithoutRefreshToken() throws Exception {
-        OIDCClientRepresentation clientRep = null;
-        OIDCClientRepresentation response = null;
-
-        clientRep = createRep();
-        clientRep.setGrantTypes(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE));
-
-        response = reg.oidc().create(clientRep);
-
-        // Test Keycloak representation
-        ClientRepresentation kcClient = getClient(response.getClientId());
-        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
-        Assert.assertFalse(config.isUseRefreshToken());
-    }
-
-    @Test
-    public void testClientWithRefreshToken() throws Exception {
-        OIDCClientRepresentation clientRep = null;
-        OIDCClientRepresentation response = null;
-
-        clientRep = createRep();
-        clientRep.setGrantTypes(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN));
-
-        response = reg.oidc().create(clientRep);
-
-        // Test Keycloak representation
-        ClientRepresentation kcClient = getClient(response.getClientId());
-        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
-        Assert.assertTrue(config.isUseRefreshToken());
-    }
-
-    @Test
-    public void testClientWithoutGrantTypes() throws Exception {
-        OIDCClientRepresentation response = create();
-
-        assertTrue(CollectionUtil.collectionEquals(
-            Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN), response.getGrantTypes()));
-
-        // Test Keycloak representation
-        ClientRepresentation kcClient = getClient(response.getClientId());
-        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
-        Assert.assertTrue(config.isUseRefreshToken());
-    }
-
-    @Test
     public void testDefaultAcrValues() throws Exception {
         // Set realm acr-to-loa mapping
         RealmRepresentation realmRep = adminClient.realm("test").toRepresentation();


### PR DESCRIPTION
…D Connect Dynamic Client Registration

closes #32801

The issue is a bit tricky as both parameters `response_types` and `grant_types` are optional in the OIDC dynamic registration specification https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata .

PR tries to provide some "Best judge" according to the fact if:
- None of them is provided
- Only `response_types` is provided
- Only `grant_types` is provided
- Both are provided

Also PR fixes some nitpick issues and tries to preserve backwards compatibility and not reject request if incompatible values are provided.

### Details

For the case (1), PR preserves backwards compatibility, which was before this PR (Browser flow enabled with refresh token enabled)

For the case (2), the behaviour is unchanged in this PR.

For the case (3) we always assumed `code` to be used in case that `response_types` parameter was not provided. Now we're instead using `grant_Types` parameter to figure which flows should be enabled. So for example browser flow is enabled just if `grant_types` contains `authorization_code`. This is the case from the description of the issue (as `kct` currently use only `grant_types`, but not `response_types` parameter)

For the case (4), it is pretty much backwards compatible with the previous behaviour. The issue is, that there could be the case when provided `grant_types` are not aligned with `response_types`. For example when using `response_types=code` and `grant_types` without `authorization_code` . If provided response_types are not 100% aligned with provided grant_types, we can in theory reject the request based on https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata and the note "The following table lists the correspondence between response_type values that the Client will use and grant_type values that MUST be included in the registered grant_types list" . But from the specs, it s not 100% clear to me if authorization server is supposed to reject the request or adjust the grant_types to be compatible with response_types (EG. assume grant type `authorization_code` included if `response_types` contains `code`). I am doing the 2nd and not rejecting the request (also for backwards compatibility).

Besides that:

- Added the automated test `OIDCClientRegistrationResponseTypesAndGrantsTest` for various combinations (Also added the excell table here for the reference https://docs.google.com/spreadsheets/d/1YdtnigYNnVMDAl5hEUzrM6j_IUpYBNwoeCH9HDWC-sc/edit?usp=sharing ). Besides added some combinations in the test, I moved some existing test from `OIDCClientRegistrationTest` to it.

- Added support for enabling `device flow` from OIDC client registration (We did not have it before this PR)

- When `password` grant type was used, we enabled Direct-grant (correct behaviour), but we did not returned `password` grant type in the registration response (incorrect behaviour). It was correctly returned just in the subsequent OIDC GET requests. Fixed it in this PR.
