### PR TITLE
Remove ignored links from the documentation tests after KC 26 release

### DIFF
--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -39,6 +39,3 @@ https://stackapps.com/apps/oauth/register
 # Failing because of broken certificate, can likely be restored later.
 https://docs.kantarainitiative.org*
 https://saml.xml.org*
-# Remove following lines once KC26 is released
-https://www.keycloak.org/server/bootstrap-admin-recovery
-https://www.keycloak.org/server/tracing


### PR DESCRIPTION
- Closes #32071

PR to main:

- https://github.com/keycloak/keycloak/pull/36254