### PR TITLE
Generate random passwords for imported users in forms and webauthn tests (26.2)

### DIFF
--- a/.github/actions/install-chrome/action.yml
+++ b/.github/actions/install-chrome/action.yml
@@ -3,17 +3,17 @@ description: Download and install the compatible Chrome and Chromedriver
 
 inputs:
   version:
-    description: The version of Chrome and Chromedriver to install.
+    description: The version of Chrome and Chromedriver to install. By default none is installed.
     required: false
-    default: 134.0.6998.165 # Ensures compatibility with the testsuite
+    default: default # E.g. 135.0.7049.84 (fixed version), default (chrome provided by GHA box)
 
 runs:
   using: composite
   steps:
 
-    # Cannot use Chrome for Testing. Acts weirdly and would probably require some changes in the testsuite.
     - id: install-chrome
       name: Install Chrome
+      if: inputs.version != 'default'
       shell: bash
       run: |
         sudo apt-get remove google-chrome-stable
@@ -22,6 +22,7 @@ runs:
 
     - id: install-chromedriver
       name: Install Chromedriver
+      if: inputs.version != 'default'
       shell: bash
       run: |
         wget https://storage.googleapis.com/chrome-for-testing-public/${{ inputs.version }}/linux64/chromedriver-linux64.zip -O /tmp/chromedriver.zip --no-verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,6 @@ jobs:
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
 
