### PR TITLE
Fix expires_in in internal to external token exchange

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
@@ -55,6 +55,8 @@ public class IdentityProviderModel implements Serializable {
     public static final String POST_BROKER_LOGIN_FLOW_ID = "postBrokerLoginFlowId";
     public static final String SEARCH = "search";
     public static final String SYNC_MODE = "syncMode";
+    public static final String MIN_VALIDITY_TOKEN = "minValidityToken";
+    public static final int DEFAULT_MIN_VALIDITY_TOKEN = 5;
 
     private String internalId;
 
@@ -342,6 +344,25 @@ public class IdentityProviderModel implements Serializable {
 
     public void setCaseSensitiveOriginalUsername(boolean caseSensitive) {
         getConfig().put(CASE_SENSITIVE_ORIGINAL_USERNAME, Boolean.valueOf(caseSensitive).toString());
+    }
+
+    public void setMinValidityToken(int minValidityToken) {
+        getConfig().put(MIN_VALIDITY_TOKEN, Integer.toString(minValidityToken));
+    }
+
+    public int getMinValidityToken() {
+        String minValidityTokenString = getConfig().get(MIN_VALIDITY_TOKEN);
+        if (minValidityTokenString != null) {
+            try {
+                int minValidityToken = Integer.parseInt(minValidityTokenString);
+                if (minValidityToken > 0) {
+                    return minValidityToken;
+                }
+            } catch (NumberFormatException e) {
+                // no-op return default
+            }
+        }
+        return DEFAULT_MIN_VALIDITY_TOKEN;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/IdentityProviderAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/IdentityProviderAttributeUpdater.java
@@ -44,6 +44,11 @@ public class IdentityProviderAttributeUpdater {
         return this;
     }
 
+    public IdentityProviderAttributeUpdater setStoreToken(boolean storeToken) {
+        rep.setStoreToken(storeToken);
+        return this;
+    }
+
     public Closeable update() {
         identityProviderResource.update(rep);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
@@ -19,11 +19,13 @@ package org.keycloak.testsuite.broker;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.util.ProtocolMapperUtil.createHardcodedClaim;
-
-import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
@@ -32,6 +34,8 @@ import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import java.io.Closeable;
+import java.util.Map;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientResource;
@@ -50,6 +54,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
@@ -58,12 +63,13 @@ import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation
 import org.keycloak.services.resources.admin.permissions.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeatures;
+import org.keycloak.testsuite.updaters.IdentityProviderAttributeUpdater;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.util.BasicAuthHelper;
-import com.google.common.collect.ImmutableMap;
 
 @EnableFeatures({@EnableFeature(Profile.Feature.TOKEN_EXCHANGE), @EnableFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ)})
 public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBrokerTest {
@@ -87,11 +93,10 @@ public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBase
         hardCodedSessionNoteMapper.setName("hard-coded");
         hardCodedSessionNoteMapper.setIdentityProviderAlias(bc.getIDPAlias());
         hardCodedSessionNoteMapper.setIdentityProviderMapper(UserAttributeMapper.PROVIDER_ID);
-        hardCodedSessionNoteMapper.setConfig(ImmutableMap.<String, String>builder()
-                .put(IdentityProviderMapperModel.SYNC_MODE, IdentityProviderMapperSyncMode.INHERIT.toString())
-                .put(UserAttributeMapper.USER_ATTRIBUTE, "mapped-from-claim")
-                .put(UserAttributeMapper.CLAIM, "hard-coded")
-                .build());
+        hardCodedSessionNoteMapper.setConfig(Map.of(
+                IdentityProviderMapperModel.SYNC_MODE, IdentityProviderMapperSyncMode.INHERIT.toString(),
+                UserAttributeMapper.USER_ATTRIBUTE, "mapped-from-claim",
+                UserAttributeMapper.CLAIM, "hard-coded"));
 
         RealmResource consumerRealm = realmsResouce().realm(bc.consumerRealmName());
         IdentityProviderResource identityProviderResource = consumerRealm.identityProviders().get(bc.getIDPAlias());
@@ -188,6 +193,30 @@ public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBase
         }
     }
 
+    @Test
+    public void testInternalExternalTokenExchangeSessionToken() throws Exception {
+        testingClient.server(bc.consumerRealmName()).run(KcOidcBrokerTokenExchangeTest::setupRealm);
+
+        try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(
+                        realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias()))
+                .setStoreToken(false)
+                .update()) {
+            testInternalExternalTokenExchange();
+        }
+    }
+
+    @Test
+    public void testInternalExternalTokenExchangeStoredToken() throws Exception {
+        testingClient.server(bc.consumerRealmName()).run(KcOidcBrokerTokenExchangeTest::setupRealm);
+
+        try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(
+                        realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias()))
+                .setStoreToken(true)
+                .update()) {
+            testInternalExternalTokenExchange();
+        }
+    }
+
     private static void setupRealm(KeycloakSession session) {
         RealmModel realm = session.getContext().getRealm();
         IdentityProviderModel idp = session.identityProviders().getByAlias(IDP_OIDC_ALIAS);
@@ -201,12 +230,13 @@ public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBase
         client.setSecret("secret");
         client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         client.setFullScopeAllowed(false);
+        ClientModel brokerApp = realm.getClientByClientId("broker-app");
 
         AdminPermissionManagement management = AdminPermissions.management(session, realm);
         management.idps().setPermissionsEnabled(idp, true);
         ClientPolicyRepresentation clientRep = new ClientPolicyRepresentation();
         clientRep.setName("toIdp");
-        clientRep.addClient(client.getId());
+        clientRep.addClient(client.getId(), brokerApp.getId());
         ResourceServer server = management.realmResourceServer();
         Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientRep);
         management.idps().exchangeToPermission(idp).addAssociatedPolicy(clientPolicy);
