### PR TITLE
Organization Members Filtering Capabilities

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -57,6 +57,16 @@ only the `query-*` role to an administrator is no longer sufficient to list role
 Instead, the administrator must have explicit permissions to view or manage the realm or client for which they want to list roles, or by
 having the `view-realm` or `manage-realm` role for realm roles, or `view-clients` or `manage-clients` role for client roles.
 
+=== Consistent filtering of organization members based on the semantics from the User API
+
+Until now, the filtering of organization members in the Organization API was not consistent with the semantics of the User API.
+
+In this version, the filtering of organization members is now consistent with the User API semantics, which means that
+the `search` parameter filters based on the username, first name, last name, and email of the organization members
+will respect wildcards and make filtering on these attributes more flexible with the possibility to match values that
+begin with, ends with, or has a value in between. This change improves the usability of the Organization API
+and makes it more intuitive for users to find organization members based on their attributes.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 
@@ -162,7 +172,7 @@ This behavior is enabled by default and can be controlled with the server option
 
 * `--truststore-kubernetes-enabled=true|false` (default: `true`)
 
-No changes are required for most deployments. If you previously relied on the Operator to manage these truststore entries, the server now performs the same function directly. 
+No changes are required for most deployments. If you previously relied on the Operator to manage these truststore entries, the server now performs the same function directly.
 
 WARNING: when `https-client-auth` is set to `required` or `request` without an explicit `https-trust-store-file`, mTLS client certificate validation falls back to the system truststore. With `truststore-kubernetes-enabled=true`, this means certificates signed by the Kubernetes cluster CA will be accepted as valid client certificates. If this is not desired, either set `https-trust-store-file` explicitly or disable `truststore-kubernetes-enabled`.
 

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -60,8 +60,8 @@ public interface OrganizationMembersResource {
     /**
      * Return members in the organization.
      *
-     * @param first index of the first element (pagination offset).
-     * @param max the maximum number of results.
+     * @param firstResult index of the first element (pagination offset).
+     * @param maxResults the maximum number of results.
      * @return a list containing organization members.
      */
     @GET
@@ -114,6 +114,41 @@ public interface OrganizationMembersResource {
             @QueryParam("max") Integer max
     );
 
+    /**
+     * Return all organization members that match the specified filters.
+     *
+     * @param search a {@code String} representing either a member's username, e-mail, first name, or last name.
+     * @param username a {@code String} representing the member's username
+     * @param email a {@code String} representing the member's email address
+     * @param firstName a {@code String} representing the member's first name
+     * @param lastName a {@code String} representing the member's last name
+     * @param searchQuery a query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param enabled Boolean indicating whether the member is enabled or disabled
+     * @param exact if {@code true}, the members will be searched using exact match for the {@code search} param - i.e.
+     *              at least one of the username main attributes must match exactly the {@code search} param. If false,
+     *              the method returns all members with at least one main attribute partially matching the {@code search} param.
+     * @param membershipType The {@link org.keycloak.representations.idm.MembershipType}
+     * @param first index of the first element (pagination offset).
+     * @param max the maximum number of results.
+     * @return a list containing the matched organization members.
+     * @since Keycloak 26.1
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<MemberRepresentation> search(
+            @QueryParam("search") String search,
+            @QueryParam("username") String username,
+            @QueryParam("email") String email,
+            @QueryParam("firstName") String firstName,
+            @QueryParam("lastName") String lastName,
+            @QueryParam("q") String searchQuery,
+            @QueryParam("enabled") Boolean enabled,
+            @QueryParam("exact") Boolean exact,
+            @QueryParam("membershipType") MembershipType membershipType,
+            @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max
+    );
+
     @Path("{id}")
     OrganizationMemberResource member(@PathParam("id") String id);
 
@@ -137,6 +172,38 @@ public interface OrganizationMembersResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     Long count();
+
+    /**
+     * Returns the number of members that match the given criteria.
+     *
+     * @param search a {@code String} representing either a member's username, e-mail, first name, or last name.
+     * @param username a {@code String} representing the member's username
+     * @param email a {@code String} representing the member's email address
+     * @param firstName a {@code String} representing the member's first name
+     * @param lastName a {@code String} representing the member's last name
+     * @param searchQuery a query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param enabled Boolean indicating whether the member is enabled or disabled
+     * @param exact if {@code true}, the members will be searched using exact match for the {@code search} param - i.e.
+     *              at least one of the username main attributes must match exactly the {@code search} param. If false,
+     *              the method returns all members with at least one main attribute partially matching the {@code search} param.
+     * @param membershipType The {@link org.keycloak.representations.idm.MembershipType}
+     * @return the number of members that match the given criteria
+     * @since Keycloak 26.1
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Long count(
+            @QueryParam("search") String search,
+            @QueryParam("username") String username,
+            @QueryParam("email") String email,
+            @QueryParam("firstName") String firstName,
+            @QueryParam("lastName") String lastName,
+            @QueryParam("q") String searchQuery,
+            @QueryParam("enabled") Boolean enabled,
+            @QueryParam("exact") Boolean exact,
+            @QueryParam("membershipType") MembershipType membershipType
+    );
 
     @Path("{id}/organizations")
     @GET

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
@@ -227,6 +227,11 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
     }
 
     @Override
+    public long getMembersCount(OrganizationModel organization, Boolean exact, Map<String, String> filters) {
+        return getDelegate().getMembersCount(organization, exact, filters);
+    }
+
+    @Override
     public UserModel getMemberById(OrganizationModel organization, String id) {
         if (userCache == null) {
             return getDelegate().getMemberById(organization, id);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -35,7 +35,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -64,7 +63,6 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 import org.keycloak.models.jpa.entities.CredentialEntity;
 import org.keycloak.models.jpa.entities.FederatedIdentityEntity;
-import org.keycloak.models.jpa.entities.UserAttributeEntity;
 import org.keycloak.models.jpa.entities.UserConsentClientScopeEntity;
 import org.keycloak.models.jpa.entities.UserConsentEntity;
 import org.keycloak.models.jpa.entities.UserEntity;
@@ -77,6 +75,8 @@ import org.keycloak.storage.client.ClientStorageProvider;
 import org.keycloak.storage.jpa.JpaHashUtils;
 import org.keycloak.utils.StringUtil;
 
+import static org.keycloak.models.jpa.JpaUserUtils.addSearchPredicates;
+import static org.keycloak.models.jpa.JpaUserUtils.createPredicates;
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.storage.jpa.JpaHashUtils.predicateForFilteringUsersByAttributes;
 import static org.keycloak.utils.StreamsUtil.closing;
@@ -88,13 +88,6 @@ import static org.keycloak.utils.StreamsUtil.closing;
  */
 @SuppressWarnings("JpaQueryApiInspection")
 public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUserPartialEvaluationProvider {
-
-    private static final String EMAIL = "email";
-    private static final String EMAIL_VERIFIED = "emailVerified";
-    private static final String USERNAME = "username";
-    private static final String FIRST_NAME = "firstName";
-    private static final String LAST_NAME = "lastName";
-    private static final char ESCAPE_BACKSLASH = '\\';
 
     private final KeycloakSession session;
     protected final EntityManager em;
@@ -625,7 +618,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         List<Predicate> predicates = new ArrayList<>();
 
         predicates.add(builder.equal(root.get("realmId"), realm.getId()));
-        addSearchPredicates(search, builder, root, predicates);
+        addSearchPredicates(search, false, builder, root, predicates);
         predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.USERS, this, realm, builder, queryBuilder, root));
 
         return em.createQuery(countQuery(queryBuilder, builder, root, predicates)).getSingleResult().intValue();
