### PR TITLE
BACKPORT: use master realm to fetch realm names list (#35128)

### DIFF
--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -34,6 +34,7 @@ import { toDashboard } from "../../dashboard/routes/Dashboard";
 import { toAddRealm } from "../../realm/routes/AddRealm";
 
 import "./realm-selector.css";
+import { environment } from "../../environment";
 
 const MAX_RESULTS = 10;
 
@@ -117,6 +118,7 @@ export const RealmSelector = () => {
 
   useFetch(
     async () => {
+      adminClient.realmName = environment.masterRealm;
       try {
         return await fetchAdminUI<RealmNameRepresentation[]>(
           adminClient,
@@ -136,12 +138,15 @@ export const RealmSelector = () => {
   );
 
   const sortedRealms = useMemo(
-    () => [
-      ...(first === 0 && !search
-        ? (recentRealms || []).map((name) => ({ name }))
-        : []),
-      ...realms.filter((r) => !(recentRealms || []).includes(r.name)),
-    ],
+    () =>
+      realms.length > MAX_RESULTS
+        ? [
+            ...(first === 0 && !search
+              ? (recentRealms || []).map((name) => ({ name }))
+              : []),
+            ...realms.filter((r) => !(recentRealms || []).includes(r.name)),
+          ]
+        : realms,
     [recentRealms, realms, first, search],
   );
 


### PR DESCRIPTION
* use master realm to fetch realm names list
backport: #35128
fixes: #34356
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

* use display name when we can

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

---------

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 6bf7dadb05ea3734459d1c38a4b036c27b33503c)
