### PR TITLE
fix: correcting the test expecation for non-ip address

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ProxyHostnameV2DistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ProxyHostnameV2DistTest.java
@@ -99,7 +99,7 @@ public class ProxyHostnameV2DistTest {
         assertXForwardedHeadersAreIgnored();
 
         CLIResult cliResult = (CLIResult)result;
-        cliResult.assertNoMessage(NOT_ADDRESS);
+        cliResult.assertMessage(NOT_ADDRESS); // non-ip addresses are still reported as the client ip
         cliResult.assertMessage(ADDRESS);
     }
 


### PR DESCRIPTION
closes: #38517
closes: #36843

Unfortunately this got missed with the intial pr because it didn't trigger the quarkus dist test run.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
