### PR TITLE
Comma removed

### DIFF
--- a/docs/guides/securing-apps/overview.adoc
+++ b/docs/guides/securing-apps/overview.adoc
@@ -6,7 +6,7 @@ title="Planning for securing applications and services"
 priority=10
 summary="Introduction and basic concepts for securing applications">
 
-As an OAuth2, OpenID Connect, and SAML compliant server, {project_name} can secure any application and service as long
+As an OAuth2, OpenID Connect and SAML compliant server, {project_name} can secure any application and service as long
 as the technology stack they are using supports any of these protocols. For more details about the security protocols
 supported by {project_name}, consider looking at link:{adminguide_link}#sso-protocols[{adminguide_name}].
 


### PR DESCRIPTION
The comma after “OpenID Connect” is not necessary. The phrase “OAuth2, OpenID Connect, and SAML compliant server” is listing three related terms, and the conjunction “and” already makes the separation clear.
