### PR TITLE
Add warning and detailed message when DB system is not specified in start command

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
@@ -60,5 +60,8 @@ public final class Messages {
     public static String invalidLogCategoryFormat(String category) {
         return "Invalid log category format: " + category + ". The format is 'category:level' such as 'org.keycloak:debug'.";
     }
+    public static String invalidOrMissingPropertyDB(){
+      return "Try to set env 'KC_DB' or set flag --db to mention database system. default (h2) is not allowed in production.";
+    }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.quarkus.runtime.cli.command;
 
+import static org.keycloak.config.DatabaseOptions.DB;
 import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import org.keycloak.quarkus.runtime.Environment;
@@ -24,6 +25,7 @@ import org.keycloak.quarkus.runtime.Messages;
 import org.keycloak.common.profile.ProfileException;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 import picocli.CommandLine;
@@ -55,6 +57,10 @@ public final class Start extends AbstractStartCommand implements Runnable {
         Environment.updateProfile(true);
         if (Environment.isDevProfile()) {
             throw new PropertyException(Messages.devProfileNotAllowedError(NAME));
+        }
+        if (Configuration.getConfigValue(DB).getConfigSourceOrdinal() == 0) {
+          picocli.warn("Usage of the default value for the db option in the production profile is deprecated. Please explicitly set the db instead.");
+          throw new PropertyException(Messages.invalidOrMissingPropertyDB());
         }
     }
 


### PR DESCRIPTION
This PR addresses [#14811](https://github.com/keycloak/keycloak/issues/14811) 

Introduces a clear **warning and explanatory message** when the database system `--db` is not specified in the `kc.sh start` command or `KC_DB` is not set.

#### What’s Changed
- Added a check for the presence of the `--db` parameter during server startup.
- If missing, a warning is logged with a detailed message explaining that the DB system must be explicitly specified.
- Prevents unexpected failures and makes it easier for users to identify and resolve the issue quickly.
`WARNING: Usage of the default value for the db option in the production profile is deprecated. Please explicitly set the db instead.
Try to set env 'KC_DB' or set flag --db to mention database system. default (h2) is not allowed in production.
`
#### Need
Previously, users might encounter confusing startup errors when they forget to specify the DB. This change improves usability by providing a meaningful error message upfront, reducing time spent debugging.

<details>
<summary>Click to expand current stack trace</summary>

```text
2025-04-07 21:29:37,597 WARN  [io.agroal.pool] (agroal-11) Datasource '<default>': Access denied for user 'sa'@'localhost' (using password: YES)
2025-04-07 21:29:37,600 WARN  [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] (JPA Startup Thread) SQL Error: 1045, SQLState: 28000
2025-04-07 21:29:37,601 ERROR [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] (JPA Startup Thread) Access denied for user 'sa'@'localhost' (using password: YES)
2025-04-07 21:29:37,604 WARN  [org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator] (JPA Startup Thread) HHH000342: Could not obtain connection to query metadata: org.hibernate.exception.GenericJDBCException: unable to obtain isolated JDBC connection [Access denied for user 'sa'@'localhost' (using password: YES)] [n/a]
        at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:63)
        at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108)
        at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:94)
</details>

