### PR TITLE
add option to the nginx x509 client cert lookup provider to not url-decode the passed client cert

### DIFF
--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -223,7 +223,7 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 | Enable trusting NGINX proxy certificate verification, instead of forwarding the certificate to {project_name} and verifying it in {project_name}.
 
 |cert-is-url-encoded
-| Whether the forwarded certificate is url-encoded or not. In NGINX, this corresponds to the `$ssl_client_cert` and `$ssl_client_escaped_cert` variables.
+| Whether the forwarded certificate is url-encoded or not. In NGINX, this corresponds to the `$ssl_client_cert` and `$ssl_client_escaped_cert` variables. This can also be used for the Traefik PassTlsClientCert middleware, as it sends the client certficate unencoded.
 |===
 
 === Configuring the NGINX provider

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -221,6 +221,9 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 
 |trust-proxy-verification
 | Enable trusting NGINX proxy certificate verification, instead of forwarding the certificate to {project_name} and verifying it in {project_name}.
+
+|cert-is-url-encoded
+| Whether the forwarded certificate is url-encoded or not. In NGINX, this corresponds to the `$ssl_client_cert` and `$ssl_client_escaped_cert` variables.
 |===
 
 === Configuring the NGINX provider

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookup.java
@@ -58,6 +58,7 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
     private static final Logger log = Logger.getLogger(NginxProxySslClientCertificateLookup.class);
 
     private final boolean isTruststoreLoaded;
+    private final boolean certIsUrlEncoded;
     private final Set<X509Certificate> trustedRootCerts;
     private final Set<X509Certificate> intermediateCerts;
 
@@ -67,7 +68,8 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
                                                 int certificateChainLength,
                                                 Set<X509Certificate> intermediateCerts,
                                                 Set<X509Certificate> trustedRootCerts,
-                                                boolean isTruststoreLoaded
+                                                boolean isTruststoreLoaded,
+                                                boolean certIsUrlEncoded
                                                 ) {
         super(sslClientCertHttpHeader, sslCertChainHttpHeaderPrefix, certificateChainLength);
 
@@ -76,6 +78,7 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
       this.intermediateCerts = intermediateCerts;
       this.trustedRootCerts = trustedRootCerts;
       this.isTruststoreLoaded = isTruststoreLoaded;
+      this.certIsUrlEncoded = certIsUrlEncoded;
 
         if (!this.isTruststoreLoaded) {
             log.warn("Keycloak Truststore is null or empty, but it's required for NGINX x509cert-lookup provider");
@@ -107,7 +110,9 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
             log.warn("End user TLS Certificate is NULL! ");
             return null;
         }
-        pem = java.net.URLDecoder.decode(pem, StandardCharsets.UTF_8);
+        if (certIsUrlEncoded) {
+            pem = java.net.URLDecoder.decode(pem, StandardCharsets.UTF_8);
+        }
 
         if (pem.startsWith(PemUtils.BEGIN_CERT)) {
             pem = removeBeginEnd(pem);

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookupFactory.java
@@ -29,7 +29,11 @@ public class NginxProxySslClientCertificateLookupFactory extends AbstractClientC
 
     protected static final String TRUST_PROXY_VERIFICATION = "trust-proxy-verification";
 
+    protected static final String CERT_IS_URL_ENCODED = "cert-is-url-encoded";
+
     protected boolean trustProxyVerification;
+
+    protected boolean certIsUrlEncoded;
 
     private volatile boolean isTruststoreLoaded;
 
@@ -42,6 +46,8 @@ public class NginxProxySslClientCertificateLookupFactory extends AbstractClientC
         super.init(config);
         this.trustProxyVerification = config.getBoolean(TRUST_PROXY_VERIFICATION, false);
         logger.tracev("{0}: ''{1}''", TRUST_PROXY_VERIFICATION, trustProxyVerification);
+        this.certIsUrlEncoded = config.getBoolean(CERT_IS_URL_ENCODED, true);
+        logger.tracev("{0}: ''{1}''", CERT_IS_URL_ENCODED, certIsUrlEncoded);
         this.isTruststoreLoaded = false;
         this.trustedRootCerts = ConcurrentHashMap.newKeySet();
         this.intermediateCerts = ConcurrentHashMap.newKeySet();
@@ -53,10 +59,10 @@ public class NginxProxySslClientCertificateLookupFactory extends AbstractClientC
         loadKeycloakTrustStore(session);
         if (trustProxyVerification) {
             return new NginxProxyTrustedClientCertificateLookup(sslClientCertHttpHeader,
-                    sslChainHttpHeaderPrefix, certificateChainLength);
+                    sslChainHttpHeaderPrefix, certificateChainLength, certIsUrlEncoded);
         } else {
             return new NginxProxySslClientCertificateLookup(sslClientCertHttpHeader,
-                    sslChainHttpHeaderPrefix, certificateChainLength, intermediateCerts, trustedRootCerts, isTruststoreLoaded);
+                    sslChainHttpHeaderPrefix, certificateChainLength, intermediateCerts, trustedRootCerts, isTruststoreLoaded, certIsUrlEncoded);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxyTrustedClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxyTrustedClientCertificateLookup.java
@@ -39,10 +39,15 @@ public class NginxProxyTrustedClientCertificateLookup extends AbstractClientCert
 
     private static final Logger log = Logger.getLogger(NginxProxyTrustedClientCertificateLookup.class);
 
+    private final boolean certIsUrlEncoded;
+
     public NginxProxyTrustedClientCertificateLookup(String sslCientCertHttpHeader,
                                                 String sslCertChainHttpHeaderPrefix,
-                                                int certificateChainLength) {
+                                                int certificateChainLength,
+                                                boolean certIsUrlEncoded) {
         super(sslCientCertHttpHeader, sslCertChainHttpHeaderPrefix, certificateChainLength);
+
+        this.certIsUrlEncoded = certIsUrlEncoded;
     }
 
     @Override
@@ -67,7 +72,9 @@ public class NginxProxyTrustedClientCertificateLookup extends AbstractClientCert
             log.warn("End user TLS Certificate is NULL! ");
             return null;
         }
-        pem = java.net.URLDecoder.decode(pem, StandardCharsets.UTF_8);
+        if (certIsUrlEncoded) {
+            pem = java.net.URLDecoder.decode(pem, StandardCharsets.UTF_8);
+        }
 
 
         return PemUtils.decodeCertificate(pem);


### PR DESCRIPTION
this fixes #17171 by making the nginx x509 client certificate lookup provider configurable enough to work with a træfik proxy. see also https://github.com/traefik/traefik/issues/9669 for the corresponding issue in træfik. the new option `cert-is-url-encoded` defaults to `true`, thus keeping the default behavior unchanged.

another option considered for implementation was adding a completely new lookup provider for træfik instead of reusing the nginx provider, but given that such a new lookup provider would share basically all of the code with the nginx provider, it's probably easier to add a new option there instead.

Closes #17171

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
