### PR TITLE
Grant Type condition for client policies

### DIFF
--- a/docs/documentation/server_admin/topics/clients/client-policies.adoc
+++ b/docs/documentation/server_admin/topics/clients/client-policies.adoc
@@ -95,7 +95,10 @@ Any Client::
     This condition always evaluates to true. It can be used for example to ensure that all clients in the particular realm are FAPI compliant.
 
 ACR Condition::
-Applied when an ACR value requested in the authentication request matches the value configured in the condition. For example, it can be used to select an authentication flow based on the requested ACR value. For more details, see the <<_client-policy-auth-flow, related documentation>> and the https://openid.net/specs/openid-connect-core-1_0.html#acrSemantics[official OIDC specification].
+    Applied when an ACR value requested in the authentication request matches the value configured in the condition. For example, it can be used to select an authentication flow based on the requested ACR value. For more details, see the <<_client-policy-auth-flow, related documentation>> and the https://openid.net/specs/openid-connect-core-1_0.html#acrSemantics[official OIDC specification].
+
+Grant Type::
+    Evaluates to true when a specific grant type is used. For example, it can be used in combination with Client Scope to block a token exchange request when a specific client scope is requested.
 
 
 === Executor

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
@@ -86,7 +86,7 @@ public class GrantTypeCondition extends AbstractClientPolicyConditionProvider<Gr
                 if (isGrantMatching(OAuth2Constants.DEVICE_CODE_GRANT_TYPE)) return ClientPolicyVote.YES;
                 return ClientPolicyVote.NO;
             default:
