### PR TITLE
Fix redirect URL for linked accounts in account security section

### DIFF
--- a/js/apps/account-ui/src/api/methods.ts
+++ b/js/apps/account-ui/src/api/methods.ts
@@ -153,8 +153,8 @@ export async function linkAccount(
       "realms",
       context.environment.realm,
       "account",
-        "account-security",
-        "linked-accounts",
+      "account-security",
+      "linked-accounts",
     ),
   );
   const response = await request(

--- a/js/apps/account-ui/src/api/methods.ts
+++ b/js/apps/account-ui/src/api/methods.ts
@@ -153,6 +153,8 @@ export async function linkAccount(
       "realms",
       context.environment.realm,
       "account",
+        "account-security",
+        "linked-accounts",
     ),
   );
   const response = await request(


### PR DESCRIPTION
Updated the redirect URL for linked accounts to ensure users are redirected to `/realms/<realm-name>/account/account-security/linked-accounts` after linking an account.

Fixes #36405

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
