### PR TITLE
Other clients but Account-Management can link account

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1176,7 +1176,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     private Response checkAccountManagementFailedLinking(AuthenticationSessionModel authSession, String error, Object... parameters) {
         UserSessionModel userSession = new AuthenticationSessionManager(session).getUserSession(authSession);
-        if (userSession != null && authSession.getClient() != null && authSession.getClient().getClientId().equals(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID)) {
+        if (userSession != null && authSession.getClient() != null) {
 
             this.event.event(EventType.FEDERATED_IDENTITY_LINK);
             UserModel user = userSession.getUser();


### PR DESCRIPTION
This PR is an attempt to fix [#12309](https://github.com/keycloak/keycloak/issues/12309).
Currently, only the client with the client-id "account" seems to be considered able to link accounts. But other clients can initiate the account linking aswell and therfor should be considered when handling linking errors.
So I removed the client-id condition...
