### PR TITLE
Upgrade to Quarkus 3.19.0.CR1

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_2_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_2_0.adoc
@@ -13,3 +13,8 @@ would now be `http://example.com`.
 
 To mitigate that, either make your reverse proxy include the port in the `X-Forwarded-Host` header or configure it to set
 the `X-Forwarded-Port` header with the desired port.
+
+=== Changes to installing Oracle JDBC driver
+
+The required JAR for the Oracle JDBC driver that needs to be explicitly added to the distribution has changed.
+Instead of providing `ojdbc11` JAR, use `ojdbc17` JAR as stated in the https://www.keycloak.org/server/db#_installing_the_oracle_database_driver[Installing the Oracle Database driver] guide.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -53,15 +53,15 @@ or skip this section if you want to connect to a different database for which th
 
 To install the Oracle Database driver for {project_name}:
 
-. Download the `ojdbc11` and `orai18n` JAR files from one of the following sources:
+. Download the `ojdbc17` and `orai18n` JAR files from one of the following sources:
 
 .. *Zipped JDBC driver and Companion Jars* version ${properties["oracle-jdbc.version"]} from the https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html[Oracle driver download page].
 
-.. Maven Central via `link:++https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/${properties["oracle-jdbc.version"]}/ojdbc11-${properties["oracle-jdbc.version"]}.jar++[ojdbc11]` and `link:++https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar++[orai18n]`.
+.. Maven Central via `link:++https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc17/${properties["oracle-jdbc.version"]}/ojdbc17-${properties["oracle-jdbc.version"]}.jar++[ojdbc17]` and `link:++https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar++[orai18n]`.
 
 .. Installation media recommended by the database vendor for the specific database in use.
 
-. When running the unzipped distribution: Place the `ojdbc11` and `orai18n` JAR files in {project_name}'s `providers` folder
+. When running the unzipped distribution: Place the `ojdbc17` and `orai18n` JAR files in {project_name}'s `providers` folder
 
 . When running containers: Build a custom {project_name} image and add the JARs in the `providers` folder. When building a custom image for the Operator, those images need to be optimized images with all build-time options of {project_name} set.
 +