@@ -646,7 +639,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         List<Predicate> predicates = new ArrayList<>();
 
         predicates.add(builder.equal(userJoin.get("realmId"), realm.getId()));
-        addSearchPredicates(search, builder, userJoin, predicates);
+        addSearchPredicates(search, false, builder, userJoin, predicates);
         predicates.add(groupMembership.get("groupId").in(groupIds));
 
         return em.createQuery(countQuery(queryBuilder, builder, userJoin, predicates)).getSingleResult().intValue();
@@ -657,10 +650,10 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         CriteriaBuilder qb = em.getCriteriaBuilder();
         CriteriaQuery<Long> userQuery = qb.createQuery(Long.class);
         Root<UserEntity> from = userQuery.from(UserEntity.class);
+        boolean exact = Boolean.parseBoolean(params.get(UserModel.EXACT));
+        List<Predicate> restrictions = createPredicates(session, qb, userQuery, params, from, exact, Map.of());
 
-        List<Predicate> restrictions = predicates(params, from, Map.of());
         restrictions.add(qb.equal(from.get("realmId"), realm.getId()));
-        restrictions.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.USERS, this, realm, qb, userQuery, from));
 
         TypedQuery<Long> query = em.createQuery(countQuery(userQuery, qb, from, restrictions));
         Long result = query.getSingleResult();
@@ -680,13 +673,11 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
         Root<UserEntity> root = countQuery.from(UserEntity.class);
         countQuery.select(cb.countDistinct(root));
-
-        List<Predicate> restrictions = predicates(params, root, Map.of());
+        boolean exact = Boolean.parseBoolean(params.get(UserModel.EXACT));
+        List<Predicate> restrictions = createPredicates(session, cb, countQuery, params, root, exact, Map.of());
         restrictions.add(cb.equal(root.get("realmId"), realm.getId()));
 
         session.setAttribute(UserModel.GROUPS, groupIds);
-
-        restrictions.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.USERS, this, realm, cb, countQuery, root));
 
         countQuery.where(restrictions);
         TypedQuery<Long> query = em.createQuery(countQuery);
@@ -800,11 +791,10 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         Root<UserEntity> root = queryBuilder.from(UserEntity.class);
 
         Map<String, String> customLongValueSearchAttributes = new HashMap<>();
-        List<Predicate> predicates = predicates(attributes, root, customLongValueSearchAttributes);
+        boolean exact = Boolean.parseBoolean(attributes.get(UserModel.EXACT));
+        List<Predicate> predicates = createPredicates(session, builder, queryBuilder, attributes, root, exact, customLongValueSearchAttributes);
 
         predicates.add(builder.equal(root.get("realmId"), realm.getId()));
-
-        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.USERS, this, realm, builder, queryBuilder, root));
 
         queryBuilder.distinct(true).where(predicates).orderBy(builder.asc(root.get(UserModel.USERNAME)));
 
@@ -974,129 +964,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         }
     }
 
