### PR TITLE
[Backport 26.1] Allow zero tracing-sampler-ratio

### DIFF
--- a/docs/guides/observability/tracing.adoc
+++ b/docs/guides/observability/tracing.adoc
@@ -140,10 +140,12 @@ The default sampler for {project_name} is `traceidratio`, which controls the rat
 
 ==== Trace ratio
 The default trace ratio is `1.0`, which means all traces are sampled - sent to the collector.
-The ratio is a floating number in the range `(0,1]`.
+The ratio is a floating number in the range `[0,1]`.
 For instance, when the ratio is `0.1`, only 10% of the traces are sampled.
 
 WARNING: For a production-ready environment, the trace ratio should be a smaller number to prevent the massive cost of trace store infrastructure and avoid performance overhead.
+
+TIP: The ratio can be set to `0.0` to disable sampling entirely _at runtime_.
 
 ==== Rationale
 

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TracingSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TracingSpec.java
@@ -45,7 +45,7 @@ public class TracingSpec {
     @JsonPropertyDescription("OpenTelemetry sampler to use for tracing (default 'traceidratio'). For more information, check the Tracing guide.")
     private String samplerType;
 
-    @JsonPropertyDescription("OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected double value in interval <0,1).")
+    @JsonPropertyDescription("OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected double value in interval [0,1].")
     private Double samplerRatio;
 
     @JsonPropertyDescription("OpenTelemetry compression method used to compress payloads. If unset, compression is disabled. Possible values are: gzip, none.")

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TracingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TracingOptions.java
@@ -71,7 +71,7 @@ public class TracingOptions {
 
     public static final Option<Double> TRACING_SAMPLER_RATIO = new OptionBuilder<>("tracing-sampler-ratio", Double.class)
             .category(OptionCategory.TRACING)
-            .description("OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected double value in interval <0,1).")
+            .description("OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected double value in interval [0,1].")
             .defaultValue(1.0d)
             .build();
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
@@ -18,7 +18,6 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import org.keycloak.common.Profile;
-import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.utils.StringUtil;
@@ -113,11 +112,12 @@ public class TracingPropertyMappers {
 
         try {
             var ratio = Double.parseDouble(value);
-            if (ratio <= 0.0 || ratio > 1.0) {
+            // note: 0.0 is a legal value, see https://quarkus.io/guides/opentelemetry-tracing#sampler
+            if (ratio < 0.0 || ratio > 1.0) {
                 throw new NumberFormatException();
             }
         } catch (NumberFormatException e) {
-            throw new PropertyException("Ratio in 'tracing-sampler-ratio' option must be a double value in interval <0,1).");
+            throw new PropertyException("Ratio in 'tracing-sampler-ratio' option must be a double value in interval [0,1].");
         }
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TracingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TracingDistTest.java
@@ -40,6 +40,10 @@ public class TracingDistTest {
     private void assertTracingDisabled(CLIResult result) {
         result.assertMessage("opentelemetry");
         result.assertNoMessage("service.name=\"keycloak\"");
+        assertSamplingDisabled(result);
+    }
+
+    private void assertSamplingDisabled(CLIResult result) {
         result.assertNoMessage("Failed to export spans.");
         result.assertNoMessage("Connection refused: localhost/127.0.0.1:4317");
     }
@@ -102,6 +106,16 @@ public class TracingDistTest {
     }
 
     @Test
+    @Launch({"start", "--hostname-strict=false", "--http-enabled=true", "--optimized", "--tracing-sampler-ratio=0.0", "--log-level=io.opentelemetry:fine"})
+    void samplingDisabledViaRatioZero(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+
+        cliResult.assertStarted();
+        assertTracingEnabled(cliResult);
+        assertSamplingDisabled(cliResult);
+    }
+
+    @Test
     @Launch({"start", "--hostname-strict=false", "--http-enabled=true", "--optimized", "--tracing-endpoint=http://endpoint:8888", "--log-level=io.opentelemetry:fine"})
     void differentEndpoint(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -143,11 +157,11 @@ public class TracingDistTest {
     }
 
     @Test
-    @Launch({"start", "--hostname-strict=false", "--http-enabled=true", "--optimized", "--tracing-sampler-ratio=0.0"})
+    @Launch({"start", "--hostname-strict=false", "--http-enabled=true", "--optimized", "--tracing-sampler-ratio=1.1"})
     void wrongSamplerRatio(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
 
-        cliResult.assertError("Ratio in 'tracing-sampler-ratio' option must be a double value in interval <0,1).");
+        cliResult.assertError("Ratio in 'tracing-sampler-ratio' option must be a double value in interval [0,1].");
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -234,7 +234,7 @@ Tracing:
                        is enabled.
 --tracing-sampler-ratio <ratio>
                      OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected
-                       double value in interval <0,1). Default: 1.0. Available only when Tracing is
+                       double value in interval [0,1]. Default: 1.0. Available only when Tracing is
                        enabled.
 --tracing-sampler-type <type>
                      OpenTelemetry sampler to use for tracing. Possible values are: always_on,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -234,7 +234,7 @@ Tracing:
                        is enabled.
 --tracing-sampler-ratio <ratio>
                      OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected
-                       double value in interval <0,1). Default: 1.0. Available only when Tracing is
+                       double value in interval [0,1]. Default: 1.0. Available only when Tracing is
                        enabled.
 --tracing-sampler-type <type>
                      OpenTelemetry sampler to use for tracing. Possible values are: always_on,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -435,7 +435,7 @@ Tracing:
                        is enabled.
 --tracing-sampler-ratio <ratio>
                      OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected
-                       double value in interval <0,1). Default: 1.0. Available only when Tracing is
+                       double value in interval [0,1]. Default: 1.0. Available only when Tracing is
                        enabled.
 --tracing-sampler-type <type>
                      OpenTelemetry sampler to use for tracing. Possible values are: always_on,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -436,7 +436,7 @@ Tracing:
                        is enabled.
 --tracing-sampler-ratio <ratio>
                      OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected
-                       double value in interval <0,1). Default: 1.0. Available only when Tracing is
+                       double value in interval [0,1]. Default: 1.0. Available only when Tracing is
                        enabled.
 --tracing-sampler-type <type>
                      OpenTelemetry sampler to use for tracing. Possible values are: always_on,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -379,7 +379,7 @@ Tracing:
                        is enabled.
 --tracing-sampler-ratio <ratio>
                      OpenTelemetry sampler ratio. Probability that a span will be sampled. Expected
-                       double value in interval <0,1). Default: 1.0. Available only when Tracing is
+                       double value in interval [0,1]. Default: 1.0. Available only when Tracing is
                        enabled.
 --tracing-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in


### PR DESCRIPTION
Closes #38764

See also: #38776

I'm not sure I'll be able to update to 26.2.0 right away, so I created this backport.

/cc @mabartos