### PR TITLE
A script to prepare commits for test migration

### DIFF
--- a/tests/migration-util/commit-migration.sh
+++ b/tests/migration-util/commit-migration.sh
@@ -64,9 +64,10 @@ read_commit_message() {
   COMMIT_MESSAGE=""
   read -r COMMIT_MESSAGE
   if [ -n "$COMMIT_MESSAGE" ]; then
-    while IFS= read -p "End input with CTRL+D" -r line; do
+    COMMIT_MESSAGE+=$'\n'
+    while IFS= read -r line; do
       if [ -z "$line" ]; then
-        COMMIT_MESSAGE+=$'\n\n'
+        COMMIT_MESSAGE+=$'\n'
       else
         COMMIT_MESSAGE+="$line"$'\n'
       fi

--- a/tests/migration-util/prepare-commit.sh
+++ b/tests/migration-util/prepare-commit.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+declare -a TEST_FILES
+declare STAGE_BACKUP=""
+declare -a DELETED_TESTS_PATHS
+declare -a CREATED_TESTS_PATHS
+declare DEFAULT_COMMIT_MESSAGE=""
+declare COMMIT_MESSAGE=""
+
+parse_test_files() {
+  local test_file
+  local test_found
+  for test_file in "$@"; do
+    test_found=$(git diff --cached --name-status | grep -w "$test_file")
+    if [ -z "$test_found" ]; then
+      echo "No such test found in stage: $test_file"
+      exit 1
+    fi
+    TEST_FILES+=("$test_file")
+  done
+}
+
+backup_staged_files() {
+  STAGE_BACKUP="$(git diff --cached --name-status | grep '^[(M|A|D|R|C]' | awk '{print $2}')"
+  STAGE_BACKUP+=$'\n'"$(git diff --cached --name-status | grep '^R' | awk '{print $3}')"
+}
+
+get_file_names_string() {
+  local file_names_string=""
+
+  for file_path in "$@"; do
+    file_name=$(basename "$file_path")
+    if [ -z "$file_names_string" ]; then
+      file_names_string="$file_name"
+    else
+      file_names_string+=", $file_name"
+    fi
+  done
+  echo "$file_names_string"
+}
+
+get_default_commit_message() {
+  local file_names
+  file_names=$(get_file_names_string "$@")
+  DEFAULT_COMMIT_MESSAGE="Move $file_names to the new testsuite"
+}
+
+read_commit_message() {
+  get_default_commit_message "${TEST_FILES[@]}"
+  DEFAULT_COMMIT_MESSAGE+=$'\n\n'"Part of: #34494"
+
+  echo ""
+  echo "Provide a different commit message (optional)"
+  echo "$DEFAULT_COMMIT_MESSAGE"
+  read -r COMMIT_MESSAGE
+  if [ -z "$COMMIT_MESSAGE" ]; then
+    COMMIT_MESSAGE="$DEFAULT_COMMIT_MESSAGE"
+  fi
+}
+
+commit_test_move() {
+  set -e
+  git restore --staged .
+  git restore "${DELETED_TESTS_PATHS[@]}"
+
+  for i in "${!CREATED_TESTS_PATHS[@]}"; do
+    mv "${CREATED_TESTS_PATHS[i]}" "${CREATED_TESTS_PATHS[i]}.new"
+    mv "${DELETED_TESTS_PATHS[i]}" "${CREATED_TESTS_PATHS[i]}"
+  done
+
+  git add "${DELETED_TESTS_PATHS[@]}" "${CREATED_TESTS_PATHS[@]}"
+  get_default_commit_message "${CREATED_TESTS_PATHS[@]}"
+  git commit --signoff -m "$DEFAULT_COMMIT_MESSAGE"
+
+  rm "${CREATED_TESTS_PATHS[@]}"
+  for NEW_TEST_PATH in "${CREATED_TESTS_PATHS[@]}"; do
+    mv "$NEW_TEST_PATH.new" "$NEW_TEST_PATH"
+  done
+  set +e
+}
+
+restore_stage() {
+  if [ -n "$STAGE_BACKUP" ]; then
+    echo "$STAGE_BACKUP" | xargs -I {} git add {} > /dev/null 2>&1
+  fi
+}
+
+commit_stage() {
+  restore_stage
+  read_commit_message
+  echo "The following files will be commited:"
+  git --no-pager diff --cached --name-status
+
+  local confirm
+  echo ""
+  read -p "Commit? [y/n]: " -r confirm
+  if [[ -z "$confirm" || "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
+    git commit --signoff -m "$COMMIT_MESSAGE"
+  else
+    exit 1
+  fi
+}
+
+
+if [ "$#" -eq 0 ]; then
+  echo "No test files provided."
+  exit 1
+fi
+
+parse_test_files "$@"
+
+cd "$(git rev-parse --show-toplevel)"
+backup_staged_files
+# Add only the migrated test files to the git stage
+git restore --staged .
+for test_file in "${TEST_FILES[@]}"; do
+  git status --porcelain | grep -E "(testsuite/|tests/).*\b${test_file%.*}(\.java)?\b" | awk '{print $2}' | xargs -I {} git add {}
+done
+
+# Store tests marked as deleted
+for test_file in "${TEST_FILES[@]}"; do
+  old_test_path=$(git diff --cached --name-status | grep -E "^D.*$test_file" | awk '{print $2}')
+  if [ -n "$old_test_path" ]; then
+    DELETED_TESTS_PATHS+=("$old_test_path")
+  fi
+done
+
+if [ ${#DELETED_TESTS_PATHS[@]} -eq 0 ]; then
+  echo "Tests can be migrated with a single commit."
+  commit_stage
+else
+  echo "Git registers some tests as deleted and created"
+
+  # Store the matching tests marked as created
+  for test_file in "${DELETED_TESTS_PATHS[@]}"; do
+    test_name=$(basename "$test_file")
+    new_test_path=$(git diff --cached --name-status | grep -E "^A.*$test_name" | awk '{print $2}')
+    CREATED_TESTS_PATHS+=("$new_test_path")
+  done
+
+  if [ ${#DELETED_TESTS_PATHS[@]} -ne ${#CREATED_TESTS_PATHS[@]} ]; then
+    echo "The number of deleted tests must equal to the number of created tests"
+    exit 1
+  fi
+
+  commit_test_move
+  git add "${CREATED_TESTS_PATHS[@]}"
+  commit_stage
+fi

--- a/tests/migration-util/prepare-commit.sh
+++ b/tests/migration-util/prepare-commit.sh
@@ -1,35 +1,41 @@
 #!/bin/bash
 
-declare -a TEST_FILES
-declare STAGE_BACKUP=""
-declare -a DELETED_TESTS_PATHS
-declare -a CREATED_TESTS_PATHS
-declare DEFAULT_COMMIT_MESSAGE=""
+declare -a DELETED_FILES_PATHS
+declare -a CREATED_FILES_PATHS
 declare COMMIT_MESSAGE=""
 
-parse_test_files() {
-  local test_file
-  local test_found
-  for test_file in "$@"; do
-    test_found=$(git diff --cached --name-status | grep -w "$test_file")
-    if [ -z "$test_found" ]; then
-      echo "No such test found in stage: $test_file"
-      exit 1
+get_deleted_and_created_files() {
+  local deleted_files_paths
+  local deleted_file_path
+  local file_name
+  local new_file_path
+
+  readarray -t deleted_files_paths < <(git diff --cached --name-status --diff-filter=D | grep -E ".*testsuite/integration-arquillian/.*" | awk '{print $2}')
+  if [ ${#deleted_files_paths} -eq 0  ]; then
+    return
+  fi
+
+  for deleted_file_path in "${deleted_files_paths[@]}"; do
+    if [ -z "$deleted_file_path" ]; then
+        continue
     fi
-    TEST_FILES+=("$test_file")
+
+    file_name=$(basename "$deleted_file_path")
+    new_file_path=$(git diff --cached --name-status --diff-filter=A | grep -E ".*\b${file_name}\b" | awk '{print $2}')
+
+    if [ -n "$new_file_path" ]; then
+      DELETED_FILES_PATHS+=("$deleted_file_path")
+      CREATED_FILES_PATHS+=("$new_file_path")
+    fi
   done
 }
 
-backup_staged_files() {
-  STAGE_BACKUP="$(git diff --cached --name-status | grep '^[(M|A|D|R|C]' | awk '{print $2}')"
-  STAGE_BACKUP+=$'\n'"$(git diff --cached --name-status | grep '^R' | awk '{print $3}')"
-}
-
-get_file_names_string() {
+get_test_names_string() {
   local file_names_string=""
-
-  for file_path in "$@"; do
-    file_name=$(basename "$file_path")
+  local -a test_names
+  local file_name
+  readarray -t test_names < <(git diff --cached --name-status --diff-filter=MR | grep -E ".*Test.java" | awk '{print $2}' | xargs -I {} basename {})
+  for file_name in "${test_names[@]}"; do
     if [ -z "$file_names_string" ]; then
       file_names_string="$file_name"
     else
@@ -40,56 +46,42 @@ get_file_names_string() {
 }
 
 get_default_commit_message() {
-  local file_names
-  file_names=$(get_file_names_string "$@")
-  DEFAULT_COMMIT_MESSAGE="Move $file_names to the new testsuite"
+  local test_names
+  test_names=$(get_test_names_string)
+  echo "Move $test_names to the new testsuite"
 }
 
 read_commit_message() {
-  get_default_commit_message "${TEST_FILES[@]}"
-  DEFAULT_COMMIT_MESSAGE+=$'\n\n'"Part of: #34494"
+  local default_commit_message
+  default_commit_message=$(get_default_commit_message)
+  default_commit_message+=$'\n\n'"Part of: #34494"
 
   echo ""
   echo "Provide a different commit message (optional)"
-  echo "$DEFAULT_COMMIT_MESSAGE"
+  echo "============================================="
+  echo "$default_commit_message"
+  echo "============================================="
+  COMMIT_MESSAGE=""
   read -r COMMIT_MESSAGE
-  if [ -z "$COMMIT_MESSAGE" ]; then
-    COMMIT_MESSAGE="$DEFAULT_COMMIT_MESSAGE"
-  fi
-}
-
-commit_test_move() {
-  set -e
-  git restore --staged .
-  git restore "${DELETED_TESTS_PATHS[@]}"
-
-  for i in "${!CREATED_TESTS_PATHS[@]}"; do
-    mv "${CREATED_TESTS_PATHS[i]}" "${CREATED_TESTS_PATHS[i]}.new"
-    mv "${DELETED_TESTS_PATHS[i]}" "${CREATED_TESTS_PATHS[i]}"
-  done
-
-  git add "${DELETED_TESTS_PATHS[@]}" "${CREATED_TESTS_PATHS[@]}"
-  get_default_commit_message "${CREATED_TESTS_PATHS[@]}"
-  git commit --signoff -m "$DEFAULT_COMMIT_MESSAGE"
-
-  rm "${CREATED_TESTS_PATHS[@]}"
-  for NEW_TEST_PATH in "${CREATED_TESTS_PATHS[@]}"; do
-    mv "$NEW_TEST_PATH.new" "$NEW_TEST_PATH"
-  done
-  set +e
-}
-
-restore_stage() {
-  if [ -n "$STAGE_BACKUP" ]; then
-    echo "$STAGE_BACKUP" | xargs -I {} git add {} > /dev/null 2>&1
+  if [ -n "$COMMIT_MESSAGE" ]; then
+    while IFS= read -p "End input with CTRL+D" -r line; do
+      if [ -z "$line" ]; then
+        COMMIT_MESSAGE+=$'\n\n'
+      else
+        COMMIT_MESSAGE+="$line"$'\n'
+      fi
+    done
+  else
+    echo "Default commit message will be used"
+    COMMIT_MESSAGE="$default_commit_message"
   fi
 }
 
 commit_stage() {
-  restore_stage
-  read_commit_message
   echo "The following files will be commited:"
   git --no-pager diff --cached --name-status
+
+  read_commit_message
 
   local confirm
   echo ""
@@ -101,51 +93,63 @@ commit_stage() {
   fi
 }
 
+backup_staged_files() {
+  local stage_backup
+  stage_backup="$(git diff --cached --name-status --diff-filter=ACDMR | awk '{print $2}')"
+  stage_backup+=$'\n'"$(git diff --cached --name-status --diff-filter=R | awk '{print $3}')"
+  echo "$stage_backup"
+}
 
-if [ "$#" -eq 0 ]; then
-  echo "No test files provided."
-  exit 1
-fi
+restore_stage() {
+  local stage_backup
+  stage_backup="$1"
 
-parse_test_files "$@"
-
-cd "$(git rev-parse --show-toplevel)"
-backup_staged_files
-# Add only the migrated test files to the git stage
-git restore --staged .
-for test_file in "${TEST_FILES[@]}"; do
-  git status --porcelain --untracked-files=all | grep -E "(testsuite/|tests/).*\b${test_file%.*}(\.java)?\b" | awk '{print $2}' | xargs -I {} git add {}
-done
-
-# Store tests marked as deleted
-for test_file in "${TEST_FILES[@]}"; do
-  old_test_path=$(git diff --cached --name-status | grep -E "^D.*$test_file" | awk '{print $2}')
-  if [ -n "$old_test_path" ]; then
-    DELETED_TESTS_PATHS+=("$old_test_path")
+  if [ -n "$stage_backup" ]; then
+    echo "$stage_backup" | xargs -I {} git add {} > /dev/null 2>&1
   fi
-done
+}
 
-if [ ${#DELETED_TESTS_PATHS[@]} -eq 0 ]; then
-  echo "Tests can be migrated with a single commit."
-  commit_stage
-else
-  echo "Git registers some tests as deleted and created"
+commit_test_move() {
+  local stage_backup
+  stage_backup=$(backup_staged_files)
+  set -e
+  git restore --staged .
+  git restore "${DELETED_FILES_PATHS[@]}"
 
-  # Store the matching tests marked as created
-  for test_file in "${DELETED_TESTS_PATHS[@]}"; do
-    test_name=$(basename "$test_file")
-    new_test_path=$(git diff --cached --name-status | grep -E "^A.*$test_name" | awk '{print $2}')
-    if [ -n "$new_test_path" ]; then
-      CREATED_TESTS_PATHS+=("$new_test_path")
-    fi
+  for i in "${!CREATED_FILES_PATHS[@]}"; do
+    mv "${CREATED_FILES_PATHS[i]}" "${CREATED_FILES_PATHS[i]}.new"
+    mv "${DELETED_FILES_PATHS[i]}" "${CREATED_FILES_PATHS[i]}"
   done
 
-  if [ ${#DELETED_TESTS_PATHS[@]} -ne ${#CREATED_TESTS_PATHS[@]} ]; then
-    echo "The number of deleted tests must equal to the number of created tests"
-    exit 1
-  fi
+  git add "${DELETED_FILES_PATHS[@]}" "${CREATED_FILES_PATHS[@]}"
+  git commit --signoff -m "Moving files to the new test suite"
 
+  rm "${CREATED_FILES_PATHS[@]}"
+  for NEW_TEST_PATH in "${CREATED_FILES_PATHS[@]}"; do
+    mv "$NEW_TEST_PATH.new" "$NEW_TEST_PATH"
+  done
+  set +e
+  restore_stage "$stage_backup"
+  echo "Move commit created"
+}
+
+
+if [ -z "$(git diff --cached)" ]; then
+  echo "Git stage is empty. Nothing to do."
+  exit 0
+fi
+cd "$(git rev-parse --show-toplevel)"
+
+get_deleted_and_created_files
+
+if [ ${#DELETED_FILES_PATHS[@]} -eq 0 ]; then
+  echo "Migration can be done with a single commit."
+  commit_stage
+else
+  echo "Git registers some files as deleted and created"
   commit_test_move
-  git add "${CREATED_TESTS_PATHS[@]}"
+  git add "${CREATED_FILES_PATHS[@]}"
+  echo ""
+  echo "Committing stage..."
   commit_stage
 fi

--- a/tests/migration-util/prepare-commit.sh
+++ b/tests/migration-util/prepare-commit.sh
@@ -114,7 +114,7 @@ backup_staged_files
 # Add only the migrated test files to the git stage
 git restore --staged .
 for test_file in "${TEST_FILES[@]}"; do
-  git status --porcelain | grep -E "(testsuite/|tests/).*\b${test_file%.*}(\.java)?\b" | awk '{print $2}' | xargs -I {} git add {}
+  git status --porcelain --untracked-files=all | grep -E "(testsuite/|tests/).*\b${test_file%.*}(\.java)?\b" | awk '{print $2}' | xargs -I {} git add {}
 done
 
 # Store tests marked as deleted
@@ -135,7 +135,9 @@ else
   for test_file in "${DELETED_TESTS_PATHS[@]}"; do
     test_name=$(basename "$test_file")
     new_test_path=$(git diff --cached --name-status | grep -E "^A.*$test_name" | awk '{print $2}')
-    CREATED_TESTS_PATHS+=("$new_test_path")
+    if [ -n "$new_test_path" ]; then
+      CREATED_TESTS_PATHS+=("$new_test_path")
+    fi
   done
 
   if [ ${#DELETED_TESTS_PATHS[@]} -ne ${#CREATED_TESTS_PATHS[@]} ]; then


### PR DESCRIPTION
Closes: #37495 
Signed-off-by: Simon Vacek <simonvacky@email.cz>

Use:
`./prepare-commit.sh`

Everything to be committed should be in the git staging area.

Files seen by git as deleted and created will be committed as moved unchanged first. Then, their changes, along with the rest of the staging area, will be committed, too.