### PR TITLE
Update default requested token-type and add switch for refresh token

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -449,6 +449,7 @@ detailsHelp=This is information about the details.
 adminEvents=Admin events
 serviceAccountHelp=Allows you to authenticate this client to Keycloak and retrieve access token dedicated to this client. In terms of OAuth2 specification, this enables support of 'Client Credentials Grant' for this client.
 standardTokenExchangeEnabledHelp=Enable Standard Token Exchange V2 for this client.
+enableRefreshRequestedTokenTypeHelp=If property is on, Standard Token Exchange V2 allows the urn:ietf:params:oauth:token-type:refresh_token value for the requested_token_type parameter and returns a refresh_token in the response. If it is off, an error is returned for that requested_token_type.
 urisHelp=Set of URIs which are protected by resource.
 eventTypes.IDENTITY_PROVIDER_RESPONSE.name=Identity provider response
 confirmClientSecretTitle=Regenerate secret for this client?
@@ -1114,6 +1115,7 @@ webAuthnPolicyRpId=Relying party ID
 ldapRolesDnHelp=LDAP DN where roles of this tree are saved. For example, 'ou\=finance,dc\=example,dc\=org'.
 serviceAccount=Service accounts roles
 standardTokenExchangeEnabled=Standard Token Exchange
+enableRefreshRequestedTokenType=Allow refresh token in Standard Token Exchange
 providerUpdatedSuccess=Client policy updated successfully
 assertionConsumerServiceRedirectBindingURL=Assertion Consumer Service Redirect Binding URL
 createClientScopeError=Could not create client scope\: '{{error}}'

--- a/js/apps/admin-ui/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
@@ -6,6 +6,7 @@ import { FormAccess } from "../../components/form/FormAccess";
 import { HelpItem } from "@keycloak/keycloak-ui-shared";
 import { convertAttributeNameToForm } from "../../util";
 import { FormFields } from "../ClientDetails";
+import useIsFeatureEnabled, { Feature } from "../../utils/useIsFeatureEnabled";
 
 type OpenIdConnectCompatibilityModesProps = {
   save: () => void;
@@ -19,7 +20,16 @@ export const OpenIdConnectCompatibilityModes = ({
   hasConfigureAccess,
 }: OpenIdConnectCompatibilityModesProps) => {
   const { t } = useTranslation();
-  const { control } = useFormContext();
+  const { control, watch } = useFormContext();
+  const isFeatureEnabled = useIsFeatureEnabled();
+  const tokenExchangeEnabled = watch(
+    convertAttributeNameToForm<FormFields>(
+      "attributes.standard.token.exchange.enabled",
+    ),
+  );
+  const useRefreshTokens = watch(
+    convertAttributeNameToForm<FormFields>("attributes.use.refresh.tokens"),
+  );
   return (
     <FormAccess
       role="manage-clients"
@@ -171,6 +181,46 @@ export const OpenIdConnectCompatibilityModes = ({
           )}
         />
       </FormGroup>
+
+      {isFeatureEnabled(Feature.StandardTokenExchangeV2) && (
+        <FormGroup
+          label={t("enableRefreshRequestedTokenType")}
+          fieldId="enableRefreshRequestedTokenType"
+          hasNoPaddingTop
+          labelIcon={
+            <HelpItem
+              helpText={t("enableRefreshRequestedTokenTypeHelp")}
+              fieldLabelId="enableRefreshRequestedTokenType"
+            />
+          }
+        >
+          <Controller
+            name={convertAttributeNameToForm<FormFields>(
+              "attributes.standard.token.exchange.enableRefreshRequestedTokenType",
+            )}
+            defaultValue="false"
+            control={control}
+            render={({ field }) => (
+              <Switch
+                id="enableRefreshRequestedTokenType"
+                label={t("on")}
+                labelOff={t("off")}
+                isChecked={
+                  field.value === "true" &&
+                  tokenExchangeEnabled?.toString() === "true" &&
+                  useRefreshTokens?.toString() === "true"
+                }
+                onChange={(_event, value) => field.onChange(value.toString())}
+                aria-label={t("enableRefreshRequestedTokenType")}
+                isDisabled={
+                  tokenExchangeEnabled?.toString() !== "true" ||
+                  useRefreshTokens?.toString() !== "true"
+                }
+              />
+            )}
+          />
+        </FormGroup>
+      )}
       <ActionGroup>
         <Button
           variant="secondary"

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -88,6 +88,7 @@ public final class OIDCConfigAttributes {
     public static final String POST_LOGOUT_REDIRECT_URIS = "post.logout.redirect.uris";
     
     public static final String STANDARD_TOKEN_EXCHANGE_ENABLED = "standard.token.exchange.enabled";
+    public static final String STANDARD_TOKEN_EXCHANGE_REFRESH_ENABLED = "standard.token.exchange.enableRefreshRequestedTokenType";
 
     private OIDCConfigAttributes() {
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
@@ -240,6 +240,14 @@ public class OIDCAdvancedConfigWrapper extends AbstractClientConfigWrapper {
         setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, val);
     }
 
+    public boolean isStandardTokenExchangeRefreshEnabled() {
+        return Boolean.parseBoolean(getAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_REFRESH_ENABLED));
+    }
+
+    public void setStandardTokenExchangeRefreshEnabled(boolean enable) {
+        setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_REFRESH_ENABLED, String.valueOf(enable));
+    }
+
     public String getTlsClientAuthSubjectDn() {
         return getAttribute(X509ClientAuthenticator.ATTR_SUBJECT_DN);
      }

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -210,14 +210,17 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         String requestedTokenType = formParams.getFirst(OAuth2Constants.REQUESTED_TOKEN_TYPE);
         if (requestedTokenType == null) {
             requestedTokenType = OAuth2Constants.REFRESH_TOKEN_TYPE;
-        } else if (!requestedTokenType.equals(OAuth2Constants.ACCESS_TOKEN_TYPE) &&
-                !requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE) &&
-                !requestedTokenType.equals(OAuth2Constants.SAML2_TOKEN_TYPE)) {
-            event.detail(Details.REASON, "requested_token_type unsupported");
-            event.error(Errors.INVALID_REQUEST);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "requested_token_type unsupported", Response.Status.BAD_REQUEST);
+            return requestedTokenType;
         }
