### PR TITLE
Replace i18next backend with `i18next-fetch-backend`

### DIFF
--- a/docs/documentation/server_development/topics/themes-react.adoc
+++ b/docs/documentation/server_development/topics/themes-react.adoc
@@ -42,7 +42,7 @@ import { KeycloakProvider } from "@keycloak/keycloak-ui-shared";
 
 The pages are translated using the `i18next` library.
 You can set it up as described on their [website](https://react.i18next.com/).
-If you want to use the translations that are provided then you need to add i18next-http-backend to your project and add:
+If you want to use the translations that are provided then you need to add `i18next-fetch-backend` to your project and add:
 
 [source,javascript]
 ----
@@ -51,9 +51,9 @@ backend: {
   parse: (data: string) => {
     const messages = JSON.parse(data);
 
-    const result: Record<string, string> = {};
-    messages.forEach((v) => (result[v.key] = v.value)); //need to convert to record
-    return result;
+    return Object.fromEntries(
+      messages.map(({ key, value }) => [key, value])
+    );
   },
 },
 ----

--- a/js/apps/account-ui/README.md
+++ b/js/apps/account-ui/README.md
@@ -33,7 +33,7 @@ import { KeycloakProvider } from "@keycloak/keycloak-ui-shared";
 ### Translation
 
 For the translation we use `react-i18next` you can [set it up](https://react.i18next.com/) as described on their website.
-If you want to use the translations that are provided then you need to add `i18next-http-backend` to your project and add:
+If you want to use the translations that are provided then you need to add `i18next-fetch-backend` to your project and add:
 
 ```ts
 
@@ -42,9 +42,9 @@ backend: {
   parse: (data: string) => {
     const messages = JSON.parse(data);
 
-    const result: Record<string, string> = {};
-    messages.forEach((v) => (result[v.key] = v.value));
-    return result;
+    return Object.fromEntries(
+      messages.map(({ key, value }) => [key, value])
+    );
   },
 },
 ```

--- a/js/apps/account-ui/package.json
+++ b/js/apps/account-ui/package.json
@@ -31,7 +31,7 @@
     "@patternfly/react-icons": "^5.4.2",
     "@patternfly/react-table": "^5.4.16",
     "i18next": "^24.2.2",
-    "i18next-http-backend": "^3.0.2",
+    "i18next-fetch-backend": "^6.0.0",
     "keycloak-js": "^26.2.0",
     "lodash-es": "^4.17.21",
     "react": "^18.3.1",

--- a/js/apps/account-ui/src/i18n.ts
+++ b/js/apps/account-ui/src/i18n.ts
@@ -1,5 +1,5 @@
 import { LanguageDetectorModule, createInstance } from "i18next";
-import HttpBackend from "i18next-http-backend";
+import FetchBackend from "i18next-fetch-backend";
 import { initReactI18next } from "react-i18next";
 
 import { environment } from "./environment";
@@ -32,16 +32,14 @@ export const i18n = createInstance({
       environment.serverBaseUrl,
       `resources/${environment.realm}/account/{{lng}}`,
     ),
-    parse: (data: string) => {
-      const messages = JSON.parse(data);
+    parse(data: string) {
+      const messages: KeyValue[] = JSON.parse(data);
 
-      const result: Record<string, string> = {};
-      messages.forEach((v: KeyValue) => (result[v.key] = v.value));
-      return result;
+      return Object.fromEntries(messages.map(({ key, value }) => [key, value]));
     },
   },
 });
 
-i18n.use(HttpBackend);
+i18n.use(FetchBackend);
 i18n.use(keycloakLanguageDetector);
 i18n.use(initReactI18next);

--- a/js/apps/admin-ui/README.md
+++ b/js/apps/admin-ui/README.md
@@ -33,7 +33,7 @@ import { KeycloakProvider } from "@keycloak/keycloak-ui-shared";
 ### Translation
 
 For the translation we use `react-i18next` you can [set it up](https://react.i18next.com/) as described on their website.
-If you want to use the translations that are provided then you need to add `i18next-http-backend` to your project and add:
+If you want to use the translations that are provided then you need to add `i18next-fetch-backend` to your project and add:
 
 ```ts
 
@@ -42,9 +42,9 @@ backend: {
   parse: (data: string) => {
     const messages = JSON.parse(data);
 
-    const result: Record<string, string> = {};
-    messages.forEach((v) => (result[v.key] = v.value));
-    return result;
+    return Object.fromEntries(
+      messages.map(({ key, value }) => [key, value])
+    );
   },
 },
 ```

--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -101,7 +101,7 @@
     "file-saver": "^2.0.5",
     "flat": "^6.0.1",
     "i18next": "^24.2.2",
-    "i18next-http-backend": "^3.0.2",
+    "i18next-fetch-backend": "^6.0.0",
     "jszip": "^3.10.1",
     "keycloak-js": "^26.2.0",
     "lodash-es": "^4.17.21",

--- a/js/apps/admin-ui/src/i18n/i18n.ts
+++ b/js/apps/admin-ui/src/i18n/i18n.ts
@@ -1,5 +1,5 @@
 import { createInstance } from "i18next";
-import HttpBackend from "i18next-http-backend";
+import FetchBackend from "i18next-fetch-backend";
 import { initReactI18next } from "react-i18next";
 
 import { environment } from "../environment";
@@ -24,14 +24,12 @@ export const i18n = createInstance({
       `resources/{{ns}}/admin/{{lng}}`,
     ),
     parse: (data: string) => {
-      const messages = JSON.parse(data);
+      const messages: KeyValue[] = JSON.parse(data);
 
-      const result: Record<string, string> = {};
-      messages.forEach((v: KeyValue) => (result[v.key] = v.value));
-      return result;
+      return Object.fromEntries(messages.map(({ key, value }) => [key, value]));
     },
   },
 });
 
