### PR TITLE
Added `ThemeManagerSpi` and ported `DefaultThemeManagerFactory` to use it

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/theme/ThemeManagerFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/theme/ThemeManagerFactory.java
@@ -1,0 +1,10 @@
+package org.keycloak.theme;
+
+import org.keycloak.models.ThemeManager;
+import org.keycloak.provider.ProviderFactory;
+
+/**
+ */
+public interface ThemeManagerFactory extends ProviderFactory<ThemeManager> {
+  void clearCache();
+}

--- a/server-spi-private/src/main/java/org/keycloak/theme/ThemeManagerSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/theme/ThemeManagerSpi.java
@@ -1,0 +1,29 @@
+package org.keycloak.theme;
+
+import org.keycloak.models.ThemeManager;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class ThemeManagerSpi implements Spi {
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "themeManager";
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return ThemeManager.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return ThemeManagerFactory.class;
+    }
+}

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -56,6 +56,7 @@ org.keycloak.email.EmailSenderSpi
 org.keycloak.email.EmailTemplateSpi
 org.keycloak.executors.ExecutorsSpi
 org.keycloak.theme.ThemeSpi
+org.keycloak.theme.ThemeManagerSpi
 org.keycloak.tracing.TracingSpi
 org.keycloak.truststore.TruststoreSpi
 org.keycloak.connections.httpclient.HttpClientSpi

--- a/server-spi/src/main/java/org/keycloak/models/ThemeManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/ThemeManager.java
@@ -1,11 +1,12 @@
 package org.keycloak.models;
 
+import org.keycloak.provider.Provider;
 import org.keycloak.theme.Theme;
 
 import java.io.IOException;
 import java.util.Set;
 
-public interface ThemeManager {
+public interface ThemeManager extends Provider {
 
     /**
      * Returns the theme for the specified type. The theme is determined by the theme selector.

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
@@ -81,7 +81,6 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
     private DatastoreProvider datastoreProvider;
     private final KeycloakContext context;
     private KeyManager keyManager;
-    private ThemeManager themeManager;
     private TokenManager tokenManager;
     private VaultTranscriber vaultTranscriber;
     private ClientPolicyManager clientPolicyManager;
@@ -314,10 +313,7 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
 
     @Override
     public ThemeManager theme() {
-        if (themeManager == null) {
-            themeManager = factory.getThemeManagerFactory().create(this);
-        }
-        return themeManager;
+        return this.getProvider(ThemeManager.class);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSessionFactory.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSessionFactory.java
@@ -42,6 +42,7 @@ import org.keycloak.component.ComponentFactoryProviderFactory;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.ThemeManager;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.InvalidationHandler;
 import org.keycloak.provider.KeycloakDeploymentInfo;
@@ -54,7 +55,7 @@ import org.keycloak.provider.ProviderManagerDeployer;
 import org.keycloak.provider.ProviderManagerRegistry;
 import org.keycloak.provider.Spi;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
-import org.keycloak.theme.DefaultThemeManagerFactory;
+import org.keycloak.theme.ThemeManagerFactory;
 
 public abstract class DefaultKeycloakSessionFactory implements KeycloakSessionFactory, ProviderManagerDeployer {
 
@@ -64,8 +65,6 @@ public abstract class DefaultKeycloakSessionFactory implements KeycloakSessionFa
     protected Map<Class<? extends Provider>, String> provider = new HashMap<>();
     protected volatile Map<Class<? extends Provider>, Map<String, ProviderFactory>> factoriesMap = new HashMap<>();
     protected CopyOnWriteArrayList<ProviderEventListener> listeners = new CopyOnWriteArrayList<>();
-
-    private final DefaultThemeManagerFactory themeManagerFactory = new DefaultThemeManagerFactory();
 
     // TODO: Likely should be changed to int and use Time.currentTime() to be compatible with all our "time" reps
     protected long serverStartupTimestamp;
@@ -222,7 +221,7 @@ public abstract class DefaultKeycloakSessionFactory implements KeycloakSessionFa
         initProviderFactories(cfChanged, deployed);
 
         if (pm.getInfo().hasThemes() || pm.getInfo().hasThemeResources()) {
-            themeManagerFactory.clearCache();
+            ((ThemeManagerFactory)getProviderFactory(ThemeManager.class)).clearCache();
         }
     }
 
@@ -261,10 +260,6 @@ public abstract class DefaultKeycloakSessionFactory implements KeycloakSessionFa
         for (ProviderFactory factory : undeployed) {
             factory.close();
         }
-    }
-
-    protected DefaultThemeManagerFactory getThemeManagerFactory() {
-        return themeManagerFactory;
     }
 
     protected void checkProvider() {

--- a/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
@@ -102,6 +102,10 @@ public class DefaultThemeManager implements ThemeManager {
         factory.clearCache();
     }
 
+    @Override
+    public void close() {
+    }
+
     private Theme loadTheme(String name, Theme.Type type) {
         Theme theme = findTheme(name, type);
         if (theme == null) {

--- a/services/src/main/java/org/keycloak/theme/DefaultThemeManagerFactory.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeManagerFactory.java
@@ -20,6 +20,7 @@ package org.keycloak.theme;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ThemeManager;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class DefaultThemeManagerFactory {
+public class DefaultThemeManagerFactory implements ThemeManagerFactory {
 
     private static final Logger log = Logger.getLogger(DefaultThemeManagerFactory.class);
 
@@ -39,8 +40,26 @@ public class DefaultThemeManagerFactory {
         }
     }
 
+    @Override
     public ThemeManager create(KeycloakSession session) {
         return new DefaultThemeManager(this, session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return "default";
     }
 
     public Theme getCachedTheme(String name, Theme.Type type) {
@@ -73,6 +92,7 @@ public class DefaultThemeManagerFactory {
         return themeCache != null;
     }
 
+    @Override
     public void clearCache() {
         if (themeCache != null) {
             themeCache.clear();

--- a/services/src/main/resources/META-INF/services/org.keycloak.theme.ThemeManagerFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.theme.ThemeManagerFactory
@@ -1,0 +1,1 @@
+org.keycloak.theme.DefaultThemeManagerFactory


### PR DESCRIPTION
Closes #38433.

Creates a `ThemeManagerFactory` as a proper SPI so that it can be accessed/overridden.

Implementation 
- creates `ThemeManagerSpi` and `ThemeManagerFactory` 
- the current `DefaultThemeManagerFactory` implements `ThemeManagerFactory` 
- update the code in `DefaultKeycloakSessionFactory` that uses the `DefaultThemeManagerFactory` 

