### PR TITLE
Improve the note about group synchronization in sssd

### DIFF
--- a/docs/documentation/server_admin/topics/user-federation/sssd.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/sssd.adoc
@@ -13,7 +13,7 @@ image:images/keycloak-sssd-freeipa-integration-overview.png[]
 
 [NOTE]
 ====
-{project_name} registers groups and roles automatically but does not synchronize them. Any changes made by the {project_name} administrator in {project_name} do not synchronize with SSSD.
+{project_name} registers groups and roles automatically but does not synchronize them. The groups are imported from SSSD the first time the user is accessed and then they are managed entirely inside {project_name}. Any changes made by the administrator in {project_name} do not synchronize with SSSD or vice-versa.
 ====
 
 ==== FreeIPA/IdM server


### PR DESCRIPTION
Closes #35643

Just a minor change in the sssd documentation to clarify the group functionality. Currently the provider just imports the SSSD groups the first time. Then groups are managed only in keycloak (no further synchronization). This is causing some confusion. We don't want to spend time improving this provider as the new ipa-tuura implementation is being developed.
