### PR TITLE
Add missing parent reference for theme-verifier-maven-plugin

### DIFF
--- a/misc/theme-verifier/pom.xml
+++ b/misc/theme-verifier/pom.xml
@@ -20,6 +20,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-parent</artifactId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
     <groupId>org.keycloak</groupId>
     <artifactId>theme-verifier-maven-plugin</artifactId>
     <version>999.0.0-SNAPSHOT</version>
@@ -99,14 +106,28 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nxrm3-maven-plugin</artifactId>
-                <configuration>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>nexus3-staging</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nxrm3-maven-plugin</artifactId>
+                        <version>${nexus3.staging.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>${jboss.releases.repo.id}</serverId>
+                            <nexusUrl>${jboss.repo.nexusUrl}</nexusUrl>
+                            <repository>${jboss.releases.repo.name}</repository>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
The PR for issue #33357 added a new POM, `misc/theme-verifier/pom.xml`, corresponding to `org.keycloak:theme-verifier-maven-plugin`. This POM does not specify any maven parent POM, when all other POMs that are a part this project specify `org.keycloak:keycloak-parent` as their parent.

This omission has no obvious effect on the standard build, but in some contexts can create a build error as follows:

```
[ERROR] Found multiple major versions of maven-deploy-plugin; this is a malformed project: [org.apache.maven.plugins:maven-deploy-plugin:maven-plugin:3.1.0:runtime, org.apache.maven.plugins:maven-deploy-plugin:maven-plugin:2.8.2:runtime]
```

Exactly why this happens I don't know. My analysis is that `2.8.2` is the version specified by jboss-parent, which is the transitive parent (via keycloak-parent) of all modules in the build except for theme-verifier. In some cases it must default to a different version (`3.1.0`) when there is no parent specified. Since two versions of deploy plugin cannot exist in the same maven build, maven crashes.

This PR adds a reference to keycloak-parent for theme-verifier, which clears this error, and may eliminate other errors that have not yet been discovered. Aligning to a single parent POM for a project is maven best-practice.