### PR TITLE
Fix some ascii doc warnings

### DIFF
--- a/docs/guides/assembly.xml
+++ b/docs/guides/assembly.xml
@@ -7,49 +7,49 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>generated-guides/**</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/server</directory>
-            <outputDirectory>/generated-guides/server/</outputDirectory>
+            <outputDirectory>generated-guides/server/</outputDirectory>
             <includes>
                 <include>pinned-guides</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/getting-started</directory>
-            <outputDirectory>/generated-guides/getting-started/</outputDirectory>
+            <outputDirectory>generated-guides/getting-started/</outputDirectory>
             <includes>
                 <include>pinned-guides</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/operator</directory>
-            <outputDirectory>/generated-guides/operator/</outputDirectory>
+            <outputDirectory>generated-guides/operator/</outputDirectory>
             <includes>
                 <include>pinned-guides</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/observability</directory>
-            <outputDirectory>/generated-guides/observability/</outputDirectory>
+            <outputDirectory>generated-guides/observability/</outputDirectory>
             <includes>
                 <include>pinned-guides</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/high-availability</directory>
-            <outputDirectory>/generated-guides/high-availability/</outputDirectory>
+            <outputDirectory>generated-guides/high-availability/</outputDirectory>
             <includes>
                 <include>pinned-guides</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/securing-apps</directory>
-            <outputDirectory>/generated-guides/securing-apps/</outputDirectory>
+            <outputDirectory>generated-guides/securing-apps/</outputDirectory>
             <includes>
                 <include>pinned-guides</include>
             </includes>

--- a/docs/guides/server/features.adoc
+++ b/docs/guides/server/features.adoc
@@ -24,11 +24,11 @@ To enable all preview features, enter this command:
 
 Enabled feature may be versioned, or unversioned.  If you use a versioned feature name, e.g. feature:v1, that exact feature version will be enabled as long as it still exists in the runtime.  If you instead use an unversioned name, e.g. just feature, the selection of the particular supported feature version may change from release to release according to the following precedence:
 
-1. The highest default supported version
-2. The highest non-default supported version
-3. The highest deprecated version
-4. The highest preview version
-5. The highest experimental version
+. The highest default supported version
+. The highest non-default supported version
+. The highest deprecated version
+. The highest preview version
+. The highest experimental version
 
 == Disabling features
 

--- a/docs/guides/server/features.adoc
+++ b/docs/guides/server/features.adoc
@@ -25,10 +25,10 @@ To enable all preview features, enter this command:
 Enabled feature may be versioned, or unversioned.  If you use a versioned feature name, e.g. feature:v1, that exact feature version will be enabled as long as it still exists in the runtime.  If you instead use an unversioned name, e.g. just feature, the selection of the particular supported feature version may change from release to release according to the following precedence:
 
 1. The highest default supported version
-1. The highest non-default supported version
-1. The highest deprecated version
-1. The highest preview version
-1. The highest experimental version
+2. The highest non-default supported version
+3. The highest deprecated version
+4. The highest preview version
+5. The highest experimental version
 
 == Disabling features
 


### PR DESCRIPTION
Closes #38479

This PR addresses the following 2 set of warnings.

> [WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /generated-guides/server/
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /generated-guides/getting-started/
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /generated-guides/operator/
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /generated-guides/observability/
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /generated-guides/high-availability/
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /generated-guides/securing-apps/


> [INFO] asciidoctor: WARN: features.adoc: line 53: list item index: expected 2, got 1
[INFO] asciidoctor: WARN: features.adoc: line 54: list item index: expected 3, got 1
[INFO] asciidoctor: WARN: features.adoc: line 55: list item index: expected 4, got 1
[INFO] asciidoctor: WARN: features.adoc: line 56: list item index: expected 5, got 1


