### PR TITLE
Manage exceptions in waitForPageToLoad for chrome error in version 132 (24.0)

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -135,13 +135,17 @@ public final class WaitUtils {
 
         // Ensure the URL is "stable", i.e. is not changing anymore; if it'd changing, some redirects are probably still in progress
         for (int maxRedirects = 4; maxRedirects > 0; maxRedirects--) {
-            currentUrl = driver.getCurrentUrl();
-            FluentWait<WebDriver> wait = new FluentWait<>(driver).withTimeout(Duration.ofMillis(250));
             try {
+                currentUrl = driver.getCurrentUrl();
+                FluentWait<WebDriver> wait = new FluentWait<>(driver).withTimeout(Duration.ofMillis(250));
                 wait.until(not(urlToBe(currentUrl)));
-            }
-            catch (TimeoutException e) {
-                break; // URL has not changed recently - ok, the URL is stable and page is current
+            } catch (TimeoutException e) {
+                if (driver.getPageSource() != null) {
+                    break; // URL has not changed recently - ok, the URL is stable and page is current
+                }
+            } catch (Exception e) {
+                log.warnf("Unknown exception thrown waiting stabilization of the URL: %s", e.getMessage());
+                pause(250);
             }
             if (maxRedirects == 1) {
                 log.warn("URL seems unstable! (Some redirect are probably still in progress)");


### PR DESCRIPTION
Closes #36781
Closes #36782
Closes #36902

PR: https://github.com/keycloak/keycloak/pull/36967
Commit: https://github.com/keycloak/keycloak/commit/efbeb8caa6170cfc870ac99757cdaedb22dcbbcc
PR branch: backport-36967-24.0
Target branch: https://github.com/keycloak/keycloak/tree/release/24.0

This commit is modified a lot. The branch 24.0 does not contain several changes we have done recently for the CI (`clickLink` changes for example are all missing). So I'm just backporting the changes in the `WaitUtils`  class. That modification is the main one for the issue with chrome 132. But in this 24.0 branch there are going to be flaky tests for sure. I'm sending this anyway because it improves the situation at least for chrome 132.
