### PR TITLE
fix: using regex to expand local ipv6 matching (#35736)

### DIFF
--- a/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
+++ b/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
@@ -11,6 +11,8 @@ import java.util.regex.Pattern;
 public class SecureContextResolver {
 
     private static final Pattern LOCALHOST_IPV4 = Pattern.compile("127.\\d{1,3}.\\d{1,3}.\\d{1,3}");
+    private static final Pattern LOCALHOST_IPV6 = Pattern.compile("\\[(0{0,4}:){1,7}0{0,3}1\\]");
+
 
     /**
      * Determines if a session is within a 'secure context', meaning its origin is considered potentially trustworthy by user-agents.
@@ -78,15 +80,15 @@ public class SecureContextResolver {
             return false;
         }
         // The host matches a CIDR notation of ::1/128
-        if (address.equals("[::1]") || address.equals("[0000:0000:0000:0000:0000:0000:0000:0001]")) {
-            return true;
+        if (address.startsWith("[")) {
+            return LOCALHOST_IPV6.matcher(address).matches();
         }
 
         // The host matches a CIDR notation of 127.0.0.0/8
         if (LOCALHOST_IPV4.matcher(address).matches()) {
             return true;
         }
-        
+
         return false;
     }
 }

--- a/services/src/test/java/org/keycloak/utils/SecureContextResolverTest.java
+++ b/services/src/test/java/org/keycloak/utils/SecureContextResolverTest.java
@@ -47,6 +47,8 @@ public class SecureContextResolverTest {
     public void testIp6() {
         assertSecureContext("http://[::1]", true);
         assertSecureContext("http://[0000:0000:0000:0000:0000:0000:0000:0001]", true);
+        assertSecureContext("http://[0:0:0:0:0:0:0:1]", true);
+        assertSecureContext("http://[0:0:0::1]", true);
         assertSecureContext("http://[::2]", false);
         assertSecureContext("http://[2001:0000:130F:0000:0000:09C0:876A:130B]", false);
         assertSecureContext("http://::1", false);
@@ -63,7 +65,7 @@ public class SecureContextResolverTest {
         assertSecureContext("http://test.localhostn", false);
         assertSecureContext("http://test.localhost.not", false);
     }
-    
+
     @Test
     public void testIsLocalhost() {
         assertTrue(SecureContextResolver.isLocalAddress("127.0.0.1"));


### PR DESCRIPTION
closes: #35675

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit 80890737d48a40d790d7594989c3f6eae567c442)
