### PR TITLE
Allow TE for clients with consents approved by the user

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -240,6 +240,11 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         if (targetAudienceClients.isEmpty()) {
             targetAudienceClients.add(client);
         }
+        return targetAudienceClients;
+    }
+
+    protected void validateAudience(AccessToken token, boolean disallowOnHolderOfTokenMismatch, List<ClientModel> targetAudienceClients) {
+        ClientModel tokenHolder = token == null ? null : realm.getClientByClientId(token.getIssuedFor());
         for (ClientModel targetClient : targetAudienceClients) {
             if (targetClient.isConsentRequired()) {
                 event.detail(Details.REASON, "audience requires consent");
@@ -253,13 +258,6 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
                 event.error(Errors.CLIENT_DISABLED);
                 throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Client disabled", Response.Status.BAD_REQUEST);
             }
-        }
-        return targetAudienceClients;
-    }
-
-    protected void validateAudience(AccessToken token, boolean disallowOnHolderOfTokenMismatch, List<ClientModel> targetAudienceClients) {
-        ClientModel tokenHolder = token == null ? null : realm.getClientByClientId(token.getIssuedFor());
-        for (ClientModel targetClient : targetAudienceClients) {
             boolean isClientTheAudience = targetClient.equals(client);
             if (isClientTheAudience) {
                 if (client.isPublicClient()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
@@ -21,12 +21,14 @@ package org.keycloak.testsuite.oauth.tokenexchange;
 
 import jakarta.ws.rs.core.Response;
 import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.TokenVerifier;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.Profile;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.AccessToken;
@@ -39,6 +41,8 @@ import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
+import org.keycloak.testsuite.pages.ConsentPage;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.TokenUtil;
 
@@ -62,6 +66,9 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
     @Rule
     public AssertEvents events = new AssertEvents(this);
 
+    @Page
+    protected ConsentPage consentPage;
+
     @Override
     public void addTestRealms(List<RealmRepresentation> testRealms) {
         RealmRepresentation testRealm = loadJson(getClass().getResourceAsStream("/token-exchange/testrealm-token-exchange-v2.json"), RealmRepresentation.class);
@@ -81,8 +88,21 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
         oauth.scope(null);
         oauth.openid(false);
         AccessTokenResponse response = oauth.doGrantAccessTokenRequest(username, password);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
         TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(response.getAccessToken(), AccessToken.class);
-        AccessToken token = accessTokenVerifier.parse().getToken();
+        accessTokenVerifier.parse();
+        return response.getAccessToken();
+    }
+
+    private String loginWithConsents(String username, String password, String clientId, String secret) throws Exception {
+        oauth.client(clientId, secret).doLogin(username, password);
+        consentPage.assertCurrent();
+        consentPage.confirm();
+        assertNotNull(oauth.getCurrentQuery().get(OAuth2Constants.CODE));
+        AccessTokenResponse response = oauth.doAccessTokenRequest(oauth.getCurrentQuery().get(OAuth2Constants.CODE));
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+        TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(response.getAccessToken(), AccessToken.class);
+        accessTokenVerifier.parse();
         return response.getAccessToken();
     }
 
@@ -234,22 +254,18 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
         oauth.realm(TEST);
         String accessToken = resourceOwnerLogin("john", "password","subject-client", "secret");
 
-        ClientResource client = ApiUtil.findClientByClientId(adminClient.realm(TEST), "subject-client");
-        ClientRepresentation clientRepresentation = client.toRepresentation();
-        clientRepresentation.setConsentRequired(Boolean.TRUE);
-        client.update(clientRepresentation);
+        try (ClientAttributeUpdater clientUpdater = ClientAttributeUpdater.forClient(adminClient, TEST, "subject-client")
+                .setConsentRequired(Boolean.TRUE)
+                .update()) {
+            AccessTokenResponse response = tokenExchange(accessToken, "subject-client", "secret", null, null);
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+            assertEquals("Missing consents for Token Exchange in client subject-client", response.getErrorDescription());
 
-        AccessTokenResponse response = tokenExchange(accessToken, "subject-client", "secret", null, null);
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
-        assertEquals("Client requires user consent", response.getErrorDescription());
-
-        response = tokenExchange(accessToken, "subject-client", "secret", List.of("subject-client"), null);
-        assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
-        assertEquals("Client requires user consent", response.getErrorDescription());
-
-        clientRepresentation.setConsentRequired(Boolean.FALSE);
-        client.update(clientRepresentation);
+            response = tokenExchange(accessToken, "subject-client", "secret", List.of("subject-client"), null);
+            assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+            assertEquals("Missing consents for Token Exchange in client subject-client", response.getErrorDescription());
+        }
     }
 
     @Test
@@ -281,14 +297,14 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
         String accessToken = resourceOwnerLogin("john", "password","subject-client", "secret");
         // request invalid client audience
         AccessTokenResponse response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client1", "invalid-client"), null);
-        org.junit.Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        org.junit.Assert.assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
-        org.junit.Assert.assertEquals("Audience not found", response.getErrorDescription());
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_CLIENT, response.getError());
+        assertEquals("Audience not found", response.getErrorDescription());
         // The "target-client3" is valid client, but audience unavailable to the user. Request not allowed
         response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client1", "target-client3"), null);
-        org.junit.Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        org.junit.Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
-        org.junit.Assert.assertEquals("Requested audience not available: target-client3", response.getErrorDescription());
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
+        assertEquals("Requested audience not available: target-client3", response.getErrorDescription());
     }
 
     @Test
@@ -299,24 +315,24 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
         oauth.scope("optional-scope3");
         AccessTokenResponse response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client1", "target-client3"), null);
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        org.junit.Assert.assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
-        org.junit.Assert.assertEquals("Invalid scopes: optional-scope3", response.getErrorDescription());
+        assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+        assertEquals("Invalid scopes: optional-scope3", response.getErrorDescription());
 
         //scope that doesn't exist
         oauth.scope("bad-scope");
         response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client1", "target-client3"), null);
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        org.junit.Assert.assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
-        org.junit.Assert.assertEquals("Invalid scopes: bad-scope", response.getErrorDescription());
+        assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+        assertEquals("Invalid scopes: bad-scope", response.getErrorDescription());
     }
 
     @Test
     public void testScopeFilter() throws Exception {
-        String accessToken = resourceOwnerLogin("john", "password","subject-client", "secret");
+        String accessToken = resourceOwnerLogin("john", "password", "subject-client", "secret");
         AccessTokenResponse response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client2"), null);
-        org.junit.Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        org.junit.Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
-        org.junit.Assert.assertEquals("Requested audience not available: target-client2", response.getErrorDescription());
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
+        assertEquals("Requested audience not available: target-client2", response.getErrorDescription());
 
         oauth.scope("optional-scope2");
         response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client2"), null);
@@ -340,11 +356,11 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
 
     @Test
     public void testScopeParamIncludedAudienceIncludedRefreshToken() throws Exception {
-        String accessToken = resourceOwnerLogin("mike", "password","subject-client", "secret");
+        String accessToken = resourceOwnerLogin("mike", "password", "subject-client", "secret");
         oauth.scope("optional-scope2");
         AccessTokenResponse response = tokenExchange(accessToken, "requester-client", "secret",  List.of("target-client1"), Collections.singletonMap(OAuth2Constants.REQUESTED_TOKEN_TYPE, OAuth2Constants.REFRESH_TOKEN_TYPE));
         assertAudiencesAndScopes(response, List.of("target-client1"), List.of("default-scope1", "optional-scope2"));
-        org.junit.Assert.assertNotNull(response.getRefreshToken());
+        assertNotNull(response.getRefreshToken());
 
         oauth.client("requester-client", "secret");
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
@@ -363,6 +379,44 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
         testingClient.disableFeature(Profile.Feature.DYNAMIC_SCOPES);
     }
 
+    @Test
+    public void testConsents() throws Exception {
+        try (ClientAttributeUpdater clientUpdater = ClientAttributeUpdater.forClient(adminClient, TEST, "requester-client")
+                .setConsentRequired(Boolean.TRUE)
+                .update()) {
+            // initial TE without any consent should fail
+            String accessToken = resourceOwnerLogin("mike", "password", "subject-client", "secret");
+            AccessTokenResponse response = tokenExchange(accessToken, "requester-client", "secret",  null, null);
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+            assertEquals("Missing consents for Token Exchange in client requester-client", response.getErrorDescription());
+
+            // logout
+            UserResource mike = ApiUtil.findUserByUsernameId(adminClient.realm(TEST), "mike");
+            mike.logout();
+
+            // perform a login and allow consent for default scopes, TE should work now
+            accessToken = loginWithConsents("mike", "password", "requester-client", "secret");
+            response = tokenExchange(accessToken, "requester-client", "secret",  null, null);
+            assertAudiencesAndScopes(response,  List.of("target-client1"), List.of("default-scope1"));
+
+            // request TE with optional-scope2 whose consent is missing, should fail
+            oauth.scope("optional-scope2");
+            response = tokenExchange(accessToken, "requester-client", "secret",  null, null);
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+            assertEquals("Missing consents for Token Exchange in client requester-client", response.getErrorDescription());
+
+            // logout
+            mike.logout();
+
+            // consent the additional scope, TE should work now
+            accessToken = loginWithConsents("mike", "password", "requester-client", "secret");
+            response = tokenExchange(accessToken, "requester-client", "secret",  null, null);
+            assertAudiencesAndScopes(response,  List.of("target-client1"), List.of("default-scope1", "optional-scope2"));
+        }
+    }
+
     private void assertAudiences(AccessToken token, List<String> expectedAudiences) {
         MatcherAssert.assertThat("Incompatible audiences", token.getAudience() == null ? List.of() : List.of(token.getAudience()), containsInAnyOrder(expectedAudiences.toArray()));
         MatcherAssert.assertThat("Incompatible resource access", token.getResourceAccess().keySet(), containsInAnyOrder(expectedAudiences.toArray()));
@@ -373,10 +427,11 @@ public class StandardTokenExchangeV2Test extends AbstractKeycloakTest {
     }
 
     private void assertAudiencesAndScopes(AccessTokenResponse tokenExchangeResponse, List<String> expectedAudiences, List<String> expectedScopes) throws Exception {
+        assertEquals(Response.Status.OK.getStatusCode(), tokenExchangeResponse.getStatusCode());
         TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(tokenExchangeResponse.getAccessToken(), AccessToken.class);
         AccessToken token = accessTokenVerifier.parse().getToken();
         if (expectedAudiences == null) {
-            org.junit.Assert.assertNull("Expected token to not contain audience", token.getAudience());
+            assertNull("Expected token to not contain audience", token.getAudience());
         } else {
             assertAudiences(token, expectedAudiences);
         }


### PR DESCRIPTION
Close #37112

Checking the consents are OK for the requested client scopes. The PR moves some validations from the `getTargetAudienceClients` to the `validateAudience` in the abstract class because now the consent is different in V1 and V2. The scopes are just checked  in protected `validateConsents` method using the same `TokenManager.verifyConsentStillAvailable` that is used in other places. Test added.
