### PR TITLE
[26.0] Flaky test: AuthenticationSessionTest

### DIFF
--- a/testsuite/model/src/main/java/org/keycloak/testsuite/model/HotRodServerRule.java
+++ b/testsuite/model/src/main/java/org/keycloak/testsuite/model/HotRodServerRule.java
@@ -1,22 +1,26 @@
 package org.keycloak.testsuite.model;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.CacheContainerAdmin;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.BackupConfiguration;
 import org.infinispan.configuration.cache.BackupFailurePolicy;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
 import org.junit.rules.ExternalResource;
 import org.keycloak.Config;
 import org.keycloak.connections.infinispan.InfinispanUtil;
 import org.keycloak.marshalling.KeycloakModelSchema;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.ACTION_TOKEN_CACHE;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHENTICATION_SESSIONS_CACHE_NAME;
@@ -28,6 +32,12 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.U
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.WORK_CACHE_NAME;
 
 public class HotRodServerRule extends ExternalResource {
+
+    private static final List<String> CACHES_NAME = List.of(
+            USER_SESSION_CACHE_NAME, OFFLINE_USER_SESSION_CACHE_NAME, CLIENT_SESSION_CACHE_NAME,
+            OFFLINE_CLIENT_SESSION_CACHE_NAME, LOGIN_FAILURE_CACHE_NAME, WORK_CACHE_NAME, ACTION_TOKEN_CACHE,
+            AUTHENTICATION_SESSIONS_CACHE_NAME
+    );
 
     protected HotRodServer hotRodServer;
 
@@ -70,45 +80,45 @@ public class HotRodServerRule extends ExternalResource {
                         + hotRodServer2.getHost() + ":" + hotRodServer2.getPort()).build();
         remoteCacheManager = new RemoteCacheManager(cfg);
 
-        boolean async = config.getBoolean("async", false);
-
         // create remote keycloak caches
-        createKeycloakCaches(async, USER_SESSION_CACHE_NAME, OFFLINE_USER_SESSION_CACHE_NAME, CLIENT_SESSION_CACHE_NAME,
-                OFFLINE_CLIENT_SESSION_CACHE_NAME, LOGIN_FAILURE_CACHE_NAME, WORK_CACHE_NAME, ACTION_TOKEN_CACHE, AUTHENTICATION_SESSIONS_CACHE_NAME);
-
-        getCaches(USER_SESSION_CACHE_NAME, OFFLINE_USER_SESSION_CACHE_NAME, CLIENT_SESSION_CACHE_NAME, OFFLINE_CLIENT_SESSION_CACHE_NAME,
-                LOGIN_FAILURE_CACHE_NAME, WORK_CACHE_NAME, ACTION_TOKEN_CACHE, AUTHENTICATION_SESSIONS_CACHE_NAME);
+        createKeycloakCaches(config.getBoolean("async", false) ? CacheMode.REPL_ASYNC : CacheMode.REPL_SYNC);
 
         // Use Keycloak time service in remote caches
         InfinispanUtil.setTimeServiceToKeycloakTime(hotRodCacheManager);
         InfinispanUtil.setTimeServiceToKeycloakTime(hotRodCacheManager2);
     }
 
