### PR TITLE
Intermediate page(to confirmExecutionOfActions) after an ExecuteActionsEmail is not localized based on the user's locale

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
@@ -90,6 +90,7 @@ public class ExecuteActionsActionTokenHandler extends AbstractActionTokenHandler
 
             return session.getProvider(LoginFormsProvider.class)
                     .setAuthenticationSession(authSession)
+                    .setUser(authSession.getAuthenticatedUser())
                     .setSuccess(Messages.CONFIRM_EXECUTION_OF_ACTIONS)
                     .setAttribute(Constants.TEMPLATE_ATTR_ACTION_URI, confirmUri)
                     .setAttribute(Constants.TEMPLATE_ATTR_REQUIRED_ACTIONS, token.getRequiredActions())


### PR DESCRIPTION
Closes #17233

Checks if the UserModel is null before executing resolveLocale, and if indeed UserModel is null then performs resolveLocale using AuthenticationSessionModel.getAuthenticatedUser