### PR TITLE
Use AvailableSettings.DATASOURCE instead of AvailableSettings.JAKARTA…

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -383,7 +383,7 @@ class KeycloakProcessor {
                 Properties properties = descriptor.getProperties();
                 // register a listener for customizing the unit configuration at runtime
                 runtimeConfigured.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem("keycloak", descriptor.getName())
-                        .setInitListener(recorder.createUserDefinedUnitListener(properties.getProperty(AvailableSettings.JAKARTA_JTA_DATASOURCE))));
+                        .setInitListener(recorder.createUserDefinedUnitListener(properties.getProperty(AvailableSettings.DATASOURCE))));
                 userManagedEntities.addAll(descriptor.getManagedClassNames());
             }
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -179,7 +179,7 @@ public class KeycloakRecorder {
                                 return name;
                             }
                         })) {
-                    propertyCollector.accept(AvailableSettings.JAKARTA_JTA_DATASOURCE, instance.get());
+                    propertyCollector.accept(AvailableSettings.DATASOURCE, instance.get());
                 }
             }
         };


### PR DESCRIPTION
…_JTA_DATASOURCE for custom datasources

Closes #37979

@keycloak/cloud-native Please check this one. With the recent quarkus upgrade the extensions in quickstarts fails (see https://github.com/rmartinc/keycloak-quickstarts/actions/runs/13768495909/job/38500895946). The reason is that something weird has happened with the custom datasource. With this change it works but I don't know if prefer to do something else or file a quarkus issue. Just sending a draft for that.
