### PR TITLE
Upgrade to latest JGroups patch version to resolve thread pinning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,8 @@
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
         <hibernate.c3p0.version>6.2.13.Final</hibernate.c3p0.version>
         <infinispan.version>15.0.13.Final</infinispan.version>
+        <!-- remove the JGroups version once it is included in an Infinispan upgrade -->
+        <jgroups.version>5.3.15.Final</jgroups.version>
         <protostream.plugin.version>5.0.13.Final</protostream.plugin.version>
 
         <!--JAKARTA-->
@@ -309,6 +311,11 @@
                 <version>${infinispan.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jgroups</groupId>
+                <artifactId>jgroups</artifactId>
+                <version>${jgroups.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>


### PR DESCRIPTION
Closes #37285

My local test didn't show pinned threads with the pure JGroups communication. Just org.infinispan.topology.ClusterCacheStatus seems to have one pinned placed when a node leaves.

It seems that the ISPN 15.0.x branch was already updated in https://github.com/infinispan/infinispan/pull/14021 so it should arrive soon with a regular ISPN release.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
