### PR TITLE
Exclude WebAuthn4J from Quarkus managed versions

### DIFF
--- a/quarkus/set-quarkus-version.sh
+++ b/quarkus/set-quarkus-version.sh
@@ -39,6 +39,7 @@ QUARKUS_BRANCH="$QUARKUS_VERSION"
 EXCLUDED_DEPENDENCIES=(
     "infinispan"
     "jakarta.mail"
+    "webauthn4j" # https://github.com/keycloak/keycloak/issues/36385
 )
 
 if [ "$QUARKUS_BRANCH" == "$DEFAULT_QUARKUS_VERSION" ]; then


### PR DESCRIPTION
This is needed as a preparation for the next Quarkus version.

I believe this doesn't need a GHI as per the [PR checklist](https://github.com/keycloak/keycloak/blob/07d374a9d74cd9bebe5227e9154839d8657c7b7e/PR-CHECKLIST.md?plain=1#L7).