### PR TITLE
project keycloak-parent: fix undertow jakarta version to 2.3.18.Final - snyk generated scan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
         <undertow.version>${undertow-legacy.version}</undertow.version>
         <undertow-legacy.version>2.2.24.Final</undertow-legacy.version>
-        <undertow-jakarta.version>2.3.2.Final</undertow-jakarta.version>
+        <undertow-jakarta.version>2.3.18.Final</undertow-jakarta.version>
         <wildfly-elytron.version>2.5.2.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
         <woodstox.version>6.0.3</woodstox.version>
@@ -286,7 +286,7 @@
         </developer>
     </developers>
 
-    <contributors></contributors>
+    <contributors/>
 
     <modules>
         <module>boms</module>


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7300153
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-8383402
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-5826041
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7300152
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7433720
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7984545
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-6567186
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-6669948
- https://snyk.io/vuln/SNYK-JAVA-ORGJBOSSXNIO-6403375
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7707751
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-3358786
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7361775
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-7433721

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
