### PR TITLE
Initialize the watch for use.refresh.tokens to true when there is no value

### DIFF
--- a/js/apps/admin-ui/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
@@ -29,6 +29,7 @@ export const OpenIdConnectCompatibilityModes = ({
   );
   const useRefreshTokens = watch(
     convertAttributeNameToForm<FormFields>("attributes.use.refresh.tokens"),
+    "true",
   );
   return (
     <FormAccess


### PR DESCRIPTION
Closes #38501

The `use.refresh.tokens` is by default `true`. Therefore the watch needs to be initialized to `true` in case the value is undefined/missing in the client.