### PR TITLE
KeyUtils warn about invalid key for valid short ids

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/KeyUtils.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/KeyUtils.java
@@ -29,26 +29,27 @@ public class KeyUtils {
     private static final Logger LOG = Logger.getLogger(KeyUtils.class);
 
     public static final Pattern UUID_PATTERN = Pattern.compile("[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}");
+    public static final Pattern SHORT_ID_PATTERN = Pattern.compile("[0-9A-Za-z_-]{22}");
 
     public static final Pattern EXPECTED_KEY_PATTERN = Pattern.compile(
       UUID_PATTERN.pattern()
       + "|"
-      + "f:" + UUID_PATTERN.pattern() + ":.*"
+      + "f:(" + UUID_PATTERN.pattern() + "|" + SHORT_ID_PATTERN.pattern() + "):.*"
       + "|"
       + LightweightUserAdapter.ID_PREFIX + UUID_PATTERN.pattern()
     );
 
     /**
-     * Returns {@code} true when the key is {@code null} or either a plain UUID or a key formatted as "f:[UUID]:any_string"
+     * Check if a string is a valid key.
      * @param key String representation of the key
-     * @return 
+     * @return true when the key is {@code null} or either a plain UUID or a key formatted as "f:[UUID]:any_string" or "f:[SHORT_ID]:any_string"
      */
     public static boolean isValidKey(String key) {
         return key == null || EXPECTED_KEY_PATTERN.matcher(key).matches();
     }
 
     /**
-     * Logs an warning when the key is not a valid key
+     * Logs a warning when the key is not a valid key
      * @param key String representation of the key
      */
     public static void assertValidKey(String key) throws IllegalArgumentException {

--- a/model/jpa/src/test/java/org/keycloak/storage/jpa/KeyUtilsTest.java
+++ b/model/jpa/src/test/java/org/keycloak/storage/jpa/KeyUtilsTest.java
@@ -18,6 +18,7 @@ package org.keycloak.storage.jpa;
 
 import java.util.UUID;
 import org.junit.Test;
+import org.keycloak.models.utils.KeycloakModelUtils;
 
 import static org.junit.Assert.*;
 
@@ -36,6 +37,10 @@ public class KeyUtilsTest {
         assertTrue(KeyUtils.isValidKey("f:" + UUID.randomUUID() + ":dsadsada"));
         assertTrue(KeyUtils.isValidKey("f:01234567-1234-1234-aAAa-123456789012:dsadsada"));
         assertTrue(KeyUtils.isValidKey("f:a1234567-1234-1234-aAAa-123456789012:dsadsada"));
+
+        assertTrue(KeyUtils.isValidKey("f:" + KeycloakModelUtils.generateShortId() + ":dsadsada"));
+        assertTrue(KeyUtils.isValidKey("f:22charsValidShort-uuid:dsadsada"));
+        assertTrue(KeyUtils.isValidKey("f:RaQXxaH_SGamVvd-6CBB2w:dsadsada"));
     }
 
     @Test
@@ -44,10 +49,13 @@ public class KeyUtilsTest {
         assertFalse(KeyUtils.isValidKey("0"));
         assertFalse(KeyUtils.isValidKey("01234567-1234-1234-aAAg-123456789012a"));
         assertFalse(KeyUtils.isValidKey("z1234567-1234-1234-aAAa-123456789012"));
+        //short ids should only be used in federated context
+        assertFalse(KeyUtils.isValidKey("22charsValidShort-uuid"));
 
         assertFalse(KeyUtils.isValidKey("f:g1234567-1234-1234-aAAa-123456789012:dsadsada"));
         assertFalse(KeyUtils.isValidKey("g:a1234567-1234-1234-aAAa-123456789012:dsadsada"));
         assertFalse(KeyUtils.isValidKey("f:a1234567-1234-1234-aAAa-123456789012"));
+        assertFalse(KeyUtils.isValidKey("f:short-Id:Invalid-Ch@rs:dsadsada"));
     }
 
 }


### PR DESCRIPTION
`org.keycloak.storage.jpa` `KeyUtils.isValidKey(String key)` method was not validating short ids generated by the `KeycloakModelUtils.generateShortId()` method, causing warning logs on authentication for LDAP federated users (with LDAP component configured with no-import and unsynced)

Fixes [https://github.com/keycloak/keycloak/issues/37992](https://github.com/keycloak/keycloak/issues/37992)