### PR TITLE
Improved performance for loading of user organizations in Admin Console

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/MembershipRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/MembershipRepresentation.java
@@ -1,0 +1,21 @@
+package org.keycloak.representations.idm;
+
+public class MembershipRepresentation extends OrganizationRepresentation {
+    private MembershipType membershipType;
+
+    public MembershipRepresentation() {
+        super();
+    }
+
+    public MembershipRepresentation(OrganizationRepresentation rep) {
+        super(rep);
+    }
+
+    public MembershipType getMembershipType() {
+        return membershipType;
+    }
+
+    public void setMembershipType(MembershipType membershipType) {
+        this.membershipType = membershipType;
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
@@ -38,6 +38,22 @@ public class OrganizationRepresentation {
     private List<MemberRepresentation> members;
     private List<IdentityProviderRepresentation> identityProviders;
 
+    public OrganizationRepresentation() {
+    }
+
+    public OrganizationRepresentation(OrganizationRepresentation rep) {
+        this.id = rep.getId();
+        this.name = rep.getName();
+        this.alias = rep.getAlias();
+        this.enabled = rep.isEnabled();
+        this.description = rep.getDescription();
+        this.redirectUrl = rep.getRedirectUrl();
+        this.attributes = rep.getAttributes();
+        this.domains = rep.getDomains();
+        this.members = rep.getMembers();
+        this.identityProviders = rep.getIdentityProviders();
+    }
+
     public String getId() {
         return id;
     }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -26,7 +26,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.keycloak.representations.idm.MemberRepresentation;
-import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.MembershipRepresentation;
 
 public interface OrganizationMemberResource {
 
@@ -46,5 +46,5 @@ public interface OrganizationMemberResource {
     @Path("organizations")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<OrganizationRepresentation> getOrganizations();
+    List<MembershipRepresentation> getOrganizations();
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationsMembersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationsMembersResource.java
@@ -24,12 +24,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.MembershipRepresentation;
 
 public interface OrganizationsMembersResource {
 
     @Path("{id}/organizations")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<OrganizationRepresentation> getOrganizations(@PathParam("id") String id);
+    List<MembershipRepresentation> getOrganizations(@PathParam("id") String id);
 }

--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -404,7 +404,7 @@ export default function EditUser() {
                   title={<TabTitleText>{t("organizations")}</TabTitleText>}
                   {...organizationsTab}
                 >
-                  <Organizations user={user} />
+                  <Organizations />
                 </Tab>
               )}
               <Tab

--- a/js/apps/admin-ui/src/user/Organizations.tsx
+++ b/js/apps/admin-ui/src/user/Organizations.tsx
@@ -1,5 +1,4 @@
 import OrganizationRepresentation from "@keycloak/keycloak-admin-client/lib/defs/organizationRepresentation";
-import UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import {
   ListEmptyState,
   OrganizationTable,
@@ -29,17 +28,7 @@ import { toUsers } from "./routes/Users";
 import { CheckboxFilterComponent } from "../components/dynamic/CheckboxFilterComponent";
 import { capitalizeFirstLetterFormatter } from "../util";
 import { SearchInputComponent } from "../components/dynamic/SearchInputComponent";
-
-type OrganizationProps = {
-  user: UserRepresentation;
-};
-
-type MembershipTypeRepresentation = OrganizationRepresentation &
-  UserRepresentation & {
-    membershipType?: string;
-  };
-
-export const Organizations = ({ user }: OrganizationProps) => {
+export const Organizations = () => {
   const { adminClient } = useAdminClient();
   const { t } = useTranslation();
   const { id } = useParams<UserParams>();
@@ -88,35 +77,15 @@ export const Organizations = ({ user }: OrganizationProps) => {
       const userOrganizations =
         await adminClient.organizations.memberOrganizations({ userId: id! });
 
-      const userOrganizationsWithMembershipTypes = await Promise.all(
-        userOrganizations.map(async (org) => {
-          const orgId = org.id;
-          const memberships: MembershipTypeRepresentation[] =
-            await adminClient.organizations.listMembers({
-              orgId: orgId!,
-            });
-
-          const userMemberships = memberships.filter(
-            (membership) => membership.username === user.username,
-          );
-
-          const membershipType = userMemberships.map((membership) => {
-            const formattedMembershipType = capitalizeFirstLetterFormatter()(
-              membership.membershipType,
-            );
-            return formattedMembershipType;
-          });
-
-          return { ...org, membershipType };
-        }),
-      );
-
-      let filteredOrgs = userOrganizationsWithMembershipTypes;
+      let filteredOrgs = userOrganizations.map((org) => {
+        org.membershipType = capitalizeFirstLetterFormatter()(
+          org.membershipType,
+        ) as string;
+        return org;
+      });
       if (filteredMembershipTypes.length > 0) {
         filteredOrgs = filteredOrgs.filter((org) =>
-          org.membershipType?.some((type) =>
-            filteredMembershipTypes.includes(type as string),
-          ),
+          filteredMembershipTypes.includes(org.membershipType as string),
         );
       }
 

--- a/js/libs/keycloak-admin-client/src/defs/membershipRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/membershipRepresentation.ts
@@ -1,0 +1,6 @@
+import type OrganizationRepresentation from "./organizationRepresentation.js";
+
+export default interface MembershipRepresentation
+  extends OrganizationRepresentation {
+  membershipType?: string;
+}

--- a/js/libs/keycloak-admin-client/src/resources/organizations.ts
+++ b/js/libs/keycloak-admin-client/src/resources/organizations.ts
@@ -3,6 +3,7 @@ import IdentityProviderRepresentation from "../defs/identityProviderRepresentati
 import type OrganizationRepresentation from "../defs/organizationRepresentation.js";
 import UserRepresentation from "../defs/userRepresentation.js";
 import Resource from "./resource.js";
+import type MembershipRepresentation from "../defs/membershipRepresentation.js";
 
 interface PaginatedQuery {
   first?: number; // The position of the first result to be processed (pagination offset)
@@ -98,7 +99,7 @@ export class Organizations extends Resource<{ realm?: string }> {
 
   public memberOrganizations = this.makeRequest<
     { userId: string },
-    OrganizationRepresentation[]
+    MembershipRepresentation[]
   >({
     method: "GET",
     path: "/members/{userId}/organizations",

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -58,6 +58,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.MembershipRepresentation;
 import org.keycloak.representations.idm.MembershipType;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.services.ErrorResponse;
@@ -240,14 +241,14 @@ public class OrganizationMemberResource {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "400", description = "Bad Request")
     })
-    public Stream<OrganizationRepresentation> getOrganizations(@PathParam("member-id") String memberId) {
+    public Stream<MembershipRepresentation> getOrganizations(@PathParam("member-id") String memberId) {
         if (StringUtil.isBlank(memberId)) {
             throw ErrorResponse.error("id cannot be null", Status.BAD_REQUEST);
         }
 
         UserModel member = getUser(memberId);
 
-        return provider.getByMember(member).map(ModelToRepresentation::toRepresentation);
+        return provider.getByMember(member).map(o -> toRepresentation(o, member));
     }
 
     @Path("count")
@@ -285,6 +286,12 @@ public class OrganizationMemberResource {
 
     private MemberRepresentation toRepresentation(UserModel member) {
         MemberRepresentation result = new MemberRepresentation(ModelToRepresentation.toRepresentation(session, realm, member));
+        result.setMembershipType(provider.isManagedMember(organization, member) ? MembershipType.MANAGED : MembershipType.UNMANAGED);
+        return result;
+    }
+
+    private MembershipRepresentation toRepresentation(OrganizationModel organization, UserModel member) {
+        MembershipRepresentation result = new MembershipRepresentation(ModelToRepresentation.toRepresentation(organization));
         result.setMembershipType(provider.isManagedMember(organization, member) ? MembershipType.MANAGED : MembershipType.UNMANAGED);
         return result;
     }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
@@ -55,6 +55,7 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.organization.validation.OrganizationsValidation;
 import org.keycloak.organization.validation.OrganizationsValidation.OrganizationValidationException;
+import org.keycloak.representations.idm.MembershipRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.KeycloakOpenAPI;
@@ -196,7 +197,7 @@ public class OrganizationsResource {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "400", description = "Bad Request")
     })
-    public Stream<OrganizationRepresentation> getOrganizations(@PathParam("member-id") String memberId) {
+    public Stream<MembershipRepresentation> getOrganizations(@PathParam("member-id") String memberId) {
         return new OrganizationMemberResource(session, null, adminEvent).getOrganizations(memberId);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberTest.java
@@ -57,6 +57,7 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.representations.idm.AbstractUserRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.MembershipRepresentation;
 import org.keycloak.representations.idm.MembershipType;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -120,17 +121,19 @@ public class OrganizationMemberTest extends AbstractOrganizationTest {
         OrganizationRepresentation orgB = createOrganization("orgb");
         testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
         OrganizationRepresentation expected = organization.toRepresentation();
-        List<OrganizationRepresentation> actual = organization.members().member(member.getId()).getOrganizations();
+        List<MembershipRepresentation> actual = organization.members().member(member.getId()).getOrganizations();
         assertNotNull(actual);
         assertEquals(2, actual.size());
         assertTrue(actual.stream().map(OrganizationRepresentation::getId).anyMatch(expected.getId()::equals));
         assertTrue(actual.stream().map(OrganizationRepresentation::getId).anyMatch(orgB.getId()::equals));
+        assertTrue(actual.stream().map(MembershipRepresentation::getMembershipType).allMatch(MembershipType.UNMANAGED::equals));
 
         actual = testRealm().organizations().members().getOrganizations(member.getId());
         assertNotNull(actual);
         assertEquals(2, actual.size());
         assertTrue(actual.stream().map(OrganizationRepresentation::getId).anyMatch(expected.getId()::equals));
         assertTrue(actual.stream().map(OrganizationRepresentation::getId).anyMatch(orgB.getId()::equals));
+        assertTrue(actual.stream().map(MembershipRepresentation::getMembershipType).allMatch(MembershipType.UNMANAGED::equals));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberWithLdapTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/member/OrganizationMemberWithLdapTest.java
@@ -31,6 +31,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.MembershipRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.storage.ldap.mappers.membership.LDAPGroupMapperMode;
@@ -89,7 +90,7 @@ public class OrganizationMemberWithLdapTest extends AbstractOrganizationTest {
         try (Response response = organization.members().addMember(ldapUser.getId())) {
             assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
         }
-        List<OrganizationRepresentation> orgMemberships = organization.members().member(ldapUser.getId()).getOrganizations();
+        List<MembershipRepresentation> orgMemberships = organization.members().member(ldapUser.getId()).getOrganizations();
         assertThat(orgMemberships, notNullValue());
         assertThat(orgMemberships, hasSize(1));
         assertThat(orgMemberships.get(0).getId(), equalTo(orgRepresentation.getId()));


### PR DESCRIPTION
I'm trying to improve #36984. This PR only tackles one part of it.

Our setup is similar to the one outlined in the issue. Running on Kubernetes, using the operator.
For us, the biggest problem currently is the organization tab of the user view. The get members requests fired when opening this can take several minutes each. And while they're running, keycloak is sometimes not able to respond to health checks and becomes unavailable.

As a first step to improving this, this PR adds memberType to the response of get organizations by member. Eliminating the need to run extra requests to get memberType. The UserRepresentation model has a subclass for MemberRepresentation. I used the same approach, adding a MembershipRepresentation for organizations.

There's a few other n+1 type problems I want to improve. But I wanted to get some feedback on this first. 
I'm wondering if it's okay to add a MembershipModel that the OrganizationProvider can load directly?

Edit: Forgot to mention that this change in itself makes a huge difference for us. Making the organization tab load in ~20 sec, instead of failing after many minutes

Closes #36984