### PR TITLE
Updated invalid URL in log message

### DIFF
--- a/js/libs/keycloak-js/lib/keycloak.js
+++ b/js/libs/keycloak-js/lib/keycloak.js
@@ -1261,7 +1261,7 @@ function Keycloak (config) {
                         "[KEYCLOAK] Your browser is blocking access to 3rd-party cookies, this means:\n\n" +
                         " - It is not possible to retrieve tokens without redirecting to the Keycloak server (a.k.a. no support for silent authentication).\n" +
                         " - It is not possible to automatically detect changes to the session status (such as the user logging out in another tab).\n\n" +
-                        "For more information see: https://www.keycloak.org/docs/latest/securing_apps/#_modern_browsers"
+                        "For more information see: https://www.keycloak.org/securing-apps/javascript-adapter#_modern_browsers"
                     );
 
                     loginIframe.enable = false;


### PR DESCRIPTION
In case of unsupported 3p cookies a warning is logged which includes an invalid URL. The message refers to https://www.keycloak.org/docs/latest/securing_apps/#_modern_browsers while it should be https://www.keycloak.org/securing-apps/javascript-adapter#_modern_browsers

Closes #36168

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
