### PR TITLE
Show spans in transaction completion at the end of a request

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/tracing/NoopTracingProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/tracing/NoopTracingProvider.java
@@ -65,6 +65,16 @@ public class NoopTracingProvider implements TracingProvider {
     }
 
     @Override
+    public void trace(Class<?> tracerClass, String spanSuffix, Consumer<Span> execution) {
+        trace((String) null, null, execution);
+    }
+
+    @Override
+    public <T> T trace(Class<?> tracerClass, String spanSuffix, Function<Span, T> execution) {
+        return trace((String) null, null, execution);
+    }
+
+    @Override
     public Tracer getTracer(String name, String scopeVersion) {
         return TracerProvider.noop().get("");
     }

--- a/server-spi-private/src/main/java/org/keycloak/tracing/TracingProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/tracing/TracingProvider.java
@@ -170,7 +170,20 @@ public interface TracingProvider extends Provider {
      * @param execution   code that is executed and traced
      */
     default void trace(Class<?> tracerClass, String spanSuffix, Consumer<Span> execution) {
-        trace(tracerClass.getName(), tracerClass.getSimpleName() + "." + spanSuffix, execution);
+        String className = prepareClassName(tracerClass);
+        trace(tracerClass.getName(), className + "." + spanSuffix, execution);
+    }
+
+    private static String prepareClassName(Class<?> tracerClass) {
+        String className = tracerClass.getSimpleName();
+        if (className.isEmpty()) {
+            className = tracerClass.getName();
+            int end = className.lastIndexOf(".");
+            if (end != -1) {
+                className = className.substring(end + 1);
+            }
+        }
+        return className;
     }
 
     /**
@@ -220,7 +233,8 @@ public interface TracingProvider extends Provider {
      * @param execution   code that is executed and traced
      */
     default <T> T trace(Class<?> tracerClass, String spanSuffix, Function<Span, T> execution) {
-        return trace(tracerClass.getName(), tracerClass.getSimpleName() + "." + spanSuffix, execution);
+        String className = prepareClassName(tracerClass);
+        return trace(tracerClass.getName(), className + "." + spanSuffix, execution);
     }
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/tracing/TracingProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/tracing/TracingProvider.java
@@ -171,7 +171,7 @@ public interface TracingProvider extends Provider {
      */
     default void trace(Class<?> tracerClass, String spanSuffix, Consumer<Span> execution) {
         String className = prepareClassName(tracerClass);
-        trace(tracerClass.getName(), className + "." + spanSuffix, execution);
+        trace(className, className + "." + spanSuffix, execution);
     }
 
     private static String prepareClassName(Class<?> tracerClass) {
@@ -234,7 +234,7 @@ public interface TracingProvider extends Provider {
      */
     default <T> T trace(Class<?> tracerClass, String spanSuffix, Function<Span, T> execution) {
         String className = prepareClassName(tracerClass);
-        return trace(tracerClass.getName(), className + "." + spanSuffix, execution);
+        return trace(className, className + "." + spanSuffix, execution);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakTransactionManager.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakTransactionManager.java
@@ -16,10 +16,10 @@
  */
 package org.keycloak.services;
 
-import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakTransaction;
 import org.keycloak.models.KeycloakTransactionManager;
+import org.keycloak.tracing.TracingProvider;
 import org.keycloak.transaction.JtaTransactionManagerLookup;
 import org.keycloak.transaction.JtaTransactionWrapper;
 
@@ -32,14 +32,12 @@ import java.util.List;
  */
 public class DefaultKeycloakTransactionManager implements KeycloakTransactionManager {
 
-    private static final Logger logger = Logger.getLogger(DefaultKeycloakTransactionManager.class);
-
-    private List<KeycloakTransaction> prepare = new LinkedList<KeycloakTransaction>();
-    private List<KeycloakTransaction> transactions = new LinkedList<KeycloakTransaction>();
-    private List<KeycloakTransaction> afterCompletion = new LinkedList<KeycloakTransaction>();
+    private final List<KeycloakTransaction> prepare = new LinkedList<>();
+    private final List<KeycloakTransaction> transactions = new LinkedList<>();
+    private final List<KeycloakTransaction> afterCompletion = new LinkedList<>();
     private boolean active;
     private boolean rollback;
-    private KeycloakSession session;
+    private final KeycloakSession session;
     private JTAPolicy jtaPolicy = JTAPolicy.REQUIRES_NEW;
     // Used to prevent double committing/rollback if there is an uncaught exception
     protected boolean completed;
@@ -119,10 +117,12 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
             completed = true;
         }
 
+        TracingProvider tracing = session.getProvider(TracingProvider.class);
+
         RuntimeException exception = null;
         for (KeycloakTransaction tx : prepare) {
             try {
-                tx.commit();
+                commitWithTracing(tx, tracing);
             } catch (RuntimeException e) {
                 exception = exception == null ? e : exception;
             }
@@ -133,7 +133,7 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
         }
         for (KeycloakTransaction tx : transactions) {
             try {
-                tx.commit();
+                commitWithTracing(tx, tracing);
             } catch (RuntimeException e) {
                 exception = exception == null ? e : exception;
             }
@@ -143,7 +143,7 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
         if (exception == null) {
             for (KeycloakTransaction tx : afterCompletion) {
                 try {
-                    tx.commit();
+                    commitWithTracing(tx, tracing);
                 } catch (RuntimeException e) {
                     exception = exception == null ? e : exception;
                 }
@@ -164,6 +164,17 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
         }
     }
 
+    private static void commitWithTracing(KeycloakTransaction tx, TracingProvider tracing) {
+        tracing.trace(tx.getClass(), "commit", span -> {
+            try {
+                tx.commit();
+            } catch (RuntimeException e) {
+                tracing.error(e);
+                throw e;
+            }
+        });
+    }
+
     @Override
     public void rollback() {
         if (completed) {
@@ -177,16 +188,18 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
     }
 
     protected void rollback(RuntimeException exception) {
+        TracingProvider tracing = session.getProvider(TracingProvider.class);
+
         for (KeycloakTransaction tx : transactions) {
             try {
-                tx.rollback();
+                rollbackWithTracing(tx, tracing);
             } catch (RuntimeException e) {
                 exception = exception != null ? e : exception;
             }
         }
         for (KeycloakTransaction tx : afterCompletion) {
             try {
-                tx.rollback();
+                rollbackWithTracing(tx, tracing);
             } catch (RuntimeException e) {
                 exception = exception != null ? e : exception;
             }
@@ -195,6 +208,17 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
         if (exception != null) {
             throw exception;
         }
+    }
+
+    private static void rollbackWithTracing(KeycloakTransaction tx, TracingProvider tracing) {
+        tracing.trace(tx.getClass(), "rollback", span -> {
+            try {
+                tx.rollback();
+            } catch (RuntimeException e) {
+                tracing.error(e);
+                throw e;
+            }
+        });
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakTransactionManager.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakTransactionManager.java
@@ -166,12 +166,7 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
 
     private static void commitWithTracing(KeycloakTransaction tx, TracingProvider tracing) {
         tracing.trace(tx.getClass(), "commit", span -> {
-            try {
-                tx.commit();
-            } catch (RuntimeException e) {
-                tracing.error(e);
-                throw e;
-            }
+            tx.commit();
         });
     }
 
@@ -212,12 +207,7 @@ public class DefaultKeycloakTransactionManager implements KeycloakTransactionMan
 
     private static void rollbackWithTracing(KeycloakTransaction tx, TracingProvider tracing) {
         tracing.trace(tx.getClass(), "rollback", span -> {
-            try {
-                tx.rollback();
-            } catch (RuntimeException e) {
-                tracing.error(e);
-                throw e;
-            }
+            tx.rollback();
         });
     }
 


### PR DESCRIPTION
Closes #35425

Example: 

![image](https://github.com/user-attachments/assets/e6ebff96-8a39-4a1c-bbbe-bf3f296096dc)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
