### PR TITLE
User session lookup optimization and fixes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -50,6 +50,8 @@ public interface Details {
     String UPDATED_LAST_NAME = PREF_UPDATED + "last_name";
     String REMEMBER_ME = "remember_me";
     String TOKEN_ID = "token_id";
+    String TOKEN_TYPE = "token_type";
+    String TOKEN_ISSUED_FOR = "token_issued_for";
     String ORG_ID = "org_id";
     String REFRESH_TOKEN_ID = "refresh_token_id";
     String REFRESH_TOKEN_TYPE = "refresh_token_type";

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -207,4 +207,9 @@ public final class Constants {
     public static final String GRANT_TYPE = OAuth2Constants.GRANT_TYPE;
     // Note in client session to know the subject client
     public static final String TOKEN_EXCHANGE_SUBJECT_CLIENT = "token_exchange_subject_client";
+
+    // Note in transient userSession specifying that it was created from "persistent" user session for the temporary purpose. The values of this note could be "online" and "offline"
+    public static final String CREATED_FROM_PERSISTENT = "created_from_persistent";
+    public static final String CREATED_FROM_PERSISTENT_ONLINE = "online";
+    public static final String CREATED_FROM_PERSISTENT_OFFLINE = "offline";
 }

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -306,8 +306,14 @@ public class KeycloakIdentity implements Identity {
             return TokenManager.lookupUserFromStatelessToken(keycloakSession, realm, accessToken);
         }
 
+        // Avoid further loookup if verified userSession already set in the context
+        UserSessionModel userSession = keycloakSession.getContext().getUserSession();
+        if (userSession != null && accessToken.getSessionState().equals(userSession.getId())) {
+            return userSession.getUser();
+        }
+
         UserSessionProvider sessions = keycloakSession.sessions();
-        UserSessionModel userSession = sessions.getUserSession(realm, accessToken.getSessionState());
+        userSession = sessions.getUserSession(realm, accessToken.getSessionState());
 
         if (userSession == null) {
             userSession = sessions.getOfflineUserSession(realm, accessToken.getSessionState());

--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -40,6 +40,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.services.Urls;
 import org.keycloak.services.util.DefaultClientSessionContext;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.tracing.TracingAttributes;
 import org.keycloak.tracing.TracingProvider;
 import org.keycloak.util.JsonSerialization;
@@ -50,12 +51,19 @@ import jakarta.ws.rs.core.Response;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvider {
+public class AccessTokenIntrospectionProvider<T extends AccessToken> implements TokenIntrospectionProvider {
 
-    private final KeycloakSession session;
-    private final TokenManager tokenManager;
-    private final RealmModel realm;
+    protected final KeycloakSession session;
+    protected final TokenManager tokenManager;
+    protected final RealmModel realm;
     private static final Logger logger = Logger.getLogger(AccessTokenIntrospectionProvider.class);
+    protected EventBuilder eventBuilder;
+
+    // Those are set after successfully verified
+    protected T token;
+    protected ClientModel client;
+    protected UserSessionModel userSession;
+    protected UserModel user;
 
     public AccessTokenIntrospectionProvider(KeycloakSession session) {
         this.session = session;
@@ -64,17 +72,15 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
     }
 
     @Override
-    public Response introspect(String token, EventBuilder eventBuilder) {
+    public Response introspect(String tokenStr, EventBuilder eventBuilder) {
+        this.eventBuilder = eventBuilder;
         AccessToken accessToken = null;
         try {
-            accessToken = verifyAccessToken(token, eventBuilder, false);
-            UserSessionModel userSession = tokenManager.getValidUserSessionIfTokenIsValid(session, realm, accessToken, eventBuilder);
-
-            ClientModel client = session.getContext().getClient();
+            ClientModel authenticatedClient = session.getContext().getClient();
 
             ObjectNode tokenMetadata;
-            if (userSession != null) {
-                accessToken = transformAccessToken(accessToken, userSession);
+            if (introspectionChecks(tokenStr)) {
+                accessToken = transformAccessToken(this.token, userSession);
 
                 tokenMetadata = JsonSerialization.createObjectNode(accessToken);
                 tokenMetadata.put("client_id", accessToken.getIssuedFor());
@@ -91,6 +97,7 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
                         UserModel userModel = userSession.getUser();
                         if (userModel != null) {
                             tokenMetadata.put("username", userModel.getUsername());
+                            eventBuilder.user(userModel);
                         }
                     }
                 }
@@ -102,19 +109,18 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
                 }
 
                 tokenMetadata.put(OAuth2Constants.TOKEN_TYPE, accessToken.getType());
-
+                tokenMetadata.put("active", true);
+                eventBuilder.success();
             } else {
                 tokenMetadata = JsonSerialization.createObjectNode();
                 logger.debug("Keycloak token introspection return false");
-                eventBuilder.error(Errors.TOKEN_INTROSPECTION_FAILED);
+                tokenMetadata.put("active", false);
             }
-
-            tokenMetadata.put("active", userSession != null);
 
             // if consumer requests application/jwt return a JWT representation of the introspection contents in an jwt field
             if (accessToken != null) {
                 boolean isJwtRequest = org.keycloak.utils.MediaType.APPLICATION_JWT.equals(session.getContext().getRequestHeaders().getHeaderString(HttpHeaders.ACCEPT));
-                if (isJwtRequest && Boolean.parseBoolean(client.getAttribute(Constants.SUPPORT_JWT_CLAIM_IN_INTROSPECTION_RESPONSE_ENABLED))) {
+                if (isJwtRequest && Boolean.parseBoolean(authenticatedClient.getAttribute(Constants.SUPPORT_JWT_CLAIM_IN_INTROSPECTION_RESPONSE_ENABLED))) {
                     // consumers can use this to convert an opaque token into an JWT based token
                     tokenMetadata.put("jwt", session.tokens().encode(accessToken));
                 }
@@ -165,35 +171,121 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
         return newToken;
     }
 
-    protected AccessToken verifyAccessToken(String token, EventBuilder eventBuilder, boolean validateSession) {
+    /**
+     * Performs introspection checks related to token, client, userSession, user etc. If some of the checks failed, this method is supposed to already set an error event.
+     * If all the checks are successful, the instance variables are supposed to be set
+     *
+     * @return true just if all the checks are working
+     */
+    protected boolean introspectionChecks(String tokenStr) {
+        if (!verifyToken(tokenStr)) {
+            return false;
+        }
+        if (!verifyClient()) {
+            return false;
+        }
 
+        eventBuilder.session(this.token.getSessionId());
+        UserSessionUtil.UserSessionValidationResult result = verifyUserSession();
+        if (result.getError() != null) {
+            logger.debugf( "Introspection access token for " + token.getIssuedFor() + " client: " + result.getError());
+            eventBuilder.detail(Details.REASON,  "Introspection access token for " + token.getIssuedFor() + " client: " + result.getError());
+            eventBuilder.error(result.getError());
+            return false;
+        } else {
+            this.userSession = result.getUserSession();
+        }
+
+        this.user = userSession.getUser();
+        eventBuilder.user(user);
+        if (!TokenManager.isUserValid(session, realm, token, userSession.getUser())) {
+            logger.debugf("Could not find valid user from user session " + userSession.getId());
+            eventBuilder.detail(Details.REASON, "Could not find valid user from user session " + userSession.getId());
+            eventBuilder.error(user == null ? Errors.USER_NOT_FOUND : Errors.USER_DISABLED);
+            return false;
+        }
+
+        if (!verifyTokenReuse()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected boolean verifyToken(String tokenStr) {
         try {
-            TokenVerifier<AccessToken> verifier = TokenVerifier.create(token, AccessToken.class)
+            TokenVerifier<T> verifier = TokenVerifier.create(tokenStr, getTokenClass())
                     .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
 
             SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
-            AccessToken accessToken = verifier.verify().getToken();
+            this.token = verifier.verify().getToken();
+            eventBuilder.detail(Details.TOKEN_ID, token.getId());
+            eventBuilder.detail(Details.TOKEN_TYPE, token.getType());
 
             var tracing = session.getProvider(TracingProvider.class);
             var span = tracing.getCurrentSpan();
             if (span.isRecording()) {
-                span.setAttribute(TracingAttributes.TOKEN_ISSUER, accessToken.getIssuer());
-                span.setAttribute(TracingAttributes.TOKEN_SID, accessToken.getSessionId());
-                span.setAttribute(TracingAttributes.TOKEN_ID, accessToken.getId());
+                span.setAttribute(TracingAttributes.TOKEN_ISSUER, token.getIssuer());
+                span.setAttribute(TracingAttributes.TOKEN_SID, token.getSessionId());
+                span.setAttribute(TracingAttributes.TOKEN_ID, token.getId());
             }
 
-            if (validateSession) {
-                return tokenManager.checkTokenValidForIntrospection(session, realm, verifier.verify().getToken(), eventBuilder);
-            }
-
-            return accessToken;
+            return true;
         } catch (VerificationException e) {
             logger.debugf("Introspection access token : JWT check failed: %s", e.getMessage());
             eventBuilder.detail(Details.REASON,"Access token JWT check failed");
-            return null;
+            eventBuilder.error(Errors.INVALID_TOKEN);
+            return false;
         }
+    }
+
+
+    protected Class<T> getTokenClass() {
+        return (Class<T>) AccessToken.class;
+    }
+
+    protected boolean verifyClient() {
+        eventBuilder.detail(Details.TOKEN_ISSUED_FOR, token.getIssuedFor());
+        ClientModel client = realm.getClientByClientId(token.getIssuedFor());
+        if (client == null) {
+            logger.debugf("Introspection access token : client with clientId %s does not exist", token.getIssuedFor() );
+            eventBuilder.detail(Details.REASON, String.format("Could not find client for %s", token.getIssuedFor()));
+            eventBuilder.error(Errors.CLIENT_NOT_FOUND);
+            return false;
+        } else {
+            if (!client.isEnabled()) {
+                logger.debugf("Introspection access token : client with clientId %s is disabled", token.getIssuedFor() );
+                eventBuilder.detail(Details.REASON, String.format("Client with clientId %s is disabled", token.getIssuedFor()));
+                eventBuilder.error(Errors.CLIENT_DISABLED);
+                return false;
+            } else {
+
+                try {
+                    TokenVerifier.createWithoutSignature(token)
+                            .withChecks(TokenManager.NotBeforeCheck.forModel(client), TokenVerifier.IS_ACTIVE, new TokenManager.TokenRevocationCheck(session))
+                            .verify();
+                    this.client = client;
+                    return true;
+                } catch (VerificationException e) {
+                    logger.debugf("Introspection access token for %s client: JWT check failed: %s", token.getIssuedFor(), e.getMessage());
+                    eventBuilder.detail(Details.REASON, "Introspection access token for " + token.getIssuedFor() +" client: JWT check failed");
+                    eventBuilder.error(Errors.INVALID_TOKEN);
+                    return false;
+                }
+            }
+        }
+    }
+
+
+    protected UserSessionUtil.UserSessionValidationResult verifyUserSession() {
+        return UserSessionUtil.findValidSessionForAccessToken(session, realm, token, client, (invalidUserSession -> {}));
+    }
+
+
+    protected boolean verifyTokenReuse() {
+        return true;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/RefreshTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/RefreshTokenIntrospectionProvider.java
@@ -17,14 +17,63 @@
  */
 package org.keycloak.protocol.oidc;
 
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.RefreshToken;
+import org.keycloak.services.util.UserSessionUtil;
+import org.keycloak.util.TokenUtil;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class RefreshTokenIntrospectionProvider extends AccessTokenIntrospectionProvider {
+public class RefreshTokenIntrospectionProvider extends AccessTokenIntrospectionProvider<RefreshToken> {
+
+    private static final Logger logger = Logger.getLogger(RefreshTokenIntrospectionProvider.class);
 
     public RefreshTokenIntrospectionProvider(KeycloakSession session) {
         super(session);
+    }
+
+    @Override
+    protected Class<RefreshToken> getTokenClass() {
+        return RefreshToken.class;
+    }
+
+    @Override
+    protected UserSessionUtil.UserSessionValidationResult verifyUserSession() {
+        return UserSessionUtil.findValidSessionForRefreshToken(session, realm, token, client, (invalidUserSession -> {}));
+    }
+
+    @Override
+    protected boolean verifyTokenReuse() {
+
+        String tokenType = token.getType();
+        if (realm.isRevokeRefreshToken()
+                && (tokenType.equals(TokenUtil.TOKEN_TYPE_REFRESH) || tokenType.equals(TokenUtil.TOKEN_TYPE_OFFLINE))
+                && !validateTokenReuse()) {
+            logger.debugf("Introspection access token for %s client: failed to validate Token reuse for introspection", token.getIssuedFor());
+            eventBuilder.detail(Details.REASON, "Realm revoke refresh token, token type is "+tokenType+ " and token is not eligible for introspection");
+            eventBuilder.error(Errors.INVALID_TOKEN);
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean validateTokenReuse() {
+        AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+
+        try {
+            tokenManager.validateTokenReuse(session, realm, token, clientSession, false);
+            return true;
+        } catch (
+                OAuthErrorException e) {
+            logger.debug("validateTokenReuseForIntrospection is false", e);
+            return false;
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -253,98 +253,6 @@ public class TokenManager {
         return new TokenValidation(user, userSession, clientSessionCtx, newToken);
     }
 
-    /**
-     * Checks if the token is valid.
-     *
-     * @param session
-     * @param realm
-     * @param token
-     * @return
-     */
-    public AccessToken checkTokenValidForIntrospection(KeycloakSession session, RealmModel realm, AccessToken token, EventBuilder eventBuilder) {
-        return getValidUserSessionIfTokenIsValid(session, realm, token, eventBuilder) != null ? token : null;
-    }
-
-    /**
-     * Checks if the token is valid and return a valid user session.
-     *
-     * @param session
-     * @param realm
-     * @param token
-     * @return
-     */
-    public UserSessionModel getValidUserSessionIfTokenIsValid(KeycloakSession session, RealmModel realm, AccessToken token, EventBuilder eventBuilder) {
-        if (token == null) {
-            return null;
-        }
-        ClientModel client = realm.getClientByClientId(token.getIssuedFor());
-        if (client == null) {
-            logger.debugf("Introspection access token : client with clientId %s does not exist", token.getIssuedFor() );
-            eventBuilder.detail(Details.REASON, String.format("Could not find client for %s", token.getIssuedFor()));
-            return null;
-        } else if (!client.isEnabled()) {
-            logger.debugf("Introspection access token : client with clientId %s is disabled", token.getIssuedFor() );
-            eventBuilder.detail(Details.REASON, String.format("Client with clientId %s is disabled", token.getIssuedFor()));
-            return null;
-        }
-
-        try {
-            TokenVerifier.createWithoutSignature(token)
-                    .withChecks(NotBeforeCheck.forModel(client), TokenVerifier.IS_ACTIVE, new TokenRevocationCheck(session))
-                    .verify();
-        } catch (VerificationException e) {
-            logger.debugf("Introspection access token for %s client: JWT check failed: %s", token.getIssuedFor(), e.getMessage());
-            eventBuilder.detail(Details.REASON, "Introspection access token for "+token.getIssuedFor() +" client: JWT check failed");
-            return null;
-        }
-
-        UserSessionModel userSession;
-        try {
-            userSession = UserSessionUtil.findValidSession(session, realm, token, eventBuilder, client);
-        } catch (Exception e) {
-            logger.debugf( "Introspection access token for " + token.getIssuedFor() + " client:" + e.getMessage());
-            eventBuilder.detail(Details.REASON,  "Introspection access token for " + token.getIssuedFor() + " client:" + e.getMessage());
-            return null;
-        }
-
-        if (!isUserValid(session, realm, token, userSession.getUser())) {
-            logger.debugf("Could not find valid user from user");
-            eventBuilder.detail(Details.REASON, "Could not find valid user from user");
-            return null;
-        }
-
-        String tokenType = token.getType();
-        if (realm.isRevokeRefreshToken()
-                && (tokenType.equals(TokenUtil.TOKEN_TYPE_REFRESH) || tokenType.equals(TokenUtil.TOKEN_TYPE_OFFLINE))
-                && !validateTokenReuseForIntrospection(session, realm, token)) {
-            logger.debugf("Introspection access token for %s client: failed to validate Token reuse for introspection", token.getIssuedFor());
-            eventBuilder.detail(Details.REASON, "Realm revoke refresh token, token type is "+tokenType+ " and token is not eligible for introspection");
-            return null;
-        }
-        return userSession;
-    }
-
-    private boolean validateTokenReuseForIntrospection(KeycloakSession session, RealmModel realm, AccessToken token) {
-        UserSessionModel userSession = null;
-        if (token.getType().equals(TokenUtil.TOKEN_TYPE_REFRESH)) {
-            userSession = session.sessions().getUserSession(realm, token.getSessionId());
-        } else {
-            UserSessionManager sessionManager = new UserSessionManager(session);
-            userSession = sessionManager.findOfflineUserSession(realm, token.getSessionId());
-        }
-
-        ClientModel client = realm.getClientByClientId(token.getIssuedFor());
-        AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-
-        try {
-            validateTokenReuse(session, realm, token, clientSession, false);
-            return true;
-        } catch (OAuthErrorException e) {
-            logger.debug("validateTokenReuseForIntrospection is false",e);
-            return false;
-        }
-    }
-
     public static boolean isUserValid(KeycloakSession session, RealmModel realm, AccessToken token, UserModel user) {
         if (user == null) {
             logger.debugf("User does not exists");
@@ -503,7 +411,7 @@ public class TokenManager {
     }
 
     // Will throw OAuthErrorException if validation fails
-    private void validateTokenReuse(KeycloakSession session, RealmModel realm, AccessToken refreshToken, AuthenticatedClientSessionModel clientSession, boolean refreshFlag) throws OAuthErrorException {
+    public void validateTokenReuse(KeycloakSession session, RealmModel realm, AccessToken refreshToken, AuthenticatedClientSessionModel clientSession, boolean refreshFlag) throws OAuthErrorException {
         int startupTime = session.getProvider(UserSessionProvider.class).getStartupTime(realm);
         String key = getReuseIdKey(refreshToken);
         String refreshTokenId = clientSession.getRefreshToken(key);

--- a/services/src/main/java/org/keycloak/protocol/oidc/encode/AccessTokenContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/encode/AccessTokenContext.java
@@ -37,19 +37,56 @@ public class AccessTokenContext {
     private final String rawTokenId;
 
     public enum SessionType {
-        ONLINE("on"),
-        OFFLINE("of"),
-        TRANSIENT("tr"),
-        UNKNOWN("un");
+        // Regular online user session with valid client session
+        ONLINE("on", false, true, false, false),
+
+        // Regular offline user session with valid client session
+        OFFLINE("of", false, false, true, false),
+
+        // Transient user session
+        TRANSIENT("tr", true, false, false, false),
+
+        // Regular online user session with transient client session (Client session may not need to exist)
+        ONLINE_TRANSIENT_CLIENT("nt", false, true, false, true),
+
+        // Regular offline user session with transient client session (Client session may not need to exist)
+        OFFLINE_TRANSIENT_CLIENT("ft", false, false, true, true),
+
+        // Unknown type. Perhaps token coming from older Keycloak version than 26.2.0. No need to support transientClientSession as this was added in 26.2 with standard token-exchange
+        UNKNOWN("un", true, true, true, false);
 
         private final String shortcut;
+        private final boolean allowTransientUserSession;
+        private final boolean allowLookupOnlineUserSession;
+        private final boolean allowLookupOfflineUserSession;
+        private final boolean allowTransientClientSession;
 
-        SessionType(String shortcut) {
+        SessionType(String shortcut, boolean allowTransientUserSession, boolean allowLookupOnlineUserSession, boolean allowLookupOfflineUserSession, boolean allowTransientClientSession) {
             this.shortcut = shortcut;
+            this.allowTransientUserSession = allowTransientUserSession;
+            this.allowLookupOnlineUserSession = allowLookupOnlineUserSession;
+            this.allowLookupOfflineUserSession = allowLookupOfflineUserSession;
+            this.allowTransientClientSession = allowTransientClientSession;
         }
 
         public String getShortcut() {
             return shortcut;
+        }
+
+        public boolean isAllowTransientUserSession() {
+            return allowTransientUserSession;
+        }
+
+        public boolean isAllowLookupOnlineUserSession() {
+            return allowLookupOnlineUserSession;
+        }
+
+        public boolean isAllowLookupOfflineUserSession() {
+            return allowLookupOfflineUserSession;
+        }
+
+        public boolean isAllowTransientClientSession() {
+            return allowTransientClientSession;
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/encode/DefaultTokenContextEncoderProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/encode/DefaultTokenContextEncoderProvider.java
@@ -46,7 +46,12 @@ public class DefaultTokenContextEncoderProvider implements TokenContextEncoderPr
         AccessTokenContext.SessionType sessionType;
         UserSessionModel userSession = clientSessionContext.getClientSession().getUserSession();
         if (userSession.getPersistenceState() == UserSessionModel.SessionPersistenceState.TRANSIENT) {
-            sessionType = AccessTokenContext.SessionType.TRANSIENT;
+            String createdFromPersistent = userSession.getNote(Constants.CREATED_FROM_PERSISTENT);
+            if (createdFromPersistent != null) {
+                sessionType = Constants.CREATED_FROM_PERSISTENT_OFFLINE.equals(createdFromPersistent) ? AccessTokenContext.SessionType.OFFLINE_TRANSIENT_CLIENT : AccessTokenContext.SessionType.ONLINE_TRANSIENT_CLIENT;
+            } else {
+                sessionType = AccessTokenContext.SessionType.TRANSIENT;
+            }
         } else {
             sessionType = clientSessionContext.isOfflineTokenRequested() ? AccessTokenContext.SessionType.OFFLINE : AccessTokenContext.SessionType.ONLINE;
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -106,12 +106,7 @@ public class TokenIntrospectionEndpoint {
         }
 
         try {
-
-            Response response = provider.introspect(token, event);
-
-            this.event.success();
-
-            return response;
+            return provider.introspect(token, event);
         } catch (ErrorResponseException ere) {
             throw ere;
         } catch (Exception e) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -229,7 +229,14 @@ public class UserInfoEndpoint {
             throw error.invalidToken("Client disabled");
         }
 
-        UserSessionModel userSession = UserSessionUtil.findValidSession(session, realm, token, event, clientModel, error);
+        event.session(token.getSessionId());
+        UserSessionUtil.UserSessionValidationResult userSessionValidation = UserSessionUtil.findValidSessionForAccessToken(session, realm, token, clientModel, (invalidUserSession -> {}));
+        if (userSessionValidation.getError() != null) {
+            event.error(userSessionValidation.getError());
+            throw error.invalidToken(userSessionValidation.getError());
+        }
+
+        UserSessionModel userSession = userSessionValidation.getUserSession();
 
         UserModel userModel = userSession.getUser();
         if (userModel == null) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -388,14 +388,6 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         RootAuthenticationSessionModel rootAuthSession = new AuthenticationSessionManager(session).createAuthenticationSession(realm, false);
         AuthenticationSessionModel authSession = createSessionModel(targetUserSession, rootAuthSession, targetUser, targetClient, scope);
 
-        if (targetUserSession == null) {
-            // if no session is associated with a subject_token, a transient session is created to only allow building a token to the audience
-            targetUserSession = new UserSessionManager(session).createUserSession(authSession.getParentSession().getId(), realm, targetUser, targetUser.getUsername(),
-                    clientConnection.getRemoteAddr(), ServiceAccountConstants.CLIENT_AUTH, false, null, null, UserSessionModel.SessionPersistenceState.TRANSIENT);
-        }
-
-        event.session(targetUserSession);
-
         AuthenticationManager.setClientScopesInSession(session, authSession);
         ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, targetUserSession, authSession);
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -34,7 +34,6 @@ import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.services.managers.Auth;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.resource.AccountResourceProvider;
-import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.theme.Theme;
 
 import jakarta.ws.rs.HttpMethod;
@@ -121,8 +120,6 @@ public class AccountLoader {
         }
 
         AccessToken accessToken = authResult.getToken();
-
-        UserSessionUtil.checkTokenIssuedAt(client.getRealm(), accessToken, authResult.getSession(), event, authResult.getClient());
 
         if (accessToken.getAudience() == null || accessToken.getResourceAccess(client.getClientId()) == null) {
             // transform for introspection to get the required claims

--- a/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
@@ -1,106 +1,195 @@
 package org.keycloak.services.util;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.events.Errors;
-import org.keycloak.events.EventBuilder;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.ImpersonationSessionNote;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.UserSessionModelDelegate;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
 import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.RefreshToken;
 import org.keycloak.services.Urls;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
-import org.keycloak.utils.OAuth2Error;
+import org.keycloak.util.TokenUtil;
 
 public class UserSessionUtil {
 
     private static final Logger logger = Logger.getLogger(UserSessionUtil.class);
 
-    public static UserSessionModel findValidSession(KeycloakSession session, RealmModel realm, AccessToken token, EventBuilder event, ClientModel client) {
-        OAuth2Error error = new OAuth2Error().json(false).realm(realm);
-        return findValidSession(session, realm, token, event, client, error);
+    public static UserSessionValidationResult findValidSessionForIdentityCookie(KeycloakSession session, RealmModel realm, AccessToken token, Consumer<UserSessionModel> invalidSessionCallback) {
+        return findValidSession(session, realm, token,  null, AccessTokenContext.SessionType.ONLINE, false, true, invalidSessionCallback);
     }
 
-    public static UserSessionModel findValidSession(KeycloakSession session, RealmModel realm,
-            AccessToken token, EventBuilder event, ClientModel client, OAuth2Error error) {
+
+    public static UserSessionValidationResult findValidSessionForRefreshToken(KeycloakSession session, RealmModel realm, RefreshToken token, ClientModel client, Consumer<UserSessionModel> invalidSessionCallback) {
+        AccessTokenContext.SessionType sessionType;
+        if (TokenUtil.TOKEN_TYPE_OFFLINE.equals(token.getType())) {
+            sessionType = AccessTokenContext.SessionType.OFFLINE;
+        } else if (TokenUtil.TOKEN_TYPE_REFRESH.equals(token.getType())) {
+            sessionType = AccessTokenContext.SessionType.ONLINE;
+        } else {
+            return UserSessionValidationResult.error(Errors.INVALID_TOKEN_TYPE);
+        }
+
+        return findValidSession(session, realm, token, client, sessionType, Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE), false, invalidSessionCallback);
+    }
+
+
+    public static UserSessionValidationResult findValidSessionForAccessToken(KeycloakSession session, RealmModel realm, AccessToken token, ClientModel client, Consumer<UserSessionModel> invalidSessionCallback) {
+        AccessTokenContext accessTokenContext = session.getProvider(TokenContextEncoderProvider.class).getTokenContextFromTokenId(token.getId());
+        AccessTokenContext.SessionType sessionType = accessTokenContext.getSessionType();
+        return findValidSession(session, realm, token, client, sessionType, Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE), false, invalidSessionCallback);
+    }
+
+    /**
+     * Find valid user session (online or offline according to which one is allowed) and performs all the needed checks on it. Like checking if the userSession is valid and if clientSession is attached to it and
+     * if userSession (and clientSession) are started earlier than the token.
+     *
+     * User session will be set to KeycloakContext if successfully found and verified
+     *
+     * @param session must be not null
+     * @param realm must be not null
+     * @param token must be not null
+     * @param client must be not null unless "skipCheckClient" is true
+     * @param sessionType sessionType from the token. It allows to hint whether session can be looked-up as "online" session or as offline session. Also whether it is allowed to have transient user session or "link" transient client session to the found userSession
+     * @param allowImpersonationFallback If true, it is possible to have impersonationCallback in which case the client is not required to be present in the userSession as long as the userSession was involved in impersonation
+     * @param skipCheckClient whether the method should skip lookup of clientSession from userSession. Usually when the passed token is not linked to any client (EG. identity cookie)
+     * @param invalidSessionCallback Callback, which is invoked when user session is found, but validation of this userSession failed. Callback not called when userSession not found or when all valiation successful
+     * @return userSession with all the successful validations OR error. Result should never contain both session and error. The error contains the error code from {@link Errors}, so it can be directly used in the error event
+     */
+    private static UserSessionValidationResult findValidSession(KeycloakSession session, RealmModel realm,
+                                                    AccessToken token, ClientModel client,
+                                                    AccessTokenContext.SessionType sessionType, boolean allowImpersonationFallback, boolean skipCheckClient, Consumer<UserSessionModel> invalidSessionCallback) {
+        logger.tracef("Lookup user session with the sessionType '%s'. Token session id: %s", sessionType, token.getSessionId());
         if (token.getSessionId() == null) {
-            return createTransientSessionForClient(session, realm, token, client, event);
+            if (sessionType.isAllowTransientUserSession()) {
+                return createTransientSessionForClient(session, realm, token, client);
+            } else {
+                return UserSessionValidationResult.error(Errors.USER_SESSION_NOT_FOUND);
+            }
         }
 
         var userSessionProvider = session.sessions();
 
-        AccessTokenContext accessTokenContext = session.getProvider(TokenContextEncoderProvider.class).getTokenContextFromTokenId(token.getId());
-        if (accessTokenContext.getSessionType() == AccessTokenContext.SessionType.TRANSIENT) {
-            UserSessionModel userSession = userSessionProvider.getUserSession(realm, token.getSessionId());
-
-            if (AuthenticationManager.isSessionValid(realm, userSession)) {
-                checkTokenIssuedAt(realm, token, userSession, event, client);
-                return createTransientSessionForClient(session, userSession, client);
+        UserSessionModel userSession = null;
+        if (sessionType.isAllowLookupOnlineUserSession()) {
+            AuthenticatedClientSessionModel clientSession = null;
+            if (skipCheckClient || sessionType.isAllowTransientClientSession()) {
+                userSession = userSessionProvider.getUserSession(realm, token.getSessionId());
+            } else {
+                userSession = userSessionProvider.getUserSessionIfClientExists(realm, token.getSessionId(), false, client.getId());
+                if (userSession != null) {
+                    clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+                    if (!checkTokenIssuedAt(token, clientSession)) {
+                        return UserSessionValidationResult.error(Errors.INVALID_TOKEN, userSession, invalidSessionCallback);
+                    }
+                }
+                if (userSession == null && allowImpersonationFallback) {
+                    // also try to resolve sessions created during token exchange when the user is impersonated
+                    userSession = getUserSessionWithImpersonatorClient(session, realm, token.getSessionId(), false, client.getId());
+                }
             }
 
-            logger.debug("User session not found or expired for transient token");
-            event.session(userSession);
-            event.error(userSession == null? Errors.USER_SESSION_NOT_FOUND : Errors.SESSION_EXPIRED);
-            throw error.invalidToken(userSession == null? "Session not found" : "Session expired");
+            if (AuthenticationManager.isSessionValid(realm, userSession)) {
+                if (!checkTokenIssuedAt(token, userSession)) {
+                    return UserSessionValidationResult.error(Errors.INVALID_TOKEN, userSession, invalidSessionCallback);
+                }
+
+                if (sessionType.isAllowTransientClientSession()) {
+                    userSession = createTransientSessionForClient(session, userSession, client);
+                    return UserSessionValidationResult.validSession(session, userSession);
+                } else {
+                    return UserSessionValidationResult.validSession(session, userSession);
+                }
+
+            }
         }
 
-        UserSessionModel userSession = userSessionProvider.getUserSessionIfClientExists(realm, token.getSessionId(), false, client.getId());
-        if (userSession == null) {
-            // also try to resolve sessions created during token exchange when the user is impersonated
-            userSession = getUserSessionWithImpersonatorClient(session, realm, token.getSessionId(), false, client.getId());
-        }
+        UserSessionModel offlineUserSession = null;
+        if (sessionType.isAllowLookupOfflineUserSession()) {
+            AuthenticatedClientSessionModel offlineClientSession = null;
+            if (sessionType.isAllowTransientClientSession()) {
+                offlineUserSession = userSessionProvider.getOfflineUserSession(realm, token.getSessionId());
+            } else {
+                offlineUserSession = userSessionProvider.getUserSessionIfClientExists(realm, token.getSessionId(), true, client.getId());
+                if (offlineUserSession != null) {
+                    offlineClientSession = offlineUserSession.getAuthenticatedClientSessionByClient(client.getId());
+                    if (!checkTokenIssuedAt(token, offlineClientSession)) {
+                        return UserSessionValidationResult.error(Errors.INVALID_TOKEN, offlineUserSession, invalidSessionCallback);
+                    }
+                }
+            }
 
-        UserSessionModel offlineUserSession;
-        if (AuthenticationManager.isSessionValid(realm, userSession)) {
-            checkTokenIssuedAt(realm, token, userSession, event, client);
-            event.session(userSession);
-            return userSession;
-        } else {
-            offlineUserSession = userSessionProvider.getUserSessionIfClientExists(realm, token.getSessionId(), true, client.getId());
             if (AuthenticationManager.isSessionValid(realm, offlineUserSession)) {
-                checkTokenIssuedAt(realm, token, offlineUserSession, event, client);
-                event.session(offlineUserSession);
-                return offlineUserSession;
+                if (!checkTokenIssuedAt(token, offlineUserSession)) {
+                    return UserSessionValidationResult.error(Errors.INVALID_TOKEN, offlineUserSession, invalidSessionCallback);
+                }
+
+                if (sessionType.isAllowTransientClientSession()) {
+                    offlineUserSession = createTransientSessionForClient(session, offlineUserSession, client);
+                    return UserSessionValidationResult.validSession(session, offlineUserSession);
+                } else {
+                    return UserSessionValidationResult.validSession(session, offlineUserSession);
+                }
             }
         }
 
         if (userSession == null && offlineUserSession == null) {
-            logger.debug("User session not found or doesn't have client attached on it");
-            event.error(Errors.USER_SESSION_NOT_FOUND);
-            throw error.invalidToken("User session not found or doesn't have client attached on it");
+            logger.debugf("User session '%s' not found or doesn't have client attached on it", token.getSessionId());
+            return UserSessionValidationResult.error(Errors.USER_SESSION_NOT_FOUND);
         }
 
-        event.session(Objects.requireNonNullElse(userSession, offlineUserSession));
-
-        logger.debug("Session expired");
-        event.error(Errors.SESSION_EXPIRED);
-        throw error.invalidToken("Session expired");
+        logger.debugf("Session '%s' expired", token.getSessionId());
+        return UserSessionValidationResult.error(Errors.SESSION_EXPIRED, userSession != null ? userSession : offlineUserSession, invalidSessionCallback);
     }
 
+
     public static UserSessionModel createTransientUserSession(KeycloakSession session, UserSessionModel userSession) {
+        if (userSession.getPersistenceState() == UserSessionModel.SessionPersistenceState.TRANSIENT) {
+            throw new IllegalArgumentException("Not expected to invoke this method with the transient session");
+        }
+
         UserSessionModel transientSession = new UserSessionManager(session).createUserSession(userSession.getId(), userSession.getRealm(),
                 userSession.getUser(), userSession.getLoginUsername(), userSession.getIpAddress(), userSession.getAuthMethod(), userSession.isRememberMe(),
                 userSession.getBrokerSessionId(), userSession.getBrokerUserId(), UserSessionModel.SessionPersistenceState.TRANSIENT);
         userSession.getNotes().entrySet().forEach(e -> transientSession.setNote(e.getKey(), e.getValue()));
-        return transientSession;
+
+        String noteValue = userSession.isOffline() ? Constants.CREATED_FROM_PERSISTENT_OFFLINE : Constants.CREATED_FROM_PERSISTENT_ONLINE;
+        transientSession.setNote(Constants.CREATED_FROM_PERSISTENT, noteValue);
+
+        // Use "started" time from the original session
+        return new UserSessionModelDelegate(transientSession) {
+
+            @Override
+            public int getStarted() {
+                return userSession.getStarted();
+            }
+
+        };
     }
 
-    private static UserSessionModel attachAuthenticationSession(KeycloakSession session, UserSessionModel userSession, ClientModel client) {
+    private static void attachAuthenticationSession(KeycloakSession session, UserSessionModel userSession, ClientModel client) {
         RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(userSession.getRealm());
         AuthenticationSessionModel authSession = rootAuthSession.createAuthenticationSession(client);
         authSession.setAuthenticatedUser(userSession.getUser());
@@ -108,7 +197,6 @@ public class UserSessionUtil {
         authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), userSession.getRealm().getName()));
         AuthenticationManager.setClientScopesInSession(session, authSession);
         TokenManager.attachAuthenticationSession(session, userSession, authSession);
-        return userSession;
     }
 
     private static UserSessionModel createTransientSessionForClient(KeycloakSession session, UserSessionModel userSession, ClientModel client) {
@@ -117,40 +205,79 @@ public class UserSessionUtil {
         return transientSession;
     }
 
-    private static UserSessionModel createTransientSessionForClient(KeycloakSession session, RealmModel realm, AccessToken token, ClientModel client, EventBuilder event) {
-        OAuth2Error error = new OAuth2Error().json(false).realm(realm);
+    private static UserSessionValidationResult createTransientSessionForClient(KeycloakSession session, RealmModel realm, AccessToken token, ClientModel client) {
         // create a transient session
         UserModel user = TokenManager.lookupUserFromStatelessToken(session, realm, token);
         if (user == null) {
             logger.debug("Transient User not found");
-            event.error(Errors.USER_NOT_FOUND);
-            throw error.invalidToken("User not found");
+            return UserSessionValidationResult.error(Errors.USER_NOT_FOUND);
         }
+        if (!user.isEnabled()) {
+            logger.debugf("User '%s' disabled", user.getUsername());
+            return UserSessionValidationResult.error(Errors.USER_DISABLED);
+        }
+
         ClientConnection clientConnection = session.getContext().getConnection();
         UserSessionModel userSession = new UserSessionManager(session).createUserSession(KeycloakModelUtils.generateId(), realm, user, user.getUsername(), clientConnection.getRemoteAddr(),
                 ServiceAccountConstants.CLIENT_AUTH, false, null, null, UserSessionModel.SessionPersistenceState.TRANSIENT);
         // attach an auth session for the client
         attachAuthenticationSession(session, userSession, client);
-        return userSession;
+        return UserSessionValidationResult.validSession(session, userSession);
     }
 
-    public static void checkTokenIssuedAt(RealmModel realm, AccessToken token, UserSessionModel userSession, EventBuilder event, ClientModel client) {
-        OAuth2Error error = new OAuth2Error().json(false).realm(realm);
+    private static boolean checkTokenIssuedAt(AccessToken token, UserSessionModel userSession) {
         if (token.isIssuedBeforeSessionStart(userSession.getStarted())) {
             logger.debug("Stale token for user session");
-            event.error(Errors.INVALID_TOKEN);
-            throw error.invalidToken("Stale token");
+            return false;
+        } else {
+            return true;
         }
+    }
 
-        AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-        if (clientSession != null && token.isIssuedBeforeSessionStart(clientSession.getStarted())) {
+    private static boolean checkTokenIssuedAt(AccessToken token, AuthenticatedClientSessionModel clientSession) {
+        if (token.isIssuedBeforeSessionStart(clientSession.getStarted())) {
             logger.debug("Stale token for client session");
-            event.error(Errors.INVALID_TOKEN);
-            throw error.invalidToken("Stale token");
+            return false;
+        } else {
+            return true;
         }
     }
 
     public static UserSessionModel getUserSessionWithImpersonatorClient(KeycloakSession session, RealmModel realm, String userSessionId, boolean offline, String clientUUID) {
         return session.sessions().getUserSessionWithPredicate(realm, userSessionId, offline, userSession -> Objects.equals(clientUUID, userSession.getNote(ImpersonationSessionNote.IMPERSONATOR_CLIENT.toString())));
+    }
+
+
+    public static class UserSessionValidationResult {
+        private final UserSessionModel userSession;
+        private final String error;
+
+        private static UserSessionValidationResult validSession(KeycloakSession session, UserSessionModel userSession) {
+            session.getContext().setUserSession(userSession);
+            return new UserSessionValidationResult(userSession, null);
+        }
+
+        private static UserSessionValidationResult error(String error) {
+            return new UserSessionValidationResult(null, error);
+        }
+
+        private static UserSessionValidationResult error(String error, UserSessionModel invalidUserSession, Consumer<UserSessionModel> invalidSessionCallback) {
+            invalidSessionCallback.accept(invalidUserSession);
+            return new UserSessionValidationResult(null, error);
+        }
+
+        // Should be only called by static creators
+        private UserSessionValidationResult(UserSessionModel userSession, String error) {
+            this.userSession = userSession;
+            this.error = error;
+        }
+
+        public UserSessionModel getUserSession() {
+            return userSession;
+        }
+
+        public String getError() {
+            return error;
+        }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -2830,14 +2830,14 @@ public class CIBATest extends AbstractClientPoliciesTest {
         assertThat(rep.isActive(), is(equalTo(true)));
         assertThat(rep.getClientId(), is(equalTo(TEST_CLIENT_NAME)));
         assertThat(rep.getIssuedFor(), is(equalTo(TEST_CLIENT_NAME)));
-        events.expect(EventType.INTROSPECT_TOKEN).user((String) null).session(accessToken.getSessionId()).clearDetails().assertEvent();
+        events.expect(EventType.INTROSPECT_TOKEN).user(AssertEvents.isUUID()).session(accessToken.getSessionId()).clearDetails().assertEvent();
 
         rep = oauth.doIntrospectionAccessTokenRequest(tokenRes.getRefreshToken()).asTokenMetadata();
         assertThat(rep.isActive(), is(equalTo(true)));
         assertThat(rep.getClientId(), is(equalTo(TEST_CLIENT_NAME)));
         assertThat(rep.getIssuedFor(), is(equalTo(TEST_CLIENT_NAME)));
         assertThat(rep.getAudience()[0], is(equalTo(rep.getIssuer())));
-        events.expect(EventType.INTROSPECT_TOKEN).user((String) null).session(accessToken.getSessionId()).clearDetails().assertEvent();
+        events.expect(EventType.INTROSPECT_TOKEN).user(AssertEvents.isUUID()).session(accessToken.getSessionId()).clearDetails().assertEvent();
 
         rep = oauth.doIntrospectionAccessTokenRequest(tokenRes.getIdToken()).asTokenMetadata();
         assertThat(rep.isActive(), is(equalTo(true)));
@@ -2846,7 +2846,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
         assertThat(rep.getIssuedFor(), is(equalTo(TEST_CLIENT_NAME)));
         assertThat(rep.getPreferredUsername(), is(equalTo(username)));
         assertThat(rep.getAudience()[0], is(equalTo(rep.getIssuedFor())));
-        events.expect(EventType.INTROSPECT_TOKEN).user((String) null).session(accessToken.getSessionId()).clearDetails().assertEvent();
+        events.expect(EventType.INTROSPECT_TOKEN).user(AssertEvents.isUUID()).session(accessToken.getSessionId()).clearDetails().assertEvent();
     }
 
     private AccessTokenResponse doRefreshTokenRequest(String oldRefreshToken, String username, String sessionId, boolean isOfflineAccess) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -664,7 +664,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         assertEquals(clientId, rep.getClientId());
         assertEquals(clientId, rep.getIssuedFor());
         assertEquals(username, rep.getUserName());
-        events.expect(EventType.INTROSPECT_TOKEN).client(clientId).session(sessionId).user((String)null).clearDetails().assertEvent();
+        events.expect(EventType.INTROSPECT_TOKEN).client(clientId).session(sessionId).user(AssertEvents.isUUID()).clearDetails().assertEvent();
     }
 
     protected void doTokenRevoke(String refreshToken, String clientId, String clientSecret, String userId, String sessionId, boolean isOfflineAccess) throws IOException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
@@ -380,13 +380,14 @@ public class ServiceAccountTest extends AbstractKeycloakTest {
 
         // Check that it is not possible to introspect token anymore
         Assert.assertFalse(getIntrospectionResponse(tokenString));
-        // TODO: This would be better to be "INTROSPECT_TOKEN_ERROR"
+
         events.expect(EventType.INTROSPECT_TOKEN_ERROR)
                 .client("service-account-cl")
                 .user(is(emptyOrNullString()))
                 .session(is(emptyOrNullString()))
-                .error(Errors.TOKEN_INTROSPECTION_FAILED)
+                .error(Errors.INVALID_TOKEN)
                 .assertEvent();
+        events.assertEmpty();
     }
 
     @Test
@@ -436,7 +437,7 @@ public class ServiceAccountTest extends AbstractKeycloakTest {
         Assert.assertTrue(getIntrospectionResponse(tokenString));
         events.expect(EventType.INTROSPECT_TOKEN)
                 .client("service-account-cl")
-                .user(is(emptyOrNullString()))
+                .user(AssertEvents.isUUID())
                 .session(is(emptyOrNullString()))
                 .assertEvent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -555,9 +555,10 @@ public class UserInfoTest extends AbstractKeycloakTest {
             events.expect(EventType.USER_INFO_REQUEST_ERROR)
                     .error(Errors.USER_SESSION_NOT_FOUND)
                     .user(Matchers.nullValue(String.class))
-                    .session(Matchers.nullValue(String.class))
+                    .session(accessTokenResponse.getSessionState())
                     .detail(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN)
                     .assertEvent();
+            events.assertEmpty();
 
         } finally {
             client.close();
@@ -631,7 +632,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
             events.expect(EventType.USER_INFO_REQUEST_ERROR)
                     .error(Errors.USER_SESSION_NOT_FOUND)
                     .user(Matchers.nullValue(String.class))
-                    .session(Matchers.nullValue(String.class))
+                    .session(accessTokenResponse.getSessionState())
                     .detail(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN)
                     .client("test-app")
                     .assertEvent();


### PR DESCRIPTION
closes #37662

I've started to do the refactoring as mentioned in the issue. The aim was to optimize lookup of user session and during token verification, avoid trying to lookup "online" session whe the token is coming from "offline" session etc. Also I've tried to re-use the same code for more places (introspection endpoint, user-info, admin/account REST API verifications) to avoid having the same/similar code for user session lookup and verification on multiple places. So I've made `AuthenticationManager.verifyIdentityToken` to re-use the `UserSessionUtil.findValidSession` for lookup of user-session and all the relevant checks.

I've ended with bigger PR than expected as I found also some bugs during the refactoring (when looking into the code and thinking about various broken scenarios...).

Here some details about the bugs

### Bug 1

Admin/account REST API invoked with the token of disabled user, which comes from offline login. Scenario like:
- User authenticates and gets some token
- Admin disables the user
- When admin REST (or account REST) API is called with the access-token of the user, request is rejected due the disabled user. Which is correct. However when the token is coming from offline session, request is still allowed.

**Cause:** Looks like missing a check in `AuthenticationManager.verifyIdentityToken`. There were quite a lot of if/else branches with various combinations and this combinations was likely missed.

### Bug 2

Events for introspection are a bit buggy.
- When there is error during token introspection request, the error event is called 3 times. Expected would be to call only 1 error event for a request
- The introspection error is always generic error `token_introspection_failed` instead of some more concrete error like what he had in other events (EG. `invalid_token`, `client_not_found`, `session_expired` etc).
- Finally the introspection successful event does not contain some relevant informations. For example user is not in the event.

### Bug 3

The token-exchange scenario like this:
- Login with offline access. Offline user session created
- Token exchange with the `subject_token` from the previous login and with `requested_token_type=access token`. Login is allowed
- Offline user session from previous step is logged-out
- Introspection endpoint called with exchanged token. Now I would expect exchanged token to be invalid (Similarly like we're doing for "online" session). However the exchanged access token is still valid.

**Cause:** The exchanged token does not have `sid` claim filled at all when it is exchanged from subject_token of some offline user session. So it is not linked to any session at all (In case of "online" the sessionType is `TRANSIENT` , but `sid` claim was set)

### Bug 4

The token-exchange scenario like this:
- Login by browser with client `subject_client`
- Doing token exchange with the `subject_token` for client `requester-client` and access token as `requested_token_type` -> SUCCESS
- After some time (EG. 10 seconds) , do SSO login in the browser to `requester-client`. At this moment, the clientSession is created for `requester-client` inside userSession (previous token-exchange did not created client session)
- Do token introspection with the access token from previous step. Introspection should be OK, but it fails (just because of SSO login and the fact that clientSession was created)
 
**Cause:** The fact that clientSession startup time of `requester-client` is newer than access-token startup time)


## Fixes and relevant changes

1) The `AuthenticationManager.verifyIdentityToken` was refactored a bit to move all the session related code and verifications in `UserSessionUtil.findUserSession` like introspection, user-info etc. Hopefully it is less error-prone in general right now with all the logic of session lookup/validation moved to single place.
**Test added:** `AdminClientTest.adminAuthUserDisabled()` (Testing scenario with disabled user for both online and offline session. Online session already rejected request before (correct), but offline session did not rejected request before changes (incorrect IMO)

2) Did some refactoring of introspection provider in general. Moved the introspection checks from `TokenManager` to introspection provider itself, so it can be overriden in `RefreshTokenIntrospectionProvider` (As refresh-token does not have context info in the token ID). Added some event assertions to `TokenIntrospectionTest` for this.

3) Added some new `AccessTokenContext.SessionType` types `ONLINE_TRANSIENT_CLIENT` and `OFFLINE_TRANSIENT_CLIENT` . They are used just during token-exchange right now. The `ONLINE_TRANSIENT_CLIENT` is used when token comes from "online" session, but there is not client session created (like during token-exchange for `requested_token_type` as access token). The `OFFLINE_TRANSIENT_CLIENT` is when token exchange is called with the `subject_token` coming from offline user session. Previously the access token session-type was `TRANSIENT`. With the new types, there is some more context as token-verification knows that it should lookup user session (either "online" or "offline"), but does not need to check it's client session.
**Test added:** `StandardTokenExchangeV2Test.testTransientOfflineSessionForRequester()` (We had similar test already for "online" user session)

4) With my changes, the exchanged token type is `ONLINE_TRANSIENT_CLIENT` . In this case, there is no verification of startup time of client-session compared with the access token.
**Test added:** `StandardTokenExchangeV2Test.testIntrospectionWithExchangedTokenAfterSSOLoginOfRequesterClient()`

