### PR TITLE
fix: key upload handling for SAML and OpenID

### DIFF
--- a/js/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
@@ -1,23 +1,19 @@
 import type KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
-import { HelpItem, SelectControl } from "@keycloak/keycloak-ui-shared";
+import {
+  HelpItem,
+  SelectControl,
+  FileUploadControl,
+} from "@keycloak/keycloak-ui-shared";
 import {
   Button,
   ButtonVariant,
-  FileUpload,
   Form,
-  FormGroup,
   Modal,
   ModalVariant,
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { useState } from "react";
-import {
-  Controller,
-  FormProvider,
-  useForm,
-  useFormContext,
-} from "react-hook-form";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { StoreSettings } from "./StoreSettings";
@@ -55,9 +51,7 @@ export const KeyForm = ({
 }: KeyFormProps) => {
   const { t } = useTranslation();
 
-  const [filename, setFilename] = useState<string>();
-
-  const { control, watch } = useFormContext<FormFields>();
+  const { watch } = useFormContext<FormFields>();
   const format = watch("format");
 
   const { cryptoInfo } = useServerInfo();
@@ -79,7 +73,7 @@ export const KeyForm = ({
         options={supportedKeystoreTypes}
       />
       {useFile && (
-        <FormGroup
+        <FileUploadControl
           label={t("importFile")}
           labelIcon={
             <HelpItem
@@ -87,28 +81,12 @@ export const KeyForm = ({
               fieldLabelId="importFile"
             />
           }
-          fieldId="importFile"
-        >
-          <Controller
-            name="file"
-            defaultValue=""
-            control={control}
-            render={({ field }) => (
-              <FileUpload
-                id="importFile"
-                type="text"
-                value={field.value}
-                hideDefaultPreview
-                filename={filename}
-                browseButtonText={t("browse")}
-                onDataChange={(_, value) => {
-                  field.onChange(value);
-                }}
-                onFileInputChange={(_, file) => setFilename(file.name)}
-              />
-            )}
-          />
-        </FormGroup>
+          rules={{
+            required: t("required"),
+          }}
+          name="file"
+          id="importFile"
+        />
       )}
       {format !== CERT_PEM && (
         <StoreSettings hidePassword={useFile} isSaml={isSaml} />

--- a/js/apps/admin-ui/src/clients/keys/ImportKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/ImportKeyDialog.tsx
@@ -1,17 +1,14 @@
-import { SelectControl } from "@keycloak/keycloak-ui-shared";
+import { SelectControl, FileUploadControl } from "@keycloak/keycloak-ui-shared";
 import {
   Button,
   ButtonVariant,
-  FileUpload,
   Form,
-  FormGroup,
   Modal,
   ModalVariant,
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import { useState } from "react";
-import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { StoreSettings } from "./StoreSettings";
@@ -25,7 +22,7 @@ export type ImportFile = {
   keystoreFormat: string;
   keyAlias: string;
   storePassword: string;
-  file: { value?: string; filename: string };
+  file: File | string;
 };
 
 export const ImportKeyDialog = ({
@@ -34,7 +31,6 @@ export const ImportKeyDialog = ({
 }: ImportKeyDialogProps) => {
   const { t } = useTranslation();
   const form = useForm<ImportFile>();
-  const [file, setFile] = useState<string>("");
   const { control, handleSubmit } = form;
 
   const baseFormats = useServerInfo().cryptoInfo?.supportedKeystoreTypes ?? [];
@@ -96,31 +92,15 @@ export const ImportKeyDialog = ({
             }}
             options={formats}
           />
+          <FileUploadControl
+            label={t("importFile")}
+            id="importFile"
+            name="file"
+            rules={{
+              required: t("required"),
+            }}
+          />
           {baseFormats.includes(format) && <StoreSettings hidePassword />}
-          <FormGroup label={t("importFile")} fieldId="importFile">
-            <Controller
-              name="file"
-              control={control}
-              defaultValue={{ value: "", filename: "" }}
-              render={({ field }) => (
-                <FileUpload
-                  id="importFile"
-                  value={field.value.value}
-                  filename={file}
-                  hideDefaultPreview
-                  type="text"
-                  onDataChange={(_, value) => {
-                    field.onChange({
-                      value,
-                    });
-                  }}
-                  onFileInputChange={(_, file) => {
-                    setFile(file.name);
-                  }}
-                />
-              )}
-            />
-          </FormGroup>
         </FormProvider>
       </Form>
     </Modal>

--- a/js/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -103,8 +103,7 @@ export const Keys = ({
         formData.append(key, value);
       }
 
-      formData.append("file", file.value!);
-
+      formData.append("file", file);
       await adminClient.clients.uploadCertificate(
         { id: clientId, attr },
         formData,

--- a/js/apps/admin-ui/src/clients/keys/SamlImportKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/SamlImportKeyDialog.tsx
@@ -23,7 +23,10 @@ export const SamlImportKeyDialog = ({
 
   const { t } = useTranslation();
   const form = useForm<SamlKeysDialogForm>();
-  const { handleSubmit } = form;
+  const {
+    handleSubmit,
+    formState: { isValid },
+  } = form;
 
   const { addAlert, addError } = useAlerts();
 
@@ -43,9 +46,9 @@ export const SamlImportKeyDialog = ({
       toggleDialog={onClose}
       continueButtonLabel="import"
       titleKey="importKey"
+      confirmButtonDisabled={!isValid}
       onConfirm={() => {
         handleSubmit(submit)();
-        onClose();
       }}
     >
       <FormProvider {...form}>

--- a/js/libs/ui-shared/src/controls/FileUploadControl.tsx
+++ b/js/libs/ui-shared/src/controls/FileUploadControl.tsx
@@ -1,0 +1,81 @@
+import {
+  FileUpload,
+  ValidatedOptions,
+  FileUploadProps,
+} from "@patternfly/react-core";
+import { ReactNode, useState } from "react";
+import {
+  FieldPath,
+  FieldValues,
+  PathValue,
+  UseControllerProps,
+  useController,
+} from "react-hook-form";
+import { getRuleValue } from "../utils/getRuleValue";
+import { FormLabel } from "./FormLabel";
+import { useTranslation } from "react-i18next";
+
+export type FileUploadControlProps<
+  T extends FieldValues,
+  P extends FieldPath<T> = FieldPath<T>,
+> = UseControllerProps<T, P> &
+  Omit<FileUploadProps, "name" | "isRequired" | "required"> & {
+    label: string;
+    labelIcon?: string | ReactNode;
+    isDisabled?: boolean;
+    "data-testid"?: string;
+    type?: string;
+  };
+
+export const FileUploadControl = <
+  T extends FieldValues,
+  P extends FieldPath<T> = FieldPath<T>,
+>(
+  props: FileUploadControlProps<T, P>,
+) => {
+  const { labelIcon, ...rest } = props;
+  const required = !!getRuleValue(props.rules?.required);
+  const defaultValue = props.defaultValue ?? ("" as PathValue<T, P>);
+
+  const { t } = useTranslation();
+
+  const [filename, setFilename] = useState<string>("");
+
+  const { field, fieldState } = useController({
+    ...props,
+    defaultValue,
+  });
+
+  return (
+    <FormLabel
+      name={props.name}
+      label={props.label}
+      labelIcon={labelIcon}
+      isRequired={required}
+      error={fieldState.error}
+    >
+      <FileUpload
+        isRequired={required}
+        data-testid={props["data-testid"] || props.name}
+        filename={filename}
+        browseButtonText={t("browse")}
+        validated={
+          fieldState.error ? ValidatedOptions.error : ValidatedOptions.default
+        }
+        hideDefaultPreview
+        isDisabled={props.isDisabled}
+        type="text"
+        onFileInputChange={(_, file) => {
+          field.onChange(file);
+          setFilename(file.name);
+        }}
+        onClearClick={() => {
+          field.onChange(null);
+          setFilename("");
+        }}
+        {...rest}
+        {...field}
+      />
+    </FormLabel>
+  );
+};

--- a/js/libs/ui-shared/src/main.ts
+++ b/js/libs/ui-shared/src/main.ts
@@ -43,6 +43,10 @@ export {
   KeycloakTextArea,
   type KeycloakTextAreaProps,
 } from "./controls/keycloak-text-area/KeycloakTextArea";
+export {
+  FileUploadControl,
+  type FileUploadControlProps,
+} from "./controls/FileUploadControl";
 export { IconMapper } from "./icons/IconMapper";
 export { FormPanel } from "./scroll-form/FormPanel";
 export { ScrollForm, mainPageContentId } from "./scroll-form/ScrollForm";

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
@@ -17,10 +17,12 @@
 
 package org.keycloak.services.resources.admin;
 
+import com.google.common.base.Strings;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotFoundException;
@@ -59,6 +61,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Set;
@@ -75,6 +78,8 @@ public class ClientAttributeCertificateResource {
     public static final String CERTIFICATE_PEM = "Certificate PEM";
     public static final String PUBLIC_KEY_PEM = "Public Key PEM";
     public static final String JSON_WEB_KEY_SET = "JSON Web Key Set";
+
+    private static final Logger logger = Logger.getLogger(ClientAttributeCertificateResource.class);
 
     protected final RealmModel realm;
     private final AdminPermissionEvaluator auth;
@@ -186,6 +191,18 @@ public class ClientAttributeCertificateResource {
         }
         String keystoreFormat = keystoreFormatPart.asString();
         FormPartValue inputParts = uploadForm.getFirst("file");
+
+        boolean fileEmpty = false;
+        try {
+            fileEmpty = inputParts == null || Strings.isNullOrEmpty(inputParts.asString());
+        } catch (Exception e) {
+            // ignore
+        }
+
+        if (fileEmpty) {
+            throw new BadRequestException("file cannot be empty");
+        }
+
         if (keystoreFormat.equals(CERTIFICATE_PEM)) {
             String pem = StreamUtil.readString(inputParts.asInputStream(), StandardCharsets.UTF_8);
             pem = PemUtils.removeBeginEnd(pem);
@@ -228,13 +245,18 @@ public class ClientAttributeCertificateResource {
             KeyStore keyStore = CryptoIntegration.getProvider().getKeyStore(KeystoreFormat.valueOf(keystoreFormat));
             keyStore.load(inputParts.asInputStream(), storePassword);
             try {
-                privateKey = (PrivateKey)keyStore.getKey(keyAlias, keyPassword);
+                privateKey = (PrivateKey) keyStore.getKey(keyAlias, keyPassword);
             } catch (Exception e) {
                 // ignore
             }
-            certificate = (X509Certificate)keyStore.getCertificate(keyAlias);
+            certificate = (X509Certificate) keyStore.getCertificate(keyAlias);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            logger.error("Error loading keystore", e);
+            if (e.getCause() instanceof UnrecoverableKeyException keyException) {
+                throw new BadRequestException(keyException.getMessage());
+            } else {
+                throw new BadRequestException("error loading keystore");
+            }
         }
 
         if (privateKey != null) {


### PR DESCRIPTION
Improves the file upload for certificates and key stores. Adds form validation and provides more detailed error messages.

Closes #38049
