### PR TITLE
Recovery codes modifications to not tamper sent values

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
@@ -27,6 +27,9 @@ import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
 
 public class RecoveryAuthnCodesFormAuthenticator implements Authenticator {
 
+    public static final String GENERATED_RECOVERY_AUTHN_CODES_NOTE = "RecoveryAuthnCodes.generatedRecoveryAuthnCodes";
+    public static final String GENERATED_AT_NOTE = "RecoveryAuthnCodes.generatedAt";
+
     public RecoveryAuthnCodesFormAuthenticator(KeycloakSession keycloakSession) {
     }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -27,6 +27,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator;
+import org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticator;
 import org.keycloak.authentication.forms.RegistrationPage;
 import org.keycloak.authentication.requiredactions.util.UpdateProfileContext;
 import org.keycloak.authentication.requiredactions.util.UserUpdateProfileContext;
@@ -261,7 +262,11 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 attributes.put("totp", totpBean);
                 break;
             case LOGIN_RECOVERY_AUTHN_CODES_CONFIG:
-                attributes.put("recoveryAuthnCodesConfigBean", new RecoveryAuthnCodesBean());
+                // generate the recovery codes and assign to the auth session
+                RecoveryAuthnCodesBean recoveryAuthnCodesBean = new RecoveryAuthnCodesBean();
+                attributes.put("recoveryAuthnCodesConfigBean", recoveryAuthnCodesBean);
+                authenticationSession.setAuthNote(RecoveryAuthnCodesFormAuthenticator.GENERATED_RECOVERY_AUTHN_CODES_NOTE, recoveryAuthnCodesBean.getGeneratedRecoveryAuthnCodesAsString());
+                authenticationSession.setAuthNote(RecoveryAuthnCodesFormAuthenticator.GENERATED_AT_NOTE, Long.toString(recoveryAuthnCodesBean.getGeneratedAt()));
                 break;
             case LOGIN_RECOVERY_AUTHN_CODES_INPUT:
                 attributes.put("recoveryAuthnCodesInputBean", new RecoveryAuthnCodeInputLoginBean(session, realm, user));

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SetupRecoveryAuthnCodesPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SetupRecoveryAuthnCodesPage.java
@@ -2,6 +2,7 @@ package org.keycloak.testsuite.pages;
 
 import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -18,12 +19,36 @@ public class SetupRecoveryAuthnCodesPage extends LogoutSessionsPage {
     @FindBy(id = "saveRecoveryAuthnCodesBtn")
     private WebElement saveRecoveryAuthnCodesButton;
 
-    @FindBy(id="kcRecoveryCodesConfirmationCheck")
+    @FindBy(id = "kcRecoveryCodesConfirmationCheck")
     private WebElement kcRecoveryCodesConfirmationCheck;
+
+    @FindBy(name = "generatedRecoveryAuthnCodes")
+    private WebElement generatedRecoveryAuthnCodesHidden;
+
+    @FindBy(name = "generatedAt")
+    private WebElement generatedAtHidden;
 
     public void clickSaveRecoveryAuthnCodesButton() {
         UIUtils.switchCheckbox(kcRecoveryCodesConfirmationCheck, true);
         UIUtils.clickLink(saveRecoveryAuthnCodesButton);
+    }
+
+    public String getGeneratedRecoveryAuthnCodesHidden() {
+        return generatedRecoveryAuthnCodesHidden.getAttribute("value");
+    }
+
+    public void setGeneratedRecoveryAuthnCodesHidden(String codes) {
+        final JavascriptExecutor js = (JavascriptExecutor) driver;
+        js.executeScript("document.getElementsByName('generatedRecoveryAuthnCodes')[0].value='" + codes + "'");
+    }
+
+    public String getGeneratedAtHidden() {
+        return generatedAtHidden.getAttribute("value");
+    }
+
+    public void setGeneratedAtHidden(String at) {
+        final JavascriptExecutor js = (JavascriptExecutor) driver;
+        js.executeScript("document.getElementsByName('generatedAt')[0].value='" + at + "'");
     }
 
     public List<String> getRecoveryAuthnCodes() {


### PR DESCRIPTION
Closes #26104
Closes #26105

The recovery codes assign to the auth session the codes generated and the time when they were generated. This way both values are checked at creation time. If they were tampered the codes are generated again and sent to the user to restart the action. Tests added.
