### PR TITLE
Set clientId in the VerifyEmailActionToken when no one is passed (26.0)

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -1137,7 +1137,7 @@ public class UserResource {
             throw ErrorResponse.error("Client doesn't exist", Status.BAD_REQUEST);
         }
         if (!client.isEnabled()) {
-            logger.debugf("Client %s is not enabled", clientId);
+            logger.debugf("Client %s is not enabled", client.getClientId());
             throw ErrorResponse.error("Client is not enabled", Status.BAD_REQUEST);
         }
 
@@ -1152,7 +1152,7 @@ public class UserResource {
             lifespan = realm.getActionTokenGeneratedByAdminLifespan();
         }
 
-        return new SendEmailParams(redirectUri, clientId, lifespan);
+        return new SendEmailParams(redirectUri, client.getClientId(), lifespan);
     }
 
     private static class SendEmailParams {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -2047,6 +2047,7 @@ public class UserTest extends AbstractAdminTest {
         try {
             final AccessToken accessToken = TokenVerifier.create(token, AccessToken.class).getToken();
             assertThat(accessToken.getExp() - accessToken.getIat(), allOf(greaterThanOrEqualTo(lifespan - 1l), lessThanOrEqualTo(lifespan + 1l)));
+            assertEquals(accessToken.getIssuedFor(), Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
         } catch (VerificationException e) {
             throw new IOException(e);
         }


### PR DESCRIPTION
Closes #35317

PR:             https://github.com/keycloak/keycloak/pull/35569
Commit:         https://github.com/keycloak/keycloak/commit/d19ba82779a1d80a0ef2b1f464744eb73ce7ad62
PR branch:      backport-35569-26.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.0

Plain cherry-pick of #35317 to 26.0.