### PR TITLE
Failed to authenticate client with method client_secret_jwt when clie…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
@@ -34,6 +34,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.ClientAuthenticationFlowContext;
+import org.keycloak.crypto.ClientSignatureVerifierProvider;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.keys.loader.PublicKeyStorageManager;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -48,6 +49,8 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
+
+import static org.keycloak.models.TokenManager.DEFAULT_VALIDATOR;
 
 /**
  * Client authentication based on JWT signed by client private key .
@@ -67,7 +70,7 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
 
     @Override
     public void authenticateClient(ClientAuthenticationFlowContext context) {
-        JWTClientValidator validator = new JWTClientValidator(context);
+        JWTClientValidator validator = new JWTClientValidator(context, getId());
         if (!validator.clientAssertionParametersValidation()) return;
 
         try {
@@ -90,7 +93,17 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
 
             boolean signatureValid;
             try {
-                JsonWebToken jwt = context.getSession().tokens().decodeClientJWT(clientAssertion, client, JsonWebToken.class);
+                JsonWebToken jwt = context.getSession().tokens().decodeClientJWT(clientAssertion, client, (jose, validatedClient) -> {
+                    DEFAULT_VALIDATOR.accept(jose, validatedClient);
+                    String signatureAlgorithm = jose.getHeader().getRawAlgorithm();
+                    ClientSignatureVerifierProvider signatureProvider = context.getSession().getProvider(ClientSignatureVerifierProvider.class, signatureAlgorithm);
+                    if (signatureProvider == null) {
+                        throw new RuntimeException("Algorithm not supported");
+                    }
+                    if (!signatureProvider.isAsymmetricAlgorithm()) {
+                        throw new RuntimeException("Algorithm is not asymmetric");
+                    }
+                }, JsonWebToken.class);
                 signatureValid = jwt != null;
             } catch (RuntimeException e) {
                 Throwable cause = e.getCause() != null ? e.getCause() : e;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
@@ -50,6 +50,7 @@ public class JWTClientValidator {
     private final ClientAuthenticationFlowContext context;
     private final RealmModel realm;
     private final int currentTime;
+    private final String clientAuthenticatorProviderId;
 
     private MultivaluedMap<String, String> params;
     private String clientAssertion;
@@ -59,10 +60,11 @@ public class JWTClientValidator {
 
     private static final int ALLOWED_CLOCK_SKEW = 15; // sec
 
-    public JWTClientValidator(ClientAuthenticationFlowContext context) {
+    public JWTClientValidator(ClientAuthenticationFlowContext context, String clientAuthenticatorProviderId) {
         this.context = context;
         this.realm = context.getRealm();
         this.currentTime = Time.currentTime();
+        this.clientAuthenticatorProviderId = clientAuthenticatorProviderId;
     }
 
     public boolean clientAssertionParametersValidation() {
@@ -135,6 +137,11 @@ public class JWTClientValidator {
 
         if (!client.isEnabled()) {
             context.failure(AuthenticationFlowError.CLIENT_DISABLED, null);
+            return false;
+        }
+
+        if (!clientAuthenticatorProviderId.equals(client.getClientAuthenticatorType())) {
+            context.failure(AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS, null);
             return false;
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
@@ -27,6 +27,7 @@ import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
+import org.keycloak.authentication.authenticators.client.JWTClientSecretAuthenticator;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.common.util.KeystoreUtil.KeystoreFormat;
 import org.keycloak.crypto.Algorithm;
@@ -673,6 +674,28 @@ public class ClientAuthSignedJWTTest extends AbstractClientAuthSignedJWTTest {
 
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
+    }
+
+    @Test
+    public void testAuthenticationFailsWhenClientSecretJWTAuthenticatorSet() throws Exception {
+        // Set client authenticator to JWT signed by client secret.
+        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "client1");
+        ClientRepresentation clientRep = clientResource.toRepresentation();
+        clientRep.setClientAuthenticatorType(JWTClientSecretAuthenticator.PROVIDER_ID);
+        clientResource.update(clientRep);
+
+        // It should not be possible to use private_key_jwt for the authentication
+        try {
+            String clientJwt = getClient1SignedJWT();
+
+            OAuthClient.AccessTokenResponse response = doClientCredentialsGrantRequest(clientJwt);
+
+            assertEquals(400, response.getStatusCode());
+            assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, response.getError());
+        } finally {
+            clientRep.setClientAuthenticatorType(JWTClientAuthenticator.PROVIDER_ID);
+            clientResource.update(clientRep);
+        }
     }
 
     @Test


### PR DESCRIPTION
…when private_key_jwt is set on the client or vice-versa

closes #34547

The issue is that client with client authentication method `client_secret_jwt` fails to authenticate if it has keys generated. Which is not good as client can have keys generated even if it doesn't use `private_key_jwt` as client authentication method (because of use-cases like IDToken encryption etc).

In case that client had keys generated, the `JWTClientAuthenticator` managed to add the token into the single-use cache. The `JWTClientSecretAuthenticator` then failed to authenticate client as token was already used in the single-use cache (The `JWTClientValidator.validateTokenReuse()` failed).

Issue is fixed it by checking that expected client authentication method earlier in the request, so the `JWTClientAuthenticator` fails early in the request. Some more checks added for preserve that JWT signed by correct key.
