### PR TITLE
Do not count current sessions in UserSessionLimitsAuthenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -1,37 +1,32 @@
 package org.keycloak.authentication.authenticators.sessionlimits;
 
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
-import org.jboss.logging.Logger;
-import org.keycloak.authentication.AuthenticationFlowException;
-import org.keycloak.authentication.Authenticator;
-import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.models.AuthenticatorConfigModel;
-import org.keycloak.models.ClientModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
-import org.keycloak.services.managers.AuthenticationManager;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationFlowException;
+import org.keycloak.authentication.Authenticator;
 import org.keycloak.events.Errors;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.utils.StringUtil;
 
 public class UserSessionLimitsAuthenticator implements Authenticator {
 
-    private static Logger logger = Logger.getLogger(UserSessionLimitsAuthenticator.class);
+    private static final Logger logger = Logger.getLogger(UserSessionLimitsAuthenticator.class);
     public static final String SESSION_LIMIT_EXCEEDED = "sessionLimitExceeded";
-    private static String realmEventDetailsTemplate = "Realm session limit exceeded. Realm: %s, Realm limit: %s. Session count: %s, User id: %s";
-    private static String clientEventDetailsTemplate = "Client session limit exceeded. Realm: %s, Client limit: %s. Session count: %s, User id: %s";
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     String behavior;
 
@@ -48,6 +43,16 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
         }
         Map<String, String> config = authenticatorConfig.getConfig();
 
+        // get the current client being authenticated
+        ClientModel currentClient = context.getAuthenticationSession().getClient();
+        logger.debugf("session-limiter's current keycloak clientId: %s", currentClient.getClientId());
+
+        // check if new user and client session are needed
+        AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true);
+        final boolean newUserSession = authResult == null || authResult.getSession() == null;
+        final boolean newClientSession = authResult == null || authResult.getSession() == null
+                || authResult.getSession().getAuthenticatedClientSessionByClient(currentClient.getId()) == null;
+
         // Get the configuration for this authenticator
         behavior = config.get(UserSessionLimitsAuthenticatorFactory.BEHAVIOR);
         int userRealmLimit = getIntConfigProperty(UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, config);
@@ -56,13 +61,12 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
         if (context.getRealm() != null && context.getUser() != null) {
 
             // Get the session count in this realm for this specific user
-            List<UserSessionModel> userSessionsForRealm = session.sessions().getUserSessionsStream(context.getRealm(), context.getUser()).collect(Collectors.toList());
+            List<UserSessionModel> userSessionsForRealm = session.sessions()
+                    .getUserSessionsStream(context.getRealm(), context.getUser())
+                    .collect(Collectors.toList());
             int userSessionCountForRealm = userSessionsForRealm.size();
 
             // Get the session count related to the current client for this user
-            ClientModel currentClient = context.getAuthenticationSession().getClient();
-            logger.debugf("session-limiter's current keycloak clientId: %s", currentClient.getClientId());
-
             List<UserSessionModel> userSessionsForClient = getUserSessionsForClientIfEnabled(userSessionsForRealm, currentClient, userClientLimit);
             int userSessionCountForClient = userSessionsForClient.size();
             logger.debugf("session-limiter's configured realm session limit: %s", userRealmLimit);
@@ -71,14 +75,16 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
             logger.debugf("session-limiter's count of total user sessions for this keycloak client: %s", userSessionCountForClient);
 
             // First check if the user has too many sessions in this realm
-            if (exceedsLimit(userSessionCountForRealm, userRealmLimit)) {
+            if (newUserSession && exceedsLimit(userSessionCountForRealm, userRealmLimit)) {
                 logger.infof("Too many session in this realm for the current user. Session count: %s", userSessionCountForRealm);
-                String eventDetails = String.format(realmEventDetailsTemplate, context.getRealm().getName(), userRealmLimit, userSessionCountForRealm, context.getUser().getId());
+                String eventDetails = String.format("Realm session limit exceeded. Realm: %s, Realm limit: %s. Session count: %s, User id: %s",
+                        context.getRealm().getName(), userRealmLimit, userSessionCountForRealm, context.getUser().getId());
                 handleLimitExceeded(context, userSessionsForRealm, eventDetails, userRealmLimit);
             } // otherwise if the user is still allowed to create a new session in the realm, check if this applies for this specific client as well.
-            else if (exceedsLimit(userSessionCountForClient, userClientLimit)) {
+            else if (newClientSession && exceedsLimit(userSessionCountForClient, userClientLimit)) {
                 logger.infof("Too many sessions related to the current client for this user. Session count: %s", userSessionCountForRealm);
-                String eventDetails = String.format(clientEventDetailsTemplate, context.getRealm().getName(), userClientLimit, userSessionCountForClient, context.getUser().getId());
+                String eventDetails = String.format("Client session limit exceeded. Realm: %s, Client limit: %s. Session count: %s, User id: %s",
+                        context.getRealm().getName(), userClientLimit, userSessionCountForClient, context.getUser().getId());
                 handleLimitExceeded(context, userSessionsForClient, eventDetails, userClientLimit);
             } else {
                 context.success();
@@ -110,7 +116,7 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
     private List<UserSessionModel> getUserSessionsForClientIfEnabled(List<UserSessionModel> userSessionsForRealm, ClientModel currentClient, int userClientLimit) {
         // Only count this users sessions for this client only in case a limit is configured, otherwise skip this costly operation.
         if (userClientLimit <= 0) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         logger.debugf("total user sessions for this keycloak client will not be counted. Will be logged as 0 (zero)");
         List<UserSessionModel> userSessionsForClient = userSessionsForRealm.stream().filter(session -> session.getAuthenticatedClientSessionByClient(currentClient.getId()) != null).collect(Collectors.toList());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -136,6 +136,20 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void testClientSessionCountNotExceededOnReAuthentication() throws Exception {
+        // Login and verify login was successful
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+        events.expectLogin().assertEvent();
+
+        // Re-authenticate the user with prompt=login
+        oauth.prompt("login");
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+        events.expectLogin().assertEvent();
+    }
+
+    @Test
     public void testClientSessionCountExceededAndOldestSessionRemovedBrowserFlow() throws Exception {
         try {
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION);


### PR DESCRIPTION
Closes #35276

The `user-session-limits` authenticator always counts the limits even if the user is re-authenticating (for example because of loa, kc-action, prompt=login,...). This behavior can detect the limits exceeded even when no new sessions are going to be created (in the user session or in the client session). The PR is doing something similar to what the cookie authenticator performs, the identity cookie is used to detect if there is a current session in place and do not count in that case. Test added with `prompt=login` and limit 1. 
