### PR TITLE
Return empty configProperties for CredentialBuilderFactory implementation

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderFactory.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
+import java.util.ArrayList;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.OffsetTimeProvider;
@@ -30,6 +31,8 @@ import java.util.List;
  */
 public class JwtCredentialBuilderFactory implements CredentialBuilderFactory {
 
+    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
     @Override
     public String getSupportedFormat() {
         return Format.JWT_VC;
@@ -42,7 +45,7 @@ public class JwtCredentialBuilderFactory implements CredentialBuilderFactory {
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return null;
+        return configProperties;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/LDCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/LDCredentialBuilderFactory.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
+import java.util.ArrayList;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.model.Format;
@@ -28,6 +29,8 @@ import java.util.List;
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
 public class LDCredentialBuilderFactory implements CredentialBuilderFactory {
+
+    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     @Override
     public String getSupportedFormat() {
@@ -41,7 +44,7 @@ public class LDCredentialBuilderFactory implements CredentialBuilderFactory {
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return null;
+        return configProperties;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderFactory.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
+import java.util.ArrayList;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
@@ -30,6 +31,8 @@ import java.util.List;
  */
 public class SdJwtCredentialBuilderFactory implements CredentialBuilderFactory {
 
+    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
     @Override
     public String getSupportedFormat() {
         return Format.SD_JWT_VC;
@@ -42,7 +45,7 @@ public class SdJwtCredentialBuilderFactory implements CredentialBuilderFactory {
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return null;
+        return configProperties;
     }
 
     @Override

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
@@ -1,0 +1,49 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.common.profile.CommaSeparatedListProfileConfigResolver;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+
+public class CredentialBuilderFactoryTest {
+
+    private static KeycloakSession session;
+
+    @BeforeClass
+    public static void beforeClass() {
+        Profile.configure(new CommaSeparatedListProfileConfigResolver(Feature.OID4VC_VCI.getVersionedKey(), ""));
+        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
+        ResteasyKeycloakSessionFactory factory = new ResteasyKeycloakSessionFactory();
+        factory.init();
+        session = new ResteasyKeycloakSession(factory);
+    }
+
+    @Test
+    public void testVerifyNonNullConfigProperties() {
+        List<CredentialBuilderFactory> credentialBuilderFactories = session
+            .getKeycloakSessionFactory()
+            .getProviderFactoriesStream(CredentialBuilder.class)
+            .filter(CredentialBuilderFactory.class::isInstance)
+            .map(CredentialBuilderFactory.class::cast)
+            .toList();
+
+        assertThat(credentialBuilderFactories, is(not(empty())));
+
+        for (CredentialBuilderFactory credentialBuilderFactory : credentialBuilderFactories) {
+            assertThat(credentialBuilderFactory.getConfigProperties(), notNullValue());
+        }
+    }
+}


### PR DESCRIPTION
Modified CredentialBuilderFactory implementations to return an empty configProperties list instead of a null value.

Prevents `ComponentUtil` to fail with a NullPointerException while iterating over factories config properties.

Closes #36826

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
