### PR TITLE
Migrate old recaptcha secret name when used (26.1)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
@@ -47,6 +47,7 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     // option keys
     public static final String SECRET_KEY = "secret.key";
+    public static final String OLD_SECRET = "secret";
 
     @Override
     public String getDisplayType() {
@@ -68,7 +69,8 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     @Override
     protected boolean validateConfig(Map<String, String> config) {
-        return !(StringUtil.isNullOrEmpty(config.get(SITE_KEY)) || StringUtil.isNullOrEmpty(config.get(SECRET_KEY)));
+        return !StringUtil.isNullOrEmpty(config.get(SITE_KEY)) &&
+                (!StringUtil.isNullOrEmpty(config.get(SECRET_KEY)) || !StringUtil.isNullOrEmpty(config.get(OLD_SECRET)));
     }
 
     @Override
@@ -78,7 +80,16 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
         HttpPost post = new HttpPost("https://www." + getRecaptchaDomain(config) + "/recaptcha/api/siteverify");
         List<NameValuePair> formparams = new LinkedList<>();
-        formparams.add(new BasicNameValuePair("secret", config.get(SECRET_KEY)));
+        String secret = config.get(SECRET_KEY);
+        if (StringUtil.isNullOrEmpty(secret)) {
+            // migrate old config name to the new one
+            secret = config.get(OLD_SECRET);
+            if (!StringUtil.isNullOrEmpty(secret)) {
+                config.put(SECRET_KEY, secret);
+                config.remove(OLD_SECRET);
+            }
+        }
+        formparams.add(new BasicNameValuePair("secret", secret));
         formparams.add(new BasicNameValuePair("response", captcha));
         formparams.add(new BasicNameValuePair("remoteip", context.getConnection().getRemoteAddr()));
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/ResetOtpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/ResetOtpPage.java
@@ -24,7 +24,7 @@ public class ResetOtpPage extends AbstractPage {
     }
 
     public void selectOtp(int index) {
-        driver.findElement(By.id("kc-otp-credential-" + index)).click();
+        UIUtils.switchCheckbox(driver.findElement(By.id("kc-otp-credential-" + index)), true);
     }
 
     public void submitOtpReset() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -340,7 +340,7 @@ public class OAuthClient {
         WaitUtils.waitForPageToLoad();
         WebElement linkAccountButton = driver.findElement(By.id("linkAccount"));
         waitUntilElement(linkAccountButton).is().clickable();
-        linkAccountButton.click();
+        UIUtils.clickLink(linkAccountButton);
 
         WaitUtils.waitForPageToLoad();
         fillLoginForm(username, password, false);
@@ -385,10 +385,10 @@ public class OAuthClient {
         passwordField.sendKeys(password);
 
         if (rememberMe) {
-            driver.findElement(By.id("rememberMe")).click();
+            UIUtils.switchCheckbox(driver.findElement(By.id("rememberMe")), true);
         }
 
-        driver.findElement(By.name("login")).click();
+        UIUtils.clickLink(driver.findElement(By.name("login")));
 
     }
 
@@ -412,7 +412,7 @@ public class OAuthClient {
 
         WebElement submitButton = driver.findElement(By.cssSelector("input[type=\"submit\"]"));
         waitUntilElement(submitButton).is().clickable();
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
 
     public void doLoginGrant(String username, String password) {


### PR DESCRIPTION
Closes #38607

PR:             https://github.com/keycloak/keycloak/pull/38731
Commit:         https://github.com/keycloak/keycloak/commit/ba91a092ab6a8266a89be254405d3a6d64dcce85
PR branch:      backport-38607-26.1
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.1

I needed to add some more `clickLink` issues in 26.1 to pass the CI (part of the ones I added already to 26.0, other changes were already done).

