### PR TITLE
When using the token revocation endpoint with refresh-token, only particular clientSession related to given refresh token should be terminated closes #35486

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -249,16 +249,16 @@ public class TokenRevocationEndpoint {
             if (userSession != null) {
                 new UserSessionManager(session).removeClientFromOfflineUserSession(realm, userSession, client, user);
             }
-        } else {
-            UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
-            if (userSession != null) {
-                AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-                if (clientSession != null) {
-                    TokenManager.dettachClientSession(clientSession);
-                    // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
-                    if (userSession.getAuthenticatedClientSessions().isEmpty()) {
-                        session.sessions().removeUserSession(realm, userSession);
-                    }
+        }
+        // Always remove "online" session as well if exists to make sure that issued access-tokens are revoked as well
+        UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
+        if (userSession != null) {
+            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+            if (clientSession != null) {
+                TokenManager.dettachClientSession(clientSession);
+                // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
+                if (userSession.getAuthenticatedClientSessions().isEmpty()) {
+                    session.sessions().removeUserSession(realm, userSession);
                 }
             }
         }

--- a/services/src/main/java/org/keycloak/services/managers/UserSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserSessionManager.java
@@ -97,20 +97,28 @@ public class UserSessionManager {
         AtomicBoolean anyRemoved = new AtomicBoolean(false);
         kcSession.sessions().getOfflineUserSessionsStream(realm, user).collect(Collectors.toList())
                 .forEach(userSession -> {
-                    AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-                    if (clientSession != null) {
-                        if (logger.isTraceEnabled()) {
-                            logger.tracef("Removing existing offline token for user '%s' and client '%s' .",
-                                    user.getUsername(), client.getClientId());
-                        }
-
-                        clientSession.detachFromUserSession();
-                        checkOfflineUserSessionHasClientSessions(realm, user, userSession);
+                    if (removeClientFromOfflineUserSession(realm, userSession, client, user)) {
                         anyRemoved.set(true);
                     }
                 });
 
         return anyRemoved.get();
+    }
+
+    public boolean removeClientFromOfflineUserSession(RealmModel realm, UserSessionModel userSession, ClientModel client, UserModel user) {
+        AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+        if (clientSession != null) {
+            if (logger.isTraceEnabled()) {
+                logger.tracef("Removing existing offline token for user '%s' and client '%s' .",
+                        user.getUsername(), client.getClientId());
+            }
+
+            clientSession.detachFromUserSession();
+            checkOfflineUserSessionHasClientSessions(realm, user, userSession);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public void revokeOfflineUserSession(UserSessionModel userSession) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -512,7 +512,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);
 
             // revoke by refresh token
-            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), sessionId, userId, true);
+            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), tokenRes.getSessionState(), userId, true);
 
         } finally {
             revertCIBASettings(clientResource, clientRep);
@@ -614,7 +614,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);
 
             // revoke by refresh token
-            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), sessionId, userId, false);
+            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), tokenRes.getSessionState(), userId, false);
 
         } finally {
             revertCIBASettings(clientResource, clientRep);
@@ -678,7 +678,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);
 
             // revoke by refresh token
-            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), sessionId, userId, false);
+            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), tokenRes.getSessionState(), userId, false);
 
         } finally {
             revertCIBASettings(clientResource, clientRep);
@@ -2889,7 +2889,11 @@ public class CIBATest extends AbstractClientPoliciesTest {
         else assertThat(tokenRes.getErrorDescription(), is(equalTo("Session not active")));
 
         RefreshToken rt = oauth.parseRefreshToken(refreshToken);
-        return events.expect(EventType.REVOKE_GRANT).clearDetails().client(TEST_CLIENT_NAME).user(rt.getSubject()).assertEvent();
+        return events.expect(EventType.REVOKE_GRANT).clearDetails()
+                .client(TEST_CLIENT_NAME)
+                .user(rt.getSubject())
+                .session(sessionId)
+                .assertEvent();
     }
 
     private void testBackchannelAuthenticationFlow(boolean isOfflineAccess) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -660,7 +660,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         events.expect(EventType.INTROSPECT_TOKEN).client(clientId).session(sessionId).user((String)null).clearDetails().assertEvent();
     }
 
