### PR TITLE
[Backport] Persist admin event only when roles is non-empty

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientRoleMappingsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientRoleMappingsResource.java
@@ -183,7 +183,9 @@ public class ClientRoleMappingsResource {
             throw new ErrorResponseException("invalid_request", "Could not add user role or group mappings!", Response.Status.BAD_REQUEST);
         }
 
-        adminEvent.operation(OperationType.CREATE).resourcePath(uriInfo).representation(roles).success();
+        if (!roles.isEmpty()) {
+            adminEvent.operation(OperationType.CREATE).resourcePath(uriInfo).representation(roles).success();
+        }
 
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
@@ -253,7 +253,9 @@ public class RoleMapperResource {
             throw new ErrorResponseException("invalid_request", "Could not add user role mappings!", Response.Status.BAD_REQUEST);
         }
 
-        adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri()).representation(roles).success();
+        if (!roles.isEmpty()) {
+            adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri()).representation(roles).success();
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, an adminEvent is created regardless of if the roles passed to the role-mapping API is empty. The event should only be created when the list `roles` is non-empty.

Closes #33195

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
