### PR TITLE
Allows querying credential from user storage providers

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/CredentialRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/CredentialRepresentation.java
@@ -62,6 +62,7 @@ public class CredentialRepresentation {
     private Integer period;
     @Deprecated
     private MultivaluedHashMap<String, String> config;
+    private String federationLink;
 
     public String getId() {
         return id;
@@ -246,5 +247,11 @@ public class CredentialRepresentation {
         return true;
     }
 
+    public void setFederationLink(String federationLink) {
+        this.federationLink = federationLink;
+    }
 
+    public String getFederationLink() {
+        return federationLink;
+    }
 }

--- a/docs/documentation/release_notes/topics/26_2_0.adoc
+++ b/docs/documentation/release_notes/topics/26_2_0.adoc
@@ -26,3 +26,19 @@ All available log handlers now support *ECS* (Elastic Common Schema) JSON format
 It helps to improve {project_name}'s observability story and centralized logging.
 
 For more details, see the https://www.keycloak.org/server/logging[Logging guide].
+
+= Federated credentials are available now when fetching user credentials
+
+Until now, querying user credentials using the User API will not return credentials managed by user storage providers and, as a consequence,
+prevent fetching additional metadata associated with federated credentials like the last time a credential was updated.
+
+In this release, we are adding a new method `getCredentials(RealmModel, UserModel)` to the `org.keycloak.credential.CredentialInputUpdater` interface so that
+user storage providers can return the credentials they manage for a specific user in a realm. By doing this, user storage providers can indicate
+whether the credential is linked to it as well as provide additional metadata so that additional information can be shown when managing users through the administration console.
+
+For LDAP, it should be possible now to see the last time the password was updated based on the standard `pwdChangedTime` attribute or, if
+using Microsoft AD, based on the `pwdLastSet` attribute.
+
+In order to check if a credential is local - managed by {project_name} - or federated, you can check the `federationLink` property available from both
+`CredentialRepresentation` and `CredentialModel` types. If set, the `federationLink` property holds the UUID of the component model associated with a given
+user storage provider.

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -18,7 +18,9 @@
 package org.keycloak.storage.ldap;
 
 import java.lang.reflect.Method;
+import java.util.Calendar;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -142,6 +145,13 @@ public class LDAPUtils {
         if (kerberosPrincipalAttr != null) {
             ldapQuery.addReturningLdapAttribute(kerberosPrincipalAttr);
             ldapQuery.addReturningReadOnlyLdapAttribute(kerberosPrincipalAttr);
+        }
+
+        if (config.isActiveDirectory()) {
+            ldapQuery.addReturningLdapAttribute(LDAPConstants.PWD_LAST_SET);
+        } else {
+            // https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy
+            ldapQuery.addReturningLdapAttribute(LDAPConstants.PWD_CHANGED_TIME);
         }
 
         return ldapQuery;
@@ -408,5 +418,50 @@ public class LDAPUtils {
         }
 
         return KerberosConstants.KERBEROS_PRINCIPAL_LDAP_ATTRIBUTE_KRB5_PRINCIPAL_NAME;
+    }
+
+    /**
+     * Convert Generalized Time as defined in RFC4517 to the Date
+     */
+    static Date generalizedTimeToDate(String generalized) {
+
+        String[] parts = generalized.split("[Z+-]");
+        String[] timeFraction = parts[0].split("[.,]");
+        String time = timeFraction[0];
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(0);
+        calendar.setLenient(false);
+
+        calendar.set(Calendar.YEAR, Integer.parseInt(time.substring(0, 4)));
+        calendar.set(Calendar.MONTH, Integer.parseInt(time.substring(4, 6)) - 1);
+        calendar.set(Calendar.DAY_OF_MONTH, Integer.parseInt(time.substring(6, 8)));
+        calendar.set(Calendar.HOUR_OF_DAY, Integer.parseInt(time.substring(8, 10)));
+        if (time.length() >= 12) calendar.set(Calendar.MINUTE, Integer.parseInt(time.substring(10, 12)));
+        if (time.length() >= 14) calendar.set(Calendar.SECOND, Integer.parseInt(time.substring(12, 14)));
+
+        // fraction
+        if (timeFraction.length >= 2) {
+            double fraction = Double.parseDouble("0." + timeFraction[1]);
+            if (time.length() >= 14) { // fraction of second
+                calendar.set(Calendar.MILLISECOND, (int) Math.round(fraction * 1000));
+            } else if (time.length() >= 12) { // fraction of minute
+                calendar.set(Calendar.SECOND, (int) Math.round(fraction * 60));
+            } else { // fraction of hour
+                calendar.set(Calendar.MINUTE, (int) Math.round(fraction * 60));
+            }
+        }
+
+        // timezone
+        if (generalized.length() > parts[0].length()) {
+            char delimiter = generalized.charAt(parts[0].length());
+            if (delimiter == 'Z') {
+                calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
+            } else {
+                calendar.setTimeZone(TimeZone.getTimeZone("GMT" + delimiter + parts[1]));
+            }
+        }
+
+        return calendar.getTime();
     }
 }

