### PR TITLE
Logout session when closing the keycloak client

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -174,6 +174,14 @@ public class Keycloak implements AutoCloseable {
     @Override
     public void close() {
         closed = true;
+        if (tokenManager != null) {
+            try {
+                tokenManager.logout();
+            } catch (RuntimeException e) {
+                // do our best closing the session but logout can fail because multiple reasons:
+                // shared jakarta client closed, realm removed or disabled, client removed or disabled,...
+            }
+        }
         client.close();
     }
 

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -123,7 +123,7 @@ public class TokenManager {
     }
 
     public synchronized void logout() {
-        if (currentToken.getRefreshToken() == null) {
+        if (currentToken == null || currentToken.getRefreshToken() == null || refreshTokenExpired()) {
             return;
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminClientTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.client.X509ClientAuthenticator;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.models.AdminRoles;
@@ -175,6 +176,19 @@ public class AdminClientTest extends AbstractKeycloakTest {
         } finally {
             setClientEnabled(clientId, true);
         }
+    }
+
+    @Test
+    public void adminAuthCloseUserSession() throws Exception {
+        UserResource user = ApiUtil.findUserByUsernameId(adminClient.realm(realmName), "test-user@localhost");
+        try (Keycloak keycloak = AdminClientUtil.createAdminClient(false, realmName, "test-user@localhost", "password", Constants.ADMIN_CLI_CLIENT_ID, null)) {
+            // Check possible to load the realm
+            RealmRepresentation realm = keycloak.realm(realmName).toRepresentation();
+            Assert.assertEquals(realmName, realm.getRealm());
+
+            Assert.assertEquals(1, user.getUserSessions().size());
+        }
+        Assert.assertEquals(0, user.getUserSessions().size());
     }
 
     @Test


### PR DESCRIPTION
Closes #33946

I took a look to this issue today. The main problem in tests was that the `logout` method failed for different reasons:

* In some tests the realm itself was deleted (therefore the token was invalid.
* In other tests the jakarta jax-rs client was shared and closed by a previous close.
* I suppose there are more reasons.

So I have just done closing the session as a best effort, if the logout call return an error it is just ignored. Previously the session was not logged out, so those situations are a backwards incompatible change. @douglaspalmer WDYT? Do you see it OK?