### PR TITLE
Bugfix: add package.json to exports to solve ERR_PACKAGE_PATH_NOT_EXP…

### DIFF
--- a/js/libs/keycloak-js/package.json
+++ b/js/libs/keycloak-js/package.json
@@ -11,7 +11,8 @@
     "./authz": {
       "types": "./lib/keycloak-authz.d.ts",
       "default": "./lib/keycloak-authz.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "lib"


### PR DESCRIPTION
Building microfrontend architecture using module federation fails due to
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports"

add package.json to exports to solve ERR_PACKAGE_PATH_NOT_EXPORTED issue
![Screenshot 2024-12-10 at 10 03 10 PM](https://github.com/user-attachments/assets/0f5338f5-864c-48db-a301-f4015fc9a337)