### PR TITLE
Changed 'http-enabled' to correct code quotes

### DIFF
--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -45,7 +45,7 @@ If this header is incorrectly configured, rogue clients can set this header and 
 
 NOTE: When using the `xforwarded` setting, the `X-Forwarded-Port` takes precedence over any port included in the `X-Forwarded-Host`.
 
-NOTE: If the TLS connection is terminated at the reverse proxy (edge termination), enabling HTTP through the ‘http-enabled’ setting is required.
+NOTE: If the TLS connection is terminated at the reverse proxy (edge termination), enabling HTTP through the `http-enabled` setting is required.
 
 == Different context-path on reverse proxy
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Changes the referenced quote from

```adoc
‘http-enabled’ 
```
to

```adoc
`http-enabled`
```

As it is referenced in as a note with the incorrect quotes, doesn't turn itself into a mini-code block, whch in then doesn't show up in the "Relevant options" part of the page, which i assume is how this works.

https://www.keycloak.org/server/reverseproxy#_relevant_options

Relevant Issues:
https://github.com/keycloak/keycloak/issues/29665
https://github.com/keycloak/keycloak/pull/30170

Closes #35611