### PR TITLE
Adding SAML adapter zip distribution back to the sources

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -41,6 +41,7 @@
     </properties>
 
     <modules>
+        <module>saml-adapters</module>
         <module>galleon-feature-packs</module>
         <module>licenses-common</module>
         <module>maven-plugins</module>

--- a/distribution/saml-adapters/pom.xml
+++ b/distribution/saml-adapters/pom.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-distribution-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+    </parent>
+
+    <name>SAML Adapters Distribution Parent</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-saml-adapters-distribution-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>wildfly-adapter</module>
+    </modules>
+
+</project>

--- a/distribution/saml-adapters/shared-cli/adapter-elytron-install-saml-offline.cli
+++ b/distribution/saml-adapters/shared-cli/adapter-elytron-install-saml-offline.cli
@@ -1,0 +1,61 @@
+embed-server --server-config=${server.config:standalone.xml}
+
+if (outcome != success) of /extension=org.keycloak.keycloak-saml-adapter-subsystem:read-resource
+    /extension=org.keycloak.keycloak-saml-adapter-subsystem/:add(module=org.keycloak.keycloak-saml-adapter-subsystem)
+else
+    echo Keycloak SAML Extension already installed
+end-if
+
+if (outcome != success) of /subsystem=keycloak-saml:read-resource
+    /subsystem=keycloak-saml:add
+else
+    echo Keycloak SAML Subsystem already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm:read-resource
+    /subsystem=elytron/custom-realm=KeycloakSAMLRealm:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+else
+    echo Keycloak SAML Realm already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/security-domain=KeycloakDomain:read-resource
+    /subsystem=elytron/security-domain=KeycloakDomain:add(default-realm=KeycloakSAMLRealm,permission-mapper=default-permission-mapper,security-event-listener=local-audit,realms=[{realm=KeycloakSAMLRealm}])
+else
+    echo Keycloak Security Domain already installed. Trying to install Keycloak SAML Realm.
+    /subsystem=elytron/security-domain=KeycloakDomain:list-add(name=realms, value={realm=KeycloakSAMLRealm})
+end-if
+
+if (outcome != success) of /subsystem=elytron/constant-realm-mapper=keycloak-saml-realm-mapper:read-resource
+    /subsystem=elytron/constant-realm-mapper=keycloak-saml-realm-mapper:add(realm-name=KeycloakSAMLRealm)
+else
+    echo Keycloak SAML Realm Mapper already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory:read-resource
+    /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+else
+    echo Keycloak SAML HTTP Mechanism Factory already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/aggregate-http-server-mechanism-factory=keycloak-http-server-mechanism-factory:read-resource
+    /subsystem=elytron/aggregate-http-server-mechanism-factory=keycloak-http-server-mechanism-factory:add(http-server-mechanism-factories=[keycloak-saml-http-server-mechanism-factory, global])
+else
+    echo Keycloak HTTP Mechanism Factory already installed. Trying to install Keycloak SAML HTTP Mechanism Factory.
+    /subsystem=elytron/aggregate-http-server-mechanism-factory=keycloak-http-server-mechanism-factory:list-add(name=http-server-mechanism-factories, value=keycloak-saml-http-server-mechanism-factory)
+end-if
+
+if (outcome != success) of /subsystem=elytron/http-authentication-factory=keycloak-http-authentication:read-resource
+    /subsystem=elytron/http-authentication-factory=keycloak-http-authentication:add(security-domain=KeycloakDomain,http-server-mechanism-factory=keycloak-http-server-mechanism-factory,mechanism-configurations=[{mechanism-name=KEYCLOAK-SAML,mechanism-realm-configurations=[{realm-name=KeycloakSAMLCRealm,realm-mapper=keycloak-saml-realm-mapper}]}])
+else
+    echo Keycloak HTTP Authentication Factory already installed. Trying to install Keycloak SAML Mechanism Configuration
+    /subsystem=elytron/http-authentication-factory=keycloak-http-authentication:list-add(name=mechanism-configurations, value={mechanism-name=KEYCLOAK-SAML,mechanism-realm-configurations=[{realm-name=KeycloakSAMLRealm,realm-mapper=keycloak-saml-realm-mapper}]})
+end-if
+
+if (outcome != success) of /subsystem=undertow/application-security-domain=other:read-resource
+    /subsystem=undertow/application-security-domain=other:add(http-authentication-factory=keycloak-http-authentication)
+else
+    batch
+    /subsystem=undertow/application-security-domain=other:undefine-attribute(name=security-domain)
+    /subsystem=undertow/application-security-domain=other:write-attribute(name=http-authentication-factory,value=keycloak-http-authentication)
+    run-batch
+end-if

