### PR TITLE
Remove failed attempt in KerberosStandaloneCrossRealmTrustTest.test03SpnegoLoginWithCorrectKerberosPrincipalRealm

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneCrossRealmTrustTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneCrossRealmTrustTest.java
@@ -94,8 +94,8 @@ public class KerberosStandaloneCrossRealmTrustTest extends AbstractKerberosTest 
         Assert.assertTrue(testAppHelper.logout());
 
         // Login in username/password form as "jduke@KC2.COM"
-        Assert.assertFalse(testAppHelper.login("jduke@kc2.com", "theduke"));
         Assert.assertTrue(testAppHelper.login("jduke@kc2.com", "theduke2"));
+        Assert.assertTrue(testAppHelper.logout());
 
         assertUser("jduke", "jduke@keycloak.org", null, null, "jduke@KEYCLOAK.ORG", false);
         assertUser("jduke@kc2.com", "jduke@kc2.com", null, null, "jduke@KC2.COM", false);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/kerberos/users-kerberos-kc2.ldif
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/kerberos/users-kerberos-kc2.ldif
@@ -87,7 +87,7 @@ sn: Duke
 mail: jduke@keycloak.org
 uid: jduke
 userPassword: theduke
-krb5PrincipalName: jduke@KEYCLOAK.ORG
+krb5PrincipalName: jdukekeycloak@KC2.COM
 krb5KeyVersionNumber: 0
 
 dn: uid=jduke2,ou=People,dc=kc2,dc=com


### PR DESCRIPTION
Closes #30037

This change probably does not fix the issue but I want to do the two little modifications:

1. The incorrect password attempt is removed because in the logs I see there is a LOGIN_FAILED reported, so that line is working, and in the next one it seems that the same user is not found (`¯\_(ツ)_/¯`). I want to try to remove the failed password login and see what happens. Besides I'm also doing the logout because maybe the error comes after the test (because it's the last one in the class).
2. In the ldif I'm moving the `krb5PrincipalName` of the duplicated user to one with `KC2.COM` just in case the apacheds does something weird searching the principal (the principal should be @KC2.com and not @KEYCLOAK.ORG in any user in this realm).

I have executed this 100 times. But this means nothing because this test fails even less than 1 in 100.

