### PR TITLE
Remove dependency to "DOM" lib in @keycloak/admin-client

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/agent.ts
+++ b/js/libs/keycloak-admin-client/src/resources/agent.ts
@@ -36,7 +36,7 @@ export interface RequestArgs {
    * Keys to be ignored, meaning that they will not be filtered out of the request payload even if they are a part of `urlParamKeys` or `queryParamKeys`,
    */
   ignoredKeys?: string[];
-  headers?: HeadersInit;
+  headers?: [string, string][] | Record<string, string> | Headers;
 }
 
 const pick = (value: Record<string, unknown>, keys: string[]) =>
@@ -197,7 +197,7 @@ export class Agent {
     catchNotFound: boolean;
     payloadKey?: string;
     returnResourceIdInLocationHeader?: { field: string };
-    headers?: HeadersInit;
+    headers?: [string, string][] | Record<string, string> | Headers;
   }) {
     const newPath = urlJoin(this.#basePath, path);
 

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -116,6 +116,6 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
     body: payload,
   });
 
-  const data: TokenResponseRaw = await response.json();
+  const data = (await response.json()) as TokenResponseRaw;
   return camelize(data);
 };

--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -14,7 +14,7 @@ export class NetworkError extends Error {
 }
 
 export async function fetchWithError(
-  input: RequestInfo | URL,
+  input: Request | string | URL,
   init?: RequestInit,
 ) {
   const response = await fetch(input, init);

--- a/js/libs/keycloak-admin-client/tsconfig.json
+++ b/js/libs/keycloak-admin-client/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
+    "lib": ["ESNext"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "outDir": "lib",


### PR DESCRIPTION
Previously, to use @keycloak/admin-client with typescript, you needed to
use the "DOM" lib in your project to avoid type errors. This is not ideal
in a server-based project because by including the "DOM" lib, you also
enable all other Web APIs that are not available on the server, and
TypeScript will no longer report errors if they are used.

Now, @keycloak/admin-client only uses the "ESNext" lib. The other projects
still use the "DOM" lib as well.

Code changes were needed because for technical reasons, @types/node
does not include any of the type aliases.

Fixes #25085.