### PR TITLE
fix duplicate priorities in authentication executions

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -777,10 +777,15 @@ public class AuthenticationManagementResource {
         if (model == null) {
             session.getTransactionManager().setRollbackOnly();
             throw new NotFoundException("Illegal execution");
-
         }
+
+        List<AuthenticationExecutionInfoRepresentation> executions = new LinkedList<>();
+        int level = 0;
+        recurseExecutions(flow, executions, level);
+
         boolean updateExecution = false;
-        if (model.getPriority() != rep.getPriority()) {
+        //ignore setting of priority if element with same priority already exists
+        if (model.getPriority() != rep.getPriority() && executions.stream().noneMatch(item -> item.getPriority() == rep.getPriority())) {
             model.setPriority(rep.getPriority());
             updateExecution = true;
         }


### PR DESCRIPTION
prevent multiple executions with the same priority to be updated

If no priority is provided it will be defaulted to 0 and it is also possible to set a priority already taken by another execution. This can result in multiple executions having the same priority and then you won't be able to higher and lower the priority with the dedicated endpoints and it is also affection the ui, which is using these endpoints.

Closes #35765
