### PR TITLE
[Backport 26.0] Allow auroradb-integration-tests to dispatch other workflows (#38289)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,9 @@ jobs:
     if: needs.conditional.outputs.ci-aurora == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes #38281

Signed-off-by: Michal Hajas <mhajas@redhat.com>
(cherry picked from commit b34c69cf3504e5891dd16377422aa8ca3616b1aa)
