### PR TITLE
Implemented ICU dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>com.ibm.icu</groupId>
+                <artifactId>icu4j</artifactId>
+                <version>76.1</version>
+            </dependency>
+            <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -310,11 +310,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.ibm.icu</groupId>
-                <artifactId>icu4j</artifactId>
-                <version>76.1</version>
-            </dependency>
-            <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.version}</version>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <scope>provided</scope>
+            <version>76.1</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -51,6 +51,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <scope>provided</scope>

--- a/services/src/main/java/org/keycloak/theme/beans/LocaleBean.java
+++ b/services/src/main/java/org/keycloak/theme/beans/LocaleBean.java
@@ -22,9 +22,9 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.models.RealmModel;
 
 import java.text.Collator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public class LocaleBean {
 
-    private static final HashMap<String, Boolean> CACHED_RTL_LANGUAGE_CODES = new HashMap<>();
+    private static final ConcurrentHashMap<String, Boolean> CACHED_RTL_LANGUAGE_CODES = new ConcurrentHashMap<>();
 
     private String current;
     private String currentLanguageTag;
@@ -73,15 +73,7 @@ public class LocaleBean {
     }
 
     public boolean isRtl(String languageTag) {
-        if (CACHED_RTL_LANGUAGE_CODES.containsKey(languageTag)) {
-            return CACHED_RTL_LANGUAGE_CODES.get(languageTag);
-        }
-
-        boolean isRTL = new ULocale(languageTag).isRightToLeft();
-
-        CACHED_RTL_LANGUAGE_CODES.put(languageTag, isRTL);
-
-        return isRTL;
+        return CACHED_RTL_LANGUAGE_CODES.computeIfAbsent(languageTag, tag -> new ULocale(languageTag).isRightToLeft());
     }
 
     public List<Locale> getSupported() {

--- a/services/src/main/java/org/keycloak/theme/beans/LocaleBean.java
+++ b/services/src/main/java/org/keycloak/theme/beans/LocaleBean.java
@@ -17,14 +17,14 @@
 
 package org.keycloak.theme.beans;
 
+import com.ibm.icu.util.ULocale;
+import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.models.RealmModel;
 
-import jakarta.ws.rs.core.UriBuilder;
-
 import java.text.Collator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -32,8 +32,7 @@ import java.util.stream.Collectors;
  */
 public class LocaleBean {
 
-    private static final Set<String> RTL_LANGUAGE_CODES =
-            Set.of("ar", "dv", "fa", "ha", "he", "iw", "ji", "ps", "sd", "ug", "ur", "yi");
+    private static final HashMap<String, Boolean> CACHED_RTL_LANGUAGE_CODES = new HashMap<>();
 
     private String current;
     private String currentLanguageTag;
@@ -43,7 +42,7 @@ public class LocaleBean {
     public LocaleBean(RealmModel realm, java.util.Locale current, UriBuilder uriBuilder, Properties messages) {
         this.currentLanguageTag = current.toLanguageTag();
         this.current = messages.getProperty("locale_" + this.currentLanguageTag, this.currentLanguageTag);
-        this.rtl = RTL_LANGUAGE_CODES.contains(current.getLanguage());
+        this.rtl = isRtl(currentLanguageTag);
 
         Collator collator = Collator.getInstance(current);
         collator.setStrength(Collator.PRIMARY); // ignore case and accents
@@ -71,6 +70,18 @@ public class LocaleBean {
      */
     public boolean isRtl() {
         return rtl;
+    }
+
+    public boolean isRtl(String languageTag) {
+        if (CACHED_RTL_LANGUAGE_CODES.containsKey(languageTag)) {
+            return CACHED_RTL_LANGUAGE_CODES.get(languageTag);
+        }
+
+        boolean isRTL = new ULocale(languageTag).isRightToLeft();
+
+        CACHED_RTL_LANGUAGE_CODES.put(languageTag, isRTL);
+
+        return isRTL;
     }
 
     public List<Locale> getSupported() {

--- a/services/src/test/java/org/keycloak/locale/LocaleBeanIsRtlTest.java
+++ b/services/src/test/java/org/keycloak/locale/LocaleBeanIsRtlTest.java
@@ -1,0 +1,47 @@
+package org.keycloak.locale;
+
+import org.junit.Test;
+import org.keycloak.forms.login.freemarker.model.LoginRealmBeanTest;
+import org.keycloak.models.RealmModel;
+import org.keycloak.theme.beans.LocaleBean;
+
+import java.lang.reflect.Proxy;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LocaleBeanIsRtlTest {
+
+    @Test
+    public void isRtl() {
+        RealmModel realmModel = (RealmModel) Proxy.newProxyInstance(LoginRealmBeanTest.class.getClassLoader(), new Class[]{RealmModel.class}, (proxy, method, args) -> {
+
+            if (method.getName().matches("getSupportedLocalesStream")) {
+                return Stream.empty();
+            }
+
+            return null;
+        });
+
+        Properties messages = new Properties();
+
+        Locale locale = Locale.forLanguageTag("ar");
+        LocaleBean localeBean = new LocaleBean(realmModel, locale, null, messages);
+        assertTrue(localeBean.isRtl());
+
+        locale = Locale.forLanguageTag("he");
+        localeBean = new LocaleBean(realmModel, locale, null, messages);
+        assertTrue(localeBean.isRtl());
+
+        locale = Locale.forLanguageTag("en");
+        localeBean = new LocaleBean(realmModel, locale, null, messages);
+        assertFalse(localeBean.isRtl());
+
+        locale = Locale.forLanguageTag("fr");
+        localeBean = new LocaleBean(realmModel, locale, null, messages);
+        assertFalse(localeBean.isRtl());
+    }
+}


### PR DESCRIPTION
This is a PR to test the implementation of ICU.

Ref: https://github.com/keycloak/keycloak/issues/34962#issuecomment-2597603323

I think that the minimum required windows version is: `Version 1703`
So this would include Windows 10 and Windows Server 2016
Because since then icu is included in Windows.
BUT it should be possible install icu even before this update.

On Linux icu4j requries the icu package to be installed.
But it is already preinstalled by a lot of distros (tested it on fedora 41).