### PR TITLE
Fix account console for usage with secure-session client-policy (#37447)

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -266,6 +266,9 @@ public class AccountConsole implements AccountResourceProvider {
         UriBuilder uriBuilder = UriBuilder.fromUri(OIDCLoginProtocolService.authUrl(session.getContext().getUri()).build(realm.getName()).toString())
                 .queryParam(OAuth2Constants.CLIENT_ID, Constants.ACCOUNT_CONSOLE_CLIENT_ID)
                 .queryParam(OAuth2Constants.REDIRECT_URI, targetUri)
+                // dummy state param to make it usable with secure-session client policy.
+                // Once bootstrapped the account-console frontend will send the actual state with the authorize request.
+                .queryParam(OAuth2Constants.STATE, UUID.randomUUID().toString())
                 .queryParam(OAuth2Constants.RESPONSE_TYPE, OAuth2Constants.CODE)
                 .queryParam(OAuth2Constants.CODE_CHALLENGE, pkceChallenge)
                 .queryParam(OAuth2Constants.CODE_CHALLENGE_METHOD, OAuth2Constants.PKCE_METHOD_S256);


### PR DESCRIPTION
Previously the missing state parameter caused issues when the client policy `secure-session` was enabled for the realm.

This adds a dummy state parameter for the initial server-side auth redirect when we check for an authenticated user in the account-console backend.

If the user is successfully authenticated the account-console backend will bootstrap the actual account-console frontend, which will then
perform the actual auth code flow with a proper state handling.

Fixes #37447

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
