### PR TITLE
Add support for RFC 8707 OAuth2 Resource Indicators (#14355)

### DIFF
--- a/core/src/main/java/org/keycloak/OAuthErrorException.java
+++ b/core/src/main/java/org/keycloak/OAuthErrorException.java
@@ -59,6 +59,9 @@ public class OAuthErrorException extends Exception {
     // DPoP
     public static final String INVALID_DPOP_PROOF = "invalid_dpop_proof";
 
+    // RFC 8707 Resource Indicators for OAuth 2.0
+    public static final String INVALID_TARGET = "invalid_target";
+
     // Others
     public static final String INVALID_CLIENT = "invalid_client";
     public static final String INVALID_GRANT = "invalid_grant";

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -70,6 +70,7 @@ public interface Details {
     String AUDIENCE = "audience";
     String PERMISSION = "permission";
     String SCOPE = "scope";
+    String RESOURCE = "resource";
     String REQUESTED_ISSUER = "requested_issuer";
     String REQUESTED_SUBJECT = "requested_subject";
     String REQUESTED_TOKEN_TYPE = "requested_token_type";

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/CheckedResourceIndicators.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/CheckedResourceIndicators.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents the result of narrowing a set of requested resource indicators to supported resource indicators.
+ * 
+ * See {@link ResourceIndicatorsUtil#narrowResourceIndicators(KeycloakSession, ClientModel, AuthenticatedClientSessionModel, Set)}
+ */
+public class CheckedResourceIndicators {
+
+    /**
+     * Represents an empty result.
+     */
+    public static final CheckedResourceIndicators EMPTY = new CheckedResourceIndicators(Collections.emptySet(), Collections.emptySet());
+
+    private final Set<String> supportedResources;
+
+    private final Set<String> unsupportedResources;
+
+    private final Set<String> requestedResources;
+
+    /**
+     * Creates a new {@link CheckedResourceIndicators}.
+     * @param allowedResources the set of allowed resource indicators
+     * @param requestedResources the set of requested resource indicators.
+     */
+    public CheckedResourceIndicators(Set<String> allowedResources, Set<String> requestedResources) {
+        var supported = new HashSet<>(allowedResources);
+        supported.retainAll(requestedResources);
+        this.supportedResources = supported;
+        var unsupported = new HashSet<>(requestedResources);
+        unsupported.removeAll(allowedResources);
+        this.unsupportedResources = unsupported;
+        this.requestedResources = requestedResources;
+    }
+
+    public Set<String> getRequestedResources() {
+        return requestedResources;
+    }
+
+    public Set<String> getSupportedResources() {
+        return supportedResources;
+    }
+
+    public Set<String> getUnsupportedResources() {
+        return unsupportedResources;
+    }
+
+    public boolean hasSupportedResources() {
+        return supportedResources != null && !supportedResources.isEmpty();
+    }
+
+    public boolean hasUnsupportedResources() {
+        return unsupportedResources != null && !unsupportedResources.isEmpty();
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/DefaultOAuth2ResourceIndicatorResolver.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/DefaultOAuth2ResourceIndicatorResolver.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.store.StoreFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.CollectionUtil;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class DefaultOAuth2ResourceIndicatorResolver implements OAuth2ResourceIndicatorResolver {
+
+    /**
+     * A resource type to denote OAuth 2.0 Resource Indicator resource definitions.
+     */
+    public static final String KEYCLOAK_RESOURCE_INDICATOR_TYPE = "urn:keycloak:oauth2:resource-indicator";
+
+    protected final KeycloakSession session;
+
+    public DefaultOAuth2ResourceIndicatorResolver(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public ClientModel findClientByResourceIndicator(String resourceIndicator) {
+        return null;
+    }
+
+    @Override
+    public Set<String> narrowResourceIndicators(ClientModel client, Set<String> resourceIndicatorCandidates) {
+
+        Set<String> allowedResources = findAllowedResourceIndicators(client);
+        if (allowedResources.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        // Only allow explicitly allowed resources on this client.
+        Set<String> checkedAllowedResources = new LinkedHashSet<>();
+        for (String allowedResource : allowedResources) {
+            URI allowedResourceUri = URI.create(allowedResource).normalize();
+
+            for (String candidate : resourceIndicatorCandidates) {
+                URI candidateUri = URI.create(candidate).normalize();
+
+                if (!Objects.equals(candidateUri.getScheme(), allowedResourceUri.getScheme())) {
+                    continue;
+                }
+
+                if (!Objects.equals(candidateUri.getHost(), allowedResourceUri.getHost())) {
+                    continue;
+                }
+
+                if (candidateUri.getPort() != allowedResourceUri.getPort()) {
+                    continue;
+                }
+
+                if (!Objects.equals(candidateUri.getAuthority(), allowedResourceUri.getAuthority())) {
+                    continue;
+                }
+
+                if (!Objects.equals(candidateUri.getPath(), allowedResourceUri.getPath())) {
+                    continue;
+                }
+
+                checkedAllowedResources.add(candidate);
+            }
+        }
+
+        return checkedAllowedResources;
+    }
+
+    /**
+     * Returns the set of allowed resource indicators for the given {@link ClientModel}.
+     *
+     * @param client
+     * @return
+     */
+    protected Set<String> findAllowedResourceIndicators(ClientModel client) {
+
+        if (!Profile.isFeatureEnabled(Profile.Feature.AUTHORIZATION)) {
+            return Collections.emptySet();
+        }
+
+        AuthorizationProvider authzProvider = session.getProvider(AuthorizationProvider.class);
+        StoreFactory storeFactory = authzProvider.getStoreFactory();
+
+        ResourceServer resourceServer = lookupResourceServer(client, storeFactory);
+        if (resourceServer == null) {
+            // no resource server definition found for the given client
+            return Collections.emptySet();
+        }
+
+        List<Resource> resources = getResources(storeFactory, resourceServer);
+        if (CollectionUtil.isEmpty(resources)) {
+            // no resource definitions found for the given client / resource server
+            return Collections.emptySet();
+        }
+
+        Set<String> allowedResources = new HashSet<>();
+        for (Resource resource : resources) {
+            allowedResources.addAll(resource.getUris());
+        }
+
+        return allowedResources;
+    }
+
+    protected List<Resource> getResources(StoreFactory storeFactory, ResourceServer resourceServer) {
+        return storeFactory.getResourceStore().findByType(resourceServer, KEYCLOAK_RESOURCE_INDICATOR_TYPE);
+    }
+
+    protected ResourceServer lookupResourceServer(ClientModel client, StoreFactory storeFactory) {
+        return storeFactory.getResourceServerStore().findByClient(client);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/DefaultOAuth2ResourceIndicatorResolverFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/DefaultOAuth2ResourceIndicatorResolverFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.keycloak.models.KeycloakSession;
+
+public class DefaultOAuth2ResourceIndicatorResolverFactory implements OAuth2ResourceIndicatorResolverFactory {
+
+    public static final String PROVIDER_ID = "default";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public OAuth2ResourceIndicatorResolver create(KeycloakSession session) {
+        return new DefaultOAuth2ResourceIndicatorResolver(session);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/OAuth2ResourceIndicatorResolver.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/OAuth2ResourceIndicatorResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.provider.Provider;
+
+import java.util.Set;
+
+/**
+ * Provider to customize OAuth2 Resource Indicators resolving.
+ *
+ * @link <a href="https://www.rfc-editor.org/rfc/rfc8707">RFC 8707 OAuth2 Resource Indicators</a>
+ */
+public interface OAuth2ResourceIndicatorResolver extends Provider {
+
+    /**
+     * Returns a client associated with the given {@code resourceIndicator} or {@literal null} if no client could be found.
+     * @param resourceIndicator
+     * @return client model
+     */
+    ClientModel findClientByResourceIndicator(String resourceIndicator);
+
+    /**
+     * Filters the given resource indicators to the supported resource indicators by the given {@link ClientModel client}.
+     *
+     * @param client client to find the resource indicators
+     * @param resourceIndicatorCandidates resource indicators to check
+     *
+     * @return Set of the resource indicators narrowed down to resource indicators that are supported by the given client.
+     */
+    Set<String> narrowResourceIndicators(ClientModel client, Set<String> resourceIndicatorCandidates);
+
+    @Override
+    default void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/OAuth2ResourceIndicatorResolverFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/OAuth2ResourceIndicatorResolverFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderFactory;
+
+/**
+ * Factory for {@link OAuth2ResourceIndicatorResolver OAuth2ResourceIndicatorsProvider's}.
+ */
+public interface OAuth2ResourceIndicatorResolverFactory extends ProviderFactory<OAuth2ResourceIndicatorResolver> {
+
+    @Override
+    default void init(Config.Scope config) {
+    }
+
+    @Override
+    default void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    default void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/OAuth2ResourceIndicatorResolverSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/OAuth2ResourceIndicatorResolverSpi.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+/**
+ * SPI for customizing RFC 8707 OAuth2 Resource Indicators lookup.
+ */
+public class OAuth2ResourceIndicatorResolverSpi implements Spi {
+
+    @Override
+    public boolean isInternal() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "resource-indicator-resolver";
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return OAuth2ResourceIndicatorResolver.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return OAuth2ResourceIndicatorResolverFactory.class;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/ResourceIndicatorsUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/resourceindicators/ResourceIndicatorsUtil.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oauth2.resourceindicators;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Helpers for RFC 8707 OAuth2 Resource Indicators support.
+ *
+ * @link <a href="https://www.rfc-editor.org/rfc/rfc8707">RFC 8707 OAuth2 Resource Indicators</a>
+ */
+public class ResourceIndicatorsUtil {
+
+    private static final Logger LOG = Logger.getLogger(CheckedResourceIndicators.class);
+
+    /**
+     * clients can use the OAUTH_2_RESOURCE_INDICATORS_PROVIDER_ATTRIBUTE client attribute to customize the resource indicator to use
+     */
+    public static final String OAUTH_2_RESOURCE_INDICATORS_PROVIDER_ATTRIBUTE = "oauth2.resource-indicators-provider";
+
+    /**
+     * Encodes the given resource indicators to a string that can be stored in the client session.
+     *
+     * @param indicators
+     * @return
+     */
+    public static String encodeResourceIndicators(Set<String> indicators) {
+        return String.join(Constants.CFG_DELIMITER, indicators);
+    }
+
+    /**
+     * Decodes the given string from the client session into a Set of resource indicators.
+     *
+     * @param encodedIndicators
+     * @return
+     */
+    public static Set<String> decodeResourceIndicators(String encodedIndicators) {
+        if (encodedIndicators == null) {
+            return Collections.emptySet();
+        }
+        return Set.of(Constants.CFG_DELIMITER_PATTERN.split(encodedIndicators));
+    }
+
+    /**
+     * See: https://datatracker.ietf.org/doc/html/rfc8693#section-2.1
+     * @param resourceIndicatorUri
+     * @return
+     */
+    public static boolean isValidResourceIndicatorUri(String resourceIndicatorUri) {
+        try {
+            var uri = URI.create(resourceIndicatorUri);
+
+            // check for generic URI
+            if (uri.getScheme() == null) {
+                return false;
+            }
+            if (uri.getHost() == null) {
+                return false;
+            }
+
+            // Must be absolute URI
+            if (!uri.isAbsolute()) {
+                return false;
+            }
+            // Must NOT include a fragment
+            if (uri.getFragment() != null) {
+                return false;
+            }
+
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Filters the given resource indicators to the supported resource indicators by the given {@link ClientModel client} in the context of the current {@link AuthenticatedClientSessionModel client session}.
+     *
+     * @param client             the client that provides the resource indicators
+     * @param clientSession      may be {@literal null} for the initial request
+     * @param resourceIndicatorCandidates the requested resource indicators
+     * @return Set of the resource indicators that are supported by the given client.
+     */
+    public static CheckedResourceIndicators narrowResourceIndicators(KeycloakSession session, ClientModel client,
+                                                                     AuthenticatedClientSessionModel clientSession, Set<String> resourceIndicatorCandidates) {
+
+        var provider = resolveProvider(session, client);
+        if (provider == null) {
+            return CheckedResourceIndicators.EMPTY;
+        }
+
+        if (clientSession == null || clientSession.getNote(OAuth2Constants.RESOURCE) == null) {
+            // This is the initial request, check if client allows the given resource indicator
+            Set<String> supported = provider.narrowResourceIndicators(client, resourceIndicatorCandidates);
+            return new CheckedResourceIndicators(supported, resourceIndicatorCandidates);
+        }
+
+        // this is a subsequent request, check if the given resource indicator was already added to client session
+        String encodedClientResourceIndicators = clientSession.getNote(OAuth2Constants.RESOURCE);
+
+        // extract already filtered resource indicators that were stored during initial request
+        Set<String> initiallyGrantedResourceIndicators = ResourceIndicatorsUtil.decodeResourceIndicators(encodedClientResourceIndicators);
+        return new CheckedResourceIndicators(initiallyGrantedResourceIndicators, resourceIndicatorCandidates);
+    }
+
+    private static OAuth2ResourceIndicatorResolver resolveProvider(KeycloakSession session, ClientModel client) {
+
+        // check if the current client wants to use a custom provider implementation
+        String providerId = client.getAttribute(OAUTH_2_RESOURCE_INDICATORS_PROVIDER_ATTRIBUTE);
+        if (providerId == null) {
+            // fallback to the default provider
+            providerId = DefaultOAuth2ResourceIndicatorResolverFactory.PROVIDER_ID;
+        }
+
+        var provider = session.getProvider(OAuth2ResourceIndicatorResolver.class, providerId);
+        if (provider == null) {
+            LOG.debugf("No resource indicators provider found. providerId=%s", providerId);
+            return null;
+        }
+
+        LOG.debugf("Found resource indicators provider. providerId=%s", providerId);
+        return provider;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -33,6 +33,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.AuthorizationEndpointBase;
+import org.keycloak.protocol.oauth2.resourceindicators.ResourceIndicatorsUtil;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
@@ -187,6 +188,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             checker.checkValidScope();
             checker.checkOIDCParams();
             checker.checkPKCEParams();
+            checker.checkResourceIndicatorParams();
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
             return redirectErrorToClient(parsedResponseMode, ex.getError(), ex.getErrorDescription());
         }
@@ -336,6 +338,11 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         authenticationSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, request.getResponseType());
         authenticationSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, request.getRedirectUriParam());
         authenticationSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+
+        if (request.getResources() != null && !request.getResources().isEmpty()) {
+            // encode validated requested OAuth Resource Indicators to authentication session for validation during token / refresh requests
+            authenticationSession.setClientNote(OAuth2Constants.RESOURCE, ResourceIndicatorsUtil.encodeResourceIndicators(request.getResources()));
+        }
 
         performActionOnParameters(request, (paramName, paramValue) -> {if (paramValue != null) authenticationSession.setClientNote(paramName, paramValue);});
         if (request.getMaxAge() != null) authenticationSession.setClientNote(OIDCLoginProtocol.MAX_AGE_PARAM, String.valueOf(request.getMaxAge()));

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -18,6 +18,7 @@
 
 package org.keycloak.protocol.oidc.endpoints;
 
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,6 +35,8 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oauth2.resourceindicators.CheckedResourceIndicators;
+import org.keycloak.protocol.oauth2.resourceindicators.ResourceIndicatorsUtil;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -396,6 +399,21 @@ public class AuthorizationEndpointChecker {
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
+        }
+    }
+
+    public void checkResourceIndicatorParams() throws AuthorizationCheckException{
+        Set<String> requestedResourceIndicators = request.getResources();
+        if (requestedResourceIndicators == null || requestedResourceIndicators.isEmpty()) {
+            return;
+        }
+
+        // explicit resource indicates were provided in the authorize request, check if all resource identifiers are allowed
+        CheckedResourceIndicators checkedResourceIndicators = ResourceIndicatorsUtil.narrowResourceIndicators(
+                session, client, null, requestedResourceIndicators);
+        if (checkedResourceIndicators.hasUnsupportedResources()) {
+            logger.debugf("Unsupported resource indicator(s) '%s'", checkedResourceIndicators.getUnsupportedResources());
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_TARGET, "Requested resource not supported");
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
@@ -22,6 +22,7 @@ import org.keycloak.rar.AuthorizationRequestContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -54,6 +55,8 @@ public class AuthorizationEndpointRequest {
     String dpopJkt;
 
     String acr;
+
+    Set<String> resources;
 
     AuthorizationRequestContext authorizationRequestContext;
 
@@ -161,5 +164,13 @@ public class AuthorizationEndpointRequest {
 
     public void setAuthorizationRequestContext(AuthorizationRequestContext authorizationRequestContext) {
         this.authorizationRequestContext = authorizationRequestContext;
+    }
+
+    public Set<String> getResources() {
+        return resources;
+    }
+
+    public void setResources(Set<String> resources) {
+        this.resources = resources;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointQueryStringParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointQueryStringParser.java
@@ -19,11 +19,11 @@ package org.keycloak.protocol.oidc.endpoints.request;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 
 /**
  * Parse the parameters from request queryString
@@ -55,6 +55,15 @@ public class AuthzEndpointQueryStringParser extends AuthzEndpointRequestParser {
         }
 
         super.validateResponseTypeParameter(responseTypeParameter, request);
+    }
+
+    @Override
+    protected Set<String> getMultiParameter(String paramName) {
+        List<String> strings = requestParams.get(paramName);
+        if (strings == null) {
+            return null;
+        }
+        return Set.copyOf(strings);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
@@ -18,6 +18,7 @@ package org.keycloak.protocol.oidc.endpoints.request;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
@@ -65,6 +66,29 @@ public class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser
         } else {
             return val.toString();
         }
+    }
+
+    @Override
+    protected Set<String> getMultiParameter(String paramName) {
+
+        JsonNode paramNode = this.requestParams.get(paramName);
+        if (paramNode == null) {
+            return null;
+        }
+
+        if (paramNode.isTextual()) {
+            return Set.of(paramNode.asText());
+        }
+
+        if (paramNode.isArray()) {
+            Set<String> result = new LinkedHashSet<>();
+            for(int i = 0; i < paramNode.size(); i++) {
+                result.add(paramNode.get(i).asText());
+            }
+            return result;
+        }
+
+        return null;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
@@ -30,6 +30,7 @@ import org.keycloak.services.ErrorResponseException;
 
 import jakarta.ws.rs.core.Response;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -68,38 +69,54 @@ public abstract class AuthzEndpointRequestParser {
     public static final String AUTHZ_REQUEST_OBJECT = "ParsedRequestObject";
     public static final String AUTHZ_REQUEST_OBJECT_ENCRYPTED = "EncryptedRequestObject";
 
-    /** Set of known protocol GET params not to be stored into additionalReqParams} */
-    public static final Set<String> KNOWN_REQ_PARAMS = new HashSet<>();
+    /**
+     * Set of known protocol request params that support repeated parameters.
+     */
+    public static final Set<String> KNOWN_MULTI_PARAMS;
+
+    /** Set of known protocol GET params not to be stored into {@code additionalReqParams} */
+    public static final Set<String> KNOWN_REQ_PARAMS;
     static {
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.CLIENT_ID_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.REDIRECT_URI_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.STATE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.SCOPE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.LOGIN_HINT_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.PROMPT_PARAM);
-        KNOWN_REQ_PARAMS.add(AdapterConstants.KC_IDP_HINT);
-        KNOWN_REQ_PARAMS.add(Constants.KC_ACTION);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.NONCE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.MAX_AGE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.UI_LOCALES_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.REQUEST_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.REQUEST_URI_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.CLAIMS_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.ACR_PARAM);
+        Set<String> knownReqParams = new HashSet<>();
+        knownReqParams.add(OIDCLoginProtocol.CLIENT_ID_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.REDIRECT_URI_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.STATE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.SCOPE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.LOGIN_HINT_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.PROMPT_PARAM);
+        knownReqParams.add(AdapterConstants.KC_IDP_HINT);
+        knownReqParams.add(Constants.KC_ACTION);
+        knownReqParams.add(OIDCLoginProtocol.NONCE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.MAX_AGE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.UI_LOCALES_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.REQUEST_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.REQUEST_URI_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.CLAIMS_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.ACR_PARAM);
 
         // https://tools.ietf.org/html/rfc7636#section-6.1
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.CODE_CHALLENGE_PARAM);
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.CODE_CHALLENGE_PARAM);
+        knownReqParams.add(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM);
 
         // https://datatracker.ietf.org/doc/html/rfc9449#section-12.3
-        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.DPOP_JKT);
+        knownReqParams.add(OIDCLoginProtocol.DPOP_JKT);
 
         // Those are not OAuth/OIDC parameters, but they should never be added to the additionalRequestParameters
-        KNOWN_REQ_PARAMS.add(OAuth2Constants.CLIENT_ASSERTION_TYPE);
-        KNOWN_REQ_PARAMS.add(OAuth2Constants.CLIENT_ASSERTION);
-        KNOWN_REQ_PARAMS.add(OAuth2Constants.CLIENT_SECRET);
+        knownReqParams.add(OAuth2Constants.CLIENT_ASSERTION_TYPE);
+        knownReqParams.add(OAuth2Constants.CLIENT_ASSERTION);
+        knownReqParams.add(OAuth2Constants.CLIENT_SECRET);
+
+        // https://www.rfc-editor.org/rfc/rfc8707#section-2
+        knownReqParams.add(OAuth2Constants.RESOURCE);
+
+        KNOWN_REQ_PARAMS = Collections.unmodifiableSet(knownReqParams);
+
+        Set<String> knownMultiReqParams= new HashSet<>();
+        knownMultiReqParams.add(OAuth2Constants.RESOURCE);
+
+        KNOWN_MULTI_PARAMS = Collections.unmodifiableSet(knownMultiReqParams);
     }
 
     protected AuthzEndpointRequestParser(KeycloakSession keycloakSession) {
@@ -146,6 +163,8 @@ public abstract class AuthzEndpointRequestParser {
         request.codeChallengeMethod = replaceIfNotNull(request.codeChallengeMethod, getParameter(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM));
 
         request.dpopJkt = replaceIfNotNull(request.dpopJkt, getParameter(OIDCLoginProtocol.DPOP_JKT));
+
+        request.resources = replaceIfNotNull(request.resources, getMultiParameter(OAuth2Constants.RESOURCE));
 
         extractAdditionalReqParams(request.additionalReqParams);
     }
@@ -219,6 +238,8 @@ public abstract class AuthzEndpointRequestParser {
     protected <T> T replaceIfNotNull(T previousVal, T newVal) {
         return newVal==null ? previousVal : newVal;
     }
+
+    protected abstract Set<String> getMultiParameter(String paramName);
 
     protected abstract String getParameter(String paramName);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -19,6 +19,8 @@ package org.keycloak.protocol.oidc.grants;
 
 import jakarta.ws.rs.core.Response;
 
+import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -35,6 +37,8 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oauth2.resourceindicators.CheckedResourceIndicators;
+import org.keycloak.protocol.oauth2.resourceindicators.ResourceIndicatorsUtil;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
@@ -206,6 +210,8 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
 
         // Set nonce as an attribute in the ClientSessionContext. Will be used for the token generation
         clientSessionCtx.setAttribute(OIDCLoginProtocol.NONCE_PARAM, codeData.getNonce());
+
+        updateResourceIndicatorsInClientSession(clientSessionCtx);
 
         return createTokenResponse(user, userSession, clientSessionCtx, scopeParam, true, s -> {return new TokenResponseContext(formParams, parseResult, clientSessionCtx, s);});
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -141,6 +141,8 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
 
         updateUserSessionFromClientAuth(userSession);
 
+        updateResourceIndicatorsInClientSession(clientSessionCtx);
+
         TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(realm, client, event, session, userSession, clientSessionCtx)
                 .generateAccessToken();
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
@@ -30,12 +30,15 @@ import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenRefreshContext;
 import org.keycloak.services.clientpolicy.context.TokenRefreshResponseContext;
 import org.keycloak.services.util.MtlsHoKTokenUtil;
+
+import java.util.Set;
 
 /**
  * OAuth 2.0 Refresh Token Grant
@@ -116,4 +119,8 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
         return EventType.REFRESH_TOKEN;
     }
 
+    @Override
+    public Set<String> getSupportedMultivaluedRequestParameters() {
+        return AuthzEndpointRequestParser.KNOWN_MULTI_PARAMS;
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
@@ -37,6 +37,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.AuthenticationFlowResolver;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.Urls;
@@ -48,6 +49,8 @@ import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
+
+import java.util.Set;
 
 /**
  * OAuth 2.0 Resource Owner Password Credentials Grant
@@ -136,6 +139,7 @@ public class ResourceOwnerPasswordCredentialsGrantType extends OAuth2GrantTypeBa
         clientSessionCtx.setAttribute(Constants.GRANT_TYPE, context.getGrantType());
         UserSessionModel userSession = processor.getUserSession();
         updateUserSessionFromClientAuth(userSession);
+        updateResourceIndicatorsInClientSession(clientSessionCtx);
 
         TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager
             .responseBuilder(realm, client, event, session, userSession, clientSessionCtx).generateAccessToken();
@@ -178,4 +182,8 @@ public class ResourceOwnerPasswordCredentialsGrantType extends OAuth2GrantTypeBa
         return EventType.LOGIN;
     }
 
+    @Override
+    public Set<String> getSupportedMultivaluedRequestParameters() {
+        return AuthzEndpointRequestParser.KNOWN_MULTI_PARAMS;
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ResourceIndicatorMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ResourceIndicatorMapper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.mappers;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.representations.IDToken;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adds the allowed requested resources to the {@code aud} claim of an access token.
+ *
+ * @author <a href="mailto:thomas.darimont@gmail.com">Thomas Darimont</a>
+ */
+public class ResourceIndicatorMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, TokenIntrospectionTokenMapper {
+
+    public static final String PROVIDER_ID = "oidc-resource-indicator-mapper";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    static {
+        List<ProviderConfigProperty> props = ProviderConfigurationBuilder.create()
+//                .property()
+//                .name(RESOURCES_PROPERTY)
+//                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+//                .label(RESOURCES_LABEL)
+//                .helpText(RESOURCES_HELP_TEXT)
+//                .add()
+                .build();
+
+        configProperties.addAll(props);
+        OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, ResourceIndicatorMapper.class);
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Resource Indicators";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Adds requested OAuth2 Resource Indicators to audience claim.";
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
+
+        Set<?> resourceIndicatorsToAdd = clientSessionCtx.getAttribute(OAuth2Constants.RESOURCE, Set.class);
+        if (resourceIndicatorsToAdd == null || resourceIndicatorsToAdd.isEmpty()) {
+            return;
+        }
+
+        // remove all resource indicators that are already contained in the audience.
+        String[] audience = token.getAudience();
+        if (audience != null && audience.length > 0) {
+            resourceIndicatorsToAdd.removeAll(Set.of(audience));
+        }
+
+        for (Object resourceIndicator : resourceIndicatorsToAdd) {
+            token.addAudience(String.valueOf(resourceIndicator));
+        }
+    }
+
+    public static ProtocolMapperModel create(String name, boolean accessToken, boolean introspectionEndpoint) {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+        mapper.setName(name);
+        mapper.setProtocolMapper(PROVIDER_ID);
+        mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        Map<String, String> config = new HashMap<>();
+        if (accessToken) {
+            config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
+        }
+        if (introspectionEndpoint) {
+            config.put(OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION, "true");
+        }
+        mapper.setConfig(config);
+        return mapper;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -25,12 +25,14 @@ import org.keycloak.common.Profile;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.headers.SecurityHeadersProvider;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
+import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.protocol.oidc.par.ParResponse;
 import org.keycloak.protocol.oidc.par.clientpolicy.context.PushedAuthorizationRequestContext;
 import org.keycloak.protocol.oidc.par.endpoints.request.ParEndpointRequestParserProcessor;
@@ -209,6 +211,11 @@ public class ParEndpoint extends AbstractParEndpoint {
             if (parameterValues.isEmpty()) {
                 // We emit the empty parameter as a marker, but only if it does not exist yet. This prevents "accidental" value overrides.
                 params.putIfAbsent(parameterName, null);
+            } else if (AuthzEndpointRequestParser.KNOWN_MULTI_PARAMS.contains(parameterName)) {
+                // Some parameters can be used multiple times, e.g. the resource param from
+                // RFC 8707 Resource Indicators for OAuth 2.0
+                String encodedParams = String.join(Constants.CFG_DELIMITER, parameterValues);
+                params.put(parameterName, encodedParams);
             } else {
                 // We flatten the MultivaluedMap values list by emitting the first value only.
                 // We override potential empty parameters that were added to the params map before.

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.SingleUseObjectProvider;
@@ -101,6 +102,18 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
     protected Integer getIntParameter(String paramName) {
         String paramVal = requestParams.get(paramName);
         return paramVal == null ? null : Integer.valueOf(paramVal);
+    }
+
+    @Override
+    protected Set<String> getMultiParameter(String paramName) {
+        String multiParamString = this.requestParams.get(paramName);
+
+        if (multiParamString == null) {
+            return null;
+        }
+
+        String[] params = Constants.CFG_DELIMITER_PATTERN.split(multiParamString);
+        return Set.of(params);
     }
 
     public String getInvalidRequestMessage() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -238,6 +238,7 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
                         "Scope offline_access not allowed for token exchange", Response.Status.BAD_REQUEST);
             }
 
+            validateTargetResources(clientSessionCtx);
             updateUserSessionFromClientAuth(targetUserSession);
 
             if (params.getAudience() != null && !targetAudienceClients.isEmpty()) {

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -58,4 +58,5 @@ org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCIssuedAtTimeClaimMapper
 org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCGeneratedIdMapper
 org.keycloak.protocol.oidc.mappers.SessionStateMapper
 org.keycloak.protocol.oidc.mappers.SubMapper
+org.keycloak.protocol.oidc.mappers.ResourceIndicatorMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oauth2.resourceindicators.OAuth2ResourceIndicatorResolverFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oauth2.resourceindicators.OAuth2ResourceIndicatorResolverFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2025 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.protocol.oauth2.resourceindicators.DefaultOAuth2ResourceIndicatorResolverFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -31,6 +31,7 @@ org.keycloak.protocol.oidc.grants.ciba.resolvers.CIBALoginUserResolverSpi
 org.keycloak.protocol.oidc.rar.AuthorizationRequestParserSpi
 org.keycloak.services.resources.admin.ext.AdminRealmResourceSpi
 org.keycloak.theme.freemarker.FreeMarkerSPI
+org.keycloak.protocol.oauth2.resourceindicators.OAuth2ResourceIndicatorResolverSpi
 org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorSpi
 org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerSpi


### PR DESCRIPTION
Add support for [RFC 8707 OAuth2 Resource Indicators](https://www.rfc-editor.org/rfc/rfc8707) (#14355)

Discussion: https://github.com/keycloak/keycloak/discussions/35743

- Adds `ResourceIndicatorMapper` OIDC protocol mapper to manage the `aud` claim based on the `resource` parameter
- Make `AuthorizationEndpoint` and `TokenEndpoint` aware of `resource` parameter.
- Enhanced Authz request parsing to support repeated parameter (resource)
- Added `OAuth2ResourceIndicatorResolver` SPI to allow filtering of resource indicators and lookup associated clients for resource indicators

If the authorization request contains one or more resource parameters, those resource values are first checked against the list of allowed resource indicators for the given client. Allowed resource indicators are determined
via the `OAuth2ResourceIndicatorResolver` SPI.
If the resource indicators are legit for the client, the initially requested resource identifier set is stored in the client session. 
Token Requests / Token Refresh Requests can later request access tokens minted to support resource indicators in the `aud` claim based on the resource indicators that were initially requested.

Note that this allows users to dynamically extend or narrow down the `aud` claim based on the given resource identifiers in token / token refresh requests.

Fixes #14355

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>