--- a/js/apps/admin-ui/src/user/UserCredentials.tsx
+++ b/js/apps/admin-ui/src/user/UserCredentials.tsx
@@ -29,6 +29,7 @@ import { CredentialRow } from "./user-credentials/CredentialRow";
 import { InlineLabelEdit } from "./user-credentials/InlineLabelEdit";
 import { ResetCredentialDialog } from "./user-credentials/ResetCredentialDialog";
 import { ResetPasswordDialog } from "./user-credentials/ResetPasswordDialog";
+import useFormatDate from "../utils/useFormatDate";
 
 import "./user-credentials.css";
 
@@ -99,6 +100,7 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
   const { t } = useTranslation();
   const { addAlert, addError } = useAlerts();
   const [key, setKey] = useState(0);
+  const formatDate = useFormatDate();
   const refresh = () => setKey(key + 1);
   const [isOpen, setIsOpen] = useState(false);
   const [openCredentialReset, setOpenCredentialReset] = useState(false);
@@ -124,6 +126,11 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
   useFetch(
     () => adminClient.users.getCredentials({ id: user.id! }),
     (credentials) => {
+      credentials = [
+        ...credentials.filter((c: CredentialRepresentation) => {
+          return c.federationLink === undefined;
+        }),
+      ];
       setUserCredentials(credentials);
 
       const groupedCredentials = credentials.reduce((r, a) => {
@@ -144,10 +151,6 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
       );
     },
     [key],
-  );
-
-  const passwordTypeFinder = userCredentials.find(
-    (credential) => credential.type === "password",
   );
 
   const toggleModal = () => setIsOpen(!isOpen);
@@ -353,12 +356,21 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
   };
 
   const useFederatedCredentials = user.federationLink;
-  const [credentialTypes, setCredentialTypes] = useState<string[]>([]);
+  const [credentialTypes, setCredentialTypes] = useState<
+    CredentialRepresentation[]
+  >([]);
 
   useFetch(
-    () => adminClient.users.getUserStorageCredentialTypes({ id: user.id! }),
-    setCredentialTypes,
-    [],
+    () => adminClient.users.getCredentials({ id: user.id! }),
+    (credentials) => {
+      credentials = [
+        ...credentials.filter((c: CredentialRepresentation) => {
+          return c.federationLink !== undefined;
+        }),
+      ];
+      setCredentialTypes(credentials);
+    },
+    [key],
   );
 
   if (!credentialTypes) {
@@ -400,22 +412,26 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
           {t("credentialResetBtn")}
         </Button>
       )}
