### PR TITLE
Password policies like NoUsername should compare in case-insensitive way

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/NotContainsUsernamePasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/NotContainsUsernamePasswordPolicyProvider.java
@@ -36,7 +36,7 @@ public class NotContainsUsernamePasswordPolicyProvider implements PasswordPolicy
         if (username == null) {
             return null;
         }
-        return password.contains(username) ? new PolicyError(ERROR_MESSAGE) : null;
+        return password.toLowerCase().contains(username.toLowerCase()) ? new PolicyError(ERROR_MESSAGE) : null;
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/policy/NotEmailPasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/NotEmailPasswordPolicyProvider.java
@@ -42,7 +42,7 @@ public class NotEmailPasswordPolicyProvider implements PasswordPolicyProvider {
         if (email == null) {
             return null;
         }
-        return email.equals(password) ? POLICY_ERROR : null;
+        return email.equalsIgnoreCase(password) ? POLICY_ERROR : null;
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/policy/NotUsernamePasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/NotUsernamePasswordPolicyProvider.java
@@ -39,7 +39,7 @@ public class NotUsernamePasswordPolicyProvider implements PasswordPolicyProvider
         if (username == null) {
             return null;
         }
-        return username.equals(password) ? new PolicyError(ERROR_MESSAGE) : null;
+        return username.equalsIgnoreCase(password) ? new PolicyError(ERROR_MESSAGE) : null;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -581,6 +581,12 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             assertTrue(registerPage.isCurrent());
             assertEquals("Invalid password: must not be equal to the username.", registerPage.getInputPasswordErrors().getPasswordError());
 
+            // Case-sensitivity - still should not allow to create password when lower-cased
+            registerPage.register("firstName", "lastName", "registerUserNotUsername@email", "registerUserNotUsername", "registerusernotusername", "registerusernotusername");
+
+            assertTrue(registerPage.isCurrent());
+            assertEquals("Invalid password: must not be equal to the username.", registerPage.getInputPasswordErrors().getPasswordError());
+
             try (Response response = adminClient.realm("test").users().create(UserBuilder.create().username("registerUserNotUsername").build())) {
                 assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
             }
@@ -616,6 +622,12 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             assertTrue(registerPage.isCurrent());
             assertEquals("Invalid password: Can not contain the username.", registerPage.getInputPasswordErrors().getPasswordError());
 
+            // Case-sensitivity - still should not allow to create password when lower-cased
+            registerPage.register("firstName", "lastName", "registerUserNotUsername@email", "Bob", "123bob", "123bob");
+
+            assertTrue(registerPage.isCurrent());
+            assertEquals("Invalid password: Can not contain the username.", registerPage.getInputPasswordErrors().getPasswordError());
+
             try (Response response = adminClient.realm("test").users().create(UserBuilder.create().username("Bob").build())) {
                 assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
             }
@@ -646,6 +658,12 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             registerPage.assertCurrent();
 
             registerPage.registerWithEmailAsUsername("firstName", "lastName", "registerUserNotEmail@email", "registerUserNotEmail@email", "registerUserNotEmail@email");
+
+            assertTrue(registerPage.isCurrent());
+            assertEquals("Invalid password: must not be equal to the email.", registerPage.getInputPasswordErrors().getPasswordError());
+
+            // Case-sensitivity - still should not allow to create password when lower-cased
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", "registerUserNotEmail@email", "registerusernotemail@email", "registerusernotemail@email");
 
             assertTrue(registerPage.isCurrent());
             assertEquals("Invalid password: must not be equal to the email.", registerPage.getInputPasswordErrors().getPasswordError());


### PR DESCRIPTION
closes #37431

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 2bcd2dbe74ac038c1b56b51b49087a9818541f2a)
