### PR TITLE
BACKPORT: Fix redirect URL for linked accounts in account security section (#36…

### DIFF
--- a/js/apps/account-ui/src/api/methods.ts
+++ b/js/apps/account-ui/src/api/methods.ts
@@ -153,6 +153,8 @@ export async function linkAccount(
       "realms",
       context.environment.realm,
       "account",
+      "account-security",
+      "linked-accounts",
     ),
   );
   const response = await request(


### PR DESCRIPTION
…550)

* Fix redirect URL for linked accounts in account security section

Updated the redirect URL for linked accounts to ensure users are redirected to /realms/<realm-name>/account/account-security/linked-accounts after linking an account.

Closes #36405

Signed-off-by: Somin Park <ps4708@naver.com>

* Remove unnecessary whitespaces

Signed-off-by: Somin Park <ps4708@naver.com>

---------

Signed-off-by: Somin Park <ps4708@naver.com>
(cherry picked from commit 36ff4829d69a8f8aebe8644e9e0fe77c74473ade)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
