### PR TITLE
Improve docs about JPA provider configuration for DB migration strategy

### DIFF
--- a/docs/guides/attributes.adoc
+++ b/docs/guides/attributes.adoc
@@ -29,5 +29,6 @@
 :quickstartRepo_name: Keycloak Quickstarts Repository
 :quickstartRepo_dir: keycloak-quickstarts
 :securing_apps_link: https://www.keycloak.org/guides#securing-apps
+:upgrading_guide_link: {project_doc_base_url}/upgrading/
 :kc_js_path: /js
 :kc_realms_path: /realms

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -342,4 +342,6 @@ In the same way the migrationExport to point to a specific file and location:
 .Setting the `migration-export` for the `quarkus` provider of the `connections-jpa` SPI
 <@kc.start parameters="--spi-connections-jpa-quarkus-migration-export=<path>/<file.sql>"/>
 
+For more information, check the link:{upgrading_guide_link}#_migrate_db[Migrating the database] documentation.
+
 </@tmpl.guide>


### PR DESCRIPTION
Closes #37079

I can confirm the link works even when building guides on the `keycloak-web`.  
