### PR TITLE
Support for prompt=create in keycloak.js

### DIFF
--- a/docs/guides/securing-apps/javascript-adapter.adoc
+++ b/docs/guides/securing-apps/javascript-adapter.adoc
@@ -372,6 +372,19 @@ adapter::
 responseType::
     Response type sent to {project_name} with login requests. This is determined based on the flow value used during initialization, but can be overridden by setting this value.
 
+omitWellKnownConfigRequest::
+    When the option is false, which is by default, adapter will send initial request to OIDC well-known endpoint. The response from this request can help to
+    retrieve some available capabilities of the server, which can allow adapter to optimize it's behaviour. If the option is true, adapter
+    will omit the request and the behaviour will stick to the default options.
+
+useDeprecatedRegisterEndpoint::
+    When false and the `keycloak.register` is invoked, adapter will use the official OIDC way to send request to {project_name} registration. This means
+    the request to OIDC authentication endpoint with the parameter `prompt=create`. When true, the adapter will use deprecated register endpoint, which is not compatible
+    with OIDC specification and might be removed in the future versions of the {project_name} server.
+    The default value of this option is retrieved from the OIDC well-known endpoint request based on the fact if new OIDC way is supported by the server,
+    which is as long as OIDC well-known response contains "create" in the supported values of the prompt parameters. From the {project_name} 26.1, this will be false by default,
+    but for the older {project_name} server versions, this will be true by default as those support only deprecated registration endpoint.
+
 === Methods
 
 *init(options)*

--- a/js/libs/keycloak-js/lib/keycloak.d.ts
+++ b/js/libs/keycloak-js/lib/keycloak.d.ts
@@ -208,6 +208,27 @@ export interface KeycloakInitOptions {
 	 * HTTP method for calling the end_session endpoint. Defaults to 'GET'.
 	 */
 	logoutMethod?: 'GET' | 'POST';
+
+	/**
+     * By default, adapter will send initial request to OIDC well-known endpoint. The response from this request can help to
+     * retrieve some available capabilities of the server, which can allow adapter to optimize it's behaviour. If the option is true, adapter
+     * will omit the request and the behaviour will stick to the default options.
+     * @default false
+     */
+    omitWellKnownConfigRequest?: boolean;
+
+   /**
+     * When false and the keycloak.register is invoked, adapter will use the official OIDC way to send request to Keycloak registration. This means
+     * the request to OIDC authentication endpoint with the parameter prompt=create. When true, the adapter will use deprecated register endpoint, which is not compatible
+     * with OIDC specification and might be removed in the future versions of the Keycloak server.
+     *
+     * The default value of this option is retrieved from the OIDC well-known endpoint request based on the fact if new OIDC way is supported by the server,
+     * which is as long as OIDC well-known response contains "create" in the supported values of the prompt parameters. From the Keycloak 26.1, this will be false by default, but for the older
+     * Keycloak server versions, this will be true by default as those support only deprecated registration endpoint.
+     *
+	 * @default false
+	 */
+	useDeprecatedRegisterEndpoint?: boolean;
 }
 
 export interface KeycloakLoginOptions {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -935,7 +935,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
 
         testExecutor
                 .configure(keycloakConfig)
-                .init(initOptions, assertErrorResponse("Timeout when waiting for 3rd party check iframe message."));
+                .init(initOptions, assertErrorResponse("Incorrect response from the OIDC well-known endpoint."));
 
     }
 
@@ -953,7 +953,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
 
         testExecutor
                 .configure(keycloakConfig)
-                .init(initOptions, assertErrorResponse("Timeout when waiting for 3rd party check iframe message."));
+                .init(initOptions, assertErrorResponse("Incorrect response from the OIDC well-known endpoint."));
 
     }
 


### PR DESCRIPTION
closes keycloak/keycloak-js#6

Marking as draft as I am not sure if we still want to add new capabilities to keycloak.js or do we rather already want to use [newly created repository for keycloak.js ](https://github.com/keycloak/keycloak-js) new features? If we want new repository, the pre-requisite for this PR would be to move keycloak.js adapter (including documentation) to that repository.

The PR introduces support to detect if Keycloak server supports new OIDC way for requesting registration (the one with `prompt=create` supported from Keycloak server 26.1) or the old way with the deprecated registration endpoint. For this purpose, the PR always sends request to OIDC well-known endpoint unless the option `omitWellKnownConfigRequest` is used. Before this PR, the request to well-known endpoint was sent just when the constructor property `oidcProvider` was used (BTW. this property `oidcProvider` is not officially documented). The request to OIDC well-known endpoint can dynamically detect if new registration is supported or not and IMO it can be possibly used for more capabilities in the future.

The 2 new properties to `init` method introduced:
- `omitWellKnownConfigRequest` - Whether to omit request to OIDC well-known endpoint (false by default)
- `useDeprecatedRegisterEndpoint` - Whether to enforce to use deprecated register endpoint. I am not 100% sure if we need this option as we can possibly always rely on the response from well-known endpoint to see whether new way is supported or not? If we avoid this option and the option `omitWellKnownConfigRequest=true`, we can default to use new register endpoint?
