### PR TITLE
BACKPORT: Fix clear button for typeaheadMulti dropdowns. (#37152)

### DIFF
--- a/js/libs/ui-shared/src/controls/select-control/TypeaheadSelectControl.tsx
+++ b/js/libs/ui-shared/src/controls/select-control/TypeaheadSelectControl.tsx
@@ -59,6 +59,7 @@ export const TypeaheadSelectControl = <
   const [focusedItemIndex, setFocusedItemIndex] = useState<number>(0);
   const textInputRef = useRef<HTMLInputElement>();
   const required = getRuleValue(controller.rules?.required) === true;
+  const isTypeaheadMulti = variant === SelectVariant.typeaheadMulti;
 
   const filteredOptions = options.filter((option) =>
     getValue(option).toLowerCase().startsWith(filterValue.toLowerCase()),
@@ -89,7 +90,7 @@ export const TypeaheadSelectControl = <
       case "Enter": {
         event.preventDefault();
 
-        if (variant !== SelectVariant.typeaheadMulti) {
+        if (!isTypeaheadMulti) {
           setFilterValue(getValue(focusedItem));
         } else {
           setFilterValue("");
@@ -246,7 +247,7 @@ export const TypeaheadSelectControl = <
                         variant="plain"
                         onClick={() => {
                           setFilterValue("");
-                          field.onChange("");
+                          field.onChange(isTypeaheadMulti ? [] : "");
                           textInputRef?.current?.focus();
                         }}
                         aria-label="Clear input value"
@@ -261,10 +262,7 @@ export const TypeaheadSelectControl = <
             onSelect={(event, v) => {
               event?.stopPropagation();
               const option = v?.toString();
-              if (
-                variant === SelectVariant.typeaheadMulti &&
-                Array.isArray(field.value)
-              ) {
+              if (isTypeaheadMulti && Array.isArray(field.value)) {
                 if (field.value.includes(option)) {
                   field.onChange(
                     field.value.filter((item: string) => item !== option),


### PR DESCRIPTION
* Fix clear button for typeaheadMulti dropdowns.

Fixes #36842

Signed-off-by: Stan Silvert <ssilvert@redhat.com>

* Fix refactored conditional.

Fixes #36842

Signed-off-by: Stan Silvert <ssilvert@redhat.com>

---------

Signed-off-by: Stan Silvert <ssilvert@redhat.com>
(cherry picked from commit 7cb2397172130cb80fef97a242c66e14042fdcec)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
