### PR TITLE
Add client ID length validation

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -62,6 +62,7 @@ import org.keycloak.models.GroupProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
+import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleContainerModel;
@@ -786,6 +787,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
         if (id == null) {
             id = KeycloakModelUtils.generateId();
+        } else if (id.length() > ClientEntity.ID_MAX_LENGTH){
+            throw new ModelValidationException("Client ID must not exceed 36 characters");
         }
 
         if (clientId == null) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
@@ -60,8 +60,10 @@ import java.util.Set;
 })
 public class ClientEntity {
 
+    public static final int ID_MAX_LENGTH = 36;
+
     @Id
-    @Column(name="ID", length = 36)
+    @Column(name="ID", length = ID_MAX_LENGTH)
     @Access(AccessType.PROPERTY) // we do this because relationships often fetch id, but not entity.  This avoids an extra SQL
     private String id;
     @Nationalized

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -32,6 +32,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
@@ -223,6 +224,8 @@ public class ClientsResource {
             throw ErrorResponse.exists("Client " + rep.getClientId() + " already exists");
         } catch (ClientPolicyException cpe) {
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+        } catch (ModelValidationException e) {
+            throw new ErrorResponseException("validation error", e.getMessage(), Response.Status.BAD_REQUEST);
         }
         catch (ClientTypeException cte) {
             throw ErrorResponse.error(cte.getMessage(), cte.getParameters(), Response.Status.BAD_REQUEST);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -171,6 +171,23 @@ public class ClientTest extends AbstractAdminTest {
     }
 
     @Test
+    public void testInvalidLengthClientIdValidation() {
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setId("test-long-invalid-client-id-validation-400-bad-request");
+        rep.setClientId("invalid-client-id-app");
+        rep.setDescription("invalid-client-id-app description");
+        rep.setEnabled(true);
+        rep.setPublicClient(true);
+        try (Response response = realm.clients().create(rep)) {
+            if (response.getStatus() != 400) {
+                response.bufferEntity();
+                String body = response.readEntity(String.class);
+                fail("expect 400 Bad request response code but receive: " + response.getStatus() + "\n" + body);
+            }
+        }
+    }
+
+    @Test
     public void testInvalidUrlClientValidation() {
         testClientUriValidation("Root URL is not a valid URL",
                 "Base URL is not a valid URL",


### PR DESCRIPTION
Create client API response 500 status code if ID length exceed 36 characters and lead to monitoring system false alarm. Return a proper response code (~~403 Forbidden~~ 400 Bad request) instead of 500

Closes #35723

