### PR TITLE
Support for multiple values of some parameters in the grant SPI

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/TokenExchangeContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/TokenExchangeContext.java
@@ -28,6 +28,7 @@ import org.keycloak.services.cors.Cors;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -130,12 +131,12 @@ public class TokenExchangeContext {
             return formParams.getFirst(OAuth2Constants.ACTOR_TOKEN_TYPE);
         }
 
-        public String getAudience() {
-            return formParams.getFirst(OAuth2Constants.AUDIENCE);
+        public List<String> getAudience() {
+            return formParams.get(OAuth2Constants.AUDIENCE);
         }
 
-        public String getResource() {
-            return formParams.getFirst(OAuth2Constants.RESOURCE);
+        public List<String> getResource() {
+            return formParams.get(OAuth2Constants.RESOURCE);
         }
 
         public String getRequestedTokenType() {

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantType.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantType.java
@@ -22,7 +22,9 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.keycloak.common.ClientConnection;
 import org.keycloak.events.EventBuilder;
@@ -48,6 +50,14 @@ public interface OAuth2GrantType extends Provider {
      * @return event type
      */
     EventType getEventType();
+
+    /**
+     * @return request parameters, which can be duplicated for the particular grant type. The grant request is typically rejected if
+     * request contains multiple values of some parameter, which is not listed here
+     */
+    default Set<String> getSupportedMultivaluedRequestParameters() {
+        return Collections.emptySet();
+    }
 
     /**
      * Processes grant request.

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -212,7 +212,7 @@ public class TokenEndpoint {
 
     private void checkParameterDuplicated() {
         for (String key : formParams.keySet()) {
-            if (formParams.get(key).size() != 1) {
+            if (formParams.get(key).size() != 1 && !grant.getSupportedMultivaluedRequestParameters().contains(key)) {
                 throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "duplicated parameter",
                         Response.Status.BAD_REQUEST);
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/TokenExchangeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/TokenExchangeGrantType.java
@@ -17,9 +17,12 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.util.Set;
+
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.protocol.oidc.TokenExchangeContext;
@@ -32,6 +35,8 @@ import org.keycloak.protocol.oidc.TokenExchangeProvider;
  * @author <a href="mailto:demetrio@carretti.pro">Dmitry Telegin</a> (et al.)
  */
 public class TokenExchangeGrantType extends OAuth2GrantTypeBase {
+
+    private static final Set<String> SUPPORTED_DUPLICATED_PARAMETERS = Set.of(OAuth2Constants.AUDIENCE, OAuth2Constants.RESOURCE);
 
     @Override
     public Response process(Context context) {
@@ -67,4 +72,8 @@ public class TokenExchangeGrantType extends OAuth2GrantTypeBase {
         return EventType.TOKEN_EXCHANGE;
     }
 
+    @Override
+    public Set<String> getSupportedMultivaluedRequestParameters() {
+        return SUPPORTED_DUPLICATED_PARAMETERS;
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -647,6 +647,12 @@ public class OAuthClient {
 
     public AccessTokenResponse doTokenExchange(String realm, String token, String targetAudience,
                                                String clientId, String clientSecret, Map<String, String> additionalParams) throws Exception {
+        List<String> targetAudienceList = targetAudience == null ? null : List.of(targetAudience);
+        return doTokenExchange(realm, token, targetAudienceList, clientId, clientSecret, additionalParams);
+    }
+
+    public AccessTokenResponse doTokenExchange(String realm, String token, List<String> targetAudiences,
+                                               String clientId, String clientSecret, Map<String, String> additionalParams) throws Exception {
         try (CloseableHttpClient client = httpClient.get()) {
             HttpPost post = new HttpPost(getResourceOwnerPasswordCredentialGrantUrl(realm));
 
@@ -655,8 +661,10 @@ public class OAuthClient {
             parameters.add(new BasicNameValuePair(OAuth2Constants.SUBJECT_TOKEN, token));
             parameters.add(new BasicNameValuePair(OAuth2Constants.SUBJECT_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE));
 
-            if (targetAudience != null) {
-                parameters.add(new BasicNameValuePair(OAuth2Constants.AUDIENCE, targetAudience));
+            if (targetAudiences != null) {
+                for (String audience : targetAudiences) {
+                    parameters.add(new BasicNameValuePair(OAuth2Constants.AUDIENCE, audience));
+                }
             }
 
             if (additionalParams != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -1010,6 +1010,19 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void testClientExchangeWithMoreAudiencesNotBreak() throws Exception {
+        testingClient.server().run(ClientTokenExchangeTest::setupRealm);
+
+        oauth.realm(TEST);
+        oauth.clientId("client-exchanger");
+        OAuthClient.AccessTokenResponse response = oauth.doGrantAccessTokenRequest("secret", "user", "password");
+        String accessToken = response.getAccessToken();
+
+        response = oauth.doTokenExchange(TEST, accessToken, List.of("target", "client-exchanger"), "client-exchanger", "secret", null);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+    }
+
+    @Test
     public void testPublicClientNotAllowed() throws Exception {
         testingClient.server().run(ClientTokenExchangeTest::setupRealm);
 


### PR DESCRIPTION
closes #35506

- PR adds support for having multiple values of some parameters in the OAuth2 grant types as some grant types (EG. token exchange) have support for multiple values of some parameters

- For token exchange, the permissions are checked for all provided audiences (for security reasons), but the behaviour is still the same. Only the first `audience` is currently used for token-exchange and others are effectively ignored and not used right now when issuing the token.
