### PR TITLE
Invoking BaseUpdater.markDeleted() more than once cause the transient…

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/BaseUpdater.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/BaseUpdater.java
@@ -75,7 +75,10 @@ public abstract class BaseUpdater<K, V> implements Updater<K, V> {
 
     @Override
     public final void markDeleted() {
-        state = isCreated() ? UpdaterState.DELETED_TRANSIENT : UpdaterState.DELETED;
+        state = switch (state) {
+            case READ, DELETED -> UpdaterState.DELETED;
+            case CREATED, DELETED_TRANSIENT -> UpdaterState.DELETED_TRANSIENT;
+        };
     }
 
     @Override

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -270,7 +270,10 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             // optimization in place:
             // create and remove in the same transaction should not trigger any operation in the Infinispan cache.
             var rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm);
+            var client = realm.getClientByClientId("test-app");
             rootAuthSession.setTimestamp(1000);
+            var authSession = rootAuthSession.createAuthenticationSession(client);
+            rootAuthSession.removeAuthenticationSessionByTabId(authSession.getTabId());
             session.authenticationSessions().removeRootAuthenticationSession(realm, rootAuthSession);
         });
 


### PR DESCRIPTION
… status to be lost

Fixes #35570

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
