### PR TITLE
Add feature flag for setting header type "at+jwt" in access tokens

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -134,6 +134,8 @@ public class Profile {
         IPA_TUURA_FEDERATION("IPA-Tuura user federation provider", Type.EXPERIMENTAL),
 
         ROLLING_UPDATES("Rolling Updates", Type.PREVIEW),
+
+        JWT_ACCESS_TOKEN_TYPE_RFC9068("Access tokens get header type 'at+jwt'", Type.EXPERIMENTAL),
         ;
 
         private final Type type;

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -19,6 +19,7 @@ package org.keycloak.jose.jws;
 import org.jboss.logging.Logger;
 import org.keycloak.Token;
 import org.keycloak.TokenCategory;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.CekManagementProvider;
@@ -238,6 +239,10 @@ public class DefaultTokenManager implements TokenManager {
 
     private String type(TokenCategory category) {
         switch (category) {
+            case ACCESS:
+                return Profile.isFeatureEnabled(Profile.Feature.JWT_ACCESS_TOKEN_TYPE_RFC9068)
+                    ? TokenUtil.TOKEN_TYPE_JWT_ACCESS_TOKEN
+                    : "JWT";
             case LOGOUT:
                 return TokenUtil.TOKEN_TYPE_JWT_LOGOUT_TOKEN;
             default:


### PR DESCRIPTION
Add feature flag for setting header type "at+jwt" in OAuth 2 access tokens to comply with RFC 9068.

See https://datatracker.ietf.org/doc/html/rfc9068#section-2.1

Closes #36696

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
