### PR TITLE
CreatedResponseUtil.getCreatedId should expose server error message (#34343)

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.CreatedResponseUtil;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.GroupResource;
 import org.keycloak.admin.client.resource.IdentityProviderResource;
@@ -131,6 +132,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -324,8 +326,13 @@ public class UserTest extends AbstractAdminTest {
             assertEquals(409, response.getStatus());
             assertAdminEvents.assertEmpty();
 
-            ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
-            Assert.assertEquals("User exists with same email", error.getErrorMessage());
+            // Alternative way of showing underlying error message
+            try {
+                CreatedResponseUtil.getCreatedId(response);
+                Assert.fail("Not expected getCreatedId to success");
+            } catch (WebApplicationException wae) {
+                Assert.assertThat(wae.getMessage(), endsWith("ErrorMessage: User exists with same email"));
+            }
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.admin.authentication;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.keycloak.admin.client.CreatedResponseUtil;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.authentication.authenticators.browser.IdentityProviderAuthenticatorFactory;
@@ -61,6 +62,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -128,6 +130,13 @@ public class FlowTest extends AbstractAuthenticationTest {
     public void testAddFlowWithRestrictedCharInAlias() {
         Response resp = authMgmtResource.createFlow(newFlow("fo]o", "Browser flow", "basic-flow", true, false));
         Assert.assertEquals(400, resp.getStatus());
+
+        try {
+            CreatedResponseUtil.getCreatedId(resp);
+            Assert.fail("Not expected getCreatedId to success");
+        } catch (WebApplicationException wae) {
+            Assert.assertThat(wae.getMessage(), endsWith("Error: Character ']' not allowed."));
+        }
     }
 
     @Test


### PR DESCRIPTION
We now expose the actual error message found in the response if present.

Fixes #34343

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>
(cherry picked from commit d94e388047418549d7228280782e804087b2586e)
