### PR TITLE
Documentation for Optional Email Events

### DIFF
--- a/docs/documentation/server_admin/topics/events/login.adoc
+++ b/docs/documentation/server_admin/topics/events/login.adoc
@@ -200,6 +200,11 @@ The Email Event Listener sends a message to the user's email address when an eve
 * Update Credential.
 * Remove Credential.
 
+Below are the optional events you can configure:
+
+* User disabled by permanent lockout.
+* User disabled by temporary lockout.
+
 The following conditions need to be met for an email to be sent:
 
 * User has an email address.
@@ -228,3 +233,8 @@ You can exclude events by using the `--spi-events-listener-email-exclude-events`
 kc.[sh|bat] --spi-events-listener-email-exclude-events=UPDATE_CREDENTIAL,REMOVE_CREDENTIAL
 ----
 
+To enable optional events, use the following command:
+[source,bash]
+----
+kc.[sh|bat] --spi-events-listener-email-include-events=USER_DISABLED_BY_TEMPORARY_LOCKOUT_ERROR,USER_DISABLED_BY_PERMANENT_LOCKOUT
+----


### PR DESCRIPTION
Updating documentation for already available optional Email Events [USER_DISABLED_BY_TEMPORARY_LOCKOUT_ERROR and USER_DISABLED_BY_PERMANENT_LOCKOUT].

Closes #37998

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
