### PR TITLE
Check client consents when audience is for the same client

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -72,7 +72,6 @@ import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.services.resources.IdentityBrokerService;
-import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -81,8 +80,6 @@ import org.keycloak.util.TokenUtil;
 
 import static org.keycloak.authentication.authenticators.util.AuthenticatorUtils.getDisabledByBruteForceEventError;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_CLIENT;
-import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_ID;
-import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_USERNAME;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -241,6 +238,11 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
             }
         }
 
+        // Assume client itself is audience in case audience parameter not provided
+        if (targetAudienceClients.isEmpty()) {
+            targetAudienceClients.add(client);
+        }
+
         for (ClientModel targetClient : targetAudienceClients) {
             if (targetClient.isConsentRequired()) {
                 event.detail(Details.REASON, "audience requires consent");
@@ -254,12 +256,6 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
                 event.error(Errors.CLIENT_DISABLED);
                 throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Client disabled", Response.Status.BAD_REQUEST);
             }
-        }
-
-
-        // Assume client itself is audience in case audience parameter not provided
-        if (targetAudienceClients.isEmpty()) {
-            targetAudienceClients.add(client);
         }
 
         for (ClientModel targetClient : targetAudienceClients) {


### PR DESCRIPTION
Closes #36732

@mposolda This is a little regression by this commit https://github.com/keycloak/keycloak/commit/4ad4a8d37b719353eb200ef4085cd7641d5ccd89. I'm just assigning the audience to the current client before doing the check for the consents. This way it is the same behavior if the audience parameter is set to the same client or not passed.

Maybe you were trying to allow exchange to the same client even with consents but then we have to check if the token is present (for example in the issue it is a external to internal request, so there is no current token issued for the client). As there is an issue in the token-exchange task about how to manage consents I preferred to just maintain the previous behavior for the moment (https://github.com/keycloak/keycloak/issues/31797).

Test added.
