### PR TITLE
fix: Add username validator for LDAP storage provider to handle speci…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -102,6 +102,7 @@ import org.keycloak.userprofile.AttributeMetadata;
 import org.keycloak.userprofile.UserProfileDecorator;
 import org.keycloak.userprofile.UserProfileMetadata;
 import org.keycloak.userprofile.UserProfileUtil;
+import org.keycloak.userprofile.validator.UsernameProhibitedCharactersValidator;
 
 import org.keycloak.utils.StreamsUtil;
 import org.keycloak.utils.StringUtil;
@@ -700,6 +701,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
     protected UserModel importUserFromLDAP(KeycloakSession session, RealmModel realm, LDAPObject ldapUser, ImportType importType) {
         String ldapUsername = LDAPUtils.getUsername(ldapUser, ldapIdentityStore.getConfig());
+        if(!UsernameProhibitedCharactersValidator.INSTANCE.validate(ldapUsername).isValid()){
+            return null;
+        }
         LDAPUtils.checkUuid(ldapUser, ldapIdentityStore.getConfig());
         if (importType == null) {
             importType = ImportType.FORCED;

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -721,8 +721,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
         } catch (ValidationException ve) {
             logger.warnf("Validation failed during LDAP import for username '%s': %s",
                     ldapUsername, ve.getMessage());
-            String warnUsername = ldapUsername + "_warn_";
-            LDAPUtils.setUsername(ldapUser, ldapIdentityStore.getConfig(), warnUsername);
+            return null;
         }
 
         UserModel imported = null;

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -189,6 +189,21 @@ public class LDAPUtils {
         return Optional.of(ldapUsername).map(String::toLowerCase).orElse(null);
     }
 
+    public static void setUsername(LDAPObject ldapUser, LDAPConfig config, String newUsername) {
+        String usernameAttr = config.getUsernameLdapAttribute();
+
+        if (newUsername == null || newUsername.trim().isEmpty()) {
+            throw new ModelException("Cannot set null or empty username for attribute: " + usernameAttr);
+        }
+
+        ldapUser.setSingleAttribute(usernameAttr, newUsername);
+
+        String rdnLdapAttr = config.getRdnLdapAttribute();
+        if (usernameAttr.equalsIgnoreCase(rdnLdapAttr)) {
+            ldapUser.setRdnAttributeName(rdnLdapAttr);
+        }
+    }
+
     public static void checkUuid(LDAPObject ldapUser, LDAPConfig config) {
         if (ldapUser.getUuid() == null) {
             throw new ModelException("User returned from LDAP has null uuid! Check configuration of your LDAP settings. UUID Attribute must be unique among your LDAP records and available on all the LDAP user records. " +

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -189,21 +189,6 @@ public class LDAPUtils {
         return Optional.of(ldapUsername).map(String::toLowerCase).orElse(null);
     }
 
-    public static void setUsername(LDAPObject ldapUser, LDAPConfig config, String newUsername) {
-        String usernameAttr = config.getUsernameLdapAttribute();
-
-        if (newUsername == null || newUsername.trim().isEmpty()) {
-            throw new ModelException("Cannot set null or empty username for attribute: " + usernameAttr);
-        }
-
-        ldapUser.setSingleAttribute(usernameAttr, newUsername);
-
-        String rdnLdapAttr = config.getRdnLdapAttribute();
-        if (usernameAttr.equalsIgnoreCase(rdnLdapAttr)) {
-            ldapUser.setRdnAttributeName(rdnLdapAttr);
-        }
-    }
-
     public static void checkUuid(LDAPObject ldapUser, LDAPConfig config) {
         if (ldapUser.getUuid() == null) {
             throw new ModelException("User returned from LDAP has null uuid! Check configuration of your LDAP settings. UUID Attribute must be unique among your LDAP records and available on all the LDAP user records. " +

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
@@ -91,6 +91,26 @@ public class LDAPProvidersFullNameMapperTest extends AbstractLDAPTest {
     }
 
     @Test
+    public void testInvalidUsernameImport() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(appRealm);
+            LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
+
+            MultivaluedHashMap<String, String> otherAttrs = new MultivaluedHashMap<>();
+            otherAttrs.put("postalAddress", List.of("123456", "654321"));
+
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, "<b>bobby<em>", "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
+
+            UserModel user = session.users().getUserByUsername(appRealm, "<b>bobby<em>");
+            // Test Should return NULL as username contains prohibited characters
+            Assert.assertNull("User with invalid username <b>bobby<em> should not be imported", user);
+        });
+    }
+
+    @Test
     public void testUpdatingFirstNameAndLastNamePropagatesToFullnameMapper() {
 
         testingClient.server().run(session -> {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
@@ -101,14 +101,48 @@ public class LDAPProvidersFullNameMapperTest extends AbstractLDAPTest {
 
             MultivaluedHashMap<String, String> otherAttrs = new MultivaluedHashMap<>();
             otherAttrs.put("postalAddress", List.of("123456", "654321"));
+            String originalUsername = "<b>bobby<em>";
+            String expectedWarnUsername = originalUsername + "_warn_";
 
-            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, "<b>bobby<em>", "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, originalUsername, "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
 
             UserModel user = session.users().getUserByUsername(appRealm, "<b>bobby<em>");
-            // Test Should return NULL as username contains prohibited characters
-            Assert.assertNull("User with invalid username <b>bobby<em> should not be imported", user);
+
+            Assert.assertNotNull(
+                    "User with invalid username should be imported with a warning suffix",
+                    user
+            );
+
+            Assert.assertEquals(
+                    "Username should be updated with a warning suffix",
+                    expectedWarnUsername,
+                    user.getUsername()
+            );
         });
     }
+
+    @Test
+    public void testValidUsernameImport() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(appRealm);
+            LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
+
+            MultivaluedHashMap<String, String> otherAttrs = new MultivaluedHashMap<>();
+            otherAttrs.put("postalAddress", List.of("123456", "654321"));
+
+
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, "bobby", "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
+
+            UserModel user = session.users().getUserByUsername(appRealm, "bobby");
+
+            Assert.assertNotNull("User with valid username 'bobby' should be imported", user);
+            Assert.assertEquals("bobby", user.getUsername());
+        });
+    }
+
 
     @Test
     public void testUpdatingFirstNameAndLastNamePropagatesToFullnameMapper() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
@@ -101,23 +101,12 @@ public class LDAPProvidersFullNameMapperTest extends AbstractLDAPTest {
 
             MultivaluedHashMap<String, String> otherAttrs = new MultivaluedHashMap<>();
             otherAttrs.put("postalAddress", List.of("123456", "654321"));
-            String originalUsername = "<b>bobby<em>";
-            String expectedWarnUsername = originalUsername + "_warn_";
 
-            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, originalUsername, "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, "<b>bobby<em>", "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
 
             UserModel user = session.users().getUserByUsername(appRealm, "<b>bobby<em>");
-
-            Assert.assertNotNull(
-                    "User with invalid username should be imported with a warning suffix",
-                    user
-            );
-
-            Assert.assertEquals(
-                    "Username should be updated with a warning suffix",
-                    expectedWarnUsername,
-                    user.getUsername()
-            );
+            // Test Should return NULL as username contains prohibited characters
+            Assert.assertNull("User with invalid username <b>bobby<em> should not be imported", user);
         });
     }
 


### PR DESCRIPTION
Hii @jonkoops @hokuda thanks a lot for assigning me this. As discussed I have made the changes by importing the **UsernameProhibitedCharactersValidator** and implementing it in the **importUserFromLDAP** method.  

Please tell me if I need to do anything more.  Thanks :)

Signed-off-by: Riju Mondal <mailrijumondal@gmail.com>

Closes: #32640
