### PR TITLE
Partial evaluation processing only permissions with scope view

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authorization/FGAPPolicyEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/FGAPPolicyEvaluator.java
@@ -35,8 +35,15 @@ import org.keycloak.authorization.store.ResourceStore;
 public class FGAPPolicyEvaluator extends DefaultPolicyEvaluator {
 
     @Override
-    protected void evaluateResourceTypePolicies(Resource resource, PolicyStore policyStore, ResourceServer resourceServer, Consumer<Policy> policyConsumer, ResourceStore resourceStore) {
-        // do not evaluate permissions based on the resource type
+    protected void evaluateResourceTypePolicies(ResourcePermission permission, Resource resource, PolicyStore policyStore, ResourceServer resourceServer, Consumer<Policy> policyConsumer, ResourceStore resourceStore) {
+        String resourceType = permission.getResourceType();
+
+        if (resourceType == null || resource.getName().equals(permission.getResourceType())) {
+            return;
+        }
+
+        Resource resourceTypeResource = resourceStore.findByName(resourceServer, resourceType);
+        policyStore.findByResource(resourceServer, resourceTypeResource, policyConsumer);
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/authorization/PartialEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/PartialEvaluator.java
@@ -32,6 +32,7 @@ import jakarta.persistence.criteria.Predicate;
 import org.keycloak.Config;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.policy.provider.PartialEvaluationPolicyProvider;
 import org.keycloak.authorization.policy.provider.PartialEvaluationStorageProvider;
 import org.keycloak.authorization.policy.provider.PartialEvaluationStorageProvider.EvaluationContext;
@@ -134,6 +135,9 @@ public class PartialEvaluator {
 
         for (PartialEvaluationPolicyProvider policyProvider : policyProviders) {
             policyProvider.getPermissions(session, resourceType, adminUser).forEach(permission -> {
+                if (permission.getScopes().stream().map(Scope::getName).noneMatch(name -> name.startsWith(AdminPermissionsSchema.VIEW))) {
+                    return;
+                }
                 Set<String> ids = permission.getResources().stream().map(Resource::getName).collect(Collectors.toSet());
                 Set<Policy> policies = permission.getAssociatedPolicies();
 

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/ResourcePermission.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/ResourcePermission.java
@@ -41,19 +41,29 @@ public class ResourcePermission {
 
     private final Resource resource;
     private final Collection<Scope> scopes;
+    private final String resourceType;
     private ResourceServer resourceServer;
     private Map<String, Set<String>> claims;
     private boolean granted;
 
     public ResourcePermission(Resource resource, Collection<Scope> scopes, ResourceServer resourceServer) {
-        this(resource, scopes, resourceServer, null);
+        this(null, resource, scopes, resourceServer, null);
+    }
+
+    public ResourcePermission(String resourceType, Resource resource, Collection<Scope> scopes, ResourceServer resourceServer) {
+        this(resourceType, resource, scopes, resourceServer, null);
     }
 
     public ResourcePermission(Resource resource, ResourceServer resourceServer, Map<String, ? extends Collection<String>> claims) {
-        this(resource, new LinkedHashSet<>(), resourceServer, claims);
+        this(null, resource, new LinkedHashSet<>(), resourceServer, claims);
     }
 
     public ResourcePermission(Resource resource, Collection<Scope> scopes, ResourceServer resourceServer, Map<String, ? extends Collection<String>> claims) {
+        this(null, resource, scopes, resourceServer, claims);
+    }
+
+    public ResourcePermission(String resourceType, Resource resource, Collection<Scope> scopes, ResourceServer resourceServer, Map<String, ? extends Collection<String>> claims) {
+        this.resourceType = resourceType;
         this.resource = resource;
         this.scopes = scopes;
         this.resourceServer = resourceServer;
@@ -63,6 +73,10 @@ public class ResourcePermission {
                 this.claims.computeIfAbsent(entry.getKey(), key -> new LinkedHashSet<>()).addAll(entry.getValue());
             }
         }
+    }
+
+    public String getResourceType() {
+        return resourceType;
     }
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
@@ -68,8 +68,8 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
         Resource resource = permission.getResource();
 
         if (resource != null) {
-            evaluateResourcePolicies(policyStore, resourceServer, resource, policyConsumer);
-            evaluateResourceTypePolicies(resource, policyStore, resourceServer, policyConsumer, resourceStore);
+            evaluateResourcePolicies(permission, policyStore, resourceServer, resource, policyConsumer);
+            evaluateResourceTypePolicies(permission, resource, policyStore, resourceServer, policyConsumer, resourceStore);
         }
 
         evaluateScopePolicies(permission, policyStore, resourceServer, policyConsumer);
@@ -84,11 +84,11 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
         }
     }
 
-    private void evaluateResourcePolicies(PolicyStore policyStore, ResourceServer resourceServer, Resource resource, Consumer<Policy> policyConsumer) {
+    private void evaluateResourcePolicies(ResourcePermission permission, PolicyStore policyStore, ResourceServer resourceServer, Resource resource, Consumer<Policy> policyConsumer) {
         policyStore.findByResource(resourceServer, resource, policyConsumer);
     }
 
-    protected void evaluateResourceTypePolicies(Resource resource, PolicyStore policyStore, ResourceServer resourceServer, Consumer<Policy> policyConsumer, ResourceStore resourceStore) {
+    protected void evaluateResourceTypePolicies(ResourcePermission permission, Resource resource, PolicyStore policyStore, ResourceServer resourceServer, Consumer<Policy> policyConsumer, ResourceStore resourceStore) {
         if (resource.getType() != null) {
             policyStore.findByResourceType(resourceServer, resource.getType(), policyConsumer);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissionsV2.java
@@ -214,21 +214,27 @@ public class ClientPermissionsV2 extends ClientPermissions {
         if (!root.isAdminSameRealm()) {
             return false;
         }
+
         ResourceServer server = root.realmResourceServer();
+
         if (server == null) return false;
 
+        String resourceType = AdminPermissionsSchema.CLIENTS_RESOURCE_TYPE;
+
         Resource resource =  resourceStore.findByName(server, client.getId(), server.getId());
+
         if (resource == null) {
             // check if there is permission for "all-clients". If so, load its resource and proceed with evaluation
-            resource = AdminPermissionsSchema.SCHEMA.getResourceTypeResource(session, server, AdminPermissionsSchema.CLIENTS_RESOURCE_TYPE);
+            resource = AdminPermissionsSchema.SCHEMA.getResourceTypeResource(session, server, resourceType);
 
             if (authz.getStoreFactory().getPolicyStore().findByResource(server, resource).isEmpty()) {
                 return false;
             }
         }
 
-        Collection<Permission> permissions = root.evaluatePermission(new ResourcePermission(resource, resource.getScopes(), server), server);
+        Collection<Permission> permissions = root.evaluatePermission(new ResourcePermission(resourceType, resource, resource.getScopes(), server), server);
         List<String> expectedScopes = Arrays.asList(scope);
+
         for (Permission permission : permissions) {
             if (permission.getResourceId().equals(resource.getId())) {
                 for (String s : permission.getScopes()) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissionsV2.java
@@ -112,10 +112,11 @@ class UserPermissionsV2 extends UserPermissions {
         }
 
         Resource resource = user == null ? null : resourceStore.findByName(server, user.getId());
+        String resourceType = AdminPermissionsSchema.USERS_RESOURCE_TYPE;
 
         if (resource == null) {
             // check if there is permission for "all-users". If so, load its resource and proceed with evaluation
-            resource = AdminPermissionsSchema.SCHEMA.getResourceTypeResource(session, server, AdminPermissionsSchema.USERS_RESOURCE_TYPE);
+            resource = AdminPermissionsSchema.SCHEMA.getResourceTypeResource(session, server, resourceType);
 
             if (policyStore.findByResource(server, resource).isEmpty()) {
                 return false;
@@ -123,8 +124,8 @@ class UserPermissionsV2 extends UserPermissions {
         }
 
         Collection<Permission> permissions = (context == null) ?
-                root.evaluatePermission(new ResourcePermission(resource, resource.getScopes(), server), server) :
-                root.evaluatePermission(new ResourcePermission(resource, resource.getScopes(), server), server, context);
+                root.evaluatePermission(new ResourcePermission(resourceType, resource, resource.getScopes(), server), server) :
+                root.evaluatePermission(new ResourcePermission(resourceType, resource, resource.getScopes(), server), server, context);
 
         List<String> expectedScopes = Arrays.asList(scopes);
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.ScopePermissionsResource;
 import org.keycloak.authorization.AdminPermissionsSchema;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -53,10 +54,12 @@ import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation
 import org.keycloak.representations.idm.authorization.ClientScopePolicyRepresentation;
 import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Logic;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.RegexPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.TimePolicyRepresentation;
 import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.testframework.annotations.InjectAdminClient;
@@ -362,5 +365,58 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
         realmAdminClient.realm(realm.getName()).users().get(myadmin.getId()).roles().clientLevel(myclient.getId()).add(List.of(role));
 
         realmAdminClient.realm(realm.getName()).clients().get(myclient.getId()).roles().get("myclient-role").addComposites(List.of(subRole));
+    }
+
+    @Test
+    public void testEvaluateAllResourcePermissionsForSpecificResourcePermission() {
+        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        UserRepresentation adminUser = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowPolicy = createUserPolicy(realm, client, "Only My Admin", adminUser.getId());
+        ScopePermissionRepresentation allResourcesPermission = createAllPermission(client, clientsType, allowPolicy, Set.of(MANAGE, MAP_ROLES));
+        // all resource permissions grants manage scope
+        ClientsResource clients = realmAdminClient.realm(realm.getName()).clients();
+        clients.get(myclient.getId()).update(myclient);
+
+        ScopePermissionRepresentation resourcePermission = createPermission(client, myclient.getId(), clientsType, Set.of(MANAGE), allowPolicy);
+        // both all and specific resource permission grants manage scope
+        clients.get(myclient.getId()).update(myclient);
+
+        allResourcesPermission = getScopePermissionsResource(client).findByName(allResourcesPermission.getName());
+        allResourcesPermission.setScopes(Set.of(MAP_ROLES));
+        getScopePermissionsResource(client).findById(allResourcesPermission.getId()).update(allResourcesPermission);
+        // all resource permission does not have the manage scope but the scope is granted by the resource permission
+        clients.get(myclient.getId()).update(myclient);
+
+        resourcePermission = getScopePermissionsResource(client).findByName(resourcePermission.getName());
+        resourcePermission.setScopes(Set.of(MAP_ROLES));
+        getScopePermissionsResource(client).findById(resourcePermission.getId()).update(resourcePermission);
+        try {
+            // neither the all and specific resource permission grants access to the manage scope
+            clients.get(myclient.getId()).update(myclient);
+            Assertions.fail("Expected Exception wasn't thrown.");
+        } catch (ForbiddenException expected) {}
+
+        allResourcesPermission.setScopes(Set.of(MANAGE));
+        getScopePermissionsResource(client).findById(allResourcesPermission.getId()).update(allResourcesPermission);
+        // all resource permission grants access again to manage
+        clients.get(myclient.getId()).update(myclient);
+
+        UserPolicyRepresentation notAllowPolicy = createUserPolicy(Logic.NEGATIVE, realm, client, "Not My Admin", adminUser.getId());
+        createPermission(client, myclient.getId(), clientsType, Set.of(MANAGE), notAllowPolicy);
+        try {
+            // a specific resource permission that explicitly negates access to the manage scope denies access to the scope
+            clients.get(myclient.getId()).update(myclient);
+            Assertions.fail("Expected Exception wasn't thrown.");
+        } catch (ForbiddenException expected) {}
+
+        resourcePermission = getScopePermissionsResource(client).findByName(resourcePermission.getName());
+        resourcePermission.setScopes(Set.of(MAP_ROLES, MANAGE));
+        getScopePermissionsResource(client).findById(resourcePermission.getId()).update(resourcePermission);
+        try {
+            // the specific resource permission that explicitly negates access to the manage scope denies access to the scope
+            // even though there is another resource permission that grants access to the scope - conflict resolution denies by default
+            clients.get(myclient.getId()).update(myclient);
+            Assertions.fail("Expected Exception wasn't thrown.");
+        } catch (ForbiddenException expected) {}
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
@@ -153,7 +153,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
         }
 
         UserPolicyRepresentation onlyMyAdminUserPolicy = createUserPolicy(realm, client, "Only My Admin User Policy", myadmin.getId());
-        createPermission(client, myclient.getId(), clientsType, Set.of(MANAGE), onlyMyAdminUserPolicy);
+        createPermission(client, myclient.getId(), clientsType, Set.of(VIEW, MANAGE), onlyMyAdminUserPolicy);
 
         // the caller can view myclient
         clientResource.toRepresentation();
@@ -263,7 +263,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
         assertThat(found, empty());
 
         UserPolicyRepresentation onlyMyAdminUserPolicy = createUserPolicy(realm, client, "Only My Admin User Policy", myadmin.getId());
-        createAllPermission(client, clientsType, onlyMyAdminUserPolicy, Set.of(MANAGE));
+        createAllPermission(client, clientsType, onlyMyAdminUserPolicy, Set.of(VIEW, MANAGE));
 
         // can create a new client
         realmAdminClient.realm(realm.getName()).clients().create(newClient).close();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeEvaluationTest.java
@@ -123,7 +123,7 @@ public class GroupResourceTypeEvaluationTest extends AbstractPermissionTest {
         }
 
         // allow my admin to manage members of the group where Alice is member of
-        createGroupPermission(topGroup, Set.of(MANAGE_MEMBERS), allowMyAdminPermission);
+        createGroupPermission(topGroup, Set.of(VIEW_MEMBERS, MANAGE_MEMBERS), allowMyAdminPermission);
 
         // my admin should be able to see Alice due to her membership and MANAGE_MEMBERS permission
         search = realmAdminClient.realm(realm.getName()).users().search(null, -1, -1);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeEvaluationTest.java
@@ -353,7 +353,7 @@ public class UserResourceTypeEvaluationTest extends AbstractPermissionTest {
     public void testTransitiveUserPermissions() {
         //create all-users manage permission for "myadmin"
         UserPolicyRepresentation policy = createUserPolicy(realm, client,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
-        createAllPermission(client, usersType, policy, Set.of(MANAGE));
+        createAllPermission(client, usersType, policy, Set.of(VIEW, MANAGE));
 
         // with manage permission it is possible also view
         List<UserRepresentation> search = realmAdminClient.realm(realm.getName()).users().search(null, -1, -1);


### PR DESCRIPTION
Closes #38436
Closes #38369

* We can eventually move the check for the `VIEW` scope in the `PartialEvaluator` to the query but for now I would keep in our deck of future improvements.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
