### PR TITLE
Reduce RealmSelector debounce to 300ms

### DIFF
--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -111,7 +111,7 @@ export const RealmSelector = () => {
     debounce((value: string) => {
       setFirst(0);
       setSearch(value);
-    }, 1000),
+    }, 300),
     [],
   );
 


### PR DESCRIPTION
This PR reduces the debounce time in the RealmSelector to 300ms. Other than the user search, realm search should always be performant. To enable a smooth administration experience when dealing with a lot of realms, the debounce should be reduced.

Closes #35676 