### PR TITLE
Keycloak can only be built from source with JDK 21

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,9 +1,15 @@
 ## Building from source
 
-Ensure you have JDK 21 (or newer) and Git installed
+Ensure you have **JDK 17** or **JDK 21** and Git installed
 
     java -version
     git --version
+
+Newer versions of the JDK are not supported. If you have multiple JDK versions
+installed, you can specify which one to use during the build by setting the `JAVA_HOME`
+environment variable (this should be the directory containing `/bin/` or `/jre/`).
+
+    JAVA_HOME=/path/to/jdk-21/ ./mvnw clean install
 
 Instead of using a locally installed Maven, call the Maven wrapper script `mvnw` in the main folder of the project.
 This will use the Maven version which is supported by this project.


### PR DESCRIPTION
Closes #36541

Keycloak can only be built from source with JDK 21 (also supposedly [JDK 17 according to CI](https://github.com/keycloak/keycloak/blob/1f0983be69673a91f13c7671fa9aa5dad863ba78/.github/workflows/ci.yml#L328))

As experienced in https://github.com/keycloak/keycloak/issues/36541, it fails to build in various ways if you try to use JDK 23.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
