### PR TITLE
Unable to set '--log-syslog-max-length' property

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -182,7 +182,7 @@ public class LoggingOptions {
             .defaultValue(SyslogHandler.SyslogType.RFC5424.toString().toLowerCase())
             .build();
 
-    public static final Option<MemorySize> LOG_SYSLOG_MAX_LENGTH = new OptionBuilder<>("log-syslog-max-length", MemorySize.class)
+    public static final Option<String> LOG_SYSLOG_MAX_LENGTH = new OptionBuilder<>("log-syslog-max-length", String.class)
             .category(OptionCategory.LOGGING)
             // based on the 'quarkus.log.syslog.max-length' property
             .description("Set the maximum length, in bytes, of the message allowed to be sent. The length includes the header and the message. " +

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -12,6 +12,7 @@ import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import org.jboss.logmanager.LogContext;
 import org.keycloak.config.LoggingOptions;
 import org.keycloak.config.Option;
@@ -144,6 +145,7 @@ public final class LoggingPropertyMappers {
                 fromOption(LoggingOptions.LOG_SYSLOG_MAX_LENGTH)
                         .isEnabled(LoggingPropertyMappers::isSyslogEnabled, SYSLOG_ENABLED_MSG)
                         .to("quarkus.log.syslog.max-length")
+                        .validator(LoggingPropertyMappers::validateSyslogMaxLength)
                         .paramLabel("max-length")
                         .build(),
                 fromOption(LoggingOptions.LOG_SYSLOG_PROTOCOL)
@@ -294,5 +296,14 @@ public final class LoggingPropertyMappers {
 
     private static String upperCase(String value, ConfigSourceInterceptorContext context) {
         return value.toUpperCase(Locale.ROOT);
+    }
+
+    private static void validateSyslogMaxLength(String value) {
+        var converter = new MemorySizeConverter();
+        try {
+            converter.convert(value);
+        } catch (IllegalArgumentException e) {
+            throw new PropertyException(String.format("Invalid value for option '--log-syslog-max-length': %s", e.getMessage()));
+        }
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -20,6 +20,7 @@ package org.keycloak.quarkus.runtime.cli;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -445,4 +446,19 @@ public class PicocliTest extends AbstractConfigurationTest {
                 containsString("Usage of the default value for the db option in the production profile is deprecated. Please explicitly set the db instead."));
     }
 
+    @Test
+    public void syslogMaxLengthMemorySize() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog", "--log-syslog-max-length=60k");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertEquals("60k", nonRunningPicocli.config.getConfigValue("quarkus.log.syslog.max-length").getValue());
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.config.getConfigValue("quarkus.log.syslog.max-length").getValue(), nullValue());
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog", "--log-syslog-max-length=wrong");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString(
+                "Invalid value for option '--log-syslog-max-length': value wrong not in correct format (regular expression): [0-9]+[BbKkMmGgTtPpEeZzYy]?"));
+    }
 }


### PR DESCRIPTION
- Fixes #35386

The root issue is a missing converter for the MemorySize data type:
```
No TypeConverter registered for io.quarkus.runtime.configuration.MemorySize of option --log-syslog-max-length
```

It means it was not even possible to use the `--log-syslog-max-length` in CLI as the server did not start. Our tests did not catch it as mainly the `ConfigurationTest` was involved - we should rather use the PicocliTest.

When an env var was set, the value could not be propagated to the Quarkus properties.

This PR introduces an explicit validation of the type and resolves the issue. I can confirm the max-length for syslog logs is properly set and works as expected (executed with `syslog-ng` tool).