### PR TITLE
When user click 'Cancel' during AIA, the success event is sent

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -1171,10 +1171,12 @@ public class LoginActionsService {
 
         Response response;
 
+        boolean cancelled = false;
         if (isCancelAppInitiatedAction(factory.getId(), authSession, context)) {
             provider.initiatedActionCanceled(session, authSession);
             AuthenticationManager.setKcActionStatus(factory.getId(), RequiredActionContext.KcActionStatus.CANCELLED, authSession);
             context.success();
+            cancelled = true;
         } else {
             provider.processAction(context);
         }
@@ -1184,7 +1186,11 @@ public class LoginActionsService {
         }
 
         if (context.getStatus() == RequiredActionContext.Status.SUCCESS) {
-            event.clone().success();
+            if (cancelled) {
+                event.clone().error(Errors.REJECTED_BY_USER);
+            } else {
+                event.clone().success();
+            }
             initLoginEvent(authSession);
             event.event(EventType.LOGIN);
             authSession.removeRequiredAction(factory.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.cookie.CookieType;
 import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.events.email.EmailEventListenerProviderFactory;
 import org.keycloak.models.RealmModel;
@@ -238,6 +239,12 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
         changePasswordPage.cancel();
 
         assertKcActionStatus(CANCELLED);
+
+        events.expect(EventType.CUSTOM_REQUIRED_ACTION_ERROR)
+                .detail(Details.CUSTOM_REQUIRED_ACTION, UserModel.RequiredAction.UPDATE_PASSWORD.name())
+                .error(Errors.REJECTED_BY_USER)
+                .assertEvent();
+        events.expectLogin().assertEvent();
     }
 
     @Test


### PR DESCRIPTION
closes #38841

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
