### PR TITLE
Fix kc.home.dir by adding a trailing slash to the path

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -34,7 +34,7 @@ abs_path () {
   fi
 }
 
-SERVER_OPTS="-Dkc.home.dir='$(abs_path '..')'"
+SERVER_OPTS="-Dkc.home.dir='$(abs_path '..')'/"
 SERVER_OPTS="$SERVER_OPTS -Djboss.server.config.dir='$(abs_path '../conf')'"
 SERVER_OPTS="$SERVER_OPTS -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 SERVER_OPTS="$SERVER_OPTS -Dpicocli.disable.closures=true"


### PR DESCRIPTION
This PR addresses the issue of incorrect path resolution in the Keycloak startup script `kc.sh`. The issue was reported in #37675 .