### PR TITLE
Added "secure-redirect-uris-enforcer" executor to FAPI 1.0 client pro…

### DIFF
--- a/services/src/main/resources/keycloak-default-client-profiles.json
+++ b/services/src/main/resources/keycloak-default-client-profiles.json
@@ -30,6 +30,18 @@
           "configuration": {}
         },
         {
+          "executor": "secure-redirect-uris-enforcer",
+          "configuration": {
+            "allow-ipv4-loopback-address": false,
+            "allow-ipv6-loopback-address": false,
+            "allow-private-use-uri-scheme": false,
+            "allow-http-scheme": false,
+            "allow-wildcard-context-path": false,
+            "oauth-2-1-compliant": false,
+            "allow-open-redirect": false
+          }
+        },
+        {
           "executor": "consent-required",
           "configuration": {
             "auto-configure": true
@@ -68,6 +80,18 @@
         {
           "executor": "secure-client-uris",
           "configuration": {}
+        },
+        {
+          "executor": "secure-redirect-uris-enforcer",
+          "configuration": {
+            "allow-ipv4-loopback-address": false,
+            "allow-ipv6-loopback-address": false,
+            "allow-private-use-uri-scheme": false,
+            "allow-http-scheme": false,
+            "allow-wildcard-context-path": false,
+            "oauth-2-1-compliant": false,
+            "allow-open-redirect": false
+          }
         },
         {
           "executor": "secure-request-object",


### PR DESCRIPTION
This is an updated and (hopefully) fixed version of #30398 
It adds the executor `secure-redirect-uris-enforcer` to these two FAPI 1 client profiles:

- `fapi-1-baseline`
- `fapi-1-advanced`

My old PR (#30398) was missing the configuration for the executor.


I was not able to run the FAPI conformance tests because I did not manage to make the conformance test suite to run and use my locally built Keycloak.
(FWIW even with an unchanged config (thus using an official keycloak build) the conformance test suite did not successfully run all tests on my system.)

I am hoping someone with a working conformance test suite can run it with this PR.

fixes #29341 