### PR TITLE
fix: remove out-dated references to hostname v1 properties

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/ConstantsDebugHostname.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/ConstantsDebugHostname.java
@@ -16,6 +16,10 @@
  */
 package org.keycloak.quarkus.runtime.services.resources;
 
+import org.keycloak.config.HostnameV2Options;
+import org.keycloak.config.HttpOptions;
+import org.keycloak.config.ProxyOptions;
+
 public class ConstantsDebugHostname {
     public static final String[] RELEVANT_HEADERS = new String[] {
             "Host",
@@ -26,34 +30,16 @@ public class ConstantsDebugHostname {
             "X-Forwarded-For"
     };
 
-    public static final String[] RELEVANT_OPTIONS = {
-            "hostname",
-            "hostname-url",
-            "hostname-admin",
-            "hostname-admin-url",
-            "hostname-strict",
-            "hostname-strict-backchannel",
-            "hostname-strict-https",
-            "hostname-path",
-            "hostname-port",
-            "proxy",
-            "proxy-headers",
-            "http-enabled",
-            "http-relative-path",
-            "http-port",
-            "https-port"
-    };
-
     public static final String[] RELEVANT_OPTIONS_V2 = {
-            "hostname",
-            "hostname-admin",
-            "hostname-backchannel-dynamic",
-            "hostname-strict",
-            "proxy-headers",
-            "http-enabled",
-            "http-relative-path",
-            "http-port",
-            "https-port"
+            HostnameV2Options.HOSTNAME.getKey(),
+            HostnameV2Options.HOSTNAME_ADMIN.getKey(),
+            HostnameV2Options.HOSTNAME_BACKCHANNEL_DYNAMIC.getKey(),
+            HostnameV2Options.HOSTNAME_STRICT.getKey(),
+            ProxyOptions.PROXY_HEADERS.getKey(),
+            HttpOptions.HTTP_ENABLED.getKey(),
+            HttpOptions.HTTP_RELATIVE_PATH.getKey(),
+            HttpOptions.HTTP_PORT.getKey(),
+            HttpOptions.HTTPS_PORT.getKey()
     };
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
@@ -62,7 +62,7 @@ public class DebugHostnameSettingsResource {
     public DebugHostnameSettingsResource() {
 
         this.allConfigPropertiesMap = new LinkedHashMap<>();
-        String[] relevantOptions = Profile.isFeatureEnabled(Profile.Feature.HOSTNAME_V2) ? ConstantsDebugHostname.RELEVANT_OPTIONS_V2 : ConstantsDebugHostname.RELEVANT_OPTIONS;
+        String[] relevantOptions = ConstantsDebugHostname.RELEVANT_OPTIONS_V2;
         for (String key : relevantOptions) {
             addOption(key);
         }

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -4,7 +4,6 @@
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.http-enabled=true
 %dev.hostname-strict=false
-%dev.hostname-strict-https=false
 %dev.cache=local
 %dev.spi-theme-cache-themes=false
 %dev.spi-theme-cache-templates=false
@@ -14,7 +13,6 @@
 %nonserver.http-enabled=true
 %nonserver.http-server-enabled=false
 %nonserver.hostname-strict=false
-%nonserver.hostname-strict-https=false
 %nonserver.cache=local
 
 #logging defaults

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -174,7 +174,6 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
 
         if (suiteContext.get().isAuthServerMigrationEnabled()) {
             commands.add("--hostname-strict=false");
-            commands.add("--hostname-strict-https=false");
         } else { // Do not set management port for older versions of Keycloak for migration tests - available since Keycloak 25
             commands.add("--http-management-port=" + configuration.getManagementPort());
         }


### PR DESCRIPTION
closes: #38253

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