-    private static Predicate getSearchOptionPredicate(String value, CriteriaBuilder builder, From<?, UserEntity> from) {
-        value = value.toLowerCase();
-
-        List<Predicate> orPredicates = new ArrayList<>();
-
-        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
-            // exact search
-            value = value.substring(1, value.length() - 1);
-
-            orPredicates.add(builder.equal(from.get(USERNAME), value));
-            orPredicates.add(builder.equal(from.get(EMAIL), value));
-            orPredicates.add(builder.equal(builder.lower(from.get(FIRST_NAME)), value));
-            orPredicates.add(builder.equal(builder.lower(from.get(LAST_NAME)), value));
-        } else {
-            value = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
-            value = value.replace("*", "%");
-            if (value.isEmpty() || value.charAt(value.length() - 1) != '%') value += "%";
-
-            orPredicates.add(builder.like(from.get(USERNAME), value, ESCAPE_BACKSLASH));
-            orPredicates.add(builder.like(from.get(EMAIL), value, ESCAPE_BACKSLASH));
-            orPredicates.add(builder.like(builder.lower(from.get(FIRST_NAME)), value, ESCAPE_BACKSLASH));
-            orPredicates.add(builder.like(builder.lower(from.get(LAST_NAME)), value, ESCAPE_BACKSLASH));
-        }
-
-        return builder.or(orPredicates);
-    }
-
     private UserEntity userInEntityManagerContext(String id) {
         UserEntity user = em.getReference(UserEntity.class, id);
         return em.contains(user) ? user : null;
-    }
-
-    private List<Predicate> predicates(Map<String, String> attributes, Root<UserEntity> root, Map<String, String> customLongValueSearchAttributes) {
-        CriteriaBuilder builder = em.getCriteriaBuilder();
-
-        List<Predicate> predicates = new ArrayList<>();
-        List<Predicate> attributePredicates = new ArrayList<>();
-
-        Join<Object, Object> federatedIdentitiesJoin = null;
-
-        for (Map.Entry<String, String> entry : attributes.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-
-            if (value == null) {
-                continue;
-            }
-
-            switch (key) {
-                case UserModel.SEARCH:
-                    addSearchPredicates(value, builder, root, predicates);
-                    break;
-                case FIRST_NAME:
-                case LAST_NAME:
-                    if (Boolean.parseBoolean(attributes.get(UserModel.EXACT))) {
-                        predicates.add(builder.equal(builder.lower(root.get(key)), value.toLowerCase()));
-                    } else {
-                        predicates.add(builder.like(builder.lower(root.get(key)), "%" + value.toLowerCase() + "%"));
-                    }
-                    break;
-                case USERNAME:
-                case EMAIL:
-                    if (Boolean.parseBoolean(attributes.get(UserModel.EXACT))) {
-                        predicates.add(builder.equal(root.get(key), value.toLowerCase()));
-                    } else {
-                        predicates.add(builder.like(root.get(key), "%" + value.toLowerCase() + "%"));
-                    }
-                    break;
-                case EMAIL_VERIFIED:
-                    predicates.add(builder.equal(root.get(key), Boolean.valueOf(value.toLowerCase())));
-                    break;
-                case UserModel.ENABLED:
-                    predicates.add(builder.equal(root.get(key), Boolean.valueOf(value)));
-                    break;
-                case UserModel.IDP_ALIAS:
-                    if (federatedIdentitiesJoin == null) {
-                        federatedIdentitiesJoin = root.join("federatedIdentities");
-                    }
-                    predicates.add(builder.equal(federatedIdentitiesJoin.get("identityProvider"), value));
-                    break;
-                case UserModel.IDP_USER_ID:
-                    if (federatedIdentitiesJoin == null) {
-                        federatedIdentitiesJoin = root.join("federatedIdentities");
-                    }
-                    predicates.add(builder.equal(federatedIdentitiesJoin.get("userId"), value));
-                    break;
-                case UserModel.EXACT:
-                    break;
-                case UserModel.INCLUDE_SERVICE_ACCOUNT: {
-                    if (!attributes.containsKey(UserModel.INCLUDE_SERVICE_ACCOUNT)
-                            || !Boolean.parseBoolean(attributes.get(UserModel.INCLUDE_SERVICE_ACCOUNT))) {
-                        predicates.add(root.get("serviceAccountClientLink").isNull());
-                    }
-                    break;
-                }
-                default:
-                    // All unknown attributes will be assumed as custom attributes
-                    Join<UserEntity, UserAttributeEntity> attributesJoin = root.join("attributes", JoinType.LEFT);
-                    if (value.length() > 255) {
-                        customLongValueSearchAttributes.put(key, value);
-                        attributePredicates.add(builder.and(
-                                builder.equal(attributesJoin.get("name"), key),
-                                builder.equal(attributesJoin.get("longValueHashLowerCase"), JpaHashUtils.hashForAttributeValueLowerCase(value))));
-                    } else {
-                        if (Boolean.parseBoolean(attributes.getOrDefault(UserModel.EXACT, Boolean.TRUE.toString()))) {
-                            attributePredicates.add(builder.and(
-                                builder.equal(attributesJoin.get("name"), key),
-                                builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
-                        } else {
-                            attributePredicates.add(builder.and(
-                                builder.equal(attributesJoin.get("name"), key),
-                                builder.like(builder.lower(attributesJoin.get("value")), "%" + value.toLowerCase() + "%")));
-                        }
-                    }
-                    break;
-            }
-        }
-
-        if (!attributePredicates.isEmpty()) {
-            predicates.add(builder.and(attributePredicates));
-        }
-
-        return predicates;
     }
 
     @Override
@@ -1107,15 +977,6 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     @Override
     public EntityManager getEntityManager() {
         return em;
-    }
-
-    private static void addSearchPredicates(String search, CriteriaBuilder builder, From<?, UserEntity> from, List<Predicate> predicates) {
-        if (search == null) {
-            return;
-        }
-        for (String stringToSearch : search.trim().split("\\s+")) {
-            predicates.add(getSearchOptionPredicate(stringToSearch, builder, from));
-        }
     }
 
     private static CriteriaQuery<Long> countQuery(CriteriaQuery<Long> query, CriteriaBuilder builder, From<?, UserEntity> from, List<Predicate> predicates) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserUtils.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserUtils.java
@@ -1,0 +1,188 @@
+package org.keycloak.models.jpa;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.models.jpa.entities.UserAttributeEntity;
+import org.keycloak.models.jpa.entities.UserEntity;
+import org.keycloak.storage.jpa.JpaHashUtils;
+
+import static org.keycloak.models.UserModel.EMAIL;
+import static org.keycloak.models.UserModel.EMAIL_VERIFIED;
+import static org.keycloak.models.UserModel.FIRST_NAME;
+import static org.keycloak.models.UserModel.LAST_NAME;
+import static org.keycloak.models.UserModel.USERNAME;
+
+public final class JpaUserUtils {
+
+    private static final char ESCAPE_BACKSLASH = '\\';
+
+    public static List<Predicate> createPredicates(KeycloakSession session,
+                                                   CriteriaBuilder builder,
+                                                   CriteriaQuery<?> query,
+                                                   Map<String, String> attributes, From<?, UserEntity> root,
+                                                   Boolean exact, Map<String, String> customLongValueSearchAttributes) {
+        List<Predicate> predicates = new ArrayList<>();
+        List<Predicate> attributePredicates = new ArrayList<>();
+        Join<Object, Object> federatedIdentitiesJoin = null;
+
+        exact = Optional.ofNullable(exact).orElse(false);
+
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            if (value == null) {
+                continue;
+            }
+
+            switch (key) {
+                case UserModel.SEARCH:
+                    addSearchPredicates(value, exact, builder, root, predicates);
+                    break;
+                case FIRST_NAME:
+                case LAST_NAME:
+                    if (exact) {
+                        predicates.add(builder.equal(builder.lower(root.get(key)), value.toLowerCase()));
+                    } else {
+                        predicates.add(builder.like(builder.lower(root.get(key)), "%" + value.toLowerCase() + "%"));
+                    }
+                    break;
+                case USERNAME:
+                case EMAIL:
+                    if (exact) {
+                        predicates.add(builder.equal(root.get(key), value.toLowerCase()));
+                    } else {
+                        predicates.add(builder.like(root.get(key), "%" + value.toLowerCase() + "%"));
+                    }
+                    break;
+                case EMAIL_VERIFIED:
+                    predicates.add(builder.equal(root.get(key), Boolean.valueOf(value.toLowerCase())));
+                    break;
+                case UserModel.ENABLED:
+                    predicates.add(builder.equal(root.get(key), Boolean.valueOf(value)));
+                    break;
+                case UserModel.IDP_ALIAS:
+                    if (federatedIdentitiesJoin == null) {
+                        federatedIdentitiesJoin = root.join("federatedIdentities");
+                    }
+                    predicates.add(builder.equal(federatedIdentitiesJoin.get("identityProvider"), value));
+                    break;
+                case UserModel.IDP_USER_ID:
+                    if (federatedIdentitiesJoin == null) {
+                        federatedIdentitiesJoin = root.join("federatedIdentities");
+                    }
+                    predicates.add(builder.equal(federatedIdentitiesJoin.get("userId"), value));
+                    break;
+                case UserModel.EXACT:
+                    break;
+                case UserModel.INCLUDE_SERVICE_ACCOUNT: {
+                    if (!attributes.containsKey(UserModel.INCLUDE_SERVICE_ACCOUNT)
+                            || !Boolean.parseBoolean(attributes.get(UserModel.INCLUDE_SERVICE_ACCOUNT))) {
+                        predicates.add(root.get("serviceAccountClientLink").isNull());
+                    }
+                    break;
+                }
+                default:
+                    // All unknown attributes will be assumed as custom attributes
+                    Join<UserEntity, UserAttributeEntity> attributesJoin = root.join("attributes", JoinType.LEFT);
+                    if (value.length() > 255) {
+                        customLongValueSearchAttributes.put(key, value);
+                        attributePredicates.add(builder.and(
+                                builder.equal(attributesJoin.get("name"), key),
+                                builder.equal(attributesJoin.get("longValueHashLowerCase"), JpaHashUtils.hashForAttributeValueLowerCase(value))));
+                    } else {
+                        if (Boolean.parseBoolean(attributes.getOrDefault(UserModel.EXACT, Boolean.TRUE.toString()))) {
+                            attributePredicates.add(builder.and(
+                                    builder.equal(attributesJoin.get("name"), key),
+                                    builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
+                        } else {
+                            attributePredicates.add(builder.and(
+                                    builder.equal(attributesJoin.get("name"), key),
+                                    builder.like(builder.lower(attributesJoin.get("value")), "%" + value.toLowerCase() + "%")));
+                        }
+                    }
+                    break;
+            }
+        }
+
+        if (!attributePredicates.isEmpty()) {
+            predicates.add(builder.and(attributePredicates));
+        }
+
+        RealmModel realm = session.getContext().getRealm();
+        JpaUserPartialEvaluationProvider partialEvaluator = (JpaUserPartialEvaluationProvider) session.getProvider(UserProvider.class, "jpa");
+
+        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(
+                session,
+                AdminPermissionsSchema.USERS,
+                partialEvaluator,
+                realm,
+                builder,
+                query,
+                root));
+
+        return predicates;
+    }
+
+    public static void addSearchPredicates(String search, boolean exact, CriteriaBuilder builder, From<?, UserEntity> from, List<Predicate> predicates) {
+        if (search == null) {
+            return;
+        }
+        for (String stringToSearch : search.trim().split("\\s+")) {
+            predicates.add(getSearchOptionPredicate(stringToSearch, exact, builder, from));
+        }
+    }
+
+    private static Predicate getSearchOptionPredicate(String value, boolean exact, CriteriaBuilder builder, From<?, UserEntity> from) {
+        if (!exact) {
+            value = value.toLowerCase();
+        }
+
+        List<Predicate> orPredicates = new ArrayList<>();
+
+        if (exact || value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+            if (!exact) {
+                value = value.substring(1, value.length() - 1);
+            }
+
+            // exact search
+            orPredicates.add(builder.equal(from.get(USERNAME), value));
+            orPredicates.add(builder.equal(from.get(EMAIL), value));
+
+            if (exact) {
+                orPredicates.add(builder.equal(from.get(FIRST_NAME), value));
+                orPredicates.add(builder.equal(from.get(LAST_NAME), value));
+            } else {
+                orPredicates.add(builder.equal(builder.lower(from.get(FIRST_NAME)), value));
+                orPredicates.add(builder.equal(builder.lower(from.get(LAST_NAME)), value));
+            }
+        } else {
+            value = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+            value = value.replace("*", "%");
+
+            if (value.isEmpty() || value.charAt(value.length() - 1) != '%') value += "%";
+
+            orPredicates.add(builder.like(from.get(USERNAME), value, ESCAPE_BACKSLASH));
+            orPredicates.add(builder.like(from.get(EMAIL), value, ESCAPE_BACKSLASH));
+            orPredicates.add(builder.like(builder.lower(from.get(FIRST_NAME)), value, ESCAPE_BACKSLASH));
+            orPredicates.add(builder.like(builder.lower(from.get(LAST_NAME)), value, ESCAPE_BACKSLASH));
+        }
+
+        return builder.or(orPredicates);
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -18,12 +18,12 @@
 package org.keycloak.organization.jpa;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
@@ -55,6 +55,7 @@ import org.keycloak.models.jpa.entities.GroupAttributeEntity;
 import org.keycloak.models.jpa.entities.GroupEntity;
 import org.keycloak.models.jpa.entities.OrganizationDomainEntity;
 import org.keycloak.models.jpa.entities.OrganizationEntity;
+import org.keycloak.models.jpa.entities.UserAttributeEntity;
 import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.jpa.entities.UserGroupMembershipEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -64,6 +65,7 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.representations.idm.MembershipType;
 import org.keycloak.storage.StorageId;
+import org.keycloak.storage.jpa.JpaHashUtils;
 import org.keycloak.utils.ReservedCharValidator;
 import org.keycloak.utils.StringUtil;
 
@@ -74,6 +76,7 @@ import static org.keycloak.models.UserModel.LAST_NAME;
 import static org.keycloak.models.UserModel.USERNAME;
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.organization.utils.Organizations.isReadOnlyOrganizationMember;
+import static org.keycloak.storage.jpa.JpaHashUtils.predicateForFilteringUsersByAttributes;
 import static org.keycloak.utils.StreamsUtil.closing;
 
 public class JpaOrganizationProvider implements OrganizationProvider {
@@ -381,39 +384,94 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
         queryBuilder.select(groupMembership.get("user").get("id"));
 
-        var predicates = new ArrayList<>();
+        List<Predicate> predicates = new ArrayList<>();
         var group = getOrganizationGroup(organization);
 
         predicates.add(builder.equal(groupMembership.get("groupId"), group.getId()));
 
         From<UserGroupMembershipEntity, UserEntity> userJoin = groupMembership.join("user");
+        Map<String, String> customLongValueSearchAttributes = new HashMap<>();
 
-        for (Entry<String, String> filter : Optional.ofNullable(filters).orElse(Map.of()).entrySet()) {
-            switch (filter.getKey()) {
-                case UserModel.SEARCH -> predicates.add(builder
-                        .or(getSearchOptionPredicateArray(filter.getValue(), Optional.ofNullable(exact).orElse(false), builder, userJoin)));
-                case MembershipType.NAME -> predicates.add(builder
-                        .equal(groupMembership.get(MembershipType.NAME), filter.getValue().toUpperCase()));
-            }
-        }
-
+        predicates.addAll(createPredicates(filters, exact, builder, userJoin, groupMembership, customLongValueSearchAttributes));
         queryBuilder.where(predicates.toArray(new Predicate[0]));
         queryBuilder.orderBy(builder.asc(userJoin.get(USERNAME)));
 
-        return closing(paginateQuery(em.createQuery(queryBuilder), first, max).getResultStream().map(id -> {
-            UserModel user = userProvider.getUserById(getRealm(), id);
+        return closing(paginateQuery(em.createQuery(queryBuilder), first, max).getResultStream()
+                .map(id -> em.getReference(UserEntity.class, id))
+                .filter(predicateForFilteringUsersByAttributes(customLongValueSearchAttributes, JpaHashUtils::compareSourceValueLowerCase)))
+                .map(entity -> {
+                    UserModel user = userProvider.getUserById(getRealm(), entity.getId());
 
-            if (isReadOnlyOrganizationMember(session, user)) {
-                return new ReadOnlyUserModelDelegate(user) {
-                    @Override
-                    public boolean isEnabled() {
-                        return false;
+                    if (isReadOnlyOrganizationMember(session, user)) {
+                        return new ReadOnlyUserModelDelegate(user) {
+                            @Override
+                            public boolean isEnabled() {
+                                return false;
+                            }
+                        };
                     }
-                };
-            }
 
-            return user;
-        }));
+                    return user;
+                });
+    }
+
+    private List<Predicate> createPredicates(Map<String, String> filters, Boolean exact, CriteriaBuilder builder, From<UserGroupMembershipEntity, UserEntity> root, Root<UserGroupMembershipEntity> groupMembership, Map<String, String> customLongValueSearchAttributes) {
+        List<Predicate> predicates = new ArrayList<>();
+        boolean exactValue = Optional.ofNullable(exact).orElse(false);
+
+        for (Entry<String, String> filter : Optional.ofNullable(filters).orElse(Map.of()).entrySet()) {
+            String value = filter.getValue();
+            String key = filter.getKey();
+
+            switch (key) {
+                case UserModel.SEARCH:
+                    predicates.add(builder
+                            .or(getSearchOptionPredicateArray(value, exactValue, builder, root)));
+                    break;
+                case MembershipType.NAME:
+                    predicates.add(builder
+                            .equal(groupMembership.get(MembershipType.NAME), value.toUpperCase()));
+                    break;
+                case UserModel.ENABLED:
+                    predicates.add(builder.equal(root.get(key), Boolean.valueOf(value)));
+                    break;
+                case UserModel.USERNAME:
+                case UserModel.EMAIL:
+                case UserModel.FIRST_NAME:
+                case UserModel.LAST_NAME:
+                    if (exactValue) {
+                        predicates.add(builder.equal(builder.lower(root.get(key)), value.toLowerCase()));
+                    } else {
+                        predicates.add(builder.like(builder.lower(root.get(key)), "%" + value.toLowerCase() + "%"));
+                    }
+                    break;
+                default:
+                    // Handle custom attributes
+                    // All unknown attributes will be assumed as custom attributes
+                    Join<UserEntity, UserAttributeEntity> attributesJoin = root.join("attributes", JoinType.LEFT);
+
+                    if (value.length() > 255) {
+                        if (customLongValueSearchAttributes != null) {
+                            customLongValueSearchAttributes.put(key, value);
+                        }
+                        predicates.add(builder.and(
+                                builder.equal(attributesJoin.get("name"), key),
+                                builder.equal(attributesJoin.get("longValueHashLowerCase"), JpaHashUtils.hashForAttributeValueLowerCase(value))));
+                    } else {
+                        if (exactValue) {
+                            predicates.add(builder.and(
+                                    builder.equal(attributesJoin.get("name"), key),
+                                    builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
+                        } else {
+                            predicates.add(builder.and(
+                                    builder.equal(attributesJoin.get("name"), key),
+                                    builder.like(builder.lower(attributesJoin.get("value")), "%" + value.toLowerCase() + "%")));
+                        }
+                    }
+            }
+        }
+
+        return predicates;
     }
 
     private Predicate[] getSearchOptionPredicateArray(String value, boolean exact, CriteriaBuilder builder, From<?, UserEntity> from) {
@@ -438,11 +496,22 @@ public class JpaOrganizationProvider implements OrganizationProvider {
     }
 
     @Override
-    public long getMembersCount(OrganizationModel organization) {
-        throwExceptionIfObjectIsNull(organization, "Organization");
-        String groupId = getOrganizationGroup(organization).getId();
+    public long getMembersCount(OrganizationModel organization, Boolean exact, Map<String, String> filters) {
+        if (organization == null) {
+            throw new IllegalStateException("Organization not found");
+        }
 
-        return userProvider.getUsersCount(getRealm(), Set.of(groupId));
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> queryBuilder = builder.createQuery(Long.class);
+        Root<UserGroupMembershipEntity> groupMembership = queryBuilder.from(UserGroupMembershipEntity.class);
+        Join<UserGroupMembershipEntity, UserEntity> userJoin = groupMembership.join("user");
+
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(builder.equal(groupMembership.get("groupId"), getOrganizationGroup(organization).getId()));
+        predicates.addAll(createPredicates(filters, exact, builder, userJoin, groupMembership, null));
+        queryBuilder.select(builder.count(userJoin)).where(predicates.toArray(new Predicate[0]));
+
+        return em.createQuery(queryBuilder).getSingleResult();
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -21,9 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
@@ -51,11 +49,11 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.jpa.JpaUserUtils;
 import org.keycloak.models.jpa.entities.GroupAttributeEntity;
 import org.keycloak.models.jpa.entities.GroupEntity;
 import org.keycloak.models.jpa.entities.OrganizationDomainEntity;
 import org.keycloak.models.jpa.entities.OrganizationEntity;
-import org.keycloak.models.jpa.entities.UserAttributeEntity;
 import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.jpa.entities.UserGroupMembershipEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -70,9 +68,6 @@ import org.keycloak.utils.ReservedCharValidator;
 import org.keycloak.utils.StringUtil;
 
 import static org.keycloak.models.OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE;
-import static org.keycloak.models.UserModel.EMAIL;
-import static org.keycloak.models.UserModel.FIRST_NAME;
-import static org.keycloak.models.UserModel.LAST_NAME;
 import static org.keycloak.models.UserModel.USERNAME;
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.organization.utils.Organizations.isReadOnlyOrganizationMember;
@@ -392,7 +387,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         From<UserGroupMembershipEntity, UserEntity> userJoin = groupMembership.join("user");
         Map<String, String> customLongValueSearchAttributes = new HashMap<>();
 
-        predicates.addAll(createPredicates(filters, exact, builder, userJoin, groupMembership, customLongValueSearchAttributes));
+        predicates.addAll(createPredicates(session, filters, exact, builder, queryBuilder, userJoin, groupMembership, customLongValueSearchAttributes));
         queryBuilder.where(predicates.toArray(new Predicate[0]));
         queryBuilder.orderBy(builder.asc(userJoin.get(USERNAME)));
 
@@ -415,84 +410,19 @@ public class JpaOrganizationProvider implements OrganizationProvider {
                 });
     }
 
-    private List<Predicate> createPredicates(Map<String, String> filters, Boolean exact, CriteriaBuilder builder, From<UserGroupMembershipEntity, UserEntity> root, Root<UserGroupMembershipEntity> groupMembership, Map<String, String> customLongValueSearchAttributes) {
+    private List<Predicate> createPredicates(KeycloakSession session, Map<String, String> filters, Boolean exact, CriteriaBuilder builder, CriteriaQuery query, From<UserGroupMembershipEntity, UserEntity> root, Root<UserGroupMembershipEntity> groupMembership, Map<String, String> customLongValueSearchAttributes) {
         List<Predicate> predicates = new ArrayList<>();
-        boolean exactValue = Optional.ofNullable(exact).orElse(false);
+        String membershipType = filters.get(MembershipType.NAME);
 
-        for (Entry<String, String> filter : Optional.ofNullable(filters).orElse(Map.of()).entrySet()) {
-            String value = filter.getValue();
-            String key = filter.getKey();
-
-            switch (key) {
-                case UserModel.SEARCH:
-                    predicates.add(builder
-                            .or(getSearchOptionPredicateArray(value, exactValue, builder, root)));
-                    break;
-                case MembershipType.NAME:
-                    predicates.add(builder
-                            .equal(groupMembership.get(MembershipType.NAME), value.toUpperCase()));
-                    break;
-                case UserModel.ENABLED:
-                    predicates.add(builder.equal(root.get(key), Boolean.valueOf(value)));
-                    break;
-                case UserModel.USERNAME:
-                case UserModel.EMAIL:
-                case UserModel.FIRST_NAME:
-                case UserModel.LAST_NAME:
-                    if (exactValue) {
-                        predicates.add(builder.equal(builder.lower(root.get(key)), value.toLowerCase()));
-                    } else {
-                        predicates.add(builder.like(builder.lower(root.get(key)), "%" + value.toLowerCase() + "%"));
-                    }
-                    break;
-                default:
-                    // Handle custom attributes
-                    // All unknown attributes will be assumed as custom attributes
-                    Join<UserEntity, UserAttributeEntity> attributesJoin = root.join("attributes", JoinType.LEFT);
-
-                    if (value.length() > 255) {
-                        if (customLongValueSearchAttributes != null) {
-                            customLongValueSearchAttributes.put(key, value);
-                        }
-                        predicates.add(builder.and(
-                                builder.equal(attributesJoin.get("name"), key),
-                                builder.equal(attributesJoin.get("longValueHashLowerCase"), JpaHashUtils.hashForAttributeValueLowerCase(value))));
-                    } else {
-                        if (exactValue) {
-                            predicates.add(builder.and(
-                                    builder.equal(attributesJoin.get("name"), key),
-                                    builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
-                        } else {
-                            predicates.add(builder.and(
-                                    builder.equal(attributesJoin.get("name"), key),
-                                    builder.like(builder.lower(attributesJoin.get("value")), "%" + value.toLowerCase() + "%")));
-                        }
-                    }
-            }
+        if (membershipType != null) {
+            predicates.add(builder.equal(groupMembership.get(MembershipType.NAME), membershipType.toUpperCase()));
+            filters = new HashMap<>(filters);
+            filters.remove(MembershipType.NAME);
         }
+
+        predicates.addAll(JpaUserUtils.createPredicates(session, builder, query, filters, root, exact, customLongValueSearchAttributes));
 
         return predicates;
-    }
-
-    private Predicate[] getSearchOptionPredicateArray(String value, boolean exact, CriteriaBuilder builder, From<?, UserEntity> from) {
-        value = value.toLowerCase();
-
-        List<Predicate> orPredicates = new ArrayList<>();
-
-        if (exact) {
-            orPredicates.add(builder.equal(from.get(USERNAME), value));
-            orPredicates.add(builder.equal(from.get(EMAIL), value));
-            orPredicates.add(builder.equal(builder.lower(from.get(FIRST_NAME)), value));
-            orPredicates.add(builder.equal(builder.lower(from.get(LAST_NAME)), value));
-        } else {
-            value = "%" + value + "%";
-            orPredicates.add(builder.like(from.get(USERNAME), value));
-            orPredicates.add(builder.like(from.get(EMAIL), value));
-            orPredicates.add(builder.like(builder.lower(from.get(FIRST_NAME)), value));
-            orPredicates.add(builder.like(builder.lower(from.get(LAST_NAME)), value));
-        }
-
-        return orPredicates.toArray(Predicate[]::new);
     }
 
     @Override
@@ -508,7 +438,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
         List<Predicate> predicates = new ArrayList<>();
         predicates.add(builder.equal(groupMembership.get("groupId"), getOrganizationGroup(organization).getId()));
-        predicates.addAll(createPredicates(filters, exact, builder, userJoin, groupMembership, null));
+        predicates.addAll(createPredicates(session, filters, exact, builder, queryBuilder, userJoin, groupMembership, null));
         queryBuilder.select(builder.count(userJoin)).where(predicates.toArray(new Predicate[0]));
 
         return em.createQuery(queryBuilder).getSingleResult();

--- a/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -190,11 +190,25 @@ public interface OrganizationProvider extends Provider {
     }
 
     /**
-     * Returns number of members in the organization.
+     * Returns the number of members in the organization.
+     *
      * @param organization the organization
-     * @return Number of members in the organization.
+     * @param filters the filters to apply to the search
+     * @return the number of members
      */
-    long getMembersCount(OrganizationModel organization);
+    default long getMembersCount(OrganizationModel organization, Boolean exact, Map<String, String> filters) {
+        return getMembersStream(organization, filters, exact, null, null).count();
+    }
+
+    /**
+     * Returns the number of members in the organization.
+     *
+     * @param organization the organization
+     * @return the number of members
+     */
+    default long getMembersCount(OrganizationModel organization) {
+        return getMembersCount(organization, false, null);
+    }
 
     /**
      * Returns the member of the {@link OrganizationModel} by its {@code id}.

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -52,6 +52,7 @@ import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.utils.SearchQueryUtils;
 import org.keycloak.utils.StringUtil;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -65,6 +66,8 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.resteasy.reactive.NoCache;
+
+import static java.util.Optional.ofNullable;
 
 @Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
 public class OrganizationMemberResource {
@@ -154,6 +157,21 @@ public class OrganizationMemberResource {
         return new OrganizationInvitationResource(session, organization, adminEvent).inviteExistingUser(id);
     }
 
+    /**
+     * Returns the number of users that match the given criteria.
+     * It can be called in three different ways.
+     * 1. Don't specify any criteria and pass {@code null}. The number of all
+     * users within that realm will be returned.
+     * <p>
+     * 2. If {@code search} is specified other criteria such as {@code last} will
+     * be ignored even though you set them. The {@code search} string will be
+     * matched against the first and last name, the username and the email of a
+     * user.
+     * <p>
+     * 3. If {@code search} is unspecified but any of {@code last}, {@code first},
+     * {@code email} or {@code username} those criteria are matched against their
+     * respective fields on a user entity. Combined with a logical and.
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
@@ -164,6 +182,12 @@ public class OrganizationMemberResource {
     })
     public Stream<MemberRepresentation> search(
             @Parameter(description = "A String representing either a member's username, e-mail, first name, or last name.") @QueryParam("search") String search,
+            @Parameter(description = "A String representing the member's username") @QueryParam("username") String username,
+            @Parameter(description = "A String representing the member's email address") @QueryParam("email") String email,
+            @Parameter(description = "A String representing the member's first name") @QueryParam("firstName") String firstName,
+            @Parameter(description = "A String representing the member's last name") @QueryParam("lastName") String lastName,
+            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
+            @Parameter(description = "Boolean indicating whether the member is enabled or disabled") @QueryParam("enabled") Boolean enabled,
             @Parameter(description = "Boolean which defines whether the param 'search' must match exactly or not") @QueryParam("exact") Boolean exact,
             @Parameter(description = "The position of the first result to be processed (pagination offset)") @QueryParam("first") @DefaultValue("0") Integer first,
             @Parameter(description = "The maximum number of results to be returned. Defaults to 10") @QueryParam("max") @DefaultValue("10") Integer max,
@@ -173,10 +197,31 @@ public class OrganizationMemberResource {
 
         if (search != null) {
             filters.put(UserModel.SEARCH, search);
+        } else {
+            if (username != null) {
+                filters.put(UserModel.USERNAME, username);
+            }
+            if (email != null) {
+                filters.put(UserModel.EMAIL, email);
+            }
+            if (firstName != null) {
+                filters.put(UserModel.FIRST_NAME, firstName);
+            }
+            if (lastName != null) {
+                filters.put(UserModel.LAST_NAME, lastName);
+            }
+        }
+
+        if (enabled != null) {
+            filters.put(UserModel.ENABLED, enabled.toString());
         }
 
         if (membershipType != null) {
             filters.put(MembershipType.NAME, MembershipType.valueOf(membershipType.toUpperCase()).name());
+        }
+
+        if (searchQuery != null) {
+            filters.putAll(SearchQueryUtils.getFields(searchQuery));
         }
 
         return provider.getMembersStream(organization, filters, exact, first, max).map(this::toRepresentation);
@@ -291,8 +336,49 @@ public class OrganizationMemberResource {
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = Long.class)))
     })
-    public Long count() {
-        return provider.getMembersCount(organization);
+    public Long count(
+            @Parameter(description = "A String representing either a member's username, e-mail, first name, or last name.") @QueryParam("search") String search,
+            @Parameter(description = "A String representing the member's username") @QueryParam("username") String username,
+            @Parameter(description = "A String representing the member's email address") @QueryParam("email") String email,
+            @Parameter(description = "A String representing the member's first name") @QueryParam("firstName") String firstName,
+            @Parameter(description = "A String representing the member's last name") @QueryParam("lastName") String lastName,
+            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
+            @Parameter(description = "Boolean indicating whether the member is enabled or disabled") @QueryParam("enabled") Boolean enabled,
+            @Parameter(description = "Boolean which defines whether the param 'search' must match exactly or not") @QueryParam("exact") Boolean exact,
+            @Parameter(description = "The membership type") @QueryParam("membershipType") String membershipType
+    ) {
+        Map<String, String> filters = new HashMap<>();
+
+        if (search != null) {
+            filters.put(UserModel.SEARCH, search);
+        } else {
+            if (username != null) {
+                filters.put(UserModel.USERNAME, username);
+            }
+            if (email != null) {
+                filters.put(UserModel.EMAIL, email);
+            }
+            if (firstName != null) {
+                filters.put(UserModel.FIRST_NAME, firstName);
+            }
+            if (lastName != null) {
+                filters.put(UserModel.LAST_NAME, lastName);
+            }   
+        }
+
+        if (enabled != null) {
+            filters.put(UserModel.ENABLED, enabled.toString());
+        }
+
+        if (membershipType != null) {
+            filters.put(MembershipType.NAME, MembershipType.valueOf(membershipType.toUpperCase()).name());
+        }
+
+        if (searchQuery != null) {
+            filters.putAll(SearchQueryUtils.getFields(searchQuery));
+        }
+
+        return provider.getMembersCount(organization, ofNullable(exact).orElse(Boolean.FALSE), filters);
     }
 
     private UserModel getMember(String id) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/AbstractOrganizationTest.java
@@ -188,14 +188,14 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
     }
 
     protected MemberRepresentation addMember(OrganizationResource organization, String email) {
-        return addMember(organization, null, email, null, null, true);
+        return addMember(organization, null, email, null, null, true,null);
     }
 
     protected MemberRepresentation addMember(OrganizationResource organization, String email, String firstName, String lastName) {
-        return addMember(organization, null, email, firstName, lastName, true);
+        return addMember(organization, null, email, firstName, lastName, true, null);
     }
 
-    protected MemberRepresentation addMember(OrganizationResource organization, String username, String email, String firstName, String lastName, boolean isSetCredentials) {
+    protected MemberRepresentation addMember(OrganizationResource organization, String username, String email, String firstName, String lastName, boolean isSetCredentials, Map<String, List<String>> attributes) {
         UserRepresentation expected = new UserRepresentation();
 
         expected.setEmail(email);
@@ -205,6 +205,10 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
         expected.setLastName(lastName);
         if (isSetCredentials) {
             Users.setPasswordFor(expected, memberPassword);
+        }
+
+        if (attributes != null) {
+            expected.setAttributes(attributes);
         }
 
         try (Response response = testRealm().users().create(expected)) {
@@ -223,6 +227,7 @@ public abstract class AbstractOrganizationTest extends AbstractAdminTest  {
             assertEquals(userId, actual.getId());
             assertEquals(expected.getUsername(), actual.getUsername());
             assertEquals(expected.getEmail(), actual.getEmail());
+            assertEquals(expected.getAttributes(), actual.getAttributes());
 
             return actual;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -502,7 +502,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
     @Test
     public void testRedirectBrokerWhenUnmanagedMemberProfileEmailMatchesOrganization() {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
-        addMember(organization, bc.getUserLogin(), bc.getUserEmail(), "f", "l", false);
+        addMember(organization, bc.getUserLogin(), bc.getUserEmail(), "f", "l", false,null);
         openIdentityFirstLoginPage(bc.getUserLogin(), true, null, false, false);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
@@ -414,7 +414,7 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
         assertThat(existing, is(empty()));
 
         // partial search - partial e-mail should match all users.
-        existing = organization.members().search("neworg", false, null, null);
+        existing = organization.members().search("*neworg*", false, null, null);
         assertThat(existing, hasSize(5));
         for (int i = 0; i < 5; i++) { // returned entries should also be ordered.
             assertThat(expected.get(i).getId(), is(equalTo(expected.get(i).getId())));
@@ -426,7 +426,7 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
 
         // partial search using 'th' search string - should match 'Katherine' by name, 'Jack' by username/e-mail
         // and 'Martha' either by username or first name.
-        existing = organization.members().search("th", false, null, null);
+        existing = organization.members().search("*th*", false, null, null);
         assertThat(existing, hasSize(3));
         assertThat(existing.get(0).getUsername(), is(equalTo("batwoman@neworg.org")));
         assertThat(existing.get(0).getFirstName(), is(equalTo("Katherine")));
@@ -617,7 +617,10 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
         assertThat(organization.members().count("Harvey", null, null, null, null, null, null, true, null), is(1L));
         assertThat(organization.members().count("Wayne", null, null, null, null, null, null, true, null), is(2L));
         assertThat(organization.members().count("Gordon", null, null, null, null, null, null, true, null), is(0L));
-        assertThat(organization.members().count("neworg", null, null, null, null, null, null, false, null), is(5L));
+        assertThat(organization.members().count("neworg", null, null, null, null, null, null, false, null), is(0L));
+        assertThat(organization.members().count("*neworg*", null, null, null, null, null, null, false, null), is(5L));
+        assertThat(organization.members().count("*NewOrg*", null, null, null, null, null, null, false, null), is(5L));
+        assertThat(organization.members().count("*NewOrg*", null, null, null, null, null, null, true, null), is(0L));
         assertThat(organization.members().count("way", null, null, null, null, null, null, false, null), is(2L));
         assertThat(organization.members().count("Neworg", null, null, null, null, null, null, true, null), is(0L));
         assertThat(organization.members().count("waY", null, null, null, null, null, null, true, null), is(0L));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.BadRequestException;
@@ -343,17 +344,54 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
     @Test
     public void testSearchMembers() {
 
+        // enable unmanaged attributes
+        UPConfig upConfig = testRealm().users().userProfile().getConfiguration();
+        upConfig.setUnmanagedAttributePolicy(UPConfig.UnmanagedAttributePolicy.ENABLED);
+        testRealm().users().userProfile().update(upConfig);
+
         // create test users, ordered by username (e-mail).
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         List<UserRepresentation> expected = new ArrayList<>();
-        expected.add(addMember(organization, "batwoman@neworg.org", "Katherine", "Kane"));
-        expected.add(addMember(organization, "brucewayne@neworg.org", "Bruce", "Wayne"));
+        expected.add(addMember(organization, "batwoman@neworg.org", "batwoman@neworg.org","Katherine", "Kane",false, Map.of("department", List.of("GothamPD"), "role", List.of("Detective"))));
+        expected.add(addMember(organization, "brucewayne@neworg.org","brucewayne@neworg.org", "Bruce", "Wayne",false, Map.of("department", List.of("WayneCorp"), "role", List.of("CEO"))));
         expected.add(addMember(organization, "harveydent@neworg.org", "Harvey", "Dent"));
         expected.add(addMember(organization, "marthaw@neworg.org", "Martha", "Wayne"));
         expected.add(addMember(organization, "thejoker@neworg.org", "Jack", "White"));
 
+        List<MemberRepresentation> result = organization.members().search("brucewayne@neworg.org", true, null, null);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getAttributes(), is(equalTo(Map.of("department", List.of("WayneCorp"), "role", List.of("CEO")))));
+
+        // Test searching by custom attributes
+        List<MemberRepresentation> existing = organization.members().search(null, null, null, null, null, "department:GothamPD", null, null, null, -1,-1);
+        assertThat(existing, hasSize(1));
+        assertThat(existing.get(0).getUsername(), is(equalTo("batwoman@neworg.org")));
+
+        existing = organization.members().search(null, null, null, null, null, "department:WayneCorp", null, null, null, -1, -1);
+        assertThat(existing, hasSize(1));
+        assertThat(existing.get(0).getUsername(), is(equalTo("brucewayne@neworg.org")));
+
+        // Test searching with multiple custom attributes
+        existing = organization.members().search(null, null, null, null, null, "department:GothamPD role:Detective", null, null,null, -1, -1);
+        assertThat(existing, hasSize(1));
+        assertThat(existing.get(0).getUsername(), is(equalTo("batwoman@neworg.org")));
+
+        // Test searching with non-existent attribute
+        existing = organization.members().search(null, null, null, null, null, "department:NonExistent", null, null, null,-1, -1);
+        assertThat(existing, is(empty()));
+
+        // Test searching with custom attributes combined with other filters
+        existing = organization.members().search(null, null, null, "Bruce", null, "department:WayneCorp", null, null, null,-1, -1);
+        assertThat(existing, hasSize(1));
+        assertThat(existing.get(0).getUsername(), is(equalTo("brucewayne@neworg.org")));
+
+        // Test searching with custom attributes and pagination
+        existing = organization.members().search(null, null, null, null, null, "department:WayneCorp", null, null, null,0, 1);
+        assertThat(existing, hasSize(1));
+        assertThat(existing.get(0).getUsername(), is(equalTo("brucewayne@neworg.org")));
+
         // exact search - username/e-mail, first name, last name.
-        List<MemberRepresentation> existing = organization.members().search("brucewayne@neworg.org", true, null, null);
+        existing = organization.members().search("brucewayne@neworg.org", true, null, null);
         assertThat(existing, hasSize(1));
         assertThat(existing.get(0).getUsername(), is(equalTo("brucewayne@neworg.org")));
         assertThat(existing.get(0).getEmail(), is(equalTo("brucewayne@neworg.org")));
@@ -548,13 +586,41 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
 
     @Test
     public void testMembersCount() {
+        // enable unmanaged attributes
+        UPConfig upConfig = testRealm().users().userProfile().getConfiguration();
+        upConfig.setUnmanagedAttributePolicy(UPConfig.UnmanagedAttributePolicy.ENABLED);
+        testRealm().users().userProfile().update(upConfig);
+
+        // create test users with custom attributes
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        addMember(organization, "batwoman", "batwoman@neworg.org", "Katherine", "Kane", false, Map.of("department", List.of("GothamPD"), "role", List.of("Detective")));
+        addMember(organization, "brucewayne", "brucewayne@neworg.org", "Bruce", "Wayne", false, Map.of("department", List.of("WayneCorp"), "role", List.of("CEO")));
+        addMember(organization, "harveydent@neworg.org", "Harvey", "Dent");
+        addMember(organization, "marthaw@neworg.org", "Martha", "Wayne");
+        addMember(organization, "thejoker@neworg.org", "Jack", "White");
 
-        for (int i = 0; i < 10; i++) {
-            addMember(organization, "user" + i +"@neworg.org", "First" + i, "Last" + i);
-        }
-
-        assertEquals(10, (long) organization.members().count());
+        assertThat(organization.members().count(), is(5L));
+        assertThat(organization.members().count("brucewayne@neworg.org", null, null, null, null, null, null, null, null), is(1L));
+        assertThat(organization.members().count(null, "batwoman", null, null, null, null, null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, "harveydent@neworg.org", null, null, null, null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, null, "Bruce", null, null, null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, null, null, "Wayne", null, null, null, null), is(2L));
+        assertThat(organization.members().count(null, null, null, null, null, "department:GothamPD", null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, null, null, null, "role:CEO", null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, null, null, null, "department:GothamPD role:Detective", null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, null, null, null, "department:NonExistent", null, null, null), is(0L));
+        assertThat(organization.members().count(null, null, null, null, null, null, true, null, null), is(5L));
+        assertThat(organization.members().count(null, null, null, null, null, null, null, null, MembershipType.UNMANAGED), is(5L));
+        assertThat(organization.members().count(null, null, null, "Bruce", null, "department:WayneCorp", null, null, null), is(1L));
+        assertThat(organization.members().count(null, null, null, null, "Wayne", "role:CEO", null, null, null), is(1L));
+        assertThat(organization.members().count("brucewayne@neworg.org", null, null, null, null, null, null, true, null), is(1L));
+        assertThat(organization.members().count("Harvey", null, null, null, null, null, null, true, null), is(1L));
+        assertThat(organization.members().count("Wayne", null, null, null, null, null, null, true, null), is(2L));
+        assertThat(organization.members().count("Gordon", null, null, null, null, null, null, true, null), is(0L));
+        assertThat(organization.members().count("neworg", null, null, null, null, null, null, false, null), is(5L));
+        assertThat(organization.members().count("way", null, null, null, null, null, null, false, null), is(2L));
+        assertThat(organization.members().count("Neworg", null, null, null, null, null, null, true, null), is(0L));
+        assertThat(organization.members().count("waY", null, null, null, null, null, null, true, null), is(0L));
     }
 
     @Test
@@ -591,9 +657,9 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
         OrganizationRepresentation orgRep = organization.toRepresentation();
         orgRep.singleAttribute("testAttribute", "testValue");
         organization.update(orgRep).close();
-        
+
         UserRepresentation member = addMember(organization);
-        
+
         // Test brief representation (default, briefRepresentation=true)
         List<OrganizationRepresentation> briefOrgs = organization.members().member(member.getId()).getOrganizations(true);
         assertNotNull(briefOrgs);
@@ -606,7 +672,7 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
         assertEquals(orgRep.getRedirectUrl(), briefRep.getRedirectUrl());
         assertEquals(orgRep.isEnabled(), briefRep.isEnabled());
         assertNull("Brief representation should not include attributes", briefRep.getAttributes());
-        
+
         // Test full representation (briefRepresentation=false)
         List<OrganizationRepresentation> fullOrgs = organization.members().member(member.getId()).getOrganizations(false);
         assertNotNull(fullOrgs);
@@ -619,21 +685,21 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
         assertEquals(orgRep.getRedirectUrl(), fullRep.getRedirectUrl());
         assertEquals(orgRep.isEnabled(), fullRep.isEnabled());
         assertNotNull("Full representation should include attributes", fullRep.getAttributes());
-        assertTrue("Full representation should include the test attribute", 
+        assertTrue("Full representation should include the test attribute",
                 fullRep.getAttributes().containsKey("testAttribute"));
         assertEquals("testValue", fullRep.getAttributes().get("testAttribute").get(0));
-        
+
         // Test the global members API endpoint as well
         List<OrganizationRepresentation> briefOrgsGlobal = testRealm().organizations().members().getOrganizations(member.getId(), true);
         assertNotNull(briefOrgsGlobal);
         assertEquals(1, briefOrgsGlobal.size());
         assertNull("Brief representation should not include attributes", briefOrgsGlobal.get(0).getAttributes());
-        
+
         List<OrganizationRepresentation> fullOrgsGlobal = testRealm().organizations().members().getOrganizations(member.getId(), false);
         assertNotNull(fullOrgsGlobal);
         assertEquals(1, fullOrgsGlobal.size());
         assertNotNull("Full representation should include attributes", fullOrgsGlobal.get(0).getAttributes());
-        assertTrue("Full representation should include the test attribute", 
+        assertTrue("Full representation should include the test attribute",
                 fullOrgsGlobal.get(0).getAttributes().containsKey("testAttribute"));
     }
 


### PR DESCRIPTION
This PR aligns the filtering capabilities of the organization members `search` and `count` endpoints with the related endpoints from the general `users` API.

Closes https://github.com/keycloak/keycloak/issues/37974
Closes https://github.com/keycloak/keycloak/issues/37312