-      - uses: ./.github/actions/install-chrome
-
       - name: Run base tests
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/base-suite.sh ${{ matrix.group }}`
@@ -161,8 +159,6 @@ jobs:
 
       - name: Build app servers
         run: ./mvnw install -DskipTests -Pbuild-app-servers -f testsuite/integration-arquillian/servers/app-server/pom.xml
-
-      - uses: ./.github/actions/install-chrome
 
       - name: Run adapter tests
         run: |

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/TestContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/TestContext.java
@@ -18,6 +18,7 @@ package org.keycloak.testsuite.arquillian;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ public final class TestContext {
     private Keycloak adminClient;
     private KeycloakTestingClient testingClient;
     private List<RealmRepresentation> testRealmReps = new ArrayList<>();
+    private Map<String, String> userPasswords = new HashMap<>();
 
     // Track if particular test was initialized. What exactly means "initialized" is test dependent (Eg. some user in @Before method was created, so we can set initialized to true
     // to avoid creating user when @Before method is executed for 2nd time)
@@ -177,6 +179,14 @@ public final class TestContext {
 
     public void addTestRealmsToTestRealmReps(List<RealmRepresentation> testRealmReps) {
         this.testRealmReps.addAll(testRealmReps);
+    }
+
+    public Map<String, String> getUserPasswords() {
+        return userPasswords;
+    }
+
+    public void setUserPasswords(Map<String, String> userPasswords) {
+        this.userPasswords = userPasswords;
     }
 
     public boolean isInitialized() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/annotation/IgnoreBrowserDriver.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/annotation/IgnoreBrowserDriver.java
@@ -39,14 +39,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface IgnoreBrowserDriver {
 
     /**
-     * Define for which WebDriver the test method/class should be ignored
+     * Define for which WebDrivers the test method/class should be ignored
+     * @return
      */
-    Class<? extends WebDriver> value();
+    Class<? extends WebDriver>[] value();
 
     /**
      * Define whether the value should be negated
      *
-     * Usable in cases when we want to execute test method/class with all WebDrivers except the one specified in value()
+     * Usable in cases when we want to execute test method/class with all WebDrivers except the ones specified in value()
+     * @return
      */
     boolean negate() default false;
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/decider/BrowserDriverIgnoreDecider.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/decider/BrowserDriverIgnoreDecider.java
@@ -68,7 +68,7 @@ public class BrowserDriverIgnoreDecider implements TestExecutionDecider {
         final WebDriver webDriver = driver.get();
 
         Predicate<IgnoreBrowserDriver> shouldBeIgnored = (item) -> {
-            return webDriver != null && (isDriverInstanceOf(webDriver, item.value()) ^ item.negate());
+            return webDriver != null && (isPresent(webDriver, item.value()) ^ item.negate());
         };
 
         return Arrays.stream(element.getAnnotationsByType(IgnoreBrowserDriver.class))
@@ -76,6 +76,13 @@ public class BrowserDriverIgnoreDecider implements TestExecutionDecider {
                 .findAny()
                 .map(f -> ExecutionDecision.dontExecute("This test should not be executed with this browser."))
                 .orElse(ExecutionDecision.execute());
+    }
+
+    private boolean isPresent(WebDriver webDriver, Class<? extends WebDriver>[] items) {
+        if (items == null) {
+            return false;
+        }
+        return Arrays.stream(items).filter(item -> isDriverInstanceOf(webDriver, item)).findAny().isPresent();
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/RegisterPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/RegisterPage.java
@@ -81,6 +81,10 @@ public class RegisterPage extends LanguageComboboxAwarePage
     @FindBy(linkText = "« Back to Login")
     private WebElement backToLoginLink;
 
+    public void register(String firstName, String lastName, String email, String username, String password) {
+        register(firstName, lastName, email, username, password, password, null, null, null);
+    }
+
     public void register(String firstName, String lastName, String email, String username, String password, String passwordConfirm) {
         register(firstName, lastName, email, username, password, passwordConfirm, null, null, null);
     }
@@ -144,6 +148,10 @@ public class RegisterPage extends LanguageComboboxAwarePage
         }
 
         UIUtils.clickLink(submitButton);
+    }
+
+    public void registerWithEmailAsUsername(String firstName, String lastName, String email, String password) {
+        registerWithEmailAsUsername(firstName, lastName, email, password, password);
     }
 
     public void registerWithEmailAsUsername(String firstName, String lastName, String email, String password, String passwordConfirm) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/TermsAndConditionsPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/TermsAndConditionsPage.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -30,15 +31,16 @@ public class TermsAndConditionsPage extends AbstractPage {
     @FindBy(id = "kc-decline")
     private WebElement cancelButton;
 
+    @Override
     public boolean isCurrent() {
         return PageUtils.getPageTitle(driver).equals("Terms and Conditions");
     }
 
     public void acceptTerms() {
-        submitButton.click();
+        UIUtils.clickLink(submitButton);
     }
     public void declineTerms() {
-        cancelButton.click();
+        UIUtils.clickLink(cancelButton);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractAuthTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractAuthTest.java
@@ -90,14 +90,18 @@ public abstract class AbstractAuthTest extends AbstractKeycloakTest {
 
 
     public void createTestUserWithAdminClient() {
-        createTestUserWithAdminClient(true);
+        createTestUserWithAdminClient(true, PASSWORD);
     }
 
     public void createTestUserWithAdminClient(boolean setRealmRoles) {
+        createTestUserWithAdminClient(setRealmRoles, PASSWORD);
+    }
+
+    public void createTestUserWithAdminClient(boolean setRealmRoles, String password) {
         ApiUtil.removeUserByUsername(testRealmResource(), "test");
 
         log.debug("creating test user");
-        String id = createUserAndResetPasswordWithAdminClient(testRealmResource(), testUser, PASSWORD);
+        String id = createUserAndResetPasswordWithAdminClient(testRealmResource(), testUser, password);
         testUser.setId(id);
 
         if (setRealmRoles) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractChangeImportedUserPasswordsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractChangeImportedUserPasswordsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.keycloak.testsuite;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.admin.ApiUtil;
+
+/**
+ * <p>Abstract class that re-generates all imported user passwords with a random one.
+ * This way all the passwords are random and cannot be rejected by security
+ * configurations in browsers (chrome for example). The passwords are stored in
+ * a map inside the test context to be retrieved using the username.</p>
+ *
+ * @author rmartinc
+ */
+abstract public class AbstractChangeImportedUserPasswordsTest extends AbstractTestRealmKeycloakTest {
+
+    private Map<String, String> userPasswords = null;
+
+    @Before
+    @Override
+    public void beforeAbstractKeycloakTest() throws Exception {
+        super.beforeAbstractKeycloakTest();
+        if (userPasswords == null) {
+            userPasswords = testContext.getUserPasswords();
+        }
+    }
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+        if (userPasswords == null) {
+            userPasswords = testContext.getUserPasswords();
+        }
+        userPasswords.clear();
+        List<UserRepresentation> users = testRealm.getUsers();
+        for (UserRepresentation user : users) {
+            List<CredentialRepresentation> credentials = user.getCredentials();
+            if (credentials != null) {
+                for (CredentialRepresentation cred : credentials) {
+                    if (CredentialRepresentation.PASSWORD.equals(cred.getType())) {
+                        // re-generate the password for the user using a random one
+                        cred.setValue(generatePassword(user.getUsername()));
+                    }
+                }
+            }
+        }
+        testContext.setUserPasswords(userPasswords);
+    }
+
+    protected String changePassword(String username) {
+        UserResource userRes = ApiUtil.findUserByUsernameId(testRealm(), username);
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(PasswordCredentialModel.TYPE);
+        credential.setTemporary(Boolean.FALSE);
+        credential.setValue(generatePassword());
+        userRes.resetPassword(credential);
+        userPasswords.put(username, credential.getValue());
+        return credential.getValue();
+    }
+
+    protected void changePasswords(String... usernames) {
+        if (usernames != null) {
+            for (String username: usernames) {
+                changePassword(username);
+            }
+        }
+    }
+
+    protected void generatePasswords(String... usernames) {
+        if (usernames != null) {
+            for (String username: usernames) {
+                generatePassword(username);
+            }
+        }
+    }
+
+    protected String generatePassword(String username) {
+        final String password = generatePassword();
+        userPasswords.put(username, password);
+        return password;
+    }
+
+    protected String getPassword(String username) {
+        final String password = userPasswords.get(username);
+        Assert.assertNotNull("password not generated for user " + username, password);
+        return password;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -37,7 +37,9 @@ import org.keycloak.admin.client.resource.RealmsResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.TimeBasedOTP;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -96,7 +98,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import org.keycloak.models.UserModel;
 import static org.keycloak.testsuite.admin.Users.setPasswordFor;
 import static org.keycloak.testsuite.auth.page.AuthRealm.MASTER;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_HOST;
@@ -785,4 +786,11 @@ public abstract class AbstractKeycloakTest {
         }
     }
 
+    protected static String generatePassword() {
+        return generatePassword(64);
+    }
+
+    protected static String generatePassword(int length) {
+        return SecretGenerator.getInstance().randomString(length);
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractTestRealmKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractTestRealmKeycloakTest.java
@@ -28,7 +28,6 @@ import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
-import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractAppInitiatedActionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractAppInitiatedActionTest.java
@@ -21,7 +21,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Rule;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.AppPage.RequestType;
@@ -49,7 +49,7 @@ import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 /**
  * @author Stan Silvert
  */
-public abstract class AbstractAppInitiatedActionTest extends AbstractTestRealmKeycloakTest {
+public abstract class AbstractAppInitiatedActionTest extends AbstractChangeImportedUserPasswordsTest {
 
     protected static final String SUCCESS = "success";
     protected static final String CANCELLED = "cancelled";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
@@ -46,7 +46,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPAttributePermissions;
 import org.keycloak.representations.userprofile.config.UPConfig;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
@@ -66,7 +66,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTest {
+public class RequiredActionUpdateProfileTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
@@ -85,6 +85,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
         ActionUtil.addRequiredActionForUser(testRealm, "test-user@localhost", UserModel.RequiredAction.UPDATE_PROFILE.name());
         ActionUtil.addRequiredActionForUser(testRealm, "john-doh@localhost", UserModel.RequiredAction.UPDATE_PROFILE.name());
     }
@@ -99,7 +100,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
                 .lastName("Brady")
                 .emailVerified(true)
                 .requiredAction(UserModel.RequiredAction.UPDATE_PROFILE.name()).build();
-        ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+        ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, generatePassword("test-user@localhost"));
 
         ApiUtil.removeUserByUsername(testRealm(), "john-doh@localhost");
         user = UserBuilder.create().enabled(true)
@@ -109,14 +110,14 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
                 .lastName("Doh")
                 .emailVerified(true)
                 .requiredAction(UserModel.RequiredAction.UPDATE_PROFILE.name()).build();
-        ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+        ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, generatePassword("john-doh@localhost"));
     }
 
     @Test
     public void updateProfile() {
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
         assertFalse(updateProfilePage.isCancelDisplayed());
@@ -145,7 +146,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateUsername() {
         loginPage.open();
 
-        loginPage.login("john-doh@localhost", "password");
+        loginPage.login("john-doh@localhost", getPassword("john-doh@localhost"));
 
         String userId = ActionUtil.findUserWithAdminClient(adminClient, "john-doh@localhost").getId();
 
@@ -177,7 +178,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileMissingFirstName() {
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -198,7 +199,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileMissingLastName() {
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -220,7 +221,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileMissingEmail() {
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -246,7 +247,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileInvalidEmail() {
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -269,7 +270,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileMissingUsername() {
         loginPage.open();
 
-        loginPage.login("john-doh@localhost", "password");
+        loginPage.login("john-doh@localhost", getPassword("john-doh@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -292,7 +293,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileDuplicateUsername() {
         loginPage.open();
 
-        loginPage.login("john-doh@localhost", "password");
+        loginPage.login("john-doh@localhost", getPassword("john-doh@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -315,7 +316,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     public void updateProfileDuplicatedEmail() {
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -336,11 +337,11 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
 
     @Test
     public void updateProfileDuplicateUsernameWithEmail() {
-        getCleanup().addUserId(createUser(TEST_REALM_NAME, "user1@local.com", "password", "user1", "user1", "user1@local.org"));
+        getCleanup().addUserId(createUser(TEST_REALM_NAME, "user1@local.com", generatePassword("user1@local.com"), "user1", "user1", "user1@local.org"));
 
         loginPage.open();
 
-        loginPage.login("john-doh@localhost", "password");
+        loginPage.login("john-doh@localhost", getPassword("john-doh@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -361,11 +362,11 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
 
     @Test
     public void updateProfileDuplicatedEmailWithUsername() {
-        getCleanup().addUserId(createUser(TEST_REALM_NAME, "user1@local.com", "password", "user1", "user1", "user1@local.org"));
+        getCleanup().addUserId(createUser(TEST_REALM_NAME, "user1@local.com", generatePassword("user1@local.com"), "user1", "user1", "user1@local.org"));
 
         loginPage.open();
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -387,7 +388,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
     @Test
     public void updateProfileExpiredCookies() {
         loginPage.open();
-        loginPage.login("john-doh@localhost", "password");
+        loginPage.login("john-doh@localhost", getPassword("john-doh@localhost"));
 
         updateProfilePage.assertCurrent();
 
@@ -421,7 +422,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
 
             loginPage.open();
 
-            loginPage.login("test-user@localhost", "password");
+            loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
             updateProfilePage.assertCurrent();
             assertFalse(updateProfilePage.isCancelDisplayed());
@@ -469,7 +470,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
             userProfile.update(testUpConfig);
 
             loginPage.open();
-            loginPage.login("john-doh@localhost", "password");
+            loginPage.login("john-doh@localhost", getPassword("john-doh@localhost"));
             updateProfilePage.assertCurrent();
 
             for (String attribute : attributes) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AbstractFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AbstractFlowTest.java
@@ -17,14 +17,14 @@
 
 package org.keycloak.testsuite.forms;
 
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 
 /**
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */
-public abstract class AbstractFlowTest extends AbstractTestRealmKeycloakTest {
+public abstract class AbstractFlowTest extends AbstractChangeImportedUserPasswordsTest {
 
     protected AuthenticationFlowRepresentation findFlowByAlias(String alias) {
         for (AuthenticationFlowRepresentation rep : testRealm().flows().getFlows()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AllowDenyAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AllowDenyAuthenticatorTest.java
@@ -13,8 +13,7 @@ import org.keycloak.authentication.authenticators.directgrant.ValidateUsername;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.models.AuthenticationExecutionModel;
-import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.authentication.authenticators.conditional.ConditionalUserAttributeValueFactory;
 import org.keycloak.testsuite.pages.ErrorPage;
@@ -35,7 +34,7 @@ import static org.keycloak.testsuite.forms.BrowserFlowTest.revertFlows;
 /**
  * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
  */
-public class AllowDenyAuthenticatorTest extends AbstractTestRealmKeycloakTest {
+public class AllowDenyAuthenticatorTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Page
     protected LoginUsernameOnlyPage loginUsernameOnlyPage;
@@ -48,10 +47,6 @@ public class AllowDenyAuthenticatorTest extends AbstractTestRealmKeycloakTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
 
     @Test
     public void testDenyAccessWithDefaultMessage() {
@@ -258,7 +253,7 @@ public class AllowDenyAuthenticatorTest extends AbstractTestRealmKeycloakTest {
             loginUsernameOnlyPage.login(userCondNotMatch);
 
             passwordPage.assertCurrent();
-            passwordPage.login("password");
+            passwordPage.login(getPassword(userCondNotMatch));
 
             events.expectLogin().user(userCondNotMatchId)
                     .detail(Details.USERNAME, userCondNotMatch)
@@ -291,7 +286,7 @@ public class AllowDenyAuthenticatorTest extends AbstractTestRealmKeycloakTest {
             final String testUserWithoutRoleId = testRealm().users().search(userWithoutRole).get(0).getId();
 
             passwordPage.assertCurrent();
-            passwordPage.login("password");
+            passwordPage.login(getPassword(userWithoutRole));
 
             events.expectLogin()
                     .user(testUserWithoutRoleId)
@@ -344,7 +339,7 @@ public class AllowDenyAuthenticatorTest extends AbstractTestRealmKeycloakTest {
 
         try {
             oauth.clientId(clientId);
-            AccessTokenResponse response = oauth.doPasswordGrantRequest(user, "password");
+            AccessTokenResponse response = oauth.doPasswordGrantRequest(user, getPassword("test-user@localhost"));
             assertEquals(401, response.getStatusCode());
             assertEquals("Access denied", response.getError());
             assertNull(response.getErrorDescription());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest.java
@@ -28,8 +28,7 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.RealmModel;
-import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.authentication.ExpectedParamAuthenticator;
 import org.keycloak.testsuite.authentication.ExpectedParamAuthenticatorFactory;
@@ -47,7 +46,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
+public class AuthenticatorSubflowsTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
@@ -60,10 +59,6 @@ public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
 
     @Page
     protected ErrorPage errorPage;
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
 
     @Before
     public void setupFlows() {
@@ -270,7 +265,7 @@ public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Fill username+password. I am successfully authenticated
-        oauth.fillLoginForm("test-user@localhost", "password");
+        oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
         appPage.assertCurrent();
 
         events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
@@ -291,7 +286,7 @@ public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Fill username+password. I am successfully authenticated
-        oauth.fillLoginForm("test-user@localhost", "password");
+        oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
         appPage.assertCurrent();
 
         events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest2.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest2.java
@@ -28,8 +28,7 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.RealmModel;
-import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.authentication.ExpectedParamAuthenticator;
 import org.keycloak.testsuite.authentication.ExpectedParamAuthenticatorFactory;
@@ -45,7 +44,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:n1330@me.com">Tomohiro Nagai</a>
  */
-public class AuthenticatorSubflowsTest2 extends AbstractTestRealmKeycloakTest {
+public class AuthenticatorSubflowsTest2 extends AbstractChangeImportedUserPasswordsTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
@@ -58,10 +57,6 @@ public class AuthenticatorSubflowsTest2 extends AbstractTestRealmKeycloakTest {
 
     @Page
     protected ErrorPage errorPage;
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
 
     @Before
     public void setupFlows() {
@@ -167,7 +162,7 @@ public class AuthenticatorSubflowsTest2 extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Fill username+password. I am successfully authenticated.
-        oauth.fillLoginForm("test-user@localhost", "password");
+        oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
         appPage.assertCurrent();
 
         events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
@@ -182,7 +177,7 @@ public class AuthenticatorSubflowsTest2 extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Fill username+password. I am redirected push the button.
-        oauth.fillLoginForm("test-user@localhost", "password");
+        oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
         Assert.assertEquals("PushTheButton", driver.getTitle());
 
         // Push the button. I am successfully authenticated.

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
@@ -27,9 +27,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.models.UserModel;
-import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.AppPage;
@@ -52,13 +51,9 @@ import org.keycloak.testsuite.util.UserBuilder;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
+public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest {
 
     private String userId;
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
 
     @Before
     public void setup() {
@@ -70,7 +65,8 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
                 .requiredAction(UserModel.RequiredAction.UPDATE_PASSWORD.toString())
                 .build();
 
-        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password", true);
+        generatePasswords("login-test");
+        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, getPassword("login-test"), true);
         expectedMessagesCount = 0;
         getCleanup().addUserId(userId);
 
@@ -146,11 +142,11 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         loginPage.open();
 
         // Login and assert on "updatePassword" page
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.assertCurrent();
 
         // Update password and assert on "updateProfile" page
-        updatePasswordPage.changePassword("password", "password");
+        updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
         updateProfilePage.assertCurrent();
 
         // Click browser back. Assert on "Page expired" page
@@ -174,7 +170,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         loginPage.open();
 
         // Login and assert on "updatePassword" page
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.assertCurrent();
 
         // Click browser refresh. Assert still on updatePassword page
@@ -182,7 +178,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         updatePasswordPage.assertCurrent();
 
         // Update password and assert on "updateProfile" page
-        updatePasswordPage.changePassword("password", "password");
+        updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
         updateProfilePage.assertCurrent();
 
         // Click browser back. Assert on "Page expired" page
@@ -198,7 +194,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Login again and assert on "updateProfile" page
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
         updateProfilePage.assertCurrent();
 
         // Click browser back. Assert on "Page expired" page
@@ -222,8 +218,8 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
 
         // Login and go through required actions
         loginPage.open();
-        loginPage.login("login-test", "password");
-        updatePasswordPage.changePassword("password", "password");
+        loginPage.login("login-test", getPassword("login-test"));
+        updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
         updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").email("john@doe3.com").submit();
 
         // Assert on consent screen
@@ -303,7 +299,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         loginPage.open();
 
         // Login and assert on "updatePassword" page
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.assertCurrent();
 
         // Click browser back. I should be on login page . URL corresponds to OIDC AuthorizationEndpoint
@@ -316,7 +312,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
     public void backButtonInResetPasswordFlow() throws Exception {
         // Click on "forgot password" and type username
         loginPage.open();
-        loginPage.login("login-test", "bad-username");
+        loginPage.login("login-test", getPassword("login-test") + "bad-username");
         loginPage.resetPassword();
 
         resetPasswordPage.assertCurrent();
@@ -346,7 +342,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         // Click browser back. And continue login. Should be on updatePasswordPage
         driver.navigate().back();
         loginPage.assertCurrent();
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.assertCurrent();
     }
 
@@ -363,7 +359,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Login
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.assertCurrent();
 
         // Click browser back. Should be on 'page expired'

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
@@ -31,7 +31,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.ActionURIUtils;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
@@ -59,13 +59,12 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITHUB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITLAB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE;
 
-public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
+public class BrowserFlowTest extends AbstractChangeImportedUserPasswordsTest {
     private static final String INVALID_AUTH_CODE = "Invalid authenticator code.";
 
     private static final String USER_WITH_ONE_OTP_OTP_SECRET = "DJmQfC73VGFhw7D4QJ8A";
@@ -99,28 +98,15 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
     @Rule
     public AssertEvents events = new AssertEvents(this);
 
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
-
-    private RealmRepresentation loadTestRealm() {
-        RealmRepresentation res = loadJson(getClass().getResourceAsStream("/testrealm.json"), RealmRepresentation.class);
-        res.setBrowserFlow("browser");
-        return res;
-    }
-
     private void importTestRealm(Consumer<RealmRepresentation> realmUpdater) {
-        RealmRepresentation realm = loadTestRealm();
+        if (testRealmReps == null) {
+            testRealmReps = testContext.getTestRealmReps();
+        }
+        RealmRepresentation realm = testRealmReps.get(0); // test realm
         if (realmUpdater != null) {
             realmUpdater.accept(realm);
         }
         importRealm(realm);
-    }
-
-    @Override
-    public void addTestRealms(List<RealmRepresentation> testRealms) {
-        log.debug("Adding test realm for import from testrealm.json");
-        testRealms.add(loadTestRealm());
     }
 
     private void provideUsernamePassword(String user) {
@@ -129,11 +115,11 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
 
         // Login attempt with an invalid password
-        loginPage.login(user, "invalid");
+        loginPage.login(user, getPassword(user) + "invalid");
         loginPage.assertCurrent();
 
         // Login attempt with a valid password - user with configured OTP
-        loginPage.login(user, "password");
+        loginPage.login(user, getPassword(user));
     }
 
     private String getOtpCode(String key) {
@@ -233,12 +219,14 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
                 // Move first OTP after second while priority are not used for import
                 user.getCredentials().add(user.getCredentials().remove(idxFirst));
             });
+            changePasswords(username);
 
             // Priority tells: second then first
             testCredentialsOrder(username, Arrays.asList(OTPFormAuthenticator.UNNAMED, "first"));
         } finally {
             // Restore default testrealm.json
-            importTestRealm(null);
+            testRealmReps = null;
+            importTestRealms();
         }
     }
 
@@ -535,7 +523,7 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
             // The conditional sub flow is executed only if a specific user attribute is not set.
             // This sub flow will set the user attribute and displays password form.
             passwordPage.assertCurrent();
-            passwordPage.login("password");
+            passwordPage.login(getPassword("user-with-two-configured-otp"));
 
             Assert.assertTrue(oneTimeCodePage.isOtpLabelPresent());
         } finally {
@@ -1056,13 +1044,13 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
 
         loginPage.open();
         loginPage.assertCurrent();
-        loginPage.login(user.getUsername(), "wrong_password");
+        loginPage.login(user.getUsername(), getPassword("test-user@localhost") + "wrong_password");
 
         Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
         events.clear();
 
         loginPage.assertCurrent();
-        loginPage.login(user.getUsername(), "password");
+        loginPage.login(user.getUsername(), getPassword("test-user@localhost"));
 
         Assert.assertFalse(loginPage.isCurrent());
         events.expectLogin()
@@ -1107,7 +1095,7 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
 
             passwordPage.assertCurrent();
             events.clear();
-            passwordPage.login("password");
+            passwordPage.login(getPassword(user.getUsername()));
 
             Assert.assertFalse(loginUsernameOnlyPage.isCurrent());
             Assert.assertFalse(passwordPage.isCurrent());
@@ -1197,7 +1185,7 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
             // Assert that the login skipped the OTP authenticator and moved to the password
             passwordPage.assertCurrent();
             passwordPage.assertTryAnotherWayLinkAvailability(true);
-            passwordPage.login("password");
+            passwordPage.login(getPassword("user-with-one-configured-otp"));
 
             Assert.assertFalse(loginPage.isCurrent());
             Assert.assertFalse(oneTimeCodePage.isOtpLabelPresent());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ConditionalUserAttributeAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ConditionalUserAttributeAuthenticatorTest.java
@@ -49,7 +49,7 @@ public class ConditionalUserAttributeAuthenticatorTest extends AbstractTestRealm
     private final static String APPROVED_USER = "approved";
     private final static String APPROVED_BY_GROUP_USER = "approved-by-group";
     private final static String APPROVED_BY_SUBGROUP_USER = "approved-by-subgroup";
-    private final static String PASSWORD = "password";
+    private final static String PASSWORD = generatePassword();
 
     @Page
     protected LoginUsernameOnlyPage loginUsernameOnlyPage;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
@@ -38,7 +38,6 @@ import org.keycloak.models.jpa.entities.AuthenticationFlowEntity;
 import org.keycloak.models.utils.TimeBasedOTP;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -90,10 +89,6 @@ public class FlowOverrideTest extends AbstractFlowTest {
     protected ErrorPage errorPage;
 
     private TimeBasedOTP totp = new TimeBasedOTP();
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
 
     @Before
     public void setupFlows() {
@@ -216,7 +211,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
         loginPage.assertCurrent();
 
         // Fill username+password. I am successfully authenticated
-        oauth.fillLoginForm("test-user@localhost", "password");
+        oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
         appPage.assertCurrent();
 
         events.expectLogin().client("test-app-flow").detail(Details.USERNAME, "test-user@localhost").assertEvent();
@@ -248,7 +243,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
         loginPage.assertCurrent();
 
         // Fill username+password. I am successfully authenticated
-        oauth.fillLoginForm("test-user@localhost", "password");
+        oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
         appPage.assertCurrent();
 
         events.expectLogin().client(clientId).detail(Details.USERNAME, "test-user@localhost").assertEvent();
@@ -299,7 +294,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
             Form form = new Form();
             form.param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD);
             form.param("username", "test-user@localhost");
-            form.param("password", "password");
+            form.param("password", getPassword("test-user@localhost"));
 
             Response response = grantTarget.request()
                     .header(HttpHeaders.AUTHORIZATION, header)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -64,7 +64,7 @@ import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.account.AccountRestClient;
@@ -102,7 +102,7 @@ import static org.keycloak.testsuite.actions.AppInitiatedActionDeleteCredentialT
  * @author <a href="mailto:sebastian.zoescher@prime-sign.com">Sebastian Zoescher</a>
  */
 @EnableFeature(value = RECOVERY_CODES, skipRestart = true)
-public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
+public class LevelOfAssuranceFlowTest extends AbstractChangeImportedUserPasswordsTest {
 
     private final static String FLOW_ALIAS = "browser -  Level of Authentication FLow";
 
@@ -142,6 +142,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
         try {
             testRealm.setOtpPolicyCodeReusable(true);
             findTestApp(testRealm).setAttributes(Collections.singletonMap(Constants.ACR_LOA_MAP, getAcrToLoaMappingForClient()));
@@ -162,7 +163,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
 
         userRep.setId(null);
         UserBuilder.edit(userRep)
-                .password("password")
+                .password(generatePassword("test-user@localhost"))
                 .totpSecret("totpSecret")
                 .otpEnabled();
         Response response = testRealm().users().create(userRep);
@@ -1100,13 +1101,13 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
 
     private void authenticateWithUsernamePassword() {
         loginPage.assertCurrent();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
     }
 
     private void reauthenticateWithPassword() {
         loginPage.assertCurrent();
         Assert.assertEquals("test-user@localhost", loginPage.getAttemptedUsername());
-        loginPage.login("password");
+        loginPage.login(getPassword("test-user@localhost"));
     }
 
     private void authenticateWithTotp() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginHotpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginHotpTest.java
@@ -27,8 +27,8 @@ import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.utils.HmacOTP;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.AppPage.RequestType;
 import org.keycloak.testsuite.pages.LoginPage;
@@ -43,12 +43,13 @@ import java.net.MalformedURLException;
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */
-public class LoginHotpTest extends AbstractTestRealmKeycloakTest {
+public class LoginHotpTest extends AbstractChangeImportedUserPasswordsTest {
 
     public static OTPPolicy policy;
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
         testRealm.setOtpPolicyType(OTPCredentialModel.HOTP);
         testRealm.setOtpPolicyAlgorithm(HmacOTP.DEFAULT_ALGORITHM);
         testRealm.setOtpPolicyLookAheadWindow(2);
@@ -98,7 +99,7 @@ public class LoginHotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithHotpFailure() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -117,7 +118,7 @@ public class LoginHotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithMissingHotp() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -136,7 +137,7 @@ public class LoginHotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithHotpSuccess() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue("expecting totpPage got: " + driver.getCurrentUrl(), loginTotpPage.isCurrent());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTotpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTotpTest.java
@@ -34,8 +34,8 @@ import org.keycloak.models.utils.TimeBasedOTP;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.AppPage.RequestType;
 import org.keycloak.testsuite.pages.LoginPage;
@@ -64,10 +64,11 @@ import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */
-public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
+public class LoginTotpTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
         UserRepresentation user = RealmRepUtil.findUser(testRealm, "test-user@localhost");
         UserBuilder.edit(user)
                    .totpSecret("totpSecret")
@@ -101,7 +102,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithTotpFailure() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -120,7 +121,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithMissingTotp() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -139,7 +140,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithTotpSuccess() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -156,7 +157,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void loginWithTotpRefreshTotpPage() throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -194,7 +195,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
         // Assert attempted-username NOT available
         loginPage.assertAttemptedUsernameAvailability(false);
 
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 
@@ -221,7 +222,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
             Form form = new Form()
                     .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD)
                     .param(OAuth2Constants.USERNAME, "test-user@localhost")
-                    .param(OAuth2Constants.PASSWORD, "password")
+                    .param(OAuth2Constants.PASSWORD, getPassword("test-user@localhost"))
                     .param(OAuth2Constants.CLIENT_ID, Constants.ADMIN_CLI_CLIENT_ID);
 
             // Compatibility between "otp" and "totp"
@@ -256,7 +257,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
         OTPCredentialData credentialData = JsonSerialization.readValue(otpCredential.getCredentialData(), OTPCredentialData.class);
         OTPCredentialData newCredentialData = new OTPCredentialData(credentialData.getSubType(), credentialData.getDigits(), credentialData.getCounter(), credentialData.getPeriod(), credentialData.getAlgorithm(),
                 SecretEncoding.BASE32.name());
-        UserRepresentation newUser = UserBuilder.create().username("test-otp-user@localhost").password("password").enabled(true).build();
+        UserRepresentation newUser = UserBuilder.create().username("test-otp-user@localhost").password(generatePassword("test-otp-user@localhost")).enabled(true).build();
         CredentialRepresentation credential = new CredentialRepresentation();
 
         credential.setType(otpCredential.getType());
@@ -273,7 +274,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
         testRealm().users().create(newUser).close();
 
         loginPage.open();
-        loginPage.login(newUser.getUsername(), "password");
+        loginPage.login(newUser.getUsername(), getPassword("test-otp-user@localhost"));
 
         Assert.assertTrue(loginTotpPage.isCurrent());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RPInitiatedFrontChannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RPInitiatedFrontChannelLogoutTest.java
@@ -25,8 +25,7 @@ import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.IDToken;
 import org.keycloak.representations.LogoutToken;
 import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
@@ -36,12 +35,7 @@ import org.keycloak.testsuite.util.oauth.OAuthClient;
  *
  * @author rmartinc
  */
-public class RPInitiatedFrontChannelLogoutTest extends AbstractTestRealmKeycloakTest {
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-        // no-op
-    }
+public class RPInitiatedFrontChannelLogoutTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Test
     public void testFrontChannelLogoutWithPostLogoutRedirectUri() throws Exception {
@@ -51,7 +45,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractTestRealmKeycloak
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout");
         clients.get(rep.getId()).update(rep);
         try {
-            oauth.doLogin("test-user@localhost", "password");
+            oauth.doLogin("test-user@localhost", getPassword("test-user@localhost"));
             String code = oauth.parseLoginResponse().getCode();
             AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
             String idTokenString = tokenResponse.getIdToken();
@@ -80,7 +74,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractTestRealmKeycloak
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED, "false");
         clients.get(rep.getId()).update(rep);
         try {
-            oauth.doLogin("test-user@localhost", "password");
+            oauth.doLogin("test-user@localhost", getPassword("test-user@localhost"));
             String code = oauth.parseLoginResponse().getCode();
             AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
             String idTokenString = tokenResponse.getIdToken();
@@ -108,7 +102,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractTestRealmKeycloak
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout");
         clients.get(rep.getId()).update(rep);
         try {
-            oauth.doLogin("test-user@localhost", "password");
+            oauth.doLogin("test-user@localhost", getPassword("test-user@localhost"));
             String code = oauth.parseLoginResponse().getCode();
             AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
             String idTokenString = tokenResponse.getIdToken();
@@ -139,7 +133,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractTestRealmKeycloak
                 .setFrontchannelLogout(true)
                 .setAttribute(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout")
                 .update()) {
-            oauth.doLogin("test-user@localhost", "password");
+            oauth.doLogin("test-user@localhost", getPassword("test-user@localhost"));
             String code = oauth.parseLoginResponse().getCode();
             AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
             String idTokenString = tokenResponse.getIdToken();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -31,7 +31,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -65,7 +65,7 @@ import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @EnableFeature(value = RECOVERY_CODES, skipRestart = true)
-public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeycloakTest {
+public class RecoveryAuthnCodesAuthenticatorTest extends AbstractChangeImportedUserPasswordsTest {
 
     private static final String BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES = "Browser with Recovery Authentication Codes";
 
@@ -115,11 +115,6 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
     @Rule
     public AssertEvents events = new AssertEvents(this);
 
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-
-    }
-
     void configureBrowserFlowWithRecoveryAuthnCodes(KeycloakTestingClient testingClient, long delay) {
         final String newFlowAlias = BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES;
         testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow(newFlowAlias));
@@ -144,14 +139,14 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
         );
 
         ApiUtil.removeUserByUsername(testRealm(), "test-user@localhost");
-        createUser("test", "test-user@localhost", "password", UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
+        createUser("test", "test-user@localhost", generatePassword("test-user@localhost"), UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
     }
 
     private void testSetupRecoveryAuthnCodesLogoutOtherSessions(boolean logoutOtherSessions) {
         // login with the user using the second driver
         UserResource testUser = testRealm().users().get(findUser("test-user@localhost").getId());
         OAuthClient oauth2 = oauth.newConfig().driver(driver2);
-        oauth2.doLogin("test-user@localhost", "password");
+        oauth2.doLogin("test-user@localhost", getPassword("test-user@localhost"));
         EventRepresentation event1 = events.expectLogin().assertEvent();
         assertEquals(1, testUser.getUserSessions().size());
 
@@ -162,7 +157,7 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
 
         // login and configure codes
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
         setupRecoveryAuthnCodesPage.assertCurrent();
         if (!logoutOtherSessions) {
             setupRecoveryAuthnCodesPage.uncheckLogoutSessions();
@@ -217,7 +212,7 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
 
         oauth.openLoginForm();
         loginPage.assertCurrent();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
         setupRecoveryAuthnCodesPage.assertCurrent();
 
         // modify generatedAt to a fixed value
@@ -249,7 +244,7 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
 
         oauth.openLoginForm();
         loginPage.assertCurrent();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
         setupRecoveryAuthnCodesPage.assertCurrent();
 
         // modify the codes with a new generated ones
@@ -412,7 +407,7 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractTestRealmKeyclo
             passwordPage.assertCurrent();
             //passwordPage.assertAttemptedUsernameAvailability(true);
             Assert.assertEquals("test-user@localhost", passwordPage.getAttemptedUsername());
-            passwordPage.login("password");
+            passwordPage.login(getPassword("test-user@localhost"));
             setupRecoveryAuthnCodesPage.assertCurrent();
             setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -115,7 +115,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", "registerExistingUser@email", "roleRichUser", "password", "password");
+        registerPage.register("firstName", "lastName", "registerExistingUser@email", "roleRichUser", generatePassword());
 
         registerPage.assertCurrent();
         assertEquals("Username already exists.", registerPage.getInputAccountErrors().getUsernameError());
@@ -139,7 +139,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", "test-user@localhost", "registerExistingUser", "password", "password");
+        registerPage.register("firstName", "lastName", "test-user@localhost", "registerExistingUser", generatePassword());
 
         registerPage.assertCurrent();
         assertEquals("Email already exists.", registerPage.getInputAccountErrors().getEmailError());
@@ -164,7 +164,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("firstName", "lastName", "test-user@localhost", "registerExistingEmailUser", "password", "password");
+            registerPage.register("firstName", "lastName", "test-user@localhost", "registerExistingEmailUser", generatePassword());
 
             assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
@@ -179,7 +179,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void registerUpperCaseEmail() throws IOException {
-        String userId = registerUpperCaseAndGetUserId(false);
+        String userId = registerUpperCaseAndGetUserId(false, generatePassword());
         assertThat(userId, notNullValue());
         testRealm().users().get(userId).remove();
     }
@@ -187,7 +187,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void registerUpperCaseEmailAsUsername() throws IOException {
         try (RealmAttributeUpdater rau = configureRealmRegistrationEmailAsUsername(true).update()) {
-            String userId = registerUpperCaseAndGetUserId(true);
+            String userId = registerUpperCaseAndGetUserId(true, generatePassword());
             assertThat(userId, notNullValue());
             testRealm().users().get(userId).remove();
         }
@@ -195,7 +195,8 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void registerUpperCaseEmailWithChangedEmailAsUsername() throws IOException {
-        String userId = registerUpperCaseAndGetUserId(false);
+        final String password = generatePassword();
+        String userId = registerUpperCaseAndGetUserId(false, password);
         assertThat(userId, notNullValue());
         oauth.logoutForm().idTokenHint(idTokenHint).open();
         events.clear();
@@ -205,7 +206,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.assertCurrent();
 
             final String EMAIL = "TEST@localhost";
-            loginPage.login(EMAIL, "password");
+            loginPage.login(EMAIL, password);
             assertThat(RequestType.AUTH_RESPONSE, is(appPage.getRequestType()));
 
             events.expectLogin()
@@ -224,7 +225,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", "registerUserInvalidPasswordConfirm@email", "registerUserInvalidPasswordConfirm", "password", "invalid");
+        registerPage.register("firstName", "lastName", "registerUserInvalidPasswordConfirm@email", "registerUserInvalidPasswordConfirm", generatePassword(), "invalid");
 
         registerPage.assertCurrent();
         assertEquals("Password confirmation doesn't match.", registerPage.getInputPasswordErrors().getPasswordConfirmError());
@@ -267,7 +268,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("firstName", "lastName", "registerPasswordPolicy@email", "registerPasswordPolicy", "pass", "pass");
+            registerPage.register("firstName", "lastName", "registerPasswordPolicy@email", "registerPasswordPolicy", generatePassword(3));
 
             registerPage.assertCurrent();
             assertEquals("Invalid password: minimum length 8.", registerPage.getInputPasswordErrors().getPasswordError());
@@ -277,7 +278,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
                     .removeDetail(Details.EMAIL)
                     .user((String) null).error("invalid_registration").assertEvent();
 
-            registerPage.register("firstName", "lastName", "registerPasswordPolicy@email", "registerPasswordPolicy", "password", "password");
+            registerPage.register("firstName", "lastName", "registerPasswordPolicy@email", "registerPasswordPolicy", generatePassword());
             assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
             String userId = events.expectRegister("registerPasswordPolicy", "registerPasswordPolicy@email").assertEvent().getUserId();
@@ -292,7 +293,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", "registerUserMissingUsername@email", null, "password", "password");
+        registerPage.register("firstName", "lastName", "registerUserMissingUsername@email", null, generatePassword());
 
         registerPage.assertCurrent();
         assertEquals("Please specify username.", registerPage.getInputAccountErrors().getUsernameError());
@@ -341,7 +342,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", null, "registerUserMissingEmail", "password", "password");
+        registerPage.register("firstName", "lastName", null, "registerUserMissingEmail", generatePassword());
         registerPage.assertCurrent();
         assertEquals("Please specify email.", registerPage.getInputAccountErrors().getEmailError());
         events.expectRegister("registerusermissingemail", null)
@@ -355,7 +356,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", "registerUserInvalidEmailemail", "registerUserInvalidEmail", "password", "password");
+        registerPage.register("firstName", "lastName", "registerUserInvalidEmailemail", "registerUserInvalidEmail", generatePassword());
         registerPage.assertCurrent();
         assertEquals("registerUserInvalidEmailemail", registerPage.getEmail());
         assertEquals("Invalid email address.", registerPage.getInputAccountErrors().getEmailError());
@@ -372,7 +373,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         //contains few special characters we want to be sure they are allowed in username
         String username = "register.U-se@rS_uccess";
 
-        registerPage.register("firstName", "lastName", "registerUserSuccess@email", username, "password", "password");
+        registerPage.register("firstName", "lastName", "registerUserSuccess@email", username, generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -394,7 +395,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         errorPage.openLanguage("Deutsch");
         assertEquals("Deutsch", errorPage.getLanguageDropdownText());
 
-        registerPage.register("firstName", "lastName", "registerGerman@localhost", "registerGerman", "password", "password");
+        registerPage.register("firstName", "lastName", "registerGerman@localhost", "registerGerman", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -425,7 +426,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
         String username = KeycloakModelUtils.generateId();
         String email = username + "@email.com";
-        registerPage.register("firstName", "lastName", email, username, "password", "password");
+        registerPage.register("firstName", "lastName", email, username, generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -453,7 +454,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
         String username = KeycloakModelUtils.generateId();
         String email = username + "@email.com";
-        registerPage.register("firstName", "lastName", email, username, "password", "password");
+        registerPage.register("firstName", "lastName", email, username, generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -482,7 +483,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("firstName", "lastName", "registerUserSuccessWithEmailVerification@email", "registerUserSuccessWithEmailVerification", "password", "password");
+            registerPage.register("firstName", "lastName", "registerUserSuccessWithEmailVerification@email", "registerUserSuccessWithEmailVerification", generatePassword());
             verifyEmailPage.assertCurrent();
 
             String userId = events.expectRegister("registerUserSuccessWithEmailVerification", "registerUserSuccessWithEmailVerification@email").assertEvent().getUserId();
@@ -524,7 +525,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("firstName", "lastName", "registerUserSuccessWithEmailVerificationWithResend@email", "registerUserSuccessWithEmailVerificationWithResend", "password", "password");
+            registerPage.register("firstName", "lastName", "registerUserSuccessWithEmailVerificationWithResend@email", "registerUserSuccessWithEmailVerificationWithResend", generatePassword());
             verifyEmailPage.assertCurrent();
 
             String userId = events.expectRegister("registerUserSuccessWithEmailVerificationWithResend", "registerUserSuccessWithEmailVerificationWithResend@email").assertEvent().getUserId();
@@ -577,7 +578,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("Äǜṳǚǘǖ", "Öṏṏ", "registeruserumlats@email", "registeruserumlats", "password", "password");
+        registerPage.register("Äǜṳǚǘǖ", "Öṏṏ", "registeruserumlats@email", "registeruserumlats", generatePassword());
 
         String userId = events.expectRegister("registeruserumlats", "registeruserumlats@email").assertEvent().getUserId();
         events.expectLogin().detail("username", "registeruserumlats").user(userId).assertEvent();
@@ -619,7 +620,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             assertTrue(registerPage.isCurrent());
             assertEquals("Username already exists.", registerPage.getInputAccountErrors().getUsernameError());
 
-            registerPage.register("firstName", "lastName", "registerUserNotUsername@email", null, "password", "password");
+            registerPage.register("firstName", "lastName", "registerUserNotUsername@email", null, generatePassword());
 
             assertTrue(registerPage.isCurrent());
             assertEquals("Please specify username.", registerPage.getInputAccountErrors().getUsernameError());
@@ -660,7 +661,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             assertTrue(registerPage.isCurrent());
             assertEquals("Username already exists.", registerPage.getInputAccountErrors().getUsernameError());
 
-            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", null, "password", "password");
+            registerPage.register("firstName", "lastName", "registerUserNotContainsUsername@email", null, generatePassword());
 
             assertTrue(registerPage.isCurrent());
             assertEquals("Please specify username.", registerPage.getInputAccountErrors().getUsernameError());
@@ -704,7 +705,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.registerWithEmailAsUsername("firstName", "lastName", "test-user@localhost", "password", "password");
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", "test-user@localhost", generatePassword());
 
             registerPage.assertCurrent();
             assertEquals("Email already exists.", registerPage.getInputAccountErrors().getEmailError());
@@ -720,12 +721,12 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.registerWithEmailAsUsername("firstName", "lastName", null, "password", "password");
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", null, generatePassword());
             registerPage.assertCurrent();
             assertEquals("Please specify email.", registerPage.getInputAccountErrors().getEmailError());
             events.expectRegister(null, null).removeDetail("username").removeDetail("email").error("invalid_registration").assertEvent();
 
-            registerPage.registerWithEmailAsUsername("firstName", "lastName", "registerUserInvalidEmailemail", "password", "password");
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", "registerUserInvalidEmailemail", generatePassword());
             registerPage.assertCurrent();
             assertEquals("Invalid email address.", registerPage.getInputAccountErrors().getEmailError());
             events.expectRegister("registeruserinvalidemailemail", "registeruserinvalidemailemail").error("invalid_registration").assertEvent();
@@ -739,7 +740,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.registerWithEmailAsUsername("firstName", "lastName", "registerUserSuccessE@email", "password", "password");
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", "registerUserSuccessE@email", generatePassword());
 
             assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
@@ -763,7 +764,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.registerWithEmailAsUsername("firstName", "lastName", "alice@email", "password", "password");
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", "alice@email", generatePassword());
 
             assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         }
@@ -808,8 +809,9 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
+            final String password = generatePassword();
             registerPage.register("firstName", "lastName", "registerUserMissingTermsAcceptance@email",
-                    "registerUserMissingTermsAcceptance", "password", "password", null, false, null);
+                    "registerUserMissingTermsAcceptance", password, password, null, false, null);
 
             registerPage.assertCurrent();
             assertEquals("You must agree to our terms and conditions.", registerPage.getInputAccountErrors().getTermsError());
@@ -834,8 +836,9 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
+            final String password = generatePassword();
             registerPage.register("firstName", "lastName", "registerUserSuccessTermsAcceptance@email",
-                    "registerUserSuccessTermsAcceptance", "password", "password", null, true, null);
+                    "registerUserSuccessTermsAcceptance", password, password, null, true, null);
 
             assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
@@ -865,9 +868,10 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
+            final String password = generatePassword();
             int currentTime = Time.currentTime();
             registerPage.register("firstName", "lastName", "registerUserSuccessTermsAcceptance2@email",
-                    "registerUserSuccessTermsAcceptance2", "password", "password", null, true, null);
+                    "registerUserSuccessTermsAcceptance2", password, password, null, true, null);
 
             assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
@@ -936,7 +940,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
      * @param emailAsUsername is flag `Email as username` enabled
      * @return user ID
      */
-    private String registerUpperCaseAndGetUserId(boolean emailAsUsername) {
+    private String registerUpperCaseAndGetUserId(boolean emailAsUsername, String password) {
         final String EMAIL = "TEST@localhost";
         final String USERNAME = "UPPERCASE";
         final String EMAIL_OR_USERNAME = emailAsUsername ? EMAIL : USERNAME;
@@ -946,9 +950,9 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         registerPage.assertCurrent();
 
         if (emailAsUsername) {
-            registerPage.registerWithEmailAsUsername("firstName", "lastName", EMAIL, "password", "password");
+            registerPage.registerWithEmailAsUsername("firstName", "lastName", EMAIL, password, password);
         } else {
-            registerPage.register("firstName", "lastName", EMAIL, USERNAME, "password", "password");
+            registerPage.register("firstName", "lastName", EMAIL, USERNAME, password, password);
         }
 
         String userId = events.expectRegister(EMAIL_OR_USERNAME, EMAIL)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
@@ -125,7 +125,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "", "registerUserSuccessLastNameOptional@email", "registerUserSuccessLastNameOptional", "password", "password");
+        registerPage.register("firstName", "", "registerUserSuccessLastNameOptional@email", "registerUserSuccessLastNameOptional", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -146,7 +146,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "", "registerUserSuccessLastNameRequiredForScope_notRequested@email", "registerUserSuccessLastNameRequiredForScope_notRequested", "password", "password");
+        registerPage.register("firstName", "", "registerUserSuccessLastNameRequiredForScope_notRequested@email", "registerUserSuccessLastNameRequiredForScope_notRequested", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -168,14 +168,14 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "", "registerUserSuccessLastNameRequiredForScope_requested@email", "registerUserSuccessLastNameRequiredForScope_requested", "password", "password");
+        registerPage.register("firstName", "", "registerUserSuccessLastNameRequiredForScope_requested@email", "registerUserSuccessLastNameRequiredForScope_requested", generatePassword());
 
         //error reported
         registerPage.assertCurrent();
         assertEquals("Please specify this field.", registerPage.getInputAccountErrors().getLastNameError());
 
         //submit correct form
-        registerPage.register("firstName", "lastName", "registerUserSuccessLastNameRequiredForScope_requested@email", "registerUserSuccessLastNameRequiredForScope_requested", "password", "password");
+        registerPage.register("firstName", "lastName", "registerUserSuccessLastNameRequiredForScope_requested@email", "registerUserSuccessLastNameRequiredForScope_requested", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -194,14 +194,14 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "", "registerUserSuccessLastNameRequiredForScope_clientDefault@email", "registerUserSuccessLastNameRequiredForScope_clientDefault", "password", "password");
+        registerPage.register("firstName", "", "registerUserSuccessLastNameRequiredForScope_clientDefault@email", "registerUserSuccessLastNameRequiredForScope_clientDefault", generatePassword());
 
         //error reported
         registerPage.assertCurrent();
         assertEquals("Please specify this field.", registerPage.getInputAccountErrors().getLastNameError());
 
         //submit correct form
-        registerPage.register("firstName", "lastName", "registerUserSuccessLastNameRequiredForScope_clientDefault@email", "registerUserSuccessLastNameRequiredForScope_clientDefault", "password", "password");
+        registerPage.register("firstName", "lastName", "registerUserSuccessLastNameRequiredForScope_clientDefault@email", "registerUserSuccessLastNameRequiredForScope_clientDefault", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -219,7 +219,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "last", "registerUserSuccessLastNameLengthValidation@email", "registerUserSuccessLastNameLengthValidation", "password", "password");
+        registerPage.register("firstName", "last", "registerUserSuccessLastNameLengthValidation@email", "registerUserSuccessLastNameLengthValidation", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -240,7 +240,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "L", "registerUserInvalidLastNameLength@email", "registerUserInvalidLastNameLength", "password", "password");
+        registerPage.register("firstName", "L", "registerUserInvalidLastNameLength@email", "registerUserInvalidLastNameLength", generatePassword());
 
         registerPage.assertCurrent();
         assertEquals("Length must be between 3 and 255.", registerPage.getInputAccountErrors().getLastNameError());
@@ -448,7 +448,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         Assert.assertFalse(registerPage.isDepartmentPresent());
 
 
-        registerPage.register("FirstName", "LastName", "requiredReadOnlyAttributeNotRenderedAndNotBlockingRegistration@email", "requiredReadOnlyAttributeNotRenderedAndNotBlockingRegistration", "password", "password");
+        registerPage.register("FirstName", "LastName", "requiredReadOnlyAttributeNotRenderedAndNotBlockingRegistration@email", "requiredReadOnlyAttributeNotRenderedAndNotBlockingRegistration", generatePassword());
 
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -469,10 +469,11 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         registerPage.assertCurrent();
 
         //check required validation works
-        registerPage.register("FirstAA", "LastAA", "attributeRequiredAndSelectedByScopeMustBeSet@email", "attributeRequiredAndSelectedByScopeMustBeSet", "password", "password", "");
+        final String password = generatePassword();
+        registerPage.register("FirstAA", "LastAA", "attributeRequiredAndSelectedByScopeMustBeSet@email", "attributeRequiredAndSelectedByScopeMustBeSet", password, password, "");
         registerPage.assertCurrent();
 
-        registerPage.register("FirstAA", "LastAA", "attributeRequiredAndSelectedByScopeMustBeSet@email", "attributeRequiredAndSelectedByScopeMustBeSet", "password", "password", "DepartmentAA");
+        registerPage.register("FirstAA", "LastAA", "attributeRequiredAndSelectedByScopeMustBeSet@email", "attributeRequiredAndSelectedByScopeMustBeSet", password, password, "DepartmentAA");
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -497,7 +498,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         registerPage.assertCurrent();
 
         Assert.assertTrue(registerPage.isDepartmentPresent());
-        registerPage.register("FirstAA", "LastAA", "attributeNotRequiredAndSelectedByScopeCanBeIgnored@email", "attributeNotRequiredAndSelectedByScopeCanBeIgnored", "password", "password");
+        registerPage.register("FirstAA", "LastAA", "attributeNotRequiredAndSelectedByScopeCanBeIgnored@email", "attributeNotRequiredAndSelectedByScopeCanBeIgnored", generatePassword());
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -523,7 +524,8 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         registerPage.assertCurrent();
 
         Assert.assertTrue(registerPage.isDepartmentPresent());
-        registerPage.register("FirstAA", "LastAA", "attributeNotRequiredAndSelectedByScopeCanBeSet@email", "attributeNotRequiredAndSelectedByScopeCanBeSet", "password", "password", "Department AA");
+        final String password = generatePassword();
+        registerPage.register("FirstAA", "LastAA", "attributeNotRequiredAndSelectedByScopeCanBeSet@email", "attributeNotRequiredAndSelectedByScopeCanBeSet", password, password, "Department AA");
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -549,7 +551,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         registerPage.assertCurrent();
 
         Assert.assertFalse(registerPage.isDepartmentPresent());
-        registerPage.register("FirstAA", "LastAA", "attributeRequiredButNotSelectedByScopeIsNotRendered@email", "attributeRequiredButNotSelectedByScopeIsNotRendered", "password", "password");
+        registerPage.register("FirstAA", "LastAA", "attributeRequiredButNotSelectedByScopeIsNotRendered@email", "attributeRequiredButNotSelectedByScopeIsNotRendered", generatePassword());
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -574,7 +576,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", null, "registerWithoutEmail", "password", "password");
+        registerPage.register("firstName", "lastName", null, "registerWithoutEmail", generatePassword());
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
     }
 
@@ -591,7 +593,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", null, "registerWithoutEmail", "password", "password");
+        registerPage.register("firstName", "lastName", null, "registerWithoutEmail", generatePassword());
         registerPage.assertCurrent();
         assertThat(registerPage.getInputAccountErrors().getEmailError(), anyOf(
                 containsString("Please specify email"),
@@ -613,7 +615,7 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         loginPage.clickRegister();
         registerPage.assertCurrent();
 
-        registerPage.register("firstName", "lastName", null, "registerWithoutEmail", "password", "password");
+        registerPage.register("firstName", "lastName", null, "registerWithoutEmail", generatePassword());
         assertThat(registerPage.getInputAccountErrors().getEmailError(), anyOf(
                 containsString("Please specify email"),
                 containsString("Please specify this field")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetCredentialsAlternativeFlowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetCredentialsAlternativeFlowsTest.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.assertEquals;
 public class ResetCredentialsAlternativeFlowsTest extends AbstractAppInitiatedActionTest {
 
     private String userId;
+    private String password;
 
     @Rule
     public GreenMailRule greenMail = new GreenMailRule();
@@ -116,7 +117,8 @@ public class ResetCredentialsAlternativeFlowsTest extends AbstractAppInitiatedAc
                 .enabled(true)
                 .build();
 
-        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+        password = generatePassword();
+        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, password);
         getCleanup().addUserId(userId);
     }
 
@@ -346,7 +348,7 @@ public class ResetCredentialsAlternativeFlowsTest extends AbstractAppInitiatedAc
 
             // Login & set up the initial OTP code for the user
             loginPage.open();
-            loginPage.login("login-test", "password");
+            loginPage.login("login-test", password);
             String code = oauth.parseLoginResponse().getCode();
             AccessTokenResponse response = oauth.doAccessTokenRequest(code);
 
@@ -409,7 +411,7 @@ public class ResetCredentialsAlternativeFlowsTest extends AbstractAppInitiatedAc
 
             // Login & set up the initial OTP code for the user
             loginPage.open();
-            loginPage.login("login@test.com", "password");
+            loginPage.login("login@test.com", password);
 
             // Create OTP credential with empty label
             final String emptyOtpLabel = "";
@@ -434,7 +436,7 @@ public class ResetCredentialsAlternativeFlowsTest extends AbstractAppInitiatedAc
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("Bruce", "Wilson", "bwilson@keycloak.org", "bwilson", "password", "password");
+            registerPage.register("Bruce", "Wilson", "bwilson@keycloak.org", "bwilson", generatePassword());
             totpPage.assertCurrent();
 
             // Create OTP credential with empty label

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -106,6 +106,7 @@ import static org.junit.Assert.*;
 public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
     private String userId;
+    private String password;
     private UserRepresentation defaultUser;
 
     @Rule
@@ -130,7 +131,8 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
                 .enabled(true)
                 .build();
 
-        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), defaultUser, "password");
+        password = generatePassword();
+        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), defaultUser, password);
         defaultUser.setId(userId);
         expectedMessagesCount = 0;
         getCleanup().addUserId(userId);
@@ -190,7 +192,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
     public void resetPasswordLoggedUser() throws IOException {
         String username = "login-test";
         loginPage.open();
-        loginPage.login(username, "password");
+        loginPage.login(username, password);
 
         events.expectLogin().user(userId).detail(Details.USERNAME, username).assertEvent();
 
@@ -421,7 +423,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
                 .session((String) null)
                 .detail(Details.EMAIL, "test-user@localhost").assertEvent();
 
-        loginPage.login("login@test.com", "password");
+        loginPage.login("login@test.com", password);
 
         EventRepresentation loginEvent = events.expectLogin().user(userId).detail(Details.USERNAME, "login@test.com").assertEvent();
 
@@ -1206,7 +1208,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
             resetPasswordInvalidPassword("login-test", "password3", "Invalid password: must not be equal to any of last 3 passwords.");
 
             setTimeOffset(8000000);
-            resetPassword("login-test", "password");
+            resetPassword("login-test", password);
         } finally {
             setTimeOffset(0);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ScriptAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ScriptAuthenticatorTest.java
@@ -74,13 +74,13 @@ public class ScriptAuthenticatorTest extends AbstractFlowTest {
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
-
+        super.configureTestRealm(testRealm);
         UserRepresentation failUser = UserBuilder.create()
                 .id(UUID.randomUUID().toString())
                 .username("fail")
                 .email("fail@test.com")
                 .enabled(true)
-                .password("password")
+                .password(generatePassword("fail"))
                 .build();
 
         UserRepresentation okayUser = UserBuilder.create()
@@ -88,7 +88,7 @@ public class ScriptAuthenticatorTest extends AbstractFlowTest {
                 .username("user")
                 .email("user@test.com")
                 .enabled(true)
-                .password("password")
+                .password(generatePassword("user"))
                 .build();
 
         RealmBuilder.edit(testRealm)
@@ -162,7 +162,7 @@ public class ScriptAuthenticatorTest extends AbstractFlowTest {
     public void loginShouldWorkWithScriptAuthenticator() {
         loginPage.open();
 
-        loginPage.login("user", "password");
+        loginPage.login("user", getPassword("user"));
 
         events.expectLogin().user(userId).detail(Details.USERNAME, "user").assertEvent();
     }
@@ -174,7 +174,7 @@ public class ScriptAuthenticatorTest extends AbstractFlowTest {
     public void loginShouldFailWithScriptAuthenticator() {
         loginPage.open();
 
-        loginPage.login("fail", "password");
+        loginPage.login("fail", getPassword("fail"));
 
         events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.USER_NOT_FOUND).assertEvent();
     }
@@ -197,7 +197,7 @@ public class ScriptAuthenticatorTest extends AbstractFlowTest {
 
         loginPage.open();
 
-        loginPage.login("user", "password");
+        loginPage.login("user", getPassword("user"));
 
         events.expectLogin().user(userId).detail(Details.USERNAME, "user").assertEvent();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/TransientSessionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/TransientSessionTest.java
@@ -24,9 +24,8 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
-import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.services.managers.AuthenticationManager;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.util.FlowUtil;
@@ -41,14 +40,10 @@ import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUI
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class TransientSessionTest extends AbstractTestRealmKeycloakTest {
+public class TransientSessionTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-    }
 
     @Test
     public void loginSuccess() throws Exception {
@@ -57,7 +52,7 @@ public class TransientSessionTest extends AbstractTestRealmKeycloakTest {
         oauth.client("direct-grant", "password");
 
         // Signal that we want userSession to be transient
-        AccessTokenResponse response = oauth.passwordGrantRequest("test-user@localhost", "password")
+        AccessTokenResponse response = oauth.passwordGrantRequest("test-user@localhost", getPassword("test-user@localhost"))
                 .param(SetClientNoteAuthenticator.PREFIX + AuthenticationManager.USER_SESSION_PERSISTENT_STATE, UserSessionModel.SessionPersistenceState.TRANSIENT.toString())
                 .send();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/VerifyProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/VerifyProfileTest.java
@@ -34,7 +34,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPConfig;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.pages.AppPage;
@@ -78,7 +78,7 @@ import static org.keycloak.testsuite.util.userprofile.UserProfileUtil.VALIDATION
 /**
  * @author Vlastimil Elias <velias@redhat.com>
  */
-public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
+public class VerifyProfileTest extends AbstractChangeImportedUserPasswordsTest {
 
     private static String userId;
 
@@ -105,13 +105,14 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
-        UserRepresentation user = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test").email("login@test.com").enabled(true).password("password").build();
-        UserRepresentation user2 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test2").email("login2@test.com").enabled(true).password("password").build();
-        UserRepresentation user3 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test3").email("login3@test.com").enabled(true).password("password").lastName("ExistingLast").build();
-        UserRepresentation user4 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test4").email("login4@test.com").enabled(true).password("password").lastName("ExistingLast").build();
-        UserRepresentation user5 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test5").email("login5@test.com").enabled(true).password("password").firstName("ExistingFirst").lastName("ExistingLast").build();
-        UserRepresentation user6 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test6").email("login6@test.com").enabled(true).password("password").firstName("ExistingFirst").lastName("ExistingLast").build();
-        UserRepresentation userWithoutEmail = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-nomail").enabled(true).password("password").firstName("NoMailFirst").lastName("NoMailLast").build();
+        super.configureTestRealm(testRealm);
+        UserRepresentation user = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test").email("login@test.com").enabled(true).password(generatePassword("login-test")).build();
+        UserRepresentation user2 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test2").email("login2@test.com").enabled(true).password(generatePassword("login-test2")).build();
+        UserRepresentation user3 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test3").email("login3@test.com").enabled(true).password(generatePassword("login-test3")).lastName("ExistingLast").build();
+        UserRepresentation user4 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test4").email("login4@test.com").enabled(true).password(generatePassword("login-test4")).lastName("ExistingLast").build();
+        UserRepresentation user5 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test5").email("login5@test.com").enabled(true).password(generatePassword("login-test5")).firstName("ExistingFirst").lastName("ExistingLast").build();
+        UserRepresentation user6 = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-test6").email("login6@test.com").enabled(true).password(generatePassword("login-test6")).firstName("ExistingFirst").lastName("ExistingLast").build();
+        UserRepresentation userWithoutEmail = UserBuilder.create().id(UUID.randomUUID().toString()).username("login-nomail").enabled(true).password(generatePassword("login-nomail")).firstName("NoMailFirst").lastName("NoMailLast").build();
 
         RealmBuilder.edit(testRealm).user(user).user(user2).user(user3).user(user4).user(user5).user(user6).user(userWithoutEmail);
 
@@ -169,7 +170,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -200,7 +201,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -240,7 +241,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         testRealm().update(realm);
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -266,7 +267,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -286,7 +287,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
         //event when form is shown
@@ -312,7 +313,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         testingClient.server(TEST_REALM_NAME).run(setEmptyFirstNameAndCustomAttribute());
 
         loginPage.open();
-        loginPage.login("login-test", "password");
+        loginPage.login("login-test", getPassword("login-test"));
 
         //submit with error
         verifyProfilePage.assertCurrent();
@@ -366,7 +367,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
             testRealm().update(realm);
 
             loginPage.open();
-            loginPage.login("login-test5", "password");
+            loginPage.login("login-test5", getPassword("login-test5"));
 
             verifyProfilePage.assertCurrent();
             assertFalse(verifyProfilePage.isUsernamePresent());
@@ -398,7 +399,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
             testRealm().update(realm);
 
             loginPage.open();
-            loginPage.login("login-test5", "password");
+            loginPage.login("login-test5", getPassword("login-test5"));
 
             verifyProfilePage.assertCurrent();
             assertFalse(verifyProfilePage.isUsernamePresent());
@@ -445,7 +446,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
             testRealm().update(realm);
 
             loginPage.open();
-            loginPage.login("login-test5", "password");
+            loginPage.login("login-test5", getPassword("login-test5"));
 
             verifyProfilePage.assertCurrent();
             assertFalse(verifyProfilePage.isUsernamePresent());
@@ -483,7 +484,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test2", "password");
+        loginPage.login("login-test2", getPassword("login-test2"));
 
         verifyProfilePage.assertCurrent();
         verifyProfilePage.update("First", "");
@@ -509,7 +510,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
         //submit with error
@@ -541,7 +542,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -566,7 +567,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                     + "]}");
 
             loginPage.open();
-            loginPage.login("login6@test.com", "password");
+            loginPage.login("login6@test.com", getPassword("login-test6"));
 
             Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
             Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -586,7 +587,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test3", "password");
+        loginPage.login("login-test3", getPassword("login-test3"));
 
         verifyProfilePage.assertCurrent();
         Assert.assertEquals("ExistingLast", verifyProfilePage.getLastName());
@@ -614,7 +615,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test6", "password");
+        loginPage.login("login-test6", getPassword("login-test6"));
 
         verifyProfilePage.assertCurrent();
         Assert.assertEquals("ExistingLast", verifyProfilePage.getLastName());
@@ -633,7 +634,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test6", "password");
+        loginPage.login("login-test6", getPassword("login-test6"));
 
         verifyProfilePage.assertCurrent();
         Assert.assertEquals("ExistingLast", verifyProfilePage.getLastName());
@@ -652,7 +653,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test6", "password");
+        loginPage.login("login-test6", getPassword("login-test6"));
 
         verifyProfilePage.assertCurrent();
         Assert.assertEquals("ExistingLast", verifyProfilePage.getLastName());
@@ -671,7 +672,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-nomail", "password");
+        loginPage.login("login-nomail", getPassword("login-nomail"));
 
         // no email is set => expect verify profile page to be displayed
         verifyProfilePage.assertCurrent();
@@ -702,7 +703,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test4", "password");
+        loginPage.login("login-test4", getPassword("login-test4"));
 
         verifyProfilePage.assertCurrent();
         Assert.assertEquals("ExistingLast", verifyProfilePage.getLastName());
@@ -732,7 +733,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -765,7 +766,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
 
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -799,7 +800,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
 
         oauth.clientId(client_scope_optional.getClientId()).openLoginForm();
 
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -823,7 +824,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.scope(SCOPE_DEPARTMENT).clientId(client_scope_optional.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -852,7 +853,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.clientId(client_scope_default.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -886,7 +887,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.clientId(client_scope_default.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -912,7 +913,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.clientId(client_scope_optional.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -933,7 +934,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.scope(SCOPE_DEPARTMENT).clientId(client_scope_optional.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -963,7 +964,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.scope(SCOPE_DEPARTMENT).clientId(client_scope_optional.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -994,7 +995,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
         oauth.clientId(client_scope_optional.getClientId()).openLoginForm();
 
         loginPage.assertCurrent();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -1023,7 +1024,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -1055,7 +1056,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         verifyProfilePage.assertCurrent();
 
@@ -1083,7 +1084,7 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
                 + "]}");
 
         loginPage.open();
-        loginPage.login("login-test5", "password");
+        loginPage.login("login-test5", getPassword("login-test5"));
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AbstractWebAuthnVirtualTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AbstractWebAuthnVirtualTest.java
@@ -33,7 +33,7 @@ import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AbstractAdminTest;
 import org.keycloak.testsuite.admin.ApiUtil;
@@ -81,7 +81,7 @@ import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
  *
  * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
  */
-public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycloakTest implements UseVirtualAuthenticators {
+public abstract class AbstractWebAuthnVirtualTest extends AbstractChangeImportedUserPasswordsTest implements UseVirtualAuthenticators {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
@@ -113,7 +113,6 @@ public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycl
     protected static final String ALL_ZERO_AAGUID = "00000000-0000-0000-0000-000000000000";
     protected static final String ALL_ONE_AAGUID = "11111111-1111-1111-1111-111111111111";
     protected static final String USERNAME = "UserWebAuthn";
-    protected static final String PASSWORD = "password";
     protected static final String EMAIL = "UserWebAuthn@email";
 
     protected final static String base64EncodedPK =
@@ -153,10 +152,7 @@ public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycl
         }
 
         testRealms.add(realmRepresentation);
-    }
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
+        configureTestRealm(realmRepresentation);
     }
 
     @Override
@@ -223,7 +219,7 @@ public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycl
     }
 
     private void registerDefaultUser(String authenticatorLabel, boolean shouldSuccess) {
-        registerUser(USERNAME, PASSWORD, EMAIL, authenticatorLabel, shouldSuccess);
+        registerUser(USERNAME, generatePassword(USERNAME), EMAIL, authenticatorLabel, shouldSuccess);
     }
 
     protected void registerUser(String username, String password, String email, String authenticatorLabel, boolean shouldSuccess) {
@@ -291,7 +287,7 @@ public abstract class AbstractWebAuthnVirtualTest extends AbstractTestRealmKeycl
     }
 
     protected void authenticateDefaultUser(boolean shouldSuccess) {
-        authenticateUser(USERNAME, PASSWORD, shouldSuccess);
+        authenticateUser(USERNAME, getPassword(USERNAME), shouldSuccess);
     }
 
     protected void authenticateUser(String username, String password, boolean shouldSuccess) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
@@ -76,7 +76,6 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
 
     protected final String WEB_AUTHN_REGISTER_PROVIDER = isPasswordless() ? WebAuthnPasswordlessRegisterFactory.PROVIDER_ID : WebAuthnRegisterFactory.PROVIDER_ID;
     protected final String DEFAULT_USERNAME = "test-user@localhost";
-    protected final String DEFAULT_PASSWORD = "password";
 
     @Page
     LoginUsernameOnlyPage usernamePage;
@@ -123,6 +122,7 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
         RequiredActionProviderRepresentation action = new RequiredActionProviderRepresentation();
         action.setAlias(WEB_AUTHN_REGISTER_PROVIDER);
         action.setProviderId(WEB_AUTHN_REGISTER_PROVIDER);
@@ -189,7 +189,7 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
                 .setBrowserFlow("browser")
                 .update()) {
             OAuthClient oauth2 = oauth.newConfig().driver(driver2);
-            oauth2.doLogin(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+            oauth2.doLogin(DEFAULT_USERNAME, getPassword(DEFAULT_USERNAME));
             event1 = events.expectLogin().assertEvent();
             assertEquals(1, testUser.getUserSessions().size());
         }
@@ -235,7 +235,7 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
         usernamePage.login(DEFAULT_USERNAME);
 
         passwordPage.assertCurrent();
-        passwordPage.login(DEFAULT_PASSWORD);
+        passwordPage.login(getPassword(DEFAULT_USERNAME));
 
         appPage.assertCurrent();
         assertThat(appPage.getRequestType(), is(AppPage.RequestType.AUTH_RESPONSE));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnIdlessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnIdlessTest.java
@@ -91,18 +91,13 @@ public class WebAuthnIdlessTest extends AbstractWebAuthnVirtualTest {
     private static final Logger logger = Logger.getLogger(WebAuthnIdlessTest.class);
 
     protected final static String username = "test-user@localhost";
-    protected final static String password = "password";
-
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-
-    }
 
     @Override
     public void addTestRealms(List<RealmRepresentation> testRealms) {
         RealmRepresentation realmRepresentation = AbstractAdminTest.loadJson(getClass().getResourceAsStream("/webauthn/testrealm-webauthn.json"), RealmRepresentation.class);
 
         testRealms.add(realmRepresentation);
+        configureTestRealm(realmRepresentation);
     }
 
     // Register webauthn-passwordless credential (resident key)
@@ -208,7 +203,7 @@ public class WebAuthnIdlessTest extends AbstractWebAuthnVirtualTest {
 
         loginPage.open();
         loginPage.assertCurrent();
-        loginPage.login(username, password);
+        loginPage.login(username, getPassword(username));
 
         webAuthnRegisterPage.assertCurrent();
         webAuthnRegisterPage.clickRegister();
@@ -298,7 +293,7 @@ public class WebAuthnIdlessTest extends AbstractWebAuthnVirtualTest {
         selectAuthenticatorPage.assertCurrent();
         selectAuthenticatorPage.selectLoginMethod(SelectAuthenticatorPage.USERNAMEPASSWORD);
         loginPage.assertCurrent();
-        loginPage.login(username, password);
+        loginPage.login(username, getPassword(username));
         webAuthnLoginPage.assertCurrent();
         webAuthnLoginPage.clickAuthenticate();
         appPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnPropertyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnPropertyTest.java
@@ -141,7 +141,7 @@ public class WebAuthnPropertyTest extends AbstractWebAuthnVirtualTest {
 
         loginPage.open();
         loginPage.assertCurrent();
-        loginPage.login(USERNAME, PASSWORD);
+        loginPage.login(USERNAME, getPassword(USERNAME));
         webAuthnLoginPage.assertCurrent();
 
         final String credType = isPasswordless() ? WebAuthnCredentialModel.TYPE_PASSWORDLESS : WebAuthnCredentialModel.TYPE_TWOFACTOR;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnRegisterAndLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnRegisterAndLoginTest.java
@@ -83,11 +83,6 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
     protected SelectAuthenticatorPage selectAuthenticatorPage;
 
     @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
-
-    }
-
-    @Override
     public void addTestRealms(List<RealmRepresentation> testRealms) {
         RealmRepresentation realmRepresentation = AbstractAdminTest.loadJson(getClass().getResourceAsStream("/webauthn/testrealm-webauthn.json"), RealmRepresentation.class);
 
@@ -98,13 +93,13 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
         realmRepresentation.setWebAuthnPolicyAcceptableAaguids(acceptableAaguids);
 
         testRealms.add(realmRepresentation);
+        configureTestRealm(realmRepresentation);
     }
 
     @Test
     @IgnoreBrowserDriver(FirefoxDriver.class) // See https://github.com/keycloak/keycloak/issues/10368
     public void registerUserSuccess() throws IOException {
         String username = "registerUserSuccess";
-        String password = "password";
         String email = "registerUserSuccess@email";
         String userId = null;
 
@@ -115,7 +110,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
             registerPage.assertCurrent();
 
             String authenticatorLabel = SecretGenerator.getInstance().randomString(24);
-            registerPage.register("firstName", "lastName", email, username, password, password);
+            registerPage.register("firstName", "lastName", email, username, generatePassword(username));
 
             // User was registered. Now he needs to register WebAuthn credential
             webAuthnRegisterPage.assertCurrent();
@@ -170,7 +165,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
 
             // login by user
             loginPage.open();
-            loginPage.login(username, password);
+            loginPage.login(username, getPassword(username));
 
             webAuthnLoginPage.assertCurrent();
 
@@ -236,7 +231,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
             loginUsernamePage.login("test-user@localhost");
 
             passwordPage.assertCurrent();
-            passwordPage.login("password");
+            passwordPage.login(getPassword("test-user@localhost"));
 
             events.clear();
 
@@ -294,7 +289,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
             loginUsernamePage.login("test-user@localhost");
 
             passwordPage.assertCurrent();
-            passwordPage.login("password");
+            passwordPage.login(getPassword("test-user@localhost"));
 
             webAuthnLoginPage.assertCurrent();
 
@@ -348,7 +343,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
                 .update()) {
 
             String username = "webauthn-tester@localhost";
-            String password = "password";
+            String password = generatePassword("webauthn-tester@localhost");
 
             UserRepresentation user = new UserRepresentation();
             user.setUsername(username);
@@ -456,7 +451,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
         try (RealmAttributeUpdater rau = new RealmAttributeUpdater(testRealm()).setBrowserFlow("browser-webauthn-passwordless").update()) {
             // Login as test-user@localhost with password
             loginPage.open();
-            loginPage.login("test-user@localhost", "password");
+            loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
 
             errorPage.assertCurrent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnTransportsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnTransportsTest.java
@@ -66,7 +66,7 @@ public class WebAuthnTransportsTest extends AbstractWebAuthnVirtualTest {
 
         loginPage.open();
         loginPage.assertCurrent();
-        loginPage.login(USERNAME, PASSWORD);
+        loginPage.login(USERNAME, getPassword(USERNAME));
 
         webAuthnLoginPage.assertCurrent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
+import static org.keycloak.testsuite.admin.Users.setPasswordFor;
 import static org.keycloak.testsuite.util.BrowserDriverUtil.isDriverFirefox;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 
@@ -104,7 +105,9 @@ public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest imple
         webAuthnCredentialType = signingInPage.getCredentialType(WebAuthnCredentialModel.TYPE_TWOFACTOR);
         webAuthnPwdlessCredentialType = signingInPage.getCredentialType(WebAuthnCredentialModel.TYPE_PASSWORDLESS);
 
-        createTestUserWithAdminClient(false);
+        final String password = generatePassword();
+        setPasswordFor(testUser, password);
+        createTestUserWithAdminClient(false, password);
 
         signingInPage.navigateTo();
         waitForPageToLoad();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnSigningInTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnSigningInTest.java
@@ -268,7 +268,7 @@ public class WebAuthnSigningInTest extends AbstractWebAuthnAccountTest {
     }
 
     @Test
-    @Ignore // TODO: Enable once chromedriver version 113.0.5672.92 is available in https://chromedriver.storage.googleapis.com/
+    @IgnoreBrowserDriver(FirefoxDriver.class) // See https://github.com/keycloak/keycloak/issues/10368
     public void checkAuthenticatorTimeLocale() throws ParseException, IOException {
         addWebAuthnCredential("authenticator#1");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysConditionalUITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysConditionalUITest.java
@@ -61,6 +61,7 @@ public class PasskeysConditionalUITest extends AbstractWebAuthnVirtualTest {
         switchExecutionInBrowserFormToPasskeysConditionalUI(realmRepresentation);
 
         testRealms.add(realmRepresentation);
+        configureTestRealm(realmRepresentation);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/registration/PolicyJsInjectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/registration/PolicyJsInjectionTest.java
@@ -153,7 +153,7 @@ public class PolicyJsInjectionTest extends AbstractWebAuthnVirtualTest {
 
             loginPage.open();
             loginPage.assertCurrent(TEST_REALM_NAME);
-            loginPage.login(USERNAME, PASSWORD);
+            loginPage.login(USERNAME, getPassword(USERNAME));
 
             webAuthnLoginPage.assertCurrent();
             WebAuthnAuthenticatorsList authenticators = webAuthnLoginPage.getAuthenticators();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/registration/WebAuthnOtherSettingsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/registration/WebAuthnOtherSettingsTest.java
@@ -137,7 +137,7 @@ public class WebAuthnOtherSettingsTest extends AbstractWebAuthnVirtualTest {
             loginPage.clickRegister();
             registerPage.assertCurrent();
 
-            registerPage.register("firstName", "lastName", EMAIL, USERNAME, PASSWORD, PASSWORD);
+            registerPage.register("firstName", "lastName", EMAIL, USERNAME, generatePassword(USERNAME));
 
             // User was registered. Now he needs to register WebAuthn credential
             webAuthnRegisterPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/testsuites/forms-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/forms-suite
@@ -1,2 +1,3 @@
 org.keycloak.testsuite.forms.**
 org.keycloak.testsuite.actions.RequiredActionUpdateProfileTest
+org.keycloak.testsuite.actions.TermsAndConditionsTest


### PR DESCRIPTION
Closes #38812 

PR:             https://github.com/keycloak/keycloak/pull/38935
Commit:         https://github.com/keycloak/keycloak/commit/0b30c872c8a5b6c224f75ef6e4e1c8be4005d6e3
PR branch:      backport-38935-26.2
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.2

Plain cherry-pick. If we prefer to run fixed 134 chrome version for 26.2 we can forget about this backport.