### PR TITLE
Wrong link for tracing in 26.1.0 release notes

### DIFF
--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -73,7 +73,7 @@
 :highavailabilityguide_name: High Availability Guide
 :highavailabilityguide_link: https://www.keycloak.org/guides#high-availability
 :tracingguide_name: Enabling Tracing
-:tracingguide_link: https://www.keycloak.org/server/tracing
+:tracingguide_link: https://www.keycloak.org/observability/tracing
 :upgradingguide_name: Upgrading Guide
 :upgradingguide_name_short: Upgrading
 :upgradingguide_link: {project_doc_base_url}/upgrading/


### PR DESCRIPTION
Fixes #36483

@ahus1 @stianst Could you please check it? Thanks!