### PR TITLE
fix: narrow fix for creating single file import without a system prop

### DIFF
--- a/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirImportProviderFactory.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirImportProviderFactory.java
@@ -28,6 +28,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.keycloak.exportimport.ExportImportConfig.DEFAULT_STRATEGY;
 
@@ -45,10 +46,10 @@ public class DirImportProviderFactory implements ImportProviderFactory {
     private Config.Scope config;
 
     @Override
-    public ImportProvider create(KeycloakSession session) {
+    public ImportProvider create(KeycloakSession session, Map<String, String> overrides) {
         Strategy strategy = Enum.valueOf(Strategy.class, System.getProperty(ExportImportConfig.STRATEGY, config.get(STRATEGY, DEFAULT_STRATEGY.toString())));
         String realmName = System.getProperty(ExportImportConfig.REALM_NAME, config.get(REALM_NAME));
-        String dir = System.getProperty(ExportImportConfig.DIR, config.get(DIR));
+        String dir = overrides.getOrDefault(ExportImportConfig.DIR, System.getProperty(ExportImportConfig.DIR, config.get(DIR)));
         return new DirImportProvider(session.getKeycloakSessionFactory(), strategy)
                 .withDir(dir)
                 .withRealmName(realmName);
@@ -73,6 +74,7 @@ public class DirImportProviderFactory implements ImportProviderFactory {
         return PROVIDER_ID;
     }
 
+    @Override
     public List<ProviderConfigProperty> getConfigMetadata() {
         return ProviderConfigurationBuilder.create()
                 .property()

--- a/model/storage-services/src/main/java/org/keycloak/exportimport/singlefile/SingleFileImportProviderFactory.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/singlefile/SingleFileImportProviderFactory.java
@@ -29,6 +29,7 @@ import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static org.keycloak.exportimport.ExportImportConfig.DEFAULT_STRATEGY;
 
@@ -47,9 +48,9 @@ public class SingleFileImportProviderFactory implements ImportProviderFactory {
     private Config.Scope config;
 
     @Override
-    public ImportProvider create(KeycloakSession session) {
+    public ImportProvider create(KeycloakSession session, Map<String, String> overrides) {
         Strategy strategy = Enum.valueOf(Strategy.class, System.getProperty(ExportImportConfig.STRATEGY, config.get(STRATEGY, DEFAULT_STRATEGY.toString())));
-        String fileName = System.getProperty(ExportImportConfig.FILE, config.get(FILE));
+        String fileName = overrides.getOrDefault(ExportImportConfig.FILE, System.getProperty(ExportImportConfig.FILE, config.get(FILE)));
         if (fileName == null) {
             throw new IllegalArgumentException("Property " + FILE + " needs to be provided!");
         }
@@ -75,6 +76,7 @@ public class SingleFileImportProviderFactory implements ImportProviderFactory {
         return PROVIDER_ID;
     }
 
+    @Override
     public List<ProviderConfigProperty> getConfigMetadata() {
         return ProviderConfigurationBuilder.create()
                 .property()

--- a/server-spi-private/src/main/java/org/keycloak/exportimport/ImportProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/exportimport/ImportProviderFactory.java
@@ -17,10 +17,21 @@
 
 package org.keycloak.exportimport;
 
+import java.util.Map;
+
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.ProviderFactory;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public interface ImportProviderFactory extends ProviderFactory<ImportProvider> {
+
+    ImportProvider create(KeycloakSession session, Map<String, String> overrides);
+
+    @Override
+    default ImportProvider create(KeycloakSession session) {
+        return create(session, Map.of());
+    }
+
 }

--- a/services/src/test/java/org/keycloak/exportimport/ExportImportManagerTest.java
+++ b/services/src/test/java/org/keycloak/exportimport/ExportImportManagerTest.java
@@ -13,30 +13,37 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.Provider;
 import org.keycloak.services.DefaultKeycloakContext;
 import org.keycloak.services.DefaultKeycloakSession;
+import org.keycloak.services.DefaultKeycloakSessionFactory;
 
 public class ExportImportManagerTest {
-    
+
     @After
     public void reset() {
         ExportImportConfig.reset();
     }
-    
+
     @Test
     public void testImportOnStartup() {
         ExportImportConfig.setDir("/some/dir");
-        new ExportImportManager(new DefaultKeycloakSession(null) {
+        new ExportImportManager(new DefaultKeycloakSession(new DefaultKeycloakSessionFactory() {
+
+            @Override
+            public KeycloakSession create() {
+                return null;
+            }
+        }) {
 
             @Override
             protected DefaultKeycloakContext createKeycloakContext(KeycloakSession session) {
                 return null;
             }
-            
+
         });
         assertEquals(ExportImportConfig.ACTION_IMPORT, ExportImportConfig.getAction());
         assertEquals(Strategy.IGNORE_EXISTING.toString(), ExportImportConfig.getStrategy());
         assertTrue(ExportImportConfig.isReplacePlaceholders());
     }
-    
+
     @Test
     public void testImport() {
         ExportImportConfig.setAction(ExportImportConfig.ACTION_IMPORT);
@@ -46,28 +53,28 @@ public class ExportImportManagerTest {
             protected DefaultKeycloakContext createKeycloakContext(KeycloakSession session) {
                 return null;
             }
-            
+
             @Override
             public <T extends Provider> T getProvider(Class<T> clazz, String id) {
                 return (T) new ImportProvider() {
-                    
+
                     @Override
                     public void close() {
-                        
+
                     }
-                    
+
                     @Override
                     public boolean isMasterRealmExported() throws IOException {
                         return false;
                     }
-                    
+
                     @Override
                     public void importModel() throws IOException {
-                        
+
                     }
                 };
             }
-            
+
         });
         assertEquals(ExportImportConfig.ACTION_IMPORT, ExportImportConfig.getAction());
         assertNull(ExportImportConfig.getStrategy());


### PR DESCRIPTION
This also addresses the concern about double parsing to determine if the master realm is present.

I also think the current usage of action by import at startup could be removed and we just alway emit the "imported realm ..." log.

There's probably no need to take the changes further until there is some interest in running the operations post-startup such that we want a clean configuration without having to utilize system properties.

An alternative, rather than a new interface, would be to add a method to KeycloakSession to get property overrides - but the contract there doesn't seem as clear.

The other alternative, of updating the provider caching logic, is possible as well - but that seemed more cumbersome than this approach.

closes: #34270

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
