### PR TITLE
When using the token revocation endpoint with refresh-token, only par…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -18,8 +18,6 @@
 package org.keycloak.protocol.oidc.endpoints;
 
 import java.util.Collections;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.OPTIONS;
@@ -38,6 +36,7 @@ import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.headers.SecurityHeadersProvider;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -52,7 +51,6 @@ import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenRevokeContext;
 import org.keycloak.services.clientpolicy.context.TokenRevokeResponseContext;
 import org.keycloak.services.cors.Cors;
-import org.keycloak.services.managers.UserConsentManager;
 import org.keycloak.services.managers.UserSessionCrossDCManager;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.util.TokenUtil;
@@ -113,8 +111,11 @@ public class TokenRevocationEndpoint {
         checkUser();
 
         if (TokenUtil.TOKEN_TYPE_REFRESH.equals(token.getType()) || TokenUtil.TOKEN_TYPE_OFFLINE.equals(token.getType())) {
-            revokeClient();
+            revokeClientSession();
             event.detail(Details.REVOKED_CLIENT, client.getClientId());
+            event.session(token.getSessionId());
+            event.detail(Details.REFRESH_TOKEN_ID, token.getId());
+            event.detail(Details.REFRESH_TOKEN_TYPE, token.getType());
         } else {
             revokeAccessToken();
             event.detail(Details.TOKEN_ID, token.getId());
@@ -245,26 +246,25 @@ public class TokenRevocationEndpoint {
         }
     }
 
-    private void revokeClient() {
-        UserConsentManager.revokeConsentForClient(session, realm, user, client.getId());
+    private void revokeClientSession() {
         if (TokenUtil.TOKEN_TYPE_OFFLINE.equals(token.getType())) {
-            new UserSessionManager(session).revokeOfflineToken(user, client);
-        }
-        session.sessions().getUserSessionsStream(realm, user)
-                .map(userSession -> userSession.getAuthenticatedClientSessionByClient(client.getId()))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList()) // collect to avoid concurrent modification as dettachClientSession removes the user sessions.
-                .forEach(clientSession -> {
-                    UserSessionModel userSession = clientSession.getUserSession();
+            UserSessionModel userSession = session.sessions().getOfflineUserSession(realm, token.getSessionId());
+            if (userSession != null) {
+                new UserSessionManager(session).removeClientFromOfflineUserSession(realm, userSession, client, user);
+            }
+        } else {
+            UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
+            if (userSession != null) {
+                AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+                if (clientSession != null) {
                     TokenManager.dettachClientSession(clientSession);
-
-                    if (userSession != null) {
-                        // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
-                        if (userSession.getAuthenticatedClientSessions().isEmpty()) {
-                            session.sessions().removeUserSession(realm, userSession);
-                        }
+                    // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
+                    if (userSession.getAuthenticatedClientSessions().isEmpty()) {
+                        session.sessions().removeUserSession(realm, userSession);
                     }
-                });
+                }
+            }
+        }
     }
 
     private void revokeAccessToken() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -252,16 +252,16 @@ public class TokenRevocationEndpoint {
             if (userSession != null) {
                 new UserSessionManager(session).removeClientFromOfflineUserSession(realm, userSession, client, user);
             }
-        } else {
-            UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
-            if (userSession != null) {
-                AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-                if (clientSession != null) {
-                    TokenManager.dettachClientSession(clientSession);
-                    // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
-                    if (userSession.getAuthenticatedClientSessions().isEmpty()) {
-                        session.sessions().removeUserSession(realm, userSession);
-                    }
+        }
+        // Always remove "online" session as well if exists to make sure that issued access-tokens are revoked as well
+        UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
+        if (userSession != null) {
+            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+            if (clientSession != null) {
+                TokenManager.dettachClientSession(clientSession);
+                // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
+                if (userSession.getAuthenticatedClientSessions().isEmpty()) {
+                    session.sessions().removeUserSession(realm, userSession);
                 }
             }
         }

--- a/services/src/main/java/org/keycloak/services/managers/UserSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserSessionManager.java
@@ -97,20 +97,28 @@ public class UserSessionManager {
         AtomicBoolean anyRemoved = new AtomicBoolean(false);
         kcSession.sessions().getOfflineUserSessionsStream(realm, user).collect(Collectors.toList())
                 .forEach(userSession -> {
-                    AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-                    if (clientSession != null) {
-                        if (logger.isTraceEnabled()) {
-                            logger.tracef("Removing existing offline token for user '%s' and client '%s' .",
-                                    user.getUsername(), client.getClientId());
-                        }
-
-                        clientSession.detachFromUserSession();
-                        checkOfflineUserSessionHasClientSessions(realm, user, userSession);
+                    if (removeClientFromOfflineUserSession(realm, userSession, client, user)) {
                         anyRemoved.set(true);
                     }
                 });
 
         return anyRemoved.get();
+    }
+
+    public boolean removeClientFromOfflineUserSession(RealmModel realm, UserSessionModel userSession, ClientModel client, UserModel user) {
+        AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+        if (clientSession != null) {
+            if (logger.isTraceEnabled()) {
+                logger.tracef("Removing existing offline token for user '%s' and client '%s' .",
+                        user.getUsername(), client.getClientId());
+            }
+
+            clientSession.detachFromUserSession();
+            checkOfflineUserSessionHasClientSessions(realm, user, userSession);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public void revokeOfflineUserSession(UserSessionModel userSession) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -512,7 +512,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);
 
             // revoke by refresh token
-            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), sessionId, userId, true);
+            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), tokenRes.getSessionState(), userId, true);
 
         } finally {
             revertCIBASettings(clientResource, clientRep);
@@ -614,7 +614,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);
 
             // revoke by refresh token
