### PR TITLE
Fix annotations for update logic

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/update/impl/BaseUpgradeLogic.java
+++ b/operator/src/main/java/org/keycloak/operator/update/impl/BaseUpgradeLogic.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.quarkus.logging.Log;
@@ -60,9 +61,10 @@ abstract class BaseUpdateLogic implements UpdateLogic {
         var existing = ContextUtils.getCurrentStatefulSet(context);
         if (existing.isEmpty()) {
             // new deployment, no update needed
-            Log.debug("New deployment - skipping update logic");
+            Log.info("New deployment - skipping update logic");
             return Optional.empty();
         }
+        Log.info("Metadata: " + Serialization.asYaml(existing.get().getMetadata()));
         copyStatusFromExistStatefulSet(existing.get());
 
         var desiredStatefulSet = ContextUtils.getDesiredStatefulSet(context);
@@ -105,6 +107,7 @@ abstract class BaseUpdateLogic implements UpdateLogic {
         }
         var reason = CRDUtils.findUpdateReason(current).orElseThrow();
         var recreate = maybeRecreate.get();
+        Log.info("Copied " + reason);
         statusConsumer = statusAggregator -> statusAggregator.addUpdateType(recreate, reason);
     }
 

--- a/operator/src/main/java/org/keycloak/operator/update/impl/BaseUpgradeLogic.java
+++ b/operator/src/main/java/org/keycloak/operator/update/impl/BaseUpgradeLogic.java
@@ -64,7 +64,7 @@ abstract class BaseUpdateLogic implements UpdateLogic {
             Log.info("New deployment - skipping update logic");
             return Optional.empty();
         }
-        Log.info("Metadata: " + Serialization.asYaml(existing.get().getMetadata()));
+        Log.info("Annotations: " + Serialization.asYaml(existing.get().getMetadata().getAnnotations()));
         copyStatusFromExistStatefulSet(existing.get());
 
         var desiredStatefulSet = ContextUtils.getDesiredStatefulSet(context);


### PR DESCRIPTION
Fixed #38487

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Two issues fixed in this PR

* The annotations with the update reason/decision were lost because they were only set when the update logic made a decision. It was the root cause of some failures. 
* When the explicit logic decided to recreate, the stateful set was annotated with the current revision value when scaling down the deployment. This led to the explicit logic deciding on a rolling update if an event is triggered right after it and the controller is invoked.  