-i18n.use(HttpBackend);
+i18n.use(FetchBackend);
 i18n.use(initReactI18next);

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -92,9 +92,9 @@ importers:
       i18next:
         specifier: ^24.2.2
         version: 24.2.2(typescript@5.7.3)
-      i18next-http-backend:
-        specifier: ^3.0.2
-        version: 3.0.2
+      i18next-fetch-backend:
+        specifier: ^6.0.0
+        version: 6.0.0
       keycloak-js:
         specifier: ^26.2.0
         version: 26.2.0
@@ -189,9 +189,9 @@ importers:
       i18next:
         specifier: ^24.2.2
         version: 24.2.2(typescript@5.7.3)
-      i18next-http-backend:
-        specifier: ^3.0.2
-        version: 3.0.2
+      i18next-fetch-backend:
+        specifier: ^6.0.0
+        version: 6.0.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -2227,9 +2227,6 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-fetch@4.0.0:
-    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3099,8 +3096,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  i18next-http-backend@3.0.2:
-    resolution: {integrity: sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==}
+  i18next-fetch-backend@6.0.0:
+    resolution: {integrity: sha512-kVqnydqLVMZfVlOuP2nf71cREydlxEKLH43jUXAFdOku/GF+6b9fBg31anoos5XncdhdtiYgL9fheqMrtXRwng==}
+    engines: {node: '>=18'}
 
   i18next@24.2.2:
     resolution: {integrity: sha512-NE6i86lBCKRYZa5TaUDkU5S4HFgLIEJRLr3Whf2psgaxBleQ2LC1YW1Vc+SCgkAW7VEzndT6al6+CzegSUHcTQ==}
@@ -3741,15 +3739,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -4596,9 +4585,6 @@ packages:
     resolution: {integrity: sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==}
     engines: {node: '>=16'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
@@ -4946,9 +4932,6 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -4964,9 +4947,6 @@ packages:
   whatwg-url@14.1.1:
     resolution: {integrity: sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==}
     engines: {node: '>=18'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5628,7 +5608,7 @@ snapshots:
       file-saver: 2.0.5
       flat: 6.0.1
       i18next: 24.2.2(typescript@5.7.3)
-      i18next-http-backend: 3.0.2
+      i18next-fetch-backend: 6.0.0
       jszip: 3.10.1
       keycloak-js: 26.2.0
       lodash-es: 4.17.21
@@ -5643,7 +5623,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/runtime'
       - '@types/react'
-      - encoding
       - immer
       - react-native
       - typescript
@@ -6966,12 +6945,6 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  cross-fetch@4.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8120,11 +8093,7 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next-http-backend@3.0.2:
-    dependencies:
-      cross-fetch: 4.0.0
-    transitivePeerDependencies:
-      - encoding
+  i18next-fetch-backend@6.0.0: {}
 
   i18next@24.2.2(typescript@5.7.3):
     dependencies:
@@ -8765,10 +8734,6 @@ snapshots:
   nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-releases@2.0.19: {}
 
@@ -9726,8 +9691,6 @@ snapshots:
     dependencies:
       tldts: 6.1.78
 
-  tr46@0.0.3: {}
-
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
@@ -10093,8 +10056,6 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -10107,11 +10068,6 @@ snapshots:
     dependencies:
       tr46: 5.0.0
       webidl-conversions: 7.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
Replaces the existing i18next backend with  `i18next-fetch-backend`. Unlike the previous backend this one has no polyfills for the Fetch API, no additional dependencies, and also does not include fallbacks to the now ancient `XMLHttpRequest` API, resulting in a smaller bundle.