@@ -215,5 +245,49 @@ public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBase
         client = realm.getClientByClientId("brokerapp");
         client.addRedirectUri(OAuthClient.APP_ROOT + "/auth");
         client.setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, OAuthClient.APP_ROOT + "/admin/backchannelLogout");
+    }
+
+    private void testInternalExternalTokenExchange() throws Exception {
+        final RealmResource consumerRealm = realmsResouce().realm(bc.consumerRealmName());
+        final int expires = realmsResouce().realm(bc.providerRealmName()).toRepresentation().getAccessTokenLifespan();
+        final ClientRepresentation brokerApp = ApiUtil.findClientByClientId(consumerRealm, "broker-app").toRepresentation();
+
+        logInAsUserInIDPForFirstTimeAndAssertSuccess();
+        final String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, brokerApp.getSecret());
+        assertThat(tokenResponse.getError(), nullValue());
+        assertThat(tokenResponse.getAccessToken(), notNullValue());
+
+        exchangeToIdP(brokerApp, tokenResponse.getAccessToken(), expires);
+
+        setTimeOffset(expires - IdentityProviderModel.DEFAULT_MIN_VALIDITY_TOKEN);
+
+        tokenResponse = oauth.doRefreshTokenRequest(tokenResponse.getRefreshToken(), brokerApp.getSecret());
+        assertThat(tokenResponse.getError(), nullValue());
+        assertThat(tokenResponse.getAccessToken(), notNullValue());
+
+        exchangeToIdP(brokerApp, tokenResponse.getAccessToken(), expires);
+    }
+
+    private void exchangeToIdP(ClientRepresentation brokerApp, String subjectToken, long expires) {
+        try (Client httpClient = AdminClientUtil.createResteasyClient();
+             Response response = httpClient.target(OAuthClient.AUTH_SERVER_ROOT)
+                .path("/realms").path(bc.consumerRealmName()).path("protocol/openid-connect/token")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, BasicAuthHelper.createHeader(brokerApp.getClientId(), brokerApp.getSecret()))
+                .post(Entity.form(new Form()
+                        .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE)
+                        .param(OAuth2Constants.SUBJECT_TOKEN, subjectToken)
+                        .param(OAuth2Constants.SUBJECT_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE)
+                        .param(OAuth2Constants.REQUESTED_ISSUER, bc.getIDPAlias()))
+                )) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+
+            AccessTokenResponse exchangeResponse = response.readEntity(AccessTokenResponse.class);
+            assertThat(exchangeResponse.getError(), nullValue());
+            assertThat(exchangeResponse.getToken(), notNullValue());
+            assertThat(exchangeResponse.getExpiresIn(), greaterThan((long) IdentityProviderModel.DEFAULT_MIN_VALIDITY_TOKEN));
+            assertThat(exchangeResponse.getExpiresIn(), lessThanOrEqualTo(expires));
+        }
     }
 }


### PR DESCRIPTION
Closes #35704

Just fixings the expiration when doing an internal to external IdP token exchange. Previously sometimes it was set the expiration time instead. Besides I added a new option in the IdP (minValidityToken) to not return tokens with very short expiration (1 or 2 seconds). I have not added the option in the IdP UI page for the moment, I can do it if you think it is necessary.