-                return ClientPolicyVote.NO;
+                return ClientPolicyVote.ABSTAIN;
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:ggrazian@redhat.com">Giuseppe Graziano/a>
+ */
+public class GrantTypeCondition extends AbstractClientPolicyConditionProvider<GrantTypeCondition.Configuration> {
+
+    private static final Logger logger = Logger.getLogger(GrantTypeCondition.class);
+
+    public GrantTypeCondition(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public Class<Configuration> getConditionConfigurationClass() {
+        return Configuration.class;
+    }
+
+    public static class Configuration extends ClientPolicyConditionConfigurationRepresentation {
+
+        protected List<String> grantTypes;
+
+        public List<String> getGrantTypes() {
+            return grantTypes;
+        }
+
+        public void setGrantTypes(List<String> grantTypes) {
+            this.grantTypes = grantTypes;
+        }
+    }
+
+    @Override
+    public String getProviderId() {
+        return ClientScopesConditionFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
+
+        switch (context.getEvent()) {
+            case AUTHORIZATION_REQUEST:
+                if (isGrantMatching((AuthorizationRequestContext)context)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case TOKEN_REFRESH:
+                if (isGrantMatching(OAuth2Constants.REFRESH_TOKEN)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
+                if (isGrantMatching(OAuth2Constants.PASSWORD)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case SERVICE_ACCOUNT_TOKEN_REQUEST:
+                if (isGrantMatching(OAuth2Constants.CLIENT_CREDENTIALS)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case TOKEN_EXCHANGE_REQUEST:
+                if (isGrantMatching(OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case DEVICE_TOKEN_REQUEST:
+                if (isGrantMatching(OAuth2Constants.DEVICE_CODE_GRANT_TYPE)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            default:
+                return ClientPolicyVote.NO;
+        }
+    }
+
+    private boolean isGrantMatching(AuthorizationRequestContext request) {
+        if (request == null) return false;
+        try {
+            OIDCResponseType parsedResponseType = OIDCResponseType.parse(request.getAuthorizationEndpointRequest().getResponseType());
+            if (parsedResponseType.hasResponseType(OIDCResponseType.CODE)) {
+                return isGrantMatching(OAuth2Constants.AUTHORIZATION_CODE);
+            }
+            else if (parsedResponseType.isImplicitFlow()) {
+                return isGrantMatching(OAuth2Constants.IMPLICIT);
+            }
+            else if (parsedResponseType.isImplicitOrHybridFlow()) {
+                return isGrantMatching(OAuth2Constants.AUTHORIZATION_CODE) || isGrantMatching(OAuth2Constants.IMPLICIT);
+            }
+            else {
+                return false;
+            }
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private boolean isGrantMatching(String grantType) {
+        return configuration.getGrantTypes() != null && configuration.getGrantTypes().contains(grantType);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeConditionFactory.java
@@ -72,9 +72,6 @@ public class GrantTypeConditionFactory extends AbstractClientPolicyConditionProv
         if (Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
             DEFAULT_GRANT_TYPES_SUPPORTED.add(OAuth2Constants.DEVICE_CODE_GRANT_TYPE);
         }
-        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI)) {
-            DEFAULT_GRANT_TYPES_SUPPORTED.add(PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE);
-        }
 
         property.setOptions(DEFAULT_GRANT_TYPES_SUPPORTED);
         configProperties.add(property);

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeConditionFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.common.Profile;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.grants.OAuth2GrantType;
+import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author <a href="mailto:ggrazian@redhat.com">Giuseppe Graziano</a>
+ */
+public class GrantTypeConditionFactory extends AbstractClientPolicyConditionProviderFactory {
+
+    public static final String PROVIDER_ID = "grant-type";
+    public static final String GRANT_TYPES = "grant_types";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        addCommonConfigProperties(configProperties);
+    }
+
+    @Override
+    public GrantTypeCondition create(KeycloakSession session) {
+        return new GrantTypeCondition(session);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The condition checks that the grant type used is one of those in the configured list.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        ProviderConfigProperty property = new ProviderConfigProperty(GRANT_TYPES, "Grant Types",
+                "The condition evaluates to true if the current grant type is one of those in the list",
+                ProviderConfigProperty.MULTIVALUED_LIST_TYPE, null);
+
+        List<String> DEFAULT_GRANT_TYPES_SUPPORTED = Stream.of(OAuth2Constants.AUTHORIZATION_CODE,  OAuth2Constants.IMPLICIT, OAuth2Constants.REFRESH_TOKEN, OAuth2Constants.PASSWORD, OAuth2Constants.CLIENT_CREDENTIALS).collect(Collectors.toList());
+        if (Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_STANDARD_V2)) {
+            DEFAULT_GRANT_TYPES_SUPPORTED.add(OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
+        }
+        if (Profile.isFeatureEnabled(Profile.Feature.DEVICE_FLOW)) {
+            DEFAULT_GRANT_TYPES_SUPPORTED.add(OAuth2Constants.DEVICE_CODE_GRANT_TYPE);
+        }
+        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI)) {
+            DEFAULT_GRANT_TYPES_SUPPORTED.add(PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE);
+        }
+
+        property.setOptions(DEFAULT_GRANT_TYPES_SUPPORTED);
+        configProperties.add(property);
+
+        return configProperties;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -9,3 +9,4 @@ org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientProtocolConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientAttributesConditionFactory
 org.keycloak.services.clientpolicy.condition.AcrConditionFactory
+org.keycloak.services.clientpolicy.condition.GrantTypeConditionFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -36,6 +36,7 @@ import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientScopesC
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientUpdateContextConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createConsentRequiredExecutorConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createFullScopeDisabledExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createGrantTypeConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createHolderOfKeyEnforceExecutorConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createIntentClientBindCheckExecutorConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createPKCEEnforceExecutorConfig;
@@ -44,14 +45,17 @@ import static org.keycloak.testsuite.util.ClientPoliciesUtil.createRejectImplici
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureClientAuthenticatorExecutorConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionExecutorConfig;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import jakarta.ws.rs.core.Response;
 
@@ -70,7 +74,9 @@ import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
 import org.keycloak.authentication.authenticators.client.JWTClientSecretAuthenticator;
 import org.keycloak.authentication.authenticators.client.X509ClientAuthenticator;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.Time;
+import org.keycloak.common.util.UriUtils;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
@@ -93,6 +99,7 @@ import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
@@ -101,6 +108,7 @@ import org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceGroupsConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceRolesConditionFactory;
+import org.keycloak.services.clientpolicy.condition.GrantTypeConditionFactory;
 import org.keycloak.services.clientpolicy.executor.ConfidentialClientAcceptExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory;
@@ -117,8 +125,10 @@ import org.keycloak.services.clientpolicy.executor.SuppressRefreshTokenRotationE
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.client.resources.TestApplicationResourceUrls;
 import org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExceptionConditionFactory;
+import org.keycloak.testsuite.services.clientpolicy.executor.TestRaiseExceptionExecutorFactory;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil;
 import org.keycloak.testsuite.util.MutualTLSUtils;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
@@ -1317,6 +1327,100 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
             oauth.responseType(OIDCResponseType.CODE);
             oauth.nonce(null);
         }
+    }
+
+    @Test
+    @EnableFeature(value = Profile.Feature.TOKEN_EXCHANGE_STANDARD_V2, skipRestart = true)
+    public void testClientGrantTypeCondition() throws Exception {
+
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+        String id = createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
+            clientRep.setSecret(clientSecret);
+            clientRep.setServiceAccountsEnabled(true);
+            clientRep.setImplicitFlowEnabled(true);
+            clientRep.setStandardFlowEnabled(true);
+            clientRep.setAttributes(Map.of(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, "true"));
+        });
+        oauth.client(clientId, clientSecret);
+
+        //auth code
+        successfulLogin(clientId, clientSecret);
+
+        configureClientPolicyToBlockGrantTypes(ClientPolicyEvent.AUTHORIZATION_REQUEST, List.of(OAuth2Constants.AUTHORIZATION_CODE));
+        oauth.openLogout();
+        oauth.openLoginForm();
+        MultivaluedHashMap<String, String> queryParams = UriUtils.decodeQueryString(new URL(Objects.requireNonNull(driver.getCurrentUrl())).getQuery());
+        assertEquals(ClientPolicyEvent.AUTHORIZATION_REQUEST.toString(), queryParams.getFirst("error"));
+        assertEquals("Exception thrown intentionally", queryParams.getFirst("error_description"));
+        revertToBuiltinPolicies();
+
+        //password
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        configureClientPolicyToBlockGrantTypes(ClientPolicyEvent.RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST, List.of(OAuth2Constants.PASSWORD));
+        response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+        assertGrantTypeBlock(response, ClientPolicyEvent.RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST);
+        revertToBuiltinPolicies();
+
+        //client credentials
+        response = oauth.clientCredentialsGrantRequest().send();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        configureClientPolicyToBlockGrantTypes(ClientPolicyEvent.SERVICE_ACCOUNT_TOKEN_REQUEST, List.of(OAuth2Constants.CLIENT_CREDENTIALS));
+        response = oauth.clientCredentialsGrantRequest().send();
+        assertGrantTypeBlock(response, ClientPolicyEvent.SERVICE_ACCOUNT_TOKEN_REQUEST);
+        revertToBuiltinPolicies();
+
+        //refresh
+        response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+        response = oauth.refreshRequest(response.getRefreshToken()).send();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        configureClientPolicyToBlockGrantTypes(ClientPolicyEvent.TOKEN_REFRESH, List.of(OAuth2Constants.REFRESH_TOKEN));
+        response = oauth.refreshRequest(response.getRefreshToken()).send();
+        assertGrantTypeBlock(response, ClientPolicyEvent.TOKEN_REFRESH);
+        revertToBuiltinPolicies();
+
+        //token exchange
+        response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+        response = oauth.tokenExchangeRequest(response.getAccessToken()).send();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        configureClientPolicyToBlockGrantTypes(ClientPolicyEvent.TOKEN_EXCHANGE_REQUEST, List.of(OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE));
+        response = oauth.tokenExchangeRequest(response.getAccessToken()).send();
+        assertGrantTypeBlock(response, ClientPolicyEvent.TOKEN_EXCHANGE_REQUEST);
+        revertToBuiltinPolicies();
+    }
+
+    private void assertGrantTypeBlock(AccessTokenResponse response, ClientPolicyEvent event){
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(event.toString(), response.getError());
+        assertEquals("Exception thrown intentionally", response.getErrorDescription());
+    }
+
+    private void configureClientPolicyToBlockGrantTypes(ClientPolicyEvent event, List<String> grantTypes) throws Exception {
+
+        String json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Profilo")
+                        .addExecutor(TestRaiseExceptionExecutorFactory.PROVIDER_ID,
+                                createTestRaiseExeptionExecutorConfig(List.of(event)))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policy with condition on client scope optional-scope2
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Client Policy", Boolean.TRUE)
+                        .addCondition(GrantTypeConditionFactory.PROVIDER_ID,
+                                createGrantTypeConditionConfig(grantTypes))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
     }
 
     private void testProhibitedImplicitOrHybridFlow(boolean isOpenid, String responseType, String nonce, String expectedError, String expectedErrorDescription) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
@@ -35,6 +35,7 @@ import org.keycloak.representations.IDToken;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory;
+import org.keycloak.services.clientpolicy.condition.GrantTypeConditionFactory;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -59,6 +60,7 @@ import static org.junit.Assert.assertNull;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientScopesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createGrantTypeConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionExecutorConfig;
 
 /**
@@ -86,7 +88,12 @@ public class StandardTokenExchangeV2Test extends AbstractClientPoliciesTest {
                 .getSessionId();
     }
 
+
     private String resourceOwnerLogin(String username, String password, String clientId, String secret) throws Exception {
+        return resourceOwnerLogin(username, password, clientId, secret, null);
+    }
+
+    private String resourceOwnerLogin(String username, String password, String clientId, String secret, String scope) throws Exception {
         oauth.realm(TEST);
         oauth.client(clientId, secret);
         oauth.scope(null);
@@ -573,6 +580,8 @@ public class StandardTokenExchangeV2Test extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Client Scope Policy", Boolean.TRUE)
                         .addCondition(ClientScopesConditionFactory.PROVIDER_ID,
                                 createClientScopesConditionConfig(ClientScopesConditionFactory.ANY, List.of("optional-scope2")))
+                        .addCondition(GrantTypeConditionFactory.PROVIDER_ID,
+                                createGrantTypeConditionConfig(List.of(OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE)))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2Test.java
@@ -88,17 +88,12 @@ public class StandardTokenExchangeV2Test extends AbstractClientPoliciesTest {
                 .getSessionId();
     }
 
-
     private String resourceOwnerLogin(String username, String password, String clientId, String secret) throws Exception {
-        return resourceOwnerLogin(username, password, clientId, secret, null);
-    }
-
-    private String resourceOwnerLogin(String username, String password, String clientId, String secret, String scope) throws Exception {
         oauth.realm(TEST);
         oauth.client(clientId, secret);
         oauth.scope(null);
         oauth.openid(false);
-        AccessTokenResponse response = oauth.doGrantAccessTokenRequest(username, password);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(username, password);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
         TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(response.getAccessToken(), AccessToken.class);
         accessTokenVerifier.parse();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -54,6 +54,7 @@ import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextConditio
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceGroupsCondition;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceHostsCondition;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceRolesCondition;
+import org.keycloak.services.clientpolicy.condition.GrantTypeCondition;
 import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutor;
 import org.keycloak.services.clientpolicy.executor.DPoPBindEnforcerExecutor;
 import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutor;
@@ -441,6 +442,12 @@ public final class ClientPoliciesUtil {
     public static ClientUpdaterSourceRolesCondition.Configuration createClientUpdateSourceRolesConditionConfig(List<String> roles) {
         ClientUpdaterSourceRolesCondition.Configuration config = new ClientUpdaterSourceRolesCondition.Configuration();
         config.setRoles(roles);
+        return config;
+    }
+
+    public static GrantTypeCondition.Configuration createGrantTypeConditionConfig(List<String> grantTypes) {
+        GrantTypeCondition.Configuration config = new GrantTypeCondition.Configuration();
+        config.setGrantTypes(grantTypes);
         return config;
     }
 


### PR DESCRIPTION
Closes #37124

- Added a Condition in client policies to check when a grant type is used.  

- The `DEFAULT_GRANT_TYPES_SUPPORTED` in `GrantTypeConditionFactory` are not resolved as in `OIDCWellKnownProvider.getGrantTypesSupported()` due to the absence of the `KeycloakSession`.  

- Added tests and small documentation.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
