### PR TITLE
fix(docs): correct typo in token exchange guide

### DIFF
--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -54,7 +54,7 @@ Many other use-cases exist for token exchange, but the preceding example is the 
 
 ==== Example token exchange request
 
-The folowing is an example token exchange request of the client `requester-client` in the realm `test`. Note that `subject_token` is the access token issued to the `initial-client`:
+The following is an example token exchange request of the client `requester-client` in the realm `test`. Note that `subject_token` is the access token issued to the `initial-client`:
 
 [source,bash]
 ----


### PR DESCRIPTION
Fixed a typo in the example token exchange request section by replacing "folowing" with "following." This improves the clarity and professionalism of the documentation.

Closes #38976

Signed-off-by: Nicola Baiocco <nicola.baiocco@intesys.it>
(cherry picked from commit 34630a4176c6bc458bf495a97d9a191228e344bc)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
