### PR TITLE
Remove updateMasterAdminPassword call in AbstractKeycloakTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -179,11 +179,6 @@ public abstract class AbstractKeycloakTest {
 
         TestEventsLogger.setDriver(driver);
 
-        // The backend cluster nodes may not be yet started. Password will be updated later for cluster setup.
-        if (!AuthServerTestEnricher.AUTH_SERVER_CLUSTER) {
-            updateMasterAdminPassword();
-        }
-
         beforeAbstractKeycloakTestRealmImport();
 
         if (testContext.getTestRealmReps().isEmpty()) {


### PR DESCRIPTION
Closes #35088

With the firefox driver sometimes when there are several redirects the `getPageSource` returns null. It seems that it's much more  problematic in the [updateMasterAdminPassword](https://github.com/keycloak/keycloak/blob/26.0.7/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java#L184) call in `AbstractKeycloakTest` class. For that reason a new [waitForPageToLoad](https://github.com/keycloak/keycloak/blob/26.0.7/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java#L283) was added. But this is just a workaround that minimizes the problem. I think that the call to this method is just a leftover. Now we use the env variables to initialize the server. So the PR just removes the call. The method is maintained because it's used for some welcome page test.

Without the `updateMasterAdminPassword` the firefox [Adapter IT Strict Cookies](https://github.com/rmartinc/keycloak/actions/runs/12297797169) was executed 100 times without retries with no issues.