### PR TITLE
custom convert so that `attributes` can be the prefix instead of `config`

### DIFF
--- a/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
+++ b/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
@@ -184,7 +184,10 @@ export const Credentials = ({ client, save, refresh }: CredentialsProps) => {
             {clientAuthenticatorType === "client-x509" && <X509 />}
             {providerProperties && (
               <Form>
-                <DynamicComponents properties={providerProperties} />
+                <DynamicComponents
+                  properties={providerProperties}
+                  convertToName={(name) => `attributes.${name}`}
+                />
               </Form>
             )}
             <ActionGroup>

--- a/js/apps/admin-ui/src/components/client/ClientSelect.tsx
+++ b/js/apps/admin-ui/src/components/client/ClientSelect.tsx
@@ -10,7 +10,9 @@ import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../admin-client";
 import type { ComponentProps } from "../dynamic/components";
 
-type ClientSelectProps = ComponentProps & { variant?: `${SelectVariant}` };
+type ClientSelectProps = Omit<ComponentProps, "convertToName"> & {
+  variant?: `${SelectVariant}`;
+};
 
 export const ClientSelect = ({
   name,

--- a/js/apps/admin-ui/src/components/dynamic/BooleanComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/BooleanComponent.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 
 import { HelpItem } from "@keycloak/keycloak-ui-shared";
 import type { ComponentProps } from "./components";
-import { convertToName } from "./DynamicComponents";
 
 export const BooleanComponent = ({
   name,
@@ -13,6 +12,7 @@ export const BooleanComponent = ({
   isDisabled = false,
   defaultValue,
   isNew = true,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const { control } = useFormContext();

--- a/js/apps/admin-ui/src/components/dynamic/ClientSelectComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/ClientSelectComponent.tsx
@@ -1,7 +1,6 @@
 import type { ComponentProps } from "./components";
 import { ClientSelect } from "../client/ClientSelect";
-import { convertToName } from "./DynamicComponents";
 
 export const ClientSelectComponent = (props: ComponentProps) => (
-  <ClientSelect {...props} name={convertToName(props.name!)} />
+  <ClientSelect {...props} name={props.convertToName(props.name!)} />
 );

--- a/js/apps/admin-ui/src/components/dynamic/DynamicComponents.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/DynamicComponents.tsx
@@ -7,9 +7,11 @@ type DynamicComponentProps = {
   properties: ConfigPropertyRepresentation[];
   stringify?: boolean;
   isNew?: boolean;
+  convertToName?: (name: string) => string;
 };
 
 export const DynamicComponents = ({
+  convertToName: convert,
   properties,
   ...rest
 }: DynamicComponentProps) => (
@@ -18,7 +20,14 @@ export const DynamicComponents = ({
       const componentType = property.type!;
       if (isValidComponentType(componentType)) {
         const Component = COMPONENTS[componentType];
-        return <Component key={property.name} {...property} {...rest} />;
+        return (
+          <Component
+            key={property.name}
+            {...property}
+            {...rest}
+            convertToName={convert || convertToName}
+          />
+        );
       } else {
         console.warn(`There is no editor registered for ${componentType}`);
       }

--- a/js/apps/admin-ui/src/components/dynamic/FileComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/FileComponent.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import type { ComponentProps } from "./components";
-import { convertToName } from "./DynamicComponents";
 
 export const FileComponent = ({
   name,
@@ -13,6 +12,7 @@ export const FileComponent = ({
   defaultValue,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const { control } = useFormContext();

--- a/js/apps/admin-ui/src/components/dynamic/GroupComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/GroupComponent.tsx
@@ -14,13 +14,13 @@ import { useTranslation } from "react-i18next";
 import { GroupPickerDialog } from "../group/GroupPickerDialog";
 import { HelpItem } from "@keycloak/keycloak-ui-shared";
 import type { ComponentProps } from "./components";
-import { convertToName } from "./DynamicComponents";
 
 export const GroupComponent = ({
   name,
   label,
   helpText,
   required,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);

--- a/js/apps/admin-ui/src/components/dynamic/IntComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/IntComponent.tsx
@@ -1,13 +1,12 @@
-import { useTranslation } from "react-i18next";
 import { TextControl } from "@keycloak/keycloak-ui-shared";
-
-import { convertToName } from "./DynamicComponents";
+import { useTranslation } from "react-i18next";
 import { NumberComponentProps } from "./components";
 
 export const IntComponent = ({
   name,
   label,
   helpText,
+  convertToName,
   ...props
 }: NumberComponentProps) => {
   const { t } = useTranslation();

--- a/js/apps/admin-ui/src/components/dynamic/ListComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/ListComponent.tsx
@@ -7,7 +7,6 @@ import { FormGroup, SelectOption } from "@patternfly/react-core";
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 export const ListComponent = ({
@@ -18,6 +17,7 @@ export const ListComponent = ({
   options,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const { control } = useFormContext();

--- a/js/apps/admin-ui/src/components/dynamic/MapComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/MapComponent.tsx
@@ -15,9 +15,7 @@ import { MinusCircleIcon, PlusCircleIcon } from "@patternfly/react-icons";
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import { KeyValueType } from "../key-value-form/key-value-convert";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 type IdKeyValueType = KeyValueType & {
@@ -30,6 +28,7 @@ export const MapComponent = ({
   helpText,
   required,
   isDisabled,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
 

--- a/js/apps/admin-ui/src/components/dynamic/MultivaluedListComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/MultivaluedListComponent.tsx
@@ -7,7 +7,6 @@ import { FormGroup, SelectOption } from "@patternfly/react-core";
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 function stringToMultiline(value?: string): string[] {
@@ -27,6 +26,7 @@ export const MultiValuedListComponent = ({
   isDisabled = false,
   stringify,
   required,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const { control } = useFormContext();

--- a/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -1,10 +1,8 @@
-import { useTranslation } from "react-i18next";
-import { FormGroup } from "@patternfly/react-core";
-
-import type { ComponentProps } from "./components";
 import { HelpItem } from "@keycloak/keycloak-ui-shared";
+import { FormGroup } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
 import { MultiLineInput } from "../multi-line-input/MultiLineInput";
-import { convertToName } from "./DynamicComponents";
+import type { ComponentProps } from "./components";
 
 function convertDefaultValue(formValue?: any): string[] {
   return formValue && Array.isArray(formValue) ? formValue : [formValue];
@@ -18,6 +16,7 @@ export const MultiValuedStringComponent = ({
   stringify,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const fieldName = convertToName(name!);

--- a/js/apps/admin-ui/src/components/dynamic/NumberComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/NumberComponent.tsx
@@ -1,13 +1,12 @@
-import { useTranslation } from "react-i18next";
 import { TextControl } from "@keycloak/keycloak-ui-shared";
-
-import { convertToName } from "./DynamicComponents";
+import { useTranslation } from "react-i18next";
 import { NumberComponentProps } from "./components";
 
 export const NumberComponent = ({
   name,
   label,
   helpText,
+  convertToName,
   ...props
 }: NumberComponentProps) => {
   const { t } = useTranslation();

--- a/js/apps/admin-ui/src/components/dynamic/PasswordComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/PasswordComponent.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import { PasswordControl } from "@keycloak/keycloak-ui-shared";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 export const PasswordComponent = ({
@@ -10,6 +9,7 @@ export const PasswordComponent = ({
   defaultValue,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
 

--- a/js/apps/admin-ui/src/components/dynamic/RoleComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/RoleComponent.tsx
@@ -1,3 +1,4 @@
+import { FormErrorText, HelpItem } from "@keycloak/keycloak-ui-shared";
 import {
   Button,
   Chip,
@@ -7,12 +8,9 @@ import {
 } from "@patternfly/react-core";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import useToggle from "../../utils/useToggle";
-import { FormErrorText, HelpItem } from "@keycloak/keycloak-ui-shared";
 import { AddRoleMappingModal } from "../role-mapping/AddRoleMappingModal";
 import { Row, ServiceRole } from "../role-mapping/RoleMapping";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 const parseValue = (value: any) =>
@@ -30,6 +28,7 @@ export const RoleComponent = ({
   defaultValue,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
 

--- a/js/apps/admin-ui/src/components/dynamic/ScriptComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/ScriptComponent.tsx
@@ -4,7 +4,6 @@ import CodeEditor from "@uiw/react-textarea-code-editor";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import type { ComponentProps } from "./components";
-import { convertToName } from "./DynamicComponents";
 
 export const ScriptComponent = ({
   name,
@@ -13,6 +12,7 @@ export const ScriptComponent = ({
   defaultValue,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const { control } = useFormContext();

--- a/js/apps/admin-ui/src/components/dynamic/StringComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/StringComponent.tsx
@@ -1,12 +1,12 @@
 import { TextControl } from "@keycloak/keycloak-ui-shared";
 import { useTranslation } from "react-i18next";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 export const StringComponent = ({
   name,
   label,
   helpText,
+  convertToName,
   ...props
 }: ComponentProps) => {
   const { t } = useTranslation();

--- a/js/apps/admin-ui/src/components/dynamic/TextComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/TextComponent.tsx
@@ -1,9 +1,7 @@
 import { FormGroup } from "@patternfly/react-core";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-
 import { KeycloakTextArea, HelpItem } from "@keycloak/keycloak-ui-shared";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 export const TextComponent = ({
@@ -13,6 +11,7 @@ export const TextComponent = ({
   defaultValue,
   required,
   isDisabled = false,
+  convertToName,
 }: ComponentProps) => {
   const { t } = useTranslation();
   const { register } = useFormContext();

--- a/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
@@ -10,7 +10,6 @@ import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../admin-client";
 import { KeySelect } from "../key-value-form/KeySelect";
-import { convertToName } from "./DynamicComponents";
 import type { ComponentProps } from "./components";
 
 export const UserProfileAttributeListComponent = ({
@@ -18,6 +17,7 @@ export const UserProfileAttributeListComponent = ({
   label,
   helpText,
   required = false,
+  convertToName,
 }: ComponentProps) => {
   const { adminClient } = useAdminClient();
 

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -23,6 +23,7 @@ export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
   isDisabled?: boolean;
   isNew?: boolean;
   stringify?: boolean;
+  convertToName: (name: string) => string;
 };
 
 export type NumberComponentProps = ComponentProps & {

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -29,7 +29,7 @@ import type { ComponentProps } from "../dynamic/components";
 
 type UserSelectVariant = "typeaheadMulti" | "typeahead";
 
-type UserSelectProps = ComponentProps & {
+type UserSelectProps = Omit<ComponentProps, "convertToName"> & {
   variant?: UserSelectVariant;
   isRequired?: boolean;
 };

--- a/js/apps/admin-ui/src/organizations/IdentityProviderSelect.tsx
+++ b/js/apps/admin-ui/src/organizations/IdentityProviderSelect.tsx
@@ -28,7 +28,7 @@ import { ComponentProps } from "../components/dynamic/components";
 import { KeycloakSpinner } from "@keycloak/keycloak-ui-shared";
 import useToggle from "../utils/useToggle";
 
-type IdentityProviderSelectProps = ComponentProps & {
+type IdentityProviderSelectProps = Omit<ComponentProps, "convertToName"> & {
   variant?: "typeaheadMulti" | "typeahead";
   isRequired?: boolean;
 };

--- a/js/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -26,8 +26,8 @@ import { useNavigate } from "react-router-dom";
 import { useAdminClient } from "../../../admin-client";
 import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
 import {
-  DynamicComponents,
   convertToName,
+  DynamicComponents,
 } from "../../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../../components/form/FormAccess";
 import { KeycloakSpinner } from "@keycloak/keycloak-ui-shared";


### PR DESCRIPTION
fixes : #36517
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
