### PR TITLE
Remove pulling image (un-authenticated) from docker.io in DockerClientTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
@@ -147,17 +147,9 @@ public class DockerClientTest extends AbstractKeycloakTest {
         printCommandResult(result);
         assertThat("Error performing login", result.getExitCode(), is(0));
 
-        result = dockerClientContainer.execInContainer("docker", "pull", "docker.io/hello-world:latest");
+        result = dockerClientContainer.execInContainer("docker", "search", REGISTRY_HOSTNAME + ":" + REGISTRY_PORT);
         printCommandResult(result);
-        assertThat("Error pulling from docker.io", result.getExitCode(), is(0));
-
-        result = dockerClientContainer.execInContainer("docker", "tag", "hello-world:latest", REGISTRY_HOSTNAME + ":" + REGISTRY_PORT + "/hello-world:latest");
-        printCommandResult(result);
-        assertThat("Error tagging the image", result.getExitCode(), is(0));
-
-        result = dockerClientContainer.execInContainer("docker", "push", REGISTRY_HOSTNAME + ":" + REGISTRY_PORT + "/hello-world:latest");
-        printCommandResult(result);
-        assertThat("Error pushing to registry", result.getExitCode(), is(0));
+        assertThat("Error using registry", result.getExitCode(), is(0));
     }
 
     private void printCommandResult(Container.ExecResult result) {


### PR DESCRIPTION
A few reasons to removing this:

* Makes no sense to test we can pull images from docker.io when we're testing a locally running registry secured with Keycloak. This just makes the test take longer to run, and adds no value from a test perspective
* We shouldn't pull images directly from docker.io
* This step has failed a few times with `Error pulling from docker.io` error

This is the simplest approach assuming that search tests stuff sufficiently; alternatively we can build a small image (FROM scatch) and push that, see https://stackoverflow.com/questions/24866373/is-it-possible-to-use-a-blank-docker-container-without-any-install-on-it

Closes #36865
