### PR TITLE
Avoid reuseConnections config to be set twice in DefaultHttpClientFactory by removing duplicate code

### DIFF
--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -176,7 +176,6 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     int maxPooledPerRoute = config.getInt("max-pooled-per-route", 64);
                     int connectionPoolSize = config.getInt("connection-pool-size", 128);
                     long connectionTTL = config.getLong("connection-ttl-millis", -1L);
-                    boolean reuseConnections = config.getBoolean("reuse-connections", true);
                     long maxConnectionIdleTime = config.getLong("max-connection-idle-time-millis", 900000L);
                     boolean disableCookies = config.getBoolean("disable-cookies", true);
                     String clientKeystore = config.get("client-keystore");
@@ -185,7 +184,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     boolean disableTrustManager = config.getBoolean("disable-trust-manager", false);
 
                     boolean expectContinueEnabled = getBooleanConfigWithSysPropFallback("expect-continue-enabled", false);
-                    boolean resuseConnections = getBooleanConfigWithSysPropFallback("reuse-connections", true);
+                    boolean reuseConnections = getBooleanConfigWithSysPropFallback("reuse-connections", true);
 
                     // optionally configure proxy mappings
                     // direct SPI config (e.g. via standalone.xml) takes precedence over env vars
@@ -209,13 +208,12 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                             .establishConnectionTimeout(establishConnectionTimeout, TimeUnit.MILLISECONDS)
                             .maxPooledPerRoute(maxPooledPerRoute)
                             .connectionPoolSize(connectionPoolSize)
-                            .reuseConnections(reuseConnections)
                             .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
                             .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
                             .disableCookies(disableCookies)
                             .proxyMappings(proxyMappings)
                             .expectContinueEnabled(expectContinueEnabled)
-                            .reuseConnections(resuseConnections);
+                            .reuseConnections(reuseConnections);
 
                     TruststoreProvider truststoreProvider = session.getProvider(TruststoreProvider.class);
                     boolean disableTruststoreProvider = truststoreProvider == null || truststoreProvider.getTruststore() == null;


### PR DESCRIPTION
Closes #36498

I found one more duplicated code block from commit https://github.com/keycloak/keycloak/commit/c3a15cb3.

Is it okay to reuse the same issue although it's closed since it is the same root cause? Or should I create a separate issue for this PR?