### PR TITLE
Avoid sending/receiving the session JSON too often

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -25,6 +25,7 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.io.Serializable;
 
@@ -50,6 +51,7 @@ import java.io.Serializable;
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity
+@DynamicUpdate
 @IdClass(PersistentClientSessionEntity.Key.class)
 public class PersistentClientSessionEntity {
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.jpa.session;
 
 import jakarta.persistence.Version;
+import org.hibernate.annotations.DynamicUpdate;
 import org.keycloak.storage.jpa.KeyUtils;
 
 import jakarta.persistence.Column;
@@ -63,6 +64,7 @@ import java.io.Serializable;
 })
 @Table(name="OFFLINE_USER_SESSION")
 @Entity
+@DynamicUpdate
 @IdClass(PersistentUserSessionEntity.Key.class)
 public class PersistentUserSessionEntity {
 

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -125,8 +125,11 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
     // Write updated model with latest serialized data
     public PersistentClientSessionModel getUpdatedModel() {
         try {
-            String updatedData = JsonSerialization.writeValueAsString(getData());
-            this.model.setData(updatedData);
+            if (data != null) {
+                // If data hasn't been initialized, it hasn't been touched and is unchanged. So need to deserialize and serialize it
+                String updatedData = JsonSerialization.writeValueAsString(getData());
+                this.model.setData(updatedData);
+            }
         } catch (IOException ioe) {
             throw new ModelException("Error persisting session", ioe);
         }

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
@@ -168,8 +168,11 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
     // Write updated model with latest serialized data
     public PersistentUserSessionModel getUpdatedModel() {
         try {
-            String updatedData = JsonSerialization.writeValueAsString(getData());
-            this.model.setData(updatedData);
+            if (data != null) {
+                // If data hasn't been initialized, it hasn't been touched and is unchanged. So need to deserialize and serialize it
+                String updatedData = JsonSerialization.writeValueAsString(getData());
+                this.model.setData(updatedData);
+            }
         } catch (IOException ioe) {
             throw new ModelException("Error persisting session", ioe);
         }


### PR DESCRIPTION
Closes #37093

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Impact is minimal when doing logins; most GC and CPU is done by the Argon2 hashing. Leaving it to the reviewer to see if it is worth the added complexity in the code.

Tested with a single instance and a local PostgreSQL instance.

> ./benchmark.sh eu-west-1 --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=${KEYCLOAK_URL} --realm-name=realm-0 --users-per-sec=100 --ramp-up=20 --refresh-token-period=2 --refresh-token-count=2 --logout-percentage=1 --measurement=300 --users-per-realm=100000 --log-http-on-failure

before: 350 mb per second, ~230% Cpu, 630kb per second db receive
after: 350 mb per second, ~230% CPU, 590kb per second db receive

