### PR TITLE
fix: wrong briefRepresentation behavior on Organization

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationsResource.java
@@ -108,7 +108,7 @@ public interface OrganizationsResource {
      *              the method returns all organizations whose name or (domains) partially match the {@code search} param.
      * @param first the position of the first result to be processed (pagination offset). Ignored if negative or {@code null}.
      * @param max the maximum number of results to be returned. Ignored if negative or {@code null}.
-     * @param briefRepresentation if {@code true} the full representation is to be returned. Otherwise, only the basic fields are returned. The parameter is supported since Keycloak 26.1
+     * @param briefRepresentation if {@code false} the full representation is to be returned. Otherwise, only the basic fields are returned. The parameter is supported since Keycloak 26.1
      * @return a list containing the matched organizations.
      * @since Keycloak 26.1. Use method {@link #search(String, Boolean, Integer, Integer)} for the older versions of the Keycloak server
      */

--- a/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -255,7 +255,7 @@ public class ExportUtils {
         if (Profile.isFeatureEnabled(Feature.ORGANIZATION) && !options.isPartial()) {
             OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
             orgProvider.getAllStream().map(model -> {
-                OrganizationRepresentation org = ModelToRepresentation.toRepresentation(model);
+                OrganizationRepresentation org = ModelToRepresentation.toRepresentation(model, false);
 
                 orgProvider.getMembersStream(model, (Map<String, String>) null, null, null, null)
                         .forEach(user -> {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -1317,15 +1317,10 @@ public class ModelToRepresentation {
     }
 
     public static OrganizationRepresentation toRepresentation(OrganizationModel model) {
-        OrganizationRepresentation rep = toBriefRepresentation(model,false);
-        if (rep == null) {
-            return null;
-        }
-        rep.setAttributes(model.getAttributes());
-        return rep;
+        return toRepresentation(model, true);
     }
 
-    public static OrganizationRepresentation toBriefRepresentation(OrganizationModel model, Boolean briefRepresentation) {
+    public static OrganizationRepresentation toRepresentation(OrganizationModel model, boolean briefRepresentation) {
         if (model == null) {
             return null;
         }
@@ -1333,7 +1328,7 @@ public class ModelToRepresentation {
         rep.setId(model.getId());
         rep.setName(model.getName());
         rep.setAlias(model.getAlias());
-        if (briefRepresentation) {
+        if (!briefRepresentation) {
             rep.setAttributes(model.getAttributes());
         }
         rep.setEnabled(model.isEnabled());

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
@@ -73,7 +73,7 @@ public class OrganizationResource {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class)))
     })
     public OrganizationRepresentation get() {
-        return ModelToRepresentation.toRepresentation(organization);
+        return ModelToRepresentation.toRepresentation(organization, false);
     }
 
     @DELETE

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
@@ -149,7 +149,7 @@ public class OrganizationsResource {
             @Parameter(description = "Boolean which defines whether the param 'search' must match exactly or not") @QueryParam("exact") Boolean exact,
             @Parameter(description = "The position of the first result to be processed (pagination offset)") @QueryParam("first") @DefaultValue("0") Integer first,
             @Parameter(description = "The maximum number of results to be returned - defaults to 10") @QueryParam("max") @DefaultValue("10") Integer max,
-            @Parameter(description = "if true, return the full representation. Otherwise, only the basic fields are returned.") @QueryParam("briefRepresentation") @DefaultValue("false") boolean briefRepresentation
+            @Parameter(description = "if false, return the full representation. Otherwise, only the basic fields are returned.") @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation
     ) {
         auth.realm().requireManageRealm();
         Organizations.checkEnabled(provider);
@@ -157,9 +157,9 @@ public class OrganizationsResource {
         // check if are searching orgs by attribute.
         if (StringUtil.isNotBlank(searchQuery)) {
             Map<String, String> attributes = SearchQueryUtils.getFields(searchQuery);
-            return provider.getAllStream(attributes, first, max).map(model -> ModelToRepresentation.toBriefRepresentation(model, briefRepresentation));
+            return provider.getAllStream(attributes, first, max).map(model -> ModelToRepresentation.toRepresentation(model, briefRepresentation));
         } else {
-            return provider.getAllStream(search, exact, first, max).map(model -> ModelToRepresentation.toBriefRepresentation(model, briefRepresentation));
+            return provider.getAllStream(search, exact, first, max).map(model -> ModelToRepresentation.toRepresentation(model, briefRepresentation));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationTest.java
@@ -161,7 +161,7 @@ public class OrganizationTest extends AbstractOrganizationTest {
         orgRep.singleAttribute("foo", "bar");
         orgRep.singleAttribute("bar", "foo");
         testRealm().organizations().get(orgRep.getId()).update(orgRep).close();
-        existing = testRealm().organizations().search("gtbank.net", true, 0, 10, true);
+        existing = testRealm().organizations().search("gtbank.net", true, 0, 10, false);
         assertThat(existing, hasSize(1));
         orgRep = existing.get(0);
         assertThat(orgRep.getAttributes(), notNullValue());


### PR DESCRIPTION
Fixes https://github.com/keycloak/keycloak/issues/36576

For organization API, behavior of briefRepresentation flag is inverted : 
- briefRepresentation=true fetches attributes
- briefRepresentation=false do not fetches attributes

this PR inverses this behavior which looks like wrong