### PR TITLE
Avoid NPE in WebAuthnAuthenticator on unknown user

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -240,7 +240,10 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
                 .detail(WebAuthnConstants.AUTHENTICATED_USER_ID, userId)
                 .detail(WebAuthnConstants.PUBKEY_CRED_ID_ATTR, encodedCredentialID);
             setErrorResponse(context, WEBAUTHN_ERROR_USER_NOT_FOUND, null);
-            context.cancelLogin();
+            /*
+             * Previously, we called context.cancelLogin() here, but this gave potential attackers
+             * information about existing user accounts. To avoid that, we just return here.
+             */
         }
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -195,6 +195,13 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
 
         UserModel user = session.users().getUserById(context.getRealm(), userId);
 
+        if (user == null) {
+            context.getEvent()
+                    .detail(WebAuthnConstants.AUTHENTICATED_USER_ID, userId);
+            setErrorResponse(context, WEBAUTHN_ERROR_USER_NOT_FOUND, null);
+            return;
+        }
+
         AuthenticationRequest authenticationRequest = new AuthenticationRequest(
                 credentialId,
                 authenticatorData,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnRegisterAndLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnRegisterAndLoginTest.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.webauthn;
 
+import jakarta.ws.rs.core.Response;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
@@ -329,6 +330,123 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
         } finally {
             removeFirstCredentialForUser(userId, WebAuthnCredentialModel.TYPE_TWOFACTOR, WEBAUTHN_LABEL);
             removeFirstCredentialForUser(userId, WebAuthnCredentialModel.TYPE_PASSWORDLESS, PASSWORDLESS_LABEL);
+        }
+    }
+
+    // See: https://github.com/keycloak/keycloak/issues/29586
+    @Test
+    @IgnoreBrowserDriver(FirefoxDriver.class)
+    public void webAuthnPasswordlessShouldFailIfUserIsDeletedInBetween() throws IOException {
+
+        final String WEBAUTHN_LABEL = "webauthn";
+        final String PASSWORDLESS_LABEL = "passwordless";
+
+        RealmResource realmResource = testRealm();
+
+        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(realmResource)
+                .setBrowserFlow(webAuthnTogetherPasswordlessFlow())
+                .update()) {
+
+            String username = "webauthn-tester@localhost";
+            String password = "password";
+
+            UserRepresentation user = new UserRepresentation();
+            user.setUsername(username);
+            user.setEnabled(true);
+            user.setFirstName("WebAuthN");
+            user.setLastName("Tester");
+
+            String userId = ApiUtil.createUserAndResetPasswordWithAdminClient(realmResource, user, password, false);
+
+            user = ApiUtil.findUserByUsername(realmResource, username);
+
+            assertThat(user, notNullValue());
+            user.getRequiredActions().add(WebAuthnPasswordlessRegisterFactory.PROVIDER_ID);
+
+            UserResource userResource = realmResource.users().get(user.getId());
+            assertThat(userResource, notNullValue());
+            userResource.update(user);
+
+            user = userResource.toRepresentation();
+            assertThat(user, notNullValue());
+            assertThat(user.getRequiredActions(), hasItem(WebAuthnPasswordlessRegisterFactory.PROVIDER_ID));
+
+            loginUsernamePage.open();
+            loginUsernamePage.login(username);
+
+            passwordPage.assertCurrent();
+            passwordPage.login(password);
+
+            events.clear();
+
+            webAuthnRegisterPage.assertCurrent();
+            webAuthnRegisterPage.clickRegister();
+            webAuthnRegisterPage.registerWebAuthnCredential(WEBAUTHN_LABEL);
+
+            webAuthnRegisterPage.assertCurrent();
+
+            events.expectRequiredAction(EventType.CUSTOM_REQUIRED_ACTION)
+                    .user(userId)
+                    .detail(Details.CUSTOM_REQUIRED_ACTION, WebAuthnRegisterFactory.PROVIDER_ID)
+                    .detail(WebAuthnConstants.PUBKEY_CRED_LABEL_ATTR, WEBAUTHN_LABEL)
+                    .assertEvent();
+            events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
+                    .user(userId)
+                    .detail(Details.CUSTOM_REQUIRED_ACTION, WebAuthnRegisterFactory.PROVIDER_ID)
+                    .detail(WebAuthnConstants.PUBKEY_CRED_LABEL_ATTR, WEBAUTHN_LABEL)
+                    .assertEvent();
+
+            webAuthnRegisterPage.clickRegister();
+            webAuthnRegisterPage.registerWebAuthnCredential(PASSWORDLESS_LABEL);
+
+            appPage.assertCurrent();
+
+            logout();
+
+            // Password + WebAuthn Passkey
+            loginUsernamePage.open();
+            loginUsernamePage.assertCurrent();
+            loginUsernamePage.login(username);
+
+            passwordPage.assertCurrent();
+            passwordPage.login(password);
+
+            webAuthnLoginPage.assertCurrent();
+
+            final WebAuthnAuthenticatorsList authenticators = webAuthnLoginPage.getAuthenticators();
+            assertThat(authenticators.getCount(), is(1));
+            assertThat(authenticators.getLabels(), Matchers.contains(WEBAUTHN_LABEL));
+
+            webAuthnLoginPage.clickAuthenticate();
+
+            appPage.assertCurrent();
+            logout();
+
+            // Only passwordless login
+            loginUsernamePage.open();
+            loginUsernamePage.login(username);
+
+            passwordPage.assertCurrent();
+            passwordPage.assertTryAnotherWayLinkAvailability(true);
+            passwordPage.clickTryAnotherWayLink();
+
+            selectAuthenticatorPage.assertCurrent();
+            assertThat(selectAuthenticatorPage.getLoginMethodHelpText(SelectAuthenticatorPage.SECURITY_KEY),
+                    is("Use your Passkey for passwordless sign in."));
+            selectAuthenticatorPage.selectLoginMethod(SelectAuthenticatorPage.SECURITY_KEY);
+
+            webAuthnLoginPage.assertCurrent();
+            assertThat(webAuthnLoginPage.getAuthenticators().getCount(), is(0));
+
+            // remove testuser before user authenticates via webauthn
+            try (Response resp = realmResource.users().delete(userId)) {
+                // ignore
+            }
+
+            webAuthnLoginPage.clickAuthenticate();
+
+            webAuthnErrorPage.assertCurrent();
+            assertThat(webAuthnErrorPage.getError(), is("Unknown user authenticated by the Passkey."));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnErrorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnErrorTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.webauthn.account;
 
+import jakarta.ws.rs.core.Response;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Test;
@@ -83,6 +84,49 @@ public class WebAuthnErrorTest extends AbstractWebAuthnAccountTest {
 
             webAuthnErrorPage.assertCurrent();
             assertThat(webAuthnErrorPage.getError(), is("Failed to authenticate by the Passkey."));
+        }
+    }
+
+    // See: https://github.com/keycloak/keycloak/issues/29586
+    @Test
+    @IgnoreBrowserDriver(FirefoxDriver.class)
+    public void errorPageIfUserDeletedDuringAuthentication() throws IOException {
+
+        final String authenticatorLabel = "authenticator";
+        addWebAuthnCredential(authenticatorLabel);
+
+        try (RealmAttributeUpdater u = new WebAuthnRealmAttributeUpdater(testRealmResource())
+                .update()) {
+
+            RealmRepresentation realm = testRealmResource().toRepresentation();
+            assertThat(realm, notNullValue());
+
+            final int webAuthnCount = webAuthnCredentialType.getUserCredentialsCount();
+            assertThat(webAuthnCount, is(1));
+
+            getWebAuthnManager().getCurrent().getAuthenticator().removeAllCredentials();
+
+            setUpWebAuthnFlow("webAuthnFlow");
+            logout();
+
+            signingInPage.navigateTo();
+            loginToAccount();
+
+            webAuthnLoginPage.assertCurrent();
+
+            final WebAuthnAuthenticatorsList authenticators = webAuthnLoginPage.getAuthenticators();
+            assertThat(authenticators.getCount(), is(1));
+            assertThat(authenticators.getLabels(), Matchers.contains(authenticatorLabel));
+
+            // remove testuser before user authenticates via webauthn
+            try (Response resp = testRealmResource().users().delete(testUser.getId())) {
+                // ignore
+            }
+
+            webAuthnLoginPage.clickAuthenticate();
+
+            webAuthnErrorPage.assertCurrent();
+            assertThat(webAuthnErrorPage.getError(), is("Unknown user authenticated by the Passkey."));
         }
     }
 }


### PR DESCRIPTION
We now check if the user returned by the userId lookup exists. If the user does not exist, we show an `WEBAUTHN_ERROR_USER_NOT_FOUND` error in the form.

Fixes #29586

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
