### PR TITLE
AgePasswordPolicy should not check password for registration

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/AgePasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/AgePasswordPolicyProvider.java
@@ -42,8 +42,7 @@ public class AgePasswordPolicyProvider implements PasswordPolicyProvider {
 
     @Override
     public PolicyError validate(String user, String password) {
-        RealmModel realm = session.getContext().getRealm();
-        return validate(realm, session.users().getUserByUsername(realm, user), password);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Closes #38331

The `passwordAge` policy should not check the password when using the registration method variant `validate(String, String)`, like the `passwordHistory`. This policy does not check the password string itself, it just checks when the user is available to check times. Test added.
