### PR TITLE
WebAuthn registration now respects the configured extra origins policy

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -236,7 +236,6 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         allOrigins.add(origin);
         Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
         ServerProperty serverProperty = new ServerProperty(allOrigins, rpId, challenge, null);
-
         // check User Verification by considering a malicious user might modify the result of calling WebAuthn API
         boolean isUserVerificationRequired = policy.getUserVerificationRequirement().equals(WebAuthnConstants.OPTION_REQUIRED);
 

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -236,6 +236,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         allOrigins.add(origin);
         Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
         ServerProperty serverProperty = new ServerProperty(allOrigins, rpId, challenge, null);
+
         // check User Verification by considering a malicious user might modify the result of calling WebAuthn API
         boolean isUserVerificationRequired = policy.getUserVerificationRequirement().equals(WebAuthnConstants.OPTION_REQUIRED);
 

--- a/services/src/main/resources/WebAuthnRegister.java
+++ b/services/src/main/resources/WebAuthnRegister.java
@@ -228,8 +228,14 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         String publicKeyCredentialId = params.getFirst(WebAuthnConstants.PUBLIC_KEY_CREDENTIAL_ID);
 
         Origin origin = new Origin(UriUtils.getOrigin(context.getUriInfo().getBaseUri()));
+        Set<Origin> allOrigins = policy
+                .getExtraOrigins()
+                .stream()
+                .map(Origin::new)
+                .collect(Collectors.toSet());
+        allOrigins.add(origin);
         Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
-        ServerProperty serverProperty = new ServerProperty(origin, rpId, challenge, null);
+        ServerProperty serverProperty = new ServerProperty(allOrigins, rpId, challenge, null);
         // check User Verification by considering a malicious user might modify the result of calling WebAuthn API
         boolean isUserVerificationRequired = policy.getUserVerificationRequirement().equals(WebAuthnConstants.OPTION_REQUIRED);
 


### PR DESCRIPTION
Closes #35110 

WebAuthn registration now respects the configured extra origins policy, aligning its behavior with the existing handling during authentication.

