### PR TITLE
Fix fragment index for SPA with hash

### DIFF
--- a/js/libs/keycloak-js/lib/keycloak.js
+++ b/js/libs/keycloak-js/lib/keycloak.js
@@ -1058,6 +1058,8 @@ function Keycloak (config) {
 
         if (kc.responseMode === 'query' && queryIndex !== -1) {
             newUrl = url.substring(0, queryIndex);
+			fragmentIndex = url.substring(queryIndex).indexOf('#');
+
             parsed = parseCallbackParams(url.substring(queryIndex + 1, fragmentIndex !== -1 ? fragmentIndex : url.length), supportedParams);
             if (parsed.paramsString !== '') {
                 newUrl += '?' + parsed.paramsString;


### PR DESCRIPTION
I'm using the Keycloak in a Angular project and faced with this problem.

The project use a property `useHash: true` in the routes. This adds `/#/` on the beginning of the path, example https://example.com/#/login.

This PR close keycloak/keycloak#36554 

Cause:

The current version of Keycloak.js is not expecting fragment (#) before of query param (?), so in following code it will parse params with the angular path instead of query params.

Example redirect uri:  https://example.com/#/callback?state=1234abc&code=123

```
parsed = parseCallbackParams(url.substring(queryIndex + 1, fragmentIndex !== -1 ? fragmentIndex : url.length), supportedParams);
```

`parsed` will be an empty object because the substring will return the path

```
url.substring(queryIndex + 1, fragmentIndex !== -1 ? fragmentIndex : url.length)

// #/callback?
```

The changes will insure the fragment index is after the query index


