### PR TITLE
Add some common headers for the links check in docs

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/password-policies.adoc
+++ b/docs/documentation/server_admin/topics/authentication/password-policies.adoc
@@ -118,7 +118,7 @@ The password cannot be the same as the email address of the user.
 ===== Regular expression
 
 Password must match one or more defined Java regular expression patterns.
-See https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html[Java's regular expression documentation] for the syntax of those expressions.
+See https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html[Java's regular expression documentation] for the syntax of those expressions.
 
 ===== Expire password
 

--- a/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
+++ b/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
@@ -10,6 +10,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
@@ -77,6 +78,9 @@ public class HttpUtils {
         };
 
         try {
+            // add common headers that are needed by some pages
+            method.addHeader(HttpHeaders.ACCEPT_LANGUAGE, "en-US,en;q=0.9");
+            method.addHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
             client.execute(method, responseHandler);
         } catch (Exception e) {
             response.setError("exception " + e.getMessage());


### PR DESCRIPTION
Closes #36675

It seems that now `https://jwt.io` requires the `Accept-Language` header. The PR adds it and also the `Accept` header to check the links. It changes the pattern link in the JDK too because it seems that 17 version is unstable (it works locally for me but not in the CI, just moving from 17 to 21).
