### PR TITLE
Apply organization feature only to realms that use it

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/idp/InfinispanIdentityProviderStorageProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/idp/InfinispanIdentityProviderStorageProvider.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.keycloak.common.Profile;
+
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderStorageProvider;
 import org.keycloak.models.IdentityProviderModel;
@@ -36,6 +36,7 @@ import org.keycloak.models.cache.infinispan.CachedCount;
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
 import org.keycloak.models.cache.infinispan.RealmCacheSession;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.OrganizationUtil;
 
 import static org.keycloak.models.IdentityProviderStorageProvider.LoginFilter.getLoginPredicate;
 
@@ -430,7 +431,7 @@ public class InfinispanIdentityProviderStorageProvider implements IdentityProvid
     }
 
     private IdentityProviderModel createOrganizationAwareIdentityProviderModel(IdentityProviderModel idp) {
-        if (!Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION)) return idp;
+        if (!OrganizationUtil.isOrganizationsFeatureEnabled(getRealm())) return idp;
         return new IdentityProviderModel(idp) {
             @Override
             public boolean isEnabled() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -60,6 +60,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.representations.idm.MembershipType;
 
 import static org.keycloak.utils.StreamsUtil.closing;
@@ -419,7 +421,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
     @Override
     public long getGroupsCount() {
         Long result = createCountGroupsQuery().getSingleResult();
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
             if (result > 0) {
                 // remove from the count the organization group membership
                 OrganizationProvider provider = session.getProvider(OrganizationProvider.class);

--- a/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -39,6 +39,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ComponentExportRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
@@ -252,7 +253,7 @@ public class ExportUtils {
         // Message Bundle
         rep.setLocalizationTexts(realm.getRealmLocalizationTexts());
 
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION) && !options.isPartial()) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm) && !options.isPartial()) {
             OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
             orgProvider.getAllStream().map(model -> {
                 OrganizationRepresentation org = ModelToRepresentation.toRepresentation(model);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -95,6 +95,7 @@ import org.keycloak.models.credential.dto.OTPCredentialData;
 import org.keycloak.models.credential.dto.OTPSecretData;
 import org.keycloak.models.credential.dto.PasswordCredentialData;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.policy.PasswordPolicyNotMetException;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;

--- a/server-spi/src/main/java/org/keycloak/organization/OrganizationUtil.java
+++ b/server-spi/src/main/java/org/keycloak/organization/OrganizationUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.organization;
+
+import org.keycloak.common.Profile;
+import org.keycloak.models.RealmModel;
+
+public class OrganizationUtil {
+
+    private static final boolean ORGANIZATIONS_FEATURE_ENABLED = Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION);
+
+    /**
+     * Checks if the organizations feature is active for the server and enabled for the given {@link RealmModel realm}.
+     * @param realm
+     * @return
+     */
+    public static boolean isOrganizationsFeatureEnabled(RealmModel realm) {
+        return ORGANIZATIONS_FEATURE_ENABLED && realm.isOrganizationsEnabled();
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
@@ -32,6 +32,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.provider.ProviderConfigProperty;
 
@@ -57,7 +58,7 @@ public class RegistrationPage implements FormAuthenticator, FormAuthenticatorFac
 
     @Override
     public Response render(FormContext context, LoginFormsProvider form) {
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(context.getRealm())) {
             try {
                 InviteOrgActionToken token = Organizations.parseInvitationToken(context.getHttpRequest());
 

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -44,6 +44,7 @@ import org.keycloak.models.RequiredActionProviderModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -288,7 +289,7 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
     }
 
     private boolean validateOrganizationInvitation(ValidationContext context, MultivaluedMap<String, String> formData, String email) {
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(context.getRealm())) {
             Consumer<List<FormMessage>> error = messages -> {
                 context.error(Errors.INVALID_TOKEN);
                 context.validationError(formData, messages);
@@ -335,7 +336,7 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
     }
 
     private void addOrganizationMember(FormContext context, UserModel user) {
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(context.getRealm())) {
             InviteOrgActionToken token = (InviteOrgActionToken) context.getSession().getAttribute(InviteOrgActionToken.class.getName());
 
             if (token != null) {

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -69,6 +69,7 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.organization.forms.login.freemarker.model.OrganizationAwareIdentityProviderBean;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.rar.AuthorizationDetails;
@@ -488,7 +489,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
 
             IdentityProviderBean idpBean = new IdentityProviderBean(session, realm, baseUriWithCodeAndClientId, context);
 
-            if (Profile.isFeatureEnabled(Feature.ORGANIZATION) && realm.isOrganizationsEnabled()) {
+            if (OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
                 idpBean = new OrganizationAwareIdentityProviderBean(idpBean);
             }
 
@@ -553,7 +554,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 lang = localeBean.getCurrentLanguageTag();
             }
 
-            if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+            if (OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
                 OrganizationModel organization = resolveOrganization(session, user);
 
                 if (organization != null) {
@@ -662,7 +663,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
             }
         }
 
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
             String email = (String) attributes.get(RegistrationPage.FIELD_EMAIL);
             if (this.formData == null) {
                 this.formData = new MultivaluedHashMap<>();

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -29,6 +29,7 @@ import org.keycloak.models.OrderedModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.services.Urls;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -242,7 +243,7 @@ public class IdentityProviderBean {
     }
 
     private static boolean organizationsDisabled(RealmModel realm) {
-        return !Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION) || !realm.isOrganizationsEnabled();
+        return !OrganizationUtil.isOrganizationsFeatureEnabled(realm);
     }
 
     public static class IdentityProvider implements OrderedModel {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -31,6 +31,7 @@ import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
@@ -230,7 +231,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         event.event(EventType.REGISTER);
         action = Action.REGISTER;
 
-        if (Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION) && tokenString != null) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm) && tokenString != null) {
             //this call should extract orgId from token and set the organization to the session context
             Response errorResponse = new LoginActionsService(session, event).preHandleActionToken(tokenString);
             if (errorResponse != null) {

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -72,6 +72,7 @@ import org.keycloak.models.utils.FormMessage;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.SystemClientUtil;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.LoginProtocol;
@@ -781,7 +782,7 @@ public class LoginActionsService {
                                     @QueryParam(Constants.TAB_ID) String tabId,
                                     @QueryParam(Constants.TOKEN) String tokenString) {
         
-        if (Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION) && tokenString != null) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm) && tokenString != null) {
             //this call should extract orgId from token and set the organization to the session context
             preHandleActionToken(tokenString);
         }
@@ -951,7 +952,7 @@ public class LoginActionsService {
     }
 
     private void configureOrganization(BrokeredIdentityContext brokerContext) {
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
             String organizationId = brokerContext.getIdpConfig().getOrganizationId();
 
             if (organizationId != null) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -64,6 +64,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.representations.account.ClientRepresentation;
 import org.keycloak.representations.account.ConsentRepresentation;
 import org.keycloak.representations.account.ConsentScopeRepresentation;
@@ -234,7 +235,7 @@ public class AccountRestService {
     @Path("/organizations")
     public OrganizationsResource organizations() {
         checkAccountApiEnabled();
-        if (!Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (!OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
             throw new NotFoundException();
         }
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);

--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -54,6 +54,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.organization.OrganizationUtil;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.account.AccountLinkUriRepresentation;
@@ -293,7 +294,7 @@ public class LinkedAccountsResource {
             throw ErrorResponse.error(translateErrorMessage(Messages.FEDERATED_IDENTITY_NOT_ACTIVE), Response.Status.BAD_REQUEST);
         }
 
-        if (Profile.isFeatureEnabled(Feature.ORGANIZATION)) {
+        if (OrganizationUtil.isOrganizationsFeatureEnabled(realm)) {
             if (Organizations.resolveHomeBroker(session, user).stream()
                     .map(IdentityProviderModel::getAlias)
                     .anyMatch(providerAlias::equals)) {


### PR DESCRIPTION
This PR introduces a new helper class `OrganizationUtil` which allows to check if the organization feature is enabled for the server and the given realm.

Note, logic that added default idp / protocol mapper defintions keep the original `if(Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION)) {...}` check for now.

Fixes #36312

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