@@ -70,7 +70,7 @@ A minimal Containerfile to build an image which can be used with the {project_na
 [source,dockerfile,subs="attributes+"]
 ----
 FROM quay.io/keycloak/keycloak:{containerlabel}
-ADD --chown=keycloak:keycloak --chmod=644 https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/${properties["oracle-jdbc.version"]}/ojdbc11-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/ojdbc11.jar
+ADD --chown=keycloak:keycloak --chmod=644 https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc17/${properties["oracle-jdbc.version"]}/ojdbc17-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/ojdbc17.jar
 ADD --chown=keycloak:keycloak --chmod=644 https://repo1.maven.org/maven2/com/oracle/database/nls/orai18n/${properties["oracle-jdbc.version"]}/orai18n-${properties["oracle-jdbc.version"]}.jar /opt/keycloak/providers/orai18n.jar
 # Setting the build parameter for the database:
 ENV KC_DB=oracle

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.18.3</quarkus.version>
-        <quarkus.build.version>3.18.3</quarkus.build.version>
+        <quarkus.version>3.19.0.CR1</quarkus.version>
+        <quarkus.build.version>3.19.0.CR1</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 
@@ -176,7 +176,7 @@
         <oracledb.version>23.5</oracledb.version>
         <oracledb.container>mirror.gcr.io/gvenzl/oracle-free:${oracledb.version}-slim-faststart</oracledb.container>
         <!-- this is the oracle driver version also used in the Quarkus BOM -->
-        <oracle-jdbc.version>23.5.0.24.07</oracle-jdbc.version>
+        <oracle-jdbc.version>23.6.0.24.10</oracle-jdbc.version>
 
         <!-- Test -->
         <greenmail.version>2.1.0-alpha-1</greenmail.version>

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@SuppressWarnings({"unchecked", "OptionalUsedAsFieldOrParameterType", "rawtypes"})
 public class OptionBuilder<T> {
 
     private static final List<String> BOOLEAN_TYPE_VALUES = List.of(Boolean.TRUE.toString(), Boolean.FALSE.toString());

--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -210,8 +210,8 @@ public final class Database {
                 "mssql"
         ),
         ORACLE("oracle",
-                "oracle.jdbc.xa.client.OracleXADataSource",
-                "oracle.jdbc.driver.OracleDriver",
+                "oracle.jdbc.datasource.OracleXADataSource",
+                "oracle.jdbc.OracleDriver",
                 "org.hibernate.dialect.OracleDialect",
                 "jdbc:oracle:thin:@//${kc.db-url-host:localhost}:${kc.db-url-port:1521}/${kc.db-url-database:keycloak}",
                 asList("liquibase.database.core.OracleDatabase")

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -305,7 +305,7 @@ class KeycloakProcessor {
     @BuildStep
     @Produce(CheckMultipleDatasourcesBuildStep.class)
     void checkMultipleDatasourcesUseXA(TransactionManagerBuildTimeConfig transactionManagerConfig, DataSourcesBuildTimeConfig dataSourcesConfig, DataSourcesJdbcBuildTimeConfig jdbcConfig) {
-        if (transactionManagerConfig.unsafeMultipleLastResources
+        if (transactionManagerConfig.unsafeMultipleLastResources()
                 .orElse(UnsafeMultipleLastResourcesMode.DEFAULT) != UnsafeMultipleLastResourcesMode.FAIL) {
             return;
         }
@@ -383,7 +383,7 @@ class KeycloakProcessor {
                 Properties properties = descriptor.getProperties();
                 // register a listener for customizing the unit configuration at runtime
                 runtimeConfigured.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem("keycloak", descriptor.getName())
-                        .setInitListener(recorder.createUserDefinedUnitListener(properties.getProperty(AvailableSettings.DATASOURCE))));
+                        .setInitListener(recorder.createUserDefinedUnitListener(properties.getProperty(AvailableSettings.JAKARTA_JTA_DATASOURCE))));
                 userManagedEntities.addAll(descriptor.getManagedClassNames());
             }
         }

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -81,7 +81,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ojdbc11</artifactId>
+                    <artifactId>ojdbc17</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.oracle.database.nls</groupId>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ExecutionExceptionHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ExecutionExceptionHandler.java
@@ -32,38 +32,45 @@ import io.smallrye.config.ConfigValue;
 import picocli.CommandLine;
 import picocli.CommandLine.ParseResult;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
 public final class ExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {
 
-    private Logger logger;
+    private static Logger logger;
     private boolean verbose;
+    private static Map<String, Function<Throwable, Throwable>> exceptionTransformers = new HashMap<>();
 
     public ExecutionExceptionHandler() {}
 
     @Override
     public int handleExecutionException(Exception cause, CommandLine cmd, ParseResult parseResult) {
-        if (cause instanceof PropertyException) {
+        var exception = handleExceptionTransformers(cause);
+        if (exception instanceof PropertyException) {
             PrintWriter writer = cmd.getErr();
-            writer.println(cmd.getColorScheme().errorText(cause.getMessage()));
-            if (verbose && cause.getCause() != null) {
-                dumpException(writer, cause.getCause());
+            writer.println(cmd.getColorScheme().errorText(exception.getMessage()));
+            if (verbose && exception.getCause() != null) {
+                dumpException(writer, exception.getCause());
             }
-            return ShortErrorMessageHandler.getInvalidInputExitCode(cause, cmd);
+            return ShortErrorMessageHandler.getInvalidInputExitCode(exception, cmd);
         }
         error(cmd.getErr(), "Failed to run '" + parseResult.subcommands().stream()
                 .map(ParseResult::commandSpec)
                 .map(CommandLine.Model.CommandSpec::name)
                 .findFirst()
-                .orElse(Environment.getCommand()) + "' command.", cause);
+                .orElse(Environment.getCommand()) + "' command.", exception);
         return cmd.getCommandSpec().exitCodeOnExecutionException();
     }
 
     public void error(PrintWriter errorWriter, String message, Throwable cause) {
+        var exception = handleExceptionTransformers(cause);
         if (message != null) {
             logError(errorWriter, "ERROR: " + message);
         }
 
-        if (cause != null) {
-            dumpException(errorWriter, cause);
+        if (exception != null) {
+            dumpException(errorWriter, exception);
 
             if (!verbose) {
                 logError(errorWriter, "For more details run the same command passing the '--verbose' option. Also you can use '--help' to see the details about the usage of the particular command.");
@@ -121,7 +128,7 @@ public final class ExecutionExceptionHandler implements CommandLine.IExecutionEx
         }
     }
 
-    private Logger getLogger() {
+    private static Logger getLogger() {
         if (logger == null) {
             logger = Logger.getLogger(ExecutionExceptionHandler.class);
         }
@@ -130,5 +137,35 @@ public final class ExecutionExceptionHandler implements CommandLine.IExecutionEx
 
     public void setVerbose(boolean verbose) {
         this.verbose = verbose;
+    }
+
+    public static void addExceptionTransformer(Class<?> fromClass, Function<Throwable, Throwable> transformer) {
+        if (exceptionTransformers.get(fromClass.getName()) != null) {
+            getLogger().warnf("Transformer for the '%s' class is overridden", fromClass.getName());
+        }
+        exceptionTransformers.put(fromClass.getName(), transformer);
+    }
+
+    public static void resetExceptionTransformers() {
+        exceptionTransformers = new HashMap<>();
+    }
+
+    private static Throwable handleExceptionTransformers(Throwable exception) {
+        if (exception == null) {
+            return null;
+        }
+
+        if (exceptionTransformers.isEmpty()) {
+            return exception;
+        }
+
+        var stackTrace = exception.getStackTrace();
+        for (var trace : stackTrace) {
+            var transformer = exceptionTransformers.get(trace.getClassName());
+            if (transformer != null) {
+                return transformer.apply(exception);
+            }
+        }
+        return exception;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
@@ -95,7 +95,7 @@ public class ShortErrorMessageHandler implements IParameterExceptionHandler {
         return getInvalidInputExitCode(ex, cmd);
     }
 
-    static int getInvalidInputExitCode(Exception ex, CommandLine cmd) {
+    static int getInvalidInputExitCode(Throwable ex, CommandLine cmd) {
         return cmd.getExitCodeExceptionMapper() != null
                 ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
                 : cmd.getCommandSpec().exitCodeOnInvalidInput();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -73,7 +73,8 @@ public class IgnoredArtifacts {
     public static final Set<String> JDBC_H2 = Set.of(
             "io.quarkus:quarkus-jdbc-h2",
             "io.quarkus:quarkus-jdbc-h2-deployment",
-            "com.h2database:h2"
+            "com.h2database:h2",
+            "org.locationtech.jts:jts-core"
     );
 
     public static final Set<String> JDBC_POSTGRES = Set.of(
@@ -103,7 +104,7 @@ public class IgnoredArtifacts {
     public static final Set<String> JDBC_ORACLE = Set.of(
             "io.quarkus:quarkus-jdbc-oracle",
             "io.quarkus:quarkus-jdbc-oracle-deployment",
-            "com.oracle.database.jdbc:ojdbc11",
+            "com.oracle.database.jdbc:ojdbc17",
             "com.oracle.database.nls:orai18n"
     );
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -45,7 +45,7 @@ public final class LoggingPropertyMappers {
                 // Console
                 fromOption(LoggingOptions.LOG_CONSOLE_OUTPUT)
                         .isEnabled(LoggingPropertyMappers::isConsoleEnabled, CONSOLE_ENABLED_MSG)
-                        .to("quarkus.log.console.json")
+                        .to("quarkus.log.console.json.enabled")
                         .paramLabel("output")
                         .transformer(LoggingPropertyMappers::resolveLogOutput)
                         .build(),
@@ -112,7 +112,7 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE_OUTPUT)
                         .isEnabled(LoggingPropertyMappers::isFileEnabled, FILE_ENABLED_MSG)
-                        .to("quarkus.log.file.json")
+                        .to("quarkus.log.file.json.enabled")
                         .paramLabel("output")
                         .transformer(LoggingPropertyMappers::resolveLogOutput)
                         .build(),
@@ -185,7 +185,7 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_SYSLOG_OUTPUT)
                         .isEnabled(LoggingPropertyMappers::isSyslogEnabled, SYSLOG_ENABLED_MSG)
-                        .to("quarkus.log.syslog.json")
+                        .to("quarkus.log.syslog.json.enabled")
                         .paramLabel("output")
                         .transformer(LoggingPropertyMappers::resolveLogOutput)
                         .build(),
@@ -199,7 +199,7 @@ public final class LoggingPropertyMappers {
     }
 
     public static boolean isConsoleJsonEnabled() {
-        return isConsoleEnabled() && Configuration.isTrue("quarkus.log.console.json");
+        return isConsoleEnabled() && Configuration.isTrue("quarkus.log.console.json.enabled");
     }
 
     public static boolean isFileEnabled() {
@@ -207,7 +207,7 @@ public final class LoggingPropertyMappers {
     }
 
     public static boolean isFileJsonEnabled() {
-        return isFileEnabled() && Configuration.isTrue("quarkus.log.file.json");
+        return isFileEnabled() && Configuration.isTrue("quarkus.log.file.json.enabled");
     }
 
     public static boolean isSyslogEnabled() {
@@ -215,7 +215,7 @@ public final class LoggingPropertyMappers {
     }
 
     public static boolean isSyslogJsonEnabled() {
-        return isSyslogEnabled() && Configuration.isTrue("quarkus.log.syslog.json");
+        return isSyslogEnabled() && Configuration.isTrue("quarkus.log.syslog.json.enabled");
     }
 
     private static BiFunction<String, ConfigSourceInterceptorContext, String> resolveLogHandler(String handler) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -270,6 +270,7 @@ public final class PropertyMappers {
         }
 
         @Override
+        @SuppressWarnings({"rawtypes", "unchecked"})
         public List<PropertyMapper<?>> get(Object key) {
             // First check if the requested option matches any wildcard mappers
             String strKey = (String) key;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusJpaUpdaterProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusJpaUpdaterProvider.java
@@ -144,7 +144,7 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
 
             // create DEPLOYMENT_ID column if it doesn't exist
             if (!hasDeploymentIdColumn) {
-                ChangeLogHistoryService changelogHistoryService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+                ChangeLogHistoryService changelogHistoryService = getChangeLogHistoryService().getChangeLogService(database);
                 changelogHistoryService.generateDeploymentId();
                 String deploymentId = changelogHistoryService.getDeploymentId();
 
@@ -281,7 +281,11 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
 
     private void resetLiquibaseServices(KeycloakLiquibase liquibase) {
         liquibase.resetServices();
-        ChangeLogHistoryServiceFactory.getInstance().register(new CustomChangeLogHistoryService());
+        getChangeLogHistoryService().register(new CustomChangeLogHistoryService());
+    }
+
+    private ChangeLogHistoryServiceFactory getChangeLogHistoryService() {
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
     }
 
     private List<ChangeSet> getLiquibaseUnrunChangeSets(Liquibase liquibase) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/QuarkusCacheManagerProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/QuarkusCacheManagerProvider.java
@@ -25,6 +25,7 @@ import org.keycloak.models.KeycloakSession;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
+@SuppressWarnings({"unchecked", "resource"})
 public final class QuarkusCacheManagerProvider implements ManagedCacheManagerProvider {
 
     @Override

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -245,21 +245,6 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
-    public void httpStoreTypeValidation() {
-        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--https-key-store-file=not-there.ks", "--hostname-strict=false");
-        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getErrString(), containsString("Unable to determine 'https-key-store-type' automatically. Adjust the file extension or specify the property"));
-
-        nonRunningPicocli = pseudoLaunch("start", "--https-key-store-file=not-there.ks", "--hostname-strict=false", "--https-key-store-type=jdk");
-        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getErrString(), containsString("Failed to load 'https-key-' material: NoSuchFileException not-there.ks"));
-
-        nonRunningPicocli = pseudoLaunch("start", "--https-trust-store-file=not-there.jks", "--https-key-store-file=not-there.ks", "--hostname-strict=false", "--https-key-store-type=jdk");
-        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getErrString(), containsString("No trust store password provided"));
-    }
-
-    @Test
     public void testShowConfigHidesSystemProperties() {
         setSystemProperty("kc.something", "password", () -> {
             NonRunningPicocli nonRunningPicocli = pseudoLaunch("show-config");
@@ -335,6 +320,7 @@ public class PicocliTest extends AbstractConfigurationTest {
     /**
      * Runs a fake build to setup the state of the persisted build properties
      */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private void build(String... args) {
         if (Stream.of(args).anyMatch("start-dev"::equals)) {
             Environment.setRebuildCheck(); // auto-build

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
+import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
@@ -115,6 +116,7 @@ public abstract class AbstractConfigurationTest {
         PersistedConfigSource.getInstance().getConfigValueProperties().clear();
         Profile.reset();
         Configuration.resetConfig();
+        ExecutionExceptionHandler.resetExceptionTransformers();
     }
 
     @After

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
@@ -88,7 +88,7 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
                 "quarkus.log.syslog.app-name", "keycloak",
                 "quarkus.log.syslog.protocol", "tcp",
                 "quarkus.log.syslog.format", DEFAULT_LOG_FORMAT,
-                "quarkus.log.syslog.json", "false"
+                "quarkus.log.syslog.json.enabled", "false"
         ));
 
         // The default max-length attribute is set in the org.jboss.logmanager.handlers.SyslogHandler if not specified in config
@@ -129,7 +129,7 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
                 "quarkus.log.syslog.app-name", "keycloak2",
                 "quarkus.log.syslog.protocol", "udp",
                 "quarkus.log.syslog.format", "some format",
-                "quarkus.log.syslog.json", "true"
+                "quarkus.log.syslog.json.enabled", "true"
         ));
     }
 
@@ -247,11 +247,11 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
         ));
 
         assertExternalConfig(Map.of(
-                "quarkus.log.console.json", "true",
+                "quarkus.log.console.json.enabled", "true",
                 "quarkus.log.console.json.log-format", "ecs",
-                "quarkus.log.file.json", "true",
+                "quarkus.log.file.json.enabled", "true",
                 "quarkus.log.file.json.log-format", "ecs",
-                "quarkus.log.syslog.json", "true",
+                "quarkus.log.syslog.json.enabled", "true",
                 "quarkus.log.syslog.json.log-format", "ecs"
         ));
     }

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -89,7 +89,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11</artifactId>
+            <artifactId>ojdbc17</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -149,8 +149,7 @@ public class FipsDistTest {
 
             CLIResult cliResult = dist.run("--verbose", "start", "--fips-mode=non-strict", "--https-key-store-password=passwordpassword",
                     "--https-trust-store-file=" + truststorePath, "--https-trust-store-password=passwordpassword");
-            cliResult.assertError("Unable to determine 'https-trust-store-type' automatically. Adjust the file extension or specify the property.");
-
+            cliResult.assertMessage("Unable to determine 'https-trust-store-type' automatically. Adjust the file extension or specify the property.");
             dist.stop();
 
             dist.copyOrReplaceFileFromClasspath("/server.keystore.pkcs12", Path.of("conf", "server.p12"));

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -202,7 +202,8 @@ public class QuarkusPropertiesDistTest {
             "--https-certificate-key-file=/tmp/kc/bin/../conf/server.key.pem" })
     @Order(13)
     void testHttpCertsPathTransformer(CLIResult cliResult) {
-        cliResult.assertError("Failed to load 'https-key-' material: NoSuchFileException /tmp/kc/bin/../conf/server.crt.pem");
+        cliResult.assertExitCode(1);
+        cliResult.assertMessage("Failed to load 'https-trust-store' or 'https-key-' material: NoSuchFileException");
     }
 
     @Test
@@ -213,7 +214,8 @@ public class QuarkusPropertiesDistTest {
             "--https-certificate-key-file=C:\\tmp\\kc\\bin\\..\\conf/server.key.pem" })
     @Order(14)
     void testHttpCertsPathTransformerOnWindows(CLIResult cliResult) {
-        cliResult.assertError("Failed to load 'https-key-' material: NoSuchFileException C:\\tmp\\kc\\bin\\..\\conf\\server.crt.pem");
+        cliResult.assertExitCode(1);
+        cliResult.assertMessage("ERROR: Failed to load 'https-trust-store' or 'https-key-' material: NoSuchFileException C:");
     }
 
     public static class AddConsoleHandlerFromQuarkusProps implements Consumer<KeycloakDistribution> {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/OracleTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/OracleTest.java
@@ -46,7 +46,7 @@ public class OracleTest extends BasicDatabaseTest {
         @Override
         public void accept(KeycloakDistribution distribution) {
             RawKeycloakDistribution rawDist = distribution.unwrap(RawKeycloakDistribution.class);
-            rawDist.copyProvider("com.oracle.database.jdbc", "ojdbc11");
+            rawDist.copyProvider("com.oracle.database.jdbc", "ojdbc17");
             rawDist.copyProvider("com.oracle.database.nls", "orai18n");
         }
     }

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -108,7 +108,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11</artifactId>
+            <artifactId>ojdbc17</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.nls</groupId>

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -85,6 +85,10 @@ public interface CLIResult extends LaunchResult {
                 getErrorOutput(), not(containsString(msg)));
     }
 
+    default void assertExitCode(int code) {
+        assertThat("Exit codes do not match: ", exitCode(), is(code));
+    }
+
     default void assertMessage(String message) {
         assertThat(getOutput(), containsString(message));
     }

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakDistributionDecorator.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakDistributionDecorator.java
@@ -138,6 +138,7 @@ public class KeycloakDistributionDecorator implements KeycloakDistribution {
         }
 
         if (type.isInstance(delegate)) {
+            //noinspection unchecked
             return (D) delegate;
         }
 

--- a/test-framework/db-oracle/pom.xml
+++ b/test-framework/db-oracle/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11</artifactId>
+            <artifactId>ojdbc17</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/test-framework/db-oracle/src/main/java/org/keycloak/testframework/database/OracleDatabaseSupplier.java
+++ b/test-framework/db-oracle/src/main/java/org/keycloak/testframework/database/OracleDatabaseSupplier.java
@@ -19,6 +19,6 @@ public class OracleDatabaseSupplier extends AbstractDatabaseSupplier {
     @Override
     public KeycloakServerConfigBuilder intercept(KeycloakServerConfigBuilder serverConfig, InstanceContext<TestDatabase, InjectTestDatabase> instanceContext) {
         return super.intercept(serverConfig, instanceContext)
-                .dependency("com.oracle.database.jdbc", "ojdbc11");
+                .dependency("com.oracle.database.jdbc", "ojdbc17");
     }
 }

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -523,7 +523,7 @@
                 <!-- For EAP testing, it is recommended to override those with system properties pointing to GAV of more appropriate JDBC driver -->
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>com.oracle.database.jdbc</jdbc.mvn.groupId>
-                <jdbc.mvn.artifactId>ojdbc11</jdbc.mvn.artifactId>
+                <jdbc.mvn.artifactId>ojdbc17</jdbc.mvn.artifactId>
                 <jdbc.mvn.version>${oracle-jdbc.version}</jdbc.mvn.version>
             </properties>
         </profile>

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -201,7 +201,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>com.oracle.database.jdbc</groupId>
-                                    <artifactId>ojdbc11</artifactId>
+                                    <artifactId>ojdbc17</artifactId>
                                     <version>${oracle-jdbc.version}</version>
                                     <type>jar</type>
                                     <outputDirectory>${auth.server.home}/providers</outputDirectory>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/tracing/OTelTracingProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/tracing/OTelTracingProviderTest.java
@@ -24,7 +24,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData;
+import io.opentelemetry.sdk.trace.data.ExceptionEventData;
 import io.opentelemetry.semconv.ExceptionAttributes;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.test.api.ArquillianResource;

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -259,7 +259,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11</artifactId>
+            <artifactId>ojdbc17</artifactId>
             <version>${oracle-jdbc.version}</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
## Provided changes

- [x] Oracle JDBC driver upgrade, replace `ojdbc11` for `ojdbc17` artifacts, update `Database#ORACLE` props
- [x] Suppressed unnecessary warnings and log sanitizing
- [x] Replace deprecated `quarkus.log.*.json` for `quarkus.log.*.json.enabled` property
- [x] Replaced various deprecations
- [x] Fixed `@ConfigMapping` issue described below

### `@ConfigMapping` issue
cc: @radcortez

We have hit an issue with the `@ConfigMapping` for the `CertificateConfig` Quarkus HTTP TLS options as there were made [some changes](https://github.com/quarkusio/quarkus/pull/45769) for Quarkus 3.19.x.

It is not possible to instantiate it like we did before in the `HttpPropertyMappers` to verify keystore/truststore settings.

The only way is to use CDI (Arc), or directly obtain it from the SmallRyeConfig (SRC).

##### CDI

- I wasn't able to get it to work in our KeycloakProcessor/KeycloakRecorder and didn't find any better place to leverage CDI
- Probably would not be a good approach to run some validations like that in CDI-aware classes like that ^^

##### Directly from SmallRyeConfig 

- Uses PR https://github.com/keycloak/keycloak/pull/37460
- It is possible to obtain the configuration as `SmallRyeConfig.getConfigMapping(VertxHttpConfig.class).ssl().certificate();`
- However, the `VertxHttpConfig` needs to be added to the SmallRye initialization like [this](https://github.com/keycloak/keycloak/pull/37460/files#diff-cc3ad6f616a6a284a241bf735da50f66c474f92b1e2738a29c9f3861e923e5b8R99)
- When the `withMapping()` is used in the SRC builder, **certain validations** for the whole config (here the HTTP options) are executed
- Cannot obtain directly the `CertificateConfig` - needs to be the config "root"
- When the validations are executed, it fetches our own config in loop causing recursion problem
- For that scenario, the default config is returned, but is quite expensive wrt to performance and does not cover all cases

#### Suggested approach

- Current PR
- It seems to me like overkill to touch our config (SmallRyeConfig instance) to only verify the keystore/truststore options
- These **same validations are executed in Quarkus later**
- We can save some CPU cycles to not duplicate these validations and just wait for these results

@vmuzikar @shawkins @Pepo48 
