### PR TITLE
Add chrome install action in GHA to force a specific version of chrome

### DIFF
--- a/.github/actions/install-chrome/action.yml
+++ b/.github/actions/install-chrome/action.yml
@@ -1,0 +1,30 @@
+name: Install Chrome browser and driver for Testing
+description: Download and install the compatible Chrome and Chromedriver
+
+inputs:
+  version:
+    description: The version of Chrome and Chromedriver to install.
+    required: false
+    default: 134.0.6998.165 # Ensures compatibility with the testsuite
+
+runs:
+  using: composite
+  steps:
+
+    # Cannot use Chrome for Testing. Acts weirdly and would probably require some changes in the testsuite.
+    - id: install-chrome
+      name: Install Chrome
+      shell: bash
+      run: |
+        sudo apt-get remove google-chrome-stable
+        wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{ inputs.version }}-1_amd64.deb -O /tmp/google-chrome-stable.deb --no-verbose
+        sudo apt-get install -y /tmp/google-chrome-stable.deb
+
+    - id: install-chromedriver
+      name: Install Chromedriver
+      shell: bash
+      run: |
+        wget https://storage.googleapis.com/chrome-for-testing-public/${{ inputs.version }}/linux64/chromedriver-linux64.zip -O /tmp/chromedriver.zip --no-verbose
+        unzip -j /tmp/chromedriver.zip -d /tmp
+        sudo mv -f /tmp/chromedriver $CHROMEWEBDRIVER/chromedriver
+        sudo chmod +x $CHROMEWEBDRIVER/chromedriver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
 
+      - uses: ./.github/actions/install-chrome
+
       - name: Run base tests
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/base-suite.sh ${{ matrix.group }}`
@@ -159,6 +161,8 @@ jobs:
 
       - name: Build app servers
         run: ./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
+
+      - uses: ./.github/actions/install-chrome
 
       - name: Run adapter tests
         run: |
@@ -911,6 +915,9 @@ jobs:
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
 
+      - uses: ./.github/actions/install-chrome
+        if: matrix.browser == 'chrome'
+
       - name: Run Forms IT
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh forms`
@@ -952,6 +959,9 @@ jobs:
       - id: integration-test-setup
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
+
+      - uses: ./.github/actions/install-chrome
+        if: matrix.browser == 'chrome'
 
       - name: Run WebAuthn IT
         run: |


### PR DESCRIPTION
Closes #38817

Just adding a fixed version of chrome using an action. For now it is fixed for the previous chrome 134. We will need to add a if/else in the scripts to not do anything and that way maintain default chrome installed in the ubuntu box. But we will do this when the fixes for 135 are in place and CI is stable again.