### PR TITLE
Adding a new issue template for website problems

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-website.yml
+++ b/.github/ISSUE_TEMPLATE/bug-website.yml
@@ -1,0 +1,32 @@
+name: Website Problem Report
+description: Report a problem on Keycloak's website
+labels: ["kind/bug", "status/triage", "area/docs"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+      description: Provide a clear and concise description of what the problem is.
+    validations:
+      required: true
+  - type: textarea
+    id: behaviorExpected
+    attributes:
+      label: Expected behavior
+      description: Describe what content you were expecting.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: How to Reproduce?
+      description: Describe how you reached this site, for example by adding a link where this page was referenced.
+    validations:
+      required: false
+  - type: textarea
+    id: other
+    attributes:
+      label: Anything else?
+      description: Links? References? Anything that will give us more context about the issue you are encountering!
+    validations:
+      required: false


### PR DESCRIPTION
Choices made: 

* Go with `kind/bug` and `status/triage` to leverage the same bug triage process that we have.
* Go with `area/docs` until we see we need a new area like `area/website`.
* Named it `website-bug.yml` so it is listed last on the templates, as GitHub sorts them alphabetically.

The first use case is to create issues for broken links. We might soon add it to other pages where we today have "Edit this page" and we also want people to report problems, so the texts are a bit more generic.

Closes #36831

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
