### PR TITLE
OTelTracingProvider should be request-scoped

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelTracingProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelTracingProvider.java
@@ -30,8 +30,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.tracing.TracingProvider;
 
-import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -45,7 +45,7 @@ public class OTelTracingProvider implements TracingProvider {
 
     public OTelTracingProvider(OpenTelemetry openTelemetry) {
         this.openTelemetry = openTelemetry;
-        this.scopes = new ArrayDeque<>();
+        this.scopes = new ConcurrentLinkedDeque<>();
     }
 
     OpenTelemetry getOpenTelemetry() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelTracingProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelTracingProviderFactory.java
@@ -30,16 +30,15 @@ import org.keycloak.tracing.TracingProviderFactory;
 
 public class OTelTracingProviderFactory implements TracingProviderFactory {
     public static final String PROVIDER_ID = "opentelemetry";
-    private static OTelTracingProvider SINGLETON;
+    private static OpenTelemetry OTEL_SINGLETON;
 
     @Override
     public TracingProvider create(KeycloakSession session) {
-        if (SINGLETON == null) {
-            var openTelemetry = CDI.current().select(OpenTelemetry.class).get();
-            SINGLETON = new OTelTracingProvider(openTelemetry);
+        if (OTEL_SINGLETON == null) {
+            OTEL_SINGLETON = CDI.current().select(OpenTelemetry.class).get();
         }
 
-        return SINGLETON;
+        return new OTelTracingProvider(OTEL_SINGLETON);
     }
 
     @Override
@@ -54,10 +53,10 @@ public class OTelTracingProviderFactory implements TracingProviderFactory {
 
     @Override
     public void close() {
-        if (SINGLETON != null) {
+        if (OTEL_SINGLETON != null) {
             // explicitly remove the OpenTelemetry bean
-            CDI.current().select(OpenTelemetry.class).destroy(SINGLETON.getOpenTelemetry());
-            SINGLETON = null;
+            CDI.current().select(OpenTelemetry.class).destroy(OTEL_SINGLETON);
+            OTEL_SINGLETON = null;
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/tracing/OTelTracingProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/tracing/OTelTracingProviderTest.java
@@ -20,13 +20,14 @@ package org.keycloak.testsuite.tracing;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData;
 import io.opentelemetry.semconv.ExceptionAttributes;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -38,7 +39,6 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.containers.AbstractQuarkusDeployableContainer;
 import org.keycloak.tracing.NoopTracingProvider;
-import org.keycloak.tracing.TracingAttributes;
 import org.keycloak.tracing.TracingProvider;
 
 import java.io.Serializable;
@@ -192,6 +192,10 @@ public class OTelTracingProviderTest extends AbstractTestRealmKeycloakTest {
 
                 assertThat(current instanceof ReadableSpan, is(true));
                 var spanData = ((ReadableSpan) current).toSpanData();
+
+                assertThat(spanData.getStatus(), notNullValue());
+                assertThat(spanData.getStatus(), is(StatusData.create(StatusCode.ERROR, "something bad happened")));
+
                 assertThat(spanData.getName(), is("something"));
                 assertThat(spanData.getTotalRecordedEvents(), is(1));
 


### PR DESCRIPTION
Fixes #35427

Also making the deque of scopes thread-safe.

@ahus1 Could you please check it? Thanks

@brunobat JFYI
