### PR TITLE
fix: removing doc that suggests using the config file for quarkus props

### DIFF
--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -142,9 +142,7 @@ You can use only a https://github.com/keycloak/keycloak/blob/main/quarkus/runtim
 * A lock icon for a Quarkus property in the https://quarkus.io/guides/all-config[Quarkus documentation] indicates a build time property. You run the `build` command to apply this property. For details about the build command, see the subsequent sections on optimizing {project_name}.
 * No lock icon for a property in the Quarkus guide indicates a runtime property for Quarkus and {project_name}.
 
-. Use the `[-cf|--config-file]` command line parameter to include that file.
-
-Similarly, you can also store Quarkus properties in a Java KeyStore.
+You can also store Quarkus properties in a Java KeyStore.
 
 Note that some Quarkus properties are already mapped in the {project_name} configuration, such as `quarkus.http.port` and similar essential properties. If the property is used by {project_Name}, defining that property key in `quarkus.properties` has no effect. The {project_Name} configuration value takes precedence over the Quarkus property value.
 


### PR DESCRIPTION
closes: #35770

@vmuzikar - this does highlight that the config keystore is the odd man out, which may contain both keycloak and quarkus configuration keys.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
