### PR TITLE
[Backport] Exact searches should be the default when querying user by attributes

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -1012,7 +1012,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
                                 builder.equal(attributesJoin.get("name"), key),
                                 builder.equal(attributesJoin.get("longValueHashLowerCase"), JpaHashUtils.hashForAttributeValueLowerCase(value))));
                     } else {
-                        if (Boolean.parseBoolean(attributes.get(UserModel.EXACT))) {
+                        if (Boolean.parseBoolean(attributes.getOrDefault(UserModel.EXACT, Boolean.TRUE.toString()))) {
                             attributePredicates.add(builder.and(
                                 builder.equal(attributesJoin.get("name"), key),
                                 builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -916,8 +916,12 @@ public class UserTest extends AbstractAdminTest {
         List<UserRepresentation> users = realm.users().searchByAttributes(mapToSearchQuery(Map.of("username", "user", "test", "test1", "attr", "common", "test1", "test1")));
         assertThat(users, hasSize(1));
 
-        //custom user attribute should use wildcard search by default
+        //custom user attribute should not use wildcard search by default
         users = realm.users().searchByAttributes(mapToSearchQuery(Map.of("username", "user", "test", "est", "attr", "mm", "test1", "test1")));
+        assertThat(users, hasSize(0));
+
+        //custom user attribute should use wildcard
+        users = realm.users().searchByAttributes(mapToSearchQuery(Map.of("username", "user", "test", "est", "attr", "mm", "test1", "test1")), false);
         assertThat(users, hasSize(1));
 
         //with exact=true the user shouldn't be returned


### PR DESCRIPTION
Closes #35822

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
