### PR TITLE
setting the user in ExecuteActionsActionTokenHandler.handleToken to manage user null case in FreeMarkerLoginFormsProvider.createResponse (24.0)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
@@ -89,6 +89,7 @@ public class ExecuteActionsActionTokenHandler extends AbstractActionTokenHandler
 
             return session.getProvider(LoginFormsProvider.class)
                     .setAuthenticationSession(authSession)
+                    .setUser(authSession.getAuthenticatedUser())
                     .setSuccess(Messages.CONFIRM_EXECUTION_OF_ACTIONS)
                     .setAttribute(Constants.TEMPLATE_ATTR_ACTION_URI, confirmUri)
                     .setAttribute(Constants.TEMPLATE_ATTR_REQUIRED_ACTIONS, token.getRequiredActions())


### PR DESCRIPTION
Closes #17233

PR:             https://github.com/keycloak/keycloak/pull/35406
Commit:         https://github.com/keycloak/keycloak/commit/8cad78b1dfff5b9154d0068702544e6ef62cbc29
PR branch:      backport-35406-24.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/24.0

Backport of #35406 for 24.0.
