### PR TITLE
doc: adding a full example of overriding the startup probe timeout

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -157,7 +157,7 @@ In particular the default startup probe timeout of 10 minutes may be too short i
 
 If your instances encounter this startup failure or if you wish to proactively prevent such a startup failure from occurring, then the startup probe timeout should be increased.
 
-With otherwise default settings, something like the following would increase the timeout to 20 minutes:
+With otherwise default settings, something like the following increases the timeout to 20 minutes:
 
 [source,yaml]
 ----

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -149,6 +149,39 @@ spec:
               secretName: keycloak-additional-secret
 ----
 
+===== Probe Timeouts
+
+The unsupported podTemplate may be used to override the default probes.
+
+In particular the default startup probe timeout of 10 minutes may be too short in scenarios where there is a long-running migration. 
+
+If your instances encounter this startup failure or if you wish to proactively prevent such a startup failure from occurring, then the startup probe timeout should be increased.
+
+With otherwise default settings, something like the following would increase the timeout to 20 minutes:
+
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  ...
+  unsupported:
+    podTemplate:
+      spec:
+        containers:
+          startupProbe:
+            httpGet:
+              path: "/health/started"
+            port: 9000
+            scheme: "HTTPS"
+            failureThreshold: 1200
+            periodSeconds: 1
+----
+
+Note that the usage of a relative HTTP path, an alternative management port, or require changes to the probe configuration.
+
 === Disabling required options
 
 {project_name} and the {project_name} Operator provide the best production-ready experience with security in mind.

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -180,7 +180,7 @@ spec:
             periodSeconds: 1
 ----
 
-Note that the usage of a relative HTTP path, an alternative management port, or require changes to the probe configuration.
+Note that the usage of a relative HTTP path, or an alternative management port, require changes to the probe configuration.
 
 === Disabling required options
 


### PR DESCRIPTION
closes: #35261

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
