### PR TITLE
fix: removing the use of hostname-strict-https mistakenly brought back

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -49,7 +49,7 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
             picocli.start();
         }
     }
-    
+
     protected void doBeforeRun() {
 
     }
@@ -58,7 +58,7 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
     protected void validateConfig() {
         super.validateConfig(); // we want to run the generic validation here first to check for unknown options
         HttpPropertyMappers.validateConfig();
-        HostnameV2PropertyMappers.validateConfig();
+        HostnameV2PropertyMappers.validateConfig(picocli);
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
@@ -6,14 +6,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.jboss.logging.Logger;
 import org.keycloak.common.Profile;
 import org.keycloak.config.HostnameV2Options;
+import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 public final class HostnameV2PropertyMappers {
-    
-    private static final Logger LOGGER = Logger.getLogger(PropertyMappers.class);
+
     private static final List<String> REMOVED_OPTIONS = Arrays.asList("hostname-admin-url", "hostname-path", "hostname-port", "hostname-strict-backchannel", "hostname-url", "proxy", "hostname-strict-https");
 
     private HostnameV2PropertyMappers(){}
@@ -35,12 +34,12 @@ public final class HostnameV2PropertyMappers {
         .map(b -> b.isEnabled(() -> Profile.isFeatureEnabled(Profile.Feature.HOSTNAME_V2), "hostname:v2 feature is enabled").build())
         .toArray(s -> new PropertyMapper<?>[s]);
     }
-    
-    public static void validateConfig() {
+
+    public static void validateConfig(Picocli picocli) {
         List<String> inUse = REMOVED_OPTIONS.stream().filter(s -> Configuration.getOptionalKcValue(s).isPresent()).toList();
-        
+
         if (!inUse.isEmpty()) {
-            LOGGER.errorf("Hostname v1 options %s are still in use, please review your configuration", inUse);
+            picocli.warn("Hostname v1 options %s are still in use, please review your configuration".formatted(inUse));
         }
     }
 

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -58,7 +58,6 @@ quarkus.http.limits.max-header-size=65535
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.kc.http-enabled=true
 %dev.kc.hostname-strict=false
-%dev.kc.hostname-strict-https=false
 %dev.kc.cache=local
 %dev.kc.spi-theme-cache-themes=false
 %dev.kc.spi-theme-cache-templates=false
@@ -68,7 +67,6 @@ quarkus.http.limits.max-header-size=65535
 %nonserver.kc.http-enabled=true
 %nonserver.kc.http-server-enabled=false
 %nonserver.kc.hostname-strict=false
-%nonserver.kc.hostname-strict-https=false
 %nonserver.kc.cache=local
 
 #logging defaults

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
@@ -63,7 +63,7 @@ public class BootstrapAdminDistTest {
     void createAdmin(LaunchResult result) {
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
     }
-    
+
     @Test
     @Launch({ "start-dev", "--bootstrap-admin-password=MY_PASSWORD" })
     void createAdminWithCliOptions(LaunchResult result) {
@@ -94,12 +94,12 @@ public class BootstrapAdminDistTest {
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
 
         rawDist.setManualStop(true);
-        rawDist.run("start-dev", "--log-level=debug");
+        rawDist.run("start-dev");
 
         CLIResult adminResult = rawDist.kcadm("get", "clients", "--server", "http://localhost:8080", "--realm", "master", "--client", "admin", "--secret", "admin123");
-        
+
         assertEquals(0, adminResult.exitCode());
         assertTrue(adminResult.getOutput().contains("clientId"));
     }
-    
+
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartDevCommandDistTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.DryRun;
@@ -34,6 +32,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 import java.io.File;
 import java.nio.file.Paths;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DistributionTest
@@ -47,6 +46,9 @@ public class StartDevCommandDistTest {
     @Launch({ "start-dev" })
     void testDevModeWarning(CLIResult cliResult) {
         cliResult.assertStartedDevMode();
+        String out = cliResult.getOutput().toUpperCase();
+        assertFalse(out.contains("WARN"));
+        assertFalse(out.contains("ERROR"));
     }
 
     @DryRun


### PR DESCRIPTION
also properly emit the http v1 check. We're now using the picocli writer for the http v1 check - as deferred logging can prevent it from being seen. The only side effect is that it will be WARN instead of an ERROR, but we can of course tweak that.

Since #38514 is getting too large, these are the minimal changes which should address this. However we do have some consistency issues in how we deal with the profile that the other pr will eventually handle.

closes: #38236

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
