### PR TITLE
Add locale attribute to the registration context

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
@@ -389,6 +389,9 @@ public class DeclarativeUserProfileProviderFactory implements UserProfileProvide
         metadata.getAttribute(UserModel.EMAIL).get(0).addValidators(Collections.singletonList(
                 new AttributeValidatorMetadata(RegistrationEmailAsUsernameEmailValueValidator.ID)));
 
+        metadata.addAttribute(UserModel.LOCALE, -1, DeclarativeUserProfileProviderFactory::isInternationalizationEnabled, DeclarativeUserProfileProviderFactory::isInternationalizationEnabled)
+                .setRequired(AttributeMetadata.ALWAYS_FALSE);
+
         return metadata;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
@@ -290,7 +290,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
 
         //assert fields location in form
         List<WebElement> element = driver.findElements(By.cssSelector("form#kc-register-form input"));
-        String[] labelOrder = new String[]{"lastName", "department", "username", "password", "password-confirm", "firstName", "email"};
+        String[] labelOrder = new String[]{"locale", "lastName", "department", "username", "password", "password-confirm", "firstName", "email"};
         for (int i = 0; i < labelOrder.length; i++) {
             WebElement webElement = element.get(i);
             String id = webElement.getAttribute("id");

--- a/themes/src/main/resources/theme/base/login/user-profile-commons.ftl
+++ b/themes/src/main/resources/theme/base/login/user-profile-commons.ftl
@@ -3,59 +3,65 @@
 	
 	<#list profile.attributes as attribute>
 
-		<#assign group = (attribute.group)!"">
-		<#if group != currentGroup>
-			<#assign currentGroup=group>
-			<#if currentGroup != "">
-				<div class="${properties.kcFormGroupClass!}"
-				<#list group.html5DataAnnotations as key, value>
-					data-${key}="${value}"
-				</#list>
-				>
+		<#if attribute.name=='locale' && realm.internationalizationEnabled && locale.currentLanguageTag?has_content>
+			<input type="hidden" id="${attribute.name}" name="${attribute.name}" value="${locale.currentLanguageTag}"/>
+		<#else>
+
+			<#assign group = (attribute.group)!"">
+			<#if group != currentGroup>
+				<#assign currentGroup=group>
+				<#if currentGroup != "">
+					<div class="${properties.kcFormGroupClass!}"
+					<#list group.html5DataAnnotations as key, value>
+						data-${key}="${value}"
+					</#list>
+					>
 	
-					<#assign groupDisplayHeader=group.displayHeader!"">
-					<#if groupDisplayHeader != "">
-						<#assign groupHeaderText=advancedMsg(groupDisplayHeader)!group>
-					<#else>
-						<#assign groupHeaderText=group.name!"">
-					</#if>
-					<div class="${properties.kcContentWrapperClass!}">
-						<label id="header-${attribute.group.name}" class="${kcFormGroupHeader!}">${groupHeaderText}</label>
-					</div>
-	
-					<#assign groupDisplayDescription=group.displayDescription!"">
-					<#if groupDisplayDescription != "">
-						<#assign groupDescriptionText=advancedMsg(groupDisplayDescription)!"">
-						<div class="${properties.kcLabelWrapperClass!}">
-							<label id="description-${group.name}" class="${properties.kcLabelClass!}">${groupDescriptionText}</label>
+						<#assign groupDisplayHeader=group.displayHeader!"">
+						<#if groupDisplayHeader != "">
+							<#assign groupHeaderText=advancedMsg(groupDisplayHeader)!group>
+						<#else>
+							<#assign groupHeaderText=group.name!"">
+						</#if>
+						<div class="${properties.kcContentWrapperClass!}">
+							<label id="header-${attribute.group.name}" class="${kcFormGroupHeader!}">${groupHeaderText}</label>
 						</div>
+	
+						<#assign groupDisplayDescription=group.displayDescription!"">
+						<#if groupDisplayDescription != "">
+							<#assign groupDescriptionText=advancedMsg(groupDisplayDescription)!"">
+							<div class="${properties.kcLabelWrapperClass!}">
+								<label id="description-${group.name}" class="${properties.kcLabelClass!}">${groupDescriptionText}</label>
+							</div>
+						</#if>
+					</div>
+				</#if>
+			</#if>
+
+			<#nested "beforeField" attribute>
+			<div class="${properties.kcFormGroupClass!}">
+				<div class="${properties.kcLabelWrapperClass!}">
+					<label for="${attribute.name}" class="${properties.kcLabelClass!}">${advancedMsg(attribute.displayName!'')}</label>
+					<#if attribute.required>*</#if>
+				</div>
+				<div class="${properties.kcInputWrapperClass!}">
+					<#if attribute.annotations.inputHelperTextBefore??>
+						<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
+					</#if>
+					<@inputFieldByType attribute=attribute/>
+					<#if messagesPerField.existsError('${attribute.name}')>
+						<span id="input-error-${attribute.name}" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+							${kcSanitize(messagesPerField.get('${attribute.name}'))?no_esc}
+						</span>
+					</#if>
+					<#if attribute.annotations.inputHelperTextAfter??>
+						<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
 					</#if>
 				</div>
-			</#if>
-		</#if>
+			</div>
+			<#nested "afterField" attribute>
 
-		<#nested "beforeField" attribute>
-		<div class="${properties.kcFormGroupClass!}">
-			<div class="${properties.kcLabelWrapperClass!}">
-				<label for="${attribute.name}" class="${properties.kcLabelClass!}">${advancedMsg(attribute.displayName!'')}</label>
-				<#if attribute.required>*</#if>
-			</div>
-			<div class="${properties.kcInputWrapperClass!}">
-				<#if attribute.annotations.inputHelperTextBefore??>
-					<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
-				</#if>
-				<@inputFieldByType attribute=attribute/>
-				<#if messagesPerField.existsError('${attribute.name}')>
-					<span id="input-error-${attribute.name}" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-						${kcSanitize(messagesPerField.get('${attribute.name}'))?no_esc}
-					</span>
-				</#if>
-				<#if attribute.annotations.inputHelperTextAfter??>
-					<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
-				</#if>
-			</div>
-		</div>
-		<#nested "afterField" attribute>
+		</#if>
 	</#list>
 
 	<#list profile.html5DataAnnotations?keys as key>

--- a/themes/src/main/resources/theme/keycloak.v2/login/user-profile-commons.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/user-profile-commons.ftl
@@ -4,51 +4,57 @@
 	
 	<#list profile.attributes as attribute>
 
-		<#assign group = (attribute.group)!"">
-		<#if group != currentGroup>
-			<#assign currentGroup=group>
-			<#if currentGroup != "">
-				<div class="${properties.kcFormGroupClass!}"
-				<#list group.html5DataAnnotations as key, value>
-					data-${key}="${value}"
-				</#list>
-				>
+		<#if attribute.name=='locale' && realm.internationalizationEnabled && locale.currentLanguageTag?has_content>
+			<input type="hidden" id="${attribute.name}" name="${attribute.name}" value="${locale.currentLanguageTag}"/>
+		<#else>
 
-					<#assign groupDisplayHeader=group.displayHeader!"">
-					<#if groupDisplayHeader != "">
-						<#assign groupHeaderText=advancedMsg(groupDisplayHeader)!group>
-					<#else>
-						<#assign groupHeaderText=group.name!"">
-					</#if>
-					<div class="${properties.kcContentWrapperClass!}">
-						<label id="header-${attribute.group.name}" class="${kcFormGroupHeader!}">${groupHeaderText}</label>
-					</div>
+			<#assign group = (attribute.group)!"">
+			<#if group != currentGroup>
+				<#assign currentGroup=group>
+				<#if currentGroup != "">
+					<div class="${properties.kcFormGroupClass!}"
+					<#list group.html5DataAnnotations as key, value>
+						data-${key}="${value}"
+					</#list>
+					>
 
-					<#assign groupDisplayDescription=group.displayDescription!"">
-					<#if groupDisplayDescription != "">
-						<#assign groupDescriptionText=advancedMsg(groupDisplayDescription)!"">
-						<div class="${properties.kcLabelWrapperClass!}">
-							<label id="description-${group.name}" class="${properties.kcLabelClass!}">${groupDescriptionText}</label>
+						<#assign groupDisplayHeader=group.displayHeader!"">
+						<#if groupDisplayHeader != "">
+							<#assign groupHeaderText=advancedMsg(groupDisplayHeader)!group>
+						<#else>
+							<#assign groupHeaderText=group.name!"">
+						</#if>
+						<div class="${properties.kcContentWrapperClass!}">
+							<label id="header-${attribute.group.name}" class="${kcFormGroupHeader!}">${groupHeaderText}</label>
 						</div>
+
+						<#assign groupDisplayDescription=group.displayDescription!"">
+						<#if groupDisplayDescription != "">
+							<#assign groupDescriptionText=advancedMsg(groupDisplayDescription)!"">
+							<div class="${properties.kcLabelWrapperClass!}">
+								<label id="description-${group.name}" class="${properties.kcLabelClass!}">${groupDescriptionText}</label>
+							</div>
+						</#if>
+					</div>
+				</#if>
+			</#if>
+
+			<#nested "beforeField" attribute>
+
+			<@field.group name=attribute.name label=advancedMsg(attribute.displayName!'') error=kcSanitize(messagesPerField.get('${attribute.name}'))?no_esc required=attribute.required>
+				<div class="${properties.kcInputWrapperClass!}">
+					<#if attribute.annotations.inputHelperTextBefore??>
+						<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
+					</#if>
+					<@inputFieldByType attribute=attribute/>
+					<#if attribute.annotations.inputHelperTextAfter??>
+						<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
 					</#if>
 				</div>
-			</#if>
+			</@field.group>
+			<#nested "afterField" attribute>
+
 		</#if>
-
-		<#nested "beforeField" attribute>
-
-		<@field.group name=attribute.name label=advancedMsg(attribute.displayName!'') error=kcSanitize(messagesPerField.get('${attribute.name}'))?no_esc required=attribute.required>
-			<div class="${properties.kcInputWrapperClass!}">
-				<#if attribute.annotations.inputHelperTextBefore??>
-					<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
-				</#if>
-				<@inputFieldByType attribute=attribute/>
-				<#if attribute.annotations.inputHelperTextAfter??>
-					<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
-				</#if>
-			</div>
-		</@field.group>
-		<#nested "afterField" attribute>
 	</#list>
 
 	<#list profile.html5DataAnnotations?keys as key>


### PR DESCRIPTION
Closes #38029

This PR adds the `locale` attribute to the User Profile in the registration context. The idea is the registration page also sends the current locale of the user as another attribute of the registration. There have been several issues about the same so I think that it's better to add this attribute when internationalization is enabled in the realm. The theme just manages the `locale` attribute separately (exactly as the admin and account console are doing in [UserProfileFields.tsx](https://github.com/keycloak/keycloak/blob/main/js/libs/ui-shared/src/user-profile/UserProfileFields.tsx#L197)). The change is better checked hiding white-spaces (the ftl files are only adding an if-else and the big change is in indentation).

It's a draft for the moment because it's a little change in behavior. But it's minor and I think that it's an improvement. WDYT? If accepted, do this need a release note?