### PR TITLE
Skip username validation in user profile when email is used as username

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -162,6 +162,11 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
 
     @Override
     public boolean validate(String name, Consumer<ValidationError>... listeners) {
+        RealmModel realm = session.getContext().getRealm();
+        if (UserModel.USERNAME.equals(name) && realm.isRegistrationEmailAsUsername()) {
+            return true;
+        }
+
         Entry<String, List<String>> attribute = createAttribute(name);
         List<AttributeMetadata> metadatas = new ArrayList<>();
 


### PR DESCRIPTION
* Previously, the **user profile validation** process still validated the username field, even when the realm was configured to use email as the username (realm.isRegistrationEmailAsUsername()). This caused unnecessary validation errors.

* This PR updates the user profile validation logic to **skip username validation** when email is used as the username, preventing incorrect validation failures

Closes #37192

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
