### PR TITLE
fix: adds more validation of proxy-headers

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
@@ -2,14 +2,19 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.keycloak.common.Profile;
 import org.keycloak.config.HostnameV2Options;
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
+import org.keycloak.config.ProxyOptions;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.utils.SecureContextResolver;
 
 public final class HostnameV2PropertyMappers {
 
@@ -40,6 +45,52 @@ public final class HostnameV2PropertyMappers {
 
         if (!inUse.isEmpty()) {
             picocli.warn("Hostname v1 options %s are still in use, please review your configuration".formatted(inUse));
+        }
+        boolean httpsEnabled = HttpPropertyMappers.isHttpsEnabled();
+        String host = Configuration.getConfigValue(HostnameV2Options.HOSTNAME).getValue();
+        if (host != null && validateFullHostname(httpsEnabled, host, picocli)) {
+            return;
+        }
+        if (httpsEnabled) {
+            // must be tls passthrough, but there's no way of knowing the intention
+            return;
+        }
+        String proxyHeaders = Configuration.getConfigValue(ProxyOptions.PROXY_HEADERS).getValue();
+        if (proxyHeaders != null) {
+            // must not be tls passthrough, but there's no way of knowing the intention
+            return;
+        }
+        if (host == null) {
+            String message = "With HTTPS not enabled and hostname-strict=false, cross-origin cookies will not be allowed.";
+            if (Environment.isDevProfile()) {
+                picocli.info(message);
+            } else {
+                picocli.warn(message);
+            }
+        } else if (!SecureContextResolver.isLocal(host)) {
+            picocli.warn("HTTPS is not enabled on the server, either the `hostname` should be set to a full URL or `proxy-headers` should be used. This is likely a misconfiguration.");
+        } // else warn on prod
+    }
+
+    static boolean validateFullHostname(boolean httpsEnabled, String host, Picocli picocli) {
+        try {
+            URL url = new URL(host);
+
+            if (!url.getProtocol().toUpperCase().equals("HTTPS")) {
+                if (!SecureContextResolver.isLocal(url.getHost())) {
+                    picocli.warn("`hostname` is set to an HTTP hostname, cross-origin cookies will not be allowed. This is likely a misconfiguration.");
+
+                    // TODO: any hostname-admin specific validation?
+
+                } // else warn on prod?
+                if (httpsEnabled) {
+                    picocli.warn("HTTPS is enabled on the server, but `hostname` specifies HTTP. This is likely a misconfiguration.");
+                }
+            }
+
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
         }
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
@@ -18,6 +18,7 @@ import org.keycloak.utils.SecureContextResolver;
 
 public final class HostnameV2PropertyMappers {
 
+    private static final String CONTEXT_WARNING = "the server is running in an insecure context. Secure contexts are required for full functionality, including cross-origin cookies.";
     private static final List<String> REMOVED_OPTIONS = Arrays.asList("hostname-admin-url", "hostname-path", "hostname-port", "hostname-strict-backchannel", "hostname-url", "proxy", "hostname-strict-https");
 
     private HostnameV2PropertyMappers(){}
@@ -62,10 +63,11 @@ public final class HostnameV2PropertyMappers {
             return;
         }
         if (isProd) {
+            String warning = CONTEXT_WARNING + " Also if you are using a proxy, requests from the proxy to the server will fail CORS checks with 403s because the wrong origin will be determined. Make sure `proxy-headers` are configured properly or use a full URL `hostname`.";
             if (host == null) {
-                picocli.warn("With HTTPS not enabled and hostname-strict=false, cross-origin cookies will not be allowed.");
+                picocli.warn("With HTTPS not enabled, `proxy-headers` unset, and `hostname-strict=false`, " + warning);
             } else if (!SecureContextResolver.isLocal(host)) {
-                picocli.warn("HTTPS is not enabled on the server, either the `hostname` should be set to a full URL or `proxy-headers` should be used. This is likely a misconfiguration.");
+                picocli.warn("Likely misconfiguration detected. With HTTPS not enabled, `proxy-headers` unset, and a non-URL `hostname`, " + warning);
             } // else warn on prod
         }
     }
@@ -76,13 +78,13 @@ public final class HostnameV2PropertyMappers {
 
             if (!url.getProtocol().toUpperCase().equals("HTTPS") && isProd) {
                 if (!SecureContextResolver.isLocal(url.getHost())) {
-                    picocli.warn("`hostname` is configured to use HTTP instead of HTTPS, cross-origin cookies will not be allowed. This is likely a misconfiguration.");
+                    picocli.warn("Likely misconfiguration detected. `hostname` is configured to use HTTP instead of HTTPS, " + CONTEXT_WARNING);
 
                     // TODO: any hostname-admin specific validation?
 
                 } // else warn on prod?
                 if (httpsEnabled) {
-                    picocli.warn("HTTPS is enabled on the server, but `hostname` specifies HTTP. This is likely a misconfiguration.");
+                    picocli.warn("Likely misconfiguration detected. HTTPS is enabled on the server, but `hostname` specifies HTTP.");
                 }
             }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
@@ -76,7 +76,7 @@ public final class HostnameV2PropertyMappers {
 
             if (!url.getProtocol().toUpperCase().equals("HTTPS") && isProd) {
                 if (!SecureContextResolver.isLocal(url.getHost())) {
-                    picocli.warn("`hostname` is set to an HTTP hostname, cross-origin cookies will not be allowed. This is likely a misconfiguration.");
+                    picocli.warn("`hostname` is configured to use HTTP instead of HTTPS, cross-origin cookies will not be allowed. This is likely a misconfiguration.");
 
                     // TODO: any hostname-admin specific validation?
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -159,11 +159,15 @@ public final class HttpPropertyMappers {
 
     public static void validateConfig() {
         boolean enabled = isHttpEnabled(getOptionalKcValue(HttpOptions.HTTP_ENABLED.getKey()).orElse(null));
-        Optional<String> certFile = getOptionalValue(QUARKUS_HTTPS_CERT_FILES);
-        Optional<String> keystoreFile = getOptionalValue(QUARKUS_HTTPS_KEY_STORE_FILE);
-        if (!enabled && certFile.isEmpty() && keystoreFile.isEmpty()) {
+        if (!enabled && !isHttpsEnabled()) {
             throw new PropertyException(Messages.httpsConfigurationNotSet());
         }
+    }
+
+    public static boolean isHttpsEnabled() {
+        Optional<String> certFile = getOptionalValue(QUARKUS_HTTPS_CERT_FILES);
+        Optional<String> keystoreFile = getOptionalValue(QUARKUS_HTTPS_KEY_STORE_FILE);
+        return certFile.isPresent() || keystoreFile.isPresent();
     }
 
     private static String transformPath(String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/ConstantsDebugHostname.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/ConstantsDebugHostname.java
@@ -16,19 +16,25 @@
  */
 package org.keycloak.quarkus.runtime.services.resources;
 
+import java.util.stream.Stream;
+
 import org.keycloak.config.HostnameV2Options;
 import org.keycloak.config.HttpOptions;
 import org.keycloak.config.ProxyOptions;
 
 public class ConstantsDebugHostname {
-    public static final String[] RELEVANT_HEADERS = new String[] {
-            "Host",
-            "Forwarded",
+    public static final String[] X_FORWARDED_PROXY_HEADERS = new String[] {
             "X-Forwarded-Host",
             "X-Forwarded-Proto",
             "X-Forwarded-Port",
             "X-Forwarded-For"
     };
+
+    public static final String FORWARDED_PROXY_HEADER = "Forwarded";
+
+    public static final String[] RELEVANT_HEADERS = Stream
+            .concat(Stream.of("Host", FORWARDED_PROXY_HEADER), Stream.of(X_FORWARDED_PROXY_HEADERS))
+            .toArray(String[]::new);
 
     public static final String[] RELEVANT_OPTIONS_V2 = {
             HostnameV2Options.HOSTNAME.getKey(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
@@ -142,7 +142,7 @@ public class DebugHostnameSettingsResource {
             HttpHeaders requestHeaders = keycloakSession.getContext().getRequestHeaders();
             boolean proxied = requestHeaders.getHeaderString("Forwarded") != null || requestHeaders.getHeaderString("X-Forwarded-For") != null;
 
-            if (!originMatches) { // might fail CORs checks
+            if (!originMatches) { // might fail CORS checks
                 try {
                     new URL(Configuration.getKcConfigValue(HostnameV2Options.HOSTNAME.getKey()).getValue());
                     // a full url is ok

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
@@ -147,7 +147,7 @@ public class DebugHostnameSettingsResource {
                     new URL(Configuration.getKcConfigValue(HostnameV2Options.HOSTNAME.getKey()).getValue());
                     // a full url is ok
                 } catch (MalformedURLException e) {
-                    text = "Default origin check failing. Please check you proxy settings.";
+                    text = "Default origin check failing, request hostname does not match frontend hostname. Please check you proxy settings.";
                     if (!keycloakSession.getContext().getHttpRequest().isProxyTrusted()) {
                         text += " Note the proxy is not trusted.";
                     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
@@ -16,22 +16,24 @@
  */
 package org.keycloak.quarkus.runtime.services.resources;
 
-import io.quarkus.resteasy.reactive.server.EndpointDisabled;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.Provider;
-import org.keycloak.common.Profile;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.keycloak.common.util.UriUtils;
+import org.keycloak.config.HostnameV2Options;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.mappers.HostnameV2PropertyMappers;
 import org.keycloak.services.Urls;
 import org.keycloak.services.cors.Cors;
 import org.keycloak.theme.FreeMarkerException;
@@ -39,12 +41,19 @@ import org.keycloak.theme.Theme;
 import org.keycloak.theme.freemarker.FreeMarkerProvider;
 import org.keycloak.urls.UrlType;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import io.quarkus.resteasy.reactive.server.EndpointDisabled;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 @Path("/realms")
@@ -81,22 +90,26 @@ public class DebugHostnameSettingsResource {
 
         FreeMarkerProvider freeMarkerProvider = keycloakSession.getProvider(FreeMarkerProvider.class);
 
+        List<String> configWarnings = new ArrayList<String>();
+        HostnameV2PropertyMappers.validateConfig(configWarnings::add);
+
         URI frontendUri = keycloakSession.getContext().getUri(UrlType.FRONTEND).getBaseUri();
         URI backendUri = keycloakSession.getContext().getUri(UrlType.BACKEND).getBaseUri();
         URI adminUri = keycloakSession.getContext().getUri(UrlType.ADMIN).getBaseUri();
 
-        String frontendTestUrl = getTest(realmModel, frontendUri);
-        String backendTestUrl = getTest(realmModel, backendUri);
-        String adminTestUrl = getTest(realmModel, adminUri);
+        String frontendTestUrl = getTest(realmModel, frontendUri, true);
+        String backendTestUrl = getTest(realmModel, backendUri, false);
+        String adminTestUrl = getTest(realmModel, adminUri, false);
 
         Map<String, Object> attributes = new HashMap<>();
+        attributes.put("configWarnings", configWarnings);
         attributes.put("frontendUrl", frontendUri.toString());
         attributes.put("backendUrl", backendUri.toString());
         attributes.put("adminUrl", adminUri.toString());
 
         attributes.put("realm", realmModel.getName());
         attributes.put("realmUrl", realmModel.getAttribute("frontendUrl"));
-        attributes.put("implVersion", Profile.isFeatureEnabled(Profile.Feature.HOSTNAME_V2) ? "V2" : "V1");
+        attributes.put("implVersion", "V2");
 
         attributes.put("frontendTestUrl", frontendTestUrl);
         attributes.put("backendTestUrl", backendTestUrl);
@@ -117,10 +130,45 @@ public class DebugHostnameSettingsResource {
     @GET
     @Path("/{realmName}/" + DEFAULT_PATH_SUFFIX + "/" + PATH_FOR_TEST_CORS_IN_HEADERS)
     @Produces(MediaType.TEXT_PLAIN)
-    public Response test(final @PathParam("realmName") String realmName) {
-        Response.ResponseBuilder builder = Response.ok(PATH_FOR_TEST_CORS_IN_HEADERS + "-OK");
-        String origin = keycloakSession.getContext().getRequestHeaders().getHeaderString(Cors.ORIGIN_HEADER);
-        builder.header(Cors.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+    public Response test(final @PathParam("realmName") String realmName, @DefaultValue("false") @QueryParam("frontEnd") boolean frontEnd) {
+        String text = "OK";
+        String corsOrigin = keycloakSession.getContext().getRequestHeaders().getHeaderString(Cors.ORIGIN_HEADER);
+        URI requestUri = keycloakSession.getContext().getUri().getRequestUri();
+        String requestOrigin = UriUtils.getOrigin(requestUri);
+        URI frontendUri = keycloakSession.getContext().getUri(UrlType.FRONTEND).getBaseUri();
+
+        if (frontEnd) {
+            boolean originMatches = requestOrigin.equals(UriUtils.getOrigin(frontendUri));
+            HttpHeaders requestHeaders = keycloakSession.getContext().getRequestHeaders();
+            boolean proxied = requestHeaders.getHeaderString("Forwarded") != null || requestHeaders.getHeaderString("X-Forwarded-For") != null;
+
+            if (!originMatches) { // might fail CORs checks
+                try {
+                    new URL(Configuration.getKcConfigValue(HostnameV2Options.HOSTNAME.getKey()).getValue());
+                    // a full url is ok
+                } catch (MalformedURLException e) {
+                    text = "Default origin check failing. Please check you proxy settings.";
+                    if (!keycloakSession.getContext().getHttpRequest().isProxyTrusted()) {
+                        text += " Note the proxy is not trusted.";
+                    }
+                    if (!proxied) {
+                        text += " No proxy headers are set on the request.";
+                    }
+                }
+            }
+
+            boolean https = requestUri.getScheme().equals("https");
+            if (https) {
+                // if reencrypt, then proxy headers may need set
+                // if passthrough, then proxy headers should not be set
+
+                // TODO: not sure if there is great way to do this. Would likely need to check that a connection to the frontend uses the same
+                // cert as what is coming in on this request
+            }
+        }
+
+        Response.ResponseBuilder builder = Response.ok(text);
+        builder.header(Cors.ACCESS_CONTROL_ALLOW_ORIGIN, corsOrigin);
         builder.header(Cors.ACCESS_CONTROL_ALLOW_METHODS, "GET");
         return builder.build();
     }
@@ -149,9 +197,10 @@ public class DebugHostnameSettingsResource {
         }
     }
 
-    private String getTest(RealmModel realmModel, URI baseUri) {
+    private String getTest(RealmModel realmModel, URI baseUri, boolean frontEnd) {
         return Urls.realmBase(baseUri)
                    .path("/{realmName}/{debugHostnameSettingsPath}/{pathForTestCORSInHeaders}")
+                   .queryParam("frontEnd", frontEnd)
                    .build(realmModel.getName(), DEFAULT_PATH_SUFFIX, PATH_FOR_TEST_CORS_IN_HEADERS)
                    .toString();
     }

--- a/quarkus/runtime/src/main/resources/theme-resources/templates/debug-hostname-settings.ftl
+++ b/quarkus/runtime/src/main/resources/theme-resources/templates/debug-hostname-settings.ftl
@@ -28,6 +28,12 @@
 
 <body>
 
+    <ul>
+    <#list configWarnings as warning>
+        <li>${warning}</li>
+    </#list>
+    </ul>
+
     <table>
         <tr>
             <th>URL</th>
@@ -109,7 +115,7 @@
                 if (xhr.readyState == 4) {
                     clearTimeout(timeout);
                     if (xhr.status == 200) {
-                        document.getElementById(responseId).textContent='OK';
+                        document.getElementById(responseId).textContent=xhr.response;
                     } else {
                         document.getElementById(responseId).textContent='FAILED';
                     }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -505,7 +505,7 @@ public class PicocliTest extends AbstractConfigurationTest {
     public void buildOptionWithOptimized() {
         build("build", "--metrics-enabled=true", "--db=dev-file");
 
-        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--optimized", "--http-enabled=true", "--hostname=keycloak");
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
     }
 
@@ -583,8 +583,29 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void hostnameProxyValidation() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=foo");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getOutString(), containsString("HTTPS is not enabled on the server, either the `hostname` should be set to a full URL or `proxy-headers` should be used"));
+    }
+
+    @Test
+    public void hostnameProxyValidationStrictFalse() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname-strict=false");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getOutString(), containsString("With HTTPS not enabled and hostname-strict=false, cross-origin cookies will not be allowed"));
+    }
+
+    @Test
+    public void hostnameValidationHttp() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=http://host");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getOutString(), containsString("`hostname` is set to an HTTP hostname, cross-origin cookies will not be allowed. This is likely a misconfiguration."));
+    }
+
+    @Test
     public void derivedPropertyUsage() {
-        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=first-class", "--spi-hostname-v2-hostname=second-class", "--http-enabled=false");
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=localhost", "--spi-hostname-v2-hostname=second-class");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getOutString(), containsString("Please use the first-class option `kc.hostname` instead of `kc.spi-hostname-v2-hostname`"));
     }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -584,21 +584,21 @@ public class PicocliTest extends AbstractConfigurationTest {
 
     @Test
     public void hostnameProxyValidation() {
-        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=foo");
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--hostname=foo", "--http-enabled=true");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getOutString(), containsString("HTTPS is not enabled on the server, either the `hostname` should be set to a full URL or `proxy-headers` should be used"));
     }
 
     @Test
     public void hostnameProxyValidationStrictFalse() {
-        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname-strict=false");
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--hostname-strict=false", "--http-enabled=true");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getOutString(), containsString("With HTTPS not enabled and hostname-strict=false, cross-origin cookies will not be allowed"));
     }
 
     @Test
     public void hostnameValidationHttp() {
-        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=http://host");
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--hostname=http://host", "--http-enabled=true");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getOutString(), containsString("`hostname` is set to an HTTP hostname, cross-origin cookies will not be allowed. This is likely a misconfiguration."));
     }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -586,21 +586,21 @@ public class PicocliTest extends AbstractConfigurationTest {
     public void hostnameProxyValidation() {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--hostname=foo", "--http-enabled=true");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), containsString("HTTPS is not enabled on the server, either the `hostname` should be set to a full URL or `proxy-headers` should be used"));
+        assertThat(nonRunningPicocli.getOutString(), containsString("Likely misconfiguration detected"));
     }
 
     @Test
     public void hostnameProxyValidationStrictFalse() {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--hostname-strict=false", "--http-enabled=true");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), containsString("With HTTPS not enabled and hostname-strict=false, cross-origin cookies will not be allowed"));
+        assertThat(nonRunningPicocli.getOutString(), containsString("With HTTPS not enabled"));
     }
 
     @Test
     public void hostnameValidationHttp() {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--hostname=http://host", "--http-enabled=true");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), containsString("`hostname` is set to an HTTP hostname, cross-origin cookies will not be allowed. This is likely a misconfiguration."));
+        assertThat(nonRunningPicocli.getOutString(), containsString("Likely misconfiguration detected"));
     }
 
     @Test

--- a/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
+++ b/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
@@ -58,10 +58,14 @@ public class SecureContextResolver {
             return false;
         }
 
-        if (isLocalAddress(host)) {
-            return true;
-        }
+        return isLocal(host);
+    }
 
+    public static boolean isLocal(String host) {
+        return isLocalHost(host) || isLocalAddress(host);
+    }
+
+    public static boolean isLocalHost(String host) {
         if (host.equals("localhost") || host.equals("localhost.")) {
             return true;
         }


### PR DESCRIPTION
cc @vmuzikar @mabartos this is a rough in of code changes to add more validation around proxy-headers. Without re-introducing something like the proxy setting, we cannot directly infer the user's intention in several cases.

In particular we still don't have a good handle on what some users were doing using Keycloak over http but not through a proxy, so the message just says something vague about reviewing the usage: "Please review whether this direct http usage of keycloak is expected." @vmuzikar I believe you mentioned something about this case being problematic with Docker usage - keycloak ends up not actually being accessed over localhost, so it's not a secure context.

It would also make more sense to put this validation (and that of the legacy property usage) in the v2 provider, but that would require broader access to the whole configuration. If we want to pursue that we could either consider adding something like Config.Scope.getDescoped(String key)  - which breaks the config encapsulation a little bit, or we'll have to map everything of interest to an spi property.

The other place where users are commonly getting tripped up is here 
https://github.com/keycloak/keycloak/blob/edd67c6ca4af1bac5c1cc883720f580c0db4c917/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java#L88 - I previously updated the debug log to reference proxy-headers, but it could be expanded upon and/or logged at a higher level.

I haven't done it yet, but some additional doc changes will be added as well.

WDYT?

closes: #38091

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
