### PR TITLE
docs: update JavaDoc for ImportSynchronization

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
@@ -57,8 +57,9 @@ public class ComponentTypeRepresentation {
     }
 
     /**
-     * Extra information about the component that might come from annotations or interfaces that the component implements
-     * For example, if UserStorageProvider implements ImportSynchronization
+     * Extra information about the component
+     * that might come from annotations or interfaces that the component implements.
+     * For example, if UserStorageProviderFactory implements ImportSynchronization
      *
      * @return
      */

--- a/model/storage-private/src/main/java/org/keycloak/storage/managers/UserStorageSyncManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/managers/UserStorageSyncManager.java
@@ -28,8 +28,8 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.KeycloakSessionTask;
-import org.keycloak.models.StorageProviderRealmModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.StorageProviderRealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
@@ -109,7 +109,7 @@ public class UserStorageSyncManager {
                     @Override
                     public SynchronizationResult call() throws Exception {
                         int lastSync = Time.currentTime();
-                        SynchronizationResult result = ((ImportSynchronization)factory).sync(sessionFactory, realmId, provider);
+                        SynchronizationResult result = ((ImportSynchronization) factory).sync(sessionFactory, realmId, provider);
                         if (!result.isIgnored()) {
                             updateLastSyncInterval(sessionFactory, provider, realmId, lastSync);
                         }
@@ -155,7 +155,7 @@ public class UserStorageSyncManager {
                         // See when we did last sync.
                         int oldLastSync = provider.getLastSync();
                         int lastSync = Time.currentTime();
-                        SynchronizationResult result = ((ImportSynchronization)factory).syncSince(Time.toDate(oldLastSync), sessionFactory, realmId, provider);
+                        SynchronizationResult result = ((ImportSynchronization) factory).syncSince(Time.toDate(oldLastSync), sessionFactory, realmId, provider);
                         if (!result.isIgnored()) {
                             updateLastSyncInterval(sessionFactory, provider, realmId, lastSync);
                         }
@@ -178,13 +178,13 @@ public class UserStorageSyncManager {
 
     public static void notifyToRefreshPeriodicSyncAll(KeycloakSession session, RealmModel realm, boolean removed) {
         ((StorageProviderRealmModel) realm).getUserStorageProvidersStream().forEachOrdered(fedProvider ->
-           notifyToRefreshPeriodicSync(session, realm, fedProvider, removed));
+                notifyToRefreshPeriodicSync(session, realm, fedProvider, removed));
     }
-    
+
     public static void notifyToRefreshPeriodicSyncSingle(KeycloakSession session, RealmModel realm, ComponentModel component, boolean removed) {
         notifyToRefreshPeriodicSync(session, realm, new UserStorageProviderModel(component), removed);
     }
-    
+
     // Ensure all cluster nodes are notified
     public static void notifyToRefreshPeriodicSync(KeycloakSession session, RealmModel realm, UserStorageProviderModel provider, boolean removed) {
         UserStorageProviderFactory factory = (UserStorageProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(UserStorageProvider.class, provider.getProviderId());
@@ -268,7 +268,7 @@ public class UserStorageSyncManager {
                         break;
                 }
             } catch (Throwable t) {
-                logger.errorf(t,"Error occurred during %s users-sync in realm %s", //
+                logger.errorf(t, "Error occurred during %s users-sync in realm %s", //
                         syncMode, realm.getName());
             }
         }

--- a/model/storage/src/main/java/org/keycloak/storage/UserStorageProvider.java
+++ b/model/storage/src/main/java/org/keycloak/storage/UserStorageProvider.java
@@ -34,7 +34,6 @@ import org.keycloak.provider.Provider;
  *     <li>{@link org.keycloak.storage.user.UserRegistrationProvider UserRegistrationProvider} - Provide methods for adding users. After implementing it is possible to store registered users in the storage.</li>
  *     <li>{@link org.keycloak.storage.user.UserBulkUpdateProvider UserBulkUpdateProvider} - After implementing it is possible to perform bulk operations on all users from storage (for example, addition of a role to all users).</li>
  *     <li>{@link org.keycloak.storage.user.ImportedUserValidation ImportedUserValidation} - Provider method for validating users within Keycloak local storage that are imported from the storage.</li>
- *     <li>{@link org.keycloak.storage.user.ImportSynchronization ImportSynchronization} - Provider methods for synchronization of the storage with Keycloak local storage. After implementing it is possible to sync users in the Admin console.</li>
  * </ul>
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -49,8 +48,7 @@ public interface UserStorageProvider extends Provider {
      *
      * @param realm
      */
-    default
-    void preRemove(RealmModel realm) {
+    default void preRemove(RealmModel realm) {
 
     }
 
@@ -61,27 +59,24 @@ public interface UserStorageProvider extends Provider {
      * @param realm
      * @param group
      */
-    default
-    void preRemove(RealmModel realm, GroupModel group) {
+    default void preRemove(RealmModel realm, GroupModel group) {
 
     }
 
     /**
      * Callback when a role is removed.  Allows you to do things like remove a user
      * role mapping in your external store if appropriate
-
+     *
      * @param realm
      * @param role
      */
-    default
-    void preRemove(RealmModel realm, RoleModel role) {
+    default void preRemove(RealmModel realm, RoleModel role) {
 
     }
 
     /**
      * Optional type that can be used by implementations to
      * describe edit mode of user storage
-     *
      */
     enum EditMode {
         /**
@@ -90,12 +85,10 @@ public interface UserStorageProvider extends Provider {
         READ_ONLY,
         /**
          * user storage is writable
-         *
          */
         WRITABLE,
         /**
          * updates to user are stored locally and not synced with user storage.
-         *
          */
         UNSYNCED
     }

--- a/model/storage/src/main/java/org/keycloak/storage/user/ImportSynchronization.java
+++ b/model/storage/src/main/java/org/keycloak/storage/user/ImportSynchronization.java
@@ -22,15 +22,16 @@ import org.keycloak.storage.UserStorageProviderModel;
 import java.util.Date;
 
 /**
- *
- * This is an optional capability interface that is intended to be implemented by any
- * {@link org.keycloak.storage.UserStorageProvider UserStorageProvider} that supports syncing users to keycloak local
- * storage. You must implement this interface if you want to be able to use sync functionality within the Admin console.
+ * This is an optional capability interface intended to be implemented by any
+ * {@link org.keycloak.storage.UserStorageProviderFactory UserStorageProviderFactory} that supports
+ * syncing users to keycloak local storage.
+ * You must implement this interface if you want to be able to use sync functionality within the Admin console.
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 public interface ImportSynchronization {
     SynchronizationResult sync(KeycloakSessionFactory sessionFactory, String realmId, UserStorageProviderModel model);
+
     SynchronizationResult syncSince(Date lastSync, KeycloakSessionFactory sessionFactory, String realmId, UserStorageProviderModel model);
 }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
@@ -30,18 +30,18 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.CacheableStorageProviderModel;
-import org.keycloak.storage.ldap.idm.model.LDAPObject;
-import org.keycloak.storage.ldap.idm.store.ldap.LDAPOperationManager;
-import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
-import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapper;
-import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapperFactory;
-import org.keycloak.storage.managers.UserStorageSyncManager;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.storage.ldap.idm.store.ldap.LDAPOperationManager;
+import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapperFactory;
+import org.keycloak.storage.managers.UserStorageSyncManager;
 import org.keycloak.storage.user.ImportSynchronization;
 import org.keycloak.storage.user.SynchronizationResult;
 import org.keycloak.testsuite.model.KeycloakModelTest;
@@ -88,7 +88,7 @@ public class UserSyncTest extends KeycloakModelTest {
             ComponentModel res = realm.addComponentModel(fs);
 
             // Check if the provider implements ImportSynchronization interface
-            UserStorageProviderFactory userStorageProviderFactory = (UserStorageProviderFactory)session.getKeycloakSessionFactory().getProviderFactory(UserStorageProvider.class, res.getProviderId());
+            UserStorageProviderFactory userStorageProviderFactory = (UserStorageProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(UserStorageProvider.class, res.getProviderId());
             if (!ImportSynchronization.class.isAssignableFrom(userStorageProviderFactory.getClass())) {
                 return;
             }
@@ -140,7 +140,7 @@ public class UserSyncTest extends KeycloakModelTest {
 
         // The sync shouldn't take more than 18 second per user
         assertThat(String.format("User sync took %f seconds per user, but it should take less than 18 seconds",
-                (float)(timeNeeded) / NUMBER_OF_USERS), timeNeeded, Matchers.lessThan((long) (18 * NUMBER_OF_USERS)));
+                (float) (timeNeeded) / NUMBER_OF_USERS), timeNeeded, Matchers.lessThan((long) (18 * NUMBER_OF_USERS)));
         assertThat(res.getAdded(), is(NUMBER_OF_USERS));
         assertThat(withRealm(realmId, (session, realm) -> UserStoragePrivateUtil.userLocalStorage(session).getUsersCount(realm)), is(NUMBER_OF_USERS));
     }


### PR DESCRIPTION
The JavaDoc for ImportSynchronization was wrongfully referencing the UserStorageProvider instead of the UserStorageProviderFactory.

Closes #36834

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
