### PR TITLE
Use UPDATE_CREDENTIAL as the enet type in RecoveryAuthnCodesAction

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/RecoveryAuthnCodesAction.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/RecoveryAuthnCodesAction.java
@@ -14,6 +14,8 @@ import org.keycloak.common.Profile;
 import org.keycloak.credential.RecoveryAuthnCodesCredentialProviderFactory;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.events.Details;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.UserModel;
@@ -82,6 +84,9 @@ public class RecoveryAuthnCodesAction implements RequiredActionProvider, Require
 
     @Override
     public void processAction(RequiredActionContext reqActionContext) {
+        EventBuilder event = reqActionContext.getEvent();
+        event.event(EventType.UPDATE_CREDENTIAL);
+
         CredentialProvider recoveryCodeCredentialProvider;
         MultivaluedMap<String, String> httpReqParamsMap;
         Long generatedAtTime;
@@ -90,7 +95,7 @@ public class RecoveryAuthnCodesAction implements RequiredActionProvider, Require
         recoveryCodeCredentialProvider = reqActionContext.getSession().getProvider(CredentialProvider.class,
                 RecoveryAuthnCodesCredentialProviderFactory.PROVIDER_ID);
 
-        reqActionContext.getEvent().detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE);
+        event.detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE);
 
         httpReqParamsMap = reqActionContext.getHttpRequest().getDecodedFormParameters();
         List<String> generatedCodes = new ArrayList<>(

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -908,7 +908,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
             loginTotpPage.login(totp.generateTOTP(totp2Secret));
             setupRecoveryAuthnCodesPage.assertCurrent();
             setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();
-            events.expectRequiredAction(EventType.CUSTOM_REQUIRED_ACTION).assertEvent();
+            events.expectRequiredAction(EventType.UPDATE_CREDENTIAL).assertEvent();
             assertLoggedInWithAcr("gold");
 
             // Removing recovery-code credential. User required to authenticate with 2nd-factor. He can choose between OTP or recovery-codes

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -156,8 +156,11 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
                     .assertEvent();
         }
 
-        EventRepresentation event2 = events.expectRequiredAction(EventType.CUSTOM_REQUIRED_ACTION)
-                .user(event1.getUserId()).detail(Details.USERNAME, "test-user@localhost").assertEvent();
+        EventRepresentation event2 = events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
+                .user(event1.getUserId())
+                .detail(Details.USERNAME, "test-user@localhost")
+                .detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE)
+                .assertEvent();
         event2 = events.expectLogin().user(event2.getUserId()).session(event2.getDetails().get(Details.CODE_ID))
                 .detail(Details.USERNAME, "test-user@localhost").assertEvent();
 


### PR DESCRIPTION
Closes #35760

Just adding the UPDATE_CREDENTIAL to the event to not send the generic CUSTOM_REQUIRED_ACTION. As the recovery codes are still in preview I'm just chaging it. This way is more aligned to other credentials types like password, otp or webauthn.
