### PR TITLE
Use lightweight access token with transient session for client registration

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
@@ -45,10 +45,12 @@ import org.keycloak.representations.idm.ClientInitialAccessPresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.util.JsonSerialization;
 
@@ -850,5 +852,40 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
 
         //controls the number of uses of the initial access token
         assertEquals(initialTokenCounts, createdCount.get());
+    }
+
+    @Test
+    public void registerWithLightweightAccessTokenAndTransientSession() throws Exception {
+
+        String TEST_ADMIN_CLIENT = "test-admin-client";
+        ClientRepresentation testAdminClient = new ClientRepresentation();
+        testAdminClient.setClientId(TEST_ADMIN_CLIENT);
+        testAdminClient.setSecret(TEST_ADMIN_CLIENT);
+        testAdminClient.setServiceAccountsEnabled(true);
+        testAdminClient.setAttributes(new HashMap<>());
+        testAdminClient.getAttributes().put(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, Boolean.TRUE.toString());
+
+        Response response = adminClient.realm("master").clients().create(testAdminClient);
+        testAdminClient = adminClient.realm("master").clients().get( ApiUtil.getCreatedId(response)).toRepresentation();
+
+        UserRepresentation serviceAccountUser = adminClient.realm("master").clients().get(testAdminClient.getId()).getServiceAccountUser();
+        RoleRepresentation adminRole =  adminClient.realm("master").roles().get("admin").toRepresentation();
+        adminClient.realm("master").users().get(serviceAccountUser.getId()).roles().realmLevel().add(List.of(adminRole));
+
+        oauth.clientId(TEST_ADMIN_CLIENT);
+        oauth.realm("master");
+        String token = oauth.doClientCredentialsGrantAccessTokenRequest(TEST_ADMIN_CLIENT).getAccessToken();
+        ClientRegistration masterReg = ClientRegistration.create().url(suiteContext.getAuthServerInfo().getContextRoot() + "/auth", "master").build();
+        masterReg.auth(Auth.token(token));
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(CLIENT_ID);
+        client.setSecret(CLIENT_SECRET);
+
+        ClientRepresentation createdClient = masterReg.create(client);
+        assertNotNull(createdClient);
+
+        adminClient.realm("master").clients().get(testAdminClient.getId()).remove();
+        adminClient.realm("master").clients().get(createdClient.getId()).remove();
     }
 }


### PR DESCRIPTION
Closes #36926

The issue is caused by the combination of lightweight access tokens and transient sessions and had already occurred for the admin API in #32802. This PR fixes this case when a lightweight token with a transient session is used to register a client. Did som e refactoring to reuse the introspection part, and test added. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
