### PR TITLE
Revert back submitRequest to submit for saml ftl

### DIFF
--- a/themes/src/main/resources/theme/base/login/saml-post-form.ftl
+++ b/themes/src/main/resources/theme/base/login/saml-post-form.ftl
@@ -3,7 +3,7 @@
     <#if section = "header">
         ${msg("saml.post-form.title")}
     <#elseif section = "form">
-        <script>window.onload = function() {document.forms[0].requestSubmit()};</script>
+        <script>window.onload = function() {document.forms[0].submit()};</script>
         <p>${msg("saml.post-form.message")}</p>
         <form name="saml-post-binding" method="post" action="${samlPost.url}">
             <#if samlPost.SAMLRequest??>


### PR DESCRIPTION
Closes #35488

Reverting the `submitRequest` to `submit` in the `saml-post-form.ftl` template used for the SAML post binding. It was OK but triggered some issues in the old RH-SSO adapters tests because they are using an old `htmlunit` which does not implement that method. As the initial issue #33071 was not related to saml we can revert for the moment only this call.