### PR TITLE
fix: excluding update commands from reaug

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -54,12 +54,10 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.KeycloakMain;
 import org.keycloak.quarkus.runtime.Messages;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
 import org.keycloak.quarkus.runtime.cli.command.Build;
-import org.keycloak.quarkus.runtime.cli.command.Completion;
 import org.keycloak.quarkus.runtime.cli.command.Main;
-import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
 import org.keycloak.quarkus.runtime.cli.command.StartDev;
-import org.keycloak.quarkus.runtime.cli.command.UpdateCompatibility;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.DisabledMappersInterceptor;
@@ -252,9 +250,7 @@ public class Picocli {
                 || cliArgs.contains("-h")
                 || cliArgs.contains("--help-all")
                 || currentCommandName.equals(Build.NAME)
-                || currentCommandName.equals(ShowConfig.NAME)
-                || currentCommandName.equals(Completion.NAME)
-                || currentCommandName.equals(UpdateCompatibility.NAME);
+                || Environment.getParsedCommand().filter(AbstractStartCommand.class::isInstance).isEmpty();
     }
 
     private static boolean requiresReAugmentation(CommandLine cmdCommand) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -307,6 +307,16 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void testNoReaugUpdateCommand() {
+        build("start-dev");
+
+        Environment.setRebuildCheck(); // will be reset by the system properties logic
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("update-compatibility", "check", "--file=x");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertFalse(nonRunningPicocli.reaug);
+    }
+
+    @Test
     public void testReaugFromProdToDev() {
         build("build", "--db=dev-file");
 


### PR DESCRIPTION
closes: #38662

@ahus1 @pruivo @vmuzikar just wanted to highlight something. These commands will accept build time options (that is the default behavior with non-optimized commands), but they will exhibit a behavior like show-config.  That is if there is an optimized image, the build time option will just overshadow that option, and you'll pick everything else up from the persisted config. As opposed to start, import, export, where we won't use an part of the persisted config if anything is different with the build time configuration.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
