### PR TITLE
VERIFY_EMAIL as supported Application Initiated Action

### DIFF
--- a/docs/documentation/server_admin/topics/users/con-aia.adoc
+++ b/docs/documentation/server_admin/topics/users/con-aia.adoc
@@ -47,7 +47,7 @@ the client can  still request re-authentication when some AIA is requested. Exce
 
 * The action `delete_account` will always require the user to actively re-authenticate
 
-* The action `update_password` might require the user to actively re-authenticate according to the configured <<maximum-authentication-age,Maximum Authentication Age Password policy>>.
+* The action `UPDATE_PASSWORD` might require the user to actively re-authenticate according to the configured <<maximum-authentication-age,Maximum Authentication Age Password policy>>.
 In case the policy is not configured, it is also possible to configure it on the required action itself in the <<proc-setting-default-required-actions_{context}, Required actions tab>>
 when configuring the particular required action. If the policy is not configured in any of those places, it defaults to five minutes.
 
@@ -65,7 +65,7 @@ In the same manner, deleting an existing 2nd-factor credential (`otp` or `webaut
 
 Some AIA can require the parameter to be sent together with the action name. For instance, the `Delete Credential` action can be triggered only by AIA and it requires a parameter to be sent together with the name
 of the action, which points to the ID of the removed credential. So the URL for this example would be `kc_action=delete_credential:ce1008ac-f811-427f-825a-c0b878d1c24b`. In this case, the
-part after the colon character (`ce1008ac-f811-427f-825a-c0b878d1c24b`) contains the ID of the credential of the particular user, which is to be deleted. The `Delete Credential` action 
+part after the colon character (`ce1008ac-f811-427f-825a-c0b878d1c24b`) contains the ID of the credential of the particular user, which is to be deleted. The `Delete Credential` action
 displays the confirmation screen where the user can confirm agreement to delete the credential.
 
 NOTE: The <<_account-service,{project_name} Account Console>> typically uses the `Delete Credential` action when deleting a 2nd-factor credential.  You can check the Account Console for examples if you want

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -196,6 +196,9 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
             case VERIFY_EMAIL:
                 UpdateProfileContext userBasedContext1 = new UserUpdateProfileContext(realm, user);
                 attributes.put("user", new ProfileBean(userBasedContext1, formData));
+                if (authenticationSession.getAuthNote(Constants.VERIFY_EMAIL_KEY) != null) {
+                    attributes.put("verifyEmail", authenticationSession.getAuthNote(Constants.VERIFY_EMAIL_KEY));
+                }
                 actionMessage = Messages.VERIFY_EMAIL;
                 page = LoginFormsPages.LOGIN_VERIFY_EMAIL;
                 break;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyEmailPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyEmailPage.java
@@ -33,6 +33,9 @@ public class VerifyEmailPage extends AbstractPage {
     @FindBy(linkText = "Click here")
     private WebElement resendEmailLink;
 
+    @FindBy(name = "cancel-aia")
+    private WebElement cancelAIAButton;
+
     @Override
     public void open() {
     }
@@ -47,6 +50,10 @@ public class VerifyEmailPage extends AbstractPage {
 
     public String getResendEmailLink() {
         return resendEmailLink.getAttribute("href");
+    }
+
+    public void cancel() {
+        cancelAIAButton.click();
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionVerifyEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionVerifyEmailTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.actions;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.pages.ErrorPage;
+import org.keycloak.testsuite.pages.VerifyEmailPage;
+import org.keycloak.testsuite.util.UserBuilder;
+
+/**
+ * Only covers basic use cases for App Initialized actions. Complete dynamic user profile behavior is tested in {@link RequiredActionUpdateProfileWithUserProfileTest} as it shares same code as the App initialized action.
+ *
+ * @author Stan Silvert
+ */
+public class AppInitiatedActionVerifyEmailTest extends AbstractAppInitiatedActionTest {
+
+    @Override
+    public String getAiaAction() {
+        return UserModel.RequiredAction.VERIFY_EMAIL.name();
+    }
+    
+    @Page
+    protected VerifyEmailPage verifyEmailPage;
+
+    @Page
+    protected ErrorPage errorPage;
+    
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+    }
+
+    @Before
+    public void beforeTest() {
+        ApiUtil.removeUserByUsername(testRealm(), "test-user@localhost");
+        UserRepresentation user = UserBuilder.create().enabled(true)
+                .username("test-user@localhost")
+                .email("test-user@localhost")
+                .firstName("Tom")
+                .lastName("Brady")
+                .build();
+        ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+    }
+  
+    @Test
+    public void sendVerifyEmail() {
+        doAIA();
+
+        loginPage.login("test-user@localhost", "password");
+        
+        verifyEmailPage.assertCurrent();
+
+    }
+    
+    @Test
+    public void cancelUpdateProfile() {
+        doAIA();
+
+        loginPage.login("test-user@localhost", "password");
+        
+        verifyEmailPage.assertCurrent();
+        verifyEmailPage.cancel();
+
+        assertKcActionStatus(CANCELLED);
+
+    }
+
+}

--- a/themes/src/main/resources/theme/base/login/login-verify-email.ftl
+++ b/themes/src/main/resources/theme/base/login/login-verify-email.ftl
@@ -3,12 +3,34 @@
     <#if section = "header">
         ${msg("emailVerifyTitle")}
     <#elseif section = "form">
-        <p class="instruction">${msg("emailVerifyInstruction1",user.email)}</p> 
-    <#elseif section = "info">
         <p class="instruction">
-            ${msg("emailVerifyInstruction2")}
-            <br/>
-            <a href="${url.loginAction}">${msg("doClickHere")}</a> ${msg("emailVerifyInstruction3")}
+            <#if verifyEmail??>
+                ${msg("emailVerifyInstruction1",verifyEmail)}
+            <#else>
+                ${msg("emailVerifyInstruction4",user.email)}
+            </#if>
         </p>
+        <#if isAppInitiatedAction??>
+            <form id="kc-verify-email-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+                <div class="${properties.kcFormGroupClass!}">
+                    <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                        <#if verifyEmail??>
+                            <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("emailVerifyResend")}" />
+                        <#else>
+                            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("emailVerifySend")}" />
+                        </#if>
+                        <button class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" type="submit" name="cancel-aia" value="true" formnovalidate/>${msg("doCancel")}</button>
+                    </div>
+                </div>
+            </form>
+        </#if>
+    <#elseif section = "info">
+        <#if !isAppInitiatedAction??>
+            <p class="instruction">
+                ${msg("emailVerifyInstruction2")}
+                <br/>
+                <a href="${url.loginAction}">${msg("doClickHere")}</a> ${msg("emailVerifyInstruction3")}
+            </p>
+        </#if>
     </#if>
 </@layout.registrationLayout>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -168,6 +168,9 @@ oauth2DeviceAuthorizationGrantDisabledMessage=Client is not allowed to initiate 
 emailVerifyInstruction1=An email with instructions to verify your email address has been sent to your address {0}.
 emailVerifyInstruction2=Haven''t received a verification code in your email?
 emailVerifyInstruction3=to re-send the email.
+emailVerifyInstruction4=To verify your email address, we are about to send you email with instructions to the address {0}.
+emailVerifyResend=Re-send verification email
+emailVerifySend=Send verification email
 
 emailLinkIdpTitle=Link {0}
 emailLinkIdp1=An email with instructions to link {0} account {1} with your {2} account has been sent to you.

--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
@@ -79,6 +79,11 @@ div.kc-logo-text span {
     overflow-wrap: break-word
 }
 
+#kc-verify-email-form {
+    margin-top: 24px;
+    margin-bottom: 24px;
+}
+
 #kc-header-wrapper {
     font-size: 29px;
     text-transform: uppercase;


### PR DESCRIPTION
Closes #25154

[Unrelated failure in external links check]

Dialog in application initiated action, after email has been sent (cancel is shown only for application initiated action): 

![image](https://github.com/user-attachments/assets/66f930a4-0801-4626-8237-d629e4e70731)

After clicking on "Send verification email", it changes to:

![image](https://github.com/user-attachments/assets/6f4198a6-72ef-45fc-97a2-1d5e23d0806b)

Clicking on "Cancel" will take the user back to the application that initiated the action.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
