### PR TITLE
Migrate old recaptcha secret name when used (26.1)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
@@ -47,6 +47,7 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     // option keys
     public static final String SECRET_KEY = "secret.key";
+    public static final String OLD_SECRET = "secret";
 
     @Override
     public String getDisplayType() {
@@ -68,7 +69,8 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     @Override
     protected boolean validateConfig(Map<String, String> config) {
-        return !(StringUtil.isNullOrEmpty(config.get(SITE_KEY)) || StringUtil.isNullOrEmpty(config.get(SECRET_KEY)));
+        return !StringUtil.isNullOrEmpty(config.get(SITE_KEY)) &&
+                (!StringUtil.isNullOrEmpty(config.get(SECRET_KEY)) || !StringUtil.isNullOrEmpty(config.get(OLD_SECRET)));
     }
 
     @Override
@@ -78,7 +80,16 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
         HttpPost post = new HttpPost("https://www." + getRecaptchaDomain(config) + "/recaptcha/api/siteverify");
         List<NameValuePair> formparams = new LinkedList<>();
-        formparams.add(new BasicNameValuePair("secret", config.get(SECRET_KEY)));
+        String secret = config.get(SECRET_KEY);
+        if (StringUtil.isNullOrEmpty(secret)) {
+            // migrate old config name to the new one
+            secret = config.get(OLD_SECRET);
+            if (!StringUtil.isNullOrEmpty(secret)) {
+                config.put(SECRET_KEY, secret);
+                config.remove(OLD_SECRET);
+            }
+        }
+        formparams.add(new BasicNameValuePair("secret", secret));
         formparams.add(new BasicNameValuePair("response", captcha));
         if (context.getConnection().getRemoteAddr() != null) {
             formparams.add(new BasicNameValuePair("remoteip", context.getConnection().getRemoteAddr()));


### PR DESCRIPTION
Closes #38607

The option for the secret was changed from `secret` to `secret.key`, so previous configurations are invalid now. The PR just fixes the issue at the recaptcha authenticator level. The new option is got and, if it does not exist, the old one is tried and migrated. I prefer this than adding a migration task that checks any possible recaptcha usage. The other option is doing migration task only for the active register workflow. There are no tests for recaptcha, so I tested manually and it works OK. The recaptcha works and the option is renamed to the new one at first recaptcha usage. Let me know if you prefer rhe migration task. 
