### PR TITLE
fix: Add username validator for LDAP storage provider to handle prohibited characters

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -100,7 +100,7 @@ import org.keycloak.userprofile.AttributeMetadata;
 import org.keycloak.userprofile.UserProfileDecorator;
 import org.keycloak.userprofile.UserProfileMetadata;
 import org.keycloak.userprofile.UserProfileUtil;
-
+import org.keycloak.userprofile.validator.UsernameProhibitedCharactersValidator;
 import org.keycloak.utils.StreamsUtil;
 import org.keycloak.utils.StringUtil;
 
@@ -705,6 +705,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
     protected UserModel importUserFromLDAP(KeycloakSession session, RealmModel realm, LDAPObject ldapUser, ImportType importType) {
         String ldapUsername = LDAPUtils.getUsername(ldapUser, ldapIdentityStore.getConfig());
         LDAPUtils.checkUuid(ldapUser, ldapIdentityStore.getConfig());
+                if(!UsernameProhibitedCharactersValidator.INSTANCE.validate(ldapUsername).isValid()){
+            return null;
+        }
         if (importType == null) {
             importType = ImportType.FORCED;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersFullNameMapperTest.java
@@ -90,6 +90,26 @@ public class LDAPProvidersFullNameMapperTest extends AbstractLDAPTest {
         });
     }
 
+      @Test
+    public void testInvalidUsernameImport() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(appRealm);
+            LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
+
+            MultivaluedHashMap<String, String> otherAttrs = new MultivaluedHashMap<>();
+            otherAttrs.put("postalAddress", List.of("123456", "654321"));
+
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, appRealm, "<b>bobby<em>", "Valid", "User", "valid@example.com", null, otherAttrs, "1234");
+
+            UserModel user = session.users().getUserByUsername(appRealm, "<b>bobby<em>");
+            // Test Should return NULL as username contains prohibited characters
+            Assert.assertNull("User with invalid username <b>bobby<em> should not be imported", user);
+        });
+    }
+
     @Test
     public void testUpdatingFirstNameAndLastNamePropagatesToFullnameMapper() {
 


### PR DESCRIPTION
closes #https://github.com/keycloak/keycloak/issues/32640