### PR TITLE
Permission checks that do not check a specific client should check the permissions granted to the client resource type

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/RoleResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/RoleResourceTypeEvaluationTest.java
@@ -71,7 +71,7 @@ public class RoleResourceTypeEvaluationTest extends AbstractPermissionTest {
 
         UserPolicyRepresentation onlyMyAdminUserPolicy = createUserPolicy(realm, client, "Only My Admin User Policy", myadmin.getId());
         // we need to be able to list client scopes
-        createPermission(client, myclient.getId(), AdminPermissionsSchema.CLIENTS.getType(), Set.of(VIEW), onlyMyAdminUserPolicy);
+        createAllPermission(client, AdminPermissionsSchema.CLIENTS.getType(), onlyMyAdminUserPolicy, Set.of(VIEW));
 
         // create a client-scope
         ClientScopeRepresentation clientScope = new ClientScopeRepresentation();


### PR DESCRIPTION
Closes #38653

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
