### PR TITLE
Allow searching for multiple users by their ids

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.services.resources.admin;
 
+import java.util.Arrays;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
@@ -299,13 +300,10 @@ public class UsersResource {
         Stream<UserModel> userModels = Stream.empty();
         if (search != null) {
             if (search.startsWith(SEARCH_ID_PARAMETER)) {
-                UserModel userModel =
-                        session.users().getUserById(realm, search.substring(SEARCH_ID_PARAMETER.length()).trim());
-                if (userModel != null) {
-                    userModels = Stream.of(userModel);
-                    if (AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
-                        userModels = userModels.filter(userPermissionEvaluator::canView);
-                    }
+                String[] userIds = search.substring(SEARCH_ID_PARAMETER.length()).trim().split("\\s+");
+                userModels = Arrays.stream(userIds).map(id -> session.users().getUserById(realm, id)).filter(Objects::nonNull);
+                if (AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
+                    userModels = userModels.filter(userPermissionEvaluator::canView);
                 }
             } else {
                 Map<String, String> attributes = new HashMap<>();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -1264,7 +1264,8 @@ public class UserTest extends AbstractAdminTest {
 
     @Test
     public void searchById() {
-        String expectedUserId = createUsers().get(0);
+        List<String> userIds = createUsers();
+        String expectedUserId = userIds.get(0);
         List<UserRepresentation> users = realm.users().search("id:" + expectedUserId, null, null);
 
         assertEquals(1, users.size());
@@ -1274,6 +1275,19 @@ public class UserTest extends AbstractAdminTest {
 
         assertEquals(1, users.size());
         assertEquals(expectedUserId, users.get(0).getId());
+
+        // Should allow searching for multiple users
+        String expectedUserId2 = userIds.get(1);
+        List<UserRepresentation> multipleUsers = realm.users().search(String.format("id:%s %s", expectedUserId, expectedUserId2), 0 , 10);;
+        assertThat(multipleUsers, hasSize(2));
+        assertThat(multipleUsers.get(0).getId(), is(expectedUserId));
+        assertThat(multipleUsers.get(1).getId(), is(expectedUserId2));
+
+        // Should take arbitrary amount of spaces in between ids
+        List<UserRepresentation> multipleUsers2 = realm.users().search(String.format("id:  %s   %s  ", expectedUserId, expectedUserId2), 0 , 10);;
+        assertThat(multipleUsers2, hasSize(2));
+        assertThat(multipleUsers2.get(0).getId(), is(expectedUserId));
+        assertThat(multipleUsers2.get(1).getId(), is(expectedUserId2));
     }
 
     @Test


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

An implementation to batch search for users by their ids.

Closes #12025.
