### PR TITLE
Keycloak arquillian testsuite not working with the default embedded u…

### DIFF
--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/JsonConfigProviderFactory.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/JsonConfigProviderFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.services.util;
+package org.keycloak.testsuite;
 
 import org.keycloak.config.ConfigProviderFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,9 +28,10 @@ import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.common.util.SystemEnvProperties;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.util.JsonConfigProvider;
 import org.keycloak.util.JsonSerialization;
 
-public abstract class JsonConfigProviderFactory implements ConfigProviderFactory {
+public class JsonConfigProviderFactory implements ConfigProviderFactory {
 
     private static final Logger LOG = Logger.getLogger(JsonConfigProviderFactory.class);
 


### PR DESCRIPTION
…ndertow

closes #35802

PR is moving the unused class `JsonConfigProviderFactory` directly from keycloak-services into the embedded undertow module. It is needed as it is referenced from [META-INF/services file](https://github.com/keycloak/keycloak/blob/main/testsuite/utils/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory), which was now missing due the changes in https://github.com/keycloak/keycloak/commit/5c901016e7ebdf5c5eebe2aea948a03df172de03#diff-7f2f15dbc5b7f3411286e328eef100d4247bf7cfe0317bde84c187a64f4be085
