### PR TITLE
"linked-accounts" endpoint displays all Identity providers

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -235,6 +235,12 @@ addedNodeSuccess=Node successfully added
 eventTypes.INTROSPECT_TOKEN_ERROR.description=Introspect token error
 webAuthnPolicyUserVerificationRequirementHelp=Communicates to an authenticator whether to require to verify a user.
 syncModes.import=Import
+
+showInAccountConsole=Show in Account console
+showInAccountConsole.always=Always
+showInAccountConsole.when_linked=When linked
+showInAccountConsole.never=Never
+
 realmSaveError=Realm could not be updated\: {{error}}
 authDataDescription=Represents a token carrying authorization data as a result of the processing of an authorization request. This representation is basically what Keycloak issues to clients asking for permission. Check the `authorization` claim for the permissions that where granted based on the current authorization request.
 allowRemoteResourceManagementHelp=Should resources be managed remotely by the resource server? If false, resources can be managed only from this Admin UI.

--- a/js/apps/admin-ui/src/identity-providers/add/AdvancedSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AdvancedSettings.tsx
@@ -95,6 +95,7 @@ const LoginFlow = ({
 };
 
 const SYNC_MODES = ["IMPORT", "LEGACY", "FORCE"];
+const SHOW_IN_ACCOUNT_CONSOLE_VALUES = ["ALWAYS", "WHEN_LINKED", "NEVER"];
 type AdvancedSettingsProps = { isOIDC: boolean; isSAML: boolean };
 
 export const AdvancedSettings = ({ isOIDC, isSAML }: AdvancedSettingsProps) => {
@@ -154,6 +155,20 @@ export const AdvancedSettings = ({ isOIDC, isSAML }: AdvancedSettingsProps) => {
         field="hideOnLogin"
         label="hideOnLoginPage"
         fieldType="boolean"
+      />
+      <SelectControl
+        name="config.showInAccountConsole"
+        label={t("showInAccountConsole")}
+        options={SHOW_IN_ACCOUNT_CONSOLE_VALUES.map((showInAccountConsole) => ({
+          key: showInAccountConsole,
+          value: t(
+            `showInAccountConsole.${showInAccountConsole.toLocaleLowerCase()}`,
+          ),
+        }))}
+        controller={{
+          defaultValue: SHOW_IN_ACCOUNT_CONSOLE_VALUES[0],
+          rules: { required: t("required") },
+        }}
       />
 
       {(!isSAML || isOIDC) && (

--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.models;
 
+import java.util.Optional;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
 import java.io.Serializable;
@@ -56,6 +57,7 @@ public class IdentityProviderModel implements Serializable {
     public static final String SEARCH = "search";
     public static final String SYNC_MODE = "syncMode";
     public static final String MIN_VALIDITY_TOKEN = "minValidityToken";
+	public static final String SHOW_IN_ACCOUNT_CONSOLE = "showInAccountConsole";
     public static final int DEFAULT_MIN_VALIDITY_TOKEN = 5;
 
     private String internalId;
@@ -349,6 +351,10 @@ public class IdentityProviderModel implements Serializable {
     public void setMinValidityToken(int minValidityToken) {
         getConfig().put(MIN_VALIDITY_TOKEN, Integer.toString(minValidityToken));
     }
+
+	public IdentityProviderShowInAccountConsole getShowInAccountConsole() {
+		return IdentityProviderShowInAccountConsole.valueOf(getConfig().getOrDefault(SHOW_IN_ACCOUNT_CONSOLE, IdentityProviderShowInAccountConsole.ALWAYS.name()));
+	}
 
     public int getMinValidityToken() {
         String minValidityTokenString = getConfig().get(MIN_VALIDITY_TOKEN);

--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderShowInAccountConsole.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderShowInAccountConsole.java
@@ -1,0 +1,10 @@
+package org.keycloak.models;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public enum IdentityProviderShowInAccountConsole {
+	ALWAYS,
+	WHEN_LINKED,
+	NEVER
+}


### PR DESCRIPTION
Fix #19732

The fix is implemented as described by https://github.com/keycloak/keycloak/issues/19732#issuecomment-1515897884