### PR TITLE
Properties mapped in our property mappers are overridden

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -7,12 +7,14 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
 import io.quarkus.runtime.configuration.MemorySizeConverter;
+import io.smallrye.config.ConfigValue;
 import org.jboss.logmanager.LogContext;
 import org.keycloak.config.LoggingOptions;
 import org.keycloak.config.Option;
@@ -29,10 +31,13 @@ public final class LoggingPropertyMappers {
     private static final String SYSLOG_ENABLED_MSG = "Syslog is activated";
     private static final String DEFAULT_ROOT_LOG_LEVEL = toLevel(LoggingOptions.LOG_LEVEL.getDefaultValue().orElseThrow().get(0)).getName();
 
+    private static List<CategoryLevel> rootLogLevels;
+
     private LoggingPropertyMappers() {
     }
 
     public static PropertyMapper<?>[] getMappers() {
+        rootLogLevels = null; // reset the cached root log level and categories
         PropertyMapper<?>[] defaultMappers = new PropertyMapper[]{
                 fromOption(LoggingOptions.LOG)
                         .paramLabel("<handler>")
@@ -254,7 +259,7 @@ public final class LoggingPropertyMappers {
     }
 
     private static String resolveRootLogLevel(String value, ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        for (CategoryLevel categoryLevel : parseLogLevels(value)) {
+        for (CategoryLevel categoryLevel : parseRootLogLevel(value)) {
             if (categoryLevel.category == null) {
                 return categoryLevel.levelName;
             }
@@ -263,7 +268,7 @@ public final class LoggingPropertyMappers {
     }
 
     private static Set<String> getConfiguredLogCategories(Set<String> categories) {
-        for (CategoryLevel categoryLevel : parseLogLevels(Configuration.getKcConfigValue("log-level").getValue())) {
+        for (CategoryLevel categoryLevel : parseRootLogLevel(null)) {
             if (categoryLevel.category != null) {
                 categories.add(categoryLevel.category);
             }
@@ -281,24 +286,33 @@ public final class LoggingPropertyMappers {
 
     private static String resolveCategoryLogLevelFromParentLogLevelOption(String category, String parentLogLevelValue, ConfigSourceInterceptorContext context) {
         String rootLevel = DEFAULT_ROOT_LOG_LEVEL;
-        for (CategoryLevel categoryLevel : parseLogLevels(parentLogLevelValue)) {
+        for (CategoryLevel categoryLevel : parseRootLogLevel(parentLogLevelValue)) {
             if (category.equals(categoryLevel.category)) {
                 return categoryLevel.levelName;
             } else if (categoryLevel.category == null) {
                 rootLevel = categoryLevel.levelName;
             }
         }
-        return rootLevel;
+
+        // If KC property is not set and the 'log-level' does not override the specific category, use value from Quarkus or properties files
+        return Optional.ofNullable(context.proceed("quarkus.log.category.\"" + category + "\".level"))
+                .map(ConfigValue::getValue)
+                .map(level -> !level.equals("inherit") ? level : null)
+                .orElse(rootLevel);
     }
 
-    private static List<CategoryLevel> parseLogLevels(String value) {
-        if (value == null) {
-            return List.of();
-        }
+    private static List<CategoryLevel> parseRootLogLevel(String values) {
+        if (rootLogLevels == null) {
+            var value = values != null ? values : Configuration.getConfigValue(LoggingOptions.LOG_LEVEL).getValue();
+            if (value == null) {
+                return List.of(); // if no value is present, we do not cache the result
+            }
 
-        return Stream.of(value.split(","))
-                .map(LoggingPropertyMappers::validateLogLevel)
-                .toList();
+            rootLogLevels = Stream.of(value.split(","))
+                    .map(LoggingPropertyMappers::validateLogLevel)
+                    .toList();
+        }
+        return rootLogLevels;
     }
 
     private static String resolveLogOutput(String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -531,35 +531,4 @@ public class ConfigurationTest extends AbstractConfigurationTest {
             assertEquals(Integer.toString(maxCount), config.getConfigValue(prop).getValue());
         }
     }
-
-    @Test
-    public void testWildcardCliOptionCanBeMappedToQuarkusOption() {
-        ConfigArgsConfigSource.setCliArgs("--log-level-org.keycloak=trace");
-        SmallRyeConfig config = createConfig();
-        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
-        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
-        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
-    }
-
-    @Test
-    public void testWildcardEnvVarOptionCanBeMappedToQuarkusOption() {
-        putEnvVar("KC_LOG_LEVEL_IO_QUARKUS", "trace");
-        SmallRyeConfig config = createConfig();
-        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
-        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
-        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
-    }
-
-    @Test
-    public void testWildcardOptionFromConfigFile() {
-        putEnvVar("SOME_CATEGORY_LOG_LEVEL", "debug");
-        SmallRyeConfig config = createConfig();
-        assertEquals("DEBUG", config.getConfigValue("quarkus.log.category.\"io.k8s\".level").getValue());
-    }
-
-    @Test
-    public void testWildcardPropertiesDontMatchEnvVarsFormat() {
-        SmallRyeConfig config = createConfig();
-        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
-    }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
@@ -255,4 +255,35 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
                 "quarkus.log.syslog.json.log-format", "ecs"
         ));
     }
+
+    @Test
+    public void testWildcardCliOptionCanBeMappedToQuarkusOption() {
+        ConfigArgsConfigSource.setCliArgs("--log-level-org.keycloak=trace");
+        SmallRyeConfig config = createConfig();
+        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
+    }
+
+    @Test
+    public void testWildcardEnvVarOptionCanBeMappedToQuarkusOption() {
+        putEnvVar("KC_LOG_LEVEL_IO_QUARKUS", "trace");
+        SmallRyeConfig config = createConfig();
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
+        assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
+    }
+
+    @Test
+    public void testWildcardOptionFromConfigFile() {
+        putEnvVar("SOME_CATEGORY_LOG_LEVEL", "debug");
+        SmallRyeConfig config = createConfig();
+        assertEquals("DEBUG", config.getConfigValue("quarkus.log.category.\"io.k8s\".level").getValue());
+    }
+
+    @Test
+    public void testWildcardPropertiesDontMatchEnvVarsFormat() {
+        SmallRyeConfig config = createConfig();
+        assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+    }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/MetricsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/MetricsDistTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.utils.KeycloakDistribution;
 
@@ -57,7 +58,10 @@ public class MetricsDistTest {
 
     @Test
     @Launch({ "start-dev", "--metrics-enabled=true" })
-    void testMetricsEndpoint() {
+    void testMetricsEndpoint(CLIResult cliResult) {
+        // See https://github.com/keycloak/keycloak/issues/36927
+        cliResult.assertNoMessage("A MeterFilter is being configured after a Meter has been registered to this registry.");
+
         // Send one request to populate some of the HTTP metrics that are not available on an instance on startup
         when().get("/metrics").then()
                 .statusCode(200);


### PR DESCRIPTION
- Fixes #36927

The issue is when the log category is specified in the `application.properties` file as the quarkus property `quarkus.log.category."<category>".level`, it does not take any effect. It started to behave like that after providing changes to https://github.com/keycloak/keycloak/pull/35138.

Basically, when the property mapper has the `.to()` builder method defined, the property is always obtained through the specific property mapper. However, it does not take into account the case when the property is specified in `application.properties`, `quarkus.properties` files, or set in Quarkus - [here](https://github.com/quarkusio/quarkus/pull/46120/files#diff-f6bc4d87c5e57cae3839c0a5b116e6f269bc0622b7526bb0a2b226b5dff1218aR206) and [here](https://github.com/quarkusio/quarkus/blob/4703297f9465b3273eafd419c12c1028816b3300/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java#L248).

I thought I could provide some general solution, but then I decided it might be better to address this special use case for log categories as the priority of config "sources" differs and we need a different values visualized as:

LoggingPropertyMappers:

```
        .from()                           .mapFrom()                    .mapFrom()
+----------------------+        +--------------------------+        +-----------------+
| log-level-<category> | -----> | log-level=category:level | -----> | log-level=level | -----> default
+----------------------+        +--------------------------+   ^    +-----------------+
                                                               |                 
                                               .to()         | (add)                   
                                           +---------------------------------------+       
                                           | quarkus.log.category.<category>.level | 
                                           +---------------------------------------+

```

### Problem with build

When the augmentation is executed, properties for `quarkus.log` are not considered, but it might be a follow-up issue.

### Diff of logs:
```
INFO  [io.quarkus.hibernate.orm.deployment.HibernateOrmProces <
INFO  [io.quarkus.hibernate.orm.deployment.HibernateOrmProces <
Running the server in development mode. DO NOT use this confi <
INFO  [io.agroal.pool] (JPA Startup Thread) Datasource '<defa	INFO  [io.agroal.pool] (JPA Startup Thread) Datasource '<defa
WARN  [io.micrometer.core.instrument.composite.CompositeMeter <
WARN  [io.micrometer.core.instrument.composite.CompositeMeter <
WARN  [io.micrometer.core.instrument.composite.CompositeMeter <
WARN  [io.micrometer.core.instrument.composite.CompositeMeter <
WARN  [io.micrometer.core.instrument.composite.CompositeMeter <
INFO  [org.keycloak.quarkus.runtime.storage.database.liquibas	INFO  [org.keycloak.quarkus.runtime.storage.database.liquibas
INFO  [org.keycloak.quarkus.runtime.storage.infinispan.CacheM	INFO  [org.keycloak.quarkus.runtime.storage.infinispan.CacheM
INFO  [org.infinispan.CONTAINER] (Quarkus Main Thread) Virtua	INFO  [org.infinispan.CONTAINER] (Quarkus Main Thread) Virtua
INFO  [org.infinispan.CONTAINER] (Quarkus Main Thread) ISPN00	INFO  [org.infinispan.CONTAINER] (Quarkus Main Thread) ISPN00
INFO  [org.infinispan.CLUSTER] (Quarkus Main Thread) ISPN0000	INFO  [org.infinispan.CLUSTER] (Quarkus Main Thread) ISPN0000
INFO  [org.infinispan.CLUSTER] (Quarkus Main Thread) ISPN0000 |	INFO  [org.infinispan.CLUSTER] (Quarkus Main Thread) ISPN0000
INFO  [org.infinispan.CLUSTER] (Quarkus Main Thread) ISPN0000 |	INFO  [org.infinispan.CLUSTER] (Quarkus Main Thread) ISPN0000
INFO  [org.keycloak.connections.infinispan.DefaultInfinispanC |	INFO  [org.keycloak.connections.infinispan.DefaultInfinispanC
INFO  [org.keycloak.broker.provider.AbstractIdentityProviderM	INFO  [org.keycloak.broker.provider.AbstractIdentityProviderM
INFO  [org.keycloak.services] (Quarkus Main Thread) KC-SERVIC	INFO  [org.keycloak.services] (Quarkus Main Thread) KC-SERVIC
INFO  [io.quarkus] (Quarkus Main Thread) Keycloak 1 on JVM (p |	INFO  [io.quarkus] (Quarkus Main Thread) Keycloak 1 on JVM (p
INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activate	INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activate
INFO  [io.quarkus] (Quarkus Main Thread) Installed features: 	INFO  [io.quarkus] (Quarkus Main Thread) Installed features:
```

### Suggestion

It would be good to gather more requirements for the wildcard mappers before we make some general approach. We will use the wildcard mappers for additional datasources (https://github.com/keycloak/keycloak/issues/29116), so we can follow-up on this after that.

@vmuzikar @shawkins Could you please check it? Thanks!