### PR TITLE
fix: using stable ordering for deprecated metadata (#34999)

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DeprecatedMetadata.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DeprecatedMetadata.java
@@ -17,32 +17,36 @@
 
 package org.keycloak.config;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 public class DeprecatedMetadata {
-    private final Set<String> newOptionsKeys;
+    private final List<String> newOptionsKeys;
     private final String note;
     private final Set<String> deprecatedValues;
 
-    private DeprecatedMetadata(Set<String> newOptionsKeys, String note, Set<String> deprecatedValues) {
-        this.newOptionsKeys = newOptionsKeys == null ? Collections.emptySet() : Collections.unmodifiableSet(newOptionsKeys);
+    private DeprecatedMetadata(List<String> newOptionsKeys, String note, Set<String> deprecatedValues) {
+        this.newOptionsKeys = newOptionsKeys;
         this.note = note;
-        this.deprecatedValues = deprecatedValues == null ? Collections.emptySet() : Collections.unmodifiableSet(deprecatedValues);
+        this.deprecatedValues = deprecatedValues;
     }
 
-    public static DeprecatedMetadata deprecateOption(String note, Set<String> newOptionsKeys) {
-        return new DeprecatedMetadata(newOptionsKeys, note, null);
+    public static DeprecatedMetadata deprecateOption(String note, String... newOptionsKeys) {
+        return new DeprecatedMetadata(Arrays.asList(newOptionsKeys), note, Set.of());
     }
 
-    public static DeprecatedMetadata deprecateValues(Set<String> values, String note) {
-        return new DeprecatedMetadata(null, note, values);
+    public static DeprecatedMetadata deprecateValues(String note, String... values) {
+        return new DeprecatedMetadata(Collections.emptyList(), note,
+                Collections.unmodifiableSet(new LinkedHashSet<String>(Arrays.asList(values))));
     }
 
-    public Set<String> getNewOptionsKeys() {
+    public List<String> getNewOptionsKeys() {
         return newOptionsKeys;
     }
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -119,30 +118,19 @@ public class OptionBuilder<T> {
     }
 
     public OptionBuilder<T> deprecated() {
-        this.deprecatedMetadata = DeprecatedMetadata.deprecateOption(null, null);
+        this.deprecatedMetadata = DeprecatedMetadata.deprecateOption(null);
         return this;
     }
 
-    public OptionBuilder<T> deprecated(String note) {
-        this.deprecatedMetadata = DeprecatedMetadata.deprecateOption(note, null);
+    public OptionBuilder<T> deprecatedMetadata(DeprecatedMetadata deprecatedMetadata) {
+        this.deprecatedMetadata = deprecatedMetadata;
         return this;
     }
 
-    public OptionBuilder<T> deprecated(Set<String> newOptionsKeys) {
-        this.deprecatedMetadata = DeprecatedMetadata.deprecateOption(null, newOptionsKeys);
+    public OptionBuilder<T> deprecatedValues(String note, T... values) {
+        this.deprecatedMetadata = DeprecatedMetadata.deprecateValues(note, Stream.of(values).map(Object::toString).toArray(String[]::new));
         return this;
     }
-
-    public OptionBuilder<T> deprecated(String note, Set<String> newOptionsKeys) {
-        this.deprecatedMetadata = DeprecatedMetadata.deprecateOption(note, newOptionsKeys);
-        return this;
-    }
-
-    public OptionBuilder<T> deprecatedValues(Set<String> values, String note) {
-        this.deprecatedMetadata = DeprecatedMetadata.deprecateValues(values, note);
-        return this;
-    }
-
 
     public Option<T> build() {
         if (deprecatedMetadata == null && category.getSupportLevel() == ConfigSupportLevel.DEPRECATED) {

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TruststoreOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TruststoreOptions.java
@@ -3,7 +3,6 @@ package org.keycloak.config;
 import org.keycloak.common.enums.HostnameVerificationPolicy;
 
 import java.util.List;
-import java.util.Set;
 
 public class TruststoreOptions {
 
@@ -16,7 +15,7 @@ public class TruststoreOptions {
             .category(OptionCategory.TRUSTSTORE)
             .description("The TLS hostname verification policy for out-going HTTPS and SMTP requests.")
             .defaultValue(HostnameVerificationPolicy.DEFAULT)
-            .deprecatedValues(Set.of("STRICT", "WILDCARD"), "STRICT and WILDCARD have been deprecated, use DEFAULT instead.")
+            .deprecatedValues("STRICT and WILDCARD have been deprecated, use DEFAULT instead.", HostnameVerificationPolicy.STRICT, HostnameVerificationPolicy.WILDCARD)
             .build();
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -841,7 +841,7 @@ public class Picocli {
 
         if (mapper.getType() != Boolean.class && !mapper.getExpectedValues().isEmpty()) {
             List<String> decoratedExpectedValues = mapper.getExpectedValues().stream().map(value -> {
-                if (mapper.getDeprecatedMetadata().isPresent() && mapper.getDeprecatedMetadata().get().getDeprecatedValues().contains(value)) {
+                if (mapper.getDeprecatedMetadata().filter(metadata -> metadata.getDeprecatedValues().contains(value)).isPresent()) {
                     return value + " (deprecated)";
                 }
                 return value;

--- a/quarkus/runtime/src/test/java/org/keycloak/config/OptionBuilderTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/config/OptionBuilderTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.config;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class OptionBuilderTest {
+
+    @Test
+    public void testDeprecatedOptionOrdering() {
+        String[] values = new String[] {"a", "d", "b", "1"};
+        var option = new OptionBuilder<>("key", String.class).deprecatedValues("These are deprecated", values).build();
+        assertArrayEquals(option.getDeprecatedMetadata().get().getDeprecatedValues().toArray(String[]::new), values);
+    }
+
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package or.keycloak.quarkus.runtime.cli;
+package org.keycloak.quarkus.runtime.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.test.AbstractConfigurationTest;


### PR DESCRIPTION
closes: #34858

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit 245498c0cbb7a9d543c94c5e01f5b5e757eed683)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
