### PR TITLE
Update UP via provider instead of going through the UserProfileResource

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmResource.java
@@ -37,7 +37,6 @@ import org.keycloak.storage.UserStorageProviderModel;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.MediaType;
@@ -96,22 +95,12 @@ public class UIRealmResource {
     }
 
     private void updateUserProfileConfiguration(UIRealmRepresentation rep) {
-        UPConfig upConfig = rep.getUpConfig();
-
-        if (upConfig == null) {
+        UserProfileResource userProfileResource = new UserProfileResource(session, auth, adminEvent);
+        UPConfig config = rep.getUpConfig();
+        if (config == null) {
             return;
         }
-
-        UserProfileResource userProfileResource = new UserProfileResource(session, auth, adminEvent);
-        if (!upConfig.equals(userProfileResource.getConfiguration())) {
-            Response response = userProfileResource.update(upConfig);
-
-            if (isSuccessful(response)) {
-                return;
-            }
-
-            throw new InternalServerErrorException("Failed to update user profile configuration");
-        }
+        userProfileResource.setAndGetConfiguration(config);
     }
 
     private boolean isSuccessful(Response response) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
@@ -95,10 +95,18 @@ public class UserProfileResource {
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UPConfig.class)))
     public Response update(UPConfig config) {
         auth.realm().requireManageRealm();
-        UserProfileProvider t = session.getProvider(UserProfileProvider.class);
+        return Response.ok(setAndGetConfiguration(config)).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    public UPConfig setAndGetConfiguration(UPConfig config) {
+        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
+
+        if (config != null && provider.getConfiguration().equals(config)) {
+            return config;
+        }
 
         try {
-            t.setConfiguration(config);
+            provider.setConfiguration(config);
         } catch (ComponentValidationException e) {
             //show validation result containing details about error
             throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
@@ -109,6 +117,6 @@ public class UserProfileResource {
                 .representation(config)
                 .success();
 
-        return Response.ok(t.getConfiguration()).type(MediaType.APPLICATION_JSON).build();
+        return provider.getConfiguration();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UIRealmResourceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UIRealmResourceTest.java
@@ -51,6 +51,7 @@ import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPAttributePermissions;
 import org.keycloak.representations.userprofile.config.UPAttributeRequired;
 import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.util.AssertAdminEvents;
 import org.keycloak.testsuite.util.UserBuilder;
@@ -203,6 +204,24 @@ public class UIRealmResourceTest extends AbstractTestRealmKeycloakTest {
         assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
     }
 
+    @Test
+    public void testRenameRealm() throws IOException {
+        RealmRepresentation rep = testRealm().toRepresentation();
+        UPConfig upConfig = testRealm().users().userProfile().getConfiguration();
+        upConfig.setUnmanagedAttributePolicy(UnmanagedAttributePolicy.ADMIN_VIEW);
+        String originalRealmName = rep.getRealm();
+        String updatedName = originalRealmName + "changed";
+
+        try {
+            rep.setRealm(updatedName);
+            updateRealmExt(toUIRealmRepresentation(rep, upConfig), originalRealmName);
+        } finally {
+            rep.setRealm(originalRealmName);
+            updateRealmExt(toUIRealmRepresentation(rep, upConfig), updatedName);
+            assertAdminEvents.clear();
+        }
+    }
+
     private static String getKeycloakServerUrl() {
         return getAuthServerContextRoot() + "/auth";
     }
@@ -225,7 +244,10 @@ public class UIRealmResourceTest extends AbstractTestRealmKeycloakTest {
     }
 
     private void updateRealmExt(UIRealmRepresentation rep) {
-        final var realmName = rep.getRealm();
+        updateRealmExt(rep, rep.getRealm());
+    }
+
+    private void updateRealmExt(UIRealmRepresentation rep, String realmName) {
         final var request = prepareHttpRequest(realmName, "ui-ext", adminClient.tokenManager());
 
         final var response = request


### PR DESCRIPTION
- prevents error when updating realm

Closes #34540

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit abf0eb7f92e83f6c081c4378f2b715c3b480320a)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
