### PR TITLE
Deployment artifacts for Quarkus extensions are not in deployment dir

### DIFF
--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -19,9 +19,11 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server</artifactId>
         </dependency>
+        <!-- Only necessary for proper Maven build order - if explicitly added, deployment JARs will not be part of /lib/deployment folder -->
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server-deployment</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
- Fixes #36460

Deployment JARs are in /lib/deployment folder again.

cc @vmuzikar 