### PR TITLE
FGA: Allow view users attached to one specific client role

### DIFF
--- a/js/apps/admin-ui/src/clients/routes/ClientRole.tsx
+++ b/js/apps/admin-ui/src/clients/routes/ClientRole.tsx
@@ -23,7 +23,7 @@ export const ClientRoleRoute: AppRouteObject = {
   element: <RealmRoleTabs />,
   breadcrumb: (t) => t("roleDetails"),
   handle: {
-    access: "view-clients",
+    access: "query-clients",
   },
 } satisfies AppRouteObject;
 


### PR DESCRIPTION
Closes #24522

Admin UI: client details: show role details if fine-grained permissions are enabled and user has access to the client and 'query-clients' permission

Backport of #30834 (changes in `RealmRoleTable.tsx` are already applied to the target branch, so only the change to `ClientRole.tsx` is missing here)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
