### PR TITLE
fix: deprecating the default db value in production mode

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_1_0.adoc
@@ -24,6 +24,10 @@ Previously, the three mappers (`Client Id`, `Client Host` and `Client IP Address
 
 This lists functionality that continues to work as before in this release, but will be removed in a future major release.
 
+=== Default `db` option for production deprecated.
+
+In previous releases, the `db` option defaulted to `dev-file` both in production (`start`) and development (`start-dev`) modes while `dev-file` has never been supported in the production mode. In this release, we have deprecated this behaviour and in some future release the `db` option won't default to `dev-file` in production mode. For `build` or non-optimized `start` and non-server commands `import`, `export`, or `bootstrap-admin` in the production profile, a value should be explicitly supplied. This is to prevent the unintentional usage of the `dev-file` (H2) database in a production environment, which is typically indicative of a misconfiguration.
+
 === Deprecated APIs for JavaScript Authorization client
 
 The following APIs for the JavaScript Authorization client are deprecated and will be removed in the next major release:

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -18,7 +18,7 @@ public class DatabaseOptions {
 
     public static final Option<String> DB = new OptionBuilder<>("db", String.class)
             .category(OptionCategory.DATABASE)
-            .description("The database vendor.")
+            .description("The database vendor. In production mode the default value of 'dev-file' is deprecated, you should explicitly specify the db instead.")
             .defaultValue("dev-file")
             .expectedValues(Database.getDatabaseAliases())
             .buildTime(true)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -18,13 +18,13 @@
 package org.keycloak.quarkus.runtime.cli.command;
 
 import static org.keycloak.config.ClassLoaderOptions.QUARKUS_REMOVED_ARTIFACTS_PROPERTY;
+import static org.keycloak.config.DatabaseOptions.DB;
 import static org.keycloak.quarkus.runtime.Environment.getHomePath;
 import static org.keycloak.quarkus.runtime.Environment.isDevProfile;
 import static org.keycloak.quarkus.runtime.cli.Picocli.println;
 
 import io.quarkus.runtime.LaunchMode;
 
-import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.Messages;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
@@ -36,7 +36,6 @@ import io.smallrye.config.ConfigValue;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-import java.util.List;
 import java.util.Optional;
 
 @Command(name = Build.NAME,
@@ -74,10 +73,13 @@ public final class Build extends AbstractCommand implements Runnable {
         if (org.keycloak.common.util.Environment.getProfile() == null) {
             Environment.setProfile(Environment.PROD_PROFILE_VALUE);
         }
-        exitWithErrorIfDevProfileIsSet();
+        checkProfileAndDb();
 
         System.setProperty("quarkus.launch.rebuild", "true");
-        validateConfig();
+        PersistedConfigSource.getInstance().runWithDisabled(() -> {
+            validateConfig();
+            return null;
+        });
 
         println(spec.commandLine(), "Updating the configuration and installing your custom providers, if any. Please wait.");
 
@@ -114,13 +116,7 @@ public final class Build extends AbstractCommand implements Runnable {
         return true;
     }
 
-    @Override
-    public List<OptionCategory> getOptionCategories() {
-        // all options should work for the build command, otherwise re-augmentation might fail due to unknown options
-        return super.getOptionCategories();
-    }
-
-    private void exitWithErrorIfDevProfileIsSet() {
+    private void checkProfileAndDb() {
         if (Environment.isDevProfile()) {
             String cmd = Environment.getParsedCommand().map(AbstractCommand::getName).orElse(getName());
             // we allow start-dev, and import|export|bootstrap-admin --profile=dev
@@ -128,6 +124,8 @@ public final class Build extends AbstractCommand implements Runnable {
             if (Start.NAME.equals(cmd) || Build.NAME.equals(cmd)) {
                 executionError(spec.commandLine(), Messages.devProfileNotAllowedError(cmd));
             }
+        } else if (Configuration.getConfigValue(DB).getConfigSourceOrdinal() == 0) {
+            picocli.warn("Usage of the default value for the db option in the production profile is deprecated. Please explicitly set the db instead.");
         }
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -104,6 +104,10 @@ public final class Configuration {
         return getConfig().getPropertyNames();
     }
 
+    public static ConfigValue getConfigValue(Option<?> option) {
+        return getKcConfigValue(option.getKey());
+    }
+
     public static ConfigValue getConfigValue(String propertyName) {
         return getConfig().getConfigValue(propertyName);
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -2,6 +2,7 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.smallrye.config.ConfigSourceInterceptorContext;
+
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.TransactionOptions;
 import org.keycloak.config.database.Database;
@@ -114,7 +115,7 @@ final class DatabasePropertyMappers {
 
     private static boolean isDevModeDatabase(ConfigSourceInterceptorContext context) {
         String db = Configuration.getConfig().getConfigValue("kc.db").getValue();
-        return Database.getDatabaseKind(db).get().equals(DatabaseKind.H2);
+        return Database.getDatabaseKind(db).filter(DatabaseKind.H2::equals).isPresent();
     }
 
     private static String transformDialect(String db, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -1,5 +1,5 @@
 # Default and non-production grade database vendor
-db=dev-file
+%dev.db=dev-file
 
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.http-enabled=true

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
@@ -27,7 +27,6 @@ import io.smallrye.config.ConfigValue.ConfigValueBuilder;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
@@ -93,6 +92,7 @@ public abstract class AbstractConfigurationTest {
 
     public static void setSystemProperty(String key, String value, Runnable runnable) {
         System.setProperty(key, value);
+        createConfig();
         try {
             runnable.run();
         } finally {
@@ -100,32 +100,32 @@ public abstract class AbstractConfigurationTest {
         }
     }
 
-    @AfterClass
-    public static void resetConfigruation() {
-        ConfigurationTest.createConfig(); // onAfter doesn't actually reset the config
-    }
-
-    @After
-    public void onAfter() {
-        Properties current = System.getProperties();
-
-        for (String name : current.stringPropertyNames()) {
-            if (!SYSTEM_PROPERTIES.containsKey(name)) {
-                current.remove(name);
-            }
-        }
+    @BeforeClass
+    public static void resetConfiguration() {
+        System.setProperties((Properties) SYSTEM_PROPERTIES.clone());
 
         for (String name : new HashMap<>(System.getenv()).keySet()) {
             if (!ENVIRONMENT_VARIABLES.containsKey(name)) {
                 removeEnvVar(name);
             }
         }
+        ENVIRONMENT_VARIABLES.forEach((key, value) -> {
+            if (!System.getenv(key).equals(value)) {
+                putEnvVar(key, value);
+            }
+        });
 
         SmallRyeConfigProviderResolver.class.cast(ConfigProviderResolver.instance()).releaseConfig(ConfigProvider.getConfig());
         PropertyMappers.reset();
         ConfigArgsConfigSource.setCliArgs();
         PersistedConfigSource.getInstance().getConfigValueProperties().clear();
         Profile.reset();
+        ConfigProviderResolver.setInstance(null);
+    }
+
+    @After
+    public void onAfter() {
+        resetConfiguration();
     }
 
     protected Config.Scope initConfig(String... scope) {
@@ -169,6 +169,9 @@ public abstract class AbstractConfigurationTest {
 
     protected static void addPersistedConfigValues(Map<String, String> values) {
         var configValueProps = PersistedConfigSource.getInstance().getConfigValueProperties();
-        values.forEach((k, v) -> configValueProps.put(k, new ConfigValueBuilder().withName(k).withValue(v).build()));
+        values.forEach((k, v) -> configValueProps.put(k,
+                new ConfigValueBuilder().withName(k).withValue(v).withRawValue(v)
+                        .withConfigSourceName(PersistedConfigSource.getInstance().getName())
+                        .withConfigSourceOrdinal(PersistedConfigSource.getInstance().getOrdinal()).build()));
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/IgnoredArtifactsTest.java
@@ -18,7 +18,6 @@
 package org.keycloak.quarkus.runtime.configuration.test;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.common.Profile;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
@@ -26,6 +25,7 @@ import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.MetricsOptions;
 import org.keycloak.config.Option;
+import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
 
@@ -46,14 +46,8 @@ import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_M
 import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_ORACLE;
 import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_POSTGRES;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.test.ConfigurationTest.setSystemProperty;
 
-public class IgnoredArtifactsTest {
-    
-    @BeforeClass
-    public static void resetConfigruation() {
-        ConfigurationTest.createConfig(); // make sure we're dealing with a clean config
-    }
+public class IgnoredArtifactsTest extends AbstractConfigurationTest {
 
     @Test
     public void fipsDisabled() {
@@ -113,6 +107,10 @@ public class IgnoredArtifactsTest {
 
     @Test
     public void multipleDatasources() {
+        // initialize the test with a default database
+        ConfigArgsConfigSource.setCliArgs("--db=dev-file");
+        createConfig();
+
         var defaultDS = Configuration.getOptionalValue("quarkus.datasource.db-kind");
         assertThat(defaultDS.isPresent(), is(true));
         assertThat(defaultDS.get(), is("h2"));

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -77,6 +77,7 @@
                     <finalName>keycloak</finalName>
                     <systemProperties>
                         <kc.home.dir>${kc.home.dir}</kc.home.dir>
+                        <kc.db>dev-file</kc.db>
                         <java.util.concurrent.ForkJoinPool.common.threadFactory>io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory</java.util.concurrent.ForkJoinPool.common.threadFactory>
                     </systemProperties>
                 </configuration>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BootstrapAdminDistTest {
 
     @Test
-    @Launch({ "bootstrap-admin", "user", "--no-prompt" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--no-prompt" })
     void failNoPassword(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("No password provided"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
@@ -44,14 +44,14 @@ public class BootstrapAdminDistTest {
 
     /**
     @Test
-    @Launch({ "bootstrap-admin", "user", "--expiration=tomorrow" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--expiration=tomorrow" })
     void failBadExpiration(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("Invalid value for option '--expiration': 'tomorrow' is not an int"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }*/
 
     @Test
-    @Launch({ "bootstrap-admin", "user", "--username=admin", "--password:env=MY_PASSWORD" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD" })
     void failEnvNotSet(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("Environment variable MY_PASSWORD not found"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
@@ -59,7 +59,7 @@ public class BootstrapAdminDistTest {
 
     @Test
     @WithEnvVars({"MY_PASSWORD", "admin123"})
-    @Launch({ "bootstrap-admin", "user", "--username=admin", "--password:env=MY_PASSWORD" })
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD" })
     void createAdmin(LaunchResult result) {
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
     }
@@ -72,14 +72,14 @@ public class BootstrapAdminDistTest {
     }
 
     @Test
-    @Launch({ "bootstrap-admin", "service", "--no-prompt" })
+    @Launch({ "bootstrap-admin", "service", "--db=dev-file", "--no-prompt" })
     void failServiceAccountNoSecret(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("No client secret provided"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }
 
     @Test
-    @Launch({ "bootstrap-admin", "service", "--client-id=admin", "--client-secret:env=MY_SECRET" })
+    @Launch({ "bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET" })
     void failServiceAccountEnvNotSet(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("Environment variable MY_SECRET not found"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
@@ -89,7 +89,7 @@ public class BootstrapAdminDistTest {
     @WithEnvVars({"MY_SECRET", "admin123"})
     void createAndUseSericeAccountAdmin(KeycloakDistribution dist) throws Exception {
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
-        CLIResult result = rawDist.run("bootstrap-admin", "service", "--client-id=admin", "--client-secret:env=MY_SECRET");
+        CLIResult result = rawDist.run("bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET");
 
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -46,7 +46,7 @@ public class BuildAndStartDistTest {
     void testBuildAndStart(KeycloakDistribution dist) {
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         // start using based on the build options set via CLI
-        CLIResult cliResult = rawDist.run("build");
+        CLIResult cliResult = rawDist.run("build", "--db=dev-file");
         cliResult.assertBuild();
         cliResult = rawDist.run("start", "--http-enabled=true", "--hostname-strict=false", OPTIMIZED_BUILD_OPTION_LONG);
         cliResult.assertNoBuild();
@@ -56,6 +56,7 @@ public class BuildAndStartDistTest {
         rawDist.setProperty("http-enabled", "true");
         rawDist.setProperty("hostname-strict", "false");
         rawDist.setProperty("http-relative-path", "/auth");
+        rawDist.setProperty("db", "dev-file");
         cliResult = rawDist.run("build");
         cliResult.assertBuild();
         cliResult = rawDist.run("start", OPTIMIZED_BUILD_OPTION_LONG);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -39,7 +39,7 @@ import java.nio.file.Paths;
 class BuildCommandDistTest {
 
     @Test
-    @Launch({ "build" })
+    @Launch({ "build", "--db=dev-file" })
     void resetConfig(CLIResult result) {
         assertTrue(result.getOutput().contains("Updating the configuration and installing your custom providers, if any. Please wait."),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -87,7 +87,7 @@ public class ClusterConfigDistTest {
 
     @Test
     @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
-    @Launch({ "start", "--log-level=info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--log-level=info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true", "--hostname-strict=false" })
     void testStartDefaultsToClustering(CLIResult result) {
         result.assertStarted();
         result.assertClusteredCache();
@@ -96,7 +96,7 @@ public class ClusterConfigDistTest {
 
     @Test
     @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell behaviour on Windows.")
-    @Launch({ "start", "--log-level=\"info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug\"","--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--log-level=\"info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug\"","--http-enabled=true", "--hostname-strict=false" })
     void testWinStartDefaultsToClustering(CLIResult result) {
         result.assertStarted();
         result.assertClusteredCache();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -25,7 +25,7 @@ import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.utils.KeycloakDistribution;
 
 @RawDistOnly(reason = "Containers are immutable")
-@DistributionTest
+@DistributionTest(defaultOptions = "--db=dev-file")
 @Tag(DistributionTest.SMOKE)
 public class ExportDistTest {
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -37,7 +37,7 @@ public class FeaturesDistTest {
 
     @Test
     public void testEnableOnBuild(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run(Build.NAME, "--features=preview");
+        CLIResult cliResult = dist.run(Build.NAME, "--db=dev-file", "--features=preview");
         cliResult.assertBuild();
         assertPreviewFeaturesEnabled(cliResult);
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -31,7 +31,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
-@DistributionTest(keepAlive = true, defaultOptions = { "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
+@DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
 @RawDistOnly(reason = "Containers are immutable")
 @Tag(DistributionTest.SLOW)
 public class FipsDistTest {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HostnameV2DistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HostnameV2DistTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RawDistOnly(reason = "Containers are immutable")
 public class HostnameV2DistTest {
     @Test
-    @Launch({"start", "--http-enabled=true"})
+    @Launch({"start", "--db=dev-file", "--http-enabled=true"})
     public void testServerFailsToStartWithoutHostnameSpecified(LaunchResult result) {
         assertThat(result.getErrorOutput(), containsString("ERROR: hostname is not configured; either configure hostname, or set hostname-strict to false"));
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
@@ -92,7 +92,7 @@ public class ImportAtStartupDistTest {
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromFileCreatedByExportAllRealms(KeycloakDistribution dist) throws IOException {
         dist.run("start-dev", "--import-realm");
-        dist.run("export", "--file=../data/import/realm.json");
+        dist.run("--profile=dev", "export", "--file=../data/import/realm.json");
 
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
@@ -107,7 +107,7 @@ public class ImportAtStartupDistTest {
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromFileCreatedByExportSingleRealm(KeycloakDistribution dist) throws IOException {
         dist.run("start-dev", "--import-realm");
-        dist.run("export", "--realm=quickstart-realm", "--file=../data/import/realm.json");
+        dist.run("--profile=dev", "export", "--realm=quickstart-realm", "--file=../data/import/realm.json");
 
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
@@ -123,7 +123,7 @@ public class ImportAtStartupDistTest {
         dist.run("start-dev", "--import-realm");
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("import").toAbsolutePath());
-        dist.run("export", "--dir=../data/import");
+        dist.run("--profile=dev", "export", "--dir=../data/import");
 
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
@@ -32,7 +32,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-@DistributionTest
+@DistributionTest(defaultOptions = "--db=dev-file")
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag(DistributionTest.SMOKE)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/IpStackDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/IpStackDistTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DistributionTest(keepAlive = true, defaultOptions = {"--http-enabled=true", "--hostname-strict=false"})
+@DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
 @RawDistOnly(reason = "Containers are immutable")
 public class IpStackDistTest {
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DistributionTest(keepAlive = true,
-        defaultOptions = {"--health-enabled=true", "--metrics-enabled=true"},
+        defaultOptions = {"--db=dev-file", "--health-enabled=true", "--metrics-enabled=true"},
         requestPort = 9000,
         containerExposedPorts = {9000, 8080, 9005})
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementHttpsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementHttpsDistTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 @DistributionTest(keepAlive = true,
         enableTls = true,
-        defaultOptions = {"--health-enabled=true", "--metrics-enabled=true"},
+        defaultOptions = {"--db=dev-file", "--health-enabled=true", "--metrics-enabled=true"},
         requestPort = 9000)
 @RawDistOnly(reason = "We do not test TLS in containers")
 public class ManagementHttpsDistTest {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
@@ -52,7 +52,7 @@ public class OptionsDistTest {
     @DryRun
     @Test
     @Order(2)
-    @Launch({"start", "--test=invalid"})
+    @Launch({"start", "--db=dev-file", "--test=invalid"})
     public void testServerDoesNotStartIfValidationFailDuringReAugStart(LaunchResult result) {
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Unknown option: '--test'")).count());
     }
@@ -60,7 +60,7 @@ public class OptionsDistTest {
     @DryRun
     @Test
     @Order(3)
-    @Launch({"start", "--log=console", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--log=console", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
     public void testServerDoesNotStartIfDisabledFileLogOption(LaunchResult result) {
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-level")).count());
@@ -69,7 +69,7 @@ public class OptionsDistTest {
     @DryRun
     @Test
     @Order(4)
-    @Launch({"start", "--log=file", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--log=file", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
     public void testServerStartIfEnabledFileLogOption(LaunchResult result) {
         assertEquals(0, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
     }
@@ -77,7 +77,7 @@ public class OptionsDistTest {
     @Test
     @Order(5)
     @WithEnvVars({"KC_LOG", "console", "KC_LOG_CONSOLE_COLOR", "true", "KC_LOG_FILE", "something-env", "KC_HTTP_ENABLED", "true", "KC_HOSTNAME_STRICT", "false"})
-    @Launch({"start"})
+    @Launch({"start", "--db=dev-file"})
     public void testSettingEnvVars(CLIResult cliResult) {
         cliResult.assertMessage("The following used run time options are UNAVAILABLE and will be ignored during build time:");
         cliResult.assertMessage("- log-file: Available only when File log handler is activated.");
@@ -91,7 +91,7 @@ public class OptionsDistTest {
     @RawDistOnly(reason = "Raw is enough and we avoid issues with including custom conf file in the container")
     public void testExpressionsInConfigFile(KeycloakDistribution distribution) {
         distribution.setEnvVar("MY_LOG_LEVEL", "warn");
-        CLIResult result = distribution.run(CONFIG_FILE_LONG_NAME + "=" + Paths.get("src/test/resources/OptionsDistTest/keycloak.conf").toAbsolutePath().normalize(), "start", "--http-enabled=true", "--hostname-strict=false");
+        CLIResult result = distribution.run(CONFIG_FILE_LONG_NAME + "=" + Paths.get("src/test/resources/OptionsDistTest/keycloak.conf").toAbsolutePath().normalize(), "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false");
         result.assertNoMessage("INFO [io.quarkus]");
         result.assertNoMessage("Listening on:");
 
@@ -103,7 +103,7 @@ public class OptionsDistTest {
 
     @Test
     @Order(7)
-    @Launch({"start", "--cache-embedded-mtls-enabled=true", "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({"start", "--db=dev-file", "--cache-embedded-mtls-enabled=true", "--http-enabled=true", "--hostname-strict=false"})
     public void testCacheEmbeddedMtlsEnabled(LaunchResult result) {
         assertTrue(result.getOutputStream().stream().anyMatch(s -> s.contains("Property cache-embedded-mtls-key-store-file required but not specified")));
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
@@ -32,7 +32,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
 
-@DistributionTest(defaultOptions = {"--http-enabled=true", "--hostname-strict=false"})
+@DistributionTest(defaultOptions = {"--db=dev-file", "--http-enabled=true", "--hostname-strict=false"})
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(OrderAnnotation.class)
 public class QuarkusPropertiesAutoBuildDistTest {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -44,7 +44,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
-@DistributionTest(reInstall = DistributionTest.ReInstall.NEVER)
+@DistributionTest(reInstall = DistributionTest.ReInstall.NEVER, defaultOptions = "--db=dev-file")
 @RawDistOnly(reason = "Containers are immutable")
 @Tag(DistributionTest.WIN)
 @TestMethodOrder(OrderAnnotation.class)
@@ -134,7 +134,7 @@ public class QuarkusPropertiesDistTest {
 
     @Test
     @KeepServerAlive
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", OPTIMIZED_BUILD_OPTION_LONG})
+    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--metrics-enabled=true"})
     @Order(8)
     void testUnknownQuarkusBuildTimePropertyApplied(CLIResult cliResult) {
         cliResult.assertNoBuild();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -29,7 +29,7 @@ public class ShowConfigCommandDistTest {
     void testShowConfigPicksUpRightConfigDependingOnCurrentMode(KeycloakDistribution distribution) {
         CLIResult initialResult = distribution.run("show-config");
         initialResult.assertMessage("Current Mode: production");
-        initialResult.assertMessage("kc.db =  dev-file");
+        initialResult.assertNoMessage("kc.db =  dev-file");
 
         distribution.run("start-dev");
 
@@ -37,7 +37,7 @@ public class ShowConfigCommandDistTest {
         devModeResult.assertMessage("Current Mode: development");
         devModeResult.assertMessage("kc.db =  dev-file");
 
-        distribution.run("build");
+        distribution.run("build", "--db=dev-file");
 
         CLIResult resetResult = distribution.run("show-config");
         resetResult.assertMessage("Current Mode: production");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -41,7 +41,7 @@ public class StartAutoBuildDistTest {
 
     @DryRun
     @Test
-    @Launch({ "--verbose", "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "--verbose", "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     @Order(1)
     void testStartAutoBuild(CLIResult cliResult) {
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
@@ -56,7 +56,7 @@ public class StartAutoBuildDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     @Order(2)
     void testShouldNotReAugIfConfigIsSame(CLIResult cliResult) {
         cliResult.assertNoBuild();
@@ -91,7 +91,7 @@ public class StartAutoBuildDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     @Order(6)
     void testReAugWhenNoOptionAfterBuild(CLIResult cliResult) {
         cliResult.assertBuild();
@@ -129,6 +129,7 @@ public class StartAutoBuildDistTest {
     @Order(9)
     void testShouldNotReAugStartDevIfConfigIsSame(CLIResult cliResult) {
         cliResult.assertNoMessage("Updating the configuration and installing your custom providers, if any. Please wait.");
+        cliResult.assertNoBuild();
         cliResult.assertStartedDevMode();
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -47,7 +47,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--hostname-strict=false" })
     void failNoTls(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("Key material not provided to setup HTTPS"),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
@@ -55,7 +55,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--spi-events-listener-jboss-logging-success-level" })
+    @Launch({ "start", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level" })
     void failSpiArgMissingValue(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("spi argument --spi-events-listener-jboss-logging-success-level requires a value"),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
@@ -63,7 +63,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "build", "--spi-events-listener-jboss-logging-success-level=debug" })
+    @Launch({ "build", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level=debug" })
     void warnSpiRuntimeAtBuildtime(CLIResult cliResult) {
         assertTrue(cliResult.getOutput().contains("The following run time options were found, but will be ignored during build time: kc.spi-events-listener-jboss-logging-success-level"),
                 () -> "The Output:\n" + cliResult.getOutput() + "doesn't contains the expected string.");
@@ -73,7 +73,7 @@ public class StartCommandDistTest {
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void errorSpiBuildtimeAtRuntime(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("build");
+        CLIResult cliResult = dist.run("build",  "--db=dev-file");
         cliResult.assertBuild();
 
         cliResult = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false", "--spi-events-listener-jboss-logging-enabled=false");
@@ -85,7 +85,7 @@ public class StartCommandDistTest {
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void noErrorSpiBuildtimeNotChanged(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("build");
+        CLIResult cliResult = dist.run("build", "--db=dev-file");
         cliResult.assertBuild();
 
         cliResult = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
@@ -94,14 +94,14 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "--profile=dev", "start" })
+    @Launch({ "--profile=dev", "start",  "--db=dev-file" })
     void failUsingDevProfile(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("ERROR: You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
     }
 
     @Test
-    @Launch({ "-v", "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "-v", "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false" })
     void testHttpEnabled(CLIResult cliResult) {
         cliResult.assertStarted();
     }
@@ -139,7 +139,7 @@ public class StartCommandDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true" })
     void failNoHostnameNotSet(CLIResult cliResult) {
         assertTrue(cliResult.getErrorOutput().contains("ERROR: hostname is not configured; either configure hostname, or set hostname-strict to false"),
                 () -> "The Output:\n" + cliResult.getOutput() + "doesn't contains the expected string.");
@@ -147,7 +147,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--metrics-enabled=true" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false", "--metrics-enabled=true" })
     void testStartUsingAutoBuild(CLIResult cliResult) {
         cliResult.assertNoMessage("ignored during build");
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
@@ -169,7 +169,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "start", "--http-enabled=true", "--cache-remote-host=localhost", "--hostname-strict=false", "--cache-remote-tls-enabled=false", "--transaction-xa-enabled=true" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=true", "--cache-remote-host=localhost", "--hostname-strict=false", "--cache-remote-tls-enabled=false", "--transaction-xa-enabled=true" })
     void testStartNoWarningOnDisabledRuntimeOption(CLIResult cliResult) {
         cliResult.assertNoMessage("cache-remote-tls-enabled: Available only when remote host is set");
     }
@@ -177,7 +177,7 @@ public class StartCommandDistTest {
     @DryRun
     @Test
     @WithEnvVars({"KC_LOG", "invalid"})
-    @Launch({ "start", "--http-enabled=false", "--hostname-strict=false" })
+    @Launch({ "start", "--db=dev-file", "--http-enabled=false", "--hostname-strict=false" })
     void testStartUsingOptimizedInvalidEnvOption(CLIResult cliResult) {
         cliResult.assertError("Invalid value for option 'KC_LOG': invalid. Expected values are: console, file, syslog");
     }
@@ -188,7 +188,7 @@ public class StartCommandDistTest {
     void testWarningWhenOverridingBuildOptionsDuringStart(KeycloakDistribution dist) {
         CLIResult cliResult = dist.run("build", "--db=postgres", "--features=preview");
         cliResult.assertBuild();
-        cliResult = dist.run("start", "--hostname=localhost", "--http-enabled=true");
+        cliResult = dist.run("start", "--db=dev-file", "--hostname=localhost", "--http-enabled=true");
         cliResult.assertMessage("The previous optimized build will be overridden with the following build options:");
         cliResult.assertMessage("- db=postgres > db=dev-file"); // back to the default value
         cliResult.assertMessage("- features=preview > features=<unset>"); // no default value, the <unset> is shown
@@ -200,7 +200,7 @@ public class StartCommandDistTest {
         cliResult.assertNoMessage("The previous optimized build will be overridden with the following build options:");
         assertTrue(cliResult.getErrorOutput().isBlank());
         dist.run("build", "--db=postgres");
-        cliResult = dist.run("start", "--hostname=localhost", "--http-enabled=true");
+        cliResult = dist.run("start", "--db=dev-file", "--hostname=localhost", "--http-enabled=true");
         cliResult.assertMessage("- db=postgres > db=dev-file");
         cliResult.assertNoMessage("- features=preview > features=<unset>");
         assertTrue(cliResult.getErrorOutput().isBlank());
@@ -224,7 +224,7 @@ public class StartCommandDistTest {
         CLIResult cliResult = dist.run("start-dev");
         cliResult.assertStartedDevMode();
 
-        cliResult = dist.run("start", "--http-enabled", "true", "--hostname-strict", "false");
+        cliResult = dist.run("start", "--db=dev-file", "--http-enabled", "true", "--hostname-strict", "false");
         cliResult.assertNotDevMode();
         assertTrue(cliResult.getErrorOutput().isBlank());
     }
@@ -233,7 +233,7 @@ public class StartCommandDistTest {
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void testErrorWhenOverridingNonCliBuildOptionsDuringStart(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("build", "--features=preview");
+        CLIResult cliResult = dist.run("build", "--db=dev-file", "--features=preview");
         cliResult.assertBuild();
         dist.setEnvVar("KC_DB", "postgres");
         cliResult = dist.run("start", "--optimized", "--hostname=localhost", "--http-enabled=true");
@@ -242,7 +242,7 @@ public class StartCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({CONFIG_FILE_LONG_NAME + "=src/test/resources/non-existing.conf", "start"})
+    @Launch({CONFIG_FILE_LONG_NAME + "=src/test/resources/non-existing.conf", "start", "--db=dev-file"})
     void testInvalidConfigFileOption(CLIResult cliResult) {
         cliResult.assertError("File specified via '--config-file' or '-cf' option does not exist.");
         cliResult.assertError(String.format("Try '%s --help' for more information on the available options.", KeycloakDistribution.SCRIPT_CMD));
@@ -253,17 +253,17 @@ public class StartCommandDistTest {
     void testRuntimeValuesAreNotCaptured(KeycloakDistribution dist) {
         // confirm that the invalid value prevents startup - if this passes, then we need to use a different
         // spi provider
-        CLIResult cliResult = dist.run("start", "--spi-events-listener-jboss-logging-success-level=invalid", "--http-enabled", "true", "--hostname-strict", "false");
+        CLIResult cliResult = dist.run("start", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level=invalid", "--http-enabled", "true", "--hostname-strict", "false");
         cliResult.assertError("Failed to start quarkus");
 
         // if there was no auto-build use an explicit build to potentially capture the runtime default
         if (!cliResult.getOutput().contains("Server configuration updated and persisted")) {
-            cliResult = dist.run("build", "--spi-events-listener-jboss-logging-success-level=invalid");
+            cliResult = dist.run("build", "--db=dev-file", "--spi-events-listener-jboss-logging-success-level=invalid");
             cliResult.assertBuild();
         }
 
         // the invalid value should not be the default
-        cliResult = dist.run("start", "--http-enabled", "true", "--hostname-strict", "false");
+        cliResult = dist.run("start", "--db=dev-file", "--http-enabled", "true", "--hostname-strict", "false");
         cliResult.assertNoBuild();
         cliResult.assertStarted();
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -66,7 +66,7 @@ public class StartDevCommandDistTest {
 
     @DryRun
     @Test
-    @Launch({ "build", "--debug" })
+    @Launch({ "build", "--debug", "--db=dev-file" })
     void testBuildMustNotRunTwoJVMs(CLIResult cliResult) {
         cliResult.assertMessageWasShownExactlyNumberOfTimes("Listening for transport dt_socket at address:", 1);
         cliResult.assertBuild();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TracingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TracingDistTest.java
@@ -83,7 +83,7 @@ public class TracingDistTest {
 
     @Test
     @Order(5)
-    @Launch({"build", "--tracing-enabled=true"})
+    @Launch({"build", "--db=dev-file", "--tracing-enabled=true"})
     void buildTracingEnabled(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TruststoreDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TruststoreDistTest.java
@@ -58,7 +58,7 @@ public class TruststoreDistTest {
         dist.copyOrReplaceFileFromClasspath("/self-signed.p12", Path.of("conf", "self-signed.p12"));
         Path keyStore = rawDist.getDistPath().resolve("conf").resolve("self-signed.p12").toAbsolutePath();
 
-        rawDist.run("--verbose", "start", "--http-enabled=true", "--hostname=mykeycloak.org",
+        rawDist.run("--verbose", "start", "--db=dev-file", "--http-enabled=true", "--hostname=mykeycloak.org",
                 "--truststore-paths=" + paths, "--https-client-auth=required", "--https-key-store-file=" + keyStore);
 
         given().trustStore(TruststoreDistTest.class.getResource("/self-signed-truststore.p12").getPath(), TruststoreBuilder.DUMMY_PASSWORD)
@@ -77,7 +77,7 @@ public class TruststoreDistTest {
         dist.copyOrReplaceFileFromClasspath("/self-signed.p12", Path.of("conf", "self-signed.p12"));
         Path keyStore = rawDist.getDistPath().resolve("conf").resolve("self-signed.p12").toAbsolutePath();
 
-        rawDist.run("--verbose", "start", "--http-enabled=true", "--hostname=mykeycloak.org",
+        rawDist.run("--verbose", "start", "--db=dev-file", "--http-enabled=true", "--hostname=mykeycloak.org",
                 "--https-client-auth=required", "--https-key-store-file=" + keyStore);
 
         given().trustStore(TruststoreDistTest.class.getResource("/self-signed-truststore.p12").getPath(), TruststoreBuilder.DUMMY_PASSWORD)

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
@@ -19,8 +19,10 @@ Options:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -25,8 +25,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -79,8 +79,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -105,8 +105,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -86,8 +86,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -106,8 +106,10 @@ Config:
 
 Database:
 
---db <vendor>        The database vendor. Possible values are: dev-file, dev-mem, mariadb, mssql,
-                       mysql, oracle, postgres. Default: dev-file.
+--db <vendor>        The database vendor. In production mode the default value of 'dev-file' is
+                       deprecated, you should explicitly specify the db instead. Possible values
+                       are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres. Default:
+                       dev-file.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 --db-password <password>

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -269,7 +269,7 @@
                 <executions>
                     <execution>
                         <id>ant-generate-default</id>
-                        <phase>generate-resources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
closes: #23805

This keeps the changes from https://github.com/keycloak/keycloak/pull/33760 but switches to using a deprecation instead.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
