### PR TITLE
Fix typos in *.md and *.adoc files using codespell interactive mode

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/passkeys.adoc
+++ b/docs/documentation/server_admin/topics/authentication/passkeys.adoc
@@ -75,7 +75,7 @@ We plan to improve the usability and allow integration of conditional passkeys w
 From https://www.w3.org/TR/webauthn-3/[Web Authn Level 3], *Resident Key* was replaced with *Discoverable Credential*.
 ====
 
-If a user's browser supports https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI/[WebAuthn Conditional UI], the follwing screen is shown.
+If a user's browser supports https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI/[WebAuthn Conditional UI], the following screen is shown.
 
 .Passkey Authentication with Conditional UI
 image:images/passkey-conditional-ui-authentication.png[Passkey Authentication with Conditional UI]
@@ -85,7 +85,7 @@ When the user clicks the *Select your passkey* textbox, a list of passkeys store
 .Passkey Authentication with Conditional UI Autofill
 image:images/passkey-conditional-ui-autofill.png[Passkey Authentication with Conditional UI Autofill]
 
-If a user's browser does not support https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI/[WebAuthn Conditional UI], the authenticaion falls back to the xref:_webauthn_loginless[LoginLess WebAuthn] as follows.
+If a user's browser does not support https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI/[WebAuthn Conditional UI], the authentication falls back to the xref:_webauthn_loginless[LoginLess WebAuthn] as follows.
 
 .Passkey Authentication with Conditional UI falling back to LoginLess WebAuthn
 image:images/passkey-conditional-ui-fallback-authentication.png[Passkey Authentication with Conditional UI falling back to LoginLess WebAuthn]

--- a/docs/documentation/server_admin/topics/threat/brute-force.adoc
+++ b/docs/documentation/server_admin/topics/threat/brute-force.adoc
@@ -25,7 +25,7 @@ To enable this protection:
 image:images/brute-force.png[]
 
 ==== Lockout permanently
-{project_name} disables a user account (blocking log in attemps) until an administrator re-enables it.
+{project_name} disables a user account (blocking log in attempts) until an administrator re-enables it.
 
 .Lockout permanently
 image:images/brute-force-permanently.png[]

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -424,7 +424,7 @@ to avoid overflow after 2038.
 Method `String encode(String rawPassword, int iterations)` on the interface `org.keycloak.credential.hash.PasswordHashProvider` is deprecated. The method will be removed in
 one of the future {project_name} releases. It might be {project_name} 27 release.
 
-= CollectionUtil intesection method removed
+= CollectionUtil intersection method removed
 
 The method `org.keycloak.common.util.CollectionUtil.intersection` has been removed. You should use the 'java.util.Collection.retainAll' instead on an existing collection.
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -319,7 +319,7 @@ The `groups.setOrCreateChild()` method has been removed from that JavaScript-bas
 
 = Keycloak JS
 
-This release includes several changes to Keycloak JS library that should be taken into account. The main motivation for these changes is to de-couple the library from the Keycloak server, so that it can be refactored independently, simplifing the code and making it easier to maintain in the future. The changes are as follows:
+This release includes several changes to Keycloak JS library that should be taken into account. The main motivation for these changes is to de-couple the library from the Keycloak server, so that it can be refactored independently, simplifying the code and making it easier to maintain in the future. The changes are as follows:
 
 == The library is no longer served statically from the server
 
@@ -347,7 +347,7 @@ Alternatively, the distribution of the server includes a copy of the library in 
 
 == Support for the UMD distribution has been removed
 
