### PR TITLE
Incorrect manage permission for getting a specific execution

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -844,7 +844,7 @@ public class AuthenticationManagementResource {
     @Operation( summary = "Get Single Execution")
     public AuthenticationExecutionRepresentation getExecution(final @PathParam("executionId") String executionId) {
     	//http://localhost:8080/auth/admin/realms/master/authentication/executions/cf26211b-9e68-4788-b754-1afd02e59d7f
-        auth.realm().requireManageRealm();
+        auth.realm().requireViewRealm();
 
         final Optional<AuthenticationExecutionModel> model = Optional.ofNullable(realm.getAuthenticationExecutionById(executionId));
         if (!model.isPresent()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -1160,6 +1160,7 @@ public class PermissionsTest extends AbstractKeycloakTest {
                 realm.flows().getExecutions("nosuch");
             }
         }, Resource.REALM, false);
+        invoke((RealmResource realm) -> realm.flows().getExecution("nosuch"), Resource.REALM, false);
         invoke(new Invocation() {
             public void invoke(RealmResource realm) {
                 realm.flows().updateExecutions("nosuch", new AuthenticationExecutionInfoRepresentation());


### PR DESCRIPTION
Closes #36121

The `getExecution` endpoint in the `AuthenticationManagementResource` was using manage instead of view realm permission. The other `getExecutions` method is using view permission as expected, so executions were returned via other endpoints. Adding the call in the `PermissionsTest` class.
