### PR TITLE
Fix content-type for content.json (#35971)

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/MimeTypeUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/MimeTypeUtil.java
@@ -29,7 +29,7 @@ public class MimeTypeUtil {
     static {
         map.addMimeTypes("text/css css CSS");
         map.addMimeTypes("text/javascript js JS");
-        map.addMimeTypes("text/javascript js JS");
+        map.addMimeTypes("application/json json JSON");
         map.addMimeTypes("image/png png PNG");
         map.addMimeTypes("image/svg+xml svg SVG");
         map.addMimeTypes("text/html html htm HTML HTM");


### PR DESCRIPTION
We now send the content-type `application/json` when JSON resources are requested via the resources endpoint. Previously, those resources were using content-type `application/octet-stream`. Also removed the duplicate entry for `text/javascript` content type mapping.

Fixes #35971

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
