### PR TITLE
saml client: Add customized AuthnContextClassRef

### DIFF
--- a/js/apps/admin-ui/src/clients/add/SamlConfig.tsx
+++ b/js/apps/admin-ui/src/clients/add/SamlConfig.tsx
@@ -26,6 +26,9 @@ export const Toggle = ({ name, label }: ToggleProps) => {
 export const SamlConfig = () => {
   const { t } = useTranslation();
 
+  const AC_UNSPECIFIED = "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified";
+  const CLAIMS_MULTIPLEAUTHN = "http://schemas.microsoft.com/claims/multipleauthn";
+
   return (
     <FormAccess
       isHorizontal
@@ -56,6 +59,15 @@ export const SamlConfig = () => {
       <Toggle
         name={convertAttributeNameToForm("attributes.saml.authnstatement")}
         label="includeAuthnStatement"
+      />
+      <SelectControl
+        name={convertAttributeNameToForm("attributes.saml.authncontextclassref")}
+        label={t("authnContextClassRef")}
+        labelIcon={t("authnContextClassRef")}
+        controller={{
+          defaultValue: AC_UNSPECIFIED
+        }}
+        options={[AC_UNSPECIFIED, CLAIMS_MULTIPLEAUTHN]}
       />
       <Toggle
         name={convertAttributeNameToForm(

--- a/services/src/main/java/org/keycloak/protocol/saml/EntityDescriptorDescriptionConverter.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/EntityDescriptorDescriptionConverter.java
@@ -186,6 +186,7 @@ public class EntityDescriptorDescriptionConverter implements ClientDescriptionCo
         attributes.put(SamlConfigAttributes.SAML_SERVER_SIGNATURE_KEYINFO_EXT, SamlProtocol.ATTRIBUTE_FALSE_VALUE); // default to false
         attributes.put(SamlConfigAttributes.SAML_SIGNATURE_ALGORITHM, SignatureAlgorithm.RSA_SHA256.toString());
         attributes.put(SamlConfigAttributes.SAML_AUTHNSTATEMENT, SamlProtocol.ATTRIBUTE_TRUE_VALUE);
+        attributes.put(SamlConfigAttributes.SAML_AUTHNCONTEXTCLASSREF, JBossSAMLURIConstants.AC_UNSPECIFIED.get());
         SPSSODescriptorType spDescriptorType = getSPDescriptor(entity);
         if (spDescriptorType.isWantAssertionsSigned()) {
             attributes.put(SamlConfigAttributes.SAML_ASSERTION_SIGNATURE, SamlProtocol.ATTRIBUTE_TRUE_VALUE);

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlClient.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlClient.java
@@ -111,6 +111,14 @@ public class SamlClient extends ClientConfigResolver {
         client.setAttribute(SamlConfigAttributes.SAML_AUTHNSTATEMENT, Boolean.toString(val));
     }
 
+    public String authnContextClassRef() {
+        return resolveAttribute(SamlConfigAttributes.SAML_AUTHNCONTEXTCLASSREF);
+    }
+
+    public void setAuthnContextClassRef(String val) {
+        client.setAttribute(SamlConfigAttributes.SAML_AUTHNCONTEXTCLASSREF, val);
+    }
+
     public boolean forceNameIDFormat() {
         return "true".equals(resolveAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE));
 

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlConfigAttributes.java
@@ -29,6 +29,7 @@ public interface SamlConfigAttributes {
     String SAML_SIGNATURE_ALGORITHM = "saml.signature.algorithm";
     String SAML_NAME_ID_FORMAT_ATTRIBUTE = "saml_name_id_format";
     String SAML_AUTHNSTATEMENT = "saml.authnstatement";
+    String SAML_AUTHNCONTEXTCLASSREF = "saml.authncontextclassref";
     String SAML_ONETIMEUSE_CONDITION = "saml.onetimeuse.condition";
     String SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE = "saml_force_name_id_format";
     String SAML_ARTIFACT_BINDING = "saml.artifact.binding";

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -479,7 +479,7 @@ public class SamlProtocol implements LoginProtocol {
                 .subjectExpiration(assertionLifespan <= 0? realm.getAccessTokenLifespan() : assertionLifespan)
                 .sessionExpiration(realm.getSsoSessionMaxLifespan())
                 .requestIssuer(clientSession.getClient().getClientId())
-                .authMethod(JBossSAMLURIConstants.AC_UNSPECIFIED.get());
+                .authMethod(samlClient.authnContextClassRef());
 
         String sessionIndex = SamlSessionUtils.getSessionIndex(clientSession);
         builder.sessionIndex(sessionIndex);

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlRepresentationAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlRepresentationAttributes.java
@@ -56,6 +56,12 @@ public class SamlRepresentationAttributes {
 
     }
 
+    public String getAuthnMethod() {
+        if (getAttributes() == null) return null;
+        return getAttributes().get(SamlConfigAttributes.SAML_AUTHNCONTEXTCLASSREF);
+
+    }
+
     public String getForceNameIDFormat() {
         if (getAttributes() == null) return null;
         return getAttributes().get(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE);

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -66,6 +66,7 @@ enum TypedClientExtendedAttribute implements TypedClientAttribute {
     SAML_ASSERTION_LIFESPAN("saml.assertion.lifespan", null),
     SAML_ASSERTION_SIGNATURE("saml.assertion.signature", "false"),
     SAML_AUTHNSTATEMENT("saml.authnstatement", "false"),
+    SAML_AUTHNCONTEXTCLASSREF("saml.authncontextclassref", null),
     SAML_CLIENT_SIGNATURE("saml.client.signature", "false"),
     SAML_ENCRYPT("saml.encrypt", "false"),
     SAML_ENCRYPTION_CERTIFICATE("saml.encryption.certificate", null),


### PR DESCRIPTION
Add a new option on saml client to customize the AuthnContextClassRef value in the saml response.

I do not expect this PR to be merged but it provides a temporary solution to #11721, and as such I thinks it is worth being referenced.