### PR TITLE
Reject token exchange request if the requested audience is not present

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -199,7 +199,9 @@ public final class Constants {
     // Note used to store the acr values if it is matched by client policy condition
     public static final String CLIENT_POLICY_REQUESTED_ACR = "client-policy-requested-acr";
 
-    //attribute name used to set client ids from requested audience in standard token exchange
-    public static final String REQUESTED_AUDIENCE_CLIENT_IDS = "audience-client-ids";
+    //attribute name used to set clients from requested audience in standard token exchange
+    public static final String REQUESTED_AUDIENCE_CLIENTS = "req-aud-clients";
+    // claim used in refresh token to know the requested audience
+    public static final String REQUESTED_AUDIENCE = "req-aud";
 
 }

--- a/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
+++ b/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
@@ -267,8 +267,10 @@ public class DefaultClientSessionContext implements ClientSessionContext {
         clientScopeRoles = RoleUtils.expandCompositeRoles(clientScopeRoles);
 
         //remove roles that are not contained in requested audience
-        if (attributes.get(Constants.REQUESTED_AUDIENCE_CLIENT_IDS) != null) {
-            Set<String> requestedClientIdsFromAudience = Arrays.stream(getAttribute(Constants.REQUESTED_AUDIENCE_CLIENT_IDS, String[].class)).collect(Collectors.toSet());
+        if (attributes.get(Constants.REQUESTED_AUDIENCE_CLIENTS) != null) {
+            final Set<String> requestedClientIdsFromAudience = Arrays.stream(getAttribute(Constants.REQUESTED_AUDIENCE_CLIENTS, ClientModel[].class))
+                    .map(ClientModel::getId)
+                    .collect(Collectors.toSet());
             clientScopeRoles.removeIf(role-> role.isClientRole() && !requestedClientIdsFromAudience.contains(role.getContainerId()));
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/TokenExchangeTestUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/TokenExchangeTestUtils.java
@@ -94,6 +94,7 @@ public class TokenExchangeTestUtils {
         clientExchanger.addProtocolMapper(AudienceProtocolMapper.createClaimMapper("different-scope-client-audience", differentScopeClient.getClientId(), null, true, false, true));
         clientExchanger.addProtocolMapper(AudienceProtocolMapper.createClaimMapper("allowed-exchanger1", null, "legal", true, false, true));
         clientExchanger.addProtocolMapper(AudienceProtocolMapper.createClaimMapper("allowed-exchanger2", null, "no-refresh-token", true, false, true));
+        clientExchanger.addProtocolMapper(AudienceProtocolMapper.createClaimMapper("audience-to-itself", "client-exchanger", null, true, false, true));
 
         ClientModel illegal = realm.addClient("illegal");
         illegal.setClientId("illegal");


### PR DESCRIPTION
Closes #37104

Draft for the moment. I'm doing the option to reject the audience because I think that all of us think that it's better. But I have two doubts with this behavior:

1. It's not the same for client scopes. Right now if the exchange request asks for scopes that are invalid (they doesn't exist or are not assigned to the requester client) they are just filtered out. Should we not return an error for them too? Do I file another issue? (Like we do in the auth endpoint right now, I didn't see an issue for that.)
2. In all these issues about restricting things in TE we need to think about the refresh token. The TE allows to obtain a refresh token too (for me it's something weird but it is in v1 and it's in the spec too, although it's said it's not common). I think that it will be expected that if the audience was restricted in TE it will be restricted too after refreshing. I'm doing that adding the info in the refresh token (it's just an idea but we need to do something or say that the refresh token does nothing special, it's just refreshing the token with no special behavior).
