### PR TITLE
Adjust documentation according to new home in keycloak/docs/documention

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -30,15 +30,15 @@ If you are using Windows, you need to run the following command with administrat
 
 To build Keycloak Documentation run:
 
-    mvn clean install -am -pl docs/documentation/dist -Pdocumentation
+    ./mvnw clean install -am -pl docs/documentation/dist -Pdocumentation
 
 Or to build a specific guide run:
 
-    mvn clean install -pl docs/documentation/GUIDE_DIR -Pdocumentation
+    ./mvnw clean install -pl docs/documentation/GUIDE_DIR -Pdocumentation
     
 By default, an archive version of the documentation is built. To build the latest build run:
 
-    mvn clean install ... -Platest,documentation
+    ./mvnw clean install ... -Platest,documentation
 
 You can then view the documentation by opening `docs/documentation/GUIDE_DIR/target/generated-docs/index.html`.
 

--- a/docs/documentation/internal_resources/contributing.adoc
+++ b/docs/documentation/internal_resources/contributing.adoc
@@ -30,21 +30,21 @@ This method is useful for any type of contribution, but necessary for larger and
 
 You only need to perform these tasks once, when preparing to contribute.
 
-. Fork the link:https://github.com/keycloak/keycloak-documentation[Keycloak documentation repository]. This will create your own version of the repository which you can find at `https://github.com/{yourusername}/keycloak-documentation` where `{yourusername}` is the username you created in GitHub.
+. Fork the link:https://github.com/keycloak/keycloak[Keycloak repository]. This will create your own version of the repository which you can find at `https://github.com/{yourusername}/keycloak` where `{yourusername}` is the username you created in GitHub.
 . Install `git` on your local machine. The procedure differs by operating system as described in link:https://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Installing Git]. Follow up with initial Git setup tasks, as described in link:https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup[First Time Git Setup].
 . Clone from your fork to create a copy on your local machine and then navigate to the new directory by entering the following from the command line on your local machine:
 +
 [source,bash]
 ----
-$ git clone https://github.com/{yourusername}/keycloak-documentation
-$ cd keycloak-documentation
+$ git clone https://github.com/{yourusername}/keycloak
+$ cd keycloak/docs/documentation
 ----
 +
 . Add a git remote to your local repository to link to the upstream version of the documentation. This makes it easier to update your fork and local version of the documentation.
 +
 [source,bash]
 ----
-$ git remote add upstream https://github.com/keycloak/keycloak-documentation
+$ git remote add upstream https://github.com/keycloak/keycloak
 ----
 +
 . Check your settings.
@@ -52,20 +52,20 @@ $ git remote add upstream https://github.com/keycloak/keycloak-documentation
 [source,bash]
 ----
 $ git remote -v
-origin	https://github.com/{yourusername}/keycloak-documentation.git (fetch)
-origin	https://github.com/{yourusername}/keycloak-documentation.git (push)
-upstream	https://github.com/keycloak/keycloak-documentation (fetch)
-upstream	https://github.com/keycloak/keycloak-documentation (push)
+origin	https://github.com/{yourusername}/keycloak.git (fetch)
+origin	https://github.com/{yourusername}/keycloak.git (push)
+upstream	https://github.com/keycloak/keycloak (fetch)
+upstream	https://github.com/keycloak/keycloak (push)
 ----
 +
 
 NOTE: It is possible to clone using SSH so you don't have to enter a username/password every time you push. Find instructions at link:https://help.github.com/articles/connecting-to-github-with-ssh/[Connecting to GitHub with SSH] and link:https://help.github.com/articles/which-remote-url-should-i-use/[Which Remote URL Should I Use]. When using SSH, the origin lines will appear like this:
-`git@github.com:{yourusername}/keycloak-documentation.git`
+`git@github.com:{yourusername}/keycloak.git`
 
 [[workflow]]
 === Typical Workflow for Keycloak Documentation Contributions
 
-When contributing, follow this procedure. Enter commands from the command line on your local machine in the  `keycloak-documentation` directory created earlier when cloning the repository.
+When contributing, follow this procedure. Enter commands from the command line on your local machine in the  `keycloak` directory created earlier when cloning the repository.
 
 . Enter `git checkout main` to checkout the main branch locally.
 . Enter `git fetch upstream` to download the current files from the upstream repository.
@@ -75,8 +75,9 @@ When contributing, follow this procedure. Enter commands from the command line o
 . Make your changes
 . (Optional) Enter `git status` now or at any time to see what branch you are on, what files you have changed, and whether those files are staged to be committed.
 . Enter `git add -A` to stage your changes to the commit you are about to make.
-. Enter `git commit -m 'KEYCLOAK-XXXX include meaningful information about changes'` where `KEYCLOAK-XXXX` refers to the link:https://issues.redhat.com/projects/KEYCLOAK/issues[Jira issue] being fixed in this commit (if any) and where you add a short sentence that clearly describes what the commit contains.
-. Follow the steps in the link:https://github.com/keycloak/keycloak-documentation/blob/main/README.md[README] to create a test build locally and confirm that your changes look correct. Make more changes and repeat steps to here, as needed.
+.. Make sure your changes only affect docs/documentation directory, or you are sure about the changes outside of that package
+. Enter `git commit --signoff --message '<message>'` where message is build as described in link:https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md#commit-messages-and-issue-linking[general contribution guide]
+. Follow the steps in the documentation link:https://github.com/keycloak/keycloak/blob/main/docs/documentation/README.md[README] to create a test build locally and confirm that your changes look correct. Make more changes and repeat steps to here, as needed.
 . Enter `git push origin {branchname}` to push your changes to your fork in GitHub.
 . Use the GitHub web interface to create a pull request. First, navigate to your branch in the web UI and click *Compare*. This will show you a diff of the changes. Examine them one more time. If necessary, make more changes locally and repeat the steps to here. When you are ready, click *Create a pull request*. Enter a title and a description with enough detail for reviewers to know what you have changed and why. Click *Submit*.
 . Wait. The documentation team will usually review pull requests within a few days. Often suggestions and changes are requested of you to help the contribution better fit within the style guidelines for the project or to fill in information that may have been missed. If this happens, repeat the steps from making your changes to `git push origin {branchname}`. No need to create another PR as the existing one will be updated automatically.


### PR DESCRIPTION
Adjust documentation according to new home in keycloak/docs/documentation.

- refer mvnw instead of mvn
- contributing.adoc reflects GitHub-Issues and new git-structure

Closes #35373