### PR TITLE
Use all 1s for ordered list in CONTRIBUTING.md for cleaner blame/diff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,14 @@ discussion first. For minor changes you can skip this part and go straight ahead
 Here's a quick checklist for a good PR, more details below:
 
 1. A discussion around the change (https://github.com/keycloak/keycloak/discussions/categories/ideas)
-2. A GitHub Issue with a good description associated with the PR
-3. One feature/change per PR
-4. One commit per PR
-5. PR rebased on main (`git rebase`, not `git pull`) 
-5. [Good descriptive commit message, with link to issue](#commit-messages-and-issue-linking)
-6. No changes to code not directly related to your PR
-7. Includes functional/integration test
-8. Includes documentation
+1. A GitHub Issue with a good description associated with the PR
+1. One feature/change per PR
+1. One commit per PR
+1. PR rebased on main (`git rebase`, not `git pull`) 
+1. [Good descriptive commit message, with link to issue](#commit-messages-and-issue-linking)
+1. No changes to code not directly related to your PR
+1. Includes functional/integration test
+1. Includes documentation
 
 Once you have submitted your PR please monitor it for comments/feedback. We reserve the right to close inactive PRs if
 you do not respond within 2 weeks (bear in mind you can always open a new PR if it is closed due to inactivity).


### PR DESCRIPTION
Closes #35254

Previously the 5 was repeated twice (presumably to keep diff small)
but that is super confusing. Better to use 1s for everything.

Signed-off-by: Cornelius Roemer <cornelius.roemer@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
