### PR TITLE
Make sure Maven builds modules within js directory in correct order

### DIFF
--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -16,6 +16,19 @@
     <name>Keycloak Account UI</name>
     <description>The user interface to manage an account on the Keycloak server.</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-admin-client</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-ui-shared</artifactId>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
     <profiles>
         <profile>
             <id>withTranslations</id>

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -16,6 +16,19 @@
     <name>Keycloak Admin UI</name>
     <description>The user interface to administrate the Keycloak server.</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-admin-client</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-ui-shared</artifactId>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
     <profiles>
         <profile>
             <id>withTranslations</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1095,6 +1095,18 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-ui-shared</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-js-admin-client</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-ui</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This will make sure the modules are built in the correct order by Maven:

```
[INFO] Reactor Summary for Keycloak JavaScript Parent 999.0.0-SNAPSHOT:
[INFO] 
[INFO] Keycloak JavaScript Parent ......................... SUCCESS [  0.521 s]
[INFO] Keycloak JavaScript Admin Client ................... SUCCESS [  3.195 s]
[INFO] Keycloak UI shared components ...................... SUCCESS [  6.706 s]
[INFO] Keycloak Account UI ................................ SUCCESS [  8.045 s]
[INFO] Keycloak Admin UI .................................. SUCCESS [ 14.614 s]
[INFO] Keycloak JavaScript Adapter ........................ SUCCESS [  1.246 s]
[INFO] ------------------------------------------------------------------------
```

Without this the `Keycloak JavaScript Admin Client` after `Keycloak UI shared components` which doesn't make any sense.