### PR TITLE
Set auth session cookies when re-authenticate using identity cookie

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
+++ b/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
@@ -197,6 +197,9 @@ public abstract class AuthorizationEndpointBase {
                         rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm, userSessionId);
                     }
                     authSession = rootAuthSession.createAuthenticationSession(client);
+                    // set auth session cookies because they can be missing if recovered from identity cookie
+                    manager.setAuthSessionCookie(rootAuthSession.getId());
+                    manager.setAuthSessionIdHashCookie(rootAuthSession.getId());
                     logger.debugf("Sent request to authz endpoint. We don't have root authentication session with ID '%s' but we have userSession." +
                             "Re-created root authentication session with same ID. Client is: %s . New authentication session tab ID: %s", userSessionId, client.getClientId(), authSession.getTabId());
                 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -43,6 +43,7 @@ import org.keycloak.authentication.authenticators.conditional.ConditionalLoaAuth
 import org.keycloak.authentication.authenticators.conditional.ConditionalLoaAuthenticatorFactory;
 import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.common.Profile;
+import org.keycloak.cookie.CookieType;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
@@ -319,6 +320,25 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
         authenticateWithTotp();
         authenticateWithButton();
         assertLoggedInWithAcr("3");
+    }
+
+    @Test
+    public void stepupAuthenticationNoAuthSessionCookie() {
+        // logging in to level 1
+        openLoginFormWithAcrClaim(true, "silver");
+        authenticateWithUsernamePassword();
+        assertLoggedInWithAcr("silver");
+        // doing step-up authentication to level 2
+        openLoginFormWithAcrClaim(true, "gold");
+        authenticateWithTotp();
+        assertLoggedInWithAcr("gold");
+        // going back to login again, otp should be presented as by default max-age is 0
+        openLoginFormWithAcrClaim(true, "gold");
+        // remove the auth session cookie emulating a browser restart in which this cookie is lost
+        driver.manage().deleteCookieNamed(CookieType.AUTH_SESSION_ID.getName());
+        openLoginFormWithAcrClaim(true, "gold");
+        authenticateWithTotp();
+        assertLoggedInWithAcr("gold");
     }
 
     @Test


### PR DESCRIPTION
Closes #37749

When the browser is restarted the auth session cookies are lost. So the authorization endpoint recovers the session from the identity cookie but, right now, the corresponding auth cookies are not reset at this point. This triggers an issue later when submitting the otp because there is no auth session cookie and when restarting it the `rememberMe` flag is not assigned. This PR just assigns the auth session cookies again when creating it from the user session, this way the otp works OK afterwards.

@mposolda @graziang Do you see any issue setting the auth cookies here? If there is no browser restart the cookies exist at this point, and in a normal login (no LoA, no identity cookie) they are always created when the auth endpoint is called.