### PR TITLE
Set ATTEMPTED_USERNAME to real username to avoid showing user attribute

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
@@ -101,7 +101,6 @@ public class ValidateX509CertificateUsername extends AbstractX509ClientCertifica
         UserModel user;
         try {
             context.getEvent().detail(Details.USERNAME, userIdentity.toString());
-            context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, userIdentity.toString());
             user = getUserIdentityToModelMapper(config).find(context, userIdentity);
         }
         catch(ModelDuplicateException e) {
@@ -142,6 +141,9 @@ public class ValidateX509CertificateUsername extends AbstractX509ClientCertifica
             return;
         }
         context.setUser(user);
+        // set real username
+        context.getEvent().detail(Details.USERNAME, user.getUsername());
+        context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, user.getUsername());
         context.success();
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -120,7 +120,6 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
             UserModel user;
             try {
                 context.getEvent().detail(Details.USERNAME, userIdentity.toString());
-                context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, userIdentity.toString());
                 user = getUserIdentityToModelMapper(config).find(context, userIdentity);
             }
             catch(ModelDuplicateException e) {
@@ -166,6 +165,9 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
                 return;
             }
             context.setUser(user);
+            // set real username
+            context.getEvent().detail(Details.USERNAME, user.getUsername());
+            context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, user.getUsername());
 
             // Check whether to display the identity confirmation
             if (!config.getConfirmationPageDisallowed()) {


### PR DESCRIPTION
Currently when logging in with mutal SSL and a Custom Attribute Mapper the attribute is shown as username.
This attribute is stored as ATTEMPTED_USER and later also shown as Username when trying another authentication method.
This is change sets the ATTEMPTED_USERNAME to the real username. 