### PR TITLE
refinement of propertymapperinterceptor names

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
@@ -2,7 +2,6 @@ package org.keycloak.config;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -77,7 +77,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
         if(args == null) {
             return Collections.emptyList();
         }
-        
+
         List<String> result = new ArrayList<String>();
         boolean escaped = false;
         StringBuilder arg = new StringBuilder();
@@ -101,7 +101,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
             }
         }
         result.add(arg.toString());
-        
+
         return result;
     }
 
@@ -125,20 +125,6 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
                 key = NS_KEYCLOAK_PREFIX + key.substring(2);
 
                 properties.put(key, value);
-
-                PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
-
-                if (mapper != null) {
-                    mapper = mapper.forKey(key);
-
-                    String to = mapper.getTo();
-
-                    if (to != null) {
-                        properties.put(mapper.getTo(), value);
-                    }
-
-                    properties.put(mapper.getFrom(), value);
-                }
             }
         }, ignored -> {});
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -28,8 +28,6 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
 
 import org.keycloak.config.Option;
-import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
-import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 import org.keycloak.utils.StringUtil;
 
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
@@ -151,17 +149,6 @@ public final class Configuration {
 
     public static Optional<Integer> getOptionalIntegerValue(String propertyName) {
         return getConfig().getOptionalValue(NS_KEYCLOAK_PREFIX.concat(propertyName), Integer.class);
-    }
-
-    public static String getMappedPropertyName(String key) {
-        PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
-
-        if (mapper == null) {
-            return key;
-        }
-
-        // we also need to make sure the target property is available when defined such as when defining alias for provider config (no spi-prefix).
-        return mapper.getTo() == null ? mapper.getFrom() : mapper.getTo();
     }
 
     public static String toEnvVarFormat(String key) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -130,11 +130,6 @@ public class IgnoredArtifacts {
             }
         });
 
