### PR TITLE
Make ProtocolMappers case insensitive

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -106,6 +106,8 @@ public class ProtocolMapperUtils {
     }
 
     public static String getUserModelValue(UserModel user, String propertyName) {
+        // To support existing configurations, we accept property names starting with both upper and lower case
+        // as earlier versions of Keycloak where applying this behavior.
         Method m = ACCESSORS.get(getLowerCasedProperty(propertyName));
         if (m == null) {
             return null;

--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -101,13 +101,12 @@ public class ProtocolMapperUtils {
             } else {
                 continue;
             }
-            propertyName = Character.toLowerCase(propertyName.charAt(0)) + propertyName.substring(1);
-            ACCESSORS.put(propertyName, method);
+            ACCESSORS.put(getLowerCasedProperty(propertyName), method);
         }
     }
 
     public static String getUserModelValue(UserModel user, String propertyName) {
-        Method m = ACCESSORS.get(propertyName);
+        Method m = ACCESSORS.get(getLowerCasedProperty(propertyName));
         if (m == null) {
             return null;
         }
@@ -119,6 +118,10 @@ public class ProtocolMapperUtils {
         }
 
         return null;
+    }
+
+    private static String getLowerCasedProperty(String propertyName) {
+        return Character.toLowerCase(propertyName.charAt(0)) + propertyName.substring(1);
     }
 
     /**

--- a/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
@@ -42,6 +42,7 @@ public class ProtocolMapperUtilsTest {
         };
 
         Assert.assertEquals("theo", ProtocolMapperUtils.getUserModelValue(useModel, "username"));
+        Assert.assertEquals("theo", ProtocolMapperUtils.getUserModelValue(useModel, "Username"));
         Assert.assertEquals("true", ProtocolMapperUtils.getUserModelValue(useModel, "emailVerified"));
         Assert.assertNull(ProtocolMapperUtils.getUserModelValue(useModel, "unknown"));
     }

--- a/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/ProtocolMapperUtilsTest.java
@@ -44,6 +44,7 @@ public class ProtocolMapperUtilsTest {
         Assert.assertEquals("theo", ProtocolMapperUtils.getUserModelValue(useModel, "username"));
         Assert.assertEquals("theo", ProtocolMapperUtils.getUserModelValue(useModel, "Username"));
         Assert.assertEquals("true", ProtocolMapperUtils.getUserModelValue(useModel, "emailVerified"));
+        Assert.assertNull(ProtocolMapperUtils.getUserModelValue(useModel, "emailverified"));
         Assert.assertNull(ProtocolMapperUtils.getUserModelValue(useModel, "unknown"));
     }
 }


### PR DESCRIPTION
## Summary

This Pull Request partially reverts the logic introduced in https://github.com/keycloak/keycloak/pull/34851 and makes the Getter method extraction mechanism case insensitive. This results in enabling users to specify User Attributes starting with capital letters like "Email" or "LastName" etc. The previous (prior 26.1.0) implementation allowed this.

This is primarily related to SAML protocol mappers where quite often the field friendly names are upper-cased, see this example: https://github.com/keycloak/keycloak/blob/fe98c30077d49822624c728e9fe668f8fb0ff074/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-6412-response-with-proxy-restriction.xml#L58

In this case, it's very easy to make a mistake in the mappers. 

fixes #37577