### PR TITLE
Better caching for federated users

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/CacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/CacheManager.java
@@ -169,7 +169,7 @@ public abstract class CacheManager {
                 return;
             }
             if (rev.equals(object.getRevision())) {
-                cache.putForExternalRead(id, object);
+                put(id, object, lifespan);
                 return;
             }
             if (rev > object.getRevision()) { // revision is ahead, don't cache
@@ -178,8 +178,7 @@ public abstract class CacheManager {
             }
             // revisions cache has a lower value than the object.revision, so update revision and add it to cache
             revisions.put(id, object.getRevision());
-            if (lifespan < 0) cache.putForExternalRead(id, object);
-            else cache.putForExternalRead(id, object, lifespan, TimeUnit.MILLISECONDS);
+            put(id, object, lifespan);
         } finally {
             endRevisionBatch();
         }
@@ -195,6 +194,14 @@ public abstract class CacheManager {
         Iterator<Map.Entry<String, Revisioned>> it = getEntryIterator(predicate);
         while (it.hasNext()) {
             invalidations.add(it.next().getKey());
+        }
+    }
+
+    private void put(String id, Revisioned object, long lifespan) {
+        if (lifespan < 0) {
+            cache.putForExternalRead(id, object);
+        } else {
+            cache.putForExternalRead(id, object, lifespan, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
@@ -1386,6 +1386,103 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
     }
 
     @Test
+    public void testAlwaysReadValueFromLdapCached() throws Exception {
+        try {
+            // import user from the ldap johnkeycloak and cache it reading it by id
+            List<UserRepresentation> users = testRealm().users().search("johnkeycloak", true);
+            Assert.assertEquals(1, users.size());
+            UserRepresentation john = users.iterator().next();
+            Assert.assertEquals("Doe", john.getLastName());
+            john = testRealm().users().get(john.getId()).toRepresentation();
+            Assert.assertEquals("Doe", john.getLastName());
+
+            // modify the sn of the user directly in ldap
+            testingClient.server().run(session -> {
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                LDAPObject johnLdapObject = ctx.getLdapProvider().loadLDAPUserByUsername(ctx.getRealm(), "johnkeycloak");
+                johnLdapObject.setSingleAttribute(LDAPConstants.SN, "sn-modified");
+                ctx.getLdapProvider().getLdapIdentityStore().update(johnLdapObject);
+            });
+
+            // it's cached so it should be still the initial one
+            users = testRealm().users().search("johnkeycloak", true);
+            Assert.assertEquals(1, users.size());
+            john = users.iterator().next();
+            Assert.assertEquals("Doe", john.getLastName());
+            john = testRealm().users().get(john.getId()).toRepresentation();
+            Assert.assertEquals("Doe", john.getLastName());
+
+            // expire the cache which is 10 minutes
+            setTimeOffset(610);
+
+            // new sn should be present
+            users = testRealm().users().search("johnkeycloak", true);
+            Assert.assertEquals(1, users.size());
+            john = users.iterator().next();
+            Assert.assertEquals("sn-modified", john.getLastName());
+            john = testRealm().users().get(john.getId()).toRepresentation();
+            Assert.assertEquals("sn-modified", john.getLastName());
+        } finally {
+            // revert
+            testingClient.server().run(session -> {
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                LDAPObject johnLdapObject = ctx.getLdapProvider().loadLDAPUserByUsername(ctx.getRealm(), "johnkeycloak");
+                johnLdapObject.setSingleAttribute(LDAPConstants.SN, "Doe");
+                ctx.getLdapProvider().getLdapIdentityStore().update(johnLdapObject);
+            });
+        }
+    }
+
+    @Test
+    public void testAlwaysReadValueFromLdapNoCache() throws Exception {
+        // set to NO_CACHE
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ctx.getLdapModel().setCachePolicy(UserStorageProviderModel.CachePolicy.NO_CACHE);
+            appRealm.updateComponent(ctx.getLdapModel());
+        });
+
+        try {
+            // import user from the ldap johnkeycloak
+            List<UserRepresentation> users = testRealm().users().search("johnkeycloak", true);
+            Assert.assertEquals(1, users.size());
+            UserRepresentation john = users.iterator().next();
+            Assert.assertEquals("Doe", john.getLastName());
+            john = testRealm().users().get(john.getId()).toRepresentation();
+            Assert.assertEquals("Doe", john.getLastName());
+
+            // modify the sn of the user directly in ldap
+            testingClient.server().run(session -> {
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                RealmModel appRealm = ctx.getRealm();
+                LDAPObject johnLdapObject = ctx.getLdapProvider().loadLDAPUserByUsername(appRealm, "johnkeycloak");
+                johnLdapObject.setSingleAttribute(LDAPConstants.SN, "sn-modified");
+                ctx.getLdapProvider().getLdapIdentityStore().update(johnLdapObject);
+            });
+
+            // no cache, so it should be validated and new data received
+            users = testRealm().users().search("johnkeycloak", true);
+            Assert.assertEquals(1, users.size());
+            john = users.iterator().next();
+            Assert.assertEquals("sn-modified", john.getLastName());
+            john = testRealm().users().get(john.getId()).toRepresentation();
+            Assert.assertEquals("sn-modified", john.getLastName());
+        } finally {
+            // revert cache to default max-liespan setting
+            testingClient.server().run(session -> {
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                LDAPObject johnLdapObject = ctx.getLdapProvider().loadLDAPUserByUsername(ctx.getRealm(), "johnkeycloak");
+                johnLdapObject.setSingleAttribute(LDAPConstants.SN, "Doe");
+                ctx.getLdapProvider().getLdapIdentityStore().update(johnLdapObject);
+                ctx.getLdapModel().setCachePolicy(UserStorageProviderModel.CachePolicy.MAX_LIFESPAN);
+                ctx.getLdapModel().setMaxLifespan(600000);
+                ctx.getRealm().updateComponent(ctx.getLdapModel());
+            });
+        }
+    }
+
+    @Test
     public void testEmailVerifiedFromImport(){
 
         // Test trusted email option


### PR DESCRIPTION
Closes #35637

The PR performs mainly two changes in the infinispan caching to make it consistent with user federation providers (like ldap):

1. The local `UserStorageManager` (used in ldap when import users is ON) does not enforce the validation if the returned user is cached. The cached user will be valid for the configured cache time and will be validated from ldap when it needs to be refreshed (cache time is expired). The users were already cached (not validated) for other methods like `getUserById` or `getUserByUsername` so I think it's OK.
2. The infinispan impl also adds the users returned by the `searchForUserStream` methods into the cache. The DB implementation already performs this, so we are already doing this in general. This point makes a little change in the `addRevisioned` method in `CacheManager` (`put` is used instead of `putForExternalRead`, because the latter only adds the user if not present like  `putIfAbsent`). This change is to cache the new user refreshed from the external storage (we can also return the cached one, but I think that this makes more sense, the user is refreshed from the provider so it's up to date). As this cache is always a local cache, I think it's OK and it's not a performance drawback. 

The change (in theory) improves the search for users in ldap in two ways. When importing into the DB, the search for users does not validate the cached users (avoiding the ldap access for each user if cached). When not importing, the search in the ldap caches the returned users from ldap for other operations. It can have a performance drawback too, because there are some minor changes. So probably we need to test ldap performance in general. Is there some tests/CI we can check for this?

It's a draft because I don't know if we want to follow this path.

@mposolda @pedroigor @sguilhen WDYT? 
