### PR TITLE
Stop cleaning JavaScript build files using Maven

### DIFF
--- a/js/pom.xml
+++ b/js/pom.xml
@@ -27,8 +27,6 @@
     <properties>
         <node.version>v22.11.0</node.version>
         <pnpm.version>9.14.4</pnpm.version>
-        <!-- The clean step is skipped on Windows -->
-        <js.skip.clean>false</js.skip.clean>
         <!-- The JavaScript projects use the non-standard 'src' folder for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>
     </properties>
@@ -73,46 +71,7 @@
                         <pnpmInheritsProxyConfigFromMaven>false</pnpmInheritsProxyConfigFromMaven>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <configuration>
-                        <followSymLinks>false</followSymLinks>
-                        <!-- Skip this step if on windows -->
-                        <skip>${js.skip.clean}</skip>
-                        <filesets>
-                            <fileset>
-                                <directory>${basedir}</directory>
-                                <includes>
-                                    <include>**/.wireit/**</include>
-                                    <include>**/node_modules/**</include>
-                                </includes>
-                            </fileset>
-                            <!-- include all non-maven projects here as well -->
-                            <fileset>
-                                <directory>js/apps/keycloak-server</directory>
-                                <includes>
-                                    <include>server/**</include>
-                                </includes>
-                            </fileset>
-                        </filesets>
-                    </configuration>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>clean-when-not-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <js.skip.clean>true</js.skip.clean>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Removes the logic from the Maven build to clean the directories and files used by the JavaScript build, as these should be kept consistent by the tooling on the JavaScript side.

Closes #35289

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
