### PR TITLE
Make sure resources are properly managed when updating permissions

### DIFF
--- a/js/apps/admin-ui/src/permissions-configuration/permission-configuration/permission-type/Users.tsx
+++ b/js/apps/admin-ui/src/permissions-configuration/permission-configuration/permission-type/Users.tsx
@@ -8,8 +8,11 @@ import { UserSelect } from "../../../components/users/UserSelect";
 export const Users = () => {
   const { t } = useTranslation();
   const form = useFormContext();
+  const resourceIds: string[] = form.getValues("resources");
   const [isSpecificUsers, setIsSpecificUsers] = useState(
-    form.getValues("resources").length > 0,
+    resourceIds.filter((id) => {
+      return "Users" !== id;
+    }).length > 0,
   );
 
   return (

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AdminPermissionsSchema.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AdminPermissionsSchema.java
@@ -158,6 +158,10 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
         return !type.equals("resource");
     }
 
+    public boolean isAdminPermissionClient(RealmModel realm, String id) {
+        return realm.getAdminPermissionsClient() != null && realm.getAdminPermissionsClient().getId().equals(id);
+    }
+
     private boolean supportsAuthorizationSchema(KeycloakSession session, ResourceServer resourceServer) {
         RealmModel realm = session.getContext().getRealm();
 
@@ -166,10 +170,6 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
         }
 
         return isAdminPermissionClient(realm, resourceServer.getId());
-    }
-
-    private boolean isAdminPermissionClient(RealmModel realm, String id) {
-        return realm.getAdminPermissionsClient() != null && realm.getAdminPermissionsClient().getId().equals(id);
     }
 
     public void throwExceptionIfAdminPermissionClient(KeycloakSession session, String id) {
@@ -182,7 +182,7 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
         RealmModel realm = session.getContext().getRealm();
         GroupModel group = session.groups().getGroupById(realm, id);
 
-        return group == null ? null : group.getId();
+        return group == null ? GROUPS_RESOURCE_TYPE : group.getId();
     }
 
     private String resolveUser(KeycloakSession session, String id) {
@@ -193,7 +193,7 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
             user = session.users().getUserByUsername(realm, id);
         }
 
-        return user == null ? null : user.getId();
+        return user == null ? USERS_RESOURCE_TYPE : user.getId();
     }
 
     private String resolveClient(KeycloakSession session, String id) {
@@ -204,7 +204,7 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
             client = session.clients().getClientByClientId(realm, id);
         }
 
-        return client == null ? null : client.getId();
+        return client == null ? CLIENTS_RESOURCE_TYPE : client.getId();
     }
 
     private StoreFactory getStoreFactory(KeycloakSession session) {
@@ -306,7 +306,6 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
         } else {
             policy.removeResource(resource);
         }
-
     }
 
     //for deletion
@@ -347,5 +346,19 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
         }
 
         return resource.getDisplayName();
+    }
+
+    public void addUResourceTypeResource(KeycloakSession session, ResourceServer resourceServer, Policy policy, String resourceType) {
+        Resource resourceTypeResource = getResourceTypeResource(session, resourceServer, resourceType);
+
+        if (resourceTypeResource != null) {
+            Set<Resource> resources = policy.getResources();
+
+            if (resources.isEmpty()) {
+                policy.addResource(resourceTypeResource);
+            } else if (resources.size() > 1) {
+                policy.removeResource(resourceTypeResource);
+            }
+        }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -1250,6 +1250,8 @@ public class RepresentationToModel {
                         throw new RuntimeException(e);
                     }
                 }
+
+                representation.setResources(resources);
             }
 
             if (scopes == null) {
@@ -1262,6 +1264,8 @@ public class RepresentationToModel {
                         throw new RuntimeException(e);
                     }
                 }
+
+                representation.setScopes(scopes);
             }
 
             if (policies == null) {
@@ -1274,6 +1278,8 @@ public class RepresentationToModel {
                         throw new RuntimeException(e);
                     }
                 }
+
+                representation.setPolicies(policies);
             }
 
             model.setConfig(policy.getConfig());
