### PR TITLE
Remove FGAP from standard token exchange v2

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -74,7 +74,7 @@ public class Profile {
         SCRIPTS("Write custom authenticators using JavaScript", Type.PREVIEW),
 
         TOKEN_EXCHANGE("Token Exchange Service", Type.PREVIEW, 1),
-        TOKEN_EXCHANGE_STANDARD_V2("Standard Token Exchange version 2", Type.EXPERIMENTAL, 2, Feature.ADMIN_FINE_GRAINED_AUTHZ), // TODO: Switch v2 token exchanges to depend admin-fine-grained-authz-v2
+        TOKEN_EXCHANGE_STANDARD_V2("Standard Token Exchange version 2", Type.EXPERIMENTAL, 2),
         TOKEN_EXCHANGE_FEDERATED_V2("Federated Token Exchange for external-internal and internal-external token exchange", Type.EXPERIMENTAL, 2, Feature.ADMIN_FINE_GRAINED_AUTHZ),
         TOKEN_EXCHANGE_SUBJECT_IMPERSONATION_V2("Subject impersonation Token Exchange", Type.EXPERIMENTAL, 2, Feature.ADMIN_FINE_GRAINED_AUTHZ),
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/AbstractStandardTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/AbstractStandardTokenExchangeTest.java
@@ -93,7 +93,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         return accessToken;
     }
 
-    private String getSessionIdFromToken(String accessToken) throws Exception {
+    protected String getSessionIdFromToken(String accessToken) throws Exception {
         return TokenVerifier.create(accessToken, AccessToken.class)
                 .parse()
                 .getToken()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ClientTokenExchangeAudienceAndScopesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ClientTokenExchangeAudienceAndScopesTest.java
@@ -47,7 +47,6 @@ import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @EnableFeature(value = Profile.Feature.TOKEN_EXCHANGE_STANDARD_V2, skipRestart = true)
-@EnableFeature(value = Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, skipRestart = true) // TODO: Remove as we may not need to use FGAP for token exchange
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ClientTokenExchangeAudienceAndScopesTest extends AbstractKeycloakTest {
 


### PR DESCRIPTION
Closes #37108
Closes #37109

Changes in this PR:

- Copied the `exchangeClientToClient()` method from `AbstractTokenExchangeProvider` to `StandardTokenExchangeProvider`, Removed the permission checks and added a reject if the requester client is not in the audience of the subject token.  
- Removed the `ADMIN_FINE_GRAINED_AUTHZ` feature from `StandardTokenExchangeV2Test` and `ClientTokenExchangeAudienceAndScopesTest`.  
- Modified `TokenExchangeTestUtils.setupRealm()` to add permissions only when the feature is enabled.  
- Copied the `tokenExchange()` test in `StandardTokenExchangeV2Test` from `AbstractStandardTokenExchangeTest`.  
- Created empty versions of two tests for public clients, as they relied on permissions and will need to be rewritten since token exchange will no longer be supported in Standard Token Exchange V2.  

The refactoring of `StandardTokenExchangeProvider.exchangeClientToClient()` was intentionally left out of this PR because many changes to scopes and audiences are currently being made.

#37105  could be a follow up task.
