### PR TITLE
Search user by id and fallback to username when needed

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/user/UserPolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/user/UserPolicyProviderFactory.java
@@ -166,10 +166,11 @@ public class UserPolicyProviderFactory implements PolicyProviderFactory<UserPoli
         KeycloakSession session = authorization.getKeycloakSession();
         RealmModel realm = authorization.getRealm();
         UserProvider userProvider = session.users();
-        UserModel user = userProvider.getUserByUsername(realm, userId);
+        UserModel user = userProvider.getUserById(realm, userId);
 
         if (user == null) {
-            user = userProvider.getUserById(realm, userId);
+            // fallback - userId is possibly a username
+            user = userProvider.getUserByUsername(realm, userId);
         }
 
         return user;


### PR DESCRIPTION
- prevents performance issues when reading policies as users are always stored by id.

Closes #35796

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>
(cherry picked from commit a43b65281d6f3631366b71858cad25676aaf635d)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
