### PR TITLE
Remove unnecessary word from docs

### DIFF
--- a/docs/documentation/server_development/topics/extensions.adoc
+++ b/docs/documentation/server_development/topics/extensions.adoc
@@ -1,4 +1,4 @@
-ExampleSpi[[_extensions]]
+[[_extensions]]
 
 == Extending the server
 


### PR DESCRIPTION
As mentioned in #36055 the word `ExampleSpi` seems unnecessary

Closes #36055