### PR TITLE
[26.1] OTelHttpClientFactory not configured properly when tracing enabled

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelHttpClientFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelHttpClientFactory.java
@@ -60,7 +60,7 @@ public class OTelHttpClientFactory extends DefaultHttpClientFactory implements E
 
     @Override
     public void init(Config.Scope config) {
-        super.init(config.scope("connectionsHttpClient", "default"));
+        super.init(Config.scope("connectionsHttpClient", "default"));
     }
 
     @Override


### PR DESCRIPTION
Closes #38740

Excluded the test case as seen in the PR to the main: https://github.com/keycloak/keycloak/pull/38749

The test case was added to the new testsuite, and for 26.1, the testsuite does not support the required functionality. 

Changes are quite straightforward and probably do not worth the effort to achieve it somehow in the old testsuite. 

@ahus1 Is it ok with you? 