-        // since the default may not be a known property name, look for it explicitly
-        Configuration.getOptionalValue("quarkus.datasource.db-kind")
-            .flatMap(Database::getVendor)
-            .ifPresent(vendorsOfAllDatasources::add);
-
         final Set<String> jdbcArtifacts = vendorsOfAllDatasources.stream()
                 .map(vendor -> switch (vendor) {
                     case H2 -> JDBC_H2;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.smallrye.config.PropertiesConfigSource;
+
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
@@ -50,13 +51,7 @@ public class KcEnvConfigSource extends PropertiesConfigSource {
                 PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
                 if (mapper != null) {
-                    mapper = mapper.forEnvKey(key);
-
-                    String to = mapper.getTo();
-
-                    if (to != null) {
-                        properties.put(to, value);
-                    }
+                    mapper = mapper.forKey(key);
 
                     properties.put(mapper.getFrom(), value);
                 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.quarkus.runtime.configuration;
 
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -33,23 +36,16 @@ import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
-import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 import io.smallrye.config.AbstractLocationConfigSourceLoader;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.common.utils.ConfigSourceUtil;
 
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getMappedPropertyName;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_QUARKUS;
-
 /**
  * A configuration source for {@code keycloak.conf}.
  */
 public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSourceLoader {
-    
+
     public static final int PROPERTIES_FILE_ORDINAL = 475;
 
     private static final Pattern DOT_SPLIT = Pattern.compile("\\.");
@@ -122,8 +118,9 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
         public Path getConfigurationFile() {
             String filePath = System.getProperty(KEYCLOAK_CONFIG_FILE_PROP);
 
-            if (filePath == null)
+            if (filePath == null) {
                 filePath = System.getenv(KEYCLOAK_CONFIG_FILE_ENV);
+            }
 
             if (filePath == null) {
                 String homeDir = Environment.getHomeDir();
@@ -147,22 +144,10 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
 
     private static Map<String, String> transform(Map<String, String> properties) {
         Map<String, String> result = new HashMap<>(properties.size());
-        properties.keySet().forEach(k -> {
-            String key = transformKey(k);
-            PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
-            //TODO: remove explicit checks for spi and feature options once we have proper support in our config mappers
-            if (mapper != null
-                    || key.contains(NS_KEYCLOAK_PREFIX + "spi")
-                    || key.contains(NS_KEYCLOAK_PREFIX + "feature")) {
-                String value = properties.get(k);
-
-                result.put(key, value);
-
-                if (mapper != null && key.charAt(0) != '%') {
-                    result.put(getMappedPropertyName(key), value);
-                }
-            }
+        properties.entrySet().forEach(entry -> {
+            String key = transformKey(entry.getKey());
+            result.put(key, entry.getValue());
         });
 
         return result;
@@ -176,7 +161,7 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
      * @return the same key but prefixed with the namespace
      */
     private static String transformKey(String key) {
-        String namespace;
+        String namespace = NS_KEYCLOAK;
         String[] keyParts = DOT_SPLIT.split(key);
         String extension = keyParts[0];
         String profile = "";
@@ -186,12 +171,6 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
             profile = String.format("%s.", keyParts[0]);
             extension = keyParts[1];
             transformed = key.substring(key.indexOf('.') + 1);
-        }
-
-        if (extension.equalsIgnoreCase(NS_QUARKUS)) {
-            return key;
-        } else {
-            namespace = NS_KEYCLOAK;
         }
 
         return profile + namespace + "." + transformed;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
@@ -57,6 +57,9 @@ public class NestedPropertyMappingInterceptor implements ConfigSourceInterceptor
                 return resolver.apply(name);
             } finally {
                 recursing.remove(name);
+                if (recursing.isEmpty()) {
+                    recursions.set(null);
+                }
             }
         }
         return nonRecursiveResolver.apply(name);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
@@ -33,6 +33,7 @@ import jakarta.annotation.Priority;
  * happens at the ExpressionConfigSourceInterceptor, which is after
  * property mapping. This interceptor appears just after the expression
  * interceptor and will restart the context for anything not actively recursing.
+ * This is needed in case the expression contains something that requires property mapping.
  */
 @Priority(Priorities.LIBRARY + 299)
 public class NestedPropertyMappingInterceptor implements ConfigSourceInterceptor {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.quarkus.runtime.configuration;
+
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Priorities;
+import jakarta.annotation.Priority;
+
+/**
+ * Some resolution of values that come from PropertyMappers
+ * happens at the ExpressionConfigSourceInterceptor, which is after
+ * property mapping. This interceptor appears just after the expression
+ * interceptor and will restart the context for anything not actively recursing.
+ */
+@Priority(Priorities.LIBRARY + 299)
+public class NestedPropertyMappingInterceptor implements ConfigSourceInterceptor {
+
+    static final ThreadLocal<LinkedHashSet<String>> recursions = new ThreadLocal<>();
+
+    @Override
+    public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+        return resolve(context::restart, context::proceed, name);
+    }
+
+    static <T> T resolve(Function<String, T> resolver, Function<String, T> nonRecursiveResolver, String name) {
+        LinkedHashSet<String> recursing = recursions.get();
+        if (recursing == null) {
+            recursing = new LinkedHashSet<String>();
+            recursions.set(recursing);
+        }
+        boolean added = recursing.add(name);
+        if (added) {
+            try {
+                return resolver.apply(name);
+            } finally {
+                recursing.remove(name);
+            }
+        }
+        return nonRecursiveResolver.apply(name);
+    }
+
+    public static Optional<String> getResolvingRoot() {
+        return Optional.ofNullable(recursions.get()).map(s -> s.iterator().next());
+    }
+
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/NestedPropertyMappingInterceptor.java
@@ -42,6 +42,10 @@ public class NestedPropertyMappingInterceptor implements ConfigSourceInterceptor
 
     @Override
     public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+        // don't look up the mapped value for direct env references
+        if (Character.isUpperCase(name.charAt(0))) {
+            return context.proceed(name);
+        }
         return resolve(context::restart, context::proceed, name, false);
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -21,7 +21,6 @@ import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -141,9 +140,7 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
             return context.proceed(name);
         }
 
-        // track that we may be starting to resolve "name". There's no recursion concern here
-        // just proceed to get the value from the PropertyMappers.
-        Function<String, ConfigValue> resolver = (n) -> PropertyMappers.getValue(context, n);
-        return NestedPropertyMappingInterceptor.resolve(resolver, resolver, name);
+        // Call through NestedPropertyMappingInterceptor to track what we are currently getting the value for
+        return NestedPropertyMappingInterceptor.getValueFromPropertyMappers(context, name);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -104,6 +104,8 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
             allMappers.remove(mapper);
 
             if (!mapper.hasWildcard()) {
+                // this is not a wildcard value, but may map to wildcards
+                // the current example is something like log-level=wildcardCat1:level,wildcardCat2:level
                 var wildCard = PropertyMappers.getWildcardMappedFrom(mapper.getOption());
                 if (wildCard != null) {
                     ConfigValue value = context.proceed(name);
@@ -115,7 +117,7 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
             mapper = mapper.forKey(name);
 
-            // there is a corner case here -1 for the reload period has no 'to' value.
+            // there is a corner case here: -1 for the reload period has no 'to' value.
             // if that becomes an issue we could use more metadata to perform a full mapping
             return toDistinctStream(name, mapper.getTo());
         });

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
@@ -1,15 +1,15 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
-import io.smallrye.config.ConfigValue;
 import org.keycloak.config.ConfigKeystoreOptions;
+import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-final class ConfigKeystorePropertyMappers {
+public final class ConfigKeystorePropertyMappers {
     private static final String SMALLRYE_KEYSTORE_PATH = "smallrye.config.source.keystore.kc-default.path";
     private static final String SMALLRYE_KEYSTORE_PASSWORD = "smallrye.config.source.keystore.kc-default.password";
 
@@ -38,18 +38,16 @@ final class ConfigKeystorePropertyMappers {
     }
 
     private static String validatePath(String option, ConfigSourceInterceptorContext context) {
-        ConfigValue path = context.proceed(SMALLRYE_KEYSTORE_PATH);
-        boolean isPasswordDefined = context.proceed(SMALLRYE_KEYSTORE_PASSWORD) != null;
-
-        if (path == null) {
-            throw new IllegalArgumentException("config-keystore must be specified");
+        if (option == null) {
+            return null;
         }
+        boolean isPasswordDefined = context.proceed(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + ConfigKeystoreOptions.CONFIG_KEYSTORE_PASSWORD.getKey()) != null;
 
         if (!isPasswordDefined) {
             throw new IllegalArgumentException("config-keystore-password must be specified");
         }
 
-        final Path realPath = Path.of(path.getValue()).toAbsolutePath().normalize();
+        final Path realPath = Path.of(option).toAbsolutePath().normalize();
         if (!Files.exists(realPath)) {
             throw new IllegalArgumentException("config-keystore path does not exist: " + realPath);
         }
@@ -58,12 +56,10 @@ final class ConfigKeystorePropertyMappers {
     }
 
     private static String validatePassword(String option, ConfigSourceInterceptorContext context) {
-        boolean isPasswordDefined = context.proceed(SMALLRYE_KEYSTORE_PASSWORD).getValue() != null;
-        boolean isPathDefined = context.proceed(SMALLRYE_KEYSTORE_PATH) != null;
-
-        if (!isPasswordDefined) {
-            throw new IllegalArgumentException("config-keystore-password must be specified");
+        if (option == null) {
+            return null;
         }
+        boolean isPathDefined = context.proceed(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + ConfigKeystoreOptions.CONFIG_KEYSTORE.getKey()) != null;
 
         if (!isPathDefined) {
             throw new IllegalArgumentException("config-keystore must be specified");

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -127,7 +127,7 @@ public final class LoggingPropertyMappers {
                         .to("quarkus.log.category.\"<categories>\".level")
                         .validator(LoggingPropertyMappers::validateCategoryLogLevel)
                         .wildcardKeysTransformer(LoggingPropertyMappers::getConfiguredLogCategories)
-                        .transformer((v,c) -> toLevel(v).getName())
+                        .transformer((v,c) -> v == null ? null : toLevel(v).getName())
                         .wildcardMapFrom(LoggingOptions.LOG_LEVEL, LoggingPropertyMappers::resolveCategoryLogLevelFromParentLogLevelOption) // a fallback to log-level
                         .paramLabel("level")
                         .build(),
@@ -267,8 +267,8 @@ public final class LoggingPropertyMappers {
         return DEFAULT_ROOT_LOG_LEVEL; // defaults are not resolved in the mapper if transformer is present, so doing it explicitly here
     }
 
-    private static Set<String> getConfiguredLogCategories(Set<String> categories) {
-        for (CategoryLevel categoryLevel : parseRootLogLevel(null)) {
+    private static Set<String> getConfiguredLogCategories(String value, Set<String> categories) {
+        for (CategoryLevel categoryLevel : parseRootLogLevel(value)) {
             if (categoryLevel.category != null) {
                 categories.add(categoryLevel.category);
             }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -18,7 +18,6 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import static java.util.Optional.ofNullable;
 import static org.keycloak.config.Option.WILDCARD_PLACEHOLDER_PATTERN;
-import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR_CHAR;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.toCliFormat;
@@ -34,7 +33,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
@@ -45,14 +43,11 @@ import io.smallrye.config.Expressions;
 import org.keycloak.config.DeprecatedMetadata;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionCategory;
-import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.ShortErrorMessageHandler;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.KcEnvConfigSource;
 import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.utils.StringUtil;
 
 public class PropertyMapper<T> {
@@ -103,10 +98,6 @@ public class PropertyMapper<T> {
         this.parentMapper = parentMapper;
     }
 
-    ConfigValue getConfigValue(ConfigSourceInterceptorContext context) {
-        return getConfigValue(to, context);
-    }
-
     ConfigValue getConfigValue(String name, ConfigSourceInterceptorContext context) {
         String from = getFrom();
 
@@ -123,7 +114,7 @@ public class PropertyMapper<T> {
             // if the property we want to map depends on another one, we use the value from the other property to call the mapper
             // not getting the value directly from SmallRye Config to avoid the risk of infinite recursion when Config is initializing
             String mapFromWithPrefix = NS_KEYCLOAK_PREFIX + mapFrom;
-            config = PropertyMappers.getMapper(mapFromWithPrefix).getConfigValue(mapFromWithPrefix, context);
+            config = context.restart(mapFromWithPrefix);
             parentValue = true;
         }
 
@@ -293,7 +284,7 @@ public class PropertyMapper<T> {
         String map(String name, String value, ConfigSourceInterceptorContext context);
     }
 
-    private final class ContextWrapper implements ConfigSourceInterceptorContext {
+    private static final class ContextWrapper implements ConfigSourceInterceptorContext {
         private final ConfigSourceInterceptorContext context;
         private final ConfigValue value;
 
@@ -336,7 +327,7 @@ public class PropertyMapper<T> {
         private String description;
         private BooleanSupplier isRequired = () -> false;
         private String requiredWhen = "";
-        private Function<Set<String>, Set<String>> wildcardKeysTransformer;
+        private BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer;
         private ValueMapper wildcardMapFrom;
 
         public Builder(Option<T> option) {
@@ -462,7 +453,7 @@ public class PropertyMapper<T> {
             return this;
         }
 
-        public Builder<T> wildcardKeysTransformer(Function<Set<String>, Set<String>> wildcardValuesTransformer) {
+        public Builder<T> wildcardKeysTransformer(BiFunction<String, Set<String>, Set<String>> wildcardValuesTransformer) {
             this.wildcardKeysTransformer = wildcardValuesTransformer;
             return this;
         }
@@ -568,31 +559,16 @@ public class PropertyMapper<T> {
     }
 
     /**
-     * Get all Keycloak config values for the mapper. A multivalued config option is a config option that
-     * has a wildcard in its name, e.g. log-level-<category>.
-     *
-     * @return a list of config values where the key is the resolved wildcard (e.g. category) and the value is the config value
-     */
-    public List<ConfigValue> getKcConfigValues() {
-        return List.of(Configuration.getConfigValue(getFrom()));
-    }
-
-    /**
-     * Returns a new PropertyMapper tailored for the given env var key.
-     * This is currently useful in {@link WildcardPropertyMapper} where "to" and "from" fields need to include a specific
-     * wildcard key.
-     */
-    public PropertyMapper<?> forEnvKey(String key) {
-        return this;
-    }
-
-    /**
      * Returns a new PropertyMapper tailored for the given key.
      * This is currently useful in {@link WildcardPropertyMapper} where "to" and "from" fields need to include a specific
      * wildcard key.
      */
     public PropertyMapper<?> forKey(String key) {
         return this;
+    }
+
+    String getMapFrom() {
+        return mapFrom;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.config.ConfigSupportLevel;
+import org.keycloak.config.Option;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
@@ -15,6 +16,7 @@ import org.keycloak.quarkus.runtime.cli.command.Build;
 import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
 import org.keycloak.quarkus.runtime.configuration.DisabledMappersInterceptor;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+import org.keycloak.quarkus.runtime.configuration.NestedPropertyMappingInterceptor;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
 import java.util.ArrayList;
@@ -24,6 +26,7 @@ import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,12 +82,13 @@ public final class PropertyMappers {
         name = removeProfilePrefixIfNeeded(name);
         PropertyMapper<?> mapper = getMapper(name);
 
-        // During re-aug do not resolve the server runtime properties and avoid they included by quarkus in the default value config source.
+        // During re-aug do not resolve server runtime properties and avoid they included by quarkus in the default value config source.
         //
         // The special handling of log properties is because some logging runtime properties are requested during build time
         // and we need to resolve them. That should be fine as they are generally not considered security sensitive.
         // See https://github.com/quarkusio/quarkus/pull/42157
-        if ((isRebuild() || Environment.isRebuildCheck()) && isKeycloakRuntime(name, mapper) && !name.startsWith("quarkus.log.")) {
+        if ((isRebuild() || Environment.isRebuildCheck()) && isKeycloakRuntime(name, mapper)
+                && !NestedPropertyMappingInterceptor.getResolvingRoot().orElse(name).startsWith("quarkus.log.")) {
             return ConfigValue.builder().withName(name).build();
         }
 
@@ -182,12 +186,19 @@ public final class PropertyMappers {
         return getMapper(property, null);
     }
 
+    /**
+     * @return a mutable copy of all known mappers
+     */
     public static Set<PropertyMapper<?>> getMappers() {
-        return MAPPERS.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+        return MAPPERS.values().stream().flatMap(Collection::stream).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public static Set<WildcardPropertyMapper<?>> getWildcardMappers() {
         return MAPPERS.getWildcardMappers();
+    }
+
+    public static WildcardPropertyMapper<?> getWildcardMappedFrom(Option<?> from) {
+        return MAPPERS.wildcardMapFrom.get(from.getKey());
     }
 
     public static boolean isSupported(PropertyMapper<?> mapper) {
@@ -232,7 +243,9 @@ public final class PropertyMappers {
 
         private final Map<String, PropertyMapper<?>> disabledBuildTimeMappers = new HashMap<>();
         private final Map<String, PropertyMapper<?>> disabledRuntimeMappers = new HashMap<>();
+
         private final Set<WildcardPropertyMapper<?>> wildcardMappers = new HashSet<>();
+        private final Map<String, WildcardPropertyMapper<?>> wildcardMapFrom = new HashMap<>();
 
         public void addAll(PropertyMapper<?>[] mappers) {
             for (PropertyMapper<?> mapper : mappers) {
@@ -252,13 +265,22 @@ public final class PropertyMappers {
 
         public void addMapper(PropertyMapper<?> mapper) {
             if (mapper.hasWildcard()) {
+                if (mapper.getMapFrom() != null) {
+                    wildcardMapFrom.put(mapper.getMapFrom(), (WildcardPropertyMapper<?>) mapper);
+                }
                 wildcardMappers.add((WildcardPropertyMapper<?>)mapper);
+            } else {
+                handleMapper(mapper, this::add);
             }
-            handleMapper(mapper, this::add);
         }
 
         public void removeMapper(PropertyMapper<?> mapper) {
-            wildcardMappers.remove(mapper);
+            if (mapper.hasWildcard()) {
+                wildcardMappers.remove(mapper);
+                if (mapper.getFrom() != null) {
+                    wildcardMapFrom.remove(mapper.getMapFrom());
+                }
+            }
             handleMapper(mapper, this::remove);
         }
 
@@ -272,17 +294,23 @@ public final class PropertyMappers {
         @Override
         @SuppressWarnings({"rawtypes", "unchecked"})
         public List<PropertyMapper<?>> get(Object key) {
-            // First check if the requested option matches any wildcard mappers
+            // First check the base mappings
             String strKey = (String) key;
-            List ret = wildcardMappers.stream()
+
+            List ret = super.get(key);
+            if (ret != null) {
+                return ret;
+            }
+
+            // TODO: we may want to introduce a prefix tree here as we add more wildcardMappers
+            ret = wildcardMappers.stream()
                     .filter(m -> m.matchesWildcardOptionName(strKey))
                     .toList();
             if (!ret.isEmpty()) {
                 return ret;
             }
 
-            // If no wildcard mappers match, check for exact matches
-            return super.get(key);
+            return null;
         }
 
         @Override
@@ -295,7 +323,9 @@ public final class PropertyMappers {
         }
 
         public void sanitizeDisabledMappers() {
-            if (Environment.getParsedCommand().isEmpty()) return; // do not sanitize when no command is present
+            if (Environment.getParsedCommand().isEmpty()) {
+                return; // do not sanitize when no command is present
+            }
 
             DisabledMappersInterceptor.runWithDisabled(() -> { // We need to have the whole configuration available
 
@@ -377,4 +407,5 @@ public final class PropertyMappers {
             operation.accept(mapper.getEnvVarFormat(), mapper);
         }
     }
+
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
@@ -3,20 +3,18 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 import static org.keycloak.config.Option.WILDCARD_PLACEHOLDER_PATTERN;
 import static org.keycloak.quarkus.runtime.cli.Picocli.ARG_PREFIX;
 
-import java.util.List;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import java.util.stream.Stream;
 
 import org.keycloak.config.Option;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
@@ -29,14 +27,14 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
     private final Pattern envVarNameWildcardPattern;
     private Matcher toWildcardMatcher;
     private Pattern toWildcardPattern;
-    private final Function<Set<String>, Set<String>> wildcardKeysTransformer;
+    private final BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer;
     private final ValueMapper wildcardMapFrom;
 
     public WildcardPropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen,
             BiFunction<String, ConfigSourceInterceptorContext, String> mapper,
             String mapFrom, BiFunction<String, ConfigSourceInterceptorContext, String> parentMapper,
             String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator,
-            String description, BooleanSupplier required, String requiredWhen, Matcher fromWildcardMatcher, Function<Set<String>, Set<String>> wildcardKeysTransformer, ValueMapper wildcardMapFrom) {
+            String description, BooleanSupplier required, String requiredWhen, Matcher fromWildcardMatcher, BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer, ValueMapper wildcardMapFrom) {
         super(option, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, mask, validator, description, required, requiredWhen, null);
         this.wildcardMapFrom = wildcardMapFrom;
         this.fromWildcardMatcher = fromWildcardMatcher;
@@ -72,25 +70,11 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
         return MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + fromWildcardMatcher.replaceFirst(wildcardKey);
     }
 
-    @Override
-    public List<ConfigValue> getKcConfigValues() {
-        return this.getWildcardKeys().stream().map(v -> Configuration.getConfigValue(getFrom(v))).toList();
-    }
-
-    public Set<String> getWildcardKeys() {
-        // this is not optimal
-        // TODO find an efficient way to get all values that match the wildcard
-        Set<String> values = StreamSupport.stream(Configuration.getPropertyNames().spliterator(), false)
-                .map(n -> getMappedKey(n, false))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toSet());
-
-        if (wildcardKeysTransformer != null) {
-            return wildcardKeysTransformer.apply(values);
+    public Stream<String> getToFromWildcardTransformer(String value) {
+        if (wildcardKeysTransformer == null) {
+            return Stream.empty();
         }
-
-        return values;
+        return wildcardKeysTransformer.apply(value, new HashSet<String>()).stream().map(toWildcardMatcher::replaceFirst);
     }
 
     /**
@@ -99,30 +83,31 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
      * E.g. for the option "log-level-<category>" and the option name "log-level-io.quarkus",
      * the wildcard value would be "io.quarkus".
      */
-    private Optional<String> getMappedKey(String originalKey, boolean tryTo) {
-        Matcher matcher = fromWildcardPattern.matcher(originalKey);
-        if (matcher.matches()) {
-            return Optional.of(matcher.group(1));
+    private Optional<String> getMappedKey(String originalKey) {
+        Matcher matcher = null;
+        if (originalKey.startsWith(Picocli.ARG_PREFIX) || originalKey.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX)) {
+            matcher = fromWildcardPattern.matcher(originalKey);
+            if (matcher.matches()) {
+                return Optional.of(matcher).map(m -> m.group(1));
+            }
         }
 
-        if (tryTo && toWildcardPattern != null) {
+        if (toWildcardPattern != null) {
             matcher = toWildcardPattern.matcher(originalKey);
             if (matcher.matches()) {
-                return Optional.of(matcher.group(1));
+                return Optional.of(matcher).map(m -> m.group(1));
+            }
+        }
+
+        if (originalKey.startsWith("KC_")) {
+            matcher = envVarNameWildcardPattern.matcher(originalKey);
+            if (matcher.matches()) {
+                // we opiniotatedly convert env var names to CLI format with dots
+                return Optional.of(matcher).map(m -> m.group(1).toLowerCase().replace("_", "."));
             }
         }
 
         return Optional.empty();
-    }
-
-    public Set<String> getToWithWildcards() {
-        if (toWildcardMatcher == null) {
-            return Set.of();
-        }
-
-        return getWildcardKeys().stream()
-                .map(v -> toWildcardMatcher.replaceFirst(v))
-                .collect(Collectors.toSet());
     }
 
     /**
@@ -130,19 +115,7 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
      * E.g. check if "log-level-io.quarkus" matches the wildcard pattern "log-level-<category>".
      */
     public boolean matchesWildcardOptionName(String name) {
-        return fromWildcardPattern.matcher(name).matches() || envVarNameWildcardPattern.matcher(name).matches()
-                || (toWildcardPattern != null && toWildcardPattern.matcher(name).matches());
-    }
-
-    @Override
-    public PropertyMapper<?> forEnvKey(String key) {
-        Matcher matcher = envVarNameWildcardPattern.matcher(key);
-        if (!matcher.matches()) {
-            throw new IllegalStateException("Env var '" + key + "' does not match the expected pattern '" + envVarNameWildcardPattern + "'");
-        }
-        String value = matcher.group(1);
-        final String wildcardValue = value.toLowerCase().replace("_", "."); // we opiniotatedly convert env var names to CLI format with dots
-        return forWildcardValue(wildcardValue);
+        return getMappedKey(name).isPresent();
     }
 
     private PropertyMapper<?> forWildcardValue(final String wildcardValue) {
@@ -153,8 +126,7 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
 
     @Override
     public PropertyMapper<?> forKey(String key) {
-        final String wildcardValue = getMappedKey(key, true).orElseThrow();
-        return forWildcardValue(wildcardValue);
+        return getMappedKey(key).map(this::forWildcardValue).orElseThrow();
     }
 
 }

--- a/quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -16,4 +16,5 @@
 #
 
 org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor
+org.keycloak.quarkus.runtime.configuration.NestedPropertyMappingInterceptor
 org.keycloak.quarkus.runtime.configuration.DisabledMappersInterceptor

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
@@ -55,7 +55,11 @@ public abstract class AbstractConfigurationTest {
         try {
             field = env.getClass().getDeclaredField("m");
             field.setAccessible(true);
-            ((Map<String, String>) field.get(env)).put(name, value);
+            if (value == null) {
+                ((Map<String, String>) field.get(env)).remove(name);
+            } else {
+                ((Map<String, String>) field.get(env)).put(name, value);
+            }
         } catch (Exception cause) {
             throw new RuntimeException("Failed to update environment variables", cause);
         } finally {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -151,6 +151,28 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void testExpressionEnvValue() {
+        putEnvVar("KC_HOSTNAME_STRICT", "false");
+        putEnvVar("MY_EXPRESSION", "${KC_HOSTNAME_STRICT}");
+        ConfigArgsConfigSource.setCliArgs("");
+        var config = createConfig();
+        // with the env variable set, we should get the same value either way
+        assertEquals("false", config.getConfigValue("KC_HOSTNAME_STRICT").getValue());
+        assertEquals("false", config.getConfigValue("MY_EXPRESSION").getValue());
+
+        // without the env variable set, the expression should use the missing env variable
+        putEnvVar("KC_HOSTNAME_STRICT", null);
+        ConfigArgsConfigSource.setCliArgs("");
+        config = createConfig();
+        // check that we get the mapped default value
+        assertEquals("true", config.getConfigValue("kc.hostname-strict").getValue());
+        // check that we don't get the mapped value
+        assertNull(config.getConfigValue("MY_EXPRESSION").getValue());
+        // could change after https://github.com/keycloak/keycloak/issues/38072
+        assertEquals("true", config.getConfigValue("KC_HOSTNAME_STRICT").getValue());
+    }
+
+    @Test
     public void testResolveTransformedValue() {
         ConfigArgsConfigSource.setCliArgs("");
         assertEquals("false", createConfig().getConfigValue("kc.proxy-allow-forwarded-header").getValue());

--- a/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
@@ -6,4 +6,5 @@ KC_LOG_LEVEL_IO_QUARKUS=trace
 config-keystore=src/test/resources/keystore
 config-keystore-password=secret
 
-quarkus.log.file.path=random/path
+#quarkus option should not be used
+quarkus.management.ssl.cipher-suites=foo

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -29,7 +29,6 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
-import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
 @RawDistOnly(reason = "Containers are immutable")

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -62,6 +62,8 @@ public class StartDevCommandDistTest {
         cliResult.assertMessageWasShownExactlyNumberOfTimes("Listening for transport dt_socket at address:", 2);
         cliResult.assertStartedDevMode();
         cliResult.assertMessage("passkeys");
+        // ensure consistency with build-time properties
+        cliResult.assertNoMessage("Build time property cannot");
     }
 
     @DryRun
@@ -80,7 +82,6 @@ public class StartDevCommandDistTest {
     }
 
     @Test
-    @DisabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "A drive letter in URI can cause a problem.")
     void testConfigKeystoreAbsolutePath(KeycloakDistribution dist) {
         CLIResult cliResult = dist.run("start-dev", "--config-keystore=" + Paths.get("src/test/resources/keystore").toAbsolutePath().normalize(),
                 "--config-keystore-password=secret");


### PR DESCRIPTION
Closes #37503
Closes #37781
Closes #37780

There's a little bit of messiness here config properties - we have one-off handling in the keycloak.conf source and now in the property mapping interceptor.

Added more about what the logic is trying to achieve in https://github.com/keycloak/keycloak/pull/37504#issuecomment-2672586446

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
