### PR TITLE
Fix: Set readonly styling to input fields of account console

### DIFF
--- a/js/libs/ui-shared/src/user-profile/TextAreaComponent.tsx
+++ b/js/libs/ui-shared/src/user-profile/TextAreaComponent.tsx
@@ -2,6 +2,7 @@ import { KeycloakTextArea } from "../controls/keycloak-text-area/KeycloakTextAre
 import { UserProfileFieldProps } from "./UserProfileFields";
 import { UserProfileGroup } from "./UserProfileGroup";
 import { fieldName, isRequiredAttribute } from "./utils";
+import { TextAreaReadOnlyVariant } from "@patternfly/react-core";
 
 export const TextAreaComponent = (props: UserProfileFieldProps) => {
   const { form, attribute } = props;
@@ -15,7 +16,9 @@ export const TextAreaComponent = (props: UserProfileFieldProps) => {
         {...form.register(fieldName(attribute.name))}
         cols={attribute.annotations?.["inputTypeCols"] as number}
         rows={attribute.annotations?.["inputTypeRows"] as number}
-        readOnly={attribute.readOnly}
+        readOnlyVariant={
+          attribute.readOnly ? TextAreaReadOnlyVariant.default : undefined
+        }
         isRequired={isRequired}
       />
     </UserProfileGroup>

--- a/js/libs/ui-shared/src/user-profile/TextComponent.tsx
+++ b/js/libs/ui-shared/src/user-profile/TextComponent.tsx
@@ -1,4 +1,8 @@
-import { TextInput, TextInputTypes } from "@patternfly/react-core";
+import {
+  TextInput,
+  TextInputReadOnlyVariant,
+  TextInputTypes,
+} from "@patternfly/react-core";
 
 import { UserProfileFieldProps } from "./UserProfileFields";
 import { UserProfileGroup } from "./UserProfileGroup";
@@ -29,7 +33,9 @@ export const TextComponent = (props: UserProfileFieldProps) => {
                 ] as string,
               )
         }
-        readOnly={attribute.readOnly}
+        readOnlyVariant={
+          attribute.readOnly ? TextInputReadOnlyVariant.default : undefined
+        }
         isRequired={isRequired}
         {...form.register(fieldName(attribute.name))}
       />


### PR DESCRIPTION
This determines readonly styling to input fields of account console.

Before the html-attribute `readonly` was already set, but the fields look was indistinguishable from active fields.

This fixes https://github.com/keycloak/keycloak/issues/38934

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
