### PR TITLE
Improve Organization endpoints with String body

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationIdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationIdentityProvidersResource.java
@@ -75,7 +75,8 @@ public class OrganizationIdentityProvidersResource {
     @Operation(summary = "Adds the identity provider with the specified id to the organization",
         description = "Adds, or associates, an existing identity provider with the organization. If no identity provider is found, " +
                 "or if it is already associated with the organization, an error response is returned")
-    @RequestBody(description = "Payload should contain only id or alias of the identity provider to be associated with the organization (id or alias without quotes).", required = true)
+    @RequestBody(description = "Payload should contain only id or alias of the identity provider to be associated with the organization " + 
+                "(id or alias with or without quotes). Surrounding whitespace characters will be trimmed.", required = true)
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -83,7 +84,7 @@ public class OrganizationIdentityProvidersResource {
         @APIResponse(responseCode = "409", description = "Conflict")
     })
     public Response addIdentityProvider(String id) {
-        id = id.replaceAll("^\"|\"$", ""); // fixes https://github.com/keycloak/keycloak/issues/34401
+        id = id.trim().replaceAll("^\"|\"$", ""); // fixes https://github.com/keycloak/keycloak/issues/34401
         
         try {
             IdentityProviderModel identityProvider = session.identityProviders().getByIdOrAlias(id);

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -88,14 +88,15 @@ public class OrganizationMemberResource {
     @Operation(summary = "Adds the user with the specified id as a member of the organization", description = "Adds, or associates, " +
             "an existing user with the organization. If no user is found, or if it is already associated with the organization, " +
             "an error response is returned")
-    @RequestBody(description = "Payload should contain only id of the user to be added to the organization (UUID without quotes).", required = true)
+    @RequestBody(description = "Payload should contain only id of the user to be added to the organization (UUID with or without quotes). " +
+            "Surrounding whitespace characters will be trimmed.", required = true)
     @APIResponses(value = {
         @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
         @APIResponse(responseCode = "409", description = "Conflict")
     })
     public Response addMember(String id) {
-        id = id.replaceAll("^\"|\"$", ""); // fixes https://github.com/keycloak/keycloak/issues/34401
+        id = id.trim().replaceAll("^\"|\"$", ""); // fixes https://github.com/keycloak/keycloak/issues/34401
         
         UserModel user = session.users().getUserById(realm, id);
 


### PR DESCRIPTION
- Added trim() call to get rid of surrounding white space characters for organization POST endpoints that expect a String body instead of an actual object

Closes #38760
