### PR TITLE
Include JNA dependency for the SSSD in the keycloak server

### DIFF
--- a/federation/sssd/src/main/java/org/keycloak/federation/sssd/impl/PAMAuthenticator.java
+++ b/federation/sssd/src/main/java/org/keycloak/federation/sssd/impl/PAMAuthenticator.java
@@ -55,7 +55,9 @@ public class PAMAuthenticator {
             logger.error("Authentication failed", e);
             e.printStackTrace();
         } finally {
-            pam.dispose();
+            if (pam != null) {
+                pam.dispose();
+            }
         }
         return user;
     }

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -646,6 +646,10 @@
             <artifactId>nashorn-core</artifactId>
             <version>${nashorn.version}</version>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Closes #37898

The jna dependency is necessary for the SSSD provider. Previously it seems that was included by the mysql driver but with the recent quarkus upgrade to 3.19.2 the driver does not depend in jna anymore. So we need to include the dependency explicitly in the keycloak server.

@keycloak/cloud-native Please take a look when you have time.