### PR TITLE
using jenvtest for local operator testing

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -55,56 +55,19 @@ jobs:
           upload-m2-repo: false
           upload-dist: true
 
-  test-local:
-    name: Test local
+  test-local-apiserver:
+    name: Test local apiserver
     runs-on: ubuntu-latest
     needs: [build]
-    strategy:
-      matrix:
-        suite: [slow, fast]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set version
-        id: vars
-        run: echo "version_local=0.0.1-${GITHUB_SHA::6}" >> $GITHUB_ENV
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
 
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.13.1
-        with:
-          minikube version: ${{ env.MINIKUBE_VERSION }}
-          kubernetes version: ${{ env.KUBERNETES_VERSION }}
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-          start args: --addons=ingress --memory=${{ env.MINIKUBE_MEMORY }} --cni cilium --cpus=max
-
-      - name: Download keycloak distribution
-        id: download-keycloak-dist
-        uses: actions/download-artifact@v4
-        with:
-          name: keycloak-dist
-          path: quarkus/container
-
-      - name: Build Keycloak Docker images
-        run: |
-          eval $(minikube -p minikube docker-env)
-          (cd quarkus/container && docker build --build-arg KEYCLOAK_DIST=$(ls keycloak-*.tar.gz) . -t keycloak:${{ env.version_local }})
-          (cd operator && ./scripts/build-testing-docker-images.sh ${{ env.version_local }} keycloak custom-keycloak)
-
       - name: Test operator running locally
         run: |
-          declare -A PARAMS
-          PARAMS["slow"]="-Dkc.quarkus.tests.groups=slow"
-          PARAMS["fast"]='-Dkc.quarkus.tests.groups=!slow'
-          
-          ./mvnw install -Poperator -pl :keycloak-operator -am \
-              -Dquarkus.kubernetes.image-pull-policy=IfNotPresent \
-              -Dkc.operator.keycloak.image=keycloak:${{ env.version_local }} \
-              -Dtest.operator.custom.image=custom-keycloak:${{ env.version_local }} \
-              -Dkc.operator.keycloak.image-pull-policy=Never ${PARAMS["${{ matrix.suite }}"]}
+          ./mvnw install -Poperator -pl :keycloak-operator -am
 
   test-remote:
     name: Test remote
@@ -250,7 +213,7 @@ jobs:
     needs:
       - conditional
       - build
-      - test-local
+      - test-local-apiserver
       - test-remote
       - test-olm
     runs-on: ubuntu-latest

--- a/operator/README.md
+++ b/operator/README.md
@@ -84,9 +84,9 @@ kubectl delete -k <previously-used-folder>
 
 ### Testing
 
-Testing allows 3 methods specified in the property `test.operator.deployment` : `local_apiserer`, `local` & `remote`. 
+Testing allows 3 methods specified in the property `test.operator.deployment` : `local_apiserver`, `local` & `remote`. 
 
-`local_apiserver` : the default, where resources will be deployed to a jenvtest controlled api server (not a full kube environment) and the operator will run locally - not all tests can run in this mode. This is the fasted mode of testing as no externally managed kube environment is needed. As long as your test does not need a running Keycloak instance, this level of testing should be applicable.
+`local_apiserver` : the default, where resources will be deployed to a jenvtest controlled api server (not a full kube environment) and the operator will run locally - not all tests can run in this mode. This is the fastest mode of testing as no externally managed kube environment is needed. As long as your test does not need a running Keycloak instance, this level of testing should be applicable.
 
 `local` : resources will be deployed to the local cluster and the operator will run out of the cluster
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -7,7 +7,7 @@ Also see [Operator guides](https://www.keycloak.org/guides#operator)
 
 ## Activating the Module
 
-When build from the project root directory, this module is only enabled if the installed JDK is 11 or newer. 
+When build from the project root directory, this module is only enabled if the installed JDK is 17 or newer. 
 
 ## Building
 
@@ -84,7 +84,9 @@ kubectl delete -k <previously-used-folder>
 
 ### Testing
 
-Testing allows 2 methods specified in the property `test.operator.deployment` : `local` & `remote`. 
+Testing allows 3 methods specified in the property `test.operator.deployment` : `local_apiserer`, `local` & `remote`. 
+
+`local_apiserver` : the default, where resources will be deployed to a jenvtest controlled api server (not a full kube environment) and the operator will run locally - not all tests can run in this mode. This is the fasted mode of testing as no externally managed kube environment is needed. As long as your test does not need a running Keycloak instance, this level of testing should be applicable.
 
 `local` : resources will be deployed to the local cluster and the operator will run out of the cluster
 

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -143,6 +143,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-component</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj-core.version}</version>

