### PR TITLE
Specification parameters tests for standard token exchange v2

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -318,6 +318,10 @@ public class OAuthClient {
         return new TokenExchangeRequest(subjectToken, this);
     }
 
+    public TokenExchangeRequest tokenExchangeRequest(String subjectToken, String subjectTokenType) {
+        return new TokenExchangeRequest(subjectToken, subjectTokenType, this);
+    }
+
     /**
      * @deprecated Set clientId and clientSecret using {@link #client(String, String)} and use {@link #tokenExchangeRequest(String)}
      */

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
@@ -7,16 +7,25 @@ import org.keycloak.constants.AdapterConstants;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class TokenExchangeRequest extends AbstractHttpPostRequest<TokenExchangeRequest, AccessTokenResponse> {
 
     private final String subjectToken;
+    private final String subjectTokenType;
     private List<String> audience;
     private Map<String, String> additionalParams;
 
     TokenExchangeRequest(String subjectToken, OAuthClient client) {
         super(client);
         this.subjectToken = subjectToken;
+        this.subjectTokenType = OAuth2Constants.ACCESS_TOKEN_TYPE;
+    }
+
+    TokenExchangeRequest(String subjectToken, String subjectTokenType, OAuthClient client) {
+        super(client);
+        this.subjectToken = subjectToken;
+        this.subjectTokenType = subjectTokenType;
     }
 
     @Override
@@ -38,7 +47,7 @@ public class TokenExchangeRequest extends AbstractHttpPostRequest<TokenExchangeR
         parameter(OAuth2Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
 
         parameter(OAuth2Constants.SUBJECT_TOKEN, subjectToken);
-        parameter(OAuth2Constants.SUBJECT_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE);
+        parameter(OAuth2Constants.SUBJECT_TOKEN_TYPE, subjectTokenType != null ? subjectTokenType : OAuth2Constants.ACCESS_TOKEN_TYPE);
 
         if (audience != null) {
             audience.forEach(a -> parameter(OAuth2Constants.AUDIENCE, a));


### PR DESCRIPTION
Added tests to check the required parameters for token exchange requests and responses in accordance with the specification

Closes #37114


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
