### PR TITLE
Add support for Initiating User Registration via prompt=create (#10701)

### DIFF
--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -73,6 +73,9 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("subject_types_supported")
     private List<String> subjectTypesSupported;
 
+    @JsonProperty("prompt_values_supported")
+    private List<String> promptValuesSupported;
+
     @JsonProperty("id_token_signing_alg_values_supported")
     private List<String> idTokenSigningAlgValuesSupported;
 
@@ -655,4 +658,11 @@ public class OIDCConfigurationRepresentation {
         this.authorizationResponseIssParameterSupported = authorizationResponseIssParameterSupported;
     }
 
+    public List<String> getPromptValuesSupported() {
+        return promptValuesSupported;
+    }
+
+    public void setPromptValuesSupported(List<String> promptValuesSupported) {
+        this.promptValuesSupported = promptValuesSupported;
+    }
 }

--- a/docs/documentation/server_admin/topics/authentication/flows.adoc
+++ b/docs/documentation/server_admin/topics/authentication/flows.adoc
@@ -419,7 +419,8 @@ Sometimes it can be useful for the client application to directly redirect the u
 user clicks *Register* or *Forget password* on the normal login screen. Automatic redirect to the registration or reset-credentials screen can be done as follows:
 
 * When the client wants the user to be redirected directly to the registration, the OIDC client should replace the very last snippet from the OIDC login URL path (`/auth`) with `/registrations` . So the full URL
-might be similar to the following: `https://keycloak.example.com/realms/your_realm/protocol/openid-connect/registrations`.
+might be similar to the following: `https://keycloak.example.com/realms/your_realm/protocol/openid-connect/registrations`. As an alternative to using the `/registrations` endpoint, clients can use the OIDC
+`prompt` parameter with `prompt=create` to redirect the user to the registration.
 
 * When the client wants a user to be redirected directly to the `Reset credentials` flow, the OIDC client should replace the very last snippet from the OIDC login URL path (`/auth`) with `/forgot-credentials` .
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -110,6 +110,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
     public static final String PROMPT_VALUE_NONE = "none";
     public static final String PROMPT_VALUE_LOGIN = "login";
     public static final String PROMPT_VALUE_CONSENT = "consent";
+    public static final String PROMPT_VALUE_CREATE = "create";
     public static final String PROMPT_VALUE_SELECT_ACCOUNT = "select_account";
 
     // Client authentication methods

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -91,7 +91,8 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     // KEYCLOAK-7451 OAuth Authorization Server Metadata for Proof Key for Code Exchange
     public static final List<String> DEFAULT_CODE_CHALLENGE_METHODS_SUPPORTED = list(OAuth2Constants.PKCE_METHOD_PLAIN, OAuth2Constants.PKCE_METHOD_S256);
 
-    public static final List<String> DEFAULT_PROMPT_VALUES_SUPPORTED = list(OIDCLoginProtocol.PROMPT_VALUE_NONE, OIDCLoginProtocol.PROMPT_VALUE_CREATE, OIDCLoginProtocol.PROMPT_VALUE_LOGIN, OIDCLoginProtocol.PROMPT_VALUE_CONSENT);
+    // See: GH-10701, note that the supported prompt value "create" is only added if the realm supports registrations.
+    public static final List<String> DEFAULT_PROMPT_VALUES_SUPPORTED = list(OIDCLoginProtocol.PROMPT_VALUE_NONE /*, OIDCLoginProtocol.PROMPT_VALUE_CREATE*/, OIDCLoginProtocol.PROMPT_VALUE_LOGIN, OIDCLoginProtocol.PROMPT_VALUE_CONSENT);
 
     private final KeycloakSession session;
     private final Map<String, Object> openidConfigOverride;
@@ -168,7 +169,8 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         config.setResponseModesSupported(DEFAULT_RESPONSE_MODES_SUPPORTED);
         config.setGrantTypesSupported(DEFAULT_GRANT_TYPES_SUPPORTED);
         config.setAcrValuesSupported(getAcrValuesSupported(realm));
-        config.setPromptValuesSupported(DEFAULT_PROMPT_VALUES_SUPPORTED);
+
+        config.setPromptValuesSupported(getPromptValuesSupported(realm));
 
         config.setTokenEndpointAuthMethodsSupported(getClientAuthMethodsSupported());
         config.setTokenEndpointAuthSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(false));
@@ -236,6 +238,14 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
 
         config = checkConfigOverride(config);
         return config;
+    }
+
+    protected List<String> getPromptValuesSupported(RealmModel realm) {
+        List<String> prompts = new ArrayList<>(DEFAULT_PROMPT_VALUES_SUPPORTED);
+        if (realm.isRegistrationAllowed()) {
+            prompts.add(OIDCLoginProtocol.PROMPT_VALUE_CREATE);
+        }
+        return prompts;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -91,6 +91,8 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     // KEYCLOAK-7451 OAuth Authorization Server Metadata for Proof Key for Code Exchange
     public static final List<String> DEFAULT_CODE_CHALLENGE_METHODS_SUPPORTED = list(OAuth2Constants.PKCE_METHOD_PLAIN, OAuth2Constants.PKCE_METHOD_S256);
 
+    public static final List<String> DEFAULT_PROMPT_VALUES_SUPPORTED = list(OIDCLoginProtocol.PROMPT_VALUE_NONE, OIDCLoginProtocol.PROMPT_VALUE_CREATE, OIDCLoginProtocol.PROMPT_VALUE_LOGIN, OIDCLoginProtocol.PROMPT_VALUE_CONSENT);
+
     private final KeycloakSession session;
     private final Map<String, Object> openidConfigOverride;
     private final boolean includeClientScopes;
@@ -166,6 +168,7 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         config.setResponseModesSupported(DEFAULT_RESPONSE_MODES_SUPPORTED);
         config.setGrantTypesSupported(DEFAULT_GRANT_TYPES_SUPPORTED);
         config.setAcrValuesSupported(getAcrValuesSupported(realm));
+        config.setPromptValuesSupported(DEFAULT_PROMPT_VALUES_SUPPORTED);
 
         config.setTokenEndpointAuthMethodsSupported(getClientAuthMethodsSupported());
         config.setTokenEndpointAuthSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(false));

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -204,6 +204,16 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
         // So back button doesn't work
         CacheControlUtil.noBackButtonCacheControlHeader(session);
+
+        // Add support for Initiating User Registration via OpenID Connect 1.0 via prompt=create
+        // see: https://openid.net/specs/openid-connect-prompt-create-1_0.html#section-4.1
+        if (OIDCLoginProtocol.PROMPT_VALUE_CREATE.equals(params.getFirst(OAuth2Constants.PROMPT))) {
+            if (!Organizations.isRegistrationAllowed(session, realm)) {
+                throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.REGISTRATION_NOT_ALLOWED);
+            }
+            return buildRegister();
+        }
+
         switch (action) {
             case REGISTER:
                 return buildRegister();


### PR DESCRIPTION
This PR adds support for "Initiating User Registration via OpenID Connect 1.0".

This allows to use the standard `prompt`parameter to initiate user registrations. Previously, users had to use
the propriatery registrations endpoint (`$KC_ISSUER/protocol/openid-connect/registrations`) for this.

See: https://openid.net/specs/openid-connect-prompt-create-1_0.html#section-4.1

Fixes #10701

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
