### PR TITLE
fix: adding the jgroups bind address for ipv6 support

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -75,6 +75,8 @@ import static org.keycloak.operator.crds.v2alpha1.deployment.spec.TracingSpec.co
 
 public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependentResource<StatefulSet, Keycloak> {
 
+    public static final String POD_IP = "POD_IP";
+
     private static final List<String> COPY_ENV = Arrays.asList("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY");
 
     private static final String ZONE_KEY = "topology.kubernetes.io/zone";
@@ -296,6 +298,7 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
                         && (customImage.isPresent() || operatorConfig.keycloak().startOptimized())) {
             containerBuilder.addToArgs(OPTIMIZED_ARG);
         }
+        containerBuilder.addToArgs(0, "-Djgroups.bind.address=$(%s)".formatted(POD_IP));
         containerBuilder.addToArgs(0, getJGroupsParameter(keycloakCR));
 
         // probes
@@ -499,6 +502,9 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
                 envVars.add(new EnvVarBuilder().withName(env).withValue(value).build());
             }
         }
+
+        envVars.add(new EnvVarBuilder().withName(POD_IP).withNewValueFrom().withNewFieldRef()
+                .withFieldPath("status.podIP").endFieldRef().endValueFrom().build());
 
         return envVars;
     }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -298,6 +298,7 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
                         && (customImage.isPresent() || operatorConfig.keycloak().startOptimized())) {
             containerBuilder.addToArgs(OPTIMIZED_ARG);
         }
+        // Set bind address as this is required for JGroups to form a cluster in IPv6 envionments
         containerBuilder.addToArgs(0, "-Djgroups.bind.address=$(%s)".formatted(POD_IP));
         containerBuilder.addToArgs(0, getJGroupsParameter(keycloakCR));
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -218,8 +218,8 @@ public class PodTemplateTest {
         // Assert
         assertEquals(1, podTemplate.getSpec().getContainers().get(0).getCommand().size());
         assertEquals(command, podTemplate.getSpec().getContainers().get(0).getCommand().get(0));
-        assertEquals(2, podTemplate.getSpec().getContainers().get(0).getArgs().size());
-        assertEquals(arg, podTemplate.getSpec().getContainers().get(0).getArgs().get(1));
+        assertEquals(3, podTemplate.getSpec().getContainers().get(0).getArgs().size());
+        assertEquals(arg, podTemplate.getSpec().getContainers().get(0).getArgs().get(2));
     }
 
     @Test
@@ -402,11 +402,13 @@ public class PodTemplateTest {
         // Assert
         assertNotNull(container);
         assertThat(container.getArgs()).doesNotContain(KeycloakDeploymentDependentResource.OPTIMIZED_ARG);
+        assertThat(container.getArgs()).contains("-Djgroups.bind.address=$(POD_IP)");
 
         var envVars = container.getEnv();
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRUSTSTORE_PATHS));
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRACING_SERVICE_NAME));
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRACING_RESOURCE_ATTRIBUTES));
+        assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.POD_IP));
 
         var readiness = container.getReadinessProbe().getHttpGet();
         assertNotNull(readiness);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
@@ -35,6 +35,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPort;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import io.netty.util.NetUtil;
 import io.quarkus.logging.Log;
 import org.assertj.core.api.ObjectAssert;
 import org.awaitility.Awaitility;
@@ -197,7 +198,7 @@ public final class CRAssert {
                 "--connect-timeout",
                 "2",
                 "-s",
-                "telnet://%s:%s".formatted(hostname, port));
+                "telnet://%s:%s".formatted(NetUtil.isValidIpV6Address(hostname)?"["+hostname+"]":hostname, port));
         // Relevant exit codes:
         // 28-Operation timeout.
         // 48-Unknown option specified to libcurl (BOGUS=1 is not a valid option, but the connection is successful).


### PR DESCRIPTION
The understanding from the kube docs is that in ipv4 or dual stack environments this will supply a ipv4 address. In ipv6 only environments it will be ipv6.

closes: #36383

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
