### PR TITLE
Refactor OAuth Client - part 2

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenRequest.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenRequest.java
@@ -1,0 +1,51 @@
+package org.keycloak.testsuite.util.oauth;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.constants.AdapterConstants;
+import org.keycloak.util.TokenUtil;
+
+import java.io.IOException;
+
+public class AccessTokenRequest extends AbstractHttpPostRequest<AccessTokenResponse> {
+
+    private final String code;
+    private String clientSecret;
+
+    AccessTokenRequest(String code, OAuthClient client) {
+        super(client);
+        this.code = code;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return client.getEndpoints().getToken();
+    }
+
+    public AccessTokenRequest clientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+
+    protected void initRequest() {
+        parameter(OAuth2Constants.GRANT_TYPE, OAuth2Constants.AUTHORIZATION_CODE);
+
+        authorization(client.getClientId(), clientSecret);
+
+        parameter(OAuth2Constants.CODE, code);
+        parameter(OAuth2Constants.REDIRECT_URI, client.getRedirectUri());
+
+        parameter(AdapterConstants.CLIENT_SESSION_STATE, client.getClientSessionState());
+        parameter(AdapterConstants.CLIENT_SESSION_HOST, client.getClientSessionHost());
+
+        parameter(OAuth2Constants.CODE_VERIFIER, client.getCodeVerifier());
+
+        header(TokenUtil.TOKEN_TYPE_DPOP, client.getDpopProof());
+    }
+
+    @Override
+    protected AccessTokenResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new AccessTokenResponse(response);
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/HttpClientManager.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/HttpClientManager.java
@@ -6,6 +6,8 @@ import org.keycloak.testsuite.util.MutualTLSUtils;
 
 public class HttpClientManager {
 
+    private static final boolean SSL_REQUIRED = Boolean.parseBoolean(System.getProperty("auth.server.ssl.required"));
+
     private CloseableHttpClient defaultClient;
     private CloseableHttpClient customClient;
 
@@ -30,7 +32,7 @@ public class HttpClientManager {
     }
 
     public static CloseableHttpClient createDefault() {
-        if (OAuthClient.SSL_REQUIRED) {
+        if (SSL_REQUIRED) {
             String keyStorePath = System.getProperty("client.certificate.keystore");
             String keyStorePassword = System.getProperty("client.certificate.keystore.passphrase");
             String trustStorePath = System.getProperty("client.truststore");

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -303,16 +303,6 @@ public class OAuthClient {
         fillLoginForm(username, password);
     }
 
-    public CloseableHttpResponse doPreflightRequest() {
-        HttpOptions options = new HttpOptions(getEndpoints().getToken());
-        options.setHeader("Origin", "http://example.com");
-        try (CloseableHttpResponse response = httpClientManager.get().execute(options)) {
-            return response;
-        } catch (IOException ioe) {
-            throw new RuntimeException(ioe);
-        }
-    }
-
     public AccessTokenResponse doAccessTokenRequest(String code, String password) {
         HttpPost post = new HttpPost(getEndpoints().getToken());
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -303,52 +303,12 @@ public class OAuthClient {
         fillLoginForm(username, password);
     }
 
-    public AccessTokenResponse doAccessTokenRequest(String code, String password) {
-        HttpPost post = new HttpPost(getEndpoints().getToken());
+    public AccessTokenResponse doAccessTokenRequest(String code) {
+        return new AccessTokenRequest(code, this).send();
+    }
 
-        List<NameValuePair> parameters = new LinkedList<>();
-        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.AUTHORIZATION_CODE));
-
-        if (origin != null) {
-            post.addHeader("Origin", origin);
-        }
-        if (code != null) {
-            parameters.add(new BasicNameValuePair(OAuth2Constants.CODE, code));
-        }
-        if (redirectUri != null) {
-            parameters.add(new BasicNameValuePair(OAuth2Constants.REDIRECT_URI, redirectUri));
-        }
-        if (clientId != null && password != null) {
-            String authorization = BasicAuthHelper.createHeader(clientId, password);
-            post.setHeader("Authorization", authorization);
-        } else if (clientId != null) {
-            parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, clientId));
-        }
-
-        if (clientSessionState != null) {
-            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_STATE, clientSessionState));
-        }
-
-        if (clientSessionHost != null) {
-            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
-        }
-
-        if (codeVerifier != null) {
-            parameters.add(new BasicNameValuePair(OAuth2Constants.CODE_VERIFIER, codeVerifier));
-        }
-
-        if (dpopProof != null) {
-            post.addHeader(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
-        }
-
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
-        post.setEntity(formEntity);
-
-        try {
-            return new AccessTokenResponse(httpClientManager.get().execute(post));
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to retrieve access token", e);
-        }
+    public AccessTokenResponse doAccessTokenRequest(String code, String clientSecret) {
+        return new AccessTokenRequest(code, this).clientSecret(clientSecret).send();
     }
 
     public String introspectTokenWithClientCredential(String clientId, String clientSecret, String tokenType, String tokenToIntrospect) {
@@ -1044,6 +1004,10 @@ public class OAuthClient {
 
     public String getResponseType() {
         return responseType;
+    }
+
+    public String getCodeVerifier() {
+        return codeVerifier;
     }
 
     public String getRegisterationsUrl() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -25,7 +25,6 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.ContentType;
@@ -62,7 +61,6 @@ import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.UserInfo;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.testsuite.broker.util.SimpleHttpDefault;
 import org.keycloak.testsuite.runonserver.RunOnServerException;
 import org.keycloak.testsuite.util.DroneUtils;
@@ -109,7 +107,6 @@ public class OAuthClient {
     public static String AUTH_SERVER_ROOT;
     public static String APP_ROOT;
     public static String APP_AUTH_ROOT;
-    static final boolean SSL_REQUIRED = Boolean.parseBoolean(System.getProperty("auth.server.ssl.required"));
 
     static {
         updateURLs(getAuthServerContextRoot());
@@ -880,7 +877,7 @@ public class OAuthClient {
         return clientId;
     }
 
-    public String getCurrentRequest() {
+    String getCurrentRequest() {
         int index = driver.getCurrentUrl().indexOf('?');
         if (index == -1) {
             index = driver.getCurrentUrl().indexOf('#');
@@ -891,7 +888,7 @@ public class OAuthClient {
         return driver.getCurrentUrl().substring(0, index);
     }
 
-    public URI getCurrentUri() {
+    private URI getCurrentUri() {
         try {
             return new URI(driver.getCurrentUrl());
         } catch (URISyntaxException e) {
@@ -955,15 +952,15 @@ public class OAuthClient {
         return this.getLoginFormUrl(this.baseUrl);
     }
 
-    public String getResponseMode() {
+    String getResponseMode() {
         return responseMode;
     }
 
-    public String getResponseType() {
+    String getResponseType() {
         return responseType;
     }
 
-    public String getCodeVerifier() {
+    String getCodeVerifier() {
         return codeVerifier;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -351,15 +351,15 @@ public class OAuthClient {
     }
 
     public AccessTokenResponse doGrantAccessTokenRequest(String clientSecret, String username, String password) throws Exception {
-        return doGrantAccessTokenRequest(realm, username, password, clientId, clientSecret);
+        return doGrantAccessTokenRequest(username, password, clientId, clientSecret);
     }
 
-    public AccessTokenResponse doGrantAccessTokenRequest(String realm, String username, String password, String clientId, String clientSecret) throws Exception {
-        return new PasswordGrantRequest(realm, username, password, clientId, clientSecret, this).send();
+    public AccessTokenResponse doGrantAccessTokenRequest(String username, String password, String clientId, String clientSecret) throws Exception {
+        return new PasswordGrantRequest(username, password, clientId, clientSecret, this).send();
     }
 
     public PasswordGrantRequest passwordGrantRequest(String username, String password) {
-        return new PasswordGrantRequest(realm, username, password, clientId, null, this);
+        return new PasswordGrantRequest(username, password, clientId, null, this);
     }
 
     public AccessTokenResponse doTokenExchange(String realm, String token, String targetAudience,
@@ -380,8 +380,8 @@ public class OAuthClient {
                 .additionalParams(additionalParams).send();
     }
 
-    public JSONWebKeySet doCertsRequest(String realm) throws Exception {
-        HttpGet get = new HttpGet(getEndpoints(realm).getJwks());
+    public JSONWebKeySet doCertsRequest() throws Exception {
+        HttpGet get = new HttpGet(getEndpoints().getJwks());
         try (CloseableHttpResponse response = httpClientManager.get().execute(get)) {
             return JsonSerialization.readValue(response.getEntity().getContent(), JSONWebKeySet.class);
         }
@@ -677,7 +677,7 @@ public class OAuthClient {
         return new AccessTokenResponse(httpClientManager.get().execute(post));
     }
 
-    public OIDCConfigurationRepresentation doWellKnownRequest(String realm) {
+    public OIDCConfigurationRepresentation doWellKnownRequest() {
         try {
             SimpleHttp request = SimpleHttpDefault.doGet(baseUrl + "/realms/" + realm + "/.well-known/openid-configuration",
                     httpClientManager.get());
@@ -1111,11 +1111,6 @@ public class OAuthClient {
 
     public OAuthClient idTokenHint(String idTokenHint) {
         this.idTokenHint = idTokenHint;
-        return this;
-    }
-
-    public OAuthClient initiatingIDP(String initiatingIDP) {
-        this.initiatingIDP = initiatingIDP;
         return this;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -362,20 +362,20 @@ public class OAuthClient {
         return new PasswordGrantRequest(username, password, clientId, null, this);
     }
 
-    public AccessTokenResponse doTokenExchange(String realm, String token, String targetAudience,
+    public AccessTokenResponse doTokenExchange(String token, String targetAudience,
                                                String clientId, String clientSecret) throws Exception {
-        return doTokenExchange(realm, token, targetAudience, clientId, clientSecret, null);
+        return doTokenExchange(token, targetAudience, clientId, clientSecret, null);
     }
 
-    public AccessTokenResponse doTokenExchange(String realm, String token, String targetAudience,
+    public AccessTokenResponse doTokenExchange(String token, String targetAudience,
                                                String clientId, String clientSecret, Map<String, String> additionalParams) throws Exception {
         List<String> targetAudienceList = targetAudience == null ? null : List.of(targetAudience);
-        return doTokenExchange(realm, token, targetAudienceList, clientId, clientSecret, additionalParams);
+        return doTokenExchange(token, targetAudienceList, clientId, clientSecret, additionalParams);
     }
 
-    public AccessTokenResponse doTokenExchange(String realm, String token, List<String> targetAudiences,
+    public AccessTokenResponse doTokenExchange(String token, List<String> targetAudiences,
                                                String clientId, String clientSecret, Map<String, String> additionalParams) throws Exception {
-        return new TokenExchangeRequest(realm, token, clientId, clientSecret, this)
+        return new TokenExchangeRequest(token, clientId, clientSecret, this)
                 .audience(targetAudiences)
                 .additionalParams(additionalParams).send();
     }
@@ -1076,10 +1076,6 @@ public class OAuthClient {
     }
 
     public Endpoints getEndpoints() {
-        return new Endpoints(baseUrl, realm);
-    }
-
-    public Endpoints getEndpoints(String realm) {
         return new Endpoints(baseUrl, realm);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -149,8 +149,6 @@ public class OAuthClient {
 
     private String idTokenHint;
 
-    private String initiatingIDP;
-
     private String kcAction;
 
     private StateParamProvider state;
@@ -937,9 +935,6 @@ public class OAuthClient {
         }
         if (idTokenHint != null) {
             b.queryParam(OAuth2Constants.ID_TOKEN_HINT, idTokenHint);
-        }
-        if (initiatingIDP != null) {
-            b.queryParam(AuthenticationManager.INITIATING_IDP_PARAM, initiatingIDP);
         }
         driver.navigate().to(b.build(realm).toString());
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -375,47 +375,9 @@ public class OAuthClient {
 
     public AccessTokenResponse doTokenExchange(String realm, String token, List<String> targetAudiences,
                                                String clientId, String clientSecret, Map<String, String> additionalParams) throws Exception {
-        HttpPost post = new HttpPost(getEndpoints(realm).getToken());
-
-        List<NameValuePair> parameters = new LinkedList<>();
-        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE));
-        parameters.add(new BasicNameValuePair(OAuth2Constants.SUBJECT_TOKEN, token));
-        parameters.add(new BasicNameValuePair(OAuth2Constants.SUBJECT_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE));
-
-        if (targetAudiences != null) {
-            for (String audience : targetAudiences) {
-                parameters.add(new BasicNameValuePair(OAuth2Constants.AUDIENCE, audience));
-            }
-        }
-
-        if (additionalParams != null) {
-            for (Map.Entry<String, String> entry : additionalParams.entrySet()) {
-                parameters.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
-            }
-        }
-
-        if (clientSecret != null) {
-            String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
-            post.setHeader("Authorization", authorization);
-        } else {
-            parameters.add(new BasicNameValuePair("client_id", clientId));
-
-        }
-
-        if (clientSessionState != null) {
-            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_STATE, clientSessionState));
-        }
-        if (clientSessionHost != null) {
-            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
-        }
-        if (scope != null) {
-            parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scope));
-        }
-
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
-        post.setEntity(formEntity);
-
-        return new AccessTokenResponse(httpClientManager.get().execute(post));
+        return new TokenExchangeRequest(realm, token, clientId, clientSecret, this)
+                .audience(targetAudiences)
+                .additionalParams(additionalParams).send();
     }
 
     public JSONWebKeySet doCertsRequest(String realm) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/PasswordGrantRequest.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/PasswordGrantRequest.java
@@ -9,16 +9,14 @@ import java.io.IOException;
 
 public class PasswordGrantRequest extends AbstractHttpPostRequest<AccessTokenResponse> {
 
-    private final String realm;
     private final String username;
     private final String password;
     private final String clientId;
     private String clientSecret;
     private String otp;
 
-    PasswordGrantRequest(String realm, String username, String password, String clientId, String clientSecret, OAuthClient client) {
+    PasswordGrantRequest(String username, String password, String clientId, String clientSecret, OAuthClient client) {
         super(client);
-        this.realm = realm;
         this.username = username;
         this.password = password;
         this.clientId = clientId;
@@ -27,7 +25,7 @@ public class PasswordGrantRequest extends AbstractHttpPostRequest<AccessTokenRes
 
     @Override
     protected String getEndpoint() {
-        return client.getEndpoints(realm).getToken();
+        return client.getEndpoints().getToken();
     }
 
     public PasswordGrantRequest clientSecret(String clientSecret) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
@@ -11,16 +11,14 @@ import java.util.Map;
 
 public class TokenExchangeRequest extends AbstractHttpPostRequest<AccessTokenResponse> {
 
-    private final String realm;
     private final String subjectToken;
     private String clientId;
     private String clientSecret;
     private List<String> audience;
     private Map<String, String> additionalParams;
 
-    TokenExchangeRequest(String realm, String subjectToken, String clientId, String clientSecret, OAuthClient client) {
+    TokenExchangeRequest(String subjectToken, String clientId, String clientSecret, OAuthClient client) {
         super(client);
-        this.realm = realm;
         this.subjectToken = subjectToken;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
@@ -28,7 +26,7 @@ public class TokenExchangeRequest extends AbstractHttpPostRequest<AccessTokenRes
 
     @Override
     protected String getEndpoint() {
-        return client.getEndpoints(realm).getToken();
+        return client.getEndpoints().getToken();
     }
 
     public TokenExchangeRequest audience(List<String> audience) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
@@ -1,0 +1,71 @@
+package org.keycloak.testsuite.util.oauth;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.constants.AdapterConstants;
+import org.keycloak.util.TokenUtil;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class TokenExchangeRequest extends AbstractHttpPostRequest<AccessTokenResponse> {
+
+    private final String realm;
+    private final String subjectToken;
+    private String clientId;
+    private String clientSecret;
+    private List<String> audience;
+    private Map<String, String> additionalParams;
+
+    TokenExchangeRequest(String realm, String subjectToken, String clientId, String clientSecret, OAuthClient client) {
+        super(client);
+        this.realm = realm;
+        this.subjectToken = subjectToken;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return client.getEndpoints(realm).getToken();
+    }
+
+    public TokenExchangeRequest audience(List<String> audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    public TokenExchangeRequest additionalParams(Map<String, String> additionalParams) {
+        this.additionalParams = additionalParams;
+        return this;
+    }
+
+    protected void initRequest() {
+        parameter(OAuth2Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
+
+        authorization(clientId, clientSecret);
+
+        parameter(OAuth2Constants.SUBJECT_TOKEN, subjectToken);
+        parameter(OAuth2Constants.SUBJECT_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE);
+
+        if (audience != null) {
+            audience.forEach(a -> parameter(OAuth2Constants.AUDIENCE, a));
+        }
+
+        if (additionalParams != null) {
+            additionalParams.forEach(this::parameter);
+        }
+
+        parameter(AdapterConstants.CLIENT_SESSION_STATE, client.getClientSessionState());
+        parameter(AdapterConstants.CLIENT_SESSION_HOST, client.getClientSessionHost());
+
+        parameter(OAuth2Constants.SCOPE, client.getScope());
+    }
+
+    @Override
+    protected AccessTokenResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new AccessTokenResponse(response);
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsoleWhoAmILocaleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsoleWhoAmILocaleTest.java
@@ -103,7 +103,7 @@ public class AdminConsoleWhoAmILocaleTest extends AbstractKeycloakTest {
     }
 
     private org.keycloak.testsuite.util.oauth.AccessTokenResponse accessToken(String realmName, String username, String password) throws Exception {
-        return oauth.doGrantAccessTokenRequest(realmName, username, password, ADMIN_CLI_CLIENT_ID, null);
+        return oauth.realm(realmName).doGrantAccessTokenRequest(username, password, ADMIN_CLI_CLIENT_ID, null);
     }
 
     private String whoAmiUrl(String realmName) {
@@ -131,7 +131,7 @@ public class AdminConsoleWhoAmILocaleTest extends AbstractKeycloakTest {
 
     @Test
     public void testLocaleRealmI18nDisabledUserWithoutLocale() throws Exception {
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doGrantAccessTokenRequest(REALM_I18N_OFF, USER_WITHOUT_LOCALE, PASSWORD, ADMIN_CLI_CLIENT_ID, null);
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.realm(REALM_I18N_OFF).doGrantAccessTokenRequest(USER_WITHOUT_LOCALE, PASSWORD, ADMIN_CLI_CLIENT_ID, null);
         JsonNode whoAmI = SimpleHttpDefault
             .doGet(whoAmiUrl(REALM_I18N_OFF), client)
             .header("Accept", "application/json")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -1318,7 +1318,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         String token = oauth.doGrantAccessTokenRequest("password", "admin", "admin").getAccessToken();
         Assert.assertNotNull(token);
         try {
-            exchanged = oauth.doTokenExchange("master", token, "admin-cli", "tokenexclient", "password").getAccessToken();
+            exchanged = oauth.doTokenExchange(token, "admin-cli", "tokenexclient", "password").getAccessToken();
         } catch (AssertionError e) {
             log.info("Error message is expected from oauth: " + e.getMessage());
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/AbstractGroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/AbstractGroupTest.java
@@ -67,7 +67,7 @@ public abstract class AbstractGroupTest extends AbstractKeycloakTest {
     }
 
     AccessToken login(String login, String clientId, String clientSecret, String userId) throws Exception {
-        AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("test", login, "password", clientId, clientSecret);
+        AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest( login, "password", clientId, clientSecret);
 
         String accessToken = tokenResponse.getAccessToken();
         String refreshToken = tokenResponse.getRefreshToken();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
@@ -242,7 +242,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
 
         // Token request
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doAccessTokenRequest(code);
 
         AuthorizationRequest request = new AuthorizationRequest();
 
@@ -269,7 +269,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
 
         // Token request
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doAccessTokenRequest(code);
 
         AuthorizationRequest request = new AuthorizationRequest();
 
@@ -2001,7 +2001,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
 
         // Token request
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         AccessToken token = toAccessToken(response.getAccessToken());
 
         assertEquals(PUBLIC_TEST_CLIENT, token.getOtherClaims().get("custom_claim"));
@@ -2027,7 +2027,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         oauth.clientId(PUBLIC_TEST_CLIENT);
         oauth.doLogin("marta", "password");
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse accessTokenResponse = oauth.doAccessTokenRequest(code, null);
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse accessTokenResponse = oauth.doAccessTokenRequest(code);
         assertNotNull(accessTokenResponse.getAccessToken());
         assertNotNull(accessTokenResponse.getRefreshToken());
 
@@ -2053,7 +2053,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         oauth.clientId(PUBLIC_TEST_CLIENT);
         oauth.doLogin("marta", "password");
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse accessTokenResponse = oauth.doAccessTokenRequest(code, null);
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse accessTokenResponse = oauth.doAccessTokenRequest(code);
         assertNotNull(accessTokenResponse.getAccessToken());
         assertNotNull(accessTokenResponse.getRefreshToken());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaDiscoveryDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaDiscoveryDocumentTest.java
@@ -66,7 +66,7 @@ public class UmaDiscoveryDocumentTest extends AbstractKeycloakTest {
 
             assertEquals(configuration.getAuthorizationEndpoint(), OIDCLoginProtocolService.authUrl(UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT)).build("test").toString());
             assertEquals(configuration.getTokenEndpoint(), oauth.getEndpoints().getToken());
-            assertEquals(configuration.getJwksUri(), oauth.getEndpoints("test").getJwks());
+            assertEquals(configuration.getJwksUri(), oauth.getEndpoints().getJwks());
             assertEquals(configuration.getIntrospectionEndpoint(), oauth.getEndpoints().getIntrospection());
 
             String registrationUri = UriBuilder

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -341,7 +341,7 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
                 oauth.init(driver);
             }
 
-            final LogoutUrlBuilder builder = oauth.getEndpoints(realm)
+            final LogoutUrlBuilder builder = oauth.realm(realm).getEndpoints()
                     .getLogoutBuilder()
                     .idTokenHint(idTokenHint)
                     .clientId(clientId)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNonceParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNonceParameterTest.java
@@ -67,7 +67,7 @@ public class KcOidcBrokerNonceParameterTest extends AbstractBrokerTest {
         AuthorizationEndpointResponse authzResponse = oauth
                 .doLoginSocial(bc.getIDPAlias(), bc.getUserLogin(), bc.getUserPassword());
         String code = authzResponse.getCode();
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         IDToken idToken = toIdToken(response.getIdToken());
         
         Assert.assertEquals("123456", idToken.getNonce());
@@ -95,7 +95,7 @@ public class KcOidcBrokerNonceParameterTest extends AbstractBrokerTest {
         AuthorizationEndpointResponse authzResponse = oauth
                 .doLoginSocial(bc.getIDPAlias(), bc.getUserLogin(), bc.getUserPassword());
         String code = authzResponse.getCode();
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         IDToken idToken = toIdToken(response.getIdToken());
 
         Assert.assertNull(idToken.getNonce());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
@@ -121,7 +121,7 @@ public abstract class KcOidcBrokerTokenExchangeTest extends AbstractInitializedB
 
         identityProviderResource.addMapper(hardCodedSessionNoteMapper).close();
 
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest(bc.providerRealmName(), bc.getUserLogin(), bc.getUserPassword(), brokerApp.getClientId(), brokerApp.getSecret());
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse tokenResponse = oauth.realm(bc.providerRealmName()).doGrantAccessTokenRequest(bc.getUserLogin(), bc.getUserPassword(), brokerApp.getClientId(), brokerApp.getSecret());
         assertThat(tokenResponse.getIdToken(), notNullValue());
 
         testingClient.server(BrokerTestConstants.REALM_CONS_NAME).run(KcOidcBrokerTokenExchangeTest::setupRealm);
@@ -176,7 +176,7 @@ public abstract class KcOidcBrokerTokenExchangeTest extends AbstractInitializedB
             identityProviderResource.update(idpRep);
         });
 
-        org.keycloak.testsuite.util.oauth.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest(bc.providerRealmName(), bc.getUserLogin(), bc.getUserPassword(), brokerApp.getClientId(), brokerApp.getSecret());
+        org.keycloak.testsuite.util.oauth.AccessTokenResponse tokenResponse = oauth.realm(bc.providerRealmName()).doGrantAccessTokenRequest(bc.getUserLogin(), bc.getUserPassword(), brokerApp.getClientId(), brokerApp.getSecret());
         assertThat(tokenResponse.getIdToken(), notNullValue());
         String idTokenString = tokenResponse.getIdToken();
         oauth.realm(bc.providerRealmName());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientRegistrationTest.java
@@ -134,7 +134,7 @@ public abstract class AbstractClientRegistrationTest extends AbstractKeycloakTes
 
     protected String getToken(String clientId, String clientSecret, String username, String password) {
         try {
-            return oauth.doGrantAccessTokenRequest(REALM_NAME, username, password, clientId, clientSecret).getAccessToken();
+            return oauth.doGrantAccessTokenRequest(username, password, clientId, clientSecret).getAccessToken();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
@@ -157,7 +157,7 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
     public void registerClientInMasterRealm() throws Exception {
         ClientRegistration masterReg = ClientRegistration.create().url(suiteContext.getAuthServerInfo().getContextRoot() + "/auth", "master").build();
 
-        String token = oauth.doGrantAccessTokenRequest("master", "admin", "admin", Constants.ADMIN_CLI_CLIENT_ID, null).getAccessToken();
+        String token = oauth.realm("master").doGrantAccessTokenRequest( "admin", "admin", Constants.ADMIN_CLI_CLIENT_ID, null).getAccessToken();
         masterReg.auth(Auth.token(token));
 
         ClientRepresentation client = new ClientRepresentation();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
@@ -294,7 +294,7 @@ public class FAPI1Test extends AbstractFAPITest {
         // Check PKCE with S256, redirectUri and nonce/state set. Login should be successful
         successfulLoginAndLogout("foo", TEST_USERNAME, false, (String code) -> {
             oauth.codeVerifier(codeVerifier);
-            return oauth.doAccessTokenRequest(code, null);
+            return oauth.doAccessTokenRequest(code);
         });
     }
 
@@ -386,7 +386,7 @@ public class FAPI1Test extends AbstractFAPITest {
         // Check PKCE with S256, redirectUri and nonce/state set. Login should be successful
         successfulLoginAndLogout("foo", TEST_USERNAME, false, (String code) -> {
             oauth.codeVerifier(codeVerifier);
-            return oauth.doAccessTokenRequest(code, null);
+            return oauth.doAccessTokenRequest(code);
         });
 
         // Set "advanced" policy
@@ -576,7 +576,7 @@ public class FAPI1Test extends AbstractFAPITest {
         assertIDTokenAsDetachedSignature(idTokenParam, code);
 
         // Check HoK required
-        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
 
         assertSuccessfulTokenResponse(tokenResponse);
         AccessToken accessToken = oauth.verifyToken(tokenResponse.getAccessToken());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
@@ -216,7 +216,7 @@ public class FAPI2Test extends AbstractFAPITest {
 
         // send a token request
         oauth.codeVerifier(codeVerifier);
-        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
 
         // check HoK required
         assertSuccessfulTokenResponse(tokenResponse);
@@ -300,7 +300,7 @@ public class FAPI2Test extends AbstractFAPITest {
 
         // send a token request
         oauth.codeVerifier(codeVerifier);
-        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
 
         // check HoK required
         assertSuccessfulTokenResponse(tokenResponse);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/MutualTLSClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/MutualTLSClientTest.java
@@ -247,7 +247,7 @@ public class MutualTLSClientTest extends AbstractTestRealmKeycloakTest {
       try {
           oauth.httpClient().set(closeableHttpClient);
           return oauth.clientId(clientId)
-                  .doAccessTokenRequest(code, null);
+                  .doAccessTokenRequest(code);
       } finally {
           oauth.httpClient().reset();
       }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OAuth2_1ConfidentialClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OAuth2_1ConfidentialClientTest.java
@@ -216,7 +216,7 @@ public class OAuth2_1ConfidentialClientTest extends AbstractFAPITest {
         setValidPkce(clientId);
         AuthorizationEndpointResponse res = oauth.doLogin(TEST_USERNAME, TEST_USERSECRET);
 
-        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(res.getCode(), null);
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(res.getCode());
         AccessToken accessToken = oauth.verifyToken(tokenResponse.getAccessToken());
         Assert.assertNotNull(accessToken.getConfirmation().getCertThumbprint());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OAuth2_1PublicClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OAuth2_1PublicClientTest.java
@@ -229,7 +229,7 @@ public class OAuth2_1PublicClientTest extends AbstractFAPITest {
         String dpopProofEcEncoded = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST, oauth.getEndpoints().getToken(), (long) Time.currentTime(), Algorithm.ES256, jwsEcHeader, ecKeyPair.getPrivate());
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
         oauth.dpopProof(dpopProofEcEncoded);
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
         oauth.verifyToken(response.getAccessToken());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -785,7 +785,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
 
     private String getToken(String username, String password) {
         try {
-            return oauth.doGrantAccessTokenRequest(REALM_NAME, username, password, Constants.ADMIN_CLI_CLIENT_ID, null).getAccessToken();
+            return oauth.doGrantAccessTokenRequest(username, password, Constants.ADMIN_CLI_CLIENT_ID, null).getAccessToken();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -171,7 +171,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
     public String getAdminToken() throws Exception {
         String clientId = Constants.ADMIN_CLI_CLIENT_ID;
-        return oauth.doGrantAccessTokenRequest("master", "admin", "admin", clientId, null).getAccessToken();
+        return oauth.realm("master").doGrantAccessTokenRequest( "admin", "admin", clientId, null).getAccessToken();
     }
 
     public AccessTokenResponse getTestToken(String password, String totp) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AbstractClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AbstractClientAuthSignedJWTTest.java
@@ -444,8 +444,8 @@ public abstract class AbstractClientAuthSignedJWTTest extends AbstractKeycloakTe
         }
 
         // Get admin access token, no matter it's master realm's admin
-        AccessTokenResponse accessTokenResponse = oauth.doGrantAccessTokenRequest(
-                AuthRealm.MASTER, AuthRealm.ADMIN, AuthRealm.ADMIN, "admin-cli", null);
+        AccessTokenResponse accessTokenResponse = oauth.realm(AuthRealm.MASTER).doGrantAccessTokenRequest(
+                AuthRealm.ADMIN, AuthRealm.ADMIN, "admin-cli", null);
         assertEquals(200, accessTokenResponse.getStatusCode());
 
         final String url = suiteContext.getAuthServerInfo().getContextRoot()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenNoEmailLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenNoEmailLoginTest.java
@@ -77,7 +77,7 @@ public class AccessTokenNoEmailLoginTest extends AbstractKeycloakTest {
 
     @Test
     public void loginWithEmail() throws Exception {
-        oauth.doLoginGrant("non-duplicate-email-user@localhost", "password");
+        oauth.doLogin("non-duplicate-email-user@localhost", "password");
         
         assertEquals("Invalid username or password.", driver.findElement(By.className("kc-feedback-text")).getText());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -206,7 +206,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
         assertEquals("Bearer", response.getTokenType());
 
-        String expectedKid = Stream.of(oauth.doCertsRequest("test").getKeys())
+        String expectedKid = Stream.of(oauth.doCertsRequest().getKeys())
                 .filter(jwk -> KeyUse.SIG.getSpecName().equals(jwk.getPublicKeyUse()))
                 .map(JWK::getKeyId)
                 .findFirst().orElseThrow(() -> new AssertionError("Was not able to find key with usage SIG in the 'test' realm keys"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -325,7 +325,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         String codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(401, response.getStatusCode());
 
         AssertEvents.ExpectedEvent expectedEvent = events.expectCodeToToken(codeId, loginEvent.getSessionId()).error("invalid_client_credentials").clearDetails().user((String) null).session((String) null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
@@ -254,7 +254,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
             oauth.doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
 
             String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-            AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+            AccessTokenResponse response = oauth.doAccessTokenRequest(code);
             // token-type must be "Bearer" because no DPoP is present within the token-request
             assertEquals(TokenUtil.TOKEN_TYPE_BEARER, response.getTokenType());
 
@@ -290,7 +290,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
         oauth.dpopProof(dpopProofEcEncoded);
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(TokenUtil.TOKEN_TYPE_DPOP, response.getTokenType());
 
         // token refresh
@@ -576,7 +576,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
         oauth.doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
 
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
         assertEquals("DPoP proof is missing", response.getErrorDescription());
@@ -590,7 +590,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
         JWSHeader jwsEcHeader = new JWSHeader(org.keycloak.jose.jws.Algorithm.ES256, DPOP_JWT_HEADER_TYPE, jwkEc.getKeyId(), jwkEc);
         String dpopProofEcEncoded = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST, oauth.getEndpoints().getToken(), (long) Time.currentTime(), Algorithm.ES256, jwsEcHeader, ecKeyPair.getPrivate());
         oauth.dpopProof(dpopProofEcEncoded);
-        response = oauth.doAccessTokenRequest(code, null);
+        response = oauth.doAccessTokenRequest(code);
 
         assertEquals(Status.OK.getStatusCode(), response.getStatusCode());
         String encodedAccessToken = response.getAccessToken();
@@ -911,7 +911,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
     private void successTokenProceduresWithDPoP(String dpopProofEncoded, String jkt) throws Exception {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
         oauth.dpopProof(dpopProofEncoded);
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(TokenUtil.TOKEN_TYPE_DPOP, response.getTokenType());
         assertEquals(Status.OK.getStatusCode(), response.getStatusCode());
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
@@ -945,7 +945,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
     private void failureTokenProceduresWithDPoP(String dpopProofEncoded, String error) throws Exception {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
         oauth.dpopProof(dpopProofEncoded);
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
         assertEquals(error, response.getErrorDescription());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
@@ -21,9 +21,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
@@ -66,7 +64,6 @@ import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfileBuilder;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfilesBuilder;
-import org.keycloak.testsuite.util.Matchers;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.UserInfoResponse;
 import org.keycloak.testsuite.util.ServerURLs;
@@ -79,13 +76,13 @@ import java.security.KeyPair;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -332,12 +329,10 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void testDPoPProofCorsPreflight() throws Exception {
-        try (CloseableHttpResponse response = oauth.doPreflightRequest()) {
-            String[] headers = response.getHeaders(Cors.ACCESS_CONTROL_ALLOW_HEADERS)[0].getValue().split(", ");
-            Set<String> allowedHeaders = new HashSet<>(Arrays.asList(headers));
+        Map<String, String> responseHeaders = TokenEndpointCorsTest.getTokenEndpointPreflightResponseHeaders(oauth);
+        Set<String> allowedHeaders = Arrays.stream(responseHeaders.get(Cors.ACCESS_CONTROL_ALLOW_HEADERS).split(", ")).collect(Collectors.toSet());
 
-            assertTrue(allowedHeaders.contains(TokenUtil.TOKEN_TYPE_DPOP));
-        }
+        assertTrue(allowedHeaders.contains(TokenUtil.TOKEN_TYPE_DPOP));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
@@ -1081,7 +1081,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
     @Test
     public void ensureDeviceFlowConfigPresentWhenDeviceFlowIsEnabled() {
 
-        OIDCConfigurationRepresentation oidcConfigRep = oauth.doWellKnownRequest(REALM_NAME);
+        OIDCConfigurationRepresentation oidcConfigRep = oauth.doWellKnownRequest();
         Assert.assertNotNull("deviceAuthorizationEndpoint should be not null", oidcConfigRep.getDeviceAuthorizationEndpoint());
         Assert.assertNotNull("mtlsEndpointAliases.deviceAuthorizationEndpoint should be not null", oidcConfigRep.getMtlsEndpointAliases().getDeviceAuthorizationEndpoint());
     }
@@ -1096,7 +1096,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
         testingClient.disableFeature(Profile.Feature.DEVICE_FLOW);
 
         try {
-            OIDCConfigurationRepresentation oidcConfigRep = oauth.doWellKnownRequest(REALM_NAME);
+            OIDCConfigurationRepresentation oidcConfigRep = oauth.doWellKnownRequest();
             Assert.assertNull("deviceAuthorizationEndpoint should be null", oidcConfigRep.getDeviceAuthorizationEndpoint());
             Assert.assertNull("mtlsEndpointAliases.deviceAuthorizationEndpoint should be null", oidcConfigRep.getMtlsEndpointAliases().getDeviceAuthorizationEndpoint());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -449,7 +449,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         assertThat(response.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(1750), lessThanOrEqualTo(1800)));
         assertEquals("Bearer", response.getTokenType());
 
-        String expectedKid = Stream.of(oauth.doCertsRequest("test").getKeys())
+        String expectedKid = Stream.of(oauth.doCertsRequest().getKeys())
                 .filter(jwk -> KeyUse.SIG.getSpecName().equals(jwk.getPublicKeyUse()))
                 .map(JWK::getKeyId)
                 .findFirst().orElseThrow(() -> new AssertionError("Was not able to find key with usage SIG in the 'test' realm keys"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
@@ -235,7 +235,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
 
         assertEquals("Bearer", response.getTokenType());
 
-        String expectedKid = Stream.of(oauth.doCertsRequest("test").getKeys())
+        String expectedKid = Stream.of(oauth.doCertsRequest().getKeys())
                 .filter(jwk -> KeyUse.SIG.getSpecName().equals(jwk.getPublicKeyUse()))
                 .map(JWK::getKeyId)
                 .findFirst().orElseThrow(() -> new AssertionError("Was not able to find key with usage SIG in the 'test' realm keys"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/AbstractStandardTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/AbstractStandardTokenExchangeTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         String accessToken = getInitialAccessTokenForClientExchanger();
 
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
             Assert.assertEquals(OAuth2Constants.REFRESH_TOKEN_TYPE, response.getIssuedTokenType());
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
@@ -124,7 +124,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         }
 
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "legal", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "legal", "secret");
             Assert.assertEquals(OAuth2Constants.REFRESH_TOKEN_TYPE, response.getIssuedTokenType());
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
@@ -136,7 +136,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
             assertTrue(exchangedToken.getRealmAccess().isUserInRole("example"));
         }
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "illegal", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "illegal", "secret");
             Assert.assertEquals(403, response.getStatusCode());
         }
     }
@@ -149,7 +149,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         String accessToken = getInitialAccessTokenForClientExchanger();
 
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret", Map.of(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE));
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret", Map.of(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE));
             Assert.assertEquals(OAuth2Constants.ACCESS_TOKEN_TYPE, response.getIssuedTokenType());
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
@@ -176,7 +176,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         Assert.assertNull(token.getSessionId());
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, "target", "my-service-account", "secret");
+            response = oauth.doTokenExchange(accessToken, "target", "my-service-account", "secret");
             Assert.assertEquals(OAuth2Constants.ACCESS_TOKEN_TYPE, response.getIssuedTokenType());
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
@@ -197,7 +197,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         String accessToken = getInitialAccessTokenForClientExchanger();
 
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, null, "different-scope-client", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, null, "different-scope-client", "secret");
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
@@ -210,7 +210,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         }
 
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "different-scope-client", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "different-scope-client", "secret");
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
@@ -244,7 +244,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         oauth.scope("openid profile email");
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, null, "different-scope-client", "secret");
+            response = oauth.doTokenExchange(accessToken, null, "different-scope-client", "secret");
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
@@ -256,7 +256,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         }
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, "target", "different-scope-client", "secret");
+            response = oauth.doTokenExchange(accessToken, "target", "different-scope-client", "secret");
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
@@ -286,7 +286,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         Assert.assertEquals(token.getPreferredUsername(), "user");
         assertTrue(token.getRealmAccess() == null || !token.getRealmAccess().isUserInRole("example"));
 
-        response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
         String exchangedTokenString = response.getAccessToken();
         TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
         AccessToken exchangedToken = verifier.parse().getToken();
@@ -296,14 +296,14 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         assertTrue(exchangedToken.getRealmAccess().isUserInRole("example"));
 
         // can exchange to itself because the client is within the audience of the token issued to the public client
-        response = oauth.doTokenExchange(TEST, accessToken, null, "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, null, "client-exchanger", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
 
         // can not exchange to itself because the client is not within the audience of the token issued to the public client
-        response = oauth.doTokenExchange(TEST, accessToken, null, "direct-legal", "secret");
+        response = oauth.doTokenExchange(accessToken, null, "direct-legal", "secret");
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
 
-        response = oauth.doTokenExchange(TEST, accessToken, null, "direct-public", null);
+        response = oauth.doTokenExchange(accessToken, null, "direct-public", null);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
     }
 
@@ -324,7 +324,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         String accessToken = response.getAccessToken();
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+            response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
             String exchangedTokenString = response.getAccessToken();
             String refreshTokenString = response.getRefreshToken();
             assertNotNull(exchangedTokenString);
@@ -332,7 +332,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         }
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, "target", "no-refresh-token", "secret");
+            response = oauth.doTokenExchange(accessToken, "target", "no-refresh-token", "secret");
             String exchangedTokenString = response.getAccessToken();
             String refreshTokenString = response.getRefreshToken();
             assertNotNull(exchangedTokenString);
@@ -349,10 +349,10 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         oauth.realm(TEST);
         String accessToken = getInitialAccessTokenForClientExchanger();
 
-        AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, null, "client-exchanger", "secret");
+        AccessTokenResponse response = oauth.doTokenExchange(accessToken, null, "client-exchanger", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
 
-        response = oauth.doTokenExchange(TEST, accessToken, "client-exchanger", "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, "client-exchanger", "client-exchanger", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
     }
 
@@ -368,12 +368,12 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         clientRepresentation.setConsentRequired(Boolean.TRUE);
         client.update(clientRepresentation);
 
-        AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, null, "client-exchanger", "secret");
+        AccessTokenResponse response = oauth.doTokenExchange(accessToken, null, "client-exchanger", "secret");
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
         assertEquals("Client requires user consent", response.getErrorDescription());
 
-        response = oauth.doTokenExchange(TEST, accessToken, "client-exchanger", "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, "client-exchanger", "client-exchanger", "secret");
         assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
         assertEquals("Client requires user consent", response.getErrorDescription());
     }
@@ -391,7 +391,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         Assert.assertEquals(token.getPreferredUsername(), "user");
         assertTrue(token.getRealmAccess() == null || !token.getRealmAccess().isUserInRole("example"));
 
-        response = oauth.doTokenExchange(TEST, accessToken, "target", "direct-legal", "secret");
+        response = oauth.doTokenExchange(accessToken, "target", "direct-legal", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
     }
 
@@ -404,7 +404,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         AccessTokenResponse response = oauth.doGrantAccessTokenRequest("secret", "user", "password");
         String accessToken = response.getAccessToken();
 
-        response = oauth.doTokenExchange(TEST, accessToken, List.of("target", "client-exchanger"), "client-exchanger", "secret", null);
+        response = oauth.doTokenExchange(accessToken, List.of("target", "client-exchanger"), "client-exchanger", "secret", null);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
     }
 
@@ -423,30 +423,30 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
 
         // public client has no permission to exchange with the client direct-legal to which the token was issued for
         // if not set, the audience is calculated based on the client to which the token was issued for
-        response = oauth.doTokenExchange(TEST, accessToken, null, "direct-public", null);
+        response = oauth.doTokenExchange(accessToken, null, "direct-public", null);
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertEquals("Client is not the holder of the token", response.getErrorDescription());
 
         // public client has no permission to exchange
-        response = oauth.doTokenExchange(TEST, accessToken, "target", "direct-public", null);
+        response = oauth.doTokenExchange(accessToken, "target", "direct-public", null);
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertEquals("Client is not the holder of the token", response.getErrorDescription());
 
-        response = oauth.doTokenExchange(TEST, accessToken, "direct-legal", "direct-public", null);
+        response = oauth.doTokenExchange(accessToken, "direct-legal", "direct-public", null);
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertEquals("Client is not the holder of the token", response.getErrorDescription());
 
         // public client can not exchange a token to itself if the token was issued to another client
-        response = oauth.doTokenExchange(TEST, accessToken, "direct-public", "direct-public", null);
+        response = oauth.doTokenExchange(accessToken, "direct-public", "direct-public", null);
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertEquals("Client is not the holder of the token", response.getErrorDescription());
 
         // client with access to exchange
-        response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
 
         // client must pass the audience because the client has no permission to exchange with the calculated audience (direct-legal)
-        response = oauth.doTokenExchange(TEST, accessToken, null, "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, null, "client-exchanger", "secret");
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertEquals("Client is not within the token audience", response.getErrorDescription());
     }
@@ -483,7 +483,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         driver.navigate().to(logoutUrl);
         logoutToken = testingClient.testApp().getBackChannelRawLogoutToken();
         Assert.assertNotNull(logoutToken);
-        AccessTokenResponse response = oauth.doTokenExchange(TEST, logoutToken, "target", "direct-legal", "secret");
+        AccessTokenResponse response = oauth.doTokenExchange(logoutToken, "target", "direct-legal", "secret");
         assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
 
     }
@@ -505,7 +505,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         String sid = token.getSessionId();
 
         // perform token exchange with client-exchanger simulating it received the previous token
-        response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
         accessToken = response.getAccessToken();
         accessTokenVerifier = TokenVerifier.create(accessToken, AccessToken.class);
@@ -516,7 +516,7 @@ public abstract class AbstractStandardTokenExchangeTest extends AbstractKeycloak
         Assert.assertEquals(sid, token.getSessionId());
 
         // perform a second token exchange just to check everything is OK
-        response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+        response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
         accessToken = response.getAccessToken();
         accessTokenVerifier = TokenVerifier.create(accessToken, AccessToken.class);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ClientTokenExchangeAudienceAndScopesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ClientTokenExchangeAudienceAndScopesTest.java
@@ -63,7 +63,7 @@ public class ClientTokenExchangeAudienceAndScopesTest extends AbstractKeycloakTe
     public void test01_scopeParamIncludedWithoutAudience() throws Exception {
         String accessToken = resourceOwnerLogin();
         oauth.scope("optional-scope2");
-        AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, (String) null, "requester-client", "secret", null);
+        AccessTokenResponse response = oauth.doTokenExchange(accessToken, (String) null, "requester-client", "secret", null);
         assertAudiencesAndScopes(response, List.of("target-client1", "target-client2"), List.of("default-scope1", "optional-scope2"));
     }
 
@@ -71,7 +71,7 @@ public class ClientTokenExchangeAudienceAndScopesTest extends AbstractKeycloakTe
     public void test02_scopeParamIncludedAudienceIncluded() throws Exception {
         String accessToken = resourceOwnerLogin();
         oauth.scope("optional-scope2");
-        AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, List.of("target-client1"), "requester-client", "secret", null);
+        AccessTokenResponse response = oauth.doTokenExchange(accessToken, List.of("target-client1"), "requester-client", "secret", null);
         assertAudiencesAndScopes(response, List.of("target-client1"), List.of("default-scope1", "optional-scope2"));
     }
 
@@ -82,7 +82,7 @@ public class ClientTokenExchangeAudienceAndScopesTest extends AbstractKeycloakTe
         oauth.scope("optional-scope2");
 
         // The "target-client3" is valid client, but unavailable to the user. Request allowed, but "target-client3" audience will not be available
-        AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, List.of("target-client1", "target-client3"), "requester-client", "secret", null);
+        AccessTokenResponse response = oauth.doTokenExchange(accessToken, List.of("target-client1", "target-client3"), "requester-client", "secret", null);
         assertAudiencesAndScopes(response, List.of("target-client1"), List.of("default-scope1", "optional-scope2"));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ClientTokenExchangeSAML2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ClientTokenExchangeSAML2Test.java
@@ -250,7 +250,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         params.put(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.SAML2_TOKEN_TYPE);
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
             String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
@@ -280,7 +280,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         }
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "legal", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_SIGNED_TARGET, "legal", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
             String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
@@ -306,7 +306,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
             Assert.assertTrue(roles.contains("example"));
         }
         {
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "illegal", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_SIGNED_TARGET, "illegal", "secret", params);
             Assert.assertEquals(403, response.getStatusCode());
         }
     }
@@ -329,7 +329,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         params.put(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.SAML2_TOKEN_TYPE);
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_ENCRYPTED_TARGET, "client-exchanger", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_ENCRYPTED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
             String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
@@ -377,7 +377,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         params.put(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.SAML2_TOKEN_TYPE);
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_AND_ENCRYPTED_TARGET, "client-exchanger", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_SIGNED_AND_ENCRYPTED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
             String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
@@ -423,7 +423,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         params.put(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.SAML2_TOKEN_TYPE);
 
         {
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_UNSIGNED_AND_UNENCRYPTED_TARGET, "client-exchanger", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_UNSIGNED_AND_UNENCRYPTED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
             String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
@@ -470,7 +470,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         // client-exchanger can impersonate from token "user" to user "impersonated-user" and to "target" client
         {
             params.put(OAuth2Constants.REQUESTED_SUBJECT, "impersonated-user");
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
 
             String exchangedTokenString = response.getAccessToken();
             String assertionXML = new String(Base64Url.decode(exchangedTokenString), StandardCharsets.UTF_8);
@@ -518,7 +518,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         // test that user does not have impersonator permission
         {
             params.put(OAuth2Constants.REQUESTED_SUBJECT, "impersonated-user");
-            response = oauth.doTokenExchange(TEST, accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
+            response = oauth.doTokenExchange(accessToken, SAML_SIGNED_TARGET, "client-exchanger", "secret", params);
             Assert.assertEquals(403, response.getStatusCode());
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
@@ -91,7 +91,7 @@ public class StandardTokenExchangeV2Test extends AbstractStandardTokenExchangeTe
         oauth.realm(TEST);
         String accessToken = getInitialAccessTokenForClientExchanger();
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "client-exchanger", "secret");
             Assert.assertEquals(OAuth2Constants.REFRESH_TOKEN_TYPE, response.getIssuedTokenType());
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
@@ -103,7 +103,7 @@ public class StandardTokenExchangeV2Test extends AbstractStandardTokenExchangeTe
             assertTrue(exchangedToken.getRealmAccess().isUserInRole("example"));
         }
         {
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "legal", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "legal", "secret");
             Assert.assertEquals(OAuth2Constants.REFRESH_TOKEN_TYPE, response.getIssuedTokenType());
             String exchangedTokenString = response.getAccessToken();
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
@@ -116,7 +116,7 @@ public class StandardTokenExchangeV2Test extends AbstractStandardTokenExchangeTe
         }
         {
             //exchange not allowed due the illegal client is not in the client-exchanger audience
-            AccessTokenResponse response = oauth.doTokenExchange(TEST, accessToken, "target", "illegal", "secret");
+            AccessTokenResponse response = oauth.doTokenExchange(accessToken, "target", "illegal", "secret");
             Assert.assertEquals(403, response.getStatusCode());
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractWellKnownProviderTest extends AbstractKeycloakTest
             assertEquals(oidcConfig.getAuthorizationEndpoint(), OIDCLoginProtocolService.authUrl(UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT)).build("test").toString());
             assertEquals(oidcConfig.getTokenEndpoint(), oauth.getEndpoints().getToken());
             assertEquals(oidcConfig.getUserinfoEndpoint(), OIDCLoginProtocolService.userInfoUrl(UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT)).build("test").toString());
-            assertEquals(oidcConfig.getJwksUri(), oauth.getEndpoints("test").getJwks());
+            assertEquals(oidcConfig.getJwksUri(), oauth.getEndpoints().getJwks());
 
             String registrationUri = UriBuilder
                     .fromUri(OAuthClient.AUTH_SERVER_ROOT)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
@@ -299,7 +299,7 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
             String accessToken = response.getAccessToken();
             logger.debug("accessToken:" + accessToken);
             assertAccessToken(oauth.verifyToken(accessToken), true, false, false);
-            response = oauth.doTokenExchange(TEST, accessToken, null, TEST_CLIENT, TEST_CLIENT_SECRET);
+            response = oauth.doTokenExchange(accessToken, null, TEST_CLIENT, TEST_CLIENT_SECRET);
             String exchangedTokenString = response.getAccessToken();
             logger.debug("exchangedTokenString:" + exchangedTokenString);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
@@ -269,7 +269,7 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
     @Test
     public void promptNoneNotLogged() {
 
-        String expectedIssuer = oauth.doWellKnownRequest(oauth.getRealm()).getIssuer();
+        String expectedIssuer = oauth.doWellKnownRequest().getIssuer();
 
         // Send request with prompt=none
         driver.navigate().to(oauth.getLoginFormUrl() + "&prompt=none");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCPublicClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCPublicClientTest.java
@@ -98,7 +98,7 @@ public class OIDCPublicClientTest extends AbstractKeycloakTest {
         String codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        AccessTokenResponse response = oauth.doAccessTokenRequest(code, null);
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
 
         assertEquals(200, response.getStatusCode());
         assertNotNull(response.getAccessToken());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -870,7 +870,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
     @Test
     public void testUserInfoRequestWithSamlClient() throws Exception {
         // obtain an access token
-        String accessToken = oauth.doGrantAccessTokenRequest("test", "test-user@localhost", "password", "saml-client", "secret").getAccessToken();
+        String accessToken = oauth.doGrantAccessTokenRequest( "test-user@localhost", "password", "saml-client", "secret").getAccessToken();
 
         // change client's protocol
         ClientRepresentation samlClient = adminClient.realm("test").clients().findByClientId("saml-client").get(0);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TLSTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TLSTest.java
@@ -42,7 +42,7 @@ public class TLSTest extends AbstractTestRealmKeycloakTest {
         oauth.baseUrl(AUTH_SERVER_ROOT_WITHOUT_TLS);
 
         //when
-        OIDCConfigurationRepresentation config = oauth.doWellKnownRequest("test");
+        OIDCConfigurationRepresentation config = oauth.doWellKnownRequest();
 
         //then
         Assert.assertTrue(config.getAuthorizationEndpoint().startsWith(AUTH_SERVER_ROOT_WITHOUT_TLS));
@@ -58,13 +58,13 @@ public class TLSTest extends AbstractTestRealmKeycloakTest {
 
         // Try access "WellKnown" endpoint unsecured. It should fail
         oauth.baseUrl(AUTH_SERVER_ROOT_WITHOUT_TLS);
-        OIDCConfigurationRepresentation config = oauth.doWellKnownRequest("test");
+        OIDCConfigurationRepresentation config = oauth.doWellKnownRequest();
         Assert.assertNull(config.getAuthorizationEndpoint());
         Assert.assertEquals("HTTPS required", config.getOtherClaims().get("error_description"));
 
         // Try access "JWKS URL" unsecured. It should fail
         try {
-            JSONWebKeySet keySet = oauth.doCertsRequest("test");
+            JSONWebKeySet keySet = oauth.doCertsRequest();
             Assert.fail("This should not be successful");
         } catch (Exception e) {
             // Expected

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/HostnameV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/HostnameV2Test.java
@@ -207,7 +207,7 @@ public class HostnameV2Test extends AbstractKeycloakTest {
     }
 
     private void testFrontendAndBackendUrls(String realm, String expectedFrontendUrl, String expectedBackendUrl) {
-        OIDCConfigurationRepresentation config = oauth.doWellKnownRequest(realm);
+        OIDCConfigurationRepresentation config = oauth.realm(realm).doWellKnownRequest();
         assertEquals(expectedFrontendUrl + "/realms/" + realm, config.getIssuer());
         assertEquals(expectedFrontendUrl + "/realms/" + realm + "/protocol/openid-connect/auth", config.getAuthorizationEndpoint());
         assertEquals(expectedBackendUrl + "/realms/" + realm + "/protocol/openid-connect/token", config.getTokenEndpoint());


### PR DESCRIPTION
Sending separate commits to easy review; will squash when merging

- **Move OAuthClient.doPreflightRequest to TokenEndpointCorsTest**
- **Move access token request from OAuthClient to AccessTokenRequest**
- **Move token exchange request from OAuthClient to TokenExchangeRequest**
- **Remove realm parameter from doGrantAccessTokenRequest**
- **Remove realm parameter from methods in OAuthClient**
- **Remove unused initiatingIDP parameter**
- **Misc**
