### PR TITLE
fix: remove propertymapper lookup by cli and env key

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Help.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Help.java
@@ -161,7 +161,7 @@ public final class Help extends CommandLine.Help {
             // do not show options without a description nor hidden
             return false;
         }
-        
+
         if (ALL_OPTIONS) {
             return true;
         }
@@ -172,11 +172,15 @@ public final class Help extends CommandLine.Help {
         if (option.group() != null && option.group().heading() != null) {
             category = OptionCategory.fromHeading(removeSuffix(option.group().heading(), ":"));
         }
-        PropertyMapper<?> mapper = getMapper(optionName, category);
+        String kcKey = PropertyMappers.getKcKeyFromCliKey(optionName).orElse(null);
+        if (kcKey == null) {
+            return true;
+        }
+        PropertyMapper<?> mapper = getMapper(kcKey, category);
 
         if (mapper == null) {
-            final var disabledMapper = PropertyMappers.getDisabledMapper(optionName);
-            
+            final var disabledMapper = PropertyMappers.getDisabledMapper(kcKey);
+
             // Show disabled mappers, which do not have a description when they're enabled
             return disabledMapper.flatMap(PropertyMapper::getEnabledWhen).isEmpty();
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -280,10 +280,10 @@ public class Picocli {
         List<String> properties = new ArrayList<>();
 
         parseConfigArgs(ConfigArgsConfigSource.getAllCliArgs(), (key, value) -> {
-            PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
+            PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(key);
 
             if (mapper == null || mapper.isRunTime()) {
-                properties.add(key + "=" + maskValue(key, value));
+                properties.add(key + "=" + maskValue(value, mapper));
             }
         }, properties::add);
 
@@ -301,7 +301,7 @@ public class Picocli {
         List<String> configArgsList = new ArrayList<>();
         configArgsList.add(Build.NAME);
         parseConfigArgs(cliArgs, (k, v) -> {
-            PropertyMapper<?> mapper = PropertyMappers.getMapper(k);
+            PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(k);
 
             if (mapper != null && mapper.isBuildTime()) {
                 configArgsList.add(k + "=" + v);
@@ -332,7 +332,7 @@ public class Picocli {
             if (arg.contains("=")) {
                 arg = arg.substring(0, arg.indexOf("="));
             }
-            PropertyMapper<?> mapper = PropertyMappers.getMapper(arg);
+            PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(arg);
             return mapper != null && mapper.hasWildcard() && allowedMappers.contains(mapper);
         });
         if (!unrecognizedArgs.isEmpty()) {
@@ -463,7 +463,7 @@ public class Picocli {
         }
 
         if (disabledMappers.contains(mapper)) {
-            if (!PropertyMappers.isDisabledMapper(from)) {
+            if (PropertyMappers.getMapper(from) != null) {
                 return; // we found enabled mapper with the same name
             }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
@@ -37,16 +37,16 @@ public class ShortErrorMessageHandler implements IParameterExceptionHandler {
 
             String cliKey = unmatched[0];
 
-            PropertyMapper<?> mapper = PropertyMappers.getMapper(cliKey);
+            PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(cliKey);
 
-            final boolean isDisabledOption = mapper == null && PropertyMappers.isDisabledMapper(cliKey);
+            Optional<PropertyMapper<?>> disabled = PropertyMappers.getKcKeyFromCliKey(cliKey).flatMap(PropertyMappers::getDisabledMapper);
+
             final BooleanSupplier isUnknownOption = () -> mapper == null || !(cmd.getCommand() instanceof AbstractCommand);
 
-            if (isDisabledOption) {
-                var enabledWhen = PropertyMappers.getDisabledMapper(cliKey)
-                        .map(PropertyMapper::getEnabledWhen)
-                        .filter(Optional::isPresent)
-                        .map(desc -> format(". %s", desc.get()))
+            if (mapper == null && disabled.isPresent()) {
+                var enabledWhen = disabled
+                        .flatMap(PropertyMapper::getEnabledWhen)
+                        .map(desc -> format(". %s", desc))
                         .orElse("");
 
                 errorMessage = format("Disabled option: '%s'%s", cliKey, enabledWhen);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -114,7 +114,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
             return; // most system properties are internally used, and not relevant during show-config
         }
 
-        value = maskValue(configValue.getName(), value, configValue.getConfigSourceName());
+        value = maskValue(value, configValue.getConfigSourceName(), mapper);
 
         spec.commandLine().getOut().printf("\t%s =  %s (%s)%n", configValue.getName(), value, KeycloakConfigSourceProvider.getConfigSourceDisplayName(configValue.getConfigSourceName()));
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -150,7 +150,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
                     unaryConsumer.accept(arg);
                     continue;
                 }
-                PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
+                PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(key);
                 // the weaknesses here:
                 // - needs to know all of the short name options that accept a value
                 // - Even though We've explicitly disabled PosixClusteredShortOptionsAllowed, it may not know all of the picocli parsing rules.

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcUnmatchedArgumentException.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcUnmatchedArgumentException.java
@@ -40,6 +40,9 @@ public class KcUnmatchedArgumentException extends CommandLine.UnmatchedArgumentE
     @Override
     public List<String> getSuggestions() {
         // filter out disabled mappers
-        return super.getSuggestions().stream().filter(f -> !PropertyMappers.isDisabledMapper(f) && !f.endsWith(DUPLICIT_OPTION_SUFFIX)).toList();
+        return super.getSuggestions().stream()
+                .filter(f -> PropertyMappers.getKcKeyFromCliKey(f).filter(PropertyMappers::isDisabledMapper).isEmpty()
+                        && !f.endsWith(DUPLICIT_OPTION_SUFFIX))
+                .toList();
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -168,8 +168,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertEquals("true", config.getConfigValue("kc.hostname-strict").getValue());
         // check that we don't get the mapped value
         assertNull(config.getConfigValue("MY_EXPRESSION").getValue());
-        // could change after https://github.com/keycloak/keycloak/issues/38072
-        assertEquals("true", config.getConfigValue("KC_HOSTNAME_STRICT").getValue());
+        assertNull(config.getConfigValue("KC_HOSTNAME_STRICT").getValue());
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
@@ -25,9 +25,11 @@ import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.keycloak.config.LoggingOptions.DEFAULT_LOG_FORMAT;
 import static org.keycloak.config.LoggingOptions.DEFAULT_SYSLOG_OUTPUT;
 
@@ -271,6 +273,7 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
         SmallRyeConfig config = createConfig();
         assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
         assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"io.quarkus\".level").getValue());
+        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).anyMatch("kc.log-level-io.quarkus"::equals));
         assertEquals("INFO", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
     }
 


### PR DESCRIPTION
Removes the ability to look up property mappers directly by env and cli keys. While we have several paths dealing with the cli key form, we really only have a single place that is looking up by env.

This addresses the irregulatity brought up in a recent pr with the config keystore - it could contain entries that looked like cli or env keys - and we'd still use them. Now we'll only use proper "kc." keys.

This presumes that we won't have idiosyncratic env or cli key for a given kc key - if that happens, then we will need to maintain separate lookup tables.

closes: #38072

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
