### PR TITLE
Introduce support for an extension to auto register a value type

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/test/framework/TestFrameworkExtension.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/TestFrameworkExtension.java
@@ -10,6 +10,10 @@ public interface TestFrameworkExtension {
 
     List<Supplier<?, ?>> suppliers();
 
+    default List<Class<?>> alwaysEnabledValueTypes() {
+        return Collections.emptyList();
+    }
+
     default Map<Class<?>, String> valueTypeAliases() {
         return Collections.emptyMap();
     }

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/injection/AbstractInterceptorHelper.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/injection/AbstractInterceptorHelper.java
@@ -1,9 +1,4 @@
-package org.keycloak.test.framework.server;
-
-import org.keycloak.test.framework.injection.InstanceContext;
-import org.keycloak.test.framework.injection.Registry;
-import org.keycloak.test.framework.injection.RequestedInstance;
-import org.keycloak.test.framework.injection.Supplier;
+package org.keycloak.test.framework.injection;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -11,13 +6,13 @@ import java.util.List;
 
 public abstract class AbstractInterceptorHelper<I, V> {
 
+    private final Registry registry;
     private final Class<?> interceptorClass;
     private final List<Interception> interceptions = new LinkedList<>();
     private final InterceptedBy interceptedBy = new InterceptedBy();
 
-
-
     public AbstractInterceptorHelper(Registry registry, Class<I> interceptorClass) {
+        this.registry = registry;
         this.interceptorClass = interceptorClass;
 
         registry.getDeployedInstances().stream().filter(i -> isInterceptor(i.getSupplier())).forEach(i -> interceptions.add(new Interception(i)));
@@ -34,6 +29,7 @@ public abstract class AbstractInterceptorHelper<I, V> {
     public V intercept(V value, InstanceContext<?, ?> instanceContext) {
         for (Interception interception : interceptions) {
             value = intercept(value, interception.supplier, interception.existingInstance);
+            registry.getLogger().logIntercepted(value, interception.supplier);
         }
         instanceContext.addNote("InterceptedBy", interceptedBy);
         return value;

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/injection/Extensions.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/injection/Extensions.java
@@ -1,0 +1,89 @@
+package org.keycloak.test.framework.injection;
+
+import org.keycloak.test.framework.TestFrameworkExtension;
+import org.keycloak.test.framework.config.Config;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+public class Extensions {
+
+    private final RegistryLogger logger;
+    private final ValueTypeAlias valueTypeAlias;
+    private final List<Supplier<?, ?>> suppliers;
+    private final List<Class<?>> alwaysEnabledValueTypes;
+
+    public Extensions() {
+        List<TestFrameworkExtension> extensions = loadExtensions();
+        valueTypeAlias = loadValueTypeAlias(extensions);
+        logger = new RegistryLogger(valueTypeAlias);
+        suppliers = loadSuppliers(extensions, valueTypeAlias);
+        alwaysEnabledValueTypes = loadAlwaysEnabledValueTypes(extensions);
+    }
+
+    public ValueTypeAlias getValueTypeAlias() {
+        return valueTypeAlias;
+    }
+
+    public List<Supplier<?, ?>> getSuppliers() {
+        return suppliers;
+    }
+
+    public List<Class<?>> getAlwaysEnabledValueTypes() {
+        return alwaysEnabledValueTypes;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Supplier<T, ?> findSupplierByType(Class<T> typeClass) {
+        return (Supplier<T, ?>) suppliers.stream().filter(s -> s.getValueType().equals(typeClass)).findFirst().orElse(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Supplier<T, ?> findSupplierByAnnotation(Annotation annotation) {
+        return (Supplier<T, ?>) suppliers.stream().filter(s -> s.getAnnotationClass().equals(annotation.annotationType())).findFirst().orElse(null);
+    }
+
+    private List<TestFrameworkExtension> loadExtensions() {
+        List<TestFrameworkExtension> extensions = new LinkedList<>();
+        ServiceLoader.load(TestFrameworkExtension.class).iterator().forEachRemaining(extensions::add);
+        return extensions;
+    }
+
+    private ValueTypeAlias loadValueTypeAlias(List<TestFrameworkExtension> extensions) {
+        ValueTypeAlias valueTypeAlias = new ValueTypeAlias();
+        extensions.forEach(e -> valueTypeAlias.addAll(e.valueTypeAliases()));
+        return valueTypeAlias;
+    }
+
+    private List<Supplier<?, ?>> loadSuppliers(List<TestFrameworkExtension> extensions, ValueTypeAlias valueTypeAlias) {
+        List<Supplier<?, ?>> suppliers = new LinkedList<>();
+        List<Supplier<?, ?>> skippedSuppliers = new LinkedList<>();
+        Set<Class<?>> loadedValueTypes = new HashSet<>();
+
+        for (TestFrameworkExtension extension : extensions) {
+            for (var supplier : extension.suppliers()) {
+                Class<?> valueType = supplier.getValueType();
+                String requestedSupplier = Config.getSelectedSupplier(valueType, valueTypeAlias);
+                if (supplier.getAlias().equals(requestedSupplier) || (requestedSupplier == null && !loadedValueTypes.contains(valueType))) {
+                    suppliers.add(supplier);
+                    loadedValueTypes.add(valueType);
+                } else {
+                    skippedSuppliers.add(supplier);
+                }
+            }
+        }
+
+        logger.logSuppliers(suppliers, skippedSuppliers);
+
+        return suppliers;
+    }
+
+    private List<Class<?>> loadAlwaysEnabledValueTypes(List<TestFrameworkExtension> extensions) {
+        return extensions.stream().flatMap(s -> s.alwaysEnabledValueTypes().stream()).toList();
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/injection/RegistryLogger.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/injection/RegistryLogger.java
@@ -3,7 +3,6 @@ package org.keycloak.test.framework.injection;
 import org.jboss.logging.Logger;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("rawtypes")
@@ -89,7 +88,7 @@ class RegistryLogger {
         LOGGER.debug("Closing all instances");
     }
 
-    public void logSuppliers(List<Supplier<?, ?>> suppliers, Set<Supplier> skippedSuppliers) {
+    public void logSuppliers(List<Supplier<?, ?>> suppliers, List<Supplier<?, ?>> skippedSuppliers) {
         if (LOGGER.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder();
             sb.append("Loaded suppliers:");
@@ -120,6 +119,10 @@ class RegistryLogger {
             sb.append(alias);
         }
 
+    }
+
+    public void logIntercepted(Object value, Supplier<?, ?> supplier) {
+        LOGGER.debugv("{0} intercepted by {1}", value.getClass().getSimpleName(), supplier.getClass().getSimpleName());
     }
 
     public enum InjectionType {

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/injection/Supplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/injection/Supplier.java
@@ -1,6 +1,8 @@
 package org.keycloak.test.framework.injection;
 
 import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Set;
 
 public interface Supplier<T, S extends Annotation> {
 
@@ -37,4 +39,9 @@ public interface Supplier<T, S extends Annotation> {
     default int order() {
         return SupplierOrder.DEFAULT;
     }
+
+    default Set<Class<?>> dependencies() {
+        return Collections.emptySet();
+    }
+
 }

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/injection/SupplierHelpers.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/injection/SupplierHelpers.java
@@ -21,6 +21,7 @@ public class SupplierHelpers {
         return value != null ? value : defaultValue;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T getAnnotationField(Annotation annotation, String name) {
         if (annotation != null) {
             for (Method m : annotation.annotationType().getMethods()) {

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/realm/RealmSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/realm/RealmSupplier.java
@@ -10,7 +10,7 @@ import org.keycloak.test.framework.injection.RequestedInstance;
 import org.keycloak.test.framework.injection.Supplier;
 import org.keycloak.test.framework.injection.SupplierHelpers;
 import org.keycloak.test.framework.injection.SupplierOrder;
-import org.keycloak.test.framework.server.AbstractInterceptorHelper;
+import org.keycloak.test.framework.injection.AbstractInterceptorHelper;
 import org.keycloak.test.framework.server.KeycloakServer;
 
 public class RealmSupplier implements Supplier<ManagedRealm, InjectRealm> {

--- a/test-framework/core/src/main/java/org/keycloak/test/framework/server/AbstractKeycloakServerSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/test/framework/server/AbstractKeycloakServerSupplier.java
@@ -1,6 +1,7 @@
 package org.keycloak.test.framework.server;
 
 import org.jboss.logging.Logger;
+import org.keycloak.test.framework.injection.AbstractInterceptorHelper;
 import org.keycloak.test.framework.annotations.KeycloakIntegrationTest;
 import org.keycloak.test.framework.config.Config;
 import org.keycloak.test.framework.database.TestDatabase;

--- a/test-framework/remote/src/main/java/org/keycloak/test/framework/remote/RemoteTestFrameworkExtension.java
+++ b/test-framework/remote/src/main/java/org/keycloak/test/framework/remote/RemoteTestFrameworkExtension.java
@@ -12,6 +12,11 @@ public class RemoteTestFrameworkExtension implements TestFrameworkExtension {
         return List.of(
                 new TimeOffsetSupplier(),
                 new RemoteProvidersSupplier()
-                );
+        );
+    }
+
+    @Override
+    public List<Class<?>> alwaysEnabledValueTypes() {
+        return List.of(RemoteProviders.class);
     }
 }

--- a/test-framework/remote/src/main/java/org/keycloak/test/framework/remote/timeoffset/TimeOffsetSupplier.java
+++ b/test-framework/remote/src/main/java/org/keycloak/test/framework/remote/timeoffset/TimeOffsetSupplier.java
@@ -7,11 +7,11 @@ import org.keycloak.test.framework.injection.RequestedInstance;
 import org.keycloak.test.framework.injection.Supplier;
 import org.keycloak.test.framework.injection.SupplierOrder;
 import org.keycloak.test.framework.remote.RemoteProviders;
-import org.keycloak.test.framework.server.KeycloakServerConfigBuilder;
-import org.keycloak.test.framework.server.KeycloakServerConfigInterceptor;
 import org.keycloak.test.framework.server.KeycloakUrls;
 
-public class TimeOffsetSupplier implements Supplier<TimeOffSet, InjectTimeOffSet>, KeycloakServerConfigInterceptor<TimeOffSet, InjectTimeOffSet> {
+import java.util.Set;
+
+public class TimeOffsetSupplier implements Supplier<TimeOffSet, InjectTimeOffSet> {
     @Override
     public Class<InjectTimeOffSet> getAnnotationClass() {
         return InjectTimeOffSet.class;
@@ -20,6 +20,11 @@ public class TimeOffsetSupplier implements Supplier<TimeOffSet, InjectTimeOffSet
     @Override
     public Class<TimeOffSet> getValueType() {
         return TimeOffSet.class;
+    }
+
+    @Override
+    public Set<Class<?>> dependencies() {
+        return Set.of(HttpClient.class, RemoteProviders.class, KeycloakUrls.class);
     }
 
     @Override
@@ -55,11 +60,6 @@ public class TimeOffsetSupplier implements Supplier<TimeOffSet, InjectTimeOffSet
     @Override
     public int order() {
         return SupplierOrder.BEFORE_KEYCLOAK_SERVER;
-        // Implementing the KeycloakServerConfigInterceptor is a workaround for RemoteProvidersSupplier to work
     }
 
-    @Override
-    public KeycloakServerConfigBuilder intercept(KeycloakServerConfigBuilder serverConfig, InstanceContext<TimeOffSet, InjectTimeOffSet> instanceContext) {
-        return serverConfig;
-    }
 }


### PR DESCRIPTION
Introduces the ability for an extension to auto-register some value types.

This solves the issue with the `remote` extension that currently results in restarting the server between tests that use `TimeOffSet` and those that don't.

Closes #35592

Signed-off-by: stianst <stianst@gmail.com>
