### PR TITLE
Fixed typos in email theme.

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -603,7 +603,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             assertIsContained(events.expect(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT).client((String) null).detail(Details.REASON, "brute_force_attack detected"), actualEvents);
             assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
 
-            checkEmailPresent("User disabled by permament lockout");
+            checkEmailPresent("User disabled by permanent lockout");
 
             // assert
             expectPermanentlyDisabled();

--- a/themes/src/main/resources/theme/base/email/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/email/messages/messages_en.properties
@@ -40,11 +40,11 @@ eventRemoveCredentialSubject=Remove credential
 eventRemoveCredentialBody=Credential {0} was removed from your account on {1} from {2}. If this was not you, please contact an administrator.
 eventRemoveCredentialBodyHtml=<p>Credential {0} was removed from your account on {1} from {2}. If this was not you, please contact an administrator.</p>
 eventUserDisabledByTemporaryLockoutSubject=User disabled by temporary lockout
-eventUserDisabledByTemporaryLockoutBody=Your user has been disabled temporarily because of multiple failed attemps on {0}. Please contact an administrator if needed.
-eventUserDisabledByTemporaryLockoutHtml=<p>Your user has been disabled temporarily because of multiple failed attemps on {0}. Please contact an administrator if needed.</p>
-eventUserDisabledByPermanentLockoutSubject=User disabled by permament lockout
-eventUserDisabledByPermanentLockoutBody=Your user has been disabled permanently because of multiple failed attemps on {0}. Please contact an administrator.
-eventUserDisabledByPermanentLockoutHtml=<p>Your user has been disabled permanently because of multiple failed attemps on {0}. Please contact an administrator.</p>
+eventUserDisabledByTemporaryLockoutBody=Your user has been disabled temporarily because of multiple failed attempts on {0}. Please contact an administrator if needed.
+eventUserDisabledByTemporaryLockoutHtml=<p>Your user has been disabled temporarily because of multiple failed attempts on {0}. Please contact an administrator if needed.</p>
+eventUserDisabledByPermanentLockoutSubject=User disabled by permanent lockout
+eventUserDisabledByPermanentLockoutBody=Your user has been disabled permanently because of multiple failed attempts on {0}. Please contact an administrator.
+eventUserDisabledByPermanentLockoutHtml=<p>Your user has been disabled permanently because of multiple failed attempts on {0}. Please contact an administrator.</p>
 
 requiredAction.CONFIGURE_TOTP=Configure OTP
 requiredAction.TERMS_AND_CONDITIONS=Terms and Conditions


### PR DESCRIPTION
There are some typos in the English email messages in the file `keycloak/themes/src/main/resources/theme/base/email/messages/messages_en.properties`.

The following strings were replaced:
* permament -> permanent
* attemps -> attempts

Closes #36988 