### PR TITLE
Add schema name for update query on Oracle

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
@@ -27,6 +27,7 @@
 
     <changeSet author="hmlnarik@redhat.com" id="2.5.0-unicode-oracle">
         <validCheckSum>7:e4c7e8f2256210aee71ddc42f538b57a</validCheckSum>
+        <validCheckSum>9:3a32bace77c84d7678d035a7f5a8084e</validCheckSum>
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <dbms type="oracle" />
         </preConditions>
@@ -52,7 +53,7 @@
         <addColumn tableName="COMPONENT_CONFIG">
             <column name="VALUE_NEW" type="NCLOB" />
         </addColumn>
-        <sql>UPDATE COMPONENT_CONFIG SET VALUE_NEW = VALUE, VALUE = NULL</sql>
+        <sql>UPDATE ${database.defaultSchemaName}.COMPONENT_CONFIG SET VALUE_NEW = VALUE, VALUE = NULL</sql>
         <dropColumn tableName="COMPONENT_CONFIG" columnName="VALUE"/>
         <renameColumn tableName="COMPONENT_CONFIG" oldColumnName="VALUE_NEW" newColumnName="VALUE" columnDataType="NCLOB"/>
 <!--


### PR DESCRIPTION
- Fixes issue with changeset 2.5.0-unicode-oracle

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>

Closes #35833

(cherry picked from commit 33283de8edeb286be5a21acf9b62d7081aa67905)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
