### PR TITLE
Set clientId in the VerifyEmailActionToken when no one is passed

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -1137,7 +1137,7 @@ public class UserResource {
             throw ErrorResponse.error("Client doesn't exist", Status.BAD_REQUEST);
         }
         if (!client.isEnabled()) {
-            logger.debugf("Client %s is not enabled", clientId);
+            logger.debugf("Client %s is not enabled", client.getClientId());
             throw ErrorResponse.error("Client is not enabled", Status.BAD_REQUEST);
         }
 
@@ -1152,7 +1152,7 @@ public class UserResource {
             lifespan = realm.getActionTokenGeneratedByAdminLifespan();
         }
 
-        return new SendEmailParams(redirectUri, clientId, lifespan);
+        return new SendEmailParams(redirectUri, client.getClientId(), lifespan);
     }
 
     private static class SendEmailParams {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -2047,6 +2047,7 @@ public class UserTest extends AbstractAdminTest {
         try {
             final AccessToken accessToken = TokenVerifier.create(token, AccessToken.class).getToken();
             assertThat(accessToken.getExp() - accessToken.getIat(), allOf(greaterThanOrEqualTo(lifespan - 1l), lessThanOrEqualTo(lifespan + 1l)));
+            assertEquals(accessToken.getIssuedFor(), Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
         } catch (VerificationException e) {
             throw new IOException(e);
         }


### PR DESCRIPTION
Closes #35317

Just passing the clientId from the client retrieved, now it could be the system account when argument is null. Also adding a small check in a test to check the `azp` is correctly filled with the `account` client.