### PR TITLE
fix: revert to submit() function instead of requestSubmit()

### DIFF
--- a/themes/src/main/resources/theme/base/login/select-organization.ftl
+++ b/themes/src/main/resources/theme/base/login/select-organization.ftl
@@ -9,7 +9,7 @@
                     <#list user.organizations as organization>
                         <li>
                             <a id="organization-${organization.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if user.organizations?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                               type="button" onclick="document.forms[0]['kc.org'].value = '${organization.alias}'; document.forms[0].requestSubmit()">
+                               type="button" onclick="document.forms[0]['kc.org'].value = '${organization.alias}'; document.forms[0].submit()">
                                 <span class="${properties.kcFormSocialAccountNameClass!}">${organization.name!}</span>
                             </a>
                         </li>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -157,7 +157,7 @@
                   <div class="${properties.kcFormGroupClass!}">
                       <input type="hidden" name="tryAnotherWay" value="on"/>
                       <a href="#" id="try-another-way"
-                         onclick="document.forms['kc-select-try-another-way-form'].requestSubmit();return false;">${msg("doTryAnotherWay")}</a>
+                         onclick="document.forms['kc-select-try-another-way-form'].submit();return false;">${msg("doTryAnotherWay")}</a>
                   </div>
               </form>
           </#if>

--- a/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
@@ -14,7 +14,7 @@
                 <form id="kc-select-credential-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
                     <input type="hidden" name="authenticationExecution" value="${authenticationSelection.authExecId}">
                 </form>
-                <div class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].requestSubmit()">
+                <div class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].submit()">
                     <div class="pf-v5-c-data-list__item-content">
                         <div class="${properties.kcSelectAuthListItemIconClass!}">
                             <i class="${properties['${authenticationSelection.iconCssClass}']!authenticationSelection.iconCssClass} ${properties.kcSelectAuthListItemIconPropertyClass!}"></i>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -209,7 +209,7 @@
         <#if auth?has_content && auth.showTryAnotherWayLink()>
           <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post" novalidate="novalidate">
               <input type="hidden" name="tryAnotherWay" value="on"/>
-              <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].requestSubmit()"
+              <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].submit()"
                   class="${properties.kcButtonSecondaryClass} ${properties.kcButtonBlockClass} ${properties.kcMarginTopClass}">
                     ${kcSanitize(msg("doTryAnotherWay"))?no_esc}
               </a>


### PR DESCRIPTION
Revert to `submit()` function instead of `requestSubmit()` to maintain backward compatibility

`requestSubmit()` is not fully supported, especially by older browsers which are used as embedded browsers for logins.

This MR is an extension of #35659 which also reverts parts of the changes introduced in #33071 / https://github.com/keycloak/keycloak/commit/7acb30269bedc32e559ab28c0a5adf8d2195a378.
Since it unintentionally breaks some older clients like the Office 365 Desktop clients, we should have the change to `requestSubmit()` as a dedicated MR. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
