### PR TITLE
[CORS] Allow Access-Control-Allow-Headers customization

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -79,6 +79,11 @@ public class HttpOptions {
             .description("The file path to a private key in PEM format.")
             .build();
 
+    public static final Option<List<String>> HTTP_CORS_HEADERS = OptionBuilder.listOptionBuilder("http-cors-headers", String.class)
+            .category(OptionCategory.HTTP)
+            .description("The comma-separated list of custom HTTP headers that should be allowed in cross-origin (CORS) requests.")
+            .build();
+
     public static final Option<File> HTTPS_KEY_STORE_FILE = new OptionBuilder<>("https-key-store-file", File.class)
             .category(OptionCategory.HTTP)
             .description("The key store which holds the certificate information instead of specifying separate files.")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -133,6 +133,10 @@ public final class HttpPropertyMappers {
                 fromOption(HttpOptions.HTTP_METRICS_SLOS)
                         .isEnabled(MetricsPropertyMappers::metricsEnabled, MetricsPropertyMappers.METRICS_ENABLED_MSG)
                         .paramLabel("list of buckets")
+                        .build(),
+                fromOption(HttpOptions.HTTP_CORS_HEADERS)
+                        .to("kc.spi-cors-default-headers")
+                        .paramLabel("headers")
                         .build()
         };
     }

--- a/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java
@@ -71,6 +71,8 @@ public interface Cors extends Provider {
 
     Cors allowedMethods(String... allowedMethods);
 
+    Cors allowedHeaders(String... allowedHeaders);
+
     Cors exposedHeaders(String... exposedHeaders);
 
     /**

--- a/services/src/main/java/org/keycloak/services/cors/DefaultCorsFactory.java
+++ b/services/src/main/java/org/keycloak/services/cors/DefaultCorsFactory.java
@@ -17,7 +17,10 @@
 
 package org.keycloak.services.cors;
 
+import java.util.Arrays;
+import java.util.List;
 import org.keycloak.Config;
+import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
@@ -27,14 +30,22 @@ import org.keycloak.models.KeycloakSessionFactory;
 public class DefaultCorsFactory implements CorsFactory {
 
     private static final String PROVIDER_ID = "default";
+    private static final String HEADERS = "headers";
+
+    private String defaultAllowHeaders = Cors.DEFAULT_ALLOW_HEADERS;
 
     @Override
     public Cors create(KeycloakSession session) {
-        return new DefaultCors(session);
+        return new DefaultCors(session, defaultAllowHeaders);
     }
 
     @Override
     public void init(Config.Scope config) {
+        String[] configHeaders = config.getArray(HEADERS);
+        if (configHeaders != null && configHeaders.length > 0) {
+            List<String> headers = Arrays.asList(configHeaders);
+                defaultAllowHeaders = String.format("%s, %s", defaultAllowHeaders, CollectionUtil.join(headers));
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR allows simple customization of HTTP headers that should be allowed in cross-origin requests, in addition to the [built-in list](https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java#L39). A new CLI option is introduced:

```
--http-cors-headers <headers>
                     The comma-separated list of custom HTTP headers that should be allowed in
                       cross-origin (CORS) requests.
```

Corresponding environment variable:
```
KC_HTTP_CORS_HEADERS
```

This is a global (server-level) setting. The main use case is supporting headers that are added by various tracing systems and web frameworks.

Closes: #12682