### PR TITLE
Show error when validate email sending fails

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
@@ -107,6 +107,7 @@ public class ResetCredentialEmail implements Authenticator, AuthenticatorFactory
             context.forkWithSuccessMessage(new FormMessage(Messages.EMAIL_SENT));
         } catch (EmailException e) {
             event.clone().event(EventType.SEND_RESET_PASSWORD)
+                    .detail(Details.REASON, e.getMessage())
                     .detail(Details.USERNAME, username)
                     .user(user)
                     .error(Errors.EMAIL_SEND_FAILED);

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
@@ -17,9 +17,16 @@
 
 package org.keycloak.authentication.requiredactions;
 
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriBuilderException;
+import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
-import org.keycloak.authentication.*;
+import org.keycloak.authentication.AuthenticationProcessor;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.authentication.actiontoken.verifyemail.VerifyEmailActionToken;
 import org.keycloak.common.util.Time;
 import org.keycloak.email.EmailException;
@@ -29,16 +36,20 @@ import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.models.*;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.services.Urls;
+import org.keycloak.services.messages.Messages;
 import org.keycloak.services.validation.Validation;
 
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import jakarta.ws.rs.core.*;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -77,7 +88,7 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
         if (! Objects.equals(authSession.getAuthNote(Constants.VERIFY_EMAIL_KEY), email)) {
             authSession.setAuthNote(Constants.VERIFY_EMAIL_KEY, email);
             EventBuilder event = context.getEvent().clone().event(EventType.SEND_VERIFY_EMAIL).detail(Details.EMAIL, email);
-            challenge = sendVerifyEmail(context.getSession(), loginFormsProvider, context.getUser(), context.getAuthenticationSession(), event);
+            challenge = sendVerifyEmail(context, event);
         } else {
             challenge = loginFormsProvider.createResponse(UserModel.RequiredAction.VERIFY_EMAIL);
         }
@@ -128,9 +139,12 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
         return UserModel.RequiredAction.VERIFY_EMAIL.name();
     }
 
-    private Response sendVerifyEmail(KeycloakSession session, LoginFormsProvider forms, UserModel user, AuthenticationSessionModel authSession, EventBuilder event) throws UriBuilderException, IllegalArgumentException {
-        RealmModel realm = session.getContext().getRealm();
-        UriInfo uriInfo = session.getContext().getUri();
+    private Response sendVerifyEmail(RequiredActionContext context, EventBuilder event) throws UriBuilderException, IllegalArgumentException {
+        RealmModel realm = context.getRealm();
+        UriInfo uriInfo = context.getUriInfo();
+        UserModel user = context.getUser();
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        KeycloakSession session = context.getSession();
 
         int validityInSecs = realm.getActionTokenGeneratedByUserLifespan(VerifyEmailActionToken.TOKEN_TYPE);
         int absoluteExpirationInSecs = Time.currentTime() + validityInSecs;
@@ -150,11 +164,17 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
               .setUser(user)
               .sendVerifyEmail(link, expirationInMinutes);
             event.success();
+            return context.form().createResponse(UserModel.RequiredAction.VERIFY_EMAIL);
         } catch (EmailException e) {
+            event.clone().event(EventType.SEND_VERIFY_EMAIL)
+                    .detail(Details.REASON, e.getMessage())
+                    .user(user)
+                    .error(Errors.EMAIL_SEND_FAILED);
             logger.error("Failed to send verification email", e);
-            event.error(Errors.EMAIL_SEND_FAILED);
+            context.failure(Messages.EMAIL_SENT_ERROR);
+            return context.form()
+                    .setError(Messages.EMAIL_SENT_ERROR)
+                    .createErrorPage(Response.Status.INTERNAL_SERVER_ERROR);
         }
-
-        return forms.createResponse(UserModel.RequiredAction.VERIFY_EMAIL);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTest.java
@@ -31,6 +31,7 @@ import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.VerifyEmailPage;
 import org.keycloak.testsuite.updaters.UserAttributeUpdater;
+import org.keycloak.testsuite.util.GreenMailRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -46,6 +47,9 @@ public class AppInitiatedActionTest extends AbstractTestRealmKeycloakTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
+
+    @Rule
+    public GreenMailRule greenMail = new GreenMailRule();
 
     @Page
     protected AppPage appPage;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TrustStoreEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TrustStoreEmailTest.java
@@ -35,6 +35,7 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.auth.page.AuthRealm;
 import org.keycloak.testsuite.auth.page.login.OIDCLogin;
 import org.keycloak.testsuite.auth.page.login.VerifyEmail;
+import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.MailServerConfiguration;
@@ -59,6 +60,9 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
 
     @Page
     private VerifyEmail testRealmVerifyEmailPage;
+
+    @Page
+    private ErrorPage errorPage;
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
@@ -169,9 +173,9 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
         // Email wasn't send
         Assert.assertNull(SslMailServer.getLastReceivedMessage());
 
-        // Email wasn't send, but we won't notify end user about that. Admin is aware due to the error in the logs and the SEND_VERIFY_EMAIL_ERROR event.
-        assertEquals("You need to verify your email address to activate your account.",
-                testRealmVerifyEmailPage.feedbackMessage().getText());
+        // Email wasn't sent, and we notify end user about that.
+        assertEquals("Failed to send email, please try again later.",
+                errorPage.getError());
     }
 
     @Test
@@ -197,9 +201,9 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
             // Email wasn't send
             Assert.assertNull(SslMailServer.getLastReceivedMessage());
 
-            // Email wasn't send, but we won't notify end user about that. Admin is aware due to the error in the logs and the SEND_VERIFY_EMAIL_ERROR event.
-            assertEquals("You need to verify your email address to activate your account.",
-                    testRealmVerifyEmailPage.feedbackMessage().getText());
+            // Email wasn't sent, and we notify end user about that.
+            assertEquals("Failed to send email, please try again later.",
+                    errorPage.getError());
         }
     }
 


### PR DESCRIPTION
Dialog when sending the email failed: 

![image](https://github.com/user-attachments/assets/aafd04fb-a373-4466-9197-231e42059123)

Closes #36409

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
