### PR TITLE
Migrate old recaptcha secret name when used Closes (26.0)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
@@ -46,6 +46,7 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     // option keys
     public static final String SECRET_KEY = "secret.key";
+    public static final String OLD_SECRET = "secret";
 
     @Override
     public String getDisplayType() {
@@ -67,7 +68,8 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
     @Override
     protected boolean validateConfig(Map<String, String> config) {
-        return !(StringUtil.isNullOrEmpty(config.get(SITE_KEY)) || StringUtil.isNullOrEmpty(config.get(SECRET_KEY)));
+        return !StringUtil.isNullOrEmpty(config.get(SITE_KEY)) &&
+                (!StringUtil.isNullOrEmpty(config.get(SECRET_KEY)) || !StringUtil.isNullOrEmpty(config.get(OLD_SECRET)));
     }
 
     @Override
@@ -77,7 +79,16 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
 
         HttpPost post = new HttpPost("https://www." + getRecaptchaDomain(config) + "/recaptcha/api/siteverify");
         List<NameValuePair> formparams = new LinkedList<>();
-        formparams.add(new BasicNameValuePair("secret", config.get(SECRET_KEY)));
+        String secret = config.get(SECRET_KEY);
+        if (StringUtil.isNullOrEmpty(secret)) {
+            // migrate old config name to the new one
+            secret = config.get(OLD_SECRET);
+            if (!StringUtil.isNullOrEmpty(secret)) {
+                config.put(SECRET_KEY, secret);
+                config.remove(OLD_SECRET);
+            }
+        }
+        formparams.add(new BasicNameValuePair("secret", secret));
         formparams.add(new BasicNameValuePair("response", captcha));
         formparams.add(new BasicNameValuePair("remoteip", context.getConnection().getRemoteAddr()));
 


### PR DESCRIPTION
Closes #38607

PR:             https://github.com/keycloak/keycloak/pull/38731
Commit:         https://github.com/keycloak/keycloak/commit/ba91a092ab6a8266a89be254405d3a6d64dcce85
PR branch:      backport-38731-26.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.0