-The UMD distribution link:https://github.com/umdjs/umd?tab=readme-ov-file#umd-universal-module-definition[Universal Module Definition] of the Keycloak JS library has been removed. This means that the library is no longer exposed as a global variable, and instead must be imported as link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[a module]. This change is in line with modern JavaScript development practices, and allows for a more consitent experience between browsers and build tooling, and generally results in more predictable code with less side-effects.
+The UMD distribution link:https://github.com/umdjs/umd?tab=readme-ov-file#umd-universal-module-definition[Universal Module Definition] of the Keycloak JS library has been removed. This means that the library is no longer exposed as a global variable, and instead must be imported as link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[a module]. This change is in line with modern JavaScript development practices, and allows for a more consistent experience between browsers and build tooling, and generally results in more predictable code with less side-effects.
 
 If you are using a bundler like Vite or Webpack nothing changes, you'll have the same experience as before. If you are using the library directly in the browser, you'll need to update your code to import the library as a module:
 
@@ -412,7 +412,7 @@ const keycloak = new Keycloak({
 });
 
 // Alternatively, you can pass a URL to a `keycloak.json` file.
-// Note this is not reccomended as it creates additional network requests, and is prone to change in the future.
+// Note this is not recommended as it creates additional network requests, and is prone to change in the future.
 const keycloak = new Keycloak('http://keycloak-server/path/to/keycloak.json');
 ----
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -60,7 +60,7 @@ cookies.
 
 = Removal of robots.txt file
 
-The `robots.txt` file, previously included by default, is now removed. The default `robots.txt` file blocked all crawling, which prevented the `noindex`/`nofollow` directives from being followed. The desired default behaviour is for {project_name} pages to not show up in search engine results and this is accomplished by the existing `X-Robots-Tag` header, which is set to `none` by default. The value of this header can be overidden per-realm if a different behaviour is needed.
+The `robots.txt` file, previously included by default, is now removed. The default `robots.txt` file blocked all crawling, which prevented the `noindex`/`nofollow` directives from being followed. The desired default behaviour is for {project_name} pages to not show up in search engine results and this is accomplished by the existing `X-Robots-Tag` header, which is set to `none` by default. The value of this header can be overridden per-realm if a different behaviour is needed.
 
 = Offline access removes the associated online session if the `offline_scope` is requested in the initial exchange
 

--- a/docs/guides/high-availability/deploy-aws-accelerator-loadbalancer.adoc
+++ b/docs/guides/high-availability/deploy-aws-accelerator-loadbalancer.adoc
@@ -290,7 +290,7 @@ spec:
 +
 To ensure that request forwarding works as expected, it is necessary for the Keycloak CR to specify the hostname through
 which clients will access the {project_name} instances. This can either be the `DualStackDnsName` or `DnsName` hostname associated
-with the Global Accelerator. If you are using a custom domain, point your custom domain to the AWS Globa Accelerator, and use your custom domain here.
+with the Global Accelerator. If you are using a custom domain, point your custom domain to the AWS Global Accelerator, and use your custom domain here.
 
 == Verify
 To verify that the Global Accelerator is correctly configured to connect to the clusters, navigate to hostname configured above, and you should be presented with the {project_name} admin console.

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -65,7 +65,7 @@ If you have any questions or need assistance, feel free to reach out to the lang
 - The Keycloak-Team will then
     - enable the specific language
     - invite the two volunteers
-    - comment on discussion thread, that the langauge has been enabled
+    - comment on discussion thread, that the language has been enabled
 - Weblate synchronizes daily, so it may take up to 24 hours after enabling the language before you can start your first translations 
 
 ### Translation status

--- a/quarkus/CONTRIBUTING.md
+++ b/quarkus/CONTRIBUTING.md
@@ -144,7 +144,7 @@ The test suite has two main types of tests:
 * `distribution`
 
 The `jvm` tests execute both the test class and server within the same JVM. While the `distribution` tests execute the server
-by running the distribution in a separte JVM.
+by running the distribution in a separate JVM.
 
 The `distribution` tests are marked as such using the `DistributionTest` annotation. If not marked with this annotation, the test is a `JVM` test.
 

--- a/services/src/main/resources/DockerComposeYamlReadme.md
+++ b/services/src/main/resources/DockerComposeYamlReadme.md
@@ -4,7 +4,7 @@
 *NOTE:* This installation method is intended for development use only.  Please don't ever let this anywhere near prod!
 
 ## Keycloak Realm Assumptions:
