### PR TITLE
Add version column to credential table to avoid simultaneous recovery codes updates

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
@@ -28,6 +28,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -72,6 +73,10 @@ public class CredentialEntity {
     @Deprecated // Needed just for backwards compatibility when migrating old credentials
     @Column(name="SALT")
     protected byte[] salt;
+
+    @Version
+    @Column(name="VERSION")
+    private int version;
 
     public String getId() {
         return id;

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.2.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.2.0.xml
@@ -29,4 +29,15 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.2.0-26106">
+        <addColumn tableName="CREDENTIAL">
+            <column name="VERSION" type="INT" defaultValueNumeric="0" />
+        </addColumn>
+        <modifySql dbms="mssql">
+            <!-- ensure that existing rows also get the new values on mssql -->
+            <!-- https://github.com/liquibase/liquibase/issues/4644 -->
+            <replace replace="DEFAULT 0" with="DEFAULT 0 WITH VALUES" />
+        </modifySql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
@@ -40,7 +40,8 @@ public class RecoveryAuthnCodesFormAuthenticator implements Authenticator {
 
     @Override
     public void action(AuthenticationFlowContext context) {
-        context.getEvent().detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE);
+        context.getEvent().detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE)
+                .user(context.getUser());
         if (isRecoveryAuthnCodeInputValid(context)) {
             context.success();
         }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/DelayedAuthenticator.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/DelayedAuthenticator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.authentication;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class DelayedAuthenticator implements Authenticator {
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        final long time = context.getAuthenticatorConfig() != null
+                ? Long.parseLong(context.getAuthenticatorConfig().getConfig().getOrDefault("delay", "1000"))
+                : 1000;
+        if (time > 0) {
+            try {
+                Thread.sleep(time);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        context.success();
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // no-op
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        // no-op
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/DelayedAuthenticatorFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/DelayedAuthenticatorFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.authentication;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.ConfigurableAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+/**
+ * <p>Just an authenticator that delays the authenticator some millis.</p>
+ *
+ * @author rmartinc
+ */
+public class DelayedAuthenticatorFactory implements AuthenticatorFactory, ConfigurableAuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "delayed-authenticator";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new DelayedAuthenticator();
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return new AuthenticationExecutionModel.Requirement[]{
+            AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+            AuthenticationExecutionModel.Requirement.DISABLED
+        };
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Just delay the autentication some millis.";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "TEST: Delayed authenticator";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "Delayed authenticator";
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // no-op
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // no-op
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name("delay")
+                .label("Delay time in millis")
+                .helpText("The delayed time to apply in the authentication.")
+                .type(ProviderConfigProperty.INTEGER_TYPE)
+                .defaultValue("1000")
+                .add()
+                .build();
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -20,6 +20,7 @@ org.keycloak.testsuite.forms.SetClientNoteAuthenticator
 org.keycloak.testsuite.forms.PassThroughRegistration
 org.keycloak.testsuite.forms.ClickThroughAuthenticator
 org.keycloak.testsuite.forms.ErrorEventAuthenticator
+org.keycloak.testsuite.authentication.DelayedAuthenticatorFactory
 org.keycloak.testsuite.authentication.ExpectedParamAuthenticatorFactory
 org.keycloak.testsuite.authentication.PushButtonAuthenticatorFactory
 org.keycloak.testsuite.forms.UsernameOnlyAuthenticator

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/EnterRecoveryAuthnCodePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/EnterRecoveryAuthnCodePage.java
@@ -1,6 +1,8 @@
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -34,7 +36,13 @@ public class EnterRecoveryAuthnCodePage extends LanguageComboboxAwarePage {
     }
 
     public void clickSignInButton() {
-        signInButton.click();
+        UIUtils.clickLink(signInButton);
+    }
+
+    public void clickSignInButtonViaJavaScriptNoDelay() {
+        // submit the form via JS but with a setTimeout to avoid any delay
+        final JavascriptExecutor js = (JavascriptExecutor) driver;
+        js.executeScript("window.setTimeout(function() {document.forms[0].submit()}, 0)");
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -414,7 +414,7 @@ public class AssertEvents implements TestRule {
                 Assert.fail("Did not find the event of expected type " + expected.getType() +". Events present: " + presentedEventTypes);
                 return null; // Unreachable code
             } else {
-                return assertEvent(poll());
+                return assertEvent(poll(seconds));
             }
         }
 
@@ -452,6 +452,11 @@ public class AssertEvents implements TestRule {
             }
 
             return actual;
+        }
+
+        @Override
+        public String toString() {
+            return this.getClass().getSimpleName() + ":" + expected.getType();
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -9,13 +9,16 @@ import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
+import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.AuthenticationFlow;
 import org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticatorFactory;
 import org.keycloak.authentication.authenticators.browser.PasswordFormFactory;
 import org.keycloak.authentication.authenticators.browser.UsernameFormFactory;
+import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.forms.login.freemarker.model.RecoveryAuthnCodesBean;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -32,7 +35,6 @@ import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
-import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.EnterRecoveryAuthnCodePage;
@@ -45,11 +47,10 @@ import org.keycloak.testsuite.util.FlowUtil;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.SecondBrowser;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -77,7 +78,15 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
     protected LoginUsernameOnlyPage loginUsernameOnlyPage;
 
     @Page
+    @SecondBrowser
+    protected LoginUsernameOnlyPage loginUsernameOnlyPageSecondBrowser;
+
+    @Page
     protected EnterRecoveryAuthnCodePage enterRecoveryAuthnCodePage;
+
+    @Page
+    @SecondBrowser
+    protected EnterRecoveryAuthnCodePage enterRecoveryAuthnCodePageSecondBrowser;
 
     @Page
     protected SetupRecoveryAuthnCodesPage setupRecoveryAuthnCodesPage;
@@ -86,7 +95,15 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
     protected SelectAuthenticatorPage selectAuthenticatorPage;
 
     @Page
+    @SecondBrowser
+    protected SelectAuthenticatorPage selectAuthenticatorPageSecondBrowser;
+
+    @Page
     protected PasswordPage passwordPage;
+
+    @Page
+    @SecondBrowser
+    protected PasswordPage passwordPageSecondBrowser;
 
     @Page
     protected AppPage appPage;
@@ -103,7 +120,7 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
 
     }
 
-    void configureBrowserFlowWithRecoveryAuthnCodes(KeycloakTestingClient testingClient) {
+    void configureBrowserFlowWithRecoveryAuthnCodes(KeycloakTestingClient testingClient, long delay) {
         final String newFlowAlias = BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES;
         testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow(newFlowAlias));
         testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session)
@@ -116,6 +133,10 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
                                 .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.ALTERNATIVE, PasswordFormFactory.PROVIDER_ID)
                                 .addSubFlowExecution("Recovery-Authn-Codes subflow", AuthenticationFlow.BASIC_FLOW, AuthenticationExecutionModel.Requirement.ALTERNATIVE, altSubFlow -> altSubFlow
                                         .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.REQUIRED, RecoveryAuthnCodesFormAuthenticatorFactory.PROVIDER_ID)
+                                        .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.REQUIRED, "delayed-authenticator", config -> {
+                                            config.setAlias("delayed-suthenticator-config");
+                                            config.setConfig(Map.of("delay", Long.toString(delay)));
+                                        })
                                 )
                         )
                 )