@@ -1281,9 +1287,9 @@ public class RepresentationToModel {
 
         StoreFactory storeFactory = authorization.getStoreFactory();
 
-        updateResources(resources, model, authorization);
-        updateScopes(scopes, model, storeFactory);
-        updateAssociatedPolicies(policies, model, storeFactory);
+        updateResources(representation, model, authorization);
+        updateScopes(representation, model, storeFactory);
+        updateAssociatedPolicies(representation, model, storeFactory);
 
         PolicyProviderFactory provider = authorization.getProviderFactory(model.getType());
 
@@ -1305,165 +1311,177 @@ public class RepresentationToModel {
         return model;
     }
 
-    private static void updateScopes(Set<String> scopeIds, Policy policy, StoreFactory storeFactory) {
-        if (scopeIds != null) {
-            if (scopeIds.isEmpty()) {
-                for (Scope scope : new HashSet<Scope>(policy.getScopes())) {
-                    policy.removeScope(scope);
-                }
-                return;
+    private static void updateScopes(AbstractPolicyRepresentation representation, Policy policy, StoreFactory storeFactory) {
+        Set<String> scopeIds = representation.getScopes();
+
+        if (scopeIds == null) {
+            return;
+        }
+
+        if (scopeIds.isEmpty()) {
+            for (Scope scope : new HashSet<Scope>(policy.getScopes())) {
+                policy.removeScope(scope);
             }
-            ResourceServer resourceServer = policy.getResourceServer();
-            for (String scopeId : scopeIds) {
-                boolean hasScope = false;
-
-                for (Scope scopeModel : new HashSet<Scope>(policy.getScopes())) {
-                    if (scopeModel.getId().equals(scopeId) || scopeModel.getName().equals(scopeId)) {
-                        hasScope = true;
-                    }
-                }
-                if (!hasScope) {
-                    Scope scope = storeFactory.getScopeStore().findById(resourceServer, scopeId);
-
-                    if (scope == null) {
-                        scope = storeFactory.getScopeStore().findByName(resourceServer, scopeId);
-                        if (scope == null) {
-                            throw new RuntimeException("Scope with id or name [" + scopeId + "] does not exist");
-                        }
-                    }
-
-                    policy.addScope(scope);
-                }
-            }
+            return;
+        }
+        ResourceServer resourceServer = policy.getResourceServer();
+        for (String scopeId : scopeIds) {
+            boolean hasScope = false;
 
             for (Scope scopeModel : new HashSet<Scope>(policy.getScopes())) {
-                boolean hasScope = false;
+                if (scopeModel.getId().equals(scopeId) || scopeModel.getName().equals(scopeId)) {
+                    hasScope = true;
+                }
+            }
+            if (!hasScope) {
+                Scope scope = storeFactory.getScopeStore().findById(resourceServer, scopeId);
 
-                for (String scopeId : scopeIds) {
-                    if (scopeModel.getId().equals(scopeId) || scopeModel.getName().equals(scopeId)) {
-                        hasScope = true;
+                if (scope == null) {
+                    scope = storeFactory.getScopeStore().findByName(resourceServer, scopeId);
+                    if (scope == null) {
+                        throw new RuntimeException("Scope with id or name [" + scopeId + "] does not exist");
                     }
                 }
-                if (!hasScope) {
-                    policy.removeScope(scopeModel);
+
+                policy.addScope(scope);
+            }
+        }
+
+        for (Scope scopeModel : new HashSet<Scope>(policy.getScopes())) {
+            boolean hasScope = false;
+
+            for (String scopeId : scopeIds) {
+                if (scopeModel.getId().equals(scopeId) || scopeModel.getName().equals(scopeId)) {
+                    hasScope = true;
                 }
+            }
+            if (!hasScope) {
+                policy.removeScope(scopeModel);
             }
         }
 
         policy.removeConfig("scopes");
     }
 
-    private static void updateAssociatedPolicies(Set<String> policyIds, Policy policy, StoreFactory storeFactory) {
+    private static void updateAssociatedPolicies(AbstractPolicyRepresentation representation, Policy policy, StoreFactory storeFactory) {
         ResourceServer resourceServer = policy.getResourceServer();
+        Set<String> policyIds = representation.getPolicies();
 
-        if (policyIds != null) {
-            if (policyIds.isEmpty()) {
-                for (Policy associated: new HashSet<Policy>(policy.getAssociatedPolicies())) {
-                    policy.removeAssociatedPolicy(associated);
-                }
-                return;
+        if (policyIds == null) {
+            return;
+        }
+
+        if (policyIds.isEmpty()) {
+            for (Policy associated: new HashSet<Policy>(policy.getAssociatedPolicies())) {
+                policy.removeAssociatedPolicy(associated);
             }
+            return;
+        }
 
-            PolicyStore policyStore = storeFactory.getPolicyStore();
+        PolicyStore policyStore = storeFactory.getPolicyStore();
 
-            for (String policyId : policyIds) {
-                boolean hasPolicy = false;
-
-                for (Policy policyModel : new HashSet<Policy>(policy.getAssociatedPolicies())) {
-                    if (policyModel.getId().equals(policyId) || policyModel.getName().equals(policyId)) {
-                        hasPolicy = true;
-                    }
-                }
-
-                if (!hasPolicy) {
-                    Policy associatedPolicy = policyStore.findById(resourceServer, policyId);
-
-                    if (associatedPolicy == null) {
-                        associatedPolicy = policyStore.findByName(resourceServer, policyId);
-                        if (associatedPolicy == null) {
-                            throw new RuntimeException("Policy with id or name [" + policyId + "] does not exist");
-                        }
-                    }
-
-                    policy.addAssociatedPolicy(associatedPolicy);
-                }
-            }
+        for (String policyId : policyIds) {
+            boolean hasPolicy = false;
 
             for (Policy policyModel : new HashSet<Policy>(policy.getAssociatedPolicies())) {
-                boolean hasPolicy = false;
+                if (policyModel.getId().equals(policyId) || policyModel.getName().equals(policyId)) {
+                    hasPolicy = true;
+                }
+            }
 
-                for (String policyId : policyIds) {
-                    if (policyModel.getId().equals(policyId) || policyModel.getName().equals(policyId)) {
-                        hasPolicy = true;
+            if (!hasPolicy) {
+                Policy associatedPolicy = policyStore.findById(resourceServer, policyId);
+
+                if (associatedPolicy == null) {
+                    associatedPolicy = policyStore.findByName(resourceServer, policyId);
+                    if (associatedPolicy == null) {
+                        throw new RuntimeException("Policy with id or name [" + policyId + "] does not exist");
                     }
                 }
-                if (!hasPolicy) {
-                    policy.removeAssociatedPolicy(policyModel);
+
+                policy.addAssociatedPolicy(associatedPolicy);
+            }
+        }
+
+        for (Policy policyModel : new HashSet<Policy>(policy.getAssociatedPolicies())) {
+            boolean hasPolicy = false;
+
+            for (String policyId : policyIds) {
+                if (policyModel.getId().equals(policyId) || policyModel.getName().equals(policyId)) {
+                    hasPolicy = true;
                 }
+            }
+            if (!hasPolicy) {
+                policy.removeAssociatedPolicy(policyModel);
             }
         }
 
         policy.removeConfig("applyPolicies");
     }
 
-    private static void updateResources(Set<String> resourceIds, Policy policy, AuthorizationProvider authorization) {
+    private static void updateResources(AbstractPolicyRepresentation representation, Policy policy, AuthorizationProvider authorization) {
+        Set<String> resourceIds = representation.getResources();
+
+        if (resourceIds == null) {
+            return;
+        }
+
         StoreFactory storeFactory = authorization.getStoreFactory();
+        KeycloakSession session = authorization.getKeycloakSession();
+        ResourceServer resourceServer = policy.getResourceServer();
 
-        if (resourceIds != null) {
-            if (resourceIds.isEmpty()) {
-                for (Resource resource : new HashSet<>(policy.getResources())) {
-                    policy.removeResource(resource);
-                }
-            }
-
-            ResourceServer resourceServer = policy.getResourceServer();
-            KeycloakSession session = authorization.getKeycloakSession();
-
-            resourceIds = resourceIds.stream().map(id -> {
-                Resource resource = AdminPermissionsSchema.SCHEMA.getOrCreateResource(session, resourceServer, policy.getType(), policy.getResourceType(), id);
-                
-                if (resource == null) {
-                    return id;
-                }
-                
-                return resource.getId();
-            }).collect(Collectors.toSet());
-
-            for (String resourceId : resourceIds) {
-                boolean hasResource = false;
-                for (Resource resourceModel : new HashSet<>(policy.getResources())) {
-                    if (resourceModel.getId().equals(resourceId) || resourceModel.getName().equals(resourceId)) {
-                        hasResource = true;
-                    }
-                }
-                if (!hasResource && !"".equals(resourceId)) {
-                    Resource resource = storeFactory.getResourceStore().findById(resourceServer, resourceId);
-
-                    if (resource == null) {
-                        resource = storeFactory.getResourceStore().findByName(resourceServer, resourceId);
-                        if (resource == null) {
-                            throw new RuntimeException("Resource with id or name [" + resourceId + "] does not exist or is not owned by the resource server");
-                        }
-                    }
-
-                    policy.addResource(resource);
-                }
-            }
-
-            for (Resource resourceModel : new HashSet<>(policy.getResources())) {
-                boolean hasResource = false;
-
-                for (String resourceId : resourceIds) {
-                    if (resourceModel.getId().equals(resourceId) || resourceModel.getName().equals(resourceId)) {
-                        hasResource = true;
-                    }
-                }
-
-                if (!hasResource) {
-                    AdminPermissionsSchema.SCHEMA.removeResource(resourceModel, policy, authorization);
-                }
+        if (resourceIds.isEmpty()) {
+            for (Resource resource : new HashSet<>(policy.getResources())) {
+                AdminPermissionsSchema.SCHEMA.removeResource(resource, policy, authorization);
             }
         }
+
+        resourceIds = resourceIds.stream().map(id -> {
+            Resource resource = AdminPermissionsSchema.SCHEMA.getOrCreateResource(session, resourceServer, policy.getType(), policy.getResourceType(), id);
+
+            if (resource == null) {
+                return id;
+            }
+
+            return resource.getId();
+        }).collect(Collectors.toSet());
+
+        for (String resourceId : resourceIds) {
+            boolean hasResource = false;
+            for (Resource resourceModel : new HashSet<>(policy.getResources())) {
+                if (resourceModel.getId().equals(resourceId) || resourceModel.getName().equals(resourceId)) {
+                    hasResource = true;
+                }
+            }
+            if (!hasResource && !"".equals(resourceId)) {
+                Resource resource = storeFactory.getResourceStore().findById(resourceServer, resourceId);
+
+                if (resource == null) {
+                    resource = storeFactory.getResourceStore().findByName(resourceServer, resourceId);
+                    if (resource == null) {
+                        throw new RuntimeException("Resource with id or name [" + resourceId + "] does not exist or is not owned by the resource server");
+                    }
+                }
+
+                policy.addResource(resource);
+            }
+        }
+
+        for (Resource resourceModel : new HashSet<>(policy.getResources())) {
+            boolean hasResource = false;
+
+            for (String resourceId : resourceIds) {
+                if (resourceModel.getId().equals(resourceId) || resourceModel.getName().equals(resourceId)) {
+                    hasResource = true;
+                }
+            }
+
+            if (!hasResource) {
+                AdminPermissionsSchema.SCHEMA.removeResource(resourceModel, policy, authorization);
+            }
+        }
+
+        AdminPermissionsSchema.SCHEMA.addUResourceTypeResource(session, resourceServer, policy, representation.getResourceType());
 
         policy.removeConfig("resources");
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissionsV2.java
@@ -45,10 +45,6 @@ class MgmtPermissionsV2 extends MgmtPermissions {
         super(session, adminsRealm, admin);
     }
 
-    public MgmtPermissionsV2(KeycloakSession session, RealmModel realm, RealmModel adminsRealm, UserModel admin) {
-        super(session, realm, adminsRealm, admin);
-    }
-
     @Override
     public ClientModel getRealmPermissionsClient() {
         return realm.getAdminPermissionsClient();

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissionsV2.java
@@ -53,6 +53,15 @@ class UserPermissionsV2 extends UserPermissions {
     }
 
     @Override
+    public boolean canView() {
+        if (root.hasOneAdminRole(AdminRoles.MANAGE_USERS, AdminRoles.VIEW_USERS)) {
+            return true;
+        }
+
+        return hasPermission((UserModel) null, null, AdminPermissionsSchema.VIEW, AdminPermissionsSchema.MANAGE);
+    }
+
+    @Override
     public boolean canManage(UserModel user) {
         if (root.hasOneAdminRole(AdminRoles.MANAGE_USERS)) {
             return true;

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
@@ -65,7 +65,7 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ManagedClient;
 
 @KeycloakIntegrationTest(config = KeycloakAdminPermissionsServerConfig.class)
-public class PermissionClientTest extends AbstractPermissionTest {
+public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
 
     @InjectAdminClient(mode = InjectAdminClient.Mode.MANAGED_REALM, client = "myclient", user = "myadmin")
     Keycloak realmAdminClient;

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypePermissionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypePermissionTest.java
@@ -21,6 +21,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -28,10 +30,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 import jakarta.ws.rs.NotFoundException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ScopePermissionResource;
 import org.keycloak.admin.client.resource.ScopePermissionsResource;
 import org.keycloak.authorization.AdminPermissionsSchema;
@@ -173,6 +177,36 @@ public class UserResourceTypePermissionTest extends AbstractPermissionTest {
         } catch (Exception ex) {
             assertThat(ex, instanceOf(NotFoundException.class));
         }
+    }
+
+    @Test
+    public void testUpdatePermissionResources() {
+        AuthorizationResource authorization = client.admin().authorization();
+        ScopePermissionRepresentation representation = createAllUserPermission();
+        representation = getScopePermissionsResource(client).findByName(representation.getName());
+        assertThat(representation, notNullValue());
+        List<ResourceRepresentation> resources = authorization.resources().resources();
+        assertThat(resources.size(), is(AdminPermissionsSchema.SCHEMA.getResourceTypes().size()));
+        ScopePermissionResource permission = authorization.permissions().scope().findById(representation.getId());
+        List<ResourceRepresentation> permissionResources = permission.resources();
+        assertThat(permissionResources.size(), is(1));
+        assertThat(permissionResources.get(0).getName(), is(AdminPermissionsSchema.USERS.getType()));
+
+        representation.setResources(Set.of(userAlice.getId()));
+        permission.update(representation);
+        resources = authorization.resources().resources();
+        assertThat(resources.size(), is(AdminPermissionsSchema.SCHEMA.getResourceTypes().size() + 1));
+        permissionResources = permission.resources();
+        assertThat(permissionResources.size(), is(1));
+        assertThat(permissionResources.get(0).getName(), is(userAlice.getId()));
+
+        representation.setResources(Set.of());
+        permission.update(representation);
+        resources = authorization.resources().resources();
+        assertThat(resources.size(), is(AdminPermissionsSchema.SCHEMA.getResourceTypes().size()));
+        permissionResources = permission.resources();
+        assertThat(permissionResources.size(), is(1));
+        assertThat(permissionResources.get(0).getName(), is(AdminPermissionsSchema.USERS.getType()));
     }
 
     private ScopePermissionRepresentation createUserPermission(ManagedUser... users) {


### PR DESCRIPTION
Closes #37337

* Allow updating permission to enforce access to all resources or to specific resources
* Fix a bug where checking if an admin can view all users is delegating to v1 code and impacting how users are filtered in lists because it won't take into account permissions set to the `Users` resource.
* Fix a regression in the UI after the change to associate permissions that apply to all resources with their corresponding resource type resource (e.g.: `Users`) causing the field `Enforce access to` to show the wrong option.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
