### PR TITLE
fix: improving the name of application.properties

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
@@ -93,10 +93,17 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider, Confi
         if (configSource == null) {
             return "Derived";
         }
+        String name = CONFIG_SOURCE_DISPLAY_NAMES.get(configSource);
+        if (name != null) {
+            return name;
+        }
         if (isKeyStoreConfigSource(configSource)) {
             return "config-keystore";
         }
-        return CONFIG_SOURCE_DISPLAY_NAMES.getOrDefault(configSource, configSource);
+        if (configSource.contains("PropertiesConfigSource") && configSource.contains("!/application.properties")) {
+            return "classpath application.properties";
+        }
+        return configSource; // some other Quarkus configsource
     }
 
     public static boolean isKeyStoreConfigSource(String configSourceName) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -113,6 +113,7 @@ public class ShowConfigCommandDistTest {
         result.assertMessage("(quarkus.properties)");
         result.assertMessage("(Persisted)");
         result.assertMessage("(config-keystore)");
+        result.assertMessage("(classpath application.properties)");
         result.assertMessage("(keycloak-keystore.conf)");
     }
 }


### PR DESCRIPTION
Follow up to #38389 - the default name for application.properties is quite verbose.

closes: #38389

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
