### PR TITLE
Update start-keycloak-container.adoc to no longer mention quay.io

### DIFF
--- a/docs/guides/getting-started/templates/start-keycloak-container.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-container.adoc
@@ -4,7 +4,7 @@ From a terminal, enter the following command to start {project_name}:
 
 [source,bash,subs="attributes+"]
 ----
-{containerCommand} run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:{version} start-dev
+{containerCommand} run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin keycloak/keycloak:{version} start-dev
 ----
 
 This command starts {project_name} exposed on the local port 8080 and creates an initial admin user with the username `admin`


### PR DESCRIPTION
quay.io isn't the supported docker image, the last official update seems to have been 3 years ago. documentation referring to quay.io should be removed to avoid confusion.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
