### PR TITLE
Failed to authenticate client with method client_secret_jwt when clie…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
@@ -67,7 +67,7 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
 
     @Override
     public void authenticateClient(ClientAuthenticationFlowContext context) {
-        JWTClientValidator validator = new JWTClientValidator(context);
+        JWTClientValidator validator = new JWTClientValidator(context, getId());
         if (!validator.clientAssertionParametersValidation()) return;
 
         try {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
@@ -55,7 +55,7 @@ public class JWTClientSecretAuthenticator extends AbstractClientAuthenticator {
 
     @Override
     public void authenticateClient(ClientAuthenticationFlowContext context) {
-        JWTClientValidator validator = new JWTClientValidator(context);
+        JWTClientValidator validator = new JWTClientValidator(context, getId());
         if (!validator.clientAssertionParametersValidation()) return;
 
         try {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
@@ -50,6 +50,7 @@ public class JWTClientValidator {
     private final ClientAuthenticationFlowContext context;
     private final RealmModel realm;
     private final int currentTime;
+    private final String clientAuthenticatorProviderId;
 
     private MultivaluedMap<String, String> params;
     private String clientAssertion;
@@ -59,10 +60,11 @@ public class JWTClientValidator {
 
     private static final int ALLOWED_CLOCK_SKEW = 15; // sec
 
-    public JWTClientValidator(ClientAuthenticationFlowContext context) {
+    public JWTClientValidator(ClientAuthenticationFlowContext context, String clientAuthenticatorProviderId) {
         this.context = context;
         this.realm = context.getRealm();
         this.currentTime = Time.currentTime();
+        this.clientAuthenticatorProviderId = clientAuthenticatorProviderId;
     }
 
     public boolean clientAssertionParametersValidation() {
@@ -135,6 +137,11 @@ public class JWTClientValidator {
 
         if (!client.isEnabled()) {
             context.failure(AuthenticationFlowError.CLIENT_DISABLED, null);
+            return false;
+        }
+
+        if (!clientAuthenticatorProviderId.equals(client.getClientAuthenticatorType())) {
+            context.failure(AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS, null);
             return false;
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
@@ -129,6 +129,16 @@ public class ClientAuthSecretSignedJWTTest extends AbstractKeycloakTest {
         testCodeToTokenRequestSuccess(Algorithm.HS512);
     }
 
+
+    // Issue 34547
+    @Test
+    public void testCodeToTokenRequestSuccessWhenClientHasGeneratedKeys() throws Exception {
+        // Test when client has public/private keys generated despite the fact that it uses client-secret for the client authentication (and not those keys)
+        ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app").getCertficateResource("jwt.credential").generate();
+
+        testCodeToTokenRequestSuccess(Algorithm.HS256);
+    }
+
     @Test
     public void testInvalidIssuer() throws Exception {
         oauth.clientId("test-app");


### PR DESCRIPTION
…nt has generated keys

closes #34547

I've looked a bit more at #34547 due suspicion it could be more serious. Figured that client with client authentication method `client_secret_jwt` fails to authenticate if it has keys generated. Which is not good as client can have keys generated even if it doesn't use `private_key_jwt` as client authentication method (because of use-cases like IDToken encryption etc).

In case that client had keys generated, the `JWTClientAuthenticator` "almost" managed to authenticate client and added the token into the single-use cache. The `JWTClientSecretAuthenticator` then failed to authenticate client as token was already used in the single-use cache (The `JWTClientValidator.validateTokenReuse()` failed).

Issue is fixed it by checking that expected client authentication method earlier in the request, so the `JWTClientAuthenticator` fails early in the request.
