### PR TITLE
fix: preventing statefulset infinite reconciliation loop

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -518,7 +518,7 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
         }
 
         envVars.add(new EnvVarBuilder().withName(POD_IP).withNewValueFrom().withNewFieldRef()
-                .withFieldPath("status.podIP").endFieldRef().endValueFrom().build());
+                .withFieldPath("status.podIP").withApiVersion("v1").endFieldRef().endValueFrom().build());
 
         return envVars;
     }


### PR DESCRIPTION
closes: #38846

It should be possible to tack on a test for this by checking a statefulset informer for events for a period of time after a test has become stable. But I was also thinking it might be worth using that time towards finally addressing this upstream.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
