### PR TITLE
fix: changing the bootstrapping suggestion to the command

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -255,7 +255,7 @@ public class WelcomeResource {
     }
 
     protected String getAdminCreationMessage() {
-        return "or set the environment variables KC_BOOTSTRAP_ADMIN_USERNAME and KC_BOOTSTRAP_ADMIN_PASSWORD before starting the server";
+        return "or use a bootstrap-admin command";
     }
 
     private boolean shouldBootstrap() {

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -132,7 +132,7 @@
                     </div>
                   </form>
                 <#else>
-                  <p>To create the temporary administrative user open <a href="${localAdminUrl}">${localAdminUrl}</a>, or set the environment variables <code>KC_BOOTSTRAP_ADMIN_USERNAME</code> and <code>KC_BOOTSTRAP_ADMIN_PASSWORD</code> when starting the server.</p>
+                  <p>To create the temporary administrative user open <a href="${localAdminUrl}">${localAdminUrl}</a>, or use a <code>bootstrap-admin</code> command.</p>
                 </#if>
               </#if>
             </div>


### PR DESCRIPTION
closes: #35526

cc @jonkoops @vmuzikar the admin message from the welcome resource doesn't seem to be used by us, but I'm not sure if it could be used by something custom and therefore needs to stay for now.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
