### PR TITLE
Fix migration for MySQL database

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_0_0_OrganizationGroupType.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_0_0_OrganizationGroupType.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.connections.jpa.updater.liquibase.custom;
 
+import liquibase.database.core.MySQLDatabase;
 import liquibase.exception.CustomChangeException;
 import liquibase.statement.core.RawSqlStatement;
 
@@ -26,7 +27,7 @@ public class JpaUpdate26_0_0_OrganizationGroupType extends CustomKeycloakTask {
         String groupTable = getTableName("KEYCLOAK_GROUP");
         String orgTable = getTableName("ORG");
 
-        if ("mariadb".equals(database.getShortName())) {
+        if (database instanceof MySQLDatabase) {
             statements.add(new RawSqlStatement("UPDATE " + groupTable + " SET TYPE = 1 WHERE CONVERT(NAME USING utf8) IN (SELECT CONVERT(ID USING utf8) FROM " +  orgTable + ")"));
         } else {
             statements.add(new RawSqlStatement("UPDATE " + groupTable + " SET TYPE = 1 WHERE NAME IN (SELECT ID FROM " +  orgTable + ")"));


### PR DESCRIPTION
- MariaDB and MySQL now use the same statement
- prevents a possible illegal mix of collations

Closes #34995

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit 88cfe426d8dea299b749008c9c45eb5e0eb70f1b)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