-        return requestedTokenType;
+        if (requestedTokenType.equals(OAuth2Constants.ACCESS_TOKEN_TYPE)
+                || requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE)
+                || requestedTokenType.equals(OAuth2Constants.SAML2_TOKEN_TYPE)) {
+            return requestedTokenType;
+        }
+
+        event.detail(Details.REASON, "requested_token_type unsupported");
+        event.error(Errors.INVALID_REQUEST);
+        throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "requested_token_type unsupported", Response.Status.BAD_REQUEST);
     }
 
     protected List<ClientModel> getTargetAudienceClients() {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/token-exchange/testrealm-token-exchange-v2.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/token-exchange/testrealm-token-exchange-v2.json
@@ -523,6 +523,9 @@
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-test" ],
+    "clientRoles" : {
+      "target-client1" : [ "target-client1-role" ]
+    },
     "notBefore" : 0,
     "groups" : [ ]
   } ],
@@ -836,7 +839,7 @@
     "fullScopeAllowed" : false,
     "nodeReRegistrationTimeout" : -1,
     "defaultClientScopes" : [ "service_account", "acr", "default-scope1", "roles", "basic" ],
-    "optionalClientScopes" : [ "optional-scope2" ]
+    "optionalClientScopes" : [ "optional-scope2", "offline_access" ]
   }, {
     "id" : "2daeae03-ff78-4f79-8e72-1c4d443e1655",
     "clientId" : "requester-client-public",


### PR DESCRIPTION
Closes #37115

Changes for the requested token type in TE:

* Access token type is the default now.
* New switch for refresh that is only enabled if use refresh token and token exchange are also enabled.
* If refresh enabled a new persistent session is created if needed (previously it was always transient).
* The `offline_access` is not allowed in TE. The issue comments about disallow it if session was offline but the reality is that currently you can create an `offline_session` from an online one. So the PR just returns an error is offline and refresh token  are requested (when scopes are evaluated, it can be that `offline_access` scope is assigned as default scope or something weird).
* Test class updated for the changes.