### PR TITLE
fix: makes the configsources consistent wrt hidden properties

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -18,7 +18,6 @@
 package org.keycloak.quarkus.runtime.configuration;
 
 import static org.keycloak.quarkus.runtime.cli.Picocli.ARG_SHORT_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR_CHAR;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +31,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.smallrye.config.ConfigValue;
 import io.smallrye.config.PropertiesConfigSource;
 
 import org.keycloak.quarkus.runtime.cli.command.Main;
@@ -102,17 +100,6 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
         result.add(arg.toString());
 
         return result;
-    }
-
-    @Override
-    public ConfigValue getConfigValue(String propertyName) {
-        ConfigValue value = super.getConfigValue(propertyName);
-
-        if (value != null) {
-            return value;
-        }
-
-        return super.getConfigValue(propertyName.replace(OPTION_PART_SEPARATOR_CHAR, '.'));
     }
 
     private static Map<String, String> parseArguments() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
@@ -70,13 +70,7 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
     @Override
     public ConfigValue getConfigValue(String propertyName) {
         if (isEnabled()) {
-            ConfigValue value = super.getConfigValue(propertyName);
-
-            if (value != null) {
-                return value;
-            }
-
-            return super.getConfigValue(propertyName.replace(Configuration.OPTION_PART_SEPARATOR_CHAR, '.'));
+            return super.getConfigValue(propertyName);
         }
 
         return null;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -17,8 +17,6 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import static java.util.Optional.ofNullable;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.OPTION_PART_SEPARATOR_CHAR;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.toCliFormat;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.toEnvVarFormat;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
@@ -100,11 +98,6 @@ public class PropertyMapper<T> {
 
     ConfigValue getConfigValue(String name, ConfigSourceInterceptorContext context) {
         String from = getFrom();
-
-        if (to != null && to.endsWith(OPTION_PART_SEPARATOR)) {
-            // in case mapping is based on prefixes instead of full property names
-            from = name.replace(to.substring(0, to.lastIndexOf('.')), from.substring(0, from.lastIndexOf(OPTION_PART_SEPARATOR_CHAR)));
-        }
 
         // try to obtain the value for the property we want to map first
         ConfigValue config = convertValue(context.proceed(from));
@@ -199,7 +192,9 @@ public class PropertyMapper<T> {
         return this.option.getCategory();
     }
 
-    public boolean isHidden() { return this.option.isHidden(); }
+    public boolean isHidden() {
+        return this.option.isHidden() || this.getDescription() == null;
+    }
 
     public boolean isBuildTime() {
         return this.option.isBuildTime();

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -502,6 +502,13 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void testHiddenCliConfigValueWithNoDescription() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--db-dialect=user-defined");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertEquals("user-defined", nonRunningPicocli.config.getConfigValue("kc.db-dialect").getValue());
+    }
+
+    @Test
     public void buildDBWithOptimized() {
         build("build", "--db=mariadb");
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -428,12 +428,6 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     }
 
     @Test
-    public void testDatabaseDialectSetExplicitly() {
-        ConfigArgsConfigSource.setCliArgs("--db-dialect=user-defined");
-        assertEquals("user-defined", createConfig().getRawValue("kc.db-dialect"));
-    }
-
-    @Test
     public void testTransactionTypeChangesDriver() {
         ConfigArgsConfigSource.setCliArgs("--db=mssql", "--transaction-xa-enabled=false");
         assertTrue(ConfigArgsConfigSource.getAllCliArgs().contains("--db=mssql"));


### PR DESCRIPTION
To make things consistent with hidden / internal properties, they can now be used by the cli as well. I think the rationale for being able to override an undocumented property rests with an existing unit test that allows for override db-dialect, which can't otherwise be set by a quarkus property because the map from will be dominant.

It should have been addressed with property naming refactor, but this also removes handling related to the - separator. We do not want to check for all . forms of kc properties.

closes: #37817

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
