### PR TITLE
Upgrading guide 26.0.6 is missing in the upgrading guide

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -5,6 +5,10 @@
 
 include::changes-26_0_7.adoc[leveloffset=3]
 
+=== Migrating to 26.0.6
+
+include::changes-26_0_6.adoc[leveloffset=3]
+
 === Migrating to 26.0.0
 
 include::changes-26_0_0.adoc[leveloffset=3]


### PR DESCRIPTION
Closes #35544

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