-            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), sessionId, userId, false);
+            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), tokenRes.getSessionState(), userId, false);
 
         } finally {
             revertCIBASettings(clientResource, clientRep);
@@ -678,7 +678,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);
 
             // revoke by refresh token
-            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), sessionId, userId, false);
+            EventRepresentation logoutEvent = doTokenRevokeByRefreshToken(tokenRes.getRefreshToken(), tokenRes.getSessionState(), userId, false);
 
         } finally {
             revertCIBASettings(clientResource, clientRep);
@@ -2888,7 +2888,11 @@ public class CIBATest extends AbstractClientPoliciesTest {
         else assertThat(tokenRes.getErrorDescription(), is(equalTo("Session not active")));
 
         RefreshToken rt = oauth.parseRefreshToken(refreshToken);
-        return events.expect(EventType.REVOKE_GRANT).clearDetails().client(TEST_CLIENT_NAME).user(rt.getSubject()).assertEvent();
+        return events.expect(EventType.REVOKE_GRANT).clearDetails()
+                .client(TEST_CLIENT_NAME)
+                .user(rt.getSubject())
+                .session(sessionId)
+                .assertEvent();
     }
 
     private void testBackchannelAuthenticationFlow(boolean isOfflineAccess) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -661,7 +661,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         events.expect(EventType.INTROSPECT_TOKEN).client(clientId).user((String)null).clearDetails().assertEvent();
     }
 
-    protected void doTokenRevoke(String refreshToken, String clientId, String clientSecret, String userId, boolean isOfflineAccess) throws IOException {
+    protected void doTokenRevoke(String refreshToken, String clientId, String clientSecret, String userId, String sessionId, boolean isOfflineAccess) throws IOException {
         oauth.clientId(clientId);
         oauth.doTokenRevoke(refreshToken, "refresh_token", clientSecret);
 
@@ -672,7 +672,11 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         if (isOfflineAccess) assertEquals("Offline user session not found", tokenRes.getErrorDescription());
         else assertEquals("Session not active", tokenRes.getErrorDescription());
 
-        events.expect(EventType.REVOKE_GRANT).clearDetails().client(clientId).user(userId).assertEvent();
+        events.expect(EventType.REVOKE_GRANT).clearDetails()
+                .client(clientId)
+                .user(userId)
+                .session(sessionId)
+                .assertEvent();
     }
 
     // Client CRUD operation by Admin REST API primitives
@@ -1532,7 +1536,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
 
         doIntrospectAccessToken(refreshResponse, userName, clientId, clientSecret);
 
-        doTokenRevoke(refreshResponse.getRefreshToken(), clientId, clientSecret, userId, false);
+        doTokenRevoke(refreshResponse.getRefreshToken(), clientId, clientSecret, userId, sessionId, false);
     }
 
     protected void failLoginByNotFollowingPKCE(String clientId) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
@@ -212,6 +212,26 @@ public class TokenRevocationTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void testRevokeOfflineTokenWithOnlineSSOSession() throws Exception {
+        OAuthClient.AccessTokenResponse tokenResponse1 = login("test-app", "test-user@localhost", "password");
+
+        // Offline login of same client in same SSO session as previous login
+        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+        OAuthClient.AccessTokenResponse tokenResponse2 = login("test-app", "test-user@localhost", "password");
+
+        // Session IDs of "offline" and online session are same for now. This may change in the future
+        Assert.assertEquals(tokenResponse1.getSessionState(), tokenResponse2.getSessionState());
+
+        isTokenEnabled(tokenResponse2, "test-app");
+
+        // Disable both offline and refresh
+        CloseableHttpResponse response = oauth.doTokenRevoke(tokenResponse2.getRefreshToken(), "refresh_token", "password");
+        assertThat(response, Matchers.statusCodeIsHC(Status.OK));
+
+        isTokenDisabled(tokenResponse2, "test-app");
+    }
+
+    @Test
     public void testTokenTypeHint() throws Exception {
         // different token_type_hint
         oauth.clientId("test-app");


### PR DESCRIPTION
…ticular clientSession related to given refresh token should be terminated

closes #35486
closes #35813

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 3fca2f3b7f132bb775a2158e978a3a546b887d7c)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