--- a/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
@@ -55,8 +55,8 @@ public class ApiServerHelper {
                         // this is not fully accurate as it's rather recreate than rolling update,
                         // but thanks to gradual scaling up it emits more events which is closer to the real behavior
                         actualReplicas = 0;
-                    } else if (specReplicas == 0 && statusReplicas > 0) { // probably recreate update requested, scaling down the deployment
-                        actualReplicas = statusReplicas - 1;
+                    } else if (specReplicas == 0) { // probably recreate update requested, scaling down the deployment
+                        actualReplicas = Math.max(0, statusReplicas - 1);
                     } else {
                         actualReplicas = statusReplicas + 1; // otherwise, just scale up
                     }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
@@ -1,0 +1,81 @@
+package org.keycloak.operator.testsuite.apiserver;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.fabric8.kubeapitest.KubeAPIServer;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+
+public class ApiServerHelper {
+
+    private KubeAPIServer kubeApi;
+
+    public ApiServerHelper() {
+        kubeApi = new KubeAPIServer();
+        kubeApi.start();
+    }
+
+    public void stop() {
+        kubeApi.stop();
+    }
+
+    public KubernetesClient createClient(String namespace) {
+        Config config = Config.fromKubeconfig(kubeApi.getKubeConfigYaml());
+        config.setNamespace(namespace);
+        var result = new KubernetesClientBuilder().withConfig(config).build();
+
+        // fake statefulset controller
+        result.apps().statefulSets().inAnyNamespace().inform(new ResourceEventHandler<StatefulSet>() {
+
+            @Override
+            public void onAdd(StatefulSet obj) {
+                updateStatefulSet(obj);
+            }
+
+            private void updateStatefulSet(StatefulSet obj) {
+                int replicas = obj.getSpec().getReplicas();
+                String revision = String.valueOf(Math.abs(obj.getSpec().hashCode()));
+                if (!Objects.equals(Optional.ofNullable(obj.getStatus().getReplicas()).orElse(0), replicas)
+                        || !Objects.equals(revision, obj.getStatus().getUpdateRevision())
+                        || !Objects.equals(obj.getStatus().getCurrentRevision(), obj.getStatus().getUpdateRevision())) {
+                    // generate intermediate rolling events
+                    int actualReplicas;
+                    if (!Objects.equals(revision, obj.getStatus().getUpdateRevision())) {
+                        actualReplicas = 0;
+                    } else if (replicas == 0) {
+                        actualReplicas = Math.max(replicas, Optional.ofNullable(obj.getStatus().getReplicas()).orElse(0) - 1);
+                    } else {
+                        actualReplicas = Math.min(replicas, Optional.ofNullable(obj.getStatus().getReplicas()).orElse(0) + 1);
+                    }
+                    obj = result.getKubernetesSerialization().clone(obj);
+                    obj.getStatus().setReplicas(actualReplicas);
+                    obj.getStatus().setReadyReplicas(actualReplicas);
+                    obj.getStatus().setUpdateRevision(revision);
+                    if (actualReplicas == replicas) {
+                        obj.getStatus().setCurrentRevision(revision);
+                    }
+                    obj.getMetadata().setResourceVersion(null);
+                    result.resource(obj).updateStatus();
+                }
+            }
+
+            @Override
+            public void onUpdate(StatefulSet oldObj, StatefulSet newObj) {
+                updateStatefulSet(newObj);
+            }
+
+            @Override
+            public void onDelete(StatefulSet obj, boolean deletedFinalStateUnknown) {
+
+            }
+
+        });
+
+        return result;
+    }
+
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
@@ -51,8 +51,10 @@ public class ApiServerHelper {
                         || !Objects.equals(obj.getStatus().getCurrentRevision(), updateRevision)) {
                     // generate intermediate rolling events
                     int actualReplicas;
-                    if (!Objects.equals(revision, updateRevision)) { // detected spec change, mimic rolling update with just one pod
-                        actualReplicas = Math.max(0, statusReplicas - 1);
+                    if (!Objects.equals(revision, updateRevision)) { // detected spec change, mimic rolling update
+                        // this is not fully accurate as it's rather recreate than rolling update,
+                        // but thanks to gradual scaling up it emits more events which is closer to the real behavior
+                        actualReplicas = 0;
                     } else if (specReplicas == 0 && statusReplicas > 0) { // probably recreate update requested, scaling down the deployment
                         actualReplicas = statusReplicas - 1;
                     } else {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/ApiServerHelper.java
@@ -58,7 +58,7 @@ public class ApiServerHelper {
                     } else if (specReplicas == 0) { // probably recreate update requested, scaling down the deployment
                         actualReplicas = Math.max(0, statusReplicas - 1);
                     } else {
-                        actualReplicas = statusReplicas + 1; // otherwise, just scale up
+                        actualReplicas = Math.min(specReplicas, statusReplicas + 1); // otherwise, just scale up
                     }
                     obj = result.getKubernetesSerialization().clone(obj);
                     obj.getStatus().setReplicas(actualReplicas);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/DisabledIfApiServerTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/apiserver/DisabledIfApiServerTest.java
@@ -1,0 +1,15 @@
+package org.keycloak.operator.testsuite.apiserver;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, METHOD, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+public @interface DisabledIfApiServerTest {
+
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/CacheTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/CacheTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.CacheSpecBuilder;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
@@ -41,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
 
+@DisabledIfApiServerTest
 @QuarkusTest
 public class CacheTest extends BaseOperatorTest {
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -38,6 +38,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
@@ -52,6 +53,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.keycloak.operator.controllers.KeycloakDeploymentDependentResource.KC_TRACING_SERVICE_NAME;
 
+@DisabledIfApiServerTest
 @QuarkusTest
 public class ClusteringTest extends BaseOperatorTest {
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -47,6 +47,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.BootstrapAdminSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpecBuilder;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.unit.WatchedResourcesTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
@@ -76,6 +77,7 @@ import static org.keycloak.operator.testsuite.utils.K8sUtils.enableHttp;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.getResourceFromFile;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.waitForKeycloakToBeReady;
 
+@DisabledIfApiServerTest
 @Tag(BaseOperatorTest.SLOW)
 @QuarkusTest
 public class KeycloakDeploymentTest extends BaseOperatorTest {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -34,6 +34,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpecBuilder;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
 import java.util.Map;
@@ -48,6 +49,7 @@ import static org.keycloak.operator.testsuite.utils.K8sUtils.enableHttp;
 @QuarkusTest
 public class KeycloakIngressTest extends BaseOperatorTest {
 
+    @DisabledIfApiServerTest
     @Test
     public void testIngressOnHTTP() {
         var kc = getTestKeycloakDeployment(false);
@@ -76,6 +78,7 @@ public class KeycloakIngressTest extends BaseOperatorTest {
         testIngressURLs(baseUrl);
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testIngressOnHTTPSAndProxySettings() {
         var kc = getTestKeycloakDeployment(false);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakNetworkPolicyTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakNetworkPolicyTest.java
@@ -35,6 +35,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpecBuilder;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.NetworkPolicySpec;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
@@ -51,6 +52,7 @@ public class KeycloakNetworkPolicyTest extends BaseOperatorTest {
                 .get();
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testHttpAndHttps() {
         var kc = create();
@@ -69,6 +71,7 @@ public class KeycloakNetworkPolicyTest extends BaseOperatorTest {
         CRAssert.assertManagementInterfaceAccessibleViaService(k8sclient, kc, true, mngtPort);
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testServiceConnectivity() {
         var kc = create();
@@ -128,6 +131,7 @@ public class KeycloakNetworkPolicyTest extends BaseOperatorTest {
         }
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testJGroupsConnectivity() {
         var kc = create();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
@@ -30,6 +30,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
@@ -54,6 +55,7 @@ public class PodTemplateTest extends BaseOperatorTest {
                 .withName("example-podtemplate");
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testPodTemplateIsMerged() {
         // Act

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -38,6 +38,7 @@ import org.keycloak.operator.controllers.KeycloakServiceDependentResource;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.crds.v2alpha1.realmimport.Placeholder;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
@@ -58,6 +59,7 @@ import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.getResourceFromFile;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.inClusterCurl;
 
+@DisabledIfApiServerTest
 @QuarkusTest
 public class RealmImportTest extends BaseOperatorTest {
 
@@ -103,6 +105,7 @@ public class RealmImportTest extends BaseOperatorTest {
         K8sUtils.set(k8sclient, getResourceFromFile("example-smtp-secret.yaml", Secret.class));
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testWorkingRealmImport() {
         // Arrange
@@ -119,6 +122,7 @@ public class RealmImportTest extends BaseOperatorTest {
         assertWorkingRealmImport(kc);
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testWorkingRealmImportWithReplacement() {
         // Arrange

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/TracingDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/TracingDeploymentTest.java
@@ -24,6 +24,7 @@ import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TracingSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TracingSpecBuilder;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 
 import java.util.Map;
 import java.util.Objects;
@@ -34,6 +35,7 @@ import static org.keycloak.operator.controllers.KeycloakDeploymentDependentResou
 import static org.keycloak.operator.controllers.KeycloakDeploymentDependentResource.KC_TRACING_SERVICE_NAME;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
 
+@DisabledIfApiServerTest
 @QuarkusTest
 public class TracingDeploymentTest extends BaseOperatorTest {
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/UpdateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/UpdateTest.java
@@ -17,6 +17,14 @@
 
 package org.keycloak.operator.testsuite.integration;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.keycloak.operator.testsuite.utils.CRAssert.eventuallyRecreateUpdateStatus;
+import static org.keycloak.operator.testsuite.utils.CRAssert.eventuallyRollingUpdateStatus;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -24,10 +32,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import io.fabric8.kubernetes.api.model.batch.v1.Job;
-import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
-import io.quarkus.test.junit.QuarkusTest;
-
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -38,17 +43,14 @@ import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.UpdateSpec;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.update.UpdateStrategy;
 import org.keycloak.operator.update.impl.AutoUpdateLogic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.keycloak.operator.testsuite.utils.CRAssert.eventuallyRecreateUpdateStatus;
-import static org.keycloak.operator.testsuite.utils.CRAssert.eventuallyRollingUpdateStatus;
-import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
+import io.quarkus.test.junit.QuarkusTest;
 
 @Tag(BaseOperatorTest.SLOW)
 @QuarkusTest
@@ -57,6 +59,7 @@ public class UpdateTest extends BaseOperatorTest {
     @ParameterizedTest(name = "testImageChange-{0}")
     @EnumSource(UpdateStrategy.class)
     public void testImageChange(UpdateStrategy updateStrategy) throws InterruptedException {
+        Assumptions.assumeTrue(operatorDeployment != OperatorDeployment.local_apiserver || updateStrategy != UpdateStrategy.AUTO);
         var kc = createInitialDeployment(updateStrategy);
         var updateCondition = assertUnknownUpdateTypeStatus(kc);
         deployKeycloak(k8sclient, kc, true);
@@ -82,6 +85,7 @@ public class UpdateTest extends BaseOperatorTest {
     @ParameterizedTest(name = "testCacheMaxCount-{0}")
     @EnumSource(UpdateStrategy.class)
     public void testCacheMaxCount(UpdateStrategy updateStrategy) throws InterruptedException {
+        Assumptions.assumeTrue(operatorDeployment != OperatorDeployment.local_apiserver || updateStrategy != UpdateStrategy.AUTO);
         var kc = createInitialDeployment(updateStrategy);
         var updateCondition = assertUnknownUpdateTypeStatus(kc);
         deployKeycloak(k8sclient, kc, true);
@@ -108,6 +112,7 @@ public class UpdateTest extends BaseOperatorTest {
     @EnumSource(UpdateStrategy.class)
     @EnabledIfSystemProperty(named = OPERATOR_CUSTOM_IMAGE, matches = ".+")
     public void testOptimizedImage(UpdateStrategy updateStrategy) throws InterruptedException {
+        Assumptions.assumeTrue(operatorDeployment != OperatorDeployment.local_apiserver || updateStrategy != UpdateStrategy.AUTO);
         // In GHA, the custom image is an optimized image of the base image.
         // We should be able to do a zero-downtime update with Auto strategy.
         var kc = createInitialDeployment(updateStrategy);
@@ -133,6 +138,7 @@ public class UpdateTest extends BaseOperatorTest {
         }
     }
 
+    @DisabledIfApiServerTest
     @EnabledIfSystemProperty(named = OPERATOR_CUSTOM_IMAGE, matches = ".+")
     @Test
     public void testNoJobReuse() throws InterruptedException {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpecBuilder;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
 import org.keycloak.operator.testsuite.unit.WatchedResourcesTest;
 
 import java.util.Base64;
@@ -75,6 +76,7 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         });
     }
 
+    @DisabledIfApiServerTest
     @Test
     public void testSecretChangesArePropagated() {
         final String username = "HomerSimpson";

--- a/operator/src/test/resources/application.properties
+++ b/operator/src/test/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.operator-sdk.start-operator=false
 quarkus.log.level=INFO
 
 kc.operator.keycloak.pod-labels."test.label"=foobar
-kc.operator.keycloak.pod-labels."testLabelWithExpression"=${OPERATOR_TEST_LABEL_EXPRESSION}
+kc.operator.keycloak.pod-labels."testLabelWithExpression"=${OPERATOR_TEST_LABEL_EXPRESSION:default}
 # allow the watching tests to complete more quickly
 kc.operator.keycloak.poll-interval-seconds=10
 # Update Pod timeout reduced to 1 min for testing


### PR DESCRIPTION
closes: #39020

It provides "transparent" usage of just api server testing.

The idea is that without any minikube or other external setup, you can just run a given test and have a quick debug loop.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