-    protected void doTokenRevoke(String refreshToken, String clientId, String clientSecret, String userId, boolean isOfflineAccess) throws IOException {
+    protected void doTokenRevoke(String refreshToken, String clientId, String clientSecret, String userId, String sessionId, boolean isOfflineAccess) throws IOException {
         oauth.clientId(clientId);
         oauth.doTokenRevoke(refreshToken, "refresh_token", clientSecret);
 
@@ -671,7 +671,11 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         if (isOfflineAccess) assertEquals("Offline user session not found", tokenRes.getErrorDescription());
         else assertEquals("Session not active", tokenRes.getErrorDescription());
 
-        events.expect(EventType.REVOKE_GRANT).clearDetails().client(clientId).user(userId).assertEvent();
+        events.expect(EventType.REVOKE_GRANT).clearDetails()
+                .client(clientId)
+                .user(userId)
+                .session(sessionId)
+                .assertEvent();
     }
 
     // Client CRUD operation by Admin REST API primitives
@@ -1531,7 +1535,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
 
         doIntrospectAccessToken(refreshResponse, userName, clientId, sessionId, clientSecret);
 
-        doTokenRevoke(refreshResponse.getRefreshToken(), clientId, clientSecret, userId, false);
+        doTokenRevoke(refreshResponse.getRefreshToken(), clientId, clientSecret, userId, sessionId, false);
     }
 
     protected void failLoginByNotFollowingPKCE(String clientId) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.keycloak.testsuite.AssertEvents.isUUID;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 
 import java.io.IOException;
@@ -54,6 +55,8 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
@@ -72,6 +75,7 @@ import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.UserInfoClientUtil;
 import org.keycloak.testsuite.util.InfinispanTestTimeServiceRule;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.TokenUtil;
 
 /**
  * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
@@ -281,6 +285,40 @@ public class TokenRevocationTest extends AbstractKeycloakTest {
         OAuth2ErrorRepresentation errorRep = JsonSerialization.readValue(revokeResponse, OAuth2ErrorRepresentation.class);
         assertEquals("duplicated parameter", errorRep.getErrorDescription());
         assertEquals(OAuthErrorException.INVALID_REQUEST, errorRep.getError());
+    }
+
+    @Test
+    public void testRevokeSingleNormalSession() throws Exception {
+        testRevokeSingleSession(TokenUtil.TOKEN_TYPE_REFRESH);
+    }
+
+    @Test
+    public void testRevokeSingleOfflineSession() throws Exception {
+        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+        testRevokeSingleSession(TokenUtil.TOKEN_TYPE_OFFLINE);
+    }
+
+    private void testRevokeSingleSession(String expectedTokenType) throws Exception {
+        oauth.clientId("test-app");
+        OAuthClient.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("password", "test-user@localhost",
+                "password");
+        OAuthClient.AccessTokenResponse tokenResponse2 = oauth.doGrantAccessTokenRequest("password", "test-user@localhost",
+                "password");
+
+        isTokenEnabled(tokenResponse, "test-app");
+        isTokenEnabled(tokenResponse2, "test-app");
+
+        CloseableHttpResponse response = oauth.doTokenRevoke(tokenResponse.getRefreshToken(), "refresh_token", "password");
+        assertThat(response, Matchers.statusCodeIsHC(Status.OK));
+        events.expect(EventType.REVOKE_GRANT)
+                .session(tokenResponse.getSessionState())
+                .detail(Details.REFRESH_TOKEN_ID, isUUID())
+                .detail(Details.REFRESH_TOKEN_TYPE, expectedTokenType)
+                .client("test-app")
+                .assertEvent(true);
+
+        isTokenDisabled(tokenResponse, "test-app");
+        isTokenEnabled(tokenResponse2, "test-app");
     }
 
     private AccessTokenResponse login(String clientId, String username, String password) {


### PR DESCRIPTION
closes #35486
closes #35813

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 3fca2f3b7f132bb775a2158e978a3a546b887d7c)