-      {userCredentials.length !== 0 && passwordTypeFinder === undefined && (
-        <>
-          <Button
-            className="kc-setPasswordBtn-tbl"
-            data-testid="setPasswordBtn-table"
-            variant="primary"
-            form="userCredentials-form"
-            onClick={() => {
-              setIsOpen(true);
-            }}
-          >
-            {t("setPassword")}
-          </Button>
-          <Divider />
-        </>
-      )}
+      {userCredentials.length !== 0 &&
+        !userCredentials.find((credential) => credential.type === "password") &&
+        !credentialTypes.find(
+          (credential) => credential.type === "password",
+        ) && (
+          <>
+            <Button
+              className="kc-setPasswordBtn-tbl"
+              data-testid="setPasswordBtn-table"
+              variant="primary"
+              form="userCredentials-form"
+              onClick={() => {
+                setIsOpen(true);
+              }}
+            >
+              {t("setPassword")}
+            </Button>
+            <Divider />
+          </>
+        )}
       {groupedUserCredentials.length !== 0 && (
         <PageSection variant={PageSectionVariants.light}>
           <Table variant={"compact"}>
@@ -554,19 +570,21 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
               <Tr>
                 <Th>{t("type")}</Th>
                 <Th>{t("providedBy")}</Th>
+                <Th>{t("createdAt")}</Th>
                 <Th aria-hidden="true" />
               </Tr>
             </Thead>
             <Tbody>
               {credentialTypes.map((credential) => (
-                <Tr key={credential}>
+                <Tr key={credential.type}>
                   <Td>
-                    <b>{credential}</b>
+                    <b>{credential.type}</b>
                   </Td>
                   <Td>
                     <FederatedUserLink user={user} />
                   </Td>
-                  {credential === "password" && (
+                  <Td>{formatDate(new Date(credential.createdDate!))}</Td>
+                  {credential.type === "password" && (
                     <Td modifier="fitContent">
                       <Button variant="secondary" onClick={toggleModal}>
                         {t("setPassword")}

--- a/js/apps/admin-ui/src/user/user-credentials/ResetPasswordDialog.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/ResetPasswordDialog.tsx
@@ -97,7 +97,10 @@ export const ResetPasswordDialog = ({
         id: user.id!,
       });
       const credentialLabel = credentials.find((c) => c.type === "password");
-      if (credentialLabel) {
+      const isLocalCredential =
+        credentialLabel && credentialLabel.federationLink === undefined;
+
+      if (isLocalCredential) {
         await adminClient.users.updateCredentialLabel(
           {
             id: user.id!,

--- a/js/libs/keycloak-admin-client/src/defs/credentialRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/credentialRepresentation.ts
@@ -12,4 +12,5 @@ export default interface CredentialRepresentation {
   type?: string;
   userLabel?: string;
   value?: string;
+  federationLink?: string;
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -119,6 +119,7 @@ public class LDAPConstants {
     public static final String GROUP_OF_UNIQUE_NAMES = "groupOfUniqueNames";
     public static final String USER_ACCOUNT_CONTROL = "userAccountControl";
     public static final String PWD_LAST_SET = "pwdLastSet";
+    public static final String PWD_CHANGED_TIME = "pwdChangedTime";
     public static final String MSDS_USER_ACCOUNT_DISABLED = "msDS-UserAccountDisabled";
     public static final String MSDS_USER_PASSWORD_NOTREQD = "msDS-UserPasswordNotRequired";
     public static final String MSDS_USER_PASSWORD_EXPIRED = "msDS-UserPasswordExpired"; // read-only

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -671,6 +671,7 @@ public class ModelToRepresentation {
         rep.setCreatedDate(cred.getCreatedDate());
         rep.setSecretData(cred.getSecretData());
         rep.setCredentialData(cred.getCredentialData());
+        rep.setFederationLink(cred.getFederationLink());
         return rep;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/CredentialHelper.java
@@ -47,16 +47,6 @@ public class CredentialHelper {
 
     private static final Logger logger = Logger.getLogger(CredentialHelper.class);
 
-    public static void setRequiredCredential(KeycloakSession session, String type, RealmModel realm) {
-        AuthenticationExecutionModel.Requirement requirement = AuthenticationExecutionModel.Requirement.REQUIRED;
-        setOrReplaceAuthenticationRequirement(session, realm, type, requirement, null);
-    }
-
-    public static void setAlternativeCredential(KeycloakSession session, String type, RealmModel realm) {
-        AuthenticationExecutionModel.Requirement requirement = AuthenticationExecutionModel.Requirement.ALTERNATIVE;
-        setOrReplaceAuthenticationRequirement(session, realm, type, requirement, null);
-    }
-
     public static void setOrReplaceAuthenticationRequirement(KeycloakSession session, RealmModel realm, String type, AuthenticationExecutionModel.Requirement requirement, AuthenticationExecutionModel.Requirement currentRequirement) {
         realm.getAuthenticationFlowsStream().forEach(flow -> realm.getAuthenticationExecutionsStream(flow.getId())
                 .filter(exe -> {
@@ -113,17 +103,6 @@ public class CredentialHelper {
         //If the type is HOTP, call verify once to consume the OTP used for registration and increase the counter.
         UserCredentialModel credential = new UserCredentialModel(credentialId, otpCredentialProvider.getType(), totpCode);
         return user.credentialManager().isValid(credential);
-    }
-
-    public static void deleteOTPCredential(KeycloakSession session, RealmModel realm, UserModel user, String credentialId) {
-        CredentialProvider otpCredentialProvider = session.getProvider(CredentialProvider.class, "keycloak-otp");
-        boolean removed = otpCredentialProvider.deleteCredential(realm, user, credentialId);
-
-        // This can usually happened when credential is stored in the userStorage. Propagate to "disable" credential in the userStorage
-        if (!removed) {
-            logger.debug("Removing OTP credential from userStorage");
-            user.credentialManager().disableCredentialType(OTPCredentialModel.TYPE);
-        }
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialInputUpdater.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialInputUpdater.java
@@ -39,4 +39,15 @@ public interface CredentialInputUpdater {
      * @return a non-null {@link Stream} of credential types.
      */
     Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user);
+
+    /**
+     * Returns a stream of {@link CredentialModel} instances managed by this provider for the given {@code user}.
+     *
+     * @param realm the realm
+     * @param user the user
+     * @return the credentials managed by this provider for the given {@code user}
+     */
+    default Stream<CredentialModel> getCredentials(RealmModel realm, UserModel user) {
+        return Stream.empty();
+    }
 }

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialModel.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.MultivaluedHashMap;
-import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.util.JsonSerialization;
 
 /**
@@ -68,6 +67,8 @@ public class CredentialModel implements Serializable {
     private String secretData;
     private String credentialData;
 
+    private String federationLink;
+
     public CredentialModel shallowClone() {
         CredentialModel res = new CredentialModel();
         res.id = id;
@@ -76,6 +77,7 @@ public class CredentialModel implements Serializable {
         res.createdDate = createdDate;
         res.secretData = secretData;
         res.credentialData = credentialData;
+        res.federationLink = federationLink;
         return res;
     }
 
@@ -294,6 +296,14 @@ public class CredentialModel implements Serializable {
     @Deprecated
     public void setConfig(MultivaluedHashMap<String, String> config) {
         writeProperty("config", config, false);
+    }
+
+    public void setFederationLink(String federationLink) {
+        this.federationLink = federationLink;
+    }
+
+    public String getFederationLink() {
+        return federationLink;
     }
 
     private Map<String, Object> readMapFromJson(boolean secret) {

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialProvider.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialProvider.java
@@ -53,4 +53,12 @@ public interface CredentialProvider<T extends CredentialModel> extends Provider 
         credentialMetadata.setCredentialModel(credentialModel);
         return credentialMetadata;
     }
+
+    default boolean supportsCredentialType(CredentialModel credential) {
+        return supportsCredentialType(credential.getType());
+    }
+
+    default boolean supportsCredentialType(String type) {
+        return getType().equals(type);
+    }
 }

--- a/server-spi/src/main/java/org/keycloak/models/SubjectCredentialManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/SubjectCredentialManager.java
@@ -81,6 +81,24 @@ public interface SubjectCredentialManager {
     Stream<CredentialModel> getStoredCredentialsStream();
 
     /**
+     * Returns a stream consisting of the federated credentials.
+     *
+     * @return a stream consisting of the federated credentials
+     */
+    default Stream<CredentialModel> getFederatedCredentialsStream() {
+        return Stream.empty();
+    }
+
+    /**
+     * Returns a stream consisting of both local and federated credentials.
+     *
+     * @return a stream of both local and federated credentials
+     */
+    default Stream<CredentialModel> getCredentials() {
+        return Stream.concat(getStoredCredentialsStream(), getFederatedCredentialsStream());
+    }
+
+    /**
      * Read stored credentials by type as a stream.
      */
     Stream<CredentialModel> getStoredCredentialsByTypeStream(String type);

--- a/server-spi/src/main/java/org/keycloak/models/credential/PasswordCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/credential/PasswordCredentialModel.java
@@ -1,5 +1,7 @@
 package org.keycloak.models.credential;
 
+import static org.keycloak.utils.StringUtil.isBlank;
+
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.models.credential.dto.PasswordCredentialData;
 import org.keycloak.models.credential.dto.PasswordSecretData;
@@ -48,9 +50,9 @@ public class PasswordCredentialModel extends CredentialModel {
 
     public static PasswordCredentialModel createFromCredentialModel(CredentialModel credentialModel) {
         try {
-            PasswordCredentialData credentialData = JsonSerialization.readValue(credentialModel.getCredentialData(),
+            PasswordCredentialData credentialData = isBlank(credentialModel.getCredentialData()) ? null : JsonSerialization.readValue(credentialModel.getCredentialData(),
                     PasswordCredentialData.class);
-            PasswordSecretData secretData = JsonSerialization.readValue(credentialModel.getSecretData(), PasswordSecretData.class);
+            PasswordSecretData secretData = isBlank(credentialModel.getSecretData()) ? null : JsonSerialization.readValue(credentialModel.getSecretData(), PasswordSecretData.class);
             PasswordCredentialModel passwordCredentialModel = new PasswordCredentialModel(credentialData, secretData);
             passwordCredentialModel.setCreatedDate(credentialModel.getCreatedDate());
             passwordCredentialModel.setCredentialData(credentialModel.getCredentialData());

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/util/CredentialDeleteHelper.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/util/CredentialDeleteHelper.java
@@ -60,6 +60,15 @@ public class CredentialDeleteHelper {
     public static CredentialModel removeCredential(KeycloakSession session, UserModel user, String credentialId, Supplier<Integer> currentLoAProvider) {
         CredentialModel credential = user.credentialManager().getStoredCredentialById(credentialId);
         if (credential == null) {
+            if (user.getFederationLink() != null) {
+                credential = user.credentialManager().getFederatedCredentialsStream().filter(c -> credentialId.equals(c.getId())).findAny().orElse(null);
+                if (credential != null) {
+                    String type = credential.getType();
+                    checkIfCanBeRemoved(session, user, type, currentLoAProvider);
+                    user.credentialManager().disableCredentialType(type);
+                    return null;
+                }
+            }
             // Backwards compatibility with account console 1 - When stored credential is not found, it may be federated credential.
             // In this case, it's ID needs to be something like "otp-id", which is returned by account REST GET endpoint as a placeholder
             // for federated credentials (See CredentialHelper.createUserStorageCredentialRepresentation )
@@ -78,7 +87,7 @@ public class CredentialDeleteHelper {
 
     private static void checkIfCanBeRemoved(KeycloakSession session, UserModel user, String credentialType, Supplier<Integer> currentLoAProvider) {
         CredentialProvider credentialProvider = AuthenticatorUtil.getCredentialProviders(session)
-                .filter(credentialProvider1 -> credentialType.equals(credentialProvider1.getType()))
+                .filter(credentialProvider1 -> credentialProvider1.supportsCredentialType(credentialType))
                 .findAny().orElse(null);
         if (credentialProvider == null) {
             logger.warnf("Credential provider %s not found", credentialType);

--- a/services/src/main/java/org/keycloak/credential/OTPCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/OTPCredentialProvider.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.credential;
 
+import java.util.List;
+
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.common.util.Time;
@@ -64,7 +66,7 @@ public class OTPCredentialProvider implements CredentialProvider<OTPCredentialMo
 
     @Override
     public boolean supportsCredentialType(String credentialType) {
-        return getType().equals(credentialType);
+        return List.of(OTPCredentialModel.TYPE, OTPCredentialModel.TOTP, OTPCredentialModel.HOTP).contains(credentialType);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
@@ -22,6 +22,7 @@ import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.utils.ModelToRepresentation;
@@ -179,8 +180,9 @@ public class AccountCredentialResource {
 
         Set<String> enabledCredentialTypes = getEnabledCredentialTypes();
 
-        Stream<CredentialModel> modelsStream = includeUserCredentials ? user.credentialManager().getStoredCredentialsStream() : Stream.empty();
-        List<CredentialModel> models = modelsStream.collect(Collectors.toList());
+        SubjectCredentialManager credentialManager = user.credentialManager();
+        Stream<CredentialModel> modelsStream = includeUserCredentials ? credentialManager.getCredentials() : Stream.empty();
+        List<CredentialModel> models = modelsStream.toList();
 
         Function<CredentialProvider, CredentialContainer> toCredentialContainer = (credentialProvider) -> {
             CredentialTypeMetadataContext ctx = CredentialTypeMetadataContext.builder()
@@ -192,8 +194,8 @@ public class AccountCredentialResource {
 
             if (includeUserCredentials) {
                 List<CredentialModel> modelsOfType = models.stream()
-                        .filter(credentialModel -> credentialProvider.getType().equals(credentialModel.getType()))
-                        .collect(Collectors.toList());
+                        .filter(credentialProvider::supportsCredentialType)
+                        .toList();
 
 
                 List<CredentialMetadata> credentialMetadataList = modelsOfType.stream()
@@ -228,7 +230,7 @@ public class AccountCredentialResource {
         };
 
         return AuthenticatorUtil.getCredentialProviders(session)
-                .filter(p -> type == null || Objects.equals(p.getType(), type))
+                .filter(p -> type == null || p.supportsCredentialType(type))
                 .filter(p -> enabledCredentialTypes.contains(p.getType()))
                 .map(toCredentialContainer)
                 .filter(Objects::nonNull)

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -738,7 +738,8 @@ public class UserResource {
     @Operation()
     public Stream<CredentialRepresentation> credentials(){
         auth.users().requireView(user);
-        return user.credentialManager().getStoredCredentialsStream()
+
+        return user.credentialManager().getCredentials()
                 .map(ModelToRepresentation::toRepresentation)
                 .peek(credentialRepresentation -> credentialRepresentation.setSecretData(null));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
@@ -99,6 +99,8 @@ public class LDAPAccountRestApiTest extends AbstractLDAPTest {
 
             LDAPObject john = LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "johnkeycloak", "John", "Doe", "john@email.org", null, "1234");
             LDAPTestUtils.updateLDAPPassword(ctx.getLdapProvider(), john, "Password1");
+            john.setSingleAttribute(LDAPConstants.PWD_CHANGED_TIME, "22000101000000Z");
+            ctx.getLdapProvider().getLdapIdentityStore().update(john);
         });
     }
 
@@ -241,7 +243,7 @@ public class LDAPAccountRestApiTest extends AbstractLDAPTest {
 
         // Password won't have createdDate and any metadata set
         Assert.assertEquals(PasswordCredentialModel.TYPE, userPassword.getType());
-        Assert.assertEquals(userPassword.getCreatedDate(), Long.valueOf(-1L));
+        Assert.assertTrue(userPassword.getCreatedDate() > -1L);
         Assert.assertNull(userPassword.getCredentialData());
         Assert.assertNull(userPassword.getSecretData());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
@@ -591,8 +591,10 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
     private void assertPasswordConfiguredThroughLDAPOnly(UserResource user) {
         // Assert password not stored locally
         List<CredentialRepresentation> storedCredentials = user.credentials();
+        assertEquals(1, storedCredentials.size());
         for (CredentialRepresentation credential : storedCredentials) {
-            Assert.assertFalse(PasswordCredentialModel.TYPE.equals(credential.getType()));
+            Assert.assertTrue(PasswordCredentialModel.TYPE.equals(credential.getType()));
+            Assert.assertNotNull(credential.getFederationLink());
         }
 
         // Assert password is stored in the LDAP


### PR DESCRIPTION
Closes #35020

* Make it possible to user storage providers to return the credentials they manage for federated users. For that, I added a method `org.keycloak.credential.CredentialInputUpdater#getCredentials(RealmModel, UserModel)` that user storage providers can implement to return `CredentialModel` objects that they manage. The `CredentialModel` was also updated to provide the `federationLink` as the component ID of the user storage provider similar to `UserModel#set|getFederationLink`.
* Added a method `org.keycloak.models.SubjectCredentialManager#getFederatedCredentialsStream` to allow retrieving the federated user credentials. It should be better than return federated user credentials from the existing method `org.keycloak.models.SubjectCredentialManager#getStoredCredentialsStream`. When using this method the server is mostly interested in the local credentials as they can be used to authenticate the user using the supported credential providers.
* The account console now displays the time when the password was set when the user is federated from LDAP
* The admin console now displays the time when the password was set when the user is federated from LDAP
* I removed some code that seems related to supporting the account console v1

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
