### PR TITLE
Remove usage of deprecated thread_dumps_threshold configuration

### DIFF
--- a/model/infinispan/src/main/resources/default-configs/default-keycloak-jgroups-udp.xml
+++ b/model/infinispan/src/main/resources/default-configs/default-keycloak-jgroups-udp.xml
@@ -21,8 +21,6 @@
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
         thread_pool.keep_alive_time="60000"
-
-        thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
    />
    <RED/>
    <PING num_discovery_runs="3"/>

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -164,8 +164,6 @@
                     <!-- See also https://github.com/wildfly/wildfly-core/blob/7e5624cf92ebe4b64a4793a8c0b2a340c0d6d363/core-feature-pack/common/src/main/resources/content/bin/common.sh#L57-L60 -->
                     <argLine>@{argLine} -Xmx1536m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
-                        <!-- ensure a log entry if we're running out of JGroup threads -->
-                        <jgroups.thread_dumps_threshold>1</jgroups.thread_dumps_threshold>
                         <!-- keycloak.model.parameters lists parameter classes from 
                              org.keycloak.model.parameters package and determine enabled providers -->
                         <keycloak.model.parameters>${keycloak.model.parameters}</keycloak.model.parameters>

--- a/testsuite/model/src/main/resources/hotrod/hotrod1.xml
+++ b/testsuite/model/src/main/resources/hotrod/hotrod1.xml
@@ -30,8 +30,6 @@
                  thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
                  thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
                  thread_pool.keep_alive_time="60000"
-
-                 thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
             />
             <!-- LOCAL_PING: discovery in the same JVM -->
             <LOCAL_PING stack.combine="REPLACE" stack.position="PING"/>

--- a/testsuite/model/src/main/resources/hotrod/hotrod2.xml
+++ b/testsuite/model/src/main/resources/hotrod/hotrod2.xml
@@ -30,8 +30,6 @@
                  thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
                  thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
                  thread_pool.keep_alive_time="60000"
-
-                 thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
             />
             <!-- LOCAL_PING: discovery in the same JVM -->
             <LOCAL_PING stack.combine="REPLACE" stack.position="PING"/>


### PR DESCRIPTION
As jgroups now uses virtual threads it is no longer required to set this option.

This change is required to avoid that warnings like:
```
WARN  [org.jgroups.stack.Configurator] (ForkJoinPool.commonPool-worker-11) JGRP000014: ThreadPool.thread_dumps_threshold has been deprecated: ignored
```
are being printed.

Closes #36633