### PR TITLE
Add supported config options for additional datasources

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -88,10 +88,10 @@ public class DatabaseOptions {
             .description("The maximum size of the connection pool.")
             .build();
 
-    public static final Option<Boolean> DB_ENABLED_DATASOURCE = new OptionBuilder<>("db-enabled-<datasource>", Boolean.class)
+    public static final Option<Boolean> DB_ACTIVE_DATASOURCE = new OptionBuilder<>("db-active-<datasource>", Boolean.class)
             .category(OptionCategory.DATABASE_DATASOURCES)
             .defaultValue(true)
-            .description("Enable/disable specific named datasource <datasource>.")
+            .description("Deactivate specific named datasource <datasource>.")
             .build();
 
     /**

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -152,17 +152,11 @@ public class DatabaseOptions {
         Option<?> option = cachedDatasourceOptions.get(key.get());
 
         if (option == null) {
-            var builder = new OptionBuilder<>(key.get(), parentOption.getType())
-                    .category(OptionCategory.DATABASE_DATASOURCES)
-                    .buildTime(parentOption.isBuildTime())
-                    .defaultValue(parentOption.getDefaultValue())
-                    .expectedValues(parentOption.getExpectedValues())
-                    .caseInsensitiveExpectedValues(parentOption.isCaseInsensitiveExpectedValues())
-                    .strictExpectedValues(parentOption.isStrictExpectedValues());
+            var builder = parentOption.toBuilder()
+                    .key(key.get())
+                    .category(OptionCategory.DATABASE_DATASOURCES);
 
-            if (parentOption.isHidden()) {
-                builder.hidden();
-            } else {
+            if (!parentOption.isHidden()) {
                 builder.description("Used for named <datasource>. " + parentOption.getDescription());
             }
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -2,6 +2,11 @@ package org.keycloak.config;
 
 import org.keycloak.config.database.Database;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 public class DatabaseOptions {
 
     public static final Option<String> DB_DIALECT = new OptionBuilder<>("db-dialect", String.class)
@@ -82,4 +87,119 @@ public class DatabaseOptions {
             .defaultValue(100)
             .description("The maximum size of the connection pool.")
             .build();
+
+    public static final Option<Boolean> DB_ENABLED_DATASOURCE = new OptionBuilder<>("db-enabled-<datasource>", Boolean.class)
+            .category(OptionCategory.DATABASE_DATASOURCES)
+            .defaultValue(true)
+            .description("Enable/disable specific named datasource <datasource>.")
+            .build();
+
+    /**
+     * Options that have their sibling for a named datasource
+     * Example: for `db-dialect`, `db-dialect-<datasource>` is created
+     */
+    public static final List<Option<?>> OPTIONS_DATASOURCES = List.of(
+            DatabaseOptions.DB_DIALECT,
+            DatabaseOptions.DB_DRIVER,
+            DatabaseOptions.DB,
+            DatabaseOptions.DB_URL,
+            DatabaseOptions.DB_URL_HOST,
+            DatabaseOptions.DB_URL_DATABASE,
+            DatabaseOptions.DB_URL_PORT,
+            DatabaseOptions.DB_URL_PROPERTIES,
+            DatabaseOptions.DB_USERNAME,
+            DatabaseOptions.DB_PASSWORD,
+            DatabaseOptions.DB_SCHEMA,
+            DatabaseOptions.DB_POOL_INITIAL_SIZE,
+            DatabaseOptions.DB_POOL_MIN_SIZE,
+            DatabaseOptions.DB_POOL_MAX_SIZE
+    );
+
+    /**
+     * In order to avoid ambiguity, we need to have unique option names for wildcard options.
+     * This map controls overriding option name to be unique for wildcard option.
+     */
+    private static final Map<String, String> DATASOURCES_OVERRIDES_SUFFIX = Map.of(
+            DatabaseOptions.DB.getKey(), "-kind", // db-kind
+            DatabaseOptions.DB_URL.getKey(), "-full"  // db-url-full
+    );
+
+    private static final Map<String, Option<?>> cachedDatasourceOptions = new HashMap<>();
+
+
+    /**
+     * Get datasource option containing named datasource mapped to parent DB options.
+     * <p>
+     * We map DB options to named datasource options like:
+     * <ul>
+     *     <li>{@code db-url-host --> db-url-host-<datasource>}</li>
+     *     <li>{@code db-username --> db-username-<datasource>}</li>
+     *     <li>{@code db --> db-kind-<datasource>}</li>
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<Option<T>> getDatasourceOption(Option<T> parentOption) {
+        if (!OPTIONS_DATASOURCES.contains(parentOption)) {
+            return Optional.empty();
+        }
+
+        var key = getKeyForDatasource(parentOption);
+        if (key.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // check if we already created the same option and return it from the cache
+        Option<?> option = cachedDatasourceOptions.get(key.get());
+
+        if (option == null) {
+            var builder = new OptionBuilder<>(key.get(), parentOption.getType())
+                    .category(OptionCategory.DATABASE_DATASOURCES)
+                    .buildTime(parentOption.isBuildTime())
+                    .defaultValue(parentOption.getDefaultValue())
+                    .expectedValues(parentOption.getExpectedValues())
+                    .caseInsensitiveExpectedValues(parentOption.isCaseInsensitiveExpectedValues())
+                    .strictExpectedValues(parentOption.isStrictExpectedValues());
+
+            if (parentOption.isHidden()) {
+                builder.hidden();
+            } else {
+                builder.description("Used for named <datasource>. " + parentOption.getDescription());
+            }
+
+            option = builder.build();
+            cachedDatasourceOptions.put(key.get(), option);
+        }
+        return Optional.of((Option<T>) option);
+    }
+
+    /**
+     * Get mapped datasource key based on DB option {@param option}
+     */
+    public static Optional<String> getKeyForDatasource(Option<?> option) {
+        return getKeyForDatasource(option.getKey());
+    }
+
+    /**
+     * Get mapped datasource key based on DB option {@param option}
+     */
+    public static Optional<String> getKeyForDatasource(String option) {
+        return Optional.of(option)
+                .filter(o -> OPTIONS_DATASOURCES.stream().map(Option::getKey).anyMatch(o::equals))
+                .map(key -> key.concat(DATASOURCES_OVERRIDES_SUFFIX.getOrDefault(key, "")))
+                .map(key -> key.concat("-<datasource>"));
+    }
+
+    /**
+     * Returns datasource option based on DB option {@code option} with actual wildcard value.
+     * It replaces the {@code <datasource>} with actual value in {@code namedProperty}.
+     * <p>
+     * f.e. Consider {@code option}={@link DatabaseOptions#DB_DRIVER}, and {@code namedProperty}=my-store.
+     * <p>
+     * Result: {@code db-driver-my-store}
+     */
+    public static Optional<String> getResultNamedKey(Option<?> option, String namedProperty) {
+        return getKeyForDatasource(option)
+                .map(key -> key.substring(0, key.indexOf("<")))
+                .map(key -> key.concat(namedProperty));
+    }
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
@@ -82,19 +82,24 @@ public class Option<T> {
     }
 
     public Option<T> withRuntimeSpecificDefault(T defaultValue) {
-        return new Option<T>(
-            this.type,
-            this.key,
-            this.category,
-            this.hidden,
-            this.buildTime,
-            this.description,
-            Optional.ofNullable(defaultValue),
-            this.expectedValues,
-            this.strictExpectedValues,
-            this.caseInsensitiveExpectedValues,
-            this.deprecatedMetadata
-        );
+        return toBuilder().defaultValue(defaultValue).build();
+    }
+
+    public OptionBuilder<T> toBuilder() {
+        var builder = new OptionBuilder<>(key, type)
+                .category(category)
+                .buildTime(buildTime)
+                .description(description)
+                .defaultValue(defaultValue)
+                .expectedValues(expectedValues)
+                .strictExpectedValues(strictExpectedValues)
+                .caseInsensitiveExpectedValues(caseInsensitiveExpectedValues)
+                .deprecatedMetadata(deprecatedMetadata);
+
+        if (hidden) {
+            builder.hidden();
+        }
+        return builder;
     }
 
     private static String getDescriptionByCategorySupportLevel(String description, OptionCategory category) {

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
@@ -16,7 +16,7 @@ public class OptionBuilder<T> {
 
     private final Class<T> type;
     private final Class<?> auxiliaryType;
-    private final String key;
+    private String key;
     private OptionCategory category;
     private boolean hidden;
     private boolean build;
@@ -49,6 +49,11 @@ public class OptionBuilder<T> {
         description = null;
         defaultValue = Optional.empty();
         strictExpectedValues = true;
+    }
+
+    OptionBuilder<T> key(String key) {
+        this.key = key;
+        return this;
     }
 
     public OptionBuilder<T> category(OptionCategory category) {

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
@@ -4,6 +4,7 @@ public enum OptionCategory {
     CACHE("Cache", 10, ConfigSupportLevel.SUPPORTED),
     CONFIG("Config", 15, ConfigSupportLevel.SUPPORTED),
     DATABASE("Database", 20, ConfigSupportLevel.SUPPORTED),
+    DATABASE_DATASOURCES("Database - additional datasources", 21, ConfigSupportLevel.SUPPORTED),
     TRANSACTION("Transaction",30, ConfigSupportLevel.SUPPORTED),
     FEATURE("Feature", 40, ConfigSupportLevel.SUPPORTED),
     HOSTNAME_V2("Hostname v2", 50, ConfigSupportLevel.SUPPORTED),

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
@@ -8,4 +8,19 @@ public class TransactionOptions {
             .buildTime(true)
             .defaultValue(Boolean.FALSE)
             .build();
+
+    public static final Option<Boolean> TRANSACTION_XA_ENABLED_DATASOURCE = new OptionBuilder<>("transaction-xa-enabled-<datasource>", Boolean.class)
+            .category(OptionCategory.TRANSACTION)
+            .description("If set to true, XA for <datasource> datasource will be used.")
+            .buildTime(true)
+            .defaultValue(Boolean.TRUE)
+            .build();
+
+    public static String getNamedTxXADatasource(String namedProperty) {
+        if ("<default>".equals(namedProperty)) {
+            return TRANSACTION_XA_ENABLED.getKey();
+        }
+        var key = TRANSACTION_XA_ENABLED_DATASOURCE.getKey();
+        return key.substring(0, key.indexOf("<")).concat(namedProperty);
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -69,6 +69,10 @@ public final class Configuration {
         return getOptionalBooleanValue(propertyName).orElse(false);
     }
 
+    public static boolean isKcPropertyTrue(String propertyName) {
+        return getOptionalBooleanKcValue(propertyName).orElse(false);
+    }
+
     public static boolean isBlank(Option<?> option) {
         return getOptionalKcValue(option.getKey())
                 .map(StringUtil::isBlank)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -88,7 +88,7 @@ final class DatabasePropertyMappers {
                         .to("quarkus.datasource.jdbc.max-size")
                         .paramLabel("size")
                         .build(),
-                fromOption(DatabaseOptions.DB_ENABLED_DATASOURCE)
+                fromOption(DatabaseOptions.DB_ACTIVE_DATASOURCE)
                         .to("quarkus.datasource.\"<datasource>\".active")
                         .build(),
                 fromOption(DB_URL_PATH)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -61,12 +61,10 @@ final class DatabasePropertyMappers {
                         .paramLabel("properties")
                         .build(),
                 fromOption(DatabaseOptions.DB_USERNAME)
-                        .mapFrom(DatabaseOptions.DB, DatabasePropertyMappers::resolveUsername)
                         .to("quarkus.datasource.username")
                         .paramLabel("username")
                         .build(),
                 fromOption(DatabaseOptions.DB_PASSWORD)
-                        .mapFrom(DatabaseOptions.DB, DatabasePropertyMappers::resolvePassword)
                         .to("quarkus.datasource.password")
                         .paramLabel("password")
                         .isMasked(true)
@@ -118,14 +116,6 @@ final class DatabasePropertyMappers {
 
     private static String toDatabaseKind(String db, ConfigSourceInterceptorContext context) {
         return Database.getDatabaseKind(db).orElse(null);
-    }
-
-    private static String resolveUsername(String database, ConfigSourceInterceptorContext context) {
-        return isDevModeDatabase(database) ? "sa" : null;
-    }
-
-    private static String resolvePassword(String database, ConfigSourceInterceptorContext context) {
-        return isDevModeDatabase(database) ? "password" : null;
     }
 
     private static boolean isDevModeDatabase(String database) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -8,14 +8,16 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.
 
 public class TransactionPropertyMappers {
 
-    private static final String QUARKUS_TXPROP_TARGET = "quarkus.datasource.jdbc.transactions";
-
     private TransactionPropertyMappers(){}
 
     public static PropertyMapper<?>[] getTransactionPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(TransactionOptions.TRANSACTION_XA_ENABLED)
-                        .to(QUARKUS_TXPROP_TARGET)
+                        .to("quarkus.datasource.jdbc.transactions")
+                        .transformer(TransactionPropertyMappers::getQuarkusTransactionsValue)
+                        .build(),
+                fromOption(TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE)
+                        .to("quarkus.datasource.\"<datasource>\".jdbc.transactions")
                         .transformer(TransactionPropertyMappers::getQuarkusTransactionsValue)
                         .build()
         };

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
@@ -15,6 +15,9 @@ import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
 
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_QUARKUS_PREFIX;
+
 public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
 
     public static final String WILDCARD_FROM_START = "<";
@@ -28,12 +31,10 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
     private String toPrefix;
     private String toSuffix;
 
-    public WildcardPropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen,
-            BiFunction<String, ConfigSourceInterceptorContext, String> mapper,
-            String mapFrom, BiFunction<String, ConfigSourceInterceptorContext, String> parentMapper,
+    public WildcardPropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen, ValueMapper mapper, String mapFrom, ValueMapper parentMapper,
             String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator,
             String description, BooleanSupplier required, String requiredWhen, BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer, ValueMapper wildcardMapFrom) {
-        super(option, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, mask, validator, description, required, requiredWhen, null);
+        super(option, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, mask, validator, description, required, requiredWhen, null, null);
         this.wildcardMapFrom = wildcardMapFrom;
 
         this.fromPrefix = getFrom().substring(0, getFrom().indexOf(WILDCARD_FROM_START));
@@ -42,8 +43,8 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
         }
 
         if (to != null) {
-            if (!to.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX)) {
-                throw new IllegalArgumentException("Wildcards should map to quarkus options. If not, PropertyMappers logic will need adjusted");
+            if (!to.startsWith(NS_QUARKUS_PREFIX) && !to.startsWith(NS_KEYCLOAK_PREFIX)) {
+                throw new IllegalArgumentException("Wildcards should map to Quarkus or Keycloak options (option '%s' mapped to '%s'). If not, PropertyMappers logic will need adjusted".formatted(option.getKey(), to));
             }
             this.toPrefix = to.substring(0, to.indexOf(WILDCARD_FROM_START));
             int lastIndexOf = to.lastIndexOf(">");
@@ -81,8 +82,14 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
         String wildcardValue = extractWildcardValue(key).orElseThrow();
         String to = getTo(wildcardValue);
         String from = getFrom(wildcardValue);
-        return new PropertyMapper<T>(this, from, to,
-                wildcardMapFrom == null ? null : (v, context) -> wildcardMapFrom.map(wildcardValue, v, context));
+        String mapFrom = getMapFrom();
+        // resolve even the mapFrom() value
+        if (mapFrom != null && mapFrom.contains(WILDCARD_FROM_START)) {
+            mapFrom = mapFrom.substring(0, mapFrom.indexOf(WILDCARD_FROM_START)).concat(wildcardValue);
+        }
+
+        return new PropertyMapper<T>(this, from, to, mapFrom, wildcardValue,
+                wildcardMapFrom == null ? null : (name, v, context) -> wildcardMapFrom.map(wildcardValue, v, context));
     }
 
     private Optional<String> extractWildcardValue(String key) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -734,4 +734,11 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getErrString(), containsString("Invalid value for option '--log-%s-async-queue-length': 'invalid' is not an int".formatted(handlerName)));
     }
+
+    @Test
+    public void datasourcesNotAllowedChar(){
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev","--db-kind-<default>=postgres");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: '--db-kind-<default>'"));
+    }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
@@ -19,6 +19,7 @@ package org.keycloak.quarkus.runtime.configuration.test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Field;
@@ -170,6 +171,19 @@ public abstract class AbstractConfigurationTest {
 
     protected void assertExternalConfig(Map<String, String> expectedValues) {
         expectedValues.forEach(this::assertExternalConfig);
+    }
+    
+    protected void assertConfigNull(String key, boolean isExternal) {
+        Function<String, ConfigValue> getConfig = isExternal ? Configuration::getConfigValue : Configuration::getKcConfigValue;
+        assertThat(String.format("We expect that the value is null for key '%s'", key), getConfig.apply(key).getValue(), nullValue());
+    }
+
+    protected void assertConfigNull(String key) {
+        assertConfigNull(key, false);
+    }
+
+    protected void assertExternalConfigNull(String key) {
+        assertConfigNull(key, true);
     }
 
     protected static void addPersistedConfigValues(Map<String, String> values) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -252,7 +252,8 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
         ConfigArgsConfigSource.setCliArgs("--db=dev-mem", "--db-username=other");
         config = createConfig();
-        assertEquals("sa", config.getConfigValue("quarkus.datasource.username").getValue());
+        // we allow changing username by default
+        assertEquals("other", config.getConfigValue("quarkus.datasource.username").getValue());
         // should be untransformed
         assertEquals("other", config.getConfigValue("kc.db-username").getValue());
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
@@ -95,11 +95,11 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-tigers=dev-mem");
-        initConfig();
-        assertExternalConfig("quarkus.datasource.\"tigers\".username", "sa");
-        assertExternalConfig("quarkus.datasource.\"tigers\".password", "password");
-        assertConfig("db-username-tigers", "sa");
-        assertConfig("db-password-tigers", "password");
+        SmallRyeConfig config = createConfig();
+        assertNull(config.getConfigValue("quarkus.datasource.\"tigers\".username").getValue());
+        assertNull(config.getConfigValue("quarkus.datasource.\"tigers\".password").getValue());
+        assertNull(config.getConfigValue("kc.db-username-tigers").getValue());
+        assertNull(config.getConfigValue("kc.db-password-tigers").getValue());
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-users=postgres", "--db-username-users=other");
@@ -108,7 +108,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-some-store=postgres");
-        SmallRyeConfig config = createConfig();
+        config = createConfig();
         // username  or password should not be set, either as the quarkus or kc property
         assertNull(config.getConfigValue("quarkus.datasource.\"some-store\".username").getValue());
         assertNull(config.getConfigValue("quarkus.datasource.\"some-store\".password").getValue());

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
@@ -139,13 +139,13 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
     public void datasourceEnabled() {
         ConfigArgsConfigSource.setCliArgs("");
         initConfig();
-        assertConfig("db-enabled-store", "true");
+        assertConfig("db-active-store", "true");
         assertExternalConfig("quarkus.datasource.\"store\".active", "true");
         onAfter();
 
-        ConfigArgsConfigSource.setCliArgs("--db-enabled-store=false");
+        ConfigArgsConfigSource.setCliArgs("--db-active-store=false");
         initConfig();
-        assertConfig("db-enabled-store", "false");
+        assertConfig("db-active-store", "false");
         assertExternalConfig("quarkus.datasource.\"store\".active", "false");
     }
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
@@ -18,10 +18,29 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
+
+    @Test
+    public void defaultDatasource() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-default=mariadb", "--db=postgres");
+        initConfig();
+
+        assertConfig("db-kind-default", "mariadb");
+        assertConfig("db", "postgres");
+        assertExternalConfig("quarkus.datasource.\"default\".db-kind", "mariadb");
+        assertExternalConfig("quarkus.datasource.db-kind", "postgresql");
+
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-some<other>datasource=mssql");
+        initConfig();
+
+        // KC value is present as CLI is available data source
+        assertConfig("db-kind-some<other>datasource", "mssql");
+        assertExternalConfigNull("quarkus.datasource.\"some<other>datasource\".db-kind");
+    }
 
     @Test
     public void propertyMapping() {
@@ -95,11 +114,11 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-tigers=dev-mem");
-        SmallRyeConfig config = createConfig();
-        assertNull(config.getConfigValue("quarkus.datasource.\"tigers\".username").getValue());
-        assertNull(config.getConfigValue("quarkus.datasource.\"tigers\".password").getValue());
-        assertNull(config.getConfigValue("kc.db-username-tigers").getValue());
-        assertNull(config.getConfigValue("kc.db-password-tigers").getValue());
+        initConfig();
+        assertExternalConfigNull("quarkus.datasource.\"tigers\".username");
+        assertExternalConfigNull("quarkus.datasource.\"tigers\".password");
+        assertConfigNull("db-username-tigers");
+        assertConfigNull("db-password-tigers");
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-users=postgres", "--db-username-users=other");
@@ -108,12 +127,12 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-some-store=postgres");
-        config = createConfig();
+        initConfig();
         // username  or password should not be set, either as the quarkus or kc property
-        assertNull(config.getConfigValue("quarkus.datasource.\"some-store\".username").getValue());
-        assertNull(config.getConfigValue("quarkus.datasource.\"some-store\".password").getValue());
-        assertNull(config.getConfigValue("kc.db-username-some-store").getValue());
-        assertNull(config.getConfigValue("kc.db-password-some-store").getValue());
+        assertExternalConfigNull("quarkus.datasource.\"some-store\".username");
+        assertExternalConfigNull("quarkus.datasource.\"some-store\".password");
+        assertConfigNull("db-username-some-store");
+        assertConfigNull("db-password-some-store");
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/DatasourcesConfigurationTest.java
@@ -1,0 +1,271 @@
+package org.keycloak.quarkus.runtime.configuration.test;
+
+import io.smallrye.config.Expressions;
+import io.smallrye.config.SmallRyeConfig;
+import org.h2.jdbcx.JdbcDataSource;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.junit.Test;
+import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.mariadb.jdbc.MariaDbDataSource;
+import org.postgresql.xa.PGXADataSource;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
+
+    @Test
+    public void propertyMapping() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-user-store=mariadb", "--db-url-full-user-store=jdbc:mariadb://localhost/keycloak");
+
+        initConfig();
+
+        assertConfig("db-dialect-user-store", MariaDBDialect.class.getName());
+        assertExternalConfig("quarkus.datasource.\"user-store\".jdbc.url", "jdbc:mariadb://localhost/keycloak");
+    }
+
+    @Test
+    public void driverSetExplicitly() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-user-store=mssql", "--db-url-full-user-store=jdbc:sqlserver://localhost/keycloak");
+        System.setProperty("kc.db-driver-user-store", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        System.setProperty("kc.transaction-xa-enabled-user-store", "false");
+        assertTrue(ConfigArgsConfigSource.getAllCliArgs().contains("--db-kind-user-store=mssql"));
+
+        initConfig();
+
+        assertConfig("db-kind-user-store", "mssql");
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"user-store\".jdbc.url", "jdbc:sqlserver://localhost/keycloak",
+                "quarkus.datasource.\"user-store\".db-kind", "mssql",
+                "quarkus.datasource.\"user-store\".jdbc.driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+                "quarkus.datasource.\"user-store\".jdbc.transactions", "enabled")
+        );
+    }
+
+    @Test
+    public void urlProperties() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-customstore=mariadb", "--db-url-full-customstore=jdbc:mariadb:aurora://foo/bar?a=1&b=2");
+
+        initConfig();
+
+        assertConfig("db-dialect-customstore", MariaDBDialect.class.getName());
+        assertExternalConfig("quarkus.datasource.\"customstore\".jdbc.url", "jdbc:mariadb:aurora://foo/bar?a=1&b=2");
+    }
+
+    @Test
+    public void expansionDisabled() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-store=mysql");
+        SmallRyeConfig config = createConfig();
+        String value = Expressions.withoutExpansion(() -> config.getConfigValue("quarkus.datasource.\"store\".jdbc.url").getValue());
+        assertEquals("jdbc:mysql://${kc.db-url-host-store:localhost}:${kc.db-url-port-store:3306}/${kc.db-url-database-store:keycloak}${kc.db-url-properties-store:}", value);
+
+        assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:mysql://localhost:3306/keycloak");
+    }
+
+    @Test
+    public void defaults() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-file");
+        initConfig();
+        assertConfig("db-dialect-store", H2Dialect.class.getName());
+        // XA datasource is the default
+        assertExternalConfig("quarkus.datasource.\"store\".jdbc.driver", JdbcDataSource.class.getName());
+        assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:file:" + Environment.getHomeDir() + "/data/h2/keycloakdb-store;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-mem");
+        initConfig();
+        assertConfig("db-dialect-store", H2Dialect.class.getName());
+        assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:mem:keycloakdb-store;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
+        assertExternalConfig("quarkus.datasource.\"store\".db-kind", "h2");
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-clients=dev-mem", "--db-username-clients=other");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.\"clients\".username", "other");
+        assertConfig("db-username-clients", "other");
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-tigers=dev-mem");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.\"tigers\".username", "sa");
+        assertExternalConfig("quarkus.datasource.\"tigers\".password", "password");
+        assertConfig("db-username-tigers", "sa");
+        assertConfig("db-password-tigers", "password");
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-users=postgres", "--db-username-users=other");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.\"users\".username", "other");
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-some-store=postgres");
+        SmallRyeConfig config = createConfig();
+        // username  or password should not be set, either as the quarkus or kc property
+        assertNull(config.getConfigValue("quarkus.datasource.\"some-store\".username").getValue());
+        assertNull(config.getConfigValue("quarkus.datasource.\"some-store\".password").getValue());
+        assertNull(config.getConfigValue("kc.db-username-some-store").getValue());
+        assertNull(config.getConfigValue("kc.db-password-some-store").getValue());
+    }
+
+    @Test
+    public void datasourceEnabled() {
+        ConfigArgsConfigSource.setCliArgs("");
+        initConfig();
+        assertConfig("db-enabled-store", "true");
+        assertExternalConfig("quarkus.datasource.\"store\".active", "true");
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-enabled-store=false");
+        initConfig();
+        assertConfig("db-enabled-store", "false");
+        assertExternalConfig("quarkus.datasource.\"store\".active", "false");
+    }
+
+    @Test
+    public void datasourceKindProperties() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-my-store=postgres", "--db-url-full-my-store=jdbc:postgresql://localhost/keycloak", "--db-username-my-store=postgres");
+        initConfig();
+
+        assertConfig("db-dialect-my-store", "org.hibernate.dialect.PostgreSQLDialect");
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"my-store\".jdbc.url", "jdbc:postgresql://localhost/keycloak",
+                "quarkus.datasource.\"my-store\".db-kind", "postgresql",
+                "quarkus.datasource.\"my-store\".username", "postgres"
+        ));
+    }
+
+    @Test
+    public void propertiesGetApplied() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-asdf=postgres");
+        initConfig();
+        assertConfig("db-dialect-asdf", "org.hibernate.dialect.PostgreSQLDialect");
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"asdf\".jdbc.url", "jdbc:postgresql://localhost:5432/keycloak",
+                "quarkus.datasource.\"asdf\".db-kind", "postgresql"
+        ));
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-kind-asdf=postgres", "--db-url-host-asdf=myhost", "--db-url-port-asdf=5432", "--db-url-database-asdf=kcdb", "--db-url-properties-asdf=?foo=bar");
+        initConfig();
+        assertConfig("db-dialect-asdf", "org.hibernate.dialect.PostgreSQLDialect");
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"asdf\".jdbc.url", "jdbc:postgresql://myhost:5432/kcdb?foo=bar",
+                "quarkus.datasource.\"asdf\".db-kind", "postgresql"
+        ));
+        onAfter();
+    }
+
+
+    @Test
+    public void removeSpaceFromValue() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-store=postgres      ");
+        initConfig();
+
+        assertConfig("db-dialect-store", "org.hibernate.dialect.PostgreSQLDialect");
+        assertExternalConfig("quarkus.datasource.\"store\".db-kind", "postgresql");
+        assertThat(Configuration.getConfigValue("quarkus.datasource.\"store\".db-kind").getRawValue(), is("postgres"));
+    }
+
+    @Test
+    public void defaultDbPortGetApplied() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-realms=mssql", "--db-url-host-realms=myhost", "--db-url-database-realms=kcdb", "--db-url-port-realms=1234", "--db-url-properties-realms=?foo=bar");
+        initConfig();
+
+        assertConfig("db-dialect-realms", "org.hibernate.dialect.SQLServerDialect");
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"realms\".jdbc.url", "jdbc:sqlserver://myhost:1234;databaseName=kcdb?foo=bar",
+                "quarkus.datasource.\"realms\".db-kind", "mssql"
+        ));
+    }
+
+    @Test
+    public void setDbUrlOverridesDefaultDataSource() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-my-super-duper-store=mariadb", "--db-url-host-my-super-duper-store=myhost", "--db-url-full-my-super-duper-store=jdbc:mariadb://localhost/keycloak");
+        initConfig();
+
+        assertConfig("db-dialect-my-super-duper-store", "org.hibernate.dialect.MariaDBDialect");
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"my-super-duper-store\".jdbc.url", "jdbc:mariadb://localhost/keycloak",
+                "quarkus.datasource.\"my-super-duper-store\".db-kind", "mariadb"
+        ));
+    }
+
+    @Test
+    public void datasourceProperties() {
+        System.setProperty("kc.db-url-properties-clients", ";;test=test;test1=test1");
+        System.setProperty("kc.db-url-path", "test-dir");
+        System.setProperty("kc.transaction-xa-enabled-clients", "true");
+        ConfigArgsConfigSource.setCliArgs("--db-kind-clients=dev-file");
+
+        initConfig();
+
+        assertConfig("db-dialect-clients", H2Dialect.class.getName());
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"clients\".jdbc.url", "jdbc:h2:file:test-dir/data/h2/keycloakdb-clients;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0",
+                "quarkus.datasource.\"clients\".jdbc.transactions", "xa"
+        ));
+
+        ConfigArgsConfigSource.setCliArgs("");
+        initConfig();
+        assertConfig("db-dialect-clients", H2Dialect.class.getName());
+        assertExternalConfig("quarkus.datasource.\"clients\".jdbc.url", "jdbc:h2:file:test-dir/data/h2/keycloakdb-clients;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
+        onAfter();
+
+        System.setProperty("kc.db-url-properties-users", "?test=test&test1=test1");
+        System.setProperty("kc.transaction-xa-enabled-users", "true");
+        ConfigArgsConfigSource.setCliArgs("--db-kind-users=mariadb");
+        initConfig();
+
+        assertConfig("db-dialect-users", MariaDBDialect.class.getName());
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"users\".jdbc.url", "jdbc:mariadb://localhost:3306/keycloak?test=test&test1=test1",
+                "quarkus.datasource.\"users\".jdbc.driver", MariaDbDataSource.class.getName()
+        ));
+        onAfter();
+
+        System.setProperty("kc.db-url-properties-elephants", "?test=test&test1=test1");
+        System.setProperty("kc.transaction-xa-enabled-elephants", "true");
+        ConfigArgsConfigSource.setCliArgs("--db-kind-elephants=postgres");
+
+        initConfig();
+        assertConfig("db-dialect-elephants", PostgreSQLDialect.class.getName());
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"elephants\".jdbc.url", "jdbc:postgresql://localhost:5432/keycloak?test=test&test1=test1",
+                "quarkus.datasource.\"elephants\".jdbc.driver", PGXADataSource.class.getName()
+        ));
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--db-schema-lions=test-schema");
+        initConfig();
+        assertConfig("db-schema-lions", "test-schema");
+    }
+
+    // KEYCLOAK-15632
+    @Test
+    public void nestedDatasourceProperties() {
+        initConfig();
+        assertExternalConfig("quarkus.datasource.foo", "jdbc:h2:file:" + Environment.getHomeDir() + "/data/keycloakdb");
+        assertExternalConfig("quarkus.datasource.bar", "foo-def-suffix");
+
+        System.setProperty("kc.prop5", "val5");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.bar", "foo-val5-suffix");
+
+        System.setProperty("kc.prop4", "val4");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.bar", "foo-val4");
+
+        System.setProperty("kc.prop3", "val3");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.bar", "foo-val3");
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
@@ -112,7 +112,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
     @Launch({ "start" })
     @Order(9)
     void nonXADatasourceFailsToStart(CLIResult cliResult) {
-        cliResult.assertError("Multiple datasources are configured but more than 1 is using non-XA transactions.");
+        cliResult.assertError("Multiple datasources are configured but more than 1 (user-store3, <default>) is using non-XA transactions.");
     }
 
     @Test
@@ -144,45 +144,43 @@ public class QuarkusPropertiesAutoBuildDistTest {
     public static class AddAdditionalDatasource implements Consumer<KeycloakDistribution> {
         @Override
         public void accept(KeycloakDistribution distribution) {
-            distribution.setQuarkusProperty("quarkus.datasource.user-store.db-kind", "h2");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store.username","sa");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store.jdbc.url","jdbc:h2:mem:user-store;DB_CLOSE_DELAY=-1");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store.jdbc.transactions", "xa");
+            distribution.setProperty("db-kind-user-store", "dev-mem");
+            distribution.setProperty("db-username-user-store", "sa");
+            distribution.setProperty("db-url-full-user-store", "jdbc:h2:mem:user-store;DB_CLOSE_DELAY=-1");
         }
     }
 
     public static class AddAdditionalDatasource2 implements Consumer<KeycloakDistribution> {
         @Override
         public void accept(KeycloakDistribution distribution) {
-            distribution.setQuarkusProperty("quarkus.datasource.user-store2.db-kind", "h2");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store2.db-transactions", "enabled");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store2.username","sa");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store2.jdbc.url","jdbc:h2:mem:user-store2;DB_CLOSE_DELAY=-1");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store2.jdbc.transactions", "xa");
+            distribution.setProperty("db-kind-user-store2", "dev-mem");
+            distribution.setProperty("transaction-xa-enabled-user-store2", "true");
+            distribution.setProperty("db-username-user-store2", "sa");
+            distribution.setProperty("db-url-full-user-store2", "jdbc:h2:mem:user-store2;DB_CLOSE_DELAY=-1");
         }
     }
 
     public static class AddNonXADatasource implements Consumer<KeycloakDistribution> {
         @Override
         public void accept(KeycloakDistribution distribution) {
-            distribution.setQuarkusProperty("quarkus.datasource.user-store3.db-kind", "h2");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store3.db-transactions", "enabled");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store3.username","sa");
-            distribution.setQuarkusProperty("quarkus.datasource.user-store3.jdbc.url","jdbc:h2:mem:user-store2;DB_CLOSE_DELAY=-1");
+            distribution.setProperty("db-kind-user-store3", "dev-mem");
+            distribution.setProperty("transaction-xa-enabled-user-store3", "false");
+            distribution.setProperty("db-username-user-store3", "sa");
+            distribution.setProperty("db-url-full-user-store3", "jdbc:h2:mem:user-store2;DB_CLOSE_DELAY=-1");
         }
     }
 
     public static class ChangeAdditionalDatasourceUsername implements Consumer<KeycloakDistribution> {
         @Override
         public void accept(KeycloakDistribution distribution) {
-            distribution.setQuarkusProperty("quarkus.datasource.user-store.username","foo");
+            distribution.setProperty("db-username-user-store", "foo");
         }
     }
 
     public static class ChangeAdditionalDatasourceDbKind implements Consumer<KeycloakDistribution> {
         @Override
         public void accept(KeycloakDistribution distribution) {
-            distribution.setQuarkusProperty("quarkus.datasource.user-store.db-kind","h2");
+            distribution.setProperty("db-kind-user-store", "dev-mem");
         }
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatasourcesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatasourcesDistTest.java
@@ -16,15 +16,15 @@ public class DatasourcesDistTest {
     @Test
     @Launch({"start-dev", "--db-kind-users=postgres", "--db-kind-clients=postgres", "--transaction-xa-enabled-users=false"})
     public void multipleNonXaDatasources(CLIResult result) {
-        result.assertNoMessage("Multiple datasources are enabled:"); // log handlers are not initialized yet, so only the error should be visible
+        result.assertNoMessage("Multiple datasources are specified:"); // log handlers are not initialized yet, so only the error should be visible
         result.assertExitCode(CommandLine.ExitCode.SOFTWARE);
         result.assertError("Multiple datasources are configured but more than 1 (<default>, users) is using non-XA transactions.");
     }
 
     @Test
-    @Launch({"start-dev", "--db-kind-users=postgres", "--db-kind-clients=mariadb"})
+    @Launch({"build", "--db-kind-users=postgres", "--db-kind-clients=mariadb"})
     public void multipleDatasourcesPrint(CLIResult result) {
-        result.assertMessage("Multiple datasources are enabled: clients, <default>, users");
-        result.assertStartedDevMode();
+        result.assertMessage("Multiple datasources are specified: clients, <default>, users");
+        result.assertBuild();
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatasourcesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatasourcesDistTest.java
@@ -1,0 +1,30 @@
+package org.keycloak.it.storage.database.dist;
+
+import io.quarkus.test.junit.main.Launch;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import picocli.CommandLine;
+
+@DistributionTest
+@RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.STORAGE)
+public class DatasourcesDistTest {
+
+    @Test
+    @Launch({"start-dev", "--db-kind-users=postgres", "--db-kind-clients=postgres", "--transaction-xa-enabled-users=false"})
+    public void multipleNonXaDatasources(CLIResult result) {
+        result.assertNoMessage("Multiple datasources are enabled:"); // log handlers are not initialized yet, so only the error should be visible
+        result.assertExitCode(CommandLine.ExitCode.SOFTWARE);
+        result.assertError("Multiple datasources are configured but more than 1 (<default>, users) is using non-XA transactions.");
+    }
+
+    @Test
+    @Launch({"start-dev", "--db-kind-users=postgres", "--db-kind-clients=mariadb"})
+    public void multipleDatasourcesPrint(CLIResult result) {
+        result.assertMessage("Multiple datasources are enabled: clients, <default>, users");
+        result.assertStartedDevMode();
+    }
+}

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -64,10 +64,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -66,10 +66,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
@@ -26,10 +26,24 @@ Database:
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
 
+Database - additional datasources:
+
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -59,10 +59,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -59,10 +59,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -59,10 +59,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -59,10 +59,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -101,10 +101,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -152,10 +152,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -133,10 +133,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -153,10 +153,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -127,6 +127,44 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Hostname v2:
 
 --hostname <hostname|URL>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -147,6 +147,44 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Hostname v2:
 
 --hostname <hostname|URL>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -132,10 +132,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -152,10 +152,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -130,10 +130,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -150,10 +150,59 @@ Database:
 --db-username <username>
                      The username of the database user.
 
+Database - additional datasources:
+
+--db-active-<datasource> <true|false>
+                     Deactivate specific named datasource <datasource>. Default: true.
+--db-driver-<datasource> <driver>
+                     Used for named <datasource>. The fully qualified class name of the JDBC
+                       driver. If not set, a default driver is set accordingly to the chosen
+                       database.
+--db-kind-<datasource> <vendor>
+                     Used for named <datasource>. The database vendor. In production mode the
+                       default value of 'dev-file' is deprecated, you should explicitly specify the
+                       db instead. Possible values are: dev-file, dev-mem, mariadb, mssql, mysql,
+                       oracle, postgres. Default: dev-file.
+--db-password-<datasource> <password>
+                     Used for named <datasource>. The password of the database user.
+--db-pool-initial-size-<datasource> <size>
+                     Used for named <datasource>. The initial size of the connection pool.
+--db-pool-max-size-<datasource> <size>
+                     Used for named <datasource>. The maximum size of the connection pool. Default:
+                       100.
+--db-pool-min-size-<datasource> <size>
+                     Used for named <datasource>. The minimal size of the connection pool.
+--db-schema-<datasource> <schema>
+                     Used for named <datasource>. The database schema to be used.
+--db-url-database-<datasource> <dbname>
+                     Used for named <datasource>. Sets the database name of the default JDBC URL of
+                       the chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-full-<datasource> <jdbc-url>
+                     Used for named <datasource>. The full database JDBC URL. If not provided, a
+                       default URL is set based on the selected database vendor. For instance, if
+                       using 'postgres', the default JDBC URL would be 'jdbc:postgresql:
+                       //localhost/keycloak'.
+--db-url-host-<datasource> <hostname>
+                     Used for named <datasource>. Sets the hostname of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-port-<datasource> <port>
+                     Used for named <datasource>. Sets the port of the default JDBC URL of the
+                       chosen vendor. If the `db-url` option is set, this option is ignored.
+--db-url-properties-<datasource> <properties>
+                     Used for named <datasource>. Sets the properties of the default JDBC URL of
+                       the chosen vendor. Make sure to set the properties accordingly to the format
+                       expected by the database vendor, as well as appending the right character at
+                       the beginning of this property value. If the `db-url` option is set, this
+                       option is ignored.
+--db-username-<datasource> <username>
+                     Used for named <datasource>. The username of the database user.
+
 Transaction:
 
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
+--transaction-xa-enabled-<datasource> <true|false>
+                     If set to true, XA for <datasource> datasource will be used. Default: true.
 
 Feature:
 


### PR DESCRIPTION
- Closes: #29116
- Closes: https://github.com/keycloak/keycloak/issues/39154

### Changes

- Automatically create sibling datasource OPTIONS for DB options 
- Automatically create sibling datasource PROPERTY MAPPERS for DB options
- New options category DATABASE_DATASOURCES -> 'Database - additional datasources'
- Default DB name for H2 dev-file is `keycloakdb-<datasource>` (f.e. `keycloakdb-persistent-sessions`)
- Providing option to enable/disable specific datasources -> `db-enabled-<datasource>`
- Additional changes for CLI for build-time wildcard options
- Solves https://github.com/keycloak/keycloak/issues/39154

### Follow-up issues:
- Amend ENV logic with wildcard mappers
- Documentation
- https://github.com/keycloak/keycloak/issues/39250

