### PR TITLE
Manage exceptions in waitForPageToLoad for chrome error in version 132

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -84,6 +84,16 @@ public final class UIUtils {
         clickElement(element, Keys.ENTER);
     }
 
+    /**
+     * Same than clickLink but it does not perform any wait after clicking or sending the
+     * enter key.
+     *
+     * @param element The element to click
+     */
+    public static void clickLinkWithoutWait(WebElement element) {
+        clickLinkWithoutWait(element, Keys.ENTER);
+    }
+
     private static void clickElement(WebElement element, CharSequence key) {
         WebDriver driver = getCurrentDriver();
 
@@ -94,6 +104,17 @@ public final class UIUtils {
                 : element::click);
     }
 
+    private static void clickLinkWithoutWait(WebElement element, CharSequence key) {
+        WebDriver driver = getCurrentDriver();
+
+        waitUntilElement(element).is().clickable();
+
+        if (BrowserDriverUtil.isDriverChrome(driver)) {
+            element.sendKeys(key);
+        } else {
+            element.click();
+        }
+    }
 
     /**
      * The method executes click in the element. This method always uses click and

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -137,19 +137,19 @@ public final class WaitUtils {
             return; // not needed
         }
 
-        String currentUrl = null;
-
         // Ensure the URL is "stable", i.e. is not changing anymore; if it'd changing, some redirects are probably still in progress
         for (int maxRedirects = 4; maxRedirects > 0; maxRedirects--) {
-            currentUrl = driver.getCurrentUrl();
-            FluentWait<WebDriver> wait = new FluentWait<>(driver).withTimeout(Duration.ofMillis(250));
             try {
+                String currentUrl = driver.getCurrentUrl();
+                FluentWait<WebDriver> wait = new FluentWait<>(driver).withTimeout(Duration.ofMillis(250));
                 wait.until(not(urlToBe(currentUrl)));
-            }
-            catch (TimeoutException e) {
+            } catch (TimeoutException e) {
                 if (driver.getPageSource() != null) {
                     break; // URL has not changed recently - ok, the URL is stable and page is current
                 }
+            } catch (Exception e) {
+                log.warnf("Unknown exception thrown waiting stabilization of the URL: %s", e.getMessage());
+                pause(250);
             }
             if (maxRedirects == 1) {
                 log.warn("URL seems unstable! (Some redirect are probably still in progress)");

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnLoginPage.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.webauthn.pages;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.keycloak.testsuite.pages.LanguageComboboxAwarePage;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -43,7 +44,7 @@ public class WebAuthnLoginPage extends LanguageComboboxAwarePage {
 
     public void clickAuthenticate() {
         WaitUtils.waitUntilElement(authenticateButton).is().clickable();
-        authenticateButton.click();
+        UIUtils.clickLink(authenticateButton);
     }
 
     public boolean isCurrent() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnRegisterPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnRegisterPage.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.webauthn.pages;
 
 import org.hamcrest.CoreMatchers;
 import org.keycloak.testsuite.pages.LogoutSessionsPage;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
@@ -56,14 +57,12 @@ public class WebAuthnRegisterPage extends LogoutSessionsPage {
     private WebElement formTitle;
 
     public void clickRegister() {
-        WaitUtils.waitUntilElement(registerButton).is().clickable();
-        registerButton.click();
+        UIUtils.clickLinkWithoutWait(registerButton);
     }
 
     public void cancelAIA() {
         assertThat("It only works with AIA", isAIA(), CoreMatchers.is(true));
-        WaitUtils.waitUntilElement(cancelAIAButton).is().clickable();
-        cancelAIAButton.click();
+        UIUtils.clickLink(cancelAIAButton);
     }
 
     public void registerWebAuthnCredential(String authenticatorLabel) {


### PR DESCRIPTION
Closes #36781
Closes #36782
Closes #36902

The main issue seems to be that with chrome/chromedriver 132 the `getCurrentUrl` throws an exception (issue https://issues.chromium.org/issues/391907160 reported by other people too). It is mainly happening after the webauthn registration (when the tests are registering a webauthn passkey using the account console). The PR is just changing the `WaitUtils.waitForPageToLoad` to catch any weird exception and retrying after a little pause. The fix is working OK although the problem is not easily reproducible, so not absolutely sure. I also did some changes to call the `clickLink` method in the affected area (just in case).

I also tried upgrading selenium without success, and I didn't want to mix both things here. We can upgrade selenium dependency in a future PR.

I ran 200 times the whole webauthn job in GHA and around 500 times the `WebAuthnTransportLocaleTest` class with no issues. In my laptop the issue happened more often (but in other points :confused:) and after this change I could run the whole webauthn 20 times (previously it failed 1 in 2 or 1 in 3, so at least it is much more robust).
