### PR TITLE
consolidating profile logic and moving reaug related logic

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -33,9 +33,7 @@ import io.smallrye.config.SmallRyeConfig;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.NetworkUtils;
-import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
 public final class Environment {
 
@@ -47,8 +45,6 @@ public final class Environment {
     public static final String DEFAULT_THEMES_PATH = File.separator +  "themes";
     public static final String PROD_PROFILE_VALUE = "prod";
     public static final String LAUNCH_MODE = "kc.launch.mode";
-
-    private static volatile AbstractCommand parsedCommand;
 
     private Environment() {}
 
@@ -107,21 +103,6 @@ public final class Environment {
         if (isTestLaunchMode()) {
             System.setProperty("mp.config.profile", profile);
         }
-    }
-
-    /**
-     * Update the profile settings based upon what was set in the system, environment, or optionally persistent values
-     */
-    public static String updateProfile(boolean usePersistent) {
-        String profile = org.keycloak.common.util.Environment.getProfile();
-        if(profile == null && usePersistent) {
-            profile = PersistedConfigSource.getInstance().getValue(org.keycloak.common.util.Environment.PROFILE);
-        }
-        if (profile == null) {
-            profile = Environment.PROD_PROFILE_VALUE;
-        }
-        setProfile(profile);
-        return profile;
     }
 
     public static boolean isDevMode() {
@@ -245,21 +226,6 @@ public final class Environment {
         }
 
         return profile;
-    }
-
-    /**
-     * Get parsed AbstractCommand we obtained from the CLI
-     */
-    public static Optional<AbstractCommand> getParsedCommand() {
-        return Optional.ofNullable(parsedCommand);
-    }
-
-    public static boolean isParsedCommand(String commandName) {
-        return getParsedCommand().filter(f -> f.getName().equals(commandName)).isPresent();
-    }
-
-    public static void setParsedCommand(AbstractCommand command) {
-        Environment.parsedCommand = command;
     }
 
     public static void removeHomeDir() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -19,16 +19,13 @@ package org.keycloak.quarkus.runtime.cli;
 
 import static java.lang.String.format;
 import static org.keycloak.quarkus.runtime.Environment.getProviderFiles;
-import static org.keycloak.quarkus.runtime.Environment.isDevMode;
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import static org.keycloak.quarkus.runtime.Environment.isRebuildCheck;
 import static org.keycloak.quarkus.runtime.Environment.isRebuilt;
 import static org.keycloak.quarkus.runtime.cli.OptionRenderer.decorateDuplicitOptionName;
 import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
-import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.parseConfigArgs;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isUserModifiable;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
-import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers.maskValue;
 import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_COMMAND_LIST;
 
 import java.io.File;
@@ -57,12 +54,9 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.KeycloakMain;
 import org.keycloak.quarkus.runtime.Messages;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractNonServerCommand;
 import org.keycloak.quarkus.runtime.cli.command.Build;
-import org.keycloak.quarkus.runtime.cli.command.Completion;
 import org.keycloak.quarkus.runtime.cli.command.Main;
-import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
-import org.keycloak.quarkus.runtime.cli.command.StartDev;
-import org.keycloak.quarkus.runtime.cli.command.UpdateCompatibility;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.DisabledMappersInterceptor;
@@ -105,6 +99,7 @@ public class Picocli {
     private final ExecutionExceptionHandler errorHandler = new ExecutionExceptionHandler();
     private Set<PropertyMapper<?>> allowedMappers;
     private final List<String> unrecognizedArgs = new ArrayList<>();
+    private Optional<AbstractCommand> parsedCommand = Optional.empty();
 
     public void parseAndRun(List<String> cliArgs) {
         // perform two passes over the cli args. First without option validation to determine the current command, then with option validation enabled
@@ -118,17 +113,7 @@ public class Picocli {
             // recreate the command specifically for the current
             cmd = createCommandLineForCommand(cliArgs, commandLineList);
 
-            int exitCode;
-            if (isRebuildCheck()) {
-                CommandLine currentCommand = null;
-                if (commandLineList.size() > 1) {
-                    currentCommand = commandLineList.get(commandLineList.size() - 1);
-                }
-                exitCode = runReAugmentationIfNeeded(cliArgs, cmd, currentCommand);
-            } else {
-                PropertyMappers.sanitizeDisabledMappers();
-                exitCode = cmd.execute(argArray);
-            }
+            int exitCode = cmd.execute(argArray);
 
             exit(exitCode);
         } catch (ParameterException parEx) {
@@ -168,21 +153,26 @@ public class Picocli {
                 addHelp(currentSpec);
             }
 
+            AbstractCommand currentCommand = null;
             if (currentSpec != null) {
                 CommandLine commandLine = currentSpec.commandLine();
                 addCommandOptions(cliArgs, commandLine);
 
                 if (commandLine != null && commandLine.getCommand() instanceof AbstractCommand ac) {
-                    // set current parsed command
-                    Environment.setParsedCommand(ac);
+                    currentCommand = ac;
                 }
             }
+            initConfig(currentCommand);
 
             if (isRebuildCheck()) {
                 // build command should be available when running re-aug
                 addCommandOptions(cliArgs, spec.subcommands().get(Build.NAME));
             }
         });
+    }
+
+    public Optional<AbstractCommand> getParsedCommand() {
+        return parsedCommand;
     }
 
     private void catchParameterException(ParameterException parEx, CommandLine cmd, String[] args) {
@@ -203,122 +193,6 @@ public class Picocli {
 
     public void exit(int exitCode) {
         System.exit(exitCode);
-    }
-
-    private int runReAugmentationIfNeeded(List<String> cliArgs, CommandLine cmd, CommandLine currentCommand) {
-        int exitCode = 0;
-
-        if (currentCommand == null) {
-            return exitCode; // possible if using --version or the user made a mistake
-        }
-
-        String currentCommandName = currentCommand.getCommandName();
-
-        if (shouldSkipRebuild(cliArgs, currentCommandName)) {
-            return exitCode;
-        }
-
-        // TODO: ensure that the config has not yet been initialized
-        // - there's currently no good way to do that directly on ConfigProviderResolver
-        initProfile(cliArgs, currentCommandName);
-
-        if (requiresReAugmentation(currentCommand)) {
-            PropertyMappers.sanitizeDisabledMappers();
-            exitCode = runReAugmentation(cliArgs, cmd);
-        }
-
-        return exitCode;
-    }
-
-    protected void initProfile(List<String> cliArgs, String currentCommandName) {
-        if (currentCommandName.equals(StartDev.NAME)) {
-            // force the server image to be set with the dev profile
-            Environment.forceDevProfile();
-        } else {
-            Environment.updateProfile(false);
-
-            // override from the cli if specified
-            parseConfigArgs(cliArgs, (k, v) -> {
-                if (k.equals(Main.PROFILE_SHORT_NAME) || k.equals(Main.PROFILE_LONG_NAME)) {
-                    Environment.setProfile(v);
-                }
-            }, ignored -> {});
-        }
-    }
-
-    private static boolean shouldSkipRebuild(List<String> cliArgs, String currentCommandName) {
-        return cliArgs.contains("--help")
-                || cliArgs.contains("-h")
-                || cliArgs.contains("--help-all")
-                || currentCommandName.equals(Build.NAME)
-                || currentCommandName.equals(ShowConfig.NAME)
-                || currentCommandName.equals(Completion.NAME)
-                || currentCommandName.equals(UpdateCompatibility.NAME);
-    }
-
-    private static boolean requiresReAugmentation(CommandLine cmdCommand) {
-        Map<String, String> rawPersistedProperties = Configuration.getRawPersistedProperties();
-        if (rawPersistedProperties.isEmpty()) {
-            return true; // no build yet
-        }
-        var current = getNonPersistedBuildTimeOptions();
-
-        // everything but the optimized value must match
-        String key = Configuration.KC_OPTIMIZED;
-        Optional.ofNullable(rawPersistedProperties.get(key)).ifPresentOrElse(value -> current.put(key, value), () -> current.remove(key));
-        return !rawPersistedProperties.equals(current);
-    }
-
-    /**
-     * checks the raw cli input for possible credentials / properties which should be masked,
-     * and masks them.
-     * @return a list of potentially masked properties in CLI format, e.g. `--db-password=*******`
-     * instead of the actual passwords value.
-     */
-    private static List<String> getSanitizedRuntimeCliOptions() {
-        List<String> properties = new ArrayList<>();
-
-        parseConfigArgs(ConfigArgsConfigSource.getAllCliArgs(), (key, value) -> {
-            PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(key);
-
-            if (mapper == null || mapper.isRunTime()) {
-                properties.add(key + "=" + maskValue(value, mapper));
-            }
-        }, properties::add);
-
-        return properties;
-    }
-
-    private static int runReAugmentation(List<String> cliArgs, CommandLine cmd) {
-        if (cmd == null) {
-            throw new IllegalStateException("CommandLine is null when trying to run re-augmentation. (CLI args: '%s')".formatted(String.join(", ", cliArgs)));
-        }
-
-        if (!isDevMode()) {
-            cmd.getOut().println("Changes detected in configuration. Updating the server image.");
-            if (Configuration.isOptimized()) {
-                checkChangesInBuildOptionsDuringAutoBuild(cmd.getOut());
-            }
-        }
-
-        List<String> configArgsList = new ArrayList<>();
-        configArgsList.add(Build.NAME);
-        parseConfigArgs(cliArgs, (k, v) -> {
-            PropertyMapper<?> mapper = PropertyMappers.getMapperByCliKey(k);
-
-            if (mapper != null && mapper.isBuildTime()) {
-                configArgsList.add(k + "=" + v);
-            }
-        }, ignored -> {});
-
-        cmd = cmd.setUnmatchedArgumentsAllowed(true);
-        int exitCode = cmd.execute(configArgsList.toArray(new String[0]));
-
-        if(!isDevMode() && exitCode == cmd.getCommandSpec().exitCodeOnSuccess()) {
-            cmd.getOut().printf("Next time you run the server, just run:%n%n\t%s %s %s%n%n", Environment.getCommand(), String.join(" ", getSanitizedRuntimeCliOptions()), OPTIMIZED_BUILD_OPTION_LONG);
-        }
-
-        return exitCode;
     }
 
     private static boolean wasBuildEverRun() {
@@ -623,6 +497,11 @@ public class Picocli {
         getOutWriter().println(defaultColorScheme.apply("INFO: ", Arrays.asList(Style.fg_green, Style.bold)) + text);
     }
 
+    public void error(String text) {
+        ColorScheme defaultColorScheme = picocli.CommandLine.Help.defaultColorScheme(Help.Ansi.AUTO);
+        getErrWriter().println(defaultColorScheme.apply(text, Arrays.asList(Style.fg_red, Style.bold)));
+    }
+
     private static void warn(String text, PrintWriter outwriter) {
         ColorScheme defaultColorScheme = picocli.CommandLine.Help.defaultColorScheme(Help.Ansi.AUTO);
         outwriter.println(defaultColorScheme.apply("WARNING: ", Arrays.asList(Style.fg_yellow, Style.bold)) + text);
@@ -922,8 +801,8 @@ public class Picocli {
         return transformedDesc.toString();
     }
 
-    public static void println(CommandLine cmd, String message) {
-        cmd.getOut().println(message);
+    public void println(String message) {
+        getOutWriter().println(message);
     }
 
     public static List<String> parseArgs(String[] rawArgs) throws PropertyException {
@@ -953,7 +832,7 @@ public class Picocli {
         return args;
     }
 
-    private static void checkChangesInBuildOptionsDuringAutoBuild(PrintWriter out) {
+    public static void checkChangesInBuildOptionsDuringAutoBuild(PrintWriter out) {
         StringBuilder options = new StringBuilder();
 
         checkChangesInBuildOptions((key, oldValue, newValue) -> optionChanged(options, key, oldValue, newValue));
@@ -1011,11 +890,26 @@ public class Picocli {
     }
 
     public void start() {
-        KeycloakMain.start(this, errorHandler);
+        KeycloakMain.start(this, (AbstractNonServerCommand) this.getParsedCommand()
+                .filter(AbstractNonServerCommand.class::isInstance).orElse(null), this.errorHandler);
     }
 
     public void build() throws Throwable {
         QuarkusEntryPoint.main();
+    }
+
+    public void initConfig(AbstractCommand command) {
+        if (Configuration.isInitialized()) {
+            throw new IllegalStateException("Config should not be initialized until profile is determined");
+        }
+        this.parsedCommand = Optional.ofNullable(command);
+
+        String profile = parsedCommand.map(AbstractCommand::getInitProfile)
+                .orElseGet(() -> Optional.ofNullable(org.keycloak.common.util.Environment.getProfile())
+                        .orElse(Environment.PROD_PROFILE_VALUE));
+
+        Environment.setProfile(profile);
+        parsedCommand.ifPresent(PropertyMappers::sanitizeDisabledMappers);
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -22,16 +22,19 @@ import static org.keycloak.quarkus.runtime.Messages.cliExecutionError;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import org.keycloak.config.OptionCategory;
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
+import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
-public abstract class AbstractCommand {
+public abstract class AbstractCommand implements Callable<Integer> {
 
     @Spec
     protected CommandSpec spec; // will be null for "start --optimized"
@@ -43,6 +46,52 @@ public abstract class AbstractCommand {
 
     protected void executionError(CommandLine cmd, String message, Throwable cause) {
         cliExecutionError(cmd, message, cause);
+    }
+
+    /**
+     * Get the effective profile used when the config is initialized
+     */
+    public String getInitProfile() {
+        String configuredProfile = org.keycloak.common.util.Environment.getProfile();
+        if (configuredProfile != null) {
+            return configuredProfile; // the profile was already set by the cli or even ENV
+        }
+        if (Environment.isRebuildCheck()) {
+            // builds default to prod, if the profile is not overriden via the cli
+            return Environment.PROD_PROFILE_VALUE;
+        }
+        // otherwise take the default profile, or what is persisted, or ultimately prod
+        return Optional.ofNullable(this.getDefaultProfile())
+                .or(() -> Optional.ofNullable(
+                        PersistedConfigSource.getInstance().getValue(org.keycloak.common.util.Environment.PROFILE)))
+                .orElse(Environment.PROD_PROFILE_VALUE);
+    }
+
+    @Override
+    public Integer call() {
+        return callCommand().orElseGet(() -> {
+            runCommand();
+            return CommandLine.ExitCode.OK;
+        });
+    }
+
+    /**
+     * An alternative to {@link #runCommand()} that allows for returning an exit code.
+     * If the Optional is empty, {@link #runCommand()} will still be called
+     * <br>
+     * see {@link #call()}
+     */
+    protected Optional<Integer> callCommand() {
+        return Optional.empty();
+    }
+
+    /**
+     * If {@link #callCommand()} returns an empty {@link Optional}, then this method will be used to run the command. OK will be returned as the exit code after successful completion.
+     * <br>
+     * see {@link #call()}
+     */
+    protected void runCommand() {
+
     }
 
     /**
@@ -78,6 +127,14 @@ public abstract class AbstractCommand {
 
     public void setPicocli(Picocli picocli) {
         this.picocli = picocli;
+    }
+
+    /**
+     * The default profile for the command, or null if the persisted profile should be checked first
+     * @return
+     */
+    protected String getDefaultProfile() {
+        return Environment.PROD_PROFILE_VALUE;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractNonServerCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractNonServerCommand.java
@@ -26,19 +26,14 @@ import picocli.CommandLine;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class AbstractNonServerCommand extends AbstractStartCommand implements Runnable {
+public abstract class AbstractNonServerCommand extends AbstractStartCommand {
 
     @CommandLine.Mixin
-    OptimizedMixin optimizedMixin;
-
-    @CommandLine.Mixin
-    HelpAllMixin helpAllMixin;
+    OptimizedMixin optimizedMixin = new OptimizedMixin();
 
     @Override
-    public void run() {
-        Environment.setProfile(Environment.NON_SERVER_MODE);
-
-        super.run();
+    public String getDefaultProfile() {
+        return Environment.NON_SERVER_MODE;
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
@@ -29,7 +29,7 @@ import java.util.EnumSet;
 @Command(name = Export.NAME,
         header = "Export data from realms to a file or directory.",
         description = "%nExport data from realms to a file or directory.")
-public final class Export extends AbstractNonServerCommand implements Runnable {
+public final class Export extends AbstractNonServerCommand {
 
     public static final String NAME = "export";
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
@@ -29,7 +29,7 @@ import java.util.EnumSet;
 @Command(name = Import.NAME,
         header = "Import data from a directory or a file.",
         description = "%nImport data from a directory or a file.")
-public final class Import extends AbstractNonServerCommand implements Runnable {
+public final class Import extends AbstractNonServerCommand {
 
     public static final String NAME = "import";
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -41,7 +41,7 @@ import picocli.CommandLine.Parameters;
 @Command(name = "show-config",
         header = "Print out the current configuration.",
         description = "%nPrint out the current configuration.")
-public final class ShowConfig extends AbstractCommand implements Runnable {
+public final class ShowConfig extends AbstractCommand {
 
     public static final String NAME = "show-config";
     private static final List<String> allowedSystemPropertyKeys = List.of(
@@ -54,8 +54,13 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
     String filter;
 
     @Override
-    public void run() {
-        String profile = Environment.updateProfile(true);
+    public String getDefaultProfile() {
+        return null;
+    }
+
+    @Override
+    protected void runCommand() {
+        String profile = org.keycloak.common.util.Environment.getProfile();
 
         spec.commandLine().getOut().printf("Current Mode: %s%n", Environment.getKeycloakModeFromProfile(profile));
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/StartDev.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/StartDev.java
@@ -17,11 +17,10 @@
 
 package org.keycloak.quarkus.runtime.cli.command;
 
-import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.common.util.Environment;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Mixin;
 
 @Command(name = StartDev.NAME,
         header = "Start the server in development mode.",
@@ -30,19 +29,21 @@ import picocli.CommandLine.Mixin;
         },
         footer = "%nDo NOT start the server using this command when deploying to production.%n%n"
                 + "Use '${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --help-all' to list all available options, including build options.")
-public final class StartDev extends AbstractStartCommand implements Runnable {
+public final class StartDev extends AbstractStartCommand {
 
     public static final String NAME = "start-dev";
-
-    @Mixin
-    HelpAllMixin helpAllMixin;
 
     @CommandLine.Mixin
     ImportRealmMixin importRealmMixin;
 
     @Override
-    protected void doBeforeRun() {
-        Environment.forceDevProfile();
+    public String getInitProfile() {
+        return Environment.DEV_PROFILE_VALUE; // only ever dev - could be a validation instead
+    }
+
+    @Override
+    public String getDefaultProfile() {
+        return Environment.DEV_PROFILE_VALUE;
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/UpdateCompatibilityCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/UpdateCompatibilityCheck.java
@@ -55,20 +55,20 @@ public class UpdateCompatibilityCheck extends AbstractUpdatesCommand {
             var id = idIterator.next();
             var provider = providers.get(id);
             if (provider == null) {
-                printError("[%s] Provider not found. Rolling Update is not available.".formatted(id));
+                picocli.error("[%s] Provider not found. Rolling Update is not available.".formatted(id));
                 return CompatibilityResult.ExitCode.RECREATE.value();
             }
 
             var result = provider.isCompatible(Map.copyOf(info.getOrDefault(id, Map.of())));
-            result.endMessage().ifPresent(this::printOut);
+            result.endMessage().ifPresent(picocli.getOutWriter()::println);
 
             if (Util.isNotCompatible(result)) {
-                result.errorMessage().ifPresent(this::printError);
+                result.errorMessage().ifPresent(picocli::error);
                 return result.exitCode();
             }
         }
 
-        printOut("[OK] Rolling Update is available.");
+        picocli.getOutWriter().println("[OK] Rolling Update is available.");
         return CompatibilityResult.ExitCode.ROLLING.value();
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/UpdateCompatibilityMetadata.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/UpdateCompatibilityMetadata.java
@@ -83,7 +83,7 @@ public class UpdateCompatibilityMetadata extends AbstractUpdatesCommand {
     private void printToConsole(Map<String, Map<String, String>> metadata) {
         try {
             var json = JsonSerialization.mapper.writerWithDefaultPrettyPrinter().writeValueAsString(metadata);
-            printOut("Metadata:%n%s".formatted(json));
+            picocli.getOutWriter().println("Metadata:%n%s".formatted(json));
         } catch (JsonProcessingException e) {
             throw new PropertyException("Unable to create JSON representation of the metadata", e);
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -89,6 +89,10 @@ public final class Configuration {
                 .isPresent();
     }
 
+    public static boolean isInitialized() {
+        return config != null;
+    }
+
     public static synchronized SmallRyeConfig getConfig() {
         if (config == null) {
             config = ConfigUtils.emptyConfigBuilder().addDiscoveredSources().build();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -12,7 +12,6 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
-import org.keycloak.quarkus.runtime.cli.command.Build;
 import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
 import org.keycloak.quarkus.runtime.configuration.DisabledMappersInterceptor;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
@@ -34,7 +33,6 @@ import java.util.function.BiConsumer;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.keycloak.quarkus.runtime.Environment.isParsedCommand;
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import static org.keycloak.quarkus.runtime.Environment.isRebuildCheck;
 import static org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider.isKeyStoreConfigSource;
@@ -138,8 +136,8 @@ public final class PropertyMappers {
     /**
      * Removes all disabled mappers from the runtime/buildtime mappers
      */
-    public static void sanitizeDisabledMappers() {
-        MAPPERS.sanitizeDisabledMappers();
+    public static void sanitizeDisabledMappers(AbstractCommand command) {
+        MAPPERS.sanitizeDisabledMappers(command);
     }
 
     public static String maskValue(String value, PropertyMapper<?> mapper) {
@@ -226,11 +224,8 @@ public final class PropertyMappers {
         return getDisabledMapper(property).isPresent() && getMapper(property) == null;
     }
 
-    private static Set<PropertyMapper<?>> filterDeniedCategories(List<PropertyMapper<?>> mappers) {
-        final var allowedCategories = Environment.getParsedCommand()
-                .map(AbstractCommand::getOptionCategories)
-                .map(EnumSet::copyOf)
-                .orElseGet(() -> EnumSet.allOf(OptionCategory.class));
+    private static Set<PropertyMapper<?>> filterDeniedCategories(List<PropertyMapper<?>> mappers, AbstractCommand command) {
+        final var allowedCategories = EnumSet.copyOf(command.getOptionCategories());
 
         return mappers.stream().filter(f -> allowedCategories.contains(f.getCategory())).collect(Collectors.toSet());
     }
@@ -326,11 +321,7 @@ public final class PropertyMappers {
             return Collections.unmodifiableSet(wildcardMappers);
         }
 
-        public void sanitizeDisabledMappers() {
-            if (Environment.getParsedCommand().isEmpty()) {
-                return; // do not sanitize when no command is present
-            }
-
+        public void sanitizeDisabledMappers(AbstractCommand command) {
             DisabledMappersInterceptor.runWithDisabled(() -> { // We need to have the whole configuration available
 
                 // Initialize profile in order to check state of features. Disable Persisted CS for re-augmentation
@@ -343,22 +334,22 @@ public final class PropertyMappers {
                 sanitizeMappers(buildTimeMappers, disabledBuildTimeMappers);
                 sanitizeMappers(runtimeTimeMappers, disabledRuntimeMappers);
 
-                assertDuplicatedMappers();
+                assertDuplicatedMappers(command);
             });
         }
 
-        private void assertDuplicatedMappers() {
+        private void assertDuplicatedMappers(AbstractCommand command) {
             final var duplicatedMappers = entrySet().stream()
                     .filter(e -> CollectionUtil.isNotEmpty(e.getValue()))
                     .filter(e -> e.getValue().size() > 1)
                     .toList();
 
-            final var isBuildPhase = isRebuild() || isRebuildCheck() || isParsedCommand(Build.NAME);
-            final var allowedForCommand = isParsedCommand(ShowConfig.NAME);
+            final var isBuildPhase = isRebuild() || isRebuildCheck() || command.includeBuildTime();
+            final var allowedForCommand = ShowConfig.NAME.equals(command.getName());
 
             if (!duplicatedMappers.isEmpty()) {
                 duplicatedMappers.forEach(f -> {
-                    final var filteredMappers = filterDeniedCategories(f.getValue());
+                    final var filteredMappers = filterDeniedCategories(f.getValue(), command);
 
                     if (filteredMappers.size() > 1) {
                         final var areBuildTimeMappers = filteredMappers.stream().anyMatch(PropertyMapper::isBuildTime);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -21,8 +21,6 @@ import org.keycloak.config.BootstrapAdminOptions;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.platform.Platform;
-import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.quarkus.runtime.cli.command.AbstractNonServerCommand;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor;
@@ -50,11 +48,6 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         QuarkusPlatform platform = (QuarkusPlatform) Platform.getPlatform();
         platform.started();
         startup();
-        Environment.getParsedCommand().ifPresent(ac -> {
-            if (ac instanceof AbstractNonServerCommand) {
-                ((AbstractNonServerCommand)ac).onStart(this);
-            }
-        });
     }
 
     void onShutdownEvent(@Observes ShutdownEvent event) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/AbstractConfigurationTest.java
@@ -63,7 +63,6 @@ public abstract class AbstractConfigurationTest {
 
     public static void setSystemProperty(String key, String value, Runnable runnable) {
         System.setProperty(key, value);
-        createConfig();
         try {
             runnable.run();
         } finally {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -61,7 +61,7 @@ public class BuildAndStartDistTest {
         cliResult.assertBuild();
         cliResult = rawDist.run("start", OPTIMIZED_BUILD_OPTION_LONG);
         cliResult.assertNoBuild();
-        assertTrue(cliResult.getErrorOutput().isBlank());
+        assertTrue(cliResult.getErrorOutput().isBlank(), cliResult.getErrorOutput());
         // running start without optimized flag should not cause a build
         cliResult = rawDist.run("start");
         cliResult.assertNoBuild();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -96,7 +96,7 @@ public class StartCommandDistTest {
     @Test
     @Launch({ "--profile=dev", "start",  "--db=dev-file" })
     void failUsingDevProfile(CLIResult cliResult) {
-        assertTrue(cliResult.getErrorOutput().contains("ERROR: You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
+        assertTrue(cliResult.getErrorOutput().contains("You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
                 () -> "The Output:\n" + cliResult.getErrorOutput() + "doesn't contains the expected string.");
     }
 


### PR DESCRIPTION
This is a follow up to #38236 - after trying to add a test via PicocliTest for the hostname-strict-https check, it was clear that our current way of emitting the warning handling profiled properties wasn't consistent. 

also aggregated the various places that were setting the profile to a single place

closes: #38581

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
