### PR TITLE
Update messages_ko.properties

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ko.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ko.properties
@@ -80,7 +80,7 @@ recaptchaFailed=잘못된 Recaptcha
 recaptchaNotConfigured=Recaptcha가 필요하지만 구성되지 않았습니다
 consentDenied=동의 거부됨.
 
-noAccount=새 사용자?
+noAccount=계정이 없으신가요?
 username=사용자 이름
 usernameOrEmail=사용자 이름 또는 이메일
 firstName=이름


### PR DESCRIPTION
Closes #36996

Updated the key-value pair "noAccount=새 사용자?" to "noAccount=계정이 없으신가요?" for improved politeness and fluency.

"새 사용자?" is a literal translation of "New user?" and "계정이 없으신가요?" means "Don't have an account?".

In Korean language, it is more natural to use "계정이 없으신가요?".

Although this is a minor change, it is important for the tone and clarity of the message, particularly as it appears on the login page.