### PR TITLE
Set CONFIGURE_OTP via auth session in ConditionalOtpFormAuthenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticator.java
@@ -25,6 +25,8 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -327,10 +329,9 @@ public class ConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
 
     @Override
     public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
-        if (!isOTPRequired(session, realm, user)) {
-            user.removeRequiredAction(UserModel.RequiredAction.CONFIGURE_TOTP);
-        } else if (user.getRequiredActionsStream().noneMatch(UserModel.RequiredAction.CONFIGURE_TOTP.name()::equals)) {
-            user.addRequiredAction(UserModel.RequiredAction.CONFIGURE_TOTP.name());
+        AuthenticationSessionModel authenticationSession = session.getContext().getAuthenticationSession();
+        if (isOTPRequired(session, realm, user) && !authenticationSession.getRequiredActions().contains(UserModel.RequiredAction.CONFIGURE_TOTP.name())) {
+            authenticationSession.addRequiredAction(UserModel.RequiredAction.CONFIGURE_TOTP);
         }
     }
 }


### PR DESCRIPTION
Added the `CONFIGURE_TOTP` required action in `ConditionalOtpFormAuthenticator` to the auth session instead of the user to avoid exceptions with LDAP read-only users (as done in `OTPFormAuthenticator`). Already tested in `CustomAuthFlowOTPTest`.

Closes #37869

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