-    private void getCaches(String... cache) {
-        for (String c: cache) {
-            hotRodCacheManager.getCache(c, true);
-            hotRodCacheManager2.getCache(c, true);
-        }
-    }
+    private void createKeycloakCaches(CacheMode cacheMode) {
+        var builder = createCacheConfigurationBuilder();
+        builder.clustering().cacheMode(cacheMode);
 
-    private void createKeycloakCaches(boolean async, String... cache) {
-        ConfigurationBuilder sessionConfigBuilder1 = createCacheConfigurationBuilder();
-        ConfigurationBuilder sessionConfigBuilder2 = createCacheConfigurationBuilder();
-        sessionConfigBuilder1.clustering().cacheMode(async ? CacheMode.REPL_ASYNC: CacheMode.REPL_SYNC);
-        sessionConfigBuilder2.clustering().cacheMode(async ? CacheMode.REPL_ASYNC: CacheMode.REPL_SYNC);
-
-        sessionConfigBuilder1.sites().addBackup()
-                .site("site-2").backupFailurePolicy(BackupFailurePolicy.IGNORE).strategy(BackupConfiguration.BackupStrategy.SYNC)
+        // cross-site configuration
+        builder.sites().addBackup()
+                .site("site-1")
+                .backupFailurePolicy(BackupFailurePolicy.FAIL)
+                .strategy(BackupConfiguration.BackupStrategy.SYNC)
                 .replicationTimeout(15000);
-        sessionConfigBuilder2.sites().addBackup()
-                .site("site-1").backupFailurePolicy(BackupFailurePolicy.IGNORE).strategy(BackupConfiguration.BackupStrategy.SYNC)
+        builder.sites().addBackup()
+                .site("site-2")
+                .backupFailurePolicy(BackupFailurePolicy.FAIL)
+                .strategy(BackupConfiguration.BackupStrategy.SYNC)
                 .replicationTimeout(15000);
 
-        Configuration sessionCacheConfiguration1 = sessionConfigBuilder1.build();
-        Configuration sessionCacheConfiguration2 = sessionConfigBuilder2.build();
-        for (String c: cache) {
-            hotRodCacheManager.defineConfiguration(c, sessionCacheConfiguration1);
-            hotRodCacheManager2.defineConfiguration(c, sessionCacheConfiguration2);
+        // reduce locking timeout as deadlocks are expected
+        builder.locking()
+                .lockAcquisitionTimeout(1, TimeUnit.SECONDS);
+
+        // enable transactions to keep data consistent when deadlocks happen
+        builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
+                .lockingMode(LockingMode.PESSIMISTIC)
+                .useSynchronization(false);
+
+        var config = builder.build();
+        var admin1 = hotRodCacheManager.administration().withFlags(CacheContainerAdmin.AdminFlag.VOLATILE);
+        var admin2 = hotRodCacheManager2.administration().withFlags(CacheContainerAdmin.AdminFlag.VOLATILE);
+        for (String c : CACHES_NAME) {
+            admin1.getOrCreateCache(c, config);
+            admin2.getOrCreateCache(c, config);
         }
     }
 

--- a/testsuite/model/src/main/resources/hotrod/hotrod1.xml
+++ b/testsuite/model/src/main/resources/hotrod/hotrod1.xml
@@ -1,8 +1,13 @@
 <infinispan>
     <jgroups>
         <stack name="bridge" extends="udp">
-            <UDP mcast_addr="228.6.7.12"/>
+            <UDP bind_addr="${jgroups.bind.address,jgroups.udp.address:127.0.0.1}"
+                 mcast_addr="228.6.7.12"
+                 ip_mcast="false"/>
+            <!-- LOCAL_PING: discovery in the same JVM -->
             <LOCAL_PING stack.combine="REPLACE" stack.position="PING"/>
+            <!-- FD_SOCK2: remove failure detection, tests do not require it -->
+            <FD_SOCK2 stack.combine="REMOVE"/>
         </stack>
         <!-- Extends the default UDP stack. -->
         <stack name="xsite" extends="udp">
@@ -16,6 +21,7 @@
                  ucast_recv_buf_size="20m"
                  mcast_recv_buf_size="25m"
                  ip_ttl="${jgroups.ip_ttl:2}"
+                 ip_mcast="false"
                  thread_naming_pattern="pl"
                  diag.enabled="${jgroups.diag.enabled:false}"
                  bundler_type="transfer-queue"
@@ -27,7 +33,10 @@
 
                  thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
             />
+            <!-- LOCAL_PING: discovery in the same JVM -->
             <LOCAL_PING stack.combine="REPLACE" stack.position="PING"/>
+            <!-- FD_SOCK2: remove failure detection, tests do not require it -->
+            <FD_SOCK2 stack.combine="REMOVE"/>
             <!-- Adds RELAY2 for cross-site replication. -->
             <!-- Names the local site as site-1. -->
             <!-- Specifies 1000 nodes as the maximum number of site masters. -->

--- a/testsuite/model/src/main/resources/hotrod/hotrod2.xml
+++ b/testsuite/model/src/main/resources/hotrod/hotrod2.xml
@@ -1,8 +1,13 @@
 <infinispan>
     <jgroups>
         <stack name="bridge" extends="udp">
-            <UDP mcast_addr="228.6.7.12"/>
+            <UDP bind_addr="${jgroups.bind.address,jgroups.udp.address:127.0.0.1}"
+                 mcast_addr="228.6.7.12"
+                 ip_mcast="false"/>
+            <!-- LOCAL_PING: discovery in the same JVM -->
             <LOCAL_PING stack.combine="REPLACE" stack.position="PING"/>
+            <!-- FD_SOCK2: remove failure detection, tests do not require it -->
+            <FD_SOCK2 stack.combine="REMOVE"/>
         </stack>
         <!-- Extends the default UDP stack. -->
         <stack name="xsite" extends="udp">
@@ -16,6 +21,7 @@
                  ucast_recv_buf_size="20m"
                  mcast_recv_buf_size="25m"
                  ip_ttl="${jgroups.ip_ttl:2}"
+                 ip_mcast="false"
                  thread_naming_pattern="pl"
                  diag.enabled="${jgroups.diag.enabled:false}"
                  bundler_type="transfer-queue"
@@ -27,7 +33,10 @@
 
                  thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
             />
+            <!-- LOCAL_PING: discovery in the same JVM -->
             <LOCAL_PING stack.combine="REPLACE" stack.position="PING"/>
+            <!-- FD_SOCK2: remove failure detection, tests do not require it -->
+            <FD_SOCK2 stack.combine="REMOVE"/>
             <!-- Adds RELAY2 for cross-site replication. -->
             <!-- Names the local site as site-2. -->
             <!-- Specifies 1000 nodes as the maximum number of site masters. -->


### PR DESCRIPTION
Enable transactions to handle conflicts.

Unrelated changes:
* Disable IP multicast (not available in MacOS by default)
* Bind JGroups to 127.0.0.1
* Remove FD_SOCK2 (single JVM tests do not require failure detection)

Closes #35087
Closes #35015

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

NOTE: This is only to keep the configuration used by the test in sync with the Keycloak documentation. 
