### PR TITLE
Create transient session for TE if requester client session is missing

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -224,7 +224,8 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
         event.session(targetUserSession);
 
         try {
-            ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, targetUserSession, authSession);
+            ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, targetUserSession, authSession,
+                    !OAuth2Constants.REFRESH_TOKEN_TYPE.equals(requestedTokenType)); // create transient session if needed except for refresh
 
             if (requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE)
                     && clientSessionCtx.getClientScopesStream().filter(s -> OAuth2Constants.OFFLINE_ACCESS.equals(s.getName())).findAny().isPresent()) {
@@ -243,8 +244,8 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
             validateConsents(targetUser, clientSessionCtx);
             clientSessionCtx.setAttribute(Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
 
-            TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(realm, client, event, this.session, targetUserSession, clientSessionCtx)
-                    .generateAccessToken();
+            TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(realm, client, event, session,
+                    clientSessionCtx.getClientSession().getUserSession(), clientSessionCtx).generateAccessToken();
 
             checkRequestedAudiences(responseBuilder);
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -159,6 +159,11 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
         return this;
     }
 
+    public ClientAttributeUpdater addOptionalClientScope(String clientScope) {
+        rep.getOptionalClientScopes().add(clientScope);
+        return this;
+    }
+
     public ClientAttributeUpdater setDirectAccessGrantsEnabled(Boolean directAccessGranted) {
         rep.setDirectAccessGrantsEnabled(directAccessGranted);
         return this;


### PR DESCRIPTION
Closes #37117

The PR avoids creating a real client session for TE when it is possible. If the client session is missing a new transient session is created and used (same notes than realm online session). The difference is that the `sid` claim in this case is set to the token (the session exists but the token is transient, there is no real client session for this client). This is only done if the TE requested type is not the refresh token which needs a persistent session.
