### PR TITLE
Fix authentication flow conditional step negate output logic

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalRoleAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalRoleAuthenticator.java
@@ -27,7 +27,7 @@ public class ConditionalRoleAuthenticator implements ConditionalAuthenticator {
                 return false;
             }
 
-            return negateOutput != user.hasRole(role);
+            return negateOutput ? !user.hasRole(role) : user.hasRole(role);
         }
         return false;
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
@@ -52,7 +52,7 @@ public class ConditionalUserAttributeValue implements ConditionalAuthenticator {
         if (!result && includeGroupAttributes) {
             result = KeycloakModelUtils.resolveAttribute(user, attributeName, true).stream().anyMatch(attr -> regexOutput ? Pattern.compile(attributeValue).matcher(attr).matches() : Objects.equals(attr, attributeValue));
         }
-        return negateOutput != result;
+        return negateOutput ? !result : result;
     }
 
     @Override


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

### Related issue
- #38385 

### Changes
- b5743732402a266464a322371c92bb765ee27259
- f032062f6b8b03d7c2b04de3bd3475cd54a4d76e

### Description
Improve negation logic based on negateOutput param for `Condition - user role config` and `Condition - user attribute` using ternary operator. 