### PR TITLE
fix: excluding update commands from reaug

### DIFF
--- a/docs/guides/server/bootstrap-admin-recovery.adoc
+++ b/docs/guides/server/bootstrap-admin-recovery.adoc
@@ -31,7 +31,7 @@ Additionally, it is strongly recommended to use the dedicated command with the s
 If you have built an optimized version of {project_name} with the `build` command as outlined in <@links.server id="configuration"/>, use the command line option `--optimized` to have {project_name} skip the build check for a faster startup time.
 When doing this, remove the build time options from the command line and keep only the runtime options.
 
-NOTE: if you do not use `--optimized` keep in mind that an `bootstrap-admin` command will implicitly create or update an optimized image for you - if you are running the command from the same machine as a server instance, this may impact the next start of your server.
+NOTE: if you do not use `--optimized` keep in mind that an `bootstrap-admin` command may implicitly create or update an optimized build for you - if you are running the command from the same machine as a server instance, this may impact the next start of your server.
 
 === Create an admin user
 

--- a/docs/guides/server/importExport.adoc
+++ b/docs/guides/server/importExport.adoc
@@ -31,7 +31,7 @@ As default, {project_name} will re-build automatically for the `export` and `imp
 If you have built an optimized version of {project_name} with the `build` command as outlined in <@links.server id="configuration"/>, use the command line option `--optimized` to have {project_name} skip the build check for a faster startup time.
 When doing this, remove the build time options from the command line and keep only the runtime options.
 
-NOTE: if you do not use `--optimized` keep in mind that an `import` or `export` command will implicitly create or update an optimized image for you - if you are running the command from the same machine as a server instance, this may impact the next start of your server.
+NOTE: if you do not use `--optimized` keep in mind that an `import` or `export` command may implicitly create or update an optimized build for you - if you are running the command from the same machine as a server instance, this may impact the next start of your server.
 
 == Exporting a Realm to a Directory
 

--- a/docs/guides/server/update-compatibility.adoc
+++ b/docs/guides/server/update-compatibility.adoc
@@ -31,14 +31,16 @@ Shut down all nodes of the cluster running the old version before starting the n
 
 == Determining the update strategy for an updated configuration
 
-To determine if a rolling update is possible, run the update compatibility command:
+To determine if a rolling update is possible:
 
-1. Generate the required metadata with the old configuration.
+1. Run the update compatibility command to generate the required metadata with the old configuration.
 2. Check the metadata with the new configuration to determine the update strategy.
+
+NOTE: If you do not use `--optimized` keep in mind that an `update` command may implicitly create or update an optimized build for you - if you are running the command from the same machine as a server instance, this may impact the next start of your server.
 
 [WARNING]
 ====
-This command currently offers only a limited functionality. At the moment, it takes into consideration only the version of {project_name} and the embedded Infinispan to determine if a rolling update is possible.
+The `check` command currently offers only a limited functionality. At the moment, it takes into consideration only the version of {project_name} and the embedded Infinispan to determine if a rolling update is possible.
 If those are unchanged, it reports that a rolling update is possible.
 
 The current version does not yet verify configuration changes and assumes all configuration changes are eligible for a rolling update.


### PR DESCRIPTION
closes: #38662

@ahus1 @pruivo @vmuzikar to align better with some of what we talked about in the meeting, the refactoring I want to do with #38514, and the thoughts on #38894, I would like to skip reaug, and also not use the persisted properties when --optimized is not specified. 

While this introduces yet another command behavior that is distinct from our other behaviors, it is more inline with our intuition about how the command should function.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
