### PR TITLE
Avoid a NullPointerException when client roles are associated with a …

### DIFF
--- a/services/src/main/java/org/keycloak/utils/RoleResolveUtil.java
+++ b/services/src/main/java/org/keycloak/utils/RoleResolveUtil.java
@@ -122,6 +122,9 @@ public class RoleResolveUtil {
 
         } else {
             ClientModel app = (ClientModel) role.getContainer();
+            if (app == null) {
+                return;
+            }
             access = token.getResourceAccess(app.getClientId());
             if (access == null) {
                 access = token.addAccess(app.getClientId());


### PR DESCRIPTION
…client that no longer exists


Closes #34444


This is a corner case but can cause the admin console to stop working if there are ghost client roles linked to a non-existent client.

The question remains as to how this situation could have occurred, whether due to a bug, a migration issue, or some other reasons.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