@@ -250,43 +271,128 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
                 .assertEvent();
     }
 
+    private void loginUsername(LoginUsernameOnlyPage loginUsernameOnlyPage, WebDriver driver) {
+        loginUsernameOnlyPage.setDriver(driver);
+        oauth.openLoginForm();
+        loginUsernameOnlyPage.assertCurrent();
+        loginUsernameOnlyPage.assertAttemptedUsernameAvailability(false);
+        loginUsernameOnlyPage.login("test-user@localhost");
+    }
+
+    private void tryAnotherWay(PasswordPage passwordPage, WebDriver driver) {
+        passwordPage.setDriver(driver);
+        passwordPage.assertCurrent();
+        passwordPage.assertAttemptedUsernameAvailability(true);
+        // On the password page, username should be shown as we know the user
+        Assert.assertEquals("test-user@localhost", passwordPage.getAttemptedUsername());
+        passwordPage.assertTryAnotherWayLinkAvailability(true);
+        passwordPage.clickTryAnotherWayLink();
+    }
+
+    private void selectRecoveryAuthnCodes(SelectAuthenticatorPage selectAuthenticatorPage, WebDriver driver) {
+        selectAuthenticatorPage.setDriver(driver);
+        selectAuthenticatorPage.assertCurrent();
+        Assert.assertEquals(Arrays.asList(SelectAuthenticatorPage.PASSWORD, SelectAuthenticatorPage.RECOVERY_AUTHN_CODES), selectAuthenticatorPage.getAvailableLoginMethods());
+        selectAuthenticatorPage.selectLoginMethod(SelectAuthenticatorPage.RECOVERY_AUTHN_CODES);
+    }
+
+    private void enterRecoveryCodes(EnterRecoveryAuthnCodePage enterRecoveryAuthnCodePage, WebDriver driver,
+            int expectedCode, List<String> generatedRecoveryAuthnCodes) {
+        enterRecoveryAuthnCodePage.setDriver(driver);
+        enterRecoveryAuthnCodePage.assertCurrent();
+        int requestedCode = enterRecoveryAuthnCodePage.getRecoveryAuthnCodeToEnterNumber();
+        Assert.assertEquals("Incorrect code presented to login", expectedCode, requestedCode);
+        enterRecoveryAuthnCodePage.enterRecoveryAuthnCode(generatedRecoveryAuthnCodes.get(requestedCode));
+    }
+
+    private void removeRequiredActionIfPresent() {
+        AuthenticationManagementResource authMgt = testRealm().flows();
+        authMgt.getRequiredActions().stream()
+                .filter(action -> UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name().equals(action.getAlias()))
+                .findAny()
+                .ifPresent(action -> authMgt.removeRequiredAction(action.getAlias()));
+    }
+
+    private List<String> createRecoveryAuthnCodesForUser() {
+        List<String> generatedRecoveryAuthnCodes = RecoveryAuthnCodesUtils.generateRawCodes();
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            UserModel user = session.users().getUserByUsername(realm, "test-user@localhost");
+            CredentialModel recoveryAuthnCodesCred = RecoveryAuthnCodesCredentialModel.createFromValues(
+                    generatedRecoveryAuthnCodes,
+                    Time.currentTimeMillis(),
+                    null);
+            user.credentialManager().createStoredCredential(recoveryAuthnCodesCred);
+        });
+        return generatedRecoveryAuthnCodes;
+    }
+
+    private void assertIsContained(AssertEvents.ExpectedEvent expectedEvent, List<? extends EventRepresentation> actualEvents) {
+        for (EventRepresentation e : actualEvents) {
+            try {
+                expectedEvent.assertEvent(e);
+                return;
+            } catch (AssertionError error) {
+                // silently fail because it can be other event in the list
+            }
+        }
+        Assert.fail("No event found in the list for " + expectedEvent);
+    }
+
+
     // In a sub-flow with alternative credential executors, test whether Recovery Authentication Codes are working
     @Test
     public void test05AuthenticateRecoveryAuthnCodes() {
         try {
-            configureBrowserFlowWithRecoveryAuthnCodes(testingClient);
-            testRealm().flows().removeRequiredAction(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
-            loginUsernameOnlyPage.open();
-            loginUsernameOnlyPage.assertAttemptedUsernameAvailability(false);
-            loginUsernameOnlyPage.login("test-user@localhost");
-            // On the password page, username should be shown as we know the user
-            passwordPage.assertCurrent();
-            passwordPage.assertAttemptedUsernameAvailability(true);
-            Assert.assertEquals("test-user@localhost", passwordPage.getAttemptedUsername());
-            passwordPage.assertTryAnotherWayLinkAvailability(true);
-            List<String> generatedRecoveryAuthnCodes = RecoveryAuthnCodesUtils.generateRawCodes();
-            testingClient.server().run(session -> {
-                RealmModel realm = session.realms().getRealmByName("test");
-                UserModel user = session.users().getUserByUsername(realm, "test-user@localhost");
-                CredentialModel recoveryAuthnCodesCred = RecoveryAuthnCodesCredentialModel.createFromValues(
-                        generatedRecoveryAuthnCodes,
-                        System.currentTimeMillis(),
-                        null);
-                user.credentialManager().createStoredCredential(recoveryAuthnCodesCred);
-            });
-            passwordPage.clickTryAnotherWayLink();
-            selectAuthenticatorPage.assertCurrent();
-            Assert.assertEquals(Arrays.asList(SelectAuthenticatorPage.PASSWORD, SelectAuthenticatorPage.RECOVERY_AUTHN_CODES), selectAuthenticatorPage.getAvailableLoginMethods());
-            selectAuthenticatorPage.selectLoginMethod(SelectAuthenticatorPage.RECOVERY_AUTHN_CODES);
-            enterRecoveryAuthnCodePage.assertCurrent();
-            enterRecoveryAuthnCodePage.enterRecoveryAuthnCode(generatedRecoveryAuthnCodes.get(enterRecoveryAuthnCodePage.getRecoveryAuthnCodeToEnterNumber()));
+            configureBrowserFlowWithRecoveryAuthnCodes(testingClient, 0);
+            removeRequiredActionIfPresent();
+            List<String> generatedRecoveryAuthnCodes = createRecoveryAuthnCodesForUser();
+
+            // perform the login username
+            loginUsername(loginUsernameOnlyPage, driver);
+            // click try another way
+            tryAnotherWay(passwordPage, driver);
+            // select recovery codes to authenticate
+            selectRecoveryAuthnCodes(selectAuthenticatorPage, driver);
+            // enter recovery codes and submit
+            enterRecoveryCodes(enterRecoveryAuthnCodePage, driver, 0, generatedRecoveryAuthnCodes);
             enterRecoveryAuthnCodePage.clickSignInButton();
             enterRecoveryAuthnCodePage.assertAccountLinkAvailability(true);
+            events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
         } finally {
-            // Remove saved Recovery Authentication Codes to keep a clean slate after this test
-            enterRecoveryAuthnCodePage.assertAccountLinkAvailability(true);
-            enterRecoveryAuthnCodePage.clickAccountLink();
-            assertThat(driver.getTitle(), containsString("Account Management"));
+            // Revert copy of browser flow to original to keep clean slate after this test
+            BrowserFlowTest.revertFlows(testRealm(), BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES);
+        }
+    }
+
+    @Test
+    public void test06AuthenticateRecoveryAuthnCodesSimultaneous() {
+        try {
+            configureBrowserFlowWithRecoveryAuthnCodes(testingClient, 1000);
+            removeRequiredActionIfPresent();
+            List<String> generatedRecoveryAuthnCodes = createRecoveryAuthnCodesForUser();
+
+            // perform the login username
+            loginUsername(loginUsernameOnlyPage, driver);
+            loginUsername(loginUsernameOnlyPageSecondBrowser, driver2);
+            // click try another way
+            tryAnotherWay(passwordPage, driver);
+            tryAnotherWay(passwordPageSecondBrowser, driver2);
+            // select recivery codes to authenticate
+            selectRecoveryAuthnCodes(selectAuthenticatorPage, driver);
+            selectRecoveryAuthnCodes(selectAuthenticatorPageSecondBrowser, driver2);
+            // enter the same recovery code to the two browers
+            enterRecoveryCodes(enterRecoveryAuthnCodePage, driver, 0, generatedRecoveryAuthnCodes);
+            enterRecoveryCodes(enterRecoveryAuthnCodePageSecondBrowser, driver2, 0, generatedRecoveryAuthnCodes);
+            // submit fast in the two browsers using javascript to not wait for the page to load
+            enterRecoveryAuthnCodePage.clickSignInButtonViaJavaScriptNoDelay();
+            enterRecoveryAuthnCodePageSecondBrowser.clickSignInButtonViaJavaScriptNoDelay();
+
+            // one event should be a login and the other a login error
+            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(5), events.poll(5));
+            assertIsContained(events.expectLogin().detail(Details.USERNAME, "test-user@localhost"), actualEvents);
+            assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
+        } finally {
             // Revert copy of browser flow to original to keep clean slate after this test
             BrowserFlowTest.revertFlows(testRealm(), BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES);
         }
@@ -294,18 +400,14 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
 
     //// In a sub-flow with alternative credential executors, test whether setup Recovery Authentication Codes flow is working
     @Test
-    @IgnoreBrowserDriver(FirefoxDriver.class)
-    @IgnoreBrowserDriver(ChromeDriver.class)
-    public void test06SetupRecoveryAuthnCodes() {
+    public void test07SetupRecoveryAuthnCodes() {
         try {
-            configureBrowserFlowWithRecoveryAuthnCodes(testingClient);
+            configureBrowserFlowWithRecoveryAuthnCodes(testingClient, 0);
             RequiredActionProviderSimpleRepresentation simpleRepresentation = new RequiredActionProviderSimpleRepresentation();
             simpleRepresentation.setProviderId(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
             simpleRepresentation.setName(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
             testRealm().flows().registerRequiredAction(simpleRepresentation);
-            loginUsernameOnlyPage.open();
-            loginUsernameOnlyPage.assertAttemptedUsernameAvailability(false);
-            loginUsernameOnlyPage.login("test-user@localhost");
+            loginUsername(loginUsernameOnlyPage, driver);
             // On the password page, username should be shown as we know the user
             passwordPage.assertCurrent();
             //passwordPage.assertAttemptedUsernameAvailability(true);
@@ -325,37 +427,19 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
     }
 
     @Test
-    @IgnoreBrowserDriver(FirefoxDriver.class) // TODO: https://github.com/keycloak/keycloak/issues/13543
-    @IgnoreBrowserDriver(ChromeDriver.class)
-    public void test07BruteforceProtectionRecoveryAuthnCodes() {
+    public void test08BruteforceProtectionRecoveryAuthnCodes() {
         try {
-            configureBrowserFlowWithRecoveryAuthnCodes(testingClient);
+            configureBrowserFlowWithRecoveryAuthnCodes(testingClient, 0);
             RealmRepresentation rep = testRealm().toRepresentation();
             rep.setBruteForceProtected(true);
             testRealm().update(rep);
-            loginUsernameOnlyPage.open();
-            loginUsernameOnlyPage.assertAttemptedUsernameAvailability(false);
-            loginUsernameOnlyPage.login("test-user@localhost");
-            // On the password page, username should be shown as we know the user
-            passwordPage.assertCurrent();
-            passwordPage.assertAttemptedUsernameAvailability(true);
-            Assert.assertEquals("test-user@localhost", passwordPage.getAttemptedUsername());
-            passwordPage.assertTryAnotherWayLinkAvailability(true);
-            List<String> generatedRecoveryAuthnCodes = RecoveryAuthnCodesUtils.generateRawCodes();
-            testingClient.server().run(session -> {
-                RealmModel realm = session.realms().getRealmByName("test");
-                UserModel user = session.users().getUserByUsername(realm, "test-user@localhost");
-                CredentialModel recoveryAuthnCodesCred = RecoveryAuthnCodesCredentialModel.createFromValues(
-                        generatedRecoveryAuthnCodes,
-                        System.currentTimeMillis(),
-                        null);
-                user.credentialManager().createStoredCredential(recoveryAuthnCodesCred);
-            });
-            passwordPage.clickTryAnotherWayLink();
-            selectAuthenticatorPage.assertCurrent();
-            Assert.assertEquals(Arrays.asList(SelectAuthenticatorPage.PASSWORD, SelectAuthenticatorPage.RECOVERY_AUTHN_CODES), selectAuthenticatorPage.getAvailableLoginMethods());
-            selectAuthenticatorPage.selectLoginMethod(SelectAuthenticatorPage.RECOVERY_AUTHN_CODES);
-            enterRecoveryAuthnCodePage.assertCurrent();
+
+            List<String> generatedRecoveryAuthnCodes = createRecoveryAuthnCodesForUser();
+
+            loginUsername(loginUsernameOnlyPage, driver);
+            tryAnotherWay(passwordPage, driver);
+            selectRecoveryAuthnCodes(selectAuthenticatorPage, driver);
+
             generatedRecoveryAuthnCodes.forEach(code -> System.out.println(code));
             for(int i=0; i < (BRUTE_FORCE_FAIL_ATTEMPTS - 1); i++) {
                 long randomNumber = (long)Math.random()*1000000000000L;


### PR DESCRIPTION
Closes #26106

The update credential now locks using Hibernate's optimistic locking and the model can decide if the update is valid based on the current value. This way the recovery credential model can check if the current value is valid for the update. In the case of the recovery codes, new value should be one code less than the current one, because recovery codes always use the next code and remove it. I have also managed the idea of adding a new method in the credential interfaces. I have been going back and forth between the two solutions. I see pros and cons in both solutions. IMHO changing interfaces is cleaner but it's a backwards incompatible change, and I think there will be implementations of those interfaces out there for other credential types. At least I could not find a change for the interfaces that could have a default implementation or similar.

Test added although it is a mess. The idea is adding a delayed authenticator that just sleeps 1s to allow to test the problem. Besides the button should be clicked using JavaScript because if not selenium waits the new page to come and the issue is not reproduced.