- - Client configuration has not changed since the installtion files were generated.  If you change your client configuration, be sure to grab a re-generated installtion .zip from the 'Installation' tab.
+ - Client configuration has not changed since the installation files were generated.  If you change your client configuration, be sure to grab a re-generated installation .zip from the 'Installation' tab.
  - Keycloak server is started with the 'docker' feature enabled.  I.E. -Dkeycloak.profile.feature.docker=enabled
 
 ## Running the Installation:

--- a/test-framework/README.md
+++ b/test-framework/README.md
@@ -193,7 +193,7 @@ public void testRealmAdmin() {
 ## Using Selenium
 
 Frequently when testing Keycloak it is required to interact with login pages, required actions, etc. through the 
-browser. This can be done in two ways, where the most convinient way is to inject a Java Page representation:
+browser. This can be done in two ways, where the most convenient way is to inject a Java Page representation:
 
 ```java
 @InjectPage
@@ -222,7 +222,7 @@ public void test() {
 
 ## OAuth Client
 
-A convenient way to test OAuth flows are with the OAuth Client. This provides convinient methods to perform different
+A convenient way to test OAuth flows are with the OAuth Client. This provides convenient methods to perform different
 OAuth flows, and it even automatically creates its own client within the realm. For example:
 
 ```java
@@ -293,7 +293,7 @@ As with system properties, using environment variables within the IDE can be cum
 
 ### Using `.env` file
 
-When running tests from an IDE using the `.env` file is very convinient, especially as this can be added to `.gitignore`
+When running tests from an IDE using the `.env` file is very convenient, especially as this can be added to `.gitignore`
 allowing developers to quickly have their own personal preference when running tests.
 
 Example `.env` file:
@@ -304,7 +304,7 @@ KC_TEST_BROWSER=firefox
 
 ### Using a properties file
 
-Using a property file allows creating a set of configuration which can be commited to a Git repository to be shareable.
+Using a property file allows creating a set of configuration which can be committed to a Git repository to be shareable.
 
 For example create the file `/path/mytestconfig.properties` with the following contents:
 
@@ -356,7 +356,7 @@ Configuration:
 
 ### Browser
 
-Option: `kc.test.broser` / `KC_TEST_BROWSER`
+Option: `kc.test.browser` / `KC_TEST_BROWSER`
 
 Valid values:
 

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -270,7 +270,7 @@ An example social.properties file looks like:
     facebook.profile.lastName=Test
 
 In the example above the common username, password and profile are shared for all providers, but Facebook has a
-different last name. Profile informations are used for assertion after login, so you have to set them to be same as
+different last name. Profile information is used for assertion after login, so you have to set it to be same as
 user profile information returned by given social login provider for used sample user.
 
 Some providers actively block bots so you need to use a proper browser to test. Either Firefox or Chrome should work.

--- a/testsuite/integration-arquillian/README.md
+++ b/testsuite/integration-arquillian/README.md
@@ -66,7 +66,7 @@ The `AppServerTestEnricher` then ensures the corresponding server is started dur
 The app-servers with installed Keycloak adapter are prepared in `servers/app-server` submodules, activated by `-Papp-server-MODULE` or `-Dapp.server=MODULE`
 [More details.](servers/app-server/README.md)
 
-NOTE: Some corresponding adapter test modules are in `tests/other/adapters` submodules, and are activated by the same profiles. It will be tranferred into base testsuite.
+NOTE: Some corresponding adapter test modules are in `tests/other/adapters` submodules, and are activated by the same profiles. It will be transferred into base testsuite.
 
 ## SuiteContext and TestContext
 


### PR DESCRIPTION
Closes #35256

This PR fixes a bunch of typos in docs files.

I ran codespell on `*.adoc` and `*.md` files in the repo in interactive mode
carefully checking each identified typo and proposed fix for false positives.

The most widely read file with typos identified is likely the changelog/migration guide.

Signed-off-by: Cornelius Roemer <cornelius.roemer@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
