### PR TITLE
Make shebang consistent. 

### DIFF
--- a/.github/actions/conditional/conditional.sh
+++ b/.github/actions/conditional/conditional.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 REPOSITORY="$1"
 REF="$2"

--- a/.github/check-area-labels.sh
+++ b/.github/check-area-labels.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 TEAMS="teams.yml"
 BUG="ISSUE_TEMPLATE/bug.yml"

--- a/.github/scripts/download-node-tooling.sh
+++ b/.github/scripts/download-node-tooling.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 abort() {
   echo $1

--- a/.github/scripts/pr-backport.sh
+++ b/.github/scripts/pr-backport.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 TARGET_REMOTE=upstream
 KEYCLOAK_REPO=https://github.com/keycloak/keycloak

--- a/.github/scripts/pr-find-issues-test.sh
+++ b/.github/scripts/pr-find-issues-test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 # Use this script to test different variants of a PR body.
 
 source ./pr-find-issues.sh

--- a/.github/scripts/pr-find-issues.sh
+++ b/.github/scripts/pr-find-issues.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 PR="$1"
 REPO="$2"

--- a/.github/scripts/prepare-quarkus-next.sh
+++ b/.github/scripts/prepare-quarkus-next.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xeuo pipefail
 
 add_repository() {

--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
+set -x
 
 rm -f /etc/system-fips
 dnf install -y java-21-openjdk-devel

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f /etc/system-fips
 dnf install -y java-21-openjdk-devel crypto-policies-scripts

--- a/.github/scripts/run-ipa-tests.sh
+++ b/.github/scripts/run-ipa-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 

--- a/.github/scripts/run-ipa.sh
+++ b/.github/scripts/run-ipa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 DOCKER=podman

--- a/distribution/licenses-common/check-licenses.sh
+++ b/distribution/licenses-common/check-licenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MODULES=`readlink -f $1`
 LICENSES=`readlink -f $2`

--- a/distribution/licenses-common/download-license-files.sh
+++ b/distribution/licenses-common/download-license-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eEu
 

--- a/distribution/licenses-common/update-licenses.sh
+++ b/distribution/licenses-common/update-licenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR=`dirname $0 | xargs readlink -f`
 cd $DIR/../../

--- a/docs/documentation/build-auto.sh
+++ b/docs/documentation/build-auto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OPTS=$1
 

--- a/docs/documentation/get-version.sh
+++ b/docs/documentation/get-version.sh
@@ -1,3 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 awk '/:project_version:/ { print $2 }' topics/templates/document-attributes.adoc

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,3 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -pl .

--- a/js/util/gh-dependabot-failure-stats.sh
+++ b/js/util/gh-dependabot-failure-stats.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Displays the count of Dependabot PRs opened in the last 7 days
 # and the number of failed Admin UI E2E and Account UI E2E checks.
 

--- a/misc/log/trimmer.sh
+++ b/misc/log/trimmer.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 cd "$(dirname "$0")"
 

--- a/misc/scripts/check-java-version.sh
+++ b/misc/scripts/check-java-version.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ZIP=$1
 JAVAV=$2

--- a/misc/scripts/dependency-report.sh
+++ b/misc/scripts/dependency-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0 | xargs readlink -f)/../../
 

--- a/operator/scripts/build-testing-docker-images.sh
+++ b/operator/scripts/build-testing-docker-images.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 VERSION="${1:-latest}"

--- a/operator/scripts/check-crd-installed.sh
+++ b/operator/scripts/check-crd-installed.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 CRD=$1

--- a/operator/scripts/check-examples-installed.sh
+++ b/operator/scripts/check-examples-installed.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 NAMESPACE=${1:-default}

--- a/operator/scripts/create-olm-bundle.sh
+++ b/operator/scripts/create-olm-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Ex: 21.0.0

--- a/operator/scripts/create-olm-test-catalog.sh
+++ b/operator/scripts/create-olm-test-catalog.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 VERSION=$1

--- a/operator/scripts/create-olm-test-resources.sh
+++ b/operator/scripts/create-olm-test-resources.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 VERSION=$1

--- a/operator/scripts/deploy-examples.sh
+++ b/operator/scripts/deploy-examples.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 NAMESPACE=${1:-default}

--- a/operator/scripts/install-keycloak-operator.sh
+++ b/operator/scripts/install-keycloak-operator.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/operator/scripts/install-olm.sh
+++ b/operator/scripts/install-olm.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 mkdir -p /tmp/olm/

--- a/operator/scripts/olm-testing.sh
+++ b/operator/scripts/olm-testing.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 UUID=${1:-$(git rev-parse --short HEAD)}

--- a/operator/scripts/prepare-olm-test.sh
+++ b/operator/scripts/prepare-olm-test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/operator/scripts/undeploy-examples.sh
+++ b/operator/scripts/undeploy-examples.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 NAMESPACE=${1:-default}

--- a/quarkus/container/ubi-null.sh
+++ b/quarkus/container/ubi-null.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 #set -x

--- a/quarkus/set-quarkus-version.sh
+++ b/quarkus/set-quarkus-version.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright 2022 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 NEW_VERSION=$1
 

--- a/test-framework/db-edb/container/init-and-start-db.sh
+++ b/test-framework/db-edb/container/init-and-start-db.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 PGSETUP_INITDB_OPTIONS="-E UTF-8" ./initdb -A md5 -U $PGUSER --pwfile=<(echo "$PGPASSWORD")

--- a/tests/migration-util/migrate.sh
+++ b/tests/migration-util/migrate.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 mvn -q clean install
 java -jar target/migration-util.jar $1

--- a/testsuite/integration-arquillian/servers/app-server/jboss/common/install-patch.sh
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/common/install-patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "JBOSS_HOME=$JBOSS_HOME"
 
 if [ ! -d "$JBOSS_HOME/bin" ] ; then

--- a/testsuite/integration-arquillian/tests/base/testsuites/base-suite.sh
+++ b/testsuite/integration-arquillian/tests/base/testsuites/base-suite.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 GROUP="$1"
 if [ "$GROUP" == "" ]; then

--- a/testsuite/integration-arquillian/tests/base/testsuites/suite.sh
+++ b/testsuite/integration-arquillian/tests/base/testsuites/suite.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 GROUP="$1"
 if [ "$GROUP" == "" ]; then

--- a/testsuite/model/test-all-profiles.sh
+++ b/testsuite/model/test-all-profiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##
 ## To include test coverage data, use -Djacoco.skip=false parameter.


### PR DESCRIPTION
Closes #34983

- Make shebang consistent (`#!/usr/bin/env bash`) across all sh files.
- Add missing shebang to set-quarkus-version.sh file.