### PR TITLE
Revert "use master realm to fetch realm names list (#35128)"

### DIFF
--- a/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/js/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -34,7 +34,6 @@ import { toDashboard } from "../../dashboard/routes/Dashboard";
 import { toAddRealm } from "../../realm/routes/AddRealm";
 
 import "./realm-selector.css";
-import { environment } from "../../environment";
 
 const MAX_RESULTS = 10;
 
@@ -118,7 +117,6 @@ export const RealmSelector = () => {
 
   useFetch(
     async () => {
-      adminClient.realmName = environment.masterRealm;
       try {
         return await fetchAdminUI<RealmNameRepresentation[]>(
           adminClient,
@@ -138,15 +136,12 @@ export const RealmSelector = () => {
   );
 
   const sortedRealms = useMemo(
-    () =>
-      realms.length > MAX_RESULTS
-        ? [
-            ...(first === 0 && !search
-              ? (recentRealms || []).map((name) => ({ name }))
-              : []),
-            ...realms.filter((r) => !(recentRealms || []).includes(r.name)),
-          ]
-        : realms,
+    () => [
+      ...(first === 0 && !search
+        ? (recentRealms || []).map((name) => ({ name }))
+        : []),
+      ...realms.filter((r) => !(recentRealms || []).includes(r.name)),
+    ],
     [recentRealms, realms, first, search],
   );
 


### PR DESCRIPTION
This reverts commit 272ebcc2e67d8d5cc54ce0ab33a1843d37c9617a.
revert #35128 that tried to fix: #34356
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
