### PR TITLE
Allow tracing packets sent to and from LDAP for troubleshooting purposes

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/MultivaluedMap.java
+++ b/common/src/main/java/org/keycloak/common/util/MultivaluedMap.java
@@ -59,6 +59,10 @@ public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
         return Optional.ofNullable(get(key)).filter(l -> !l.isEmpty()).map(l -> l.get(0)).orElse(null);
     }
 
+    default V getFirstOrDefault(K key, V defaultValue) {
+        return Optional.ofNullable(getFirst(key)).orElse(defaultValue);
+    }
+
     public default List<V> getList(K key) {
         return compute(key, (k, v) -> v != null ? v : createListInstance());
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -252,6 +252,9 @@ public class LDAPConfig {
         return binaryAttributeNames;
     }
 
+    public boolean isConnectionTrace() {
+        return Boolean.parseBoolean(config.getFirstOrDefault(LDAPConstants.CONNECTION_TRACE, Boolean.FALSE.toString()));
+    }
 
     @Override
     public boolean equals(Object obj) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -211,6 +211,10 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .defaultValue("false")
                 .add()
+                .property().name(LDAPConstants.CONNECTION_TRACE)
+                .type(ProviderConfigProperty.BOOLEAN_TYPE)
+                .defaultValue("false")
+                .add()
                 .build();
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -74,6 +74,10 @@ public final class LDAPContextManager implements AutoCloseable {
                 }
             }
 
+            if (ldapConfig.isConnectionTrace()) {
+                connProp.put(LDAPConstants.CONNECTION_TRACE_BER, System.err);
+            }
+
             ldapContext = new InitialLdapContext(connProp, null);
             if (ldapConfig.isStartTls()) {
                 SSLSocketFactory sslSocketFactory = null;

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3332,3 +3332,5 @@ deleteConfirmUsers_other=Delete {{count}} users?
 downloadThemeJar=Download theme JAR
 themeColorInfo=Here you can set the patternfly color variables and create a "theme jar" file that you can download and put in your providers folder to apply the theme to your realm.
 permissionsSubTitle=Fine-grained admin permissions allow assigning detailed, specific access rights, controlling which resources and actions can be managed.
+connectionTrace=Connection trace
+connectionTraceHelp=If enabled, incoming and outgoing LDAP ASN.1 BER packets will be dumped to the error output stream. Be careful when enabling this option in production as it will expose all data sent to and from the LDAP server. 

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -151,6 +151,35 @@ export const LdapSettingsAdvanced = ({
             )}
           ></Controller>
         </FormGroup>
+        <FormGroup
+          label={t("connectionTrace")}
+          labelIcon={
+            <HelpItem
+              helpText={t("connectionTraceHelp")}
+              fieldLabelId="connectionTrace"
+            />
+          }
+          fieldId="kc-connection-trace"
+          hasNoPaddingTop
+        >
+          <Controller
+            name="config.connectionTrace"
+            defaultValue={["false"]}
+            control={form.control}
+            render={({ field }) => (
+              <Switch
+                id={"kc-connection-trace"}
+                data-testid="connection-trace"
+                isDisabled={false}
+                onChange={(_event, value) => field.onChange([`${value}`])}
+                isChecked={field.value[0] === "true"}
+                label={t("on")}
+                labelOff={t("off")}
+                aria-label={t("connectionTrace")}
+              />
+            )}
+          ></Controller>
+        </FormGroup>
         <FormGroup fieldId="query-extensions">
           <Button
             variant="secondary"

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -59,6 +59,8 @@ public class LDAPConstants {
     public static final String USE_TRUSTSTORE_ALWAYS = "always";
     public static final String USE_TRUSTSTORE_NEVER = "never";
 
+    public static final String CONNECTION_TRACE_BER = "com.sun.jndi.ldap.trace.ber";
+
     /**
      * @deprecated Use {@link #USE_TRUSTSTORE_ALWAYS} instead.
      */
@@ -140,6 +142,8 @@ public class LDAPConstants {
     public static final String LDAP_MATCHING_RULE_IN_CHAIN = ":1.2.840.113556.1.4.1941:";
 
     public static final String REFERRAL = "referral";
+
+    public static final String CONNECTION_TRACE = "connectionTrace";
 
     public static String getUuidAttributeName(String vendor) {
         if (vendor != null) {


### PR DESCRIPTION
Closes #36087

* Adds an LDAP provider setting to dump ASN.1 BER packets for troubleshooting purposes, only.
* Not sure if we want to allow setting a different output (e.g.: separate file) stream but `System.err`. I'm setting to system err by default as this setting should be enabled only when needed and without exposing data to the system out or logs.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
