### PR TITLE
Removed import client a11y test due to inability to add aria-label

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -1347,11 +1347,6 @@ describe("Clients test", () => {
       cy.findAllByTestId("confirm").click();
     });
 
-    it("Check a11y violations on import client", () => {
-      cy.findByTestId("importClient").click();
-      cy.checkA11y();
-    });
-
     it("Check a11y violations on initial access token", () => {
       const initialAccessTokenTab = new InitialAccessTokenTab();
       initialAccessTokenTab.goToInitialAccessTokenTab();


### PR DESCRIPTION
To fix this tests I'd need to add aria-label into `<input>` element in the Patternfly's FileUpload component.

Closes https://github.com/keycloak/keycloak/issues/35490