### PR TITLE
Don't require events enabled to view event tabs.

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -456,7 +456,8 @@ describe("Clients test", () => {
         .checkTabExists(ClientsDetailsTab.Sessions, true)
         .checkTabExists(ClientsDetailsTab.Permissions, true)
         .checkTabExists(ClientsDetailsTab.Advanced, true)
-        .checkNumberOfTabsIsEqual(5);
+        .checkTabExists(ClientsDetailsTab.UserEvents, true)
+        .checkNumberOfTabsIsEqual(6);
     });
 
     it("Hides the delete action", () => {

--- a/js/apps/admin-ui/src/clients/ClientDetails.tsx
+++ b/js/apps/admin-ui/src/clients/ClientDetails.tsx
@@ -194,7 +194,7 @@ export default function ClientDetails() {
 
   const { t } = useTranslation();
   const { addAlert, addError } = useAlerts();
-  const { realm, realmRepresentation } = useRealm();
+  const { realm } = useRealm();
   const { hasAccess } = useAccess();
   const isFeatureEnabled = useIsFeatureEnabled();
 
@@ -683,37 +683,31 @@ export default function ClientDetails() {
             >
               <AdvancedTab save={save} client={client} />
             </Tab>
-            {hasAccess("view-events") &&
-              (realmRepresentation?.adminEventsEnabled ||
-                realmRepresentation?.eventsEnabled) && (
-                <Tab
-                  data-testid="events-tab"
-                  title={<TabTitleText>{t("events")}</TabTitleText>}
-                  {...eventsTab}
+            {hasAccess("view-events") && (
+              <Tab
+                data-testid="events-tab"
+                title={<TabTitleText>{t("events")}</TabTitleText>}
+                {...eventsTab}
+              >
+                <Tabs
+                  activeKey={activeEventsTab}
+                  onSelect={(_, key) => setActiveEventsTab(key as string)}
                 >
-                  <Tabs
-                    activeKey={activeEventsTab}
-                    onSelect={(_, key) => setActiveEventsTab(key as string)}
+                  <Tab
+                    eventKey="userEvents"
+                    title={<TabTitleText>{t("userEvents")}</TabTitleText>}
                   >
-                    {realmRepresentation?.eventsEnabled && (
-                      <Tab
-                        eventKey="userEvents"
-                        title={<TabTitleText>{t("userEvents")}</TabTitleText>}
-                      >
-                        <UserEvents client={client.clientId} />
-                      </Tab>
-                    )}
-                    {realmRepresentation?.adminEventsEnabled && (
-                      <Tab
-                        eventKey="adminEvents"
-                        title={<TabTitleText>{t("adminEvents")}</TabTitleText>}
-                      >
-                        <AdminEvents resourcePath={`clients/${client.id}`} />
-                      </Tab>
-                    )}
-                  </Tabs>
-                </Tab>
-              )}
+                    <UserEvents client={client.clientId} />
+                  </Tab>
+                  <Tab
+                    eventKey="adminEvents"
+                    title={<TabTitleText>{t("adminEvents")}</TabTitleText>}
+                  >
+                    <AdminEvents resourcePath={`clients/${client.id}`} />
+                  </Tab>
+                </Tabs>
+              </Tab>
+            )}
           </RoutableTabs>
         </FormProvider>
       </PageSection>

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -49,7 +49,7 @@ export default function GroupsSection() {
   const [activeTab, setActiveTab] = useState(0);
 
   const { subGroups, setSubGroups, currentGroup } = useSubGroups();
-  const { realm, realmRepresentation } = useRealm();
+  const { realm } = useRealm();
 
   const [rename, setRename] = useState<GroupRepresentation>();
   const [deleteOpen, toggleDeleteOpen] = useToggle();
@@ -237,54 +237,43 @@ export default function GroupsSection() {
                       <PermissionsTab id={id} type="groups" />
                     </Tab>
                   )}
-                  {realmRepresentation?.adminEventsEnabled &&
-                    hasAccess("view-events") && (
-                      <Tab
-                        eventKey={5}
-                        data-testid="admin-events-tab"
-                        title={<TabTitleText>{t("adminEvents")}</TabTitleText>}
+                  {hasAccess("view-events") && (
+                    <Tab
+                      eventKey={5}
+                      data-testid="admin-events-tab"
+                      title={<TabTitleText>{t("adminEvents")}</TabTitleText>}
+                    >
+                      <Tabs
+                        activeKey={activeEventsTab}
+                        onSelect={(_, key) => setActiveEventsTab(key as string)}
                       >
-                        <Tabs
-                          activeKey={activeEventsTab}
-                          onSelect={(_, key) =>
-                            setActiveEventsTab(key as string)
+                        <Tab
+                          eventKey="adminEvents"
+                          title={
+                            <TabTitleText>{t("adminEvents")}</TabTitleText>
                           }
                         >
-                          <Tab
-                            eventKey="adminEvents"
-                            title={
-                              <TabTitleText>{t("adminEvents")}</TabTitleText>
-                            }
-                          >
-                            <AdminEvents resourcePath={`groups/${id}`} />
-                          </Tab>
-                          <Tab
-                            eventKey="membershipEvents"
-                            title={
-                              <TabTitleText>
-                                {t("membershipEvents")}
-                              </TabTitleText>
-                            }
-                          >
-                            <AdminEvents
-                              resourcePath={`users/*/groups/${id}`}
-                            />
-                          </Tab>
-                          <Tab
-                            eventKey="childGroupEvents"
-                            title={
-                              <TabTitleText>
-                                {t("childGroupEvents")}
-                              </TabTitleText>
-                            }
-                          >
-                            <AdminEvents
-                              resourcePath={`groups/${id}/children`}
-                            />
-                          </Tab>
-                        </Tabs>
-                      </Tab>
-                    )}
+                          <AdminEvents resourcePath={`groups/${id}`} />
+                        </Tab>
+                        <Tab
+                          eventKey="membershipEvents"
+                          title={
+                            <TabTitleText>{t("membershipEvents")}</TabTitleText>
+                          }
+                        >
+                          <AdminEvents resourcePath={`users/*/groups/${id}`} />
+                        </Tab>
+                        <Tab
+                          eventKey="childGroupEvents"
+                          title={
+                            <TabTitleText>{t("childGroupEvents")}</TabTitleText>
+                          }
+                        >
+                          <AdminEvents resourcePath={`groups/${id}/children`} />
+                        </Tab>
+                      </Tabs>
+                    </Tab>
+                  )}
                 </Tabs>
               )}
               {subGroups.length === 0 && <GroupTable refresh={refresh} />}

--- a/js/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
+++ b/js/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
@@ -347,7 +347,7 @@ export default function RealmRoleTabs() {
                   <PermissionsTab id={id} type="roles" />
                 </Tab>
               )}
-            {realm?.adminEventsEnabled && hasAccess("view-events") && (
+            {hasAccess("view-events") && (
               <Tab
                 data-testid="admin-events-tab"
                 title={<TabTitleText>{t("adminEvents")}</TabTitleText>}

--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -430,38 +430,31 @@ export default function EditUser() {
               >
                 <UserSessions />
               </Tab>
-              {hasAccess("view-events") &&
-                (realm?.adminEventsEnabled || realm?.eventsEnabled) && (
-                  <Tab
-                    data-testid="events-tab"
-                    title={<TabTitleText>{t("events")}</TabTitleText>}
-                    {...eventsTab}
+              {hasAccess("view-events") && (
+                <Tab
+                  data-testid="events-tab"
+                  title={<TabTitleText>{t("events")}</TabTitleText>}
+                  {...eventsTab}
+                >
+                  <Tabs
+                    activeKey={activeEventsTab}
+                    onSelect={(_, key) => setActiveEventsTab(key as string)}
                   >
-                    <Tabs
-                      activeKey={activeEventsTab}
-                      onSelect={(_, key) => setActiveEventsTab(key as string)}
+                    <Tab
+                      eventKey="userEvents"
+                      title={<TabTitleText>{t("userEvents")}</TabTitleText>}
                     >
-                      {realm.eventsEnabled && (
-                        <Tab
-                          eventKey="userEvents"
-                          title={<TabTitleText>{t("userEvents")}</TabTitleText>}
-                        >
-                          <UserEvents user={user.id} />
-                        </Tab>
-                      )}
-                      {realm.adminEventsEnabled && (
-                        <Tab
-                          eventKey="adminEvents"
-                          title={
-                            <TabTitleText>{t("adminEvents")}</TabTitleText>
-                          }
-                        >
-                          <AdminEvents resourcePath={`users/${user.id}`} />
-                        </Tab>
-                      )}
-                    </Tabs>
-                  </Tab>
-                )}
+                      <UserEvents user={user.id} />
+                    </Tab>
+                    <Tab
+                      eventKey="adminEvents"
+                      title={<TabTitleText>{t("adminEvents")}</TabTitleText>}
+                    >
+                      <AdminEvents resourcePath={`users/${user.id}`} />
+                    </Tab>
+                  </Tabs>
+                </Tab>
+              )}
             </RoutableTabs>
           </FormProvider>
         </UserProfileProvider>


### PR DESCRIPTION
Fixes #36527

Events don't actually need to be enabled to view events.  They can be disabled but you should still be able to query for old events that were created when events were previously enabled.  So `view-realm` should not be required.  Only `view-events` should be required to view the events tabs.
