### PR TITLE
fix: refactor LightweightUserAdapter instantiation for DefaultTokenEx…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/light/LightweightUserAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/light/LightweightUserAdapter.java
@@ -88,6 +88,15 @@ public class LightweightUserAdapter extends AbstractInMemoryUserAdapter {
         super(session, null, ID_PREFIX + (id == null ? SecretGenerator.getInstance().randomString(16) : id));
     }
 
+    public LightweightUserAdapter(KeycloakSession session, RealmModel realm) {
+        this(session, realm, null);
+    }
+
+    public LightweightUserAdapter(KeycloakSession session, RealmModel realm, String id) {
+        super(session, realm, ID_PREFIX + (id == null ? SecretGenerator.getInstance().randomString(16) : id));
+    }
+
+
     public void setOwningUserSessionId(String id) {
         this.id = ID_PREFIX + (id == null ? UUID.randomUUID().toString() : id);
         update();

--- a/server-spi-private/src/main/java/org/keycloak/models/light/LightweightUserAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/light/LightweightUserAdapter.java
@@ -88,10 +88,6 @@ public class LightweightUserAdapter extends AbstractInMemoryUserAdapter {
         super(session, null, ID_PREFIX + (id == null ? SecretGenerator.getInstance().randomString(16) : id));
     }
 
-    public LightweightUserAdapter(KeycloakSession session, RealmModel realm) {
-        this(session, realm, null);
-    }
-
     public LightweightUserAdapter(KeycloakSession session, RealmModel realm, String id) {
         super(session, realm, ID_PREFIX + (id == null ? SecretGenerator.getInstance().randomString(16) : id));
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -630,7 +630,7 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
             }
 
             if (context.getIdpConfig().isTransientUsers()) {
-                user = new LightweightUserAdapter(session, context.getAuthenticationSession().getParentSession().getId());
+                user = new LightweightUserAdapter(session, realm);
             } else {
                 user = session.users().addUser(realm, username);
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -630,7 +630,9 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
             }
 
             if (context.getIdpConfig().isTransientUsers()) {
-                user = new LightweightUserAdapter(session, realm);
+                String authSessionId = context.getAuthenticationSession() != null && context.getAuthenticationSession().getParentSession() != null
+                                       ? context.getAuthenticationSession().getParentSession().getId() : null;
+                user = new LightweightUserAdapter(session, realm, authSessionId);
             } else {
                 user = session.users().addUser(realm, username);
             }


### PR DESCRIPTION
Avoid NullPointerException during external to internal token-exchange iff transient user is enabled. Modified LightweightUserAdapter instantiation to include the realm parameter to avoid NullPointerException in org.keycloak.storage.adapter.AbstractInMemoryUserAdapter#getGroupsStream.

Closes #28241
