### PR TITLE
[js][libs][keycloak-admin-client] Fix missing props from OrganizationRepresentation

### DIFF
--- a/js/libs/keycloak-admin-client/src/defs/memberRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/memberRepresentation.ts
@@ -1,0 +1,5 @@
+import type UserRepresentation from './userRepresentation.js';
+
+export default interface MemberRepresentation extends UserRepresentation {
+  membershipType?: string;
+}

--- a/js/libs/keycloak-admin-client/src/defs/memberRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/memberRepresentation.ts
@@ -1,4 +1,4 @@
-import type UserRepresentation from './userRepresentation.js';
+import type UserRepresentation from "./userRepresentation.js";
 
 export default interface MemberRepresentation extends UserRepresentation {
   membershipType?: string;

--- a/js/libs/keycloak-admin-client/src/defs/organizationRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/organizationRepresentation.ts
@@ -1,11 +1,16 @@
 import type OrganizationDomainRepresentation from "./organizationDomainRepresentation.js";
+import type IdentityProviderRepresentation from './identityProviderRepresentation.js';
+import type MemberRepresentation from './memberRepresentation.js';
 
 export default interface OrganizationRepresentation {
   id?: string;
   name?: string;
+  alias?: string;
   description?: string;
   redirectUrl?: string;
   enabled?: boolean;
   attributes?: Record<string, string[]>;
   domains?: OrganizationDomainRepresentation[];
+  members?: MemberRepresentation[];
+  identityProviders?: IdentityProviderRepresentation[];
 }

--- a/js/libs/keycloak-admin-client/src/defs/organizationRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/organizationRepresentation.ts
@@ -1,6 +1,6 @@
 import type OrganizationDomainRepresentation from "./organizationDomainRepresentation.js";
-import type IdentityProviderRepresentation from './identityProviderRepresentation.js';
-import type MemberRepresentation from './memberRepresentation.js';
+import type IdentityProviderRepresentation from "./identityProviderRepresentation.js";
+import type MemberRepresentation from "./memberRepresentation.js";
 
 export default interface OrganizationRepresentation {
   id?: string;


### PR DESCRIPTION
As per [the API docs](https://www.keycloak.org/docs-api/latest/rest-api/index.html#OrganizationRepresentation), `OrganizationRepresentation` should have `alias`, `members` and `identityProviders` properties, but these are missing from `@keycloak/keycloak-admin-client`, this PR adds the missing props.