### PR TITLE
Add valid checksum v8 to the 2.5.0-unicode-oracle changeset

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
@@ -27,6 +27,7 @@
 
     <changeSet author="hmlnarik@redhat.com" id="2.5.0-unicode-oracle">
         <validCheckSum>7:e4c7e8f2256210aee71ddc42f538b57a</validCheckSum>
+        <validCheckSum>8:8b6fd445958882efe55deb26fc541a7b</validCheckSum>
         <validCheckSum>9:3a32bace77c84d7678d035a7f5a8084e</validCheckSum>
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <dbms type="oracle" />


### PR DESCRIPTION
- allows migration from earlier Keycloak versions where liquibase was using version 8 of the checksum algorithm

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>

Closes #38937

(cherry picked from commit 8b35fa58de6c4297391da04e9f1bec21260ec356)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