--- a/distribution/saml-adapters/shared-cli/adapter-elytron-install-saml.cli
+++ b/distribution/saml-adapters/shared-cli/adapter-elytron-install-saml.cli
@@ -1,0 +1,59 @@
+if (outcome != success) of /extension=org.keycloak.keycloak-saml-adapter-subsystem:read-resource
+    /extension=org.keycloak.keycloak-saml-adapter-subsystem/:add(module=org.keycloak.keycloak-saml-adapter-subsystem)
+else
+    echo Keycloak SAML Extension already installed
+end-if
+
+if (outcome != success) of /subsystem=keycloak-saml:read-resource
+    /subsystem=keycloak-saml:add
+else
+    echo Keycloak SAML Subsystem already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/custom-realm=KeycloakSAMLRealm:read-resource
+    /subsystem=elytron/custom-realm=KeycloakSAMLRealm:add(class-name=org.keycloak.adapters.saml.elytron.KeycloakSecurityRealm, module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+else
+    echo Keycloak SAML Realm already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/security-domain=KeycloakDomain:read-resource
+    /subsystem=elytron/security-domain=KeycloakDomain:add(default-realm=KeycloakSAMLRealm,permission-mapper=default-permission-mapper,security-event-listener=local-audit,realms=[{realm=KeycloakSAMLRealm}])
+else
+    echo Keycloak Security Domain already installed. Trying to install Keycloak SAML Realm.
+    /subsystem=elytron/security-domain=KeycloakDomain:list-add(name=realms, value={realm=KeycloakSAMLRealm})
+end-if
+
+if (outcome != success) of /subsystem=elytron/constant-realm-mapper=keycloak-saml-realm-mapper:read-resource
+    /subsystem=elytron/constant-realm-mapper=keycloak-saml-realm-mapper:add(realm-name=KeycloakSAMLRealm)
+else
+    echo Keycloak SAML Realm Mapper already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory:read-resource
+    /subsystem=elytron/service-loader-http-server-mechanism-factory=keycloak-saml-http-server-mechanism-factory:add(module=org.keycloak.keycloak-saml-wildfly-elytron-adapter)
+else
+    echo Keycloak SAML HTTP Mechanism Factory already installed
+end-if
+
+if (outcome != success) of /subsystem=elytron/aggregate-http-server-mechanism-factory=keycloak-http-server-mechanism-factory:read-resource
+    /subsystem=elytron/aggregate-http-server-mechanism-factory=keycloak-http-server-mechanism-factory:add(http-server-mechanism-factories=[keycloak-saml-http-server-mechanism-factory, global])
+else
+    echo Keycloak HTTP Mechanism Factory already installed. Trying to install Keycloak SAML HTTP Mechanism Factory.
+    /subsystem=elytron/aggregate-http-server-mechanism-factory=keycloak-http-server-mechanism-factory:list-add(name=http-server-mechanism-factories, value=keycloak-saml-http-server-mechanism-factory)
+end-if
+
+if (outcome != success) of /subsystem=elytron/http-authentication-factory=keycloak-http-authentication:read-resource
+    /subsystem=elytron/http-authentication-factory=keycloak-http-authentication:add(security-domain=KeycloakDomain,http-server-mechanism-factory=keycloak-http-server-mechanism-factory,mechanism-configurations=[{mechanism-name=KEYCLOAK-SAML,mechanism-realm-configurations=[{realm-name=KeycloakSAMLCRealm,realm-mapper=keycloak-saml-realm-mapper}]}])
+else
+    echo Keycloak HTTP Authentication Factory already installed. Trying to install Keycloak SAML Mechanism Configuration
+    /subsystem=elytron/http-authentication-factory=keycloak-http-authentication:list-add(name=mechanism-configurations, value={mechanism-name=KEYCLOAK-SAML,mechanism-realm-configurations=[{realm-name=KeycloakSAMLRealm,realm-mapper=keycloak-saml-realm-mapper}]})
+end-if
+
+if (outcome != success) of /subsystem=undertow/application-security-domain=other:read-resource
+    /subsystem=undertow/application-security-domain=other:add(http-authentication-factory=keycloak-http-authentication)
+else
+    batch
+    /subsystem=undertow/application-security-domain=other:undefine-attribute(name=security-domain)
+    /subsystem=undertow/application-security-domain=other:write-attribute(name=http-authentication-factory,value=keycloak-http-authentication)
+    run-batch
+end-if

--- a/distribution/saml-adapters/shared-cli/adapter-install-saml-offline.cli
+++ b/distribution/saml-adapters/shared-cli/adapter-install-saml-offline.cli
@@ -1,0 +1,3 @@
+embed-server --server-config=${server.config:standalone.xml}
+/extension=org.keycloak.keycloak-saml-adapter-subsystem/:add(module=org.keycloak.keycloak-saml-adapter-subsystem)
+/subsystem=keycloak-saml:add

--- a/distribution/saml-adapters/shared-cli/adapter-install-saml.cli
+++ b/distribution/saml-adapters/shared-cli/adapter-install-saml.cli
@@ -1,0 +1,2 @@
+/extension=org.keycloak.keycloak-saml-adapter-subsystem/:add(module=org.keycloak.keycloak-saml-adapter-subsystem)
+/subsystem=keycloak-saml:add

--- a/distribution/saml-adapters/wildfly-adapter/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/pom.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <name>Keycloak Wildfly SAML Adapter</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-saml-wildfly-adapter-dist-pom</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>wildfly-modules</module>
+        <module>wildfly-adapter-zip</module>
+    </modules>
+
+</project>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/assembly.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/assembly.xml
@@ -1,0 +1,58 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly>
+    <id>war-dist</id>
+
+    <formats>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/unpacked/modules</directory>
+            <includes>
+                <include>**/**</include>
+            </includes>
+            <outputDirectory>modules</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/unpacked/licenses</directory>
+            <outputDirectory>docs/licenses-keycloak</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+             <source>../../shared-cli/adapter-install-saml.cli</source>
+             <outputDirectory>bin</outputDirectory>
+        </file>
+        <file>
+             <source>../../shared-cli/adapter-install-saml-offline.cli</source>
+             <outputDirectory>bin</outputDirectory>
+        </file>
+        <file>
+            <source>../../shared-cli/adapter-elytron-install-saml.cli</source>
+            <outputDirectory>bin</outputDirectory>
+        </file>
+        <file>
+            <source>../../shared-cli/adapter-elytron-install-saml-offline.cli</source>
+            <outputDirectory>bin</outputDirectory>
+        </file>
+    </files>
+</assembly>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
@@ -1,0 +1,93 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>keycloak-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>keycloak-saml-wildfly-adapter-dist</artifactId>
+    <packaging>pom</packaging>
+    <name>Keycloak SAML Wildfly Adapter Distro</name>
+    <description/>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-wildfly-modules</artifactId>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.keycloak</groupId>
+                                    <artifactId>keycloak-saml-wildfly-modules</artifactId>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <outputDirectory>
+                                target
+                            </outputDirectory>
+                            <workDirectory>
+                                target/assembly/work
+                            </workDirectory>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/assembly.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/assembly.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly>
+    <id>dist</id>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources/licenses/keycloak</directory>
+            <outputDirectory>licenses</outputDirectory>
+            <excludes>
+                <exclude>licenses.xml</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/licenses</directory>
+            <outputDirectory>licenses</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/modules</directory>
+            <outputDirectory>modules</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/build.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/build.xml
@@ -1,0 +1,94 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="module-repository" basedir="." default="all">
+
+    <import file="lib.xml"/>
+
+    <property name="output.dir" value="target"/>
+
+    <target name="all">
+        <!-- copy modules definitions from saml-galleon-feature-pack resources
+             org.keycloak:keycloak-saml-adapter-galleon-pack
+        -->
+        <copy todir="${output.dir}/modules">
+            <fileset dir="../../../galleon-feature-packs/saml-adapter-galleon-pack/src/main/resources/modules"/>
+        </copy>
+        <!-- prepare module.xml files to further processing -->
+        <replaceregexp match="&lt;artifact.*/&gt;" replace="&lt;!-- Insert resources here --&gt;" byline="true">
+            <fileset dir="${output.dir}/modules" includes="**/module.xml"/>
+        </replaceregexp>
+        <antcall target="modules">
+            <param name="mavenized.modules" value="false"/>
+            <param name="output.dir" value="target"/>
+        </antcall>
+    </target>
+
+
+    <target name="modules">
+
+        <!-- server min dependencies -->
+
+        <module-def name="org.keycloak.keycloak-common">
+            <maven-resource group="org.keycloak" artifact="keycloak-common"/>
+        </module-def>
+
+        <!-- subsystems -->
+
+        <module-def name="org.keycloak.keycloak-adapter-spi">
+            <maven-resource group="org.keycloak" artifact="keycloak-adapter-spi"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-saml-core">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-core"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-saml-core-public">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-core-public"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-saml-adapter-api-public">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-adapter-api-public"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-saml-adapter-core">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-adapter-core"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-jboss-adapter-core">
+            <maven-resource group="org.keycloak" artifact="keycloak-jboss-adapter-core"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-saml-wildfly-subsystem">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-wildfly-subsystem"/>
+        </module-def>
+
+        <module-def name="org.keycloak.keycloak-saml-wildfly-elytron-adapter">
+            <maven-resource group="org.keycloak" artifact="keycloak-saml-wildfly-elytron-adapter"/>
+        </module-def>
+
+    </target>
+
+    <target name="clean-target">
+        <delete dir="${output.dir}"/>
+    </target>
+
+    <target name="clean" depends="clean-target">
+        <delete file="maven-ant-tasks.jar"/>
+    </target>
+
+</project>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/lib.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/lib.xml
@@ -1,0 +1,270 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="module-repository-lib">
+
+    <property name="src.dir" value="src"/>
+    <property name="module.repo.src.dir" value="${src.dir}/main/resources/modules"/>
+    <property name="module.xml" value="module.xml"/>
+
+    <taskdef resource="net/sf/antcontrib/antlib.xml"/>
+    <taskdef name="jandex" classname="org.jboss.jandex.JandexAntTask" />
+
+    <macrodef name="module-def">
+        <attribute name="name"/>
+        <attribute name="slot" default="main"/>
+        <element name="resources" implicit="yes" optional="yes"/>
+
+        <sequential>
+            <echo message="Initializing module -> @{name}"/>
+            <property name="module.repo.output.dir" value="${output.dir}/modules/system/add-ons/keycloak"/>
+            <!-- Figure out the correct module path -->
+            <define-module-dir name="@{name}" slot="@{slot}"/>
+
+            <!-- Make the module output director -->
+            <mkdir dir="${module.repo.output.dir}/${current.module.path}"/>
+
+            <!-- Process the resource -->
+            <resources/>
+            
+            <!-- Add keycloak version property to module xml -->
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}"
+                     token="$${project.version}"
+                     value="${project.version}"/>
+            
+            <!-- Some final cleanup -->
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                <replacetoken>
+                    <![CDATA[
+        <!-- Insert resources here -->]]></replacetoken>
+                <replacevalue>
+                </replacevalue>
+            </replace>
+
+        </sequential>
+    </macrodef>
+
+    <macrodef name="bundle-def">
+        <attribute name="name"/>
+        <attribute name="slot" default="main"/>
+        <element name="resources" implicit="yes" optional="yes"/>
+
+        <sequential>
+            <echo message="Initializing bundle -> @{name}"/>
+            <property name="bundle.repo.output.dir" value="${output.dir}/bundles/system/layers/base"/>
+            <!-- Figure out the correct bundle path -->
+            <define-bundle-dir name="@{name}" slot="@{slot}" />
+
+            <!-- Make the bundle output director -->
+            <mkdir dir="${bundle.repo.output.dir}/${current.bundle.path}"/>
+
+            <!-- Process the resource -->
+            <resources/>
+
+        </sequential>
+    </macrodef>
+
+    <macrodef name="maven-bundle" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+
+        <sequential>
+            <!-- Copy the jar to the bundle dir -->
+            <property name="bundle.repo.output.dir" value="${output.dir}/bundles/system/layers/base"/>
+            <copy todir="${bundle.repo.output.dir}/${current.bundle.path}" failonerror="true">
+                <fileset file="${@{group}:@{artifact}:jar}"/>
+                <mapper type="flatten" />
+            </copy>
+        </sequential>
+    </macrodef>
+
+    <scriptdef name="define-module-dir" language="javascript" manager="bsf">
+        <attribute name="name"/>
+        <attribute name="slot"/>
+        <![CDATA[
+            name = attributes.get("name");
+            name = name.replace(".", "/");
+            project.setProperty("current.module.path", name + "/" + attributes.get("slot"));
+        ]]>
+    </scriptdef>
+
+    <scriptdef name="define-bundle-dir" language="javascript"  manager="bsf">
+        <attribute name="name"/>
+        <attribute name="slot"/>
+        <![CDATA[
+            name = attributes.get("name");
+            name = name.replace(".", "/");
+            project.setProperty("current.bundle.path", name + "/" + attributes.get("slot"));
+        ]]>
+    </scriptdef>
+
+    <!--
+       Get the version from the parent directory of the jar.  If the parent directory is 'target' this
+       means that the jar is contained in AS build so extract the version from the file name
+    -->
+    <scriptdef name="define-maven-artifact" language="javascript"  manager="bsf">
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <attribute name="classifier"/>
+        <attribute name="element"/>
+        <attribute name="path"/>
+        <![CDATA[
+            importClass(Packages.java.io.File);
+            group = attributes.get("group");
+            artifact = attributes.get("artifact");
+            classifier = attributes.get("classifier");
+            element = attributes.get("element");
+            path = attributes.get("path");
+            if(path.indexOf('${') != -1) {
+                throw "Module resource root not found, make sure it is listed in build/pom.xml" + path;
+            }
+            fp = new File(path);
+            version = fp.getParentFile().getName();
+            if (version.equals("target")) {
+               version = fp.getName();
+               version = version.substring(artifact.length() + 1);
+               suffix = ".jar";
+               if (classifier) {
+                  suffix = "-" + classifier + suffix;
+               }
+               version = version.replace(suffix, "");
+            }
+
+            root = "<" + element + " name=\"" + group + ":" + artifact + ":" + version;
+            if (classifier) {
+               root = root + ":" + classifier;
+            }
+            root = root + "\"/>";
+            project.setProperty("current.maven.root", root);
+        ]]>
+    </scriptdef>
+
+    <macrodef name="maven-resource" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <attribute name="jandex" default="false" />
+
+        <sequential>
+            <if>
+               <equals arg1="${mavenized.modules}" arg2="true"/>
+               <then>
+                <define-maven-artifact group="@{group}" artifact="@{artifact}" element="artifact" path="${@{group}:@{artifact}:jar}"/>
+                <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                    <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.maven.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+                </replace>
+               </then>
+
+            <else>
+            <!-- Copy the jar to the module dir -->
+            <copy todir="${module.repo.output.dir}/${current.module.path}" failonerror="true">
+                <fileset file="${@{group}:@{artifact}:jar}"/>
+                <mapper type="flatten" />
+            </copy>
+
+            <basename file="${@{group}:@{artifact}:jar}" property="resourcename.@{group}.@{artifact}"/>
+            <!-- Generate the Jandex Index -->
+            <jandex run="@{jandex}" newJar="true" >
+                <fileset dir="${module.repo.output.dir}/${current.module.path}" />
+            </jandex>
+            <!-- Update the resource entry in module.xml -->
+            <define-resource-root path="${resourcename.@{group}.@{artifact}}" jandex="@{jandex}"/>
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.resource.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+            </replace>
+            </else>
+            </if>
+        </sequential>
+    </macrodef>
+
+
+
+    <macrodef name="maven-resource-with-classifier" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <attribute name="classifier"/>
+        <attribute name="jandex" default="false" />
+
+        <sequential>
+            <if>
+            <equals arg1="${mavenized.modules}" arg2="true"/>
+            <then>
+                <define-maven-artifact group="@{group}" artifact="@{artifact}" element="artifact" classifier="@{classifier}" path="${@{group}:@{artifact}:jar:@{classifier}}"/>
+                <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                    <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.maven.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+                </replace>
+            </then>
+            <else>
+            <!-- Copy the jar to the module dir -->
+            <copy todir="${module.repo.output.dir}/${current.module.path}" failonerror="true">
+                <fileset file="${@{group}:@{artifact}:jar:@{classifier}}"/>
+                <!-- http://jira.codehaus.org/browse/MANTRUN-159 -->
+                <mapper type="flatten" />
+            </copy>
+
+            <basename file="${@{group}:@{artifact}:jar:@{classifier}}" property="resourcename.@{group}.@{artifact}.@{classifier}"/>
+
+            <!-- Update the resource entry in module.xml -->
+            <define-resource-root path="${resourcename.@{group}.@{artifact}.@{classifier}}"/>
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.resource.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+            </replace>
+            </else>
+            </if>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="extract-native-jar" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <sequential>
+            <if>
+            <equals arg1="${mavenized.modules}" arg2="true"/>
+            <then>
+                <define-maven-artifact group="@{group}" artifact="@{artifact}" element="native-artifact" path="${@{group}:@{artifact}:jar}"/>
+                <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                    <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.maven.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+                </replace>
+            </then>
+
+            <else>
+            <unzip src="${@{group}:@{artifact}:jar}" dest="${module.repo.output.dir}/${current.module.path}">
+           <patternset>
+               <include name="lib/**"/>
+           </patternset>
+           </unzip>
+           </else>
+           </if>
+        </sequential>
+    </macrodef>
+
+    <scriptdef name="define-resource-root" language="javascript" manager="bsf">
+        <attribute name="path"/>
+        <attribute name="jandex"/>
+        <![CDATA[
+            path = attributes.get("path");
+            root = "<resource-root path=\"" + path + "\"/>";
+            if(path.indexOf('${') != -1) {
+                throw "Module resource root not found, make sure it is listed in build/pom.xml" + path;
+            }
+            if(attributes.get("jandex") == "true" ) {
+                root = root + "\n\t<resource-root path=\"" + path.replace(".jar","-jandex.jar") + "\"/>";
+            }
+            project.setProperty("current.resource.root", root);
+        ]]>
+    </scriptdef>
+
+</project>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>keycloak-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>keycloak-saml-wildfly-modules</artifactId>
+
+    <name>Keycloak SAML Wildfly Modules</name>
+    <packaging>pom</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-api-public</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-jboss-adapter-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-core-public</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-wildfly-elytron-adapter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-wildfly-subsystem</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-galleon-pack</artifactId>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>build-dist</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <target>
+                                <ant antfile="build.xml" inheritRefs="true">
+                                    <target name="all"/>
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jandex</artifactId>
+                        <version>1.0.3.Final</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>ant-contrib</groupId>
+                        <artifactId>ant-contrib</artifactId>
+                        <version>1.0b3</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>ant</groupId>
+                                <artifactId>ant</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant-apache-bsf</artifactId>
+                        <version>1.9.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.bsf</groupId>
+                        <artifactId>bsf-api</artifactId>
+                        <version>3.1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>rhino</groupId>
+                        <artifactId>js</artifactId>
+                        <version>1.7R2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <outputDirectory>
+                                target
+                            </outputDirectory>
+                            <workDirectory>
+                                target/assembly/work
+                            </workDirectory>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-distribution-licenses-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/licenses/keycloak/licenses.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/licenses/keycloak/licenses.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<licenseSummary>
+  <dependencies>
+  </dependencies>
+</licenseSummary>

--- a/pom.xml
+++ b/pom.xml
@@ -1098,7 +1098,12 @@
                 <artifactId>keycloak-rest-admin-ui-ext</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-saml-wildfly-modules</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-quarkus-dist</artifactId>


### PR DESCRIPTION
Add SAML adapter zip distribution back to the sources due to downstream rpm build consumes the added artifact.

Closes #36450