### PR TITLE
Use clickLink and upgrade arquillian/selenium for chrome 134 (26.0)

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -41,10 +41,12 @@
         <cache.server.java.home>${java.home}</cache.server.java.home>
 
         <!--component versions-->
-        <arquillian-core.version>1.8.0.Final</arquillian-core.version>
+        <arquillian-core.version>1.9.3.Final</arquillian-core.version>
+        <arquillian.protocol.servlet.jakarta.version>10.0.0.Final</arquillian.protocol.servlet.jakarta.version>
         <!--the version of shrinkwrap_resolver should align with the version in arquillian-bom-->
         <shrinkwrap-resolver.version>3.2.1</shrinkwrap-resolver.version>
-        <selenium.version>4.21.0</selenium.version>
+        <selenium.version>4.28.1</selenium.version>
+        <selenium.htmlunit3.version>4.28.0</selenium.htmlunit3.version>
         <arquillian-drone.version>3.0.0-alpha.8</arquillian-drone.version>
         <arquillian-graphene.version>3.0.0-alpha.4</arquillian-graphene.version>
         <arquillian-wildfly-container.version>3.0.1.Final</arquillian-wildfly-container.version>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>htmlunit3-driver</artifactId>
-                <version>${selenium.version}</version>
+                <version>${selenium.htmlunit3.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginConfigTotpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginConfigTotpPage.java
@@ -59,21 +59,21 @@ public class LoginConfigTotpPage extends LogoutSessionsPage {
 
     public void configure(String totp) {
         totpInput.sendKeys(totp);
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void configure(String totp, String userLabel) {
         totpInput.sendKeys(totp);
         totpLabelInput.sendKeys(userLabel);
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void submit() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
     
     public void cancel() {
-        cancelAIAButton.click();
+        UIUtils.clickLink(cancelAIAButton);
     }
 
     public String getTotpSecret() {
@@ -94,11 +94,11 @@ public class LoginConfigTotpPage extends LogoutSessionsPage {
     }
 
     public void clickManual() {
-        manualLink.click();
+        UIUtils.clickLink(manualLink);
     }
 
     public void clickBarcode() {
-        barcodeLink.click();
+        UIUtils.clickLink(barcodeLink);
     }
 
     public String getInputCodeError() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordResetPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordResetPage.java
@@ -48,14 +48,14 @@ public class LoginPasswordResetPage extends LanguageComboboxAwarePage {
     private WebElement infoWrapper;
 
     public void changePassword() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void changePassword(String username) {
         usernameInput.clear();
         usernameInput.sendKeys(username);
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public boolean isCurrent() {
@@ -91,7 +91,7 @@ public class LoginPasswordResetPage extends LanguageComboboxAwarePage {
     }
 
     public void backToLogin() {
-        backToLogin.click();
+        UIUtils.clickLink(backToLogin);
     }
 
     public String getInfoMessage() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordUpdatePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordUpdatePage.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -48,11 +49,11 @@ public class LoginPasswordUpdatePage extends LogoutSessionsPage {
         newPasswordInput.sendKeys(newPassword);
         passwordConfirmInput.sendKeys(passwordConfirm);
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void cancel() {
-        cancelAIAButton.click();
+        UIUtils.clickLink(cancelAIAButton);
     }
 
     public boolean isCurrent() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginTotpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginTotpPage.java
@@ -52,7 +52,7 @@ public class LoginTotpPage extends LanguageComboboxAwarePage {
         otpInput.clear();
         if (totp != null) otpInput.sendKeys(totp);
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public String getAlertError() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginUsernameOnlyPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginUsernameOnlyPage.java
@@ -21,7 +21,7 @@ public class LoginUsernameOnlyPage extends LoginPage {
         usernameInput.clear();
         usernameInput.sendKeys(username);
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public String getUsernameError() {
@@ -34,7 +34,7 @@ public class LoginUsernameOnlyPage extends LoginPage {
 
     // Click button without fill anything
     public void clickSubmitButton() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LogoutSessionsPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LogoutSessionsPage.java
@@ -47,11 +47,11 @@ public abstract class LogoutSessionsPage extends LanguageComboboxAwarePage {
 
     public void checkLogoutSessions() {
         Assert.assertFalse("Logout sessions is checked", isLogoutSessionsChecked());
-        logoutSessionsCheckbox.click();
+        UIUtils.switchCheckbox(logoutSessionsCheckbox, true);
     }
 
     public void uncheckLogoutSessions() {
         Assert.assertTrue("Logout sessions is not checked", isLogoutSessionsChecked());
-        logoutSessionsCheckbox.click();
+        UIUtils.switchCheckbox(logoutSessionsCheckbox, false);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/PasswordPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/PasswordPage.java
@@ -38,11 +38,11 @@ public class PasswordPage extends LanguageComboboxAwarePage {
         passwordInput.clear();
         passwordInput.sendKeys(password);
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void clickResetPassword() {
-        resetPasswordLink.click();
+        UIUtils.clickLink(resetPasswordLink);
     }
 
     public String getPassword() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/PushTheButtonPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/PushTheButtonPage.java
@@ -19,6 +19,7 @@
 package org.keycloak.testsuite.pages;
 
 import org.keycloak.testsuite.util.DroneUtils;
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -45,6 +46,6 @@ public class PushTheButtonPage extends AbstractPage {
     }
 
     public void submit() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/ResetOtpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/ResetOtpPage.java
@@ -1,5 +1,6 @@
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -27,6 +28,6 @@ public class ResetOtpPage extends AbstractPage {
     }
 
     public void submitOtpReset() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SetupRecoveryAuthnCodesPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SetupRecoveryAuthnCodesPage.java
@@ -1,5 +1,6 @@
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -21,8 +22,8 @@ public class SetupRecoveryAuthnCodesPage extends LogoutSessionsPage {
     private WebElement kcRecoveryCodesConfirmationCheck;
 
     public void clickSaveRecoveryAuthnCodesButton() {
-        kcRecoveryCodesConfirmationCheck.click();
-        saveRecoveryAuthnCodesButton.click();
+        UIUtils.switchCheckbox(kcRecoveryCodesConfirmationCheck, true);
+        UIUtils.clickLink(saveRecoveryAuthnCodesButton);
     }
 
     public List<String> getRecoveryAuthnCodes() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyProfilePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyProfilePage.java
@@ -64,7 +64,7 @@ public class VerifyProfilePage extends AbstractPage {
             lastNameInput.sendKeys(lastName);
         }
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
     
     public void update(String firstName, String lastName, String department) {
@@ -93,7 +93,7 @@ public class VerifyProfilePage extends AbstractPage {
             lastNameInput.sendKeys(lastName);
         }
 
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public String getAlertError() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -340,7 +340,7 @@ public class OAuthClient {
         WaitUtils.waitForPageToLoad();
         WebElement linkAccountButton = driver.findElement(By.id("linkAccount"));
         waitUntilElement(linkAccountButton).is().clickable();
-        linkAccountButton.click();
+        UIUtils.clickLink(linkAccountButton);
 
         WaitUtils.waitForPageToLoad();
         fillLoginForm(username, password, false);
@@ -385,10 +385,10 @@ public class OAuthClient {
         passwordField.sendKeys(password);
 
         if (rememberMe) {
-            driver.findElement(By.id("rememberMe")).click();
+            UIUtils.switchCheckbox(driver.findElement(By.id("rememberMe")), true);
         }
 
-        driver.findElement(By.name("login")).click();
+        UIUtils.clickLink(driver.findElement(By.name("login")));
 
     }
 
@@ -412,7 +412,7 @@ public class OAuthClient {
 
         WebElement submitButton = driver.findElement(By.cssSelector("input[type=\"submit\"]"));
         waitUntilElement(submitButton).is().clickable();
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void doLoginGrant(String username, String password) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest.java
@@ -37,6 +37,7 @@ import org.keycloak.testsuite.authentication.PushButtonAuthenticatorFactory;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 
 import java.util.HashMap;
@@ -295,7 +296,7 @@ public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals("PushTheButton", driver.getTitle());
 
         // Push the button. I am redirected to username+password form
-        driver.findElement(By.name("submit1")).click();
+        UIUtils.clickLink(driver.findElement(By.name("submit1")));
 
 
         loginPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -159,7 +159,6 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             realm.setMaxDeltaTimeSeconds(60 * 60 * 12); // 12 hours
             realm.setFailureFactor(30);
             adminClient.realm("test").update(realm);
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(0)));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -423,7 +422,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
             //Wait for brute force executor to process the login and then wait for delta time
             waitForExecutors(numExecutors + 1);
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(5)));
+            setTimeOffset(5);
 
             loginInvalidPassword();
             loginSuccess();
@@ -445,7 +444,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
             //Wait for brute force executor to process the login and then wait for delta time
             waitForExecutors(numExecutors + 1);
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(5)));
+            setTimeOffset(5);
 
             loginInvalidPassword();
             expectPermanentlyDisabled();
@@ -494,13 +493,12 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         // KEYCLOAK-5420
         // Test to make sure that temporarily disabled doesn't increment failure count
-        testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(21)));
+        setTimeOffset(21);
         // should be unlocked now
         loginSuccess();
         clearUserFailures();
         clearAllUserFailures();
         loginSuccess();
-        testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(0)));
     }
 
     @Test
@@ -727,11 +725,11 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             loginInvalidPassword();
             loginInvalidPassword();
             expectTemporarilyDisabled();
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(21)));
+            setTimeOffset(21);
 
             loginInvalidPassword();
             expectTemporarilyDisabled();
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(42)));
+            setTimeOffset(42);
 
             loginInvalidPassword();
             expectPermanentlyDisabled();
@@ -756,7 +754,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             loginInvalidPassword();
             loginInvalidPassword();
             expectTemporarilyDisabled();
-            testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(21)));
+            setTimeOffset(21);
             UserRepresentation user = adminClient.realm("test").users().search("test-user@localhost", 0, 1).get(0);
             Map<String, Object> status = adminClient.realm("test").attackDetection().bruteForceUserStatus(user.getId());
             assertEquals(1, status.get("numTemporaryLockouts"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
@@ -49,6 +49,7 @@ import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.FlowUtil;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.util.BasicAuthHelper;
 import org.openqa.selenium.By;
 
@@ -214,7 +215,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
         Assert.assertEquals("PushTheButton", driver.getTitle());
 
         // Push the button. I am redirected to username+password form
-        driver.findElement(By.name("submit1")).click();
+        UIUtils.clickLink(driver.findElement(By.name("submit1")));
 
 
         loginPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -70,6 +70,8 @@ import org.keycloak.testsuite.util.MailUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.SecondBrowser;
+import org.keycloak.testsuite.util.UIUtils;
+import org.keycloak.testsuite.util.URLUtils;
 import org.keycloak.testsuite.util.UserActionTokenBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.testsuite.util.WaitUtils;
@@ -770,12 +772,12 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message).replace("&amp;", "&");
 
+            log.debug("Removing cookies."); // This is necessary to delete KC_RESTART cookie that is restricted to /auth/realms/test path
+            driver.manage().deleteAllCookies();
+
             setTimeOffset(70);
 
             log.debug("Going to reset password URI.");
-            driver.navigate().to(oauth.AUTH_SERVER_ROOT + "/realms/test/login-actions/reset-credentials"); // This is necessary to delete KC_RESTART cookie that is restricted to /auth/realms/test path
-            log.debug("Removing cookies.");
-            driver.manage().deleteAllCookies();
             driver.navigate().to(changePasswordUrl.trim());
 
             errorPage.assertCurrent();
@@ -813,13 +815,13 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message).replace("&amp;", "&");
 
+            log.debug("Removing cookies."); // This is necessary to delete KC_RESTART cookie that is restricted to /auth/realms/test path
+            driver.manage().deleteAllCookies();
+
             setTimeOffset(70);
 
             log.debug("Going to reset password URI.");
-            driver.navigate().to(oauth.AUTH_SERVER_ROOT + "/realms/test/login-actions/reset-credentials"); // This is necessary to delete KC_RESTART cookie that is restricted to /auth/realms/test path
-            log.debug("Removing cookies.");
-            driver.manage().deleteAllCookies();
-            driver.navigate().to(changePasswordUrl.trim());
+            URLUtils.navigateToUri(changePasswordUrl.trim());
 
             errorPage.assertCurrent();
             Assert.assertEquals("Action expired.", errorPage.getError());
@@ -857,12 +859,12 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message).replace("&amp;", "&");
 
+            log.debug("Removing cookies."); // This is necessary to delete KC_RESTART cookie that is restricted to /auth/realms/test path
+            driver.manage().deleteAllCookies();
+
             setTimeOffset(70);
 
             log.debug("Going to reset password URI.");
-            driver.navigate().to(oauth.AUTH_SERVER_ROOT + "/realms/test/login-actions/reset-credentials"); // This is necessary to delete KC_RESTART cookie that is restricted to /auth/realms/test path
-            log.debug("Removing cookies.");
-            driver.manage().deleteAllCookies();
             driver.navigate().to(changePasswordUrl.trim());
 
             errorPage.assertCurrent();
@@ -1449,7 +1451,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         confirmPassword.sendKeys("resetPassword");
         final WebElement submit = driver.findElement(By.cssSelector("button[type=\"submit\"]"));
 
-        submit.click();
+        UIUtils.clickLink(submit);
     }
 
     private void resetPasswordInNewTab(UserRepresentation user, String clientId, String redirectUri) throws IOException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
@@ -36,6 +36,7 @@ import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testsuite.actions.AbstractAppInitiatedActionTest;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
+import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginUsernameOnlyPage;
 import org.keycloak.testsuite.pages.PasswordPage;
 import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
@@ -60,6 +61,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.keycloak.models.AuthenticationExecutionModel.Requirement.ALTERNATIVE;
 import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
 import static org.keycloak.testsuite.util.BrowserDriverUtil.isDriverFirefox;
@@ -229,12 +231,16 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
     }
 
     private EventRepresentation loginUser() {
-        usernamePage.open();
+        oauth.openLoginForm();
         usernamePage.assertCurrent();
         usernamePage.login(DEFAULT_USERNAME);
 
         passwordPage.assertCurrent();
         passwordPage.login(DEFAULT_PASSWORD);
+
+        appPage.assertCurrent();
+        assertThat(appPage.getRequestType(), is(AppPage.RequestType.AUTH_RESPONSE));
+        assertNotNull(oauth.parseLoginResponse().getCode());
 
         return events.expectLogin()
                 .detail(Details.USERNAME, DEFAULT_USERNAME)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
@@ -240,7 +240,8 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
 
         appPage.assertCurrent();
         assertThat(appPage.getRequestType(), is(AppPage.RequestType.AUTH_RESPONSE));
-        assertNotNull(oauth.parseLoginResponse().getCode());
+        OAuthClient.AuthorizationEndpointResponse response = new OAuthClient.AuthorizationEndpointResponse(oauth);
+        assertNotNull(response.getCode());
 
         return events.expectLogin()
                 .detail(Details.USERNAME, DEFAULT_USERNAME)

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1552,6 +1552,7 @@
                 <dependency>
                     <groupId>org.jboss.arquillian.protocol</groupId>
                     <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+                    <version>${arquillian.protocol.servlet.jakarta.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.arquillian.graphene</groupId>


### PR DESCRIPTION
Closes #38041

PR: https://github.com/keycloak/keycloak/pull/38081
Commit: https://github.com/keycloak/keycloak/commit/4ff2c473ef9a003e53a0752e7d84f42a0c310d6a
Target branch: https://github.com/keycloak/keycloak/tree/release/26.0

There were some more changes needed and also this issue #35964 in upstream. With this I could pass Form IT 50 times in 26.0.
