### PR TITLE
docs: Use BASH TCP redirect for HEALTHCHECK

### DIFF
--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -63,7 +63,7 @@ By default, no check is returned from the health endpoints.
 
 == Using the health checks
 
-It is recommended that the health endpoints be monitored by external HTTP requests. Due to security measures that remove `curl` and other packages from the {project_name} container image, local command-based monitoring will not function easily.
+Due to security measures that remove `curl` and other packages from the {project_name} container image, you are not able to easily run checks against HTTPS endpoints.
 
 If you are not using {project_name} in a container, use whatever you want to access the health check endpoints.
 
@@ -71,7 +71,7 @@ If you are not using {project_name} in a container, use whatever you want to acc
 
 You may use a simple HTTP HEAD request to determine the `+live+` or `+ready+` state of {project_name}. `+curl+` is a good HTTP client for this purpose.
 
-If {project_name} is deployed in a container, you must run this command from outside it due to the previously mentioned security measures. For example:
+If {project_name} is deployed in a container, you must use a custom image or run this command from outside it due to the previously mentioned security measures. For example:
 
 [source, bash]
 ----
@@ -95,7 +95,13 @@ The Containerfile https://docs.docker.com/reference/dockerfile/#healthcheck[`+HE
 { printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000
 ----
 
-The above code depends on the values of the {project_name} options `http-relative-path` (`http-management-relative-path`) and `http-management-port`. In case those are changed the code needs to be modified accordingly.
+The above code depends on the values of the {project_name} options such as `http-relative-path` (`http-management-relative-path`) and `http-management-port`. In case those are changed the code needs to be modified accordingly.
+
+If you enable TLS, the management interface will also use TLS. Depending upon how the management interface endpoints are intended to be used you can still have plain HTTP health checks if:
+
+- the management interface uses HTTP, not HTTPS, by setting `http-management-scheme` to `http`.
+- or the health checks are enabled for the main interface by setting `http-management-health-enabled` to `false` and accessible via HTTP with setting `http-enabled` to `true`. 
+In this scenario external traffic to the HTTP port (defaults to 8080) or to the health endpoints (defaults to /health) should not be allowed by your proxy.
 
 == Available Checks
 

--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -65,7 +65,7 @@ By default, no check is returned from the health endpoints.
 
 Due to security measures that remove `curl` and other packages from the {project_name} container image, you are not able to easily run checks against HTTPS endpoints.
 
-If you are not using {project_name} in a container, use whatever you want to access the health check endpoints.
+If you are not using {project_name} in a container, or if you are running the health checks outside of the container, use any tool to access the health check endpoints.
 
 === curl
 

--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -63,7 +63,7 @@ By default, no check is returned from the health endpoints.
 
 == Using the health checks
 
-Due to security measures that remove `curl` and other packages from the {project_name} container image, you are not able to easily run checks against HTTPS endpoints.
+Due to security measures that remove `curl` and other packages from the {project_name} container image, you are not able to run checks against HTTPS endpoints from within the container.
 
 If you are not using {project_name} in a container, or if you are running the health checks outside of the container, use any tool to access the health check endpoints.
 

--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -97,11 +97,10 @@ The Containerfile https://docs.docker.com/reference/dockerfile/#healthcheck[`+HE
 
 The above code depends on the values of the {project_name} options such as `http-relative-path` (`http-management-relative-path`) and `http-management-port`. In case those are changed the code needs to be modified accordingly.
 
-If you enable TLS, the management interface will also use TLS. Depending upon how the management interface endpoints are intended to be used you can still have plain HTTP health checks if:
+If you enable TLS as shown in <@links.server id="enabletls" />, the management interface will also use TLS. Depending upon how the management interface endpoints are intended to be used you can still have plain HTTP health checks if:
 
 - the management interface uses HTTP, not HTTPS, by setting `http-management-scheme` to `http`.
-- or the health checks are enabled for the main interface by setting `http-management-health-enabled` to `false` and accessible via HTTP with setting `http-enabled` to `true`. 
-In this scenario external traffic to the HTTP port (defaults to 8080) or to the health endpoints (defaults to /health) should not be allowed by your proxy.
+- or the health checks are enabled for the main interface by setting `http-management-health-enabled` to `false` and accessible via HTTP with setting `http-enabled` to `true`. In this scenario external traffic to the HTTP port (defaults to 8080) or to the health endpoints (defaults to /health) should not be allowed by your proxy.
 
 == Available Checks
 

--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -88,7 +88,14 @@ NOTE: If you configure mTLS with `https-client-auth` set to `required`, this con
 
 === HEALTHCHECK
 
-The Containerfile `+HEALTHCHECK+` instruction defines a command that will be periodically executed inside the container as it runs. The {project_name} container does not have any CLI HTTP clients installed. Consider installing `+curl+` as an additional RPM, as detailed by the <@links.server id="containers" /> {section}. Note that your container may be less secure because of this.
+The Containerfile https://docs.docker.com/reference/dockerfile/#healthcheck[`+HEALTHCHECK+`] instruction defines a command that will be periodically executed inside the container as it runs. While the {project_name} container does not have any CLI HTTP clients installed, it is possible to leverage BASH support for redirects to TCP sockets and craft a simple HTTP request to the healthcheck endpoint:
+
+[source, bash]
+----
+{ printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000
+----
+
+The above code depends on the values of the {project_name} options `http-relative-path` (`http-management-relative-path`) and `http-management-port`. In case those are changed the code needs to be modified accordingly.
 
 == Available Checks
 


### PR DESCRIPTION
Add a BASH script to perform an in-container healtcheck.

For the curious, here's how this works:

1. For the code within braces, a TCP connection is made to the keycloak's management port and a successful connection is redirected in the read-write fashion to the descriptor 0 (stdin).
   - When bash fails to connect (TCP RST), it ends up with an error right away.
   - When the connection is hanging (no reply till TCP retry timeout, usually about 1 minute), it just hangs, virtually being a subject to the HEALTHCHECK's timeout (which should be definitely smaller than the usual TCP retry timeout).
2. Then a simple hand-crafted HTTP HEAD request is sent to the socket using printf. This is supposed to always succeed, unless the send buffer of the socket is set ridiculously small on the target OS. In the other case it will just hang again, not being able to push all the bytes through, until that eventually happens or times out.
3. Next, the eventual response is being checked with grep to be the successful one. Only at this time it's return code (and the final) is 0.
   - When no response comes, it's hanging forever and is subject to timeout.
   - When a 503 response comes, grep doesn't match anything and returns 1.

Closes: #38126

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
