### PR TITLE
avoid missing css in attributes tab of realm roles #38162

### DIFF
--- a/js/apps/admin-ui/src/components/key-value-form/AttributeForm.css
+++ b/js/apps/admin-ui/src/components/key-value-form/AttributeForm.css
@@ -1,0 +1,4 @@
+.pf-v5-c-tab-content.kc-attributes-tab {
+    padding-left: var(--pf-v5-global--spacer--xl);
+    padding-top: var(--pf-v5-global--spacer--lg);
+}

--- a/js/apps/admin-ui/src/components/key-value-form/AttributeForm.tsx
+++ b/js/apps/admin-ui/src/components/key-value-form/AttributeForm.tsx
@@ -6,6 +6,8 @@ import type { KeyValueType } from "./key-value-convert";
 import { KeyValueInput } from "./KeyValueInput";
 import { FixedButtonsGroup } from "../form/FixedButtonGroup";
 
+import "./AttributeForm.css";
+
 export type AttributeForm = Omit<RoleRepresentation, "attributes"> & {
   attributes?: KeyValueType[];
 };

--- a/js/apps/admin-ui/src/components/roles-list/RolesList.css
+++ b/js/apps/admin-ui/src/components/roles-list/RolesList.css
@@ -35,8 +35,3 @@ button#default-role-help-icon.pf-v5-c-form__group-label-help {
   margin-left: var(--pf-v5-global--spacer--xs);
   vertical-align: middle;
 }
-
-.pf-v5-c-tab-content.kc-attributes-tab {
-  padding-left: var(--pf-v5-global--spacer--xl);
-  padding-top: var(--pf-v5-global--spacer--lg);
-}


### PR DESCRIPTION
Currently the **kc-attributes-tab** css is located in **RoleList.css** which is loaded when clicking the "Realm Roles" sidebar entry (**RealmRolesSection**). When refreshing the realm roles attributes tab this css is missing, unless you click again the sidebar entry. 

To fix this issue i moved the css directly to the **AttributesForm**. So the css is always present when you click the attributes tab.

Closes #38162

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
