### PR TITLE
Add operationId to Admin REST API for OpenAPI spec generation

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationIdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationIdentityProvidersResource.java
@@ -74,7 +74,9 @@ public class OrganizationIdentityProvidersResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Adds the identity provider with the specified id to the organization",
         description = "Adds, or associates, an existing identity provider with the organization. If no identity provider is found, " +
-                "or if it is already associated with the organization, an error response is returned")
+                "or if it is already associated with the organization, an error response is returned",
+        operationId = "addIdentityProvider"
+    )
     @RequestBody(description = "Payload should contain only id or alias of the identity provider to be associated with the organization " + 
                 "(id or alias with or without quotes). Surrounding whitespace characters will be trimmed.", required = true)
     @APIResponses(value = {
@@ -107,7 +109,10 @@ public class OrganizationIdentityProvidersResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns all identity providers associated with the organization")
+    @Operation(
+            summary = "Returns all identity providers associated with the organization",
+            operationId = "getIdentityProviders"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = IdentityProviderRepresentation.class, type = SchemaType.ARRAY)))
     })
@@ -122,7 +127,9 @@ public class OrganizationIdentityProvidersResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Returns the identity provider associated with the organization that has the specified alias",
         description = "Searches for an identity provider with the given alias. If one is found and is associated with the " +
-                "organization, it is returned. Otherwise, an error response with status NOT_FOUND is returned")
+                "organization, it is returned. Otherwise, an error response with status NOT_FOUND is returned",
+        operationId = "getIdentityProvider"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = IdentityProviderRepresentation.class))),
         @APIResponse(responseCode = "404", description = "Not Found")
@@ -143,7 +150,9 @@ public class OrganizationIdentityProvidersResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Removes the identity provider with the specified alias from the organization",
         description = "Breaks the association between the identity provider and the organization. The provider itself is not deleted. " +
-                "If no provider is found, or if it is not currently associated with the org, an error response is returned")
+                "If no provider is found, or if it is not currently associated with the org, an error response is returned",
+        operationId = "deleteIdentityProvider"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -87,7 +87,9 @@ public class OrganizationMemberResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Adds the user with the specified id as a member of the organization", description = "Adds, or associates, " +
             "an existing user with the organization. If no user is found, or if it is already associated with the organization, " +
-            "an error response is returned")
+            "an error response is returned",
+            operationId = "addMember"
+    )
     @RequestBody(description = "Payload should contain only id of the user to be added to the organization (UUID with or without quotes). " +
             "Surrounding whitespace characters will be trimmed.", required = true)
     @APIResponses(value = {
@@ -126,7 +128,9 @@ public class OrganizationMemberResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Invites an existing user or sends a registration link to a new user, based on the provided e-mail address.",
-            description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link.")
+            description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link.",
+            operationId = "inviteUser"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -143,7 +147,10 @@ public class OrganizationMemberResource {
     @Path("invite-existing-user")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Invites an existing user to the organization, using the specified user id")
+    @Operation(
+            summary = "Invites an existing user to the organization, using the specified user id",
+            operationId = "inviteExistingUser"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -157,7 +164,10 @@ public class OrganizationMemberResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation( summary = "Returns a paginated list of organization members filtered according to the specified parameters")
+    @Operation(
+            summary = "Returns a paginated list of organization members filtered according to the specified parameters",
+            operationId = "searchMember"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = MemberRepresentation.class, type = SchemaType.ARRAY)))
     })
@@ -188,7 +198,9 @@ public class OrganizationMemberResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation( summary = "Returns the member of the organization with the specified id", description = "Searches for a" +
             "user with the given id. If one is found, and is currently a member of the organization, returns it. Otherwise," +
-            "an error response with status NOT_FOUND is returned")
+            "an error response with status NOT_FOUND is returned",
+            operationId = "getMember"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = MemberRepresentation.class))),
         @APIResponse(responseCode = "400", description = "Bad Request")
@@ -206,7 +218,9 @@ public class OrganizationMemberResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Removes the user with the specified id from the organization", description = "Breaks the association " +
             "between the user and organization. The user itself is deleted in case the membership is managed, otherwise the user is not deleted. " +
-            "If no user is found, or if they are not a member of the organization, an error response is returned")
+            "If no user is found, or if they are not a member of the organization, an error response is returned",
+            operationId = "deleteMember"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request")
@@ -236,7 +250,10 @@ public class OrganizationMemberResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns the organizations associated with the user that has the specified id")
+    @Operation(
+            summary = "Returns the organizations associated with the user that has the specified id",
+            operationId = "getOrganizations"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "400", description = "Bad Request")
@@ -256,7 +273,7 @@ public class OrganizationMemberResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation( summary = "Returns number of members in the organization.")
+    @Operation(summary = "Returns number of members in the organization.", operationId = "countMembers")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = Long.class)))
     })

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
@@ -68,7 +68,7 @@ public class OrganizationResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns the organization representation")
+    @Operation(summary = "Returns the organization representation", operationId = "getOrganization")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class)))
     })
@@ -78,7 +78,7 @@ public class OrganizationResource {
 
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Deletes the organization")
+    @Operation(summary = "Deletes the organization", operationId = "deleteOrganization")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request")
@@ -96,7 +96,7 @@ public class OrganizationResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Updates the organization")
+    @Operation(summary = "Updates the organization", operationId = "updateOrganization")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request")

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationsResource.java
@@ -90,7 +90,7 @@ public class OrganizationsResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation( summary = "Creates a new organization")
+    @Operation(summary = "Creates a new organization", operationId = "createOrganization")
     @APIResponses(value = {
         @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -137,7 +137,10 @@ public class OrganizationsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns a paginated list of organizations filtered according to the specified parameters")
+    @Operation(
+            summary = "Returns a paginated list of organizations filtered according to the specified parameters",
+            operationId = "search"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -196,7 +199,7 @@ public class OrganizationsResource {
     @Path("count")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns the organizations counts.")
+    @Operation(summary = "Returns the organizations counts.", operationId = "getOrganizationCount")
     public long getOrganizationCount(
             @Parameter(description = "A String representing either an organization name or domain") @QueryParam("search") String search,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
@@ -217,7 +220,10 @@ public class OrganizationsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
-    @Operation(summary = "Returns the organizations associated with the user that has the specified id")
+    @Operation(
+            summary = "Returns the organizations associated with the user that has the specified id",
+            operationId = "getOrganizations"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "400", description = "Bad Request")

--- a/services/src/main/java/org/keycloak/services/resources/admin/AttackDetectionResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AttackDetectionResource.java
@@ -83,7 +83,7 @@ public class AttackDetectionResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ATTACK_DETECTION)
-    @Operation( summary = "Get status of a username in brute force detection")
+    @Operation(summary = "Get status of a username in brute force detection", operationId = "bruteForceUserStatus")
     public Map<String, Object> bruteForceUserStatus(@PathParam("userId") String userId) {
         UserModel user = session.users().getUserById(realm, userId);
         if (user == null) {
@@ -145,7 +145,10 @@ public class AttackDetectionResource {
     @Path("brute-force/users/{userId}")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ATTACK_DETECTION)
-    @Operation( summary="Clear any user login failures for the user This can release temporary disabled user")
+    @Operation(
+            summary = "Clear any user login failures for the user This can release temporary disabled user",
+            operationId = "clearBruteForceForUser"
+    )
     public void clearBruteForceForUser(@PathParam("userId") String userId) {
         UserModel user = session.users().getUserById(realm, userId);
         if (user == null) {
@@ -169,7 +172,10 @@ public class AttackDetectionResource {
     @Path("brute-force/users")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ATTACK_DETECTION)
-    @Operation( summary = "Clear any user login failures for all users This can release temporary disabled users")
+    @Operation(
+            summary = "Clear any user login failures for all users This can release temporary disabled users",
+            operationId = "clearAllBruteForce"
+    )
     public void clearAllBruteForce() {
         auth.users().requireManage();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -126,7 +126,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation(summary = "Get form providers Returns a stream of form providers.")
+    @Operation(
+            summary = "Get form providers Returns a stream of form providers.",
+            operationId = "getFormProviders"
+    )
     public Stream<Map<String, Object>> getFormProviders() {
         auth.realm().requireViewRealm();
 
@@ -144,7 +147,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get authenticator providers Returns a stream of authenticator providers.")
+    @Operation(
+            summary = "Get authenticator providers Returns a stream of authenticator providers.",
+            operationId = "getAuthenticatorProviders"
+    )
     public Stream<Map<String, Object>> getAuthenticatorProviders() {
         auth.realm().requireViewRealm();
 
@@ -162,7 +168,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get client authenticator providers Returns a stream of client authenticator providers.")
+    @Operation(
+            summary = "Get client authenticator providers Returns a stream of client authenticator providers.",
+            operationId = "getClientAuthenticatorProviders"
+    )
     public Stream<Map<String, Object>> getClientAuthenticatorProviders() {
         auth.realm().requireViewClientAuthenticatorProviders();
         Stream<ProviderFactory> factories =  session.getKeycloakSessionFactory().getProviderFactoriesStream(ClientAuthenticator.class);
@@ -201,7 +210,9 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get form action providers Returns a stream of form action providers."
+    @Operation(
+            summary = "Get form action providers Returns a stream of form action providers.",
+            operationId = "getFormActionProviders"
     )
     public Stream<Map<String, Object>> getFormActionProviders() {
         auth.realm().requireViewRealm();
@@ -221,7 +232,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get authentication flows Returns a stream of authentication flows.")
+    @Operation(
+            summary = "Get authentication flows Returns a stream of authentication flows.",
+            operationId = "getFlows"
+    )
     public Stream<AuthenticationFlowRepresentation> getFlows() {
         auth.realm().requireViewAuthenticationFlows();
 
@@ -241,7 +255,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Create a new authentication flow")
+    @Operation(
+            summary = "Create a new authentication flow",
+            operationId = "createFlow"
+    )
     @APIResponse(responseCode = "201", description = "Created")
     public Response createFlow(@Parameter( description = "Authentication flow representation") AuthenticationFlowRepresentation flow) {
         auth.realm().requireManageRealm();
@@ -279,7 +296,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get authentication flow for id")
+    @Operation(
+            summary = "Get authentication flow for id",
+            operationId = "getFlow"
+    )
     public AuthenticationFlowRepresentation getFlow(@Parameter(description = "Flow id") @PathParam("id") String id) {
         auth.realm().requireViewRealm();
 
@@ -303,7 +323,10 @@ public class AuthenticationManagementResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Update an authentication flow")
+    @Operation(
+            summary = "Update an authentication flow",
+            operationId = "updateFlow"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void updateFlow(@PathParam("id") String id, AuthenticationFlowRepresentation flow) {
         auth.realm().requireManageRealm();
@@ -357,7 +380,10 @@ public class AuthenticationManagementResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Delete an authentication flow")
+    @Operation(
+            summary = "Delete an authentication flow",
+            operationId = "deleteFlow"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void deleteFlow(@Parameter(description = "Flow id") @PathParam("id") String id) {
         auth.realm().requireManageRealm();
@@ -392,7 +418,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Copy existing authentication flow under a new name The new name is given as 'newName' attribute of the passed JSON object")
+    @Operation(
+            summary = "Copy existing authentication flow under a new name The new name is given as 'newName' attribute of the passed JSON object",
+            operationId = "copy"
+    )
     @APIResponse(responseCode = "201", description = "Created")
     public Response copy(@Parameter(description="name of the existing authentication flow") @PathParam("flowAlias") String flowAlias, Map<String, String> data) {
         auth.realm().requireManageRealm();
@@ -494,7 +523,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Add new flow with new execution to existing flow")
+    @Operation(
+            summary = "Add new flow with new execution to existing flow",
+            operationId = "addExecutionFlow"
+    )
     @APIResponse(responseCode = "201", description = "Created")
     public Response addExecutionFlow(@Parameter(description = "Alias of parent authentication flow") @PathParam("flowAlias") String flowAlias, @Parameter(description = "New authentication flow / execution JSON data containing 'alias', 'type', 'provider', 'priority', and 'description' attributes") Map<String, Object> data) {
         auth.realm().requireManageRealm();
@@ -560,7 +592,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary="Add new authentication execution to a flow")
+    @Operation(
+            summary = "Add new authentication execution to a flow",
+            operationId = "addExecutionToFlow"
+    )
     @APIResponse(responseCode = "201", description = "Created")
     public Response addExecutionToFlow(@Parameter(description = "Alias of parent flow") @PathParam("flowAlias") String flowAlias, @Parameter(description = "New execution JSON data containing 'provider' and 'priority' (optional) attribute") Map<String, Object> data) {
         auth.realm().requireManageRealm();
@@ -645,7 +680,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get authentication executions for a flow")
+    @Operation(
+            summary = "Get authentication executions for a flow",
+            operationId = "getExecutions"
+    )
     public List<AuthenticationExecutionInfoRepresentation> getExecutions(@Parameter(description = "Flow alias") @PathParam("flowAlias") String flowAlias) {
         auth.realm().requireViewRealm();
 
@@ -762,7 +800,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Update authentication executions of a Flow")
+    @Operation(
+            summary = "Update authentication executions of a Flow",
+            operationId = "updateExecutions"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void updateExecutions(@Parameter(description = "Flow alias") @PathParam("flowAlias") String flowAlias, @Parameter(description = "AuthenticationExecutionInfoRepresentation") AuthenticationExecutionInfoRepresentation rep) {
         auth.realm().requireManageRealm();
@@ -841,7 +882,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get Single Execution")
+    @Operation(
+            summary = "Get Single Execution",
+            operationId = "getExecution"
+    )
     public AuthenticationExecutionRepresentation getExecution(final @PathParam("executionId") String executionId) {
     	//http://localhost:8080/auth/admin/realms/master/authentication/executions/cf26211b-9e68-4788-b754-1afd02e59d7f
         auth.realm().requireViewRealm();
@@ -866,7 +910,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Add new authentication execution")
+    @Operation(
+            summary = "Add new authentication execution",
+            operationId = "addExecution"
+    )
     @APIResponse(responseCode = "201", description = "Created")
     public Response addExecution(@Parameter(description = "JSON model describing authentication execution") AuthenticationExecutionRepresentation execution) {
         auth.realm().requireManageRealm();
@@ -911,7 +958,10 @@ public class AuthenticationManagementResource {
     @POST
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Raise execution's priority")
+    @Operation(
+            summary = "Raise execution's priority",
+            operationId = "raisePriority"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void raisePriority(@Parameter(description = "Execution id") @PathParam("executionId") String execution) {
         auth.realm().requireManageRealm();
@@ -954,7 +1004,10 @@ public class AuthenticationManagementResource {
     @POST
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Lower execution's priority")
+    @Operation(
+            summary = "Lower execution's priority",
+            operationId = "lowerPriority"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void lowerPriority(@Parameter( description = "Execution id") @PathParam("executionId") String execution) {
         auth.realm().requireManageRealm();
@@ -997,7 +1050,10 @@ public class AuthenticationManagementResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Delete execution")
+    @Operation(
+            summary = "Delete execution",
+            operationId = "removeExecution"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void removeExecution(@Parameter(description = "Execution id") @PathParam("executionId") String execution) {
         auth.realm().requireManageRealm();
@@ -1036,7 +1092,10 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Update execution with new configuration")
+    @Operation(
+            summary = "Update execution with new configuration",
+            operationId = "newExecutionConfig"
+    )
     @APIResponse(responseCode = "201", description = "Created")
     public Response newExecutionConfig(@Parameter(description = "Execution id") @PathParam("executionId") String execution, @Parameter(description = "JSON with new configuration") AuthenticatorConfigRepresentation json) {
         auth.realm().requireManageRealm();
@@ -1092,7 +1151,11 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get execution's configuration", deprecated = true)
+    @Operation(
+            summary = "Get execution's configuration",
+            operationId = "getAuthenticatorConfig",
+            deprecated = true
+    )
     @Deprecated
     public AuthenticatorConfigRepresentation getAuthenticatorConfig(@Parameter(description = "Execution id") @PathParam("executionId") String execution, @Parameter(description = "Configuration id") @PathParam("id") String id) {
         auth.realm().requireViewRealm();
@@ -1116,7 +1179,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get unregistered required actions Returns a stream of unregistered required actions.")
+    @Operation(
+            summary = "Get unregistered required actions Returns a stream of unregistered required actions.",
+            operationId = "getUnregisteredRequiredActions"
+    )
     public Stream<Map<String, String>> getUnregisteredRequiredActions() {
         auth.realm().requireViewRealm();
 
@@ -1144,7 +1210,10 @@ public class AuthenticationManagementResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Register a new required actions")
+    @Operation(
+            summary = "Register a new required actions",
+            operationId = "registerRequiredAction"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void registerRequiredAction(@Parameter(description = "JSON containing 'providerId', and 'name' attributes.") Map<String, String> data) {
         auth.realm().requireManageRealm();
@@ -1186,7 +1255,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get required actions Returns a stream of required actions.")
+    @Operation(
+            summary = "Get required actions Returns a stream of required actions.",
+            operationId = "getRequiredActions"
+    )
     public Stream<RequiredActionProviderRepresentation> getRequiredActions() {
         auth.realm().requireViewRequiredActions();
 
@@ -1215,7 +1287,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get required action for alias")
+    @Operation(
+            summary = "Get required action for alias",
+            operationId = "getRequiredAction"
+    )
     public RequiredActionProviderRepresentation getRequiredAction(@Parameter(description = "Alias of required action") @PathParam("alias") String alias) {
         auth.realm().requireViewRealm();
 
@@ -1237,7 +1312,10 @@ public class AuthenticationManagementResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Update required action")
+    @Operation(
+            summary = "Update required action",
+            operationId = "updateRequiredAction"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void updateRequiredAction(@Parameter(description = "Alias of required action") @PathParam("alias") String alias, @Parameter(description = "JSON describing new state of required action") RequiredActionProviderRepresentation rep) {
         auth.realm().requireManageRealm();
@@ -1267,7 +1345,10 @@ public class AuthenticationManagementResource {
     @Path("required-actions/{alias}")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Delete required action")
+    @Operation(
+            summary = "Delete required action",
+            operationId = "removeRequiredAction"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void removeRequiredAction(@Parameter(description = "Alias of required action") @PathParam("alias") String alias) {
         auth.realm().requireManageRealm();
@@ -1290,7 +1371,10 @@ public class AuthenticationManagementResource {
     @POST
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Raise required action's priority")
+    @Operation(
+            summary = "Raise required action's priority",
+            operationId = "raiseRequiredActionPriority"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void raiseRequiredActionPriority(@Parameter(description = "Alias of required action") @PathParam("alias") String alias) {
         auth.realm().requireManageRealm();
@@ -1326,7 +1410,10 @@ public class AuthenticationManagementResource {
     @POST
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Lower required action's priority")
+    @Operation(
+            summary = "Lower required action's priority",
+            operationId = "lowerRequiredActionPriority"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void lowerRequiredActionPriority(@Parameter(description = "Alias of required action") @PathParam("alias") String alias) {
         auth.realm().requireManageRealm();
@@ -1364,7 +1451,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get RequiredAction provider configuration description")
+    @Operation(
+            summary = "Get RequiredAction provider configuration description",
+            operationId = "getRequiredActionConfigDescription"
+    )
     public RequiredActionConfigInfoRepresentation getRequiredActionConfigDescription(@Parameter(description = "Alias of required action")  @PathParam("alias") String alias) {
         auth.realm().requireViewRealm();
 
@@ -1393,7 +1483,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get RequiredAction configuration")
+    @Operation(
+            summary = "Get RequiredAction configuration",
+            operationId = "getRequiredActionConfig"
+    )
     public RequiredActionConfigRepresentation getRequiredActionConfig(@Parameter(description = "Alias of required action")  @PathParam("alias") String alias) {
         auth.realm().requireViewRealm();
 
@@ -1418,7 +1511,10 @@ public class AuthenticationManagementResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Delete RequiredAction configuration")
+    @Operation(
+            summary = "Delete RequiredAction configuration",
+            operationId = "removeRequiredActionConfig"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void removeRequiredActionConfig(@Parameter(description = "Alias of required action")  @PathParam("alias") String alias) {
         auth.realm().requireManageRealm();
@@ -1450,7 +1546,10 @@ public class AuthenticationManagementResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Update RequiredAction configuration")
+    @Operation(
+            summary = "Update RequiredAction configuration",
+            operationId = "updateRequiredActionConfig"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void updateRequiredActionConfig(@Parameter(description = "Alias of required action")  @PathParam("alias") String alias, @Parameter(description = "JSON describing new state of required action configuration") RequiredActionConfigRepresentation rep) {
         auth.realm().requireManageRealm();
@@ -1489,7 +1588,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get authenticator provider's configuration description")
+    @Operation(
+            summary = "Get authenticator provider's configuration description",
+            operationId = "getAuthenticatorConfigDescription"
+    )
     public AuthenticatorConfigInfoRepresentation getAuthenticatorConfigDescription(@PathParam("providerId") String providerId) {
         auth.realm().requireViewRealm();
 
@@ -1530,7 +1632,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get configuration descriptions for all clients")
+    @Operation(
+            summary = "Get configuration descriptions for all clients",
+            operationId = "getPerClientConfigDescription"
+    )
     public Map<String, List<ConfigPropertyRepresentation>> getPerClientConfigDescription() {
         auth.realm().requireViewClientAuthenticatorProviders();
 
@@ -1556,7 +1661,11 @@ public class AuthenticationManagementResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Create new authenticator configuration", deprecated = true)
+    @Operation(
+            summary = "Create new authenticator configuration",
+            operationId = "createAuthenticatorConfig",
+            deprecated = true
+    )
     @APIResponse(responseCode = "201", description = "Created")
     @Deprecated
     public Response createAuthenticatorConfig(@Parameter(description = "JSON describing new authenticator configuration") AuthenticatorConfigRepresentation rep) {
@@ -1587,7 +1696,10 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Get authenticator configuration")
+    @Operation(
+            summary = "Get authenticator configuration",
+            operationId = "getAuthenticatorConfig"
+    )
     public AuthenticatorConfigRepresentation getAuthenticatorConfig(@Parameter(description = "Configuration id") @PathParam("id") String id) {
         auth.realm().requireViewRealm();
 
@@ -1607,7 +1719,10 @@ public class AuthenticationManagementResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Delete authenticator configuration")
+    @Operation(
+            summary = "Delete authenticator configuration",
+            operationId = "removeAuthenticatorConfig"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void removeAuthenticatorConfig(@Parameter(description = "Configuration id") @PathParam("id") String id) {
         auth.realm().requireManageRealm();
@@ -1639,7 +1754,10 @@ public class AuthenticationManagementResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
-    @Operation( summary = "Update authenticator configuration")
+    @Operation(
+            summary = "Update authenticator configuration",
+            operationId = "updateAuthenticatorConfig"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void updateAuthenticatorConfig(@Parameter(description = "Configuration id") @PathParam("id") String id, @Parameter(description = "JSON describing new state of authenticator configuration") AuthenticatorConfigRepresentation rep) {
         auth.realm().requireManageRealm();

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
@@ -101,7 +101,7 @@ public class ClientAttributeCertificateResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ATTRIBUTE_CERTIFICATE)
-    @Operation( summary = "Get key info")
+    @Operation(summary = "Get key info", operationId = "getKeyInfo")
     public CertificateRepresentation getKeyInfo() {
         auth.clients().requireView(client);
 
@@ -119,7 +119,7 @@ public class ClientAttributeCertificateResource {
     @Path("generate")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ATTRIBUTE_CERTIFICATE)
-    @Operation( summary = "Generate a new certificate with new key pair")
+    @Operation( summary = "Generate a new certificate with new key pair", operationId = "generate")
     public CertificateRepresentation generate() {
         auth.clients().requireConfigure(client);
 
@@ -143,7 +143,7 @@ public class ClientAttributeCertificateResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ATTRIBUTE_CERTIFICATE)
-    @Operation( summary = "Upload certificate and eventually private key")
+    @Operation(summary = "Upload certificate and eventually private key", operationId = "uploadJks")
     public CertificateRepresentation uploadJks() throws IOException {
         try {
             CertificateRepresentation info = updateCertFromRequest();
@@ -165,7 +165,7 @@ public class ClientAttributeCertificateResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ATTRIBUTE_CERTIFICATE)
-    @Operation( summary = "Upload only certificate, not private key")
+    @Operation(summary = "Upload only certificate, not private key", operationId = "uploadJksCertificate")
     public CertificateRepresentation uploadJksCertificate() throws IOException {
         try {
             CertificateRepresentation info = updateCertFromRequest();
@@ -263,7 +263,10 @@ public class ClientAttributeCertificateResource {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ATTRIBUTE_CERTIFICATE)
-    @Operation( summary = "Get a keystore file for the client, containing private key and public certificate")
+    @Operation(
+            summary = "Get a keystore file for the client, containing private key and public certificate",
+            operationId = "getKeystore"
+    )
     public byte[] getKeystore(@Parameter(description = "Keystore configuration as JSON") final KeyStoreConfig config) {
         auth.clients().requireView(client);
 
@@ -306,7 +309,9 @@ public class ClientAttributeCertificateResource {
             "Generate a new keypair and certificate, and get the private key file\n" +
                     "\n" +
                     "Generates a keypair and certificate and serves the private key in a specified keystore format.\n" +
-                    "Only generated public certificate is saved in Keycloak DB - the private key is not.")
+                    "Only generated public certificate is saved in Keycloak DB - the private key is not.",
+            operationId = "generateAndGetKeystore"
+    )
     public byte[] generateAndGetKeystore(@Parameter(description = "Keystore configuration as JSON") final KeyStoreConfig config) {
         auth.clients().requireConfigure(client);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientInitialAccessResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientInitialAccessResource.java
@@ -82,7 +82,7 @@ public class ClientInitialAccessResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_INITIAL_ACCESS)
-    @Operation( summary = "Create a new initial access token.")
+    @Operation(summary = "Create a new initial access token.", operationId = "createClientInitialAccess")
     @APIResponse(responseCode = "201", description = "Created", content = @Content(schema = @Schema(implementation = ClientInitialAccessCreatePresentation.class)))
     public Object create(ClientInitialAccessCreatePresentation config) {
         auth.clients().requireManage();
@@ -118,7 +118,7 @@ public class ClientInitialAccessResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_INITIAL_ACCESS)
-    @Operation()
+    @Operation(operationId = "list")
     public Stream<ClientInitialAccessPresentation> list() {
         auth.clients().requireView();
 
@@ -128,7 +128,7 @@ public class ClientInitialAccessResource {
     @DELETE
     @Path("{id}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_INITIAL_ACCESS)
-    @Operation()
+    @Operation(operationId = "deleteClientInitialAccess")
     public void delete(final @PathParam("id") String id) {
         auth.clients().requireManage();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientPoliciesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientPoliciesResource.java
@@ -65,7 +65,7 @@ public class ClientPoliciesResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getPolicies")
     public ClientPoliciesRepresentation getPolicies(@QueryParam("include-global-policies") boolean includeGlobalPolicies) {
         auth.realm().requireViewRealm();
 
@@ -79,7 +79,7 @@ public class ClientPoliciesResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "updatePolicies")
     public Response updatePolicies(final ClientPoliciesRepresentation clientPolicies) {
         auth.realm().requireManageRealm();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientProfilesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientProfilesResource.java
@@ -66,7 +66,7 @@ public class ClientProfilesResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getProfiles")
     public ClientProfilesRepresentation getProfiles(@QueryParam("include-global-profiles") boolean includeGlobalProfiles) {
         auth.realm().requireViewRealm();
 
@@ -80,7 +80,7 @@ public class ClientProfilesResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "updateProfiles")
     public Response updateProfiles(final ClientProfilesRepresentation clientProfiles) {
         auth.realm().requireManageRealm();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientRegistrationPolicyResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientRegistrationPolicyResource.java
@@ -72,7 +72,10 @@ public class ClientRegistrationPolicyResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_REGISTRATION_POLICY)
-    @Operation( summary="Base path for retrieve providers with the configProperties properly filled")
+    @Operation(
+            summary = "Base path for retrieve providers with the configProperties properly filled",
+            operationId = "getProviders"
+    )
     public Stream<ComponentTypeRepresentation> getProviders() {
         auth.realm().requireViewRealm();
         return session.getKeycloakSessionFactory().getProviderFactoriesStream(ClientRegistrationPolicy.class)

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -140,7 +140,7 @@ public class ClientResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Update the client")
+    @Operation(summary = "Update the client", operationId = "updateClient")
     public Response update(final ClientRepresentation rep) {
         auth.clients().requireConfigure(client);
 
@@ -186,7 +186,7 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get representation of the client")
+    @Operation(summary = "Get representation of the client", operationId = "getClient")
     public ClientRepresentation getClient() {
         try {
             session.clientPolicy().triggerOnEvent(new AdminClientViewContext(client, auth.adminAuth()));
@@ -218,7 +218,7 @@ public class ClientResource {
     @NoCache
     @Path("installation/providers/{providerId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation()
+    @Operation(operationId = "getInstallationProvider")
     public Response getInstallationProvider(@PathParam("providerId") String providerId) {
         auth.clients().requireView(client);
 
@@ -234,7 +234,7 @@ public class ClientResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Delete the client")
+    @Operation(summary = "Delete the client", operationId = "deleteClient")
     public void deleteClient() {
         auth.clients().requireManage(client);
 
@@ -270,7 +270,7 @@ public class ClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Generate a new secret for the client")
+    @Operation(summary = "Generate a new secret for the client", operationId = "regenerateSecret")
     public CredentialRepresentation regenerateSecret() {
         try{
             auth.clients().requireConfigure(client);
@@ -315,7 +315,10 @@ public class ClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Generate a new registration access token for the client")
+    @Operation(
+            summary = "Generate a new registration access token for the client",
+            operationId = "regenerateRegistrationAccessToken"
+    )
     public ClientRepresentation regenerateRegistrationAccessToken() {
         auth.clients().requireManage(client);
 
@@ -338,7 +341,7 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get the client secret")
+    @Operation(summary = "Get the client secret", operationId = "getClientSecret")
     public CredentialRepresentation getClientSecret() {
         auth.clients().requireView(client);
 
@@ -376,7 +379,10 @@ public class ClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("default-client-scopes")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get default client scopes.  Only name and ids are returned.")
+    @Operation(
+            summary = "Get default client scopes.  Only name and ids are returned.",
+            operationId = "getDefaultClientScopes"
+    )
     public Stream<ClientScopeRepresentation> getDefaultClientScopes() {
         return getDefaultClientScopes(true);
     }
@@ -392,7 +398,7 @@ public class ClientResource {
     @NoCache
     @Path("default-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation()
+    @Operation(operationId = "addDefaultClientScope")
     public void addDefaultClientScope(@PathParam("clientScopeId") String clientScopeId) {
         addDefaultClientScope(clientScopeId,true);
     }
@@ -417,7 +423,7 @@ public class ClientResource {
     @NoCache
     @Path("default-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation()
+    @Operation(operationId = "removeDefaultClientScope")
     public void removeDefaultClientScope(@PathParam("clientScopeId") String clientScopeId) {
         auth.clients().requireManage(client);
 
@@ -441,7 +447,10 @@ public class ClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("optional-client-scopes")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get optional client scopes.  Only name and ids are returned.")
+    @Operation(
+            summary = "Get optional client scopes.  Only name and ids are returned.",
+            operationId = "getOptionalClientScopes"
+    )
     public Stream<ClientScopeRepresentation> getOptionalClientScopes() {
         return getDefaultClientScopes(false);
     }
@@ -450,7 +459,7 @@ public class ClientResource {
     @NoCache
     @Path("optional-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation()
+    @Operation(operationId = "addOptionalClientScope")
     public void addOptionalClientScope(@PathParam("clientScopeId") String clientScopeId) {
         addDefaultClientScope(clientScopeId, false);
     }
@@ -459,7 +468,7 @@ public class ClientResource {
     @NoCache
     @Path("optional-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation()
+    @Operation(operationId = "removeOptionalClientScope")
     public void removeOptionalClientScope(@PathParam("clientScopeId") String clientScopeId) {
         removeDefaultClientScope(clientScopeId);
     }
@@ -479,7 +488,7 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get a user dedicated to the service account")
+    @Operation(summary = "Get a user dedicated to the service account", operationId = "getServiceAccountUser")
     public UserRepresentation getServiceAccountUser() {
         auth.clients().requireView(client);
 
@@ -505,7 +514,10 @@ public class ClientResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Push the client's revocation policy to its admin URL If the client has an admin URL, push revocation policy to it.")
+    @Operation(
+            summary = "Push the client's revocation policy to its admin URL If the client has an admin URL, push revocation policy to it.",
+            operationId = "pushRevocation"
+    )
     public GlobalRequestResult pushRevocation() {
         auth.clients().requireConfigure(client);
 
@@ -530,7 +542,10 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get application session count Returns a number of user sessions associated with this client { \"count\": number }")
+    @Operation(
+            summary = "Get application session count Returns a number of user sessions associated with this client { \"count\": number }",
+            operationId = "getApplicationSessionCount"
+    )
     public Map<String, Long> getApplicationSessionCount() {
         auth.clients().requireView(client);
 
@@ -553,7 +568,10 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get user sessions for client Returns a list of user sessions associated with this client\n")
+    @Operation(
+            summary = "Get user sessions for client Returns a list of user sessions associated with this client\n",
+            operationId = "getUserSessions"
+    )
     public Stream<UserSessionRepresentation> getUserSessions(@Parameter(description = "Paging offset") @QueryParam("first") Integer firstResult, @Parameter(description = "Maximum results size (defaults to 100)") @QueryParam("max") Integer maxResults) {
         auth.clients().requireView(client);
 
@@ -579,7 +597,10 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get application offline session count Returns a number of offline user sessions associated with this client { \"count\": number }")
+    @Operation(
+            summary = "Get application offline session count Returns a number of offline user sessions associated with this client { \"count\": number }",
+            operationId = "getOfflineSessionCount"
+    )
     public Map<String, Long> getOfflineSessionCount() {
         auth.clients().requireView(client);
 
@@ -602,7 +623,10 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get offline sessions for client Returns a list of offline user sessions associated with this client")
+    @Operation(
+            summary = "Get offline sessions for client Returns a list of offline user sessions associated with this client",
+            operationId = "getOfflineUserSessions"
+    )
     public Stream<UserSessionRepresentation> getOfflineUserSessions(@Parameter(description = "Paging offset") @QueryParam("first") Integer firstResult, @Parameter(description = "Maximum results size (defaults to 100)") @QueryParam("max") Integer maxResults) {
         auth.clients().requireView(client);
 
@@ -625,7 +649,10 @@ public class ClientResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Register a cluster node with the client Manually register cluster node to this client - usually it’s not needed to call this directly as adapter should handle by sending registration request to Keycloak")
+    @Operation(
+            summary = "Register a cluster node with the client Manually register cluster node to this client - usually it’s not needed to call this directly as adapter should handle by sending registration request to Keycloak",
+            operationId = "registerNode"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void registerNode(Map<String, String> formParams) {
         auth.clients().requireConfigure(client);
@@ -651,7 +678,7 @@ public class ClientResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Unregister a cluster node from the client")
+    @Operation(summary = "Unregister a cluster node from the client", operationId = "unregisterNode")
     public void unregisterNode(final @PathParam("node") String node) {
         auth.clients().requireConfigure(client);
 
@@ -677,7 +704,10 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Test if registered cluster nodes are available Tests availability by sending 'ping' request to all cluster nodes.")
+    @Operation(
+            summary = "Test if registered cluster nodes are available Tests availability by sending 'ping' request to all cluster nodes.",
+            operationId = "testNodesAvailable"
+    )
     public GlobalRequestResult testNodesAvailable() {
         auth.clients().requireConfigure(client);
 
@@ -704,7 +734,10 @@ public class ClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference",
+            operationId = "getManagementPermissions"
+    )
     public ManagementPermissionReference getManagementPermissions() {
         ProfileHelper.requireFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
         auth.roles().requireView(client);
@@ -737,7 +770,10 @@ public class ClientResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference",
+            operationId = "setManagementPermissionsEnabled"
+    )
     public ManagementPermissionReference setManagementPermissionsEnabled(ManagementPermissionReference ref) {
         ProfileHelper.requireFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
         auth.clients().requireManage(client);
@@ -760,7 +796,7 @@ public class ClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Invalidate the rotated secret for the client")
+    @Operation(summary = "Invalidate the rotated secret for the client", operationId = "invalidateRotatedSecret")
     public Response invalidateRotatedSecret() {
         try{
             auth.clients().requireConfigure(client);
@@ -794,7 +830,7 @@ public class ClientResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get the rotated client secret")
+    @Operation(summary = "Get the rotated client secret", operationId = "getClientRotatedSecret")
     public CredentialRepresentation getClientRotatedSecret() {
         auth.clients().requireView(client);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientRoleMappingsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientRoleMappingsResource.java
@@ -102,7 +102,10 @@ public class ClientRoleMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ROLE_MAPPINGS)
-    @Operation( summary = "Get client-level role mappings for the user or group, and the app")
+    @Operation(
+            summary = "Get client-level role mappings for the user or group, and the app",
+            operationId = "getClientRoleMappings"
+    )
     public Stream<RoleRepresentation> getClientRoleMappings() {
         viewPermission.require();
 
@@ -123,7 +126,10 @@ public class ClientRoleMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ROLE_MAPPINGS)
-    @Operation( summary = "Get effective client-level role mappings This recurses any composite roles")
+    @Operation(
+            summary = "Get effective client-level role mappings This recurses any composite roles",
+            operationId = "getCompositeClientRoleMappings"
+    )
     public Stream<RoleRepresentation> getCompositeClientRoleMappings(@Parameter(description = "if false, return roles with their attributes") @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         viewPermission.require();
 
@@ -143,7 +149,10 @@ public class ClientRoleMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ROLE_MAPPINGS)
-    @Operation( summary = "Get available client-level roles that can be mapped to the user or group")
+    @Operation(
+            summary = "Get available client-level roles that can be mapped to the user or group",
+            operationId = "getAvailableClientRoleMappings"
+    )
     public Stream<RoleRepresentation> getAvailableClientRoleMappings() {
         viewPermission.require();
 
@@ -161,7 +170,10 @@ public class ClientRoleMappingsResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ROLE_MAPPINGS)
-    @Operation( summary = "Add client-level roles to the user or group role mapping")
+    @Operation(
+            summary = "Add client-level roles to the user or group role mapping",
+            operationId = "addClientRoleMapping"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void addClientRoleMapping(List<RoleRepresentation> roles) {
         managePermission.require();
@@ -197,7 +209,10 @@ public class ClientRoleMappingsResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_ROLE_MAPPINGS)
-    @Operation( summary = "Delete client-level roles from user or group role mapping")
+    @Operation(
+            summary = "Delete client-level roles from user or group role mapping",
+            operationId = "deleteClientRoleMapping"
+    )
     public void deleteClientRoleMapping(List<RoleRepresentation> roles) {
         managePermission.require();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
@@ -134,8 +134,11 @@ public class ClientScopeEvaluateResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation(summary = "Return list of all protocol mappers, which will be used when generating tokens issued for particular client.",
-            description = "This means protocol mappers assigned to this client directly and protocol mappers assigned to all client scopes of this client.")
+    @Operation(
+            summary = "Return list of all protocol mappers, which will be used when generating tokens issued for particular client.",
+            description = "This means protocol mappers assigned to this client directly and protocol mappers assigned to all client scopes of this client.",
+            operationId = "getGrantedProtocolMappers"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ProtocolMapperEvaluationRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -180,7 +183,7 @@ public class ClientScopeEvaluateResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation(summary = "Create JSON with payload of example user info")
+    @Operation(summary = "Create JSON with payload of example user info", operationId = "generateExampleUserinfo")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = Map.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -211,7 +214,7 @@ public class ClientScopeEvaluateResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation(summary = "Create JSON with payload of example id token")
+    @Operation(summary = "Create JSON with payload of example id token", operationId = "generateExampleIdToken")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = IDToken.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -249,7 +252,7 @@ public class ClientScopeEvaluateResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation(summary = "Create JSON with payload of example access token")
+    @Operation(summary = "Create JSON with payload of example access token", operationId = "generateExampleAccessToken")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = AccessToken.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateScopeMappingsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateScopeMappingsResource.java
@@ -81,8 +81,11 @@ public class ClientScopeEvaluateScopeMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation(summary = "Get effective scope mapping of all roles of particular role container, which this client is defacto allowed to have in the accessToken issued for him.",
-            description = "This contains scope mappings, which this client has directly, as well as scope mappings, which are granted to all client scopes, which are linked with this client.")
+    @Operation(
+            summary = "Get effective scope mapping of all roles of particular role container, which this client is defacto allowed to have in the accessToken issued for him.",
+            description = "This contains scope mappings, which this client has directly, as well as scope mappings, which are granted to all client scopes, which are linked with this client.",
+            operationId = "getGrantedScopeMappings"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -102,7 +105,10 @@ public class ClientScopeEvaluateScopeMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation(summary = "Get roles, which this client doesn't have scope for and can't have them in the accessToken issued for him.", description = "Defacto all the other roles of particular role container, which are not in {@link #getGrantedScopeMappings()}")
+    @Operation(
+            summary = "Get roles, which this client doesn't have scope for and can't have them in the accessToken issued for him.", description = "Defacto all the other roles of particular role container, which are not in {@link #getGrantedScopeMappings()}",
+            operationId = "getNotGrantedScopeMappings"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -111,7 +111,7 @@ public class ClientScopeResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_SCOPES)
-    @Operation(summary = "Update the client scope")
+    @Operation(summary = "Update the client scope", operationId = "updateClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -143,7 +143,7 @@ public class ClientScopeResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_SCOPES)
-    @Operation(summary = "Get representation of the client scope")
+    @Operation(summary = "Get representation of the client scope", operationId = "getClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ClientScopeRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -160,7 +160,7 @@ public class ClientScopeResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_SCOPES)
-    @Operation(summary = "Delete the client scope")
+    @Operation(summary = "Delete the client scope", operationId = "deleteClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -82,7 +82,10 @@ public class ClientScopesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_SCOPES)
-    @Operation(summary = "Get client scopes belonging to the realm Returns a list of client scopes belonging to the realm")
+    @Operation(
+            summary = "Get client scopes belonging to the realm Returns a list of client scopes belonging to the realm",
+            operationId = "getClientScopes"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ClientScopeRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -107,7 +110,10 @@ public class ClientScopesResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENT_SCOPES)
-    @Operation(summary = "Create a new client scope Client Scope’s name must be unique!")
+    @Operation(
+            summary = "Create a new client scope Client Scope’s name must be unique!",
+            operationId = "createClientScope"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "403", description = "Forbidden"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientTypesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientTypesResource.java
@@ -62,8 +62,10 @@ public class ClientTypesResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "List all client types available in the current realm",
-            description = "This endpoint returns a list of both global and realm level client types and the attributes they set"
+    @Operation(
+            summary = "List all client types available in the current realm",
+            description = "This endpoint returns a list of both global and realm level client types and the attributes they set",
+            operationId = "getClientTypes"
     )
     public ClientTypesRepresentation getClientTypes() {
         auth.realm().requireViewRealm();
@@ -79,8 +81,10 @@ public class ClientTypesResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Update a client type",
-            description = "This endpoint allows you to update a realm level client type"
+    @Operation(
+            summary = "Update a client type",
+            description = "This endpoint allows you to update a realm level client type",
+            operationId = "updateClientTypes"
     )
     @APIResponse(responseCode = "204", description = "No Content")
     public Response updateClientTypes(final ClientTypesRepresentation clientTypes) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -109,8 +109,11 @@ public class ClientsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Get clients belonging to the realm.",
-        description = "If a client can’t be retrieved from the storage due to a problem with the underlying storage, it is silently removed from the returned list. This ensures that concurrent modifications to the list don’t prevent callers from retrieving this list.")
+    @Operation(
+            summary = "Get clients belonging to the realm.",
+            description = "If a client can’t be retrieved from the storage due to a problem with the underlying storage, it is silently removed from the returned list. This ensures that concurrent modifications to the list don’t prevent callers from retrieving this list.",
+            operationId = "getClients"
+    )
     public Stream<ClientRepresentation> getClients(@Parameter(description = "filter by clientId") @QueryParam("clientId") String clientId,
                                                  @Parameter(description = "filter clients that cannot be viewed in full by admin") @QueryParam("viewableOnly") @DefaultValue("false") boolean viewableOnly,
                                                  @Parameter(description = "whether this is a search query or a getClientById query") @QueryParam("search") @DefaultValue("false") boolean search,
@@ -184,7 +187,7 @@ public class ClientsResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
-    @Operation( summary = "Create a new client Client’s client_id must be unique!")
+    @Operation(summary = "Create a new client Client’s client_id must be unique!", operationId = "createClient")
     @APIResponse(responseCode = "201", description = "Created")
     public Response createClient(final ClientRepresentation rep) {
         auth.clients().requireManage();

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -99,7 +99,7 @@ public class ComponentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
-    @Operation()
+    @Operation(operationId = "getComponents")
     public Stream<ComponentRepresentation> getComponents(@QueryParam("parent") String parent,
                                                        @QueryParam("type") String type,
                                                        @QueryParam("name") String name) {
@@ -131,7 +131,7 @@ public class ComponentResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
-    @Operation()
+    @Operation(operationId = "createComponent")
     public Response create(ComponentRepresentation rep) {
         auth.realm().requireManageRealm();
         try {
@@ -154,7 +154,7 @@ public class ComponentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
-    @Operation()
+    @Operation(operationId = "getComponent")
     public ComponentRepresentation getComponent(@PathParam("id") String id) {
         auth.realm().requireViewRealm();
         ComponentModel model = realm.getComponent(id);
@@ -169,7 +169,7 @@ public class ComponentResource {
     @Path("{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
-    @Operation()
+    @Operation(operationId = "updateComponent")
     public Response updateComponent(@PathParam("id") String id, ComponentRepresentation rep) {
         auth.realm().requireManageRealm();
         try {
@@ -190,7 +190,7 @@ public class ComponentResource {
     @DELETE
     @Path("{id}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
-    @Operation()
+    @Operation(operationId = "removeComponent")
     public void removeComponent(@PathParam("id") String id) {
         auth.realm().requireManageRealm();
         ComponentModel model = realm.getComponent(id);
@@ -231,7 +231,10 @@ public class ComponentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
-    @Operation( summary = "List of subcomponent types that are available to configure for a particular parent component.")
+    @Operation(
+            summary = "List of subcomponent types that are available to configure for a particular parent component.",
+            operationId = "getSubcomponentConfig"
+    )
     public Stream<ComponentTypeRepresentation> getSubcomponentConfig(@PathParam("id") String parentId, @QueryParam("type") String subtype) {
         auth.realm().requireViewRealm();
         ComponentModel parent = realm.getComponent(parentId);

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -97,7 +97,7 @@ public class GroupResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation()
+    @Operation(operationId = "getGroup")
     public GroupRepresentation getGroup() {
         this.auth.groups().requireView(group);
 
@@ -116,7 +116,7 @@ public class GroupResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Update group, ignores subgroups.")
+    @Operation(summary = "Update group, ignores subgroups.", operationId = "updateGroup")
     public Response updateGroup(GroupRepresentation rep) {
         this.auth.groups().requireManage(group);
 
@@ -154,7 +154,7 @@ public class GroupResource {
 
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation()
+    @Operation(operationId = "deleteGroup")
     public void deleteGroup() {
         this.auth.groups().requireManage(group);
 
@@ -167,7 +167,10 @@ public class GroupResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Return a paginated list of subgroups that have a parent group corresponding to the group on the URL")
+    @Operation(
+            summary = "Return a paginated list of subgroups that have a parent group corresponding to the group on the URL",
+            operationId = "getSubGroups"
+    )
     public Stream<GroupRepresentation> getSubGroups(
             @Parameter(description = "A String representing either an exact group name or a partial name") @QueryParam("search") String search,
             @Parameter(description = "Boolean which defines whether the params \"search\" must match exactly or not") @QueryParam("exact") Boolean exact,
@@ -198,7 +201,11 @@ public class GroupResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Set or create child.", description = "This will just set the parent if it exists. Create it and set the parent if the group doesn’t exist.")
+    @Operation(
+            summary = "Set or create child.",
+            description = "This will just set the parent if it exists. Create it and set the parent if the group doesn’t exist.",
+            operationId = "addChild"
+    )
     public Response addChild(GroupRepresentation rep) {
         this.auth.groups().requireManage(group);
 
@@ -296,7 +303,10 @@ public class GroupResource {
     @Path("members")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Get users Returns a stream of users, filtered according to query parameters")
+    @Operation(
+            summary = "Get users Returns a stream of users, filtered according to query parameters",
+            operationId = "getMembers"
+    )
     public Stream<UserRepresentation> getMembers(@Parameter(description = "Pagination offset") @QueryParam("first") Integer firstResult,
                                                  @Parameter(description = "Maximum results size (defaults to 100)") @QueryParam("max") Integer maxResults,
                                                  @Parameter(description = "Only return basic information (only guaranteed to return id, username, created, first and last name, email, enabled state, email verification state, federation link, and access. Note that it means that namely user attributes, required actions, and not before are not returned.)")
@@ -323,7 +333,10 @@ public class GroupResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference",
+            operationId = "getManagementPermissions"
+    )
     public ManagementPermissionReference getManagementPermissions() {
         ProfileHelper.requireFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
         auth.groups().requireView(group);
@@ -356,7 +369,10 @@ public class GroupResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference",
+            operationId = "setManagementPermissionsEnabled"
+    )
     public ManagementPermissionReference setManagementPermissionsEnabled(ManagementPermissionReference ref) {
         ProfileHelper.requireFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
         auth.groups().requireManage(group);

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -86,7 +86,10 @@ public class GroupsResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Get group hierarchy.  Only `name` and `id` are returned.  `subGroups` are only returned when using the `search` or `q` parameter. If none of these parameters is provided, the top-level groups are returned without `subGroups` being filled.")
+    @Operation(
+            summary = "Get group hierarchy.  Only `name` and `id` are returned.  `subGroups` are only returned when using the `search` or `q` parameter. If none of these parameters is provided, the top-level groups are returned without `subGroups` being filled.",
+            operationId = "getGroups"
+    )
     public Stream<GroupRepresentation> getGroups(@QueryParam("search") String search,
                                                  @QueryParam("q") String searchQuery,
                                                  @QueryParam("exact") @DefaultValue("false") Boolean exact,
@@ -125,7 +128,10 @@ public class GroupsResource {
      * @return
      */
     @Path("{group-id}")
-    @Operation( summary = "Get group details. Does not expand hierarchy.  Subgroups will not be set.")
+    @Operation(
+            summary = "Get group details. Does not expand hierarchy.  Subgroups will not be set.",
+            operationId = "getGroupById"
+    )
     public GroupResource getGroupById(@PathParam("group-id") String id) {
         GroupModel group = realm.getGroupById(id);
 
@@ -150,7 +156,7 @@ public class GroupsResource {
     @Path("count")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "Returns the groups counts.")
+    @Operation(summary = "Returns the groups counts.", operationId = "getGroupCount")
     public Map<String, Long> getGroupCount(@QueryParam("search") String search,
                                            @QueryParam("top") @DefaultValue("false") boolean onlyTopGroups) {
         GroupPermissionEvaluator groupsEvaluator = auth.groups();
@@ -179,8 +185,11 @@ public class GroupsResource {
             @APIResponse(responseCode = "204", description = "No Content")
     })
     @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
-    @Operation( summary = "create or add a top level realm groupSet or create child.",
-        description = "This will update the group and set the parent if it exists. Create it and set the parent if the group doesn’t exist.")
+    @Operation(
+            summary = "create or add a top level realm groupSet or create child.",
+            description = "This will update the group and set the parent if it exists. Create it and set the parent if the group doesn’t exist.",
+            operationId = "addTopLevelGroup"
+    )
     public Response addTopLevelGroup(GroupRepresentation rep) {
         auth.groups().requireManage();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -107,7 +107,7 @@ public class IdentityProviderResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Get the identity provider")
+    @Operation(summary = "Get the identity provider", operationId = "getIdentityProvider")
     public IdentityProviderRepresentation getIdentityProvider() {
         this.auth.realm().requireViewIdentityProviders();
 
@@ -126,7 +126,7 @@ public class IdentityProviderResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Delete the identity provider")
+    @Operation(summary = "Delete the identity provider", operationId = "deleteIdentityProvider")
     public Response delete() {
         this.auth.realm().requireManageIdentityProviders();
 
@@ -156,7 +156,7 @@ public class IdentityProviderResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Update the identity provider")
+    @Operation(summary = "Update the identity provider", operationId = "updateIdentityProvider")
     public Response update(IdentityProviderRepresentation providerRep) {
         this.auth.realm().requireManageIdentityProviders();
 
@@ -247,7 +247,10 @@ public class IdentityProviderResource {
     @Path("export")
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Export public broker configuration for identity provider")
+    @Operation(
+            summary = "Export public broker configuration for identity provider",
+            operationId = "export"
+    )
     public Response export(@Parameter(description = "Format to use") @QueryParam("format") String format) {
         this.auth.realm().requireViewIdentityProviders();
 
@@ -274,7 +277,7 @@ public class IdentityProviderResource {
     @Path("mapper-types")
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Get mapper types for identity provider")
+    @Operation(summary = "Get mapper types for identity provider", operationId = "getMapperTypes")
     public Map<String, IdentityProviderMapperTypeRepresentation> getMapperTypes() {
         this.auth.realm().requireViewIdentityProviders();
 
@@ -309,7 +312,7 @@ public class IdentityProviderResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Get mappers for identity provider")
+    @Operation(summary = "Get mappers for identity provider", operationId = "getMappers")
     public Stream<IdentityProviderMapperRepresentation> getMappers() {
         this.auth.realm().requireViewIdentityProviders();
 
@@ -331,7 +334,7 @@ public class IdentityProviderResource {
     @Path("mappers")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Add a mapper to identity provider")
+    @Operation(summary = "Add a mapper to identity provider", operationId = "addMapper")
     public Response addMapper(IdentityProviderMapperRepresentation mapper) {
         this.auth.realm().requireManageIdentityProviders();
 
@@ -365,7 +368,7 @@ public class IdentityProviderResource {
     @Path("mappers/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Get mapper by id for the identity provider")
+    @Operation(summary = "Get mapper by id for the identity provider", operationId = "getMapperById")
     public IdentityProviderMapperRepresentation getMapperById(@PathParam("id") String id) {
         this.auth.realm().requireViewIdentityProviders();
 
@@ -389,7 +392,7 @@ public class IdentityProviderResource {
     @Path("mappers/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Update a mapper for the identity provider")
+    @Operation(summary = "Update a mapper for the identity provider", operationId = "updateMapper")
     public void update(@Parameter(description = "Mapper id") @PathParam("id") String id, IdentityProviderMapperRepresentation rep) {
         this.auth.realm().requireManageIdentityProviders();
 
@@ -414,7 +417,7 @@ public class IdentityProviderResource {
     @NoCache
     @Path("mappers/{id}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Delete a mapper for the identity provider")
+    @Operation(summary = "Delete a mapper for the identity provider", operationId = "deleteMapper")
     public void delete(@Parameter(description = "Mapper id") @PathParam("id") String id) {
         this.auth.realm().requireManageIdentityProviders();
 
@@ -439,7 +442,10 @@ public class IdentityProviderResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference",
+            operationId = "getManagementPermissions"
+    )
     public ManagementPermissionReference getManagementPermissions() {
         ProfileHelper.requireFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
         this.auth.realm().requireViewIdentityProviders();
@@ -476,7 +482,10 @@ public class IdentityProviderResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether client Authorization permissions have been initialized or not and a reference",
+            operationId = "setManagementPermissionsEnabled"
+    )
     public ManagementPermissionReference setManagementPermissionsEnabled(ManagementPermissionReference ref) {
         ProfileHelper.requireFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
         this.auth.realm().requireManageIdentityProviders();
@@ -499,7 +508,10 @@ public class IdentityProviderResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation(summary = "Reaload keys for the identity provider if the provider supports it, \"true\" is returned if reload was performed, \"false\" if not.")
+    @Operation(
+            summary = "Reaload keys for the identity provider if the provider supports it, \"true\" is returned if reload was performed, \"false\" if not.",
+            operationId = "reloadKeys"
+    )
     public boolean reloadKeys() {
         this.auth.realm().requireManageIdentityProviders();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
@@ -97,7 +97,10 @@ public class IdentityProvidersResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Get the identity provider factory for that provider id")
+    @Operation(
+            summary = "Get the identity provider factory for that provider id",
+            operationId = "getIdentityProviderFactory"
+    )
     public IdentityProviderFactory getIdentityProviderFactory(@Parameter(description = "The provider id to get the factory") @PathParam("provider_id") String providerId) {
         this.auth.realm().requireViewIdentityProviders();
         IdentityProviderFactory providerFactory = getProviderFactoryById(providerId);
@@ -115,7 +118,10 @@ public class IdentityProvidersResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( description = "Import identity provider from uploaded JSON file")
+    @Operation(
+            description = "Import identity provider from uploaded JSON file",
+            operationId = "importFrom"
+    )
     public Map<String, String> importFrom() throws IOException {
         this.auth.realm().requireManageIdentityProviders();
         MultivaluedMap<String, FormPartValue> formDataMap = session.getContext().getHttpRequest().getMultiPartFormParameters();
@@ -145,7 +151,10 @@ public class IdentityProvidersResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Import identity provider from JSON body")
+    @Operation(
+            summary = "Import identity provider from JSON body",
+            operationId = "importFrom"
+    )
     public Map<String, String> importFrom(@Parameter(description = "JSON body") Map<String, Object> data) throws IOException {
         this.auth.realm().requireManageIdentityProviders();
         if (data == null || !(data.containsKey("providerId") && data.containsKey("fromUrl"))) {
@@ -178,7 +187,7 @@ public class IdentityProvidersResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation(summary = "List identity providers")
+    @Operation(summary = "List identity providers", operationId = "getIdentityProviders")
     public Stream<IdentityProviderRepresentation> getIdentityProviders(
             @Parameter(description = "Filter specific providers by name. Search can be prefix (name*), contains (*name*) or exact (\"name\"). Default prefixed.") @QueryParam("search") String search,
             @Parameter(description = "Boolean which defines whether brief representations are returned (default: false)") @QueryParam("briefRepresentation") Boolean briefRepresentation,
@@ -217,7 +226,7 @@ public class IdentityProvidersResource {
     @Path("instances")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.IDENTITY_PROVIDERS)
-    @Operation( summary = "Create a new identity provider")
+    @Operation(summary = "Create a new identity provider", operationId = "createIdentityProvider")
     public Response create(@Parameter(description = "JSON body") IdentityProviderRepresentation representation) {
         this.auth.realm().requireManageIdentityProviders();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/KeyResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/KeyResource.java
@@ -61,7 +61,7 @@ public class KeyResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.KEY)
-    @Operation()
+    @Operation(operationId = "getKeyMetadata")
     public KeysMetadataRepresentation getKeyMetadata() {
         auth.realm().requireViewRealm();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
@@ -107,7 +107,10 @@ public class ProtocolMappersResource {
     @Path("protocol/{protocol}")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Get mappers by name for a specific protocol")
+    @Operation(
+            summary = "Get mappers by name for a specific protocol",
+            operationId = "getMappersPerProtocol"
+    )
     public Stream<ProtocolMapperRepresentation> getMappersPerProtocol(@PathParam("protocol") String protocol) {
         viewPermission.require();
 
@@ -126,7 +129,7 @@ public class ProtocolMappersResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Create a mapper")
+    @Operation(summary = "Create a mapper", operationId = "createMapper")
     public Response createMapper(ProtocolMapperRepresentation rep) {
         managePermission.require();
 
@@ -152,7 +155,7 @@ public class ProtocolMappersResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Create multiple mappers")
+    @Operation(summary = "Create multiple mappers", operationId = "createMapper")
     @APIResponse(responseCode = "204", description = "No Content")
     public void createMapper(List<ProtocolMapperRepresentation> reps) {
         managePermission.require();
@@ -176,7 +179,7 @@ public class ProtocolMappersResource {
     @Path("models")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Get mappers")
+    @Operation(summary = "Get mappers", operationId = "getMappers")
     public Stream<ProtocolMapperRepresentation> getMappers() {
         viewPermission.require();
 
@@ -196,7 +199,7 @@ public class ProtocolMappersResource {
     @Path("models/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Get mapper by id")
+    @Operation(summary = "Get mapper by id", operationId = "getMapperById")
     public ProtocolMapperRepresentation getMapperById(@Parameter(description = "Mapper id") @PathParam("id") String id) {
         viewPermission.require();
 
@@ -227,7 +230,7 @@ public class ProtocolMappersResource {
     @Path("models/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Update the mapper")
+    @Operation(summary = "Update the mapper", operationId = "updateMapper")
     public void update(@Parameter(description = "Mapper id") @PathParam("id") String id, ProtocolMapperRepresentation rep) {
         managePermission.require();
 
@@ -250,7 +253,7 @@ public class ProtocolMappersResource {
     @NoCache
     @Path("models/{id}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.PROTOCOL_MAPPERS)
-    @Operation(summary = "Delete the mapper")
+    @Operation(summary = "Delete the mapper", operationId = "deleteMapper")
     public void delete(@Parameter(description = "Mapper id") @PathParam("id") String id) {
         managePermission.require();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -162,7 +162,10 @@ public class RealmAdminResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Base path for importing clients under this realm.")
+    @Operation(
+            summary = "Base path for importing clients under this realm.",
+            operationId = "convertClientDescription"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ClientRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -242,7 +245,10 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("default-default-client-scopes")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get realm default client scopes. Only name and ids are returned.")
+    @Operation(
+            summary = "Get realm default client scopes. Only name and ids are returned.",
+            operationId = "getDefaultDefaultClientScopes"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ClientScopeRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -267,7 +273,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("default-default-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "addDefaultDefaultClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -293,7 +299,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("default-default-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "removeDefaultDefaultClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -321,7 +327,10 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("default-optional-client-scopes")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get realm optional client scopes. Only name and ids are returned.")
+    @Operation(
+            summary = "Get realm optional client scopes. Only name and ids are returned.",
+            operationId = "getDefaultOptionalClientScopes"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ClientScopeRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -334,7 +343,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("default-optional-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "addDefaultOptionalClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -348,7 +357,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("default-optional-client-scopes/{clientScopeId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "removeDefaultOptionalClientScope")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -404,7 +413,10 @@ public class RealmAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get the top-level representation of the realm It will not include nested information like User and Client representations.")
+    @Operation(
+            summary = "Get the top-level representation of the realm It will not include nested information like User and Client representations.",
+            operationId = "getRealm"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RealmRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -443,8 +455,11 @@ public class RealmAdminResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Update the top-level information of the realm Any user, roles or client information in the representation will be ignored.",
-            description = "This will only update top-level attributes of the realm.")
+    @Operation(
+            summary = "Update the top-level information of the realm Any user, roles or client information in the representation will be ignored.",
+            description = "This will only update top-level attributes of the realm.",
+            operationId = "updateRealm"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -529,7 +544,7 @@ public class RealmAdminResource {
      */
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Delete the realm")
+    @Operation(summary = "Delete the realm", operationId = "deleteRealm")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -569,7 +584,7 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("users-management-permissions")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getUserMgmtPermissions")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ManagementPermissionReference.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -592,7 +607,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("users-management-permissions")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "setUsersManagementPermissionsEnabled")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ManagementPermissionReference.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -661,7 +676,10 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @POST
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Push the realm's revocation policy to any client that has an admin url associated with it.")
+    @Operation(
+            summary = "Push the realm's revocation policy to any client that has an admin url associated with it.",
+            operationId = "pushRevocation"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = GlobalRequestResult.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -683,7 +701,11 @@ public class RealmAdminResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Removes all user sessions.", description = "Any client that has an admin url will also be told to invalidate any sessions they have.")
+    @Operation(
+            summary = "Removes all user sessions.",
+            description = "Any client that has an admin url will also be told to invalidate any sessions they have.",
+            operationId = "logoutAll"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = GlobalRequestResult.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -706,7 +728,11 @@ public class RealmAdminResource {
     @Path("sessions/{session}")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Remove a specific user session.", description = "Any client that has an admin url will also be told to invalidate this particular session.")
+    @Operation(
+            summary = "Remove a specific user session.",
+            description = "Any client that has an admin url will also be told to invalidate this particular session.",
+            operationId = "deleteSession"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -740,8 +766,11 @@ public class RealmAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get client session stats Returns a JSON map.",
-        description = "The key is the client id, the value is the number of sessions that currently are active with that client. Only clients that actually have a session associated with them will be in this map.")
+    @Operation(
+            summary = "Get client session stats Returns a JSON map.",
+            description = "The key is the client id, the value is the number of sessions that currently are active with that client. Only clients that actually have a session associated with them will be in this map.",
+            operationId = "getClientSessionStats"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -797,7 +826,10 @@ public class RealmAdminResource {
     @Path("events/config")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get the events provider configuration Returns JSON object with events provider configuration")
+    @Operation(
+            summary = "Get the events provider configuration Returns JSON object with events provider configuration",
+            operationId = "getRealmEventsConfig"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RealmEventsConfigRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -827,7 +859,10 @@ public class RealmAdminResource {
     @Path("events/config")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation( description = "Update the events provider Change the events provider and/or its configuration")
+    @Operation(
+            description = "Update the events provider Change the events provider and/or its configuration",
+            operationId = "updateRealmEventsConfig"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -864,7 +899,10 @@ public class RealmAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get events Returns all events, or filters them based on URL query parameters listed here")
+    @Operation(
+            summary = "Get events Returns all events, or filters them based on URL query parameters listed here",
+            operationId = "getEvents"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EventRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -964,7 +1002,10 @@ public class RealmAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get admin events Returns all admin events, or filters events based on URL query parameters listed here")
+    @Operation(
+            summary = "Get admin events Returns all admin events, or filters events based on URL query parameters listed here",
+            operationId = "getEvents"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AdminEventRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -1065,7 +1106,7 @@ public class RealmAdminResource {
     @Path("events")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Delete all events")
+    @Operation(summary = "Delete all events", operationId = "clearEvents")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -1084,7 +1125,7 @@ public class RealmAdminResource {
     @Path("admin-events")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Delete all admin events")
+    @Operation(summary = "Delete all admin events", operationId = "clearAdminEvents")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -1109,7 +1150,7 @@ public class RealmAdminResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Deprecated
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Test SMTP connection with current logged in user")
+    @Operation(summary = "Test SMTP connection with current logged in user", operationId = "testSMTPConnection")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "500", description = "Internal Server Error")
@@ -1125,7 +1166,7 @@ public class RealmAdminResource {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "testSMTPConnection")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "500", description = "Internal Server Error")
@@ -1167,7 +1208,7 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("default-groups")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get group hierarchy.  Only name and ids are returned.")
+    @Operation(summary = "Get group hierarchy.  Only name and ids are returned.", operationId = "getDefaultGroups")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = GroupRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -1182,7 +1223,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("default-groups/{groupId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "addDefaultGroup")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -1205,7 +1246,7 @@ public class RealmAdminResource {
     @NoCache
     @Path("default-groups/{groupId}")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "removeDefaultGroup")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -1234,7 +1275,7 @@ public class RealmAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getGroupByPath")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = GroupRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -1260,7 +1301,10 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Partial import from a JSON file to an existing realm.")
+    @Operation(
+            summary = "Partial import from a JSON file to an existing realm.",
+            operationId = "partialImport"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PartialImportResults.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -1319,7 +1363,7 @@ public class RealmAdminResource {
     @Produces(MediaType.APPLICATION_JSON)
     @POST
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Partial export of existing realm into a JSON file.")
+    @Operation(summary = "Partial export of existing realm into a JSON file.", operationId = "partialExport")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RealmRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -1370,7 +1414,7 @@ public class RealmAdminResource {
     @NoCache
     @Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getCredentialRegistrators")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden")

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmLocalizationResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmLocalizationResource.java
@@ -75,7 +75,7 @@ public class RealmLocalizationResource {
     @PUT
     @Consumes(MediaType.TEXT_PLAIN)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "saveRealmLocalizationText")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -101,7 +101,10 @@ public class RealmLocalizationResource {
     @Path("{locale}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Import localization from uploaded JSON file")
+    @Operation(
+            summary = "Import localization from uploaded JSON file",
+            operationId = "createOrUpdateRealmLocalizationTextsFromFile"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -128,7 +131,7 @@ public class RealmLocalizationResource {
     @Path("{locale}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "createOrUpdateRealmLocalizationTexts")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -142,7 +145,7 @@ public class RealmLocalizationResource {
     @Path("{locale}")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "deleteRealmLocalizationTexts")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -158,7 +161,7 @@ public class RealmLocalizationResource {
     @Path("{locale}/{key}")
     @DELETE
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "deleteRealmLocalizationText")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -174,7 +177,7 @@ public class RealmLocalizationResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getRealmLocalizationLocales")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -189,7 +192,7 @@ public class RealmLocalizationResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getRealmLocalizationTexts")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -219,7 +222,7 @@ public class RealmLocalizationResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation()
+    @Operation(operationId = "getRealmLocalizationText")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -111,7 +111,10 @@ public class RealmsAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Get accessible realms Returns a list of accessible realms. The list is filtered based on what realms the caller is allowed to view.")
+    @Operation(
+        summary = "Get accessible realms Returns a list of accessible realms. The list is filtered based on what realms the caller is allowed to view.",
+        operationId = "getRealms"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RealmRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -143,7 +146,11 @@ public class RealmsAdminResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Operation(summary = "Import a realm. Imports a realm from a full representation of that realm.", description = "Realm name must be unique.")
+    @Operation(
+        summary = "Import a realm. Imports a realm from a full representation of that realm.",
+        description = "Realm name must be unique.",
+        operationId = "importRealm"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "400", description = "Bad Request"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
@@ -94,7 +94,7 @@ public class RoleByIdResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Get a specific role's representation")
+    @Operation(summary = "Get a specific role's representation", operationId = "getRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -122,7 +122,7 @@ public class RoleByIdResource extends RoleResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Delete the role")
+    @Operation(summary = "Delete the role", operationId = "deleteRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -159,7 +159,7 @@ public class RoleByIdResource extends RoleResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Update the role")
+    @Operation(summary = "Update the role", operationId = "updateRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -188,7 +188,10 @@ public class RoleByIdResource extends RoleResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Make the role a composite role by associating some child roles")
+    @Operation(
+            summary = "Make the role a composite role by associating some child roles",
+            operationId = "addComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -212,7 +215,10 @@ public class RoleByIdResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Get role's children Returns a set of role's children provided the role is a composite.")
+    @Operation(
+            summary = "Get role's children Returns a set of role's children provided the role is a composite.",
+            operationId = "getRoleComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -245,7 +251,10 @@ public class RoleByIdResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Get realm-level roles that are in the role's composite")
+    @Operation(
+            summary = "Get realm-level roles that are in the role's composite",
+            operationId = "getRealmRoleComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -268,7 +277,10 @@ public class RoleByIdResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Get client-level roles for the client that are in the role's composite")
+    @Operation(
+            summary = "Get client-level roles for the client that are in the role's composite",
+            operationId = "getClientRoleComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -296,7 +308,10 @@ public class RoleByIdResource extends RoleResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Remove a set of roles from the role's composite")
+    @Operation(
+            summary = "Remove a set of roles from the role's composite",
+            operationId = "deleteComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -320,7 +335,10 @@ public class RoleByIdResource extends RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference",
+            operationId = "getManagementPermissions"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ManagementPermissionReference.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -358,7 +376,10 @@ public class RoleByIdResource extends RoleResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES_BY_ID)
-    @Operation(summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference",
+            operationId = "setManagementPermissionsEnabled"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ManagementPermissionReference.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -109,7 +109,7 @@ public class RoleContainerResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Get all roles for the realm or client")
+    @Operation(summary = "Get all roles for the realm or client", operationId = "getRoles")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -145,7 +145,7 @@ public class RoleContainerResource extends RoleResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Create a new role for the realm or client")
+    @Operation(summary = "Create a new role for the realm or client", operationId = "createRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -238,7 +238,7 @@ public class RoleContainerResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Get a role by name")
+    @Operation(summary = "Get a role by name", operationId = "getRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -264,7 +264,7 @@ public class RoleContainerResource extends RoleResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Delete a role by name")
+    @Operation(summary = "Delete a role by name", operationId = "deleteRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -303,7 +303,7 @@ public class RoleContainerResource extends RoleResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Update a role by name")
+    @Operation(summary = "Update a role by name", operationId = "updateRole")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -343,7 +343,7 @@ public class RoleContainerResource extends RoleResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Add a composite to the role")
+    @Operation(summary = "Add a composite to the role", operationId = "addComposites")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -369,7 +369,7 @@ public class RoleContainerResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Get composites of the role")
+    @Operation(summary = "Get composites of the role", operationId = "getRoleComposites")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -395,7 +395,10 @@ public class RoleContainerResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Get realm-level roles of the role's composite")
+    @Operation(
+            summary = "Get realm-level roles of the role's composite",
+            operationId = "getRealmRoleComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -422,7 +425,10 @@ public class RoleContainerResource extends RoleResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Get client-level roles for the client that are in the role's composite")
+    @Operation(
+            summary = "Get client-level roles for the client that are in the role's composite",
+            operationId = "getClientRoleComposites"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -454,7 +460,7 @@ public class RoleContainerResource extends RoleResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Remove roles from the role's composite")
+    @Operation(summary = "Remove roles from the role's composite", operationId = "deleteComposites")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -484,7 +490,10 @@ public class RoleContainerResource extends RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference",
+            operationId = "getManagementPermissions"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ManagementPermissionReference.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -518,7 +527,10 @@ public class RoleContainerResource extends RoleResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference")
+    @Operation(
+            summary = "Return object stating whether role Authorization permissions have been initialized or not and a reference",
+            operationId = "setManagementPermissionsEnabled"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = ManagementPermissionReference.class))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -556,7 +568,10 @@ public class RoleContainerResource extends RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Returns a stream of users that have the specified role name.")
+    @Operation(
+            summary = "Returns a stream of users that have the specified role name.",
+            operationId = "getUsersInRole"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = UserRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -598,7 +613,10 @@ public class RoleContainerResource extends RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
-    @Operation(summary = "Returns a stream of groups that have the specified role name")
+    @Operation(
+            summary = "Returns a stream of groups that have the specified role name",
+            operationId = "getGroupsInRole"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = UserRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
@@ -128,7 +128,7 @@ public class RoleMapperResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLE_MAPPER)
-    @Operation(summary = "Get role mappings")
+    @Operation(summary = "Get role mappings", operationId = "getRoleMappings")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = MappingsRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -176,7 +176,7 @@ public class RoleMapperResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLE_MAPPER)
-    @Operation(summary = "Get realm-level role mappings")
+    @Operation(summary = "Get realm-level role mappings", operationId = "getRealmRoleMappings")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -201,7 +201,10 @@ public class RoleMapperResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLE_MAPPER)
-    @Operation(summary = "Get effective realm-level role mappings This will recurse all composite roles to get the result.")
+    @Operation(
+            summary = "Get effective realm-level role mappings This will recurse all composite roles to get the result.",
+            operationId = "getCompositeRealmRoleMappings"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -226,7 +229,10 @@ public class RoleMapperResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLE_MAPPER)
-    @Operation(summary = "Get realm-level roles that can be mapped")
+    @Operation(
+            summary = "Get realm-level roles that can be mapped",
+            operationId = "getAvailableRealmRoleMappings"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = RoleRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -249,7 +255,10 @@ public class RoleMapperResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLE_MAPPER)
-    @Operation(summary = "Add realm-level role mappings to the user")
+    @Operation(
+            summary = "Add realm-level role mappings to the user",
+            operationId = "addRealmRoleMappings"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -293,7 +302,10 @@ public class RoleMapperResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLE_MAPPER)
-    @Operation(summary = "Delete realm-level role mappings")
+    @Operation(
+            summary = "Delete realm-level role mappings",
+            operationId = "deleteRealmRoleMappings"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),

--- a/services/src/main/java/org/keycloak/services/resources/admin/ScopeMappedClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ScopeMappedClientResource.java
@@ -92,7 +92,10 @@ public class ScopeMappedClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Get the roles associated with a client's scope Returns roles for the client.")
+    @Operation(
+            summary = "Get the roles associated with a client's scope Returns roles for the client.",
+            operationId = "getClientScopeMappings"
+    )
     public Stream<RoleRepresentation> getClientScopeMappings() {
         viewPermission.require();
 
@@ -112,7 +115,10 @@ public class ScopeMappedClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "The available client-level roles Returns the roles for the client that can be associated with the client's scope")
+    @Operation(
+            summary = "The available client-level roles Returns the roles for the client that can be associated with the client's scope",
+            operationId = "getAvailableClientScopeMappings"
+    )
     public Stream<RoleRepresentation> getAvailableClientScopeMappings() {
         viewPermission.require();
 
@@ -136,7 +142,10 @@ public class ScopeMappedClientResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Get effective client roles Returns the roles for the client that are associated with the client's scope.")
+    @Operation(
+            summary = "Get effective client roles Returns the roles for the client that are associated with the client's scope.",
+            operationId = "getCompositeClientScopeMappings"
+    )
     public Stream<RoleRepresentation> getCompositeClientScopeMappings(@Parameter(description = "if false, return roles with their attributes") @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         viewPermission.require();
 
@@ -155,7 +164,10 @@ public class ScopeMappedClientResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Add client-level roles to the client's scope")
+    @Operation(
+            summary = "Add client-level roles to the client's scope",
+            operationId = "addClientScopeMapping"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void addClientScopeMapping(List<RoleRepresentation> roles) {
         managePermission.require();
@@ -179,7 +191,10 @@ public class ScopeMappedClientResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Remove client-level roles from the client's scope.")
+    @Operation(
+            summary = "Remove client-level roles from the client's scope.",
+            operationId = "deleteClientScopeMapping"
+    )
     public void deleteClientScopeMapping(List<RoleRepresentation> roles) {
         managePermission.require();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ScopeMappedResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ScopeMappedResource.java
@@ -99,7 +99,11 @@ public class ScopeMappedResource {
     @NoCache
     @Deprecated
     @Tag(name= KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Get all scope mappings for the client", deprecated = true)
+    @Operation(
+            summary = "Get all scope mappings for the client",
+            operationId = "getScopeMappings",
+            deprecated = true
+    )
     public MappingsRepresentation getScopeMappings() {
         viewPermission.require();
 
@@ -137,7 +141,10 @@ public class ScopeMappedResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Get realm-level roles associated with the client's scope")
+    @Operation(
+            summary = "Get realm-level roles associated with the client's scope",
+            operationId = "getRealmScopeMappings"
+    )
     public Stream<RoleRepresentation> getRealmScopeMappings() {
         viewPermission.require();
 
@@ -159,7 +166,10 @@ public class ScopeMappedResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Get realm-level roles that are available to attach to this client's scope")
+    @Operation(
+            summary = "Get realm-level roles that are available to attach to this client's scope",
+            operationId = "getAvailableRealmScopeMappings"
+    )
     public Stream<RoleRepresentation> getAvailableRealmScopeMappings() {
         viewPermission.require();
 
@@ -189,8 +199,11 @@ public class ScopeMappedResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Get effective realm-level roles associated with the client’s scope What this does is recurse any composite roles associated with the client’s scope and adds the roles to this lists.",
-        description = "The method is really to show a comprehensive total view of realm-level roles associated with the client.")
+    @Operation(
+            summary = "Get effective realm-level roles associated with the client’s scope What this does is recurse any composite roles associated with the client’s scope and adds the roles to this lists.",
+            description = "The method is really to show a comprehensive total view of realm-level roles associated with the client.",
+            operationId = "getCompositeRealmScopeMappings"
+    )
     public Stream<RoleRepresentation> getCompositeRealmScopeMappings(@Parameter(description = "if false, return roles with their attributes") @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         viewPermission.require();
 
@@ -214,7 +227,10 @@ public class ScopeMappedResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Add a set of realm-level roles to the client's scope")
+    @Operation(
+            summary = "Add a set of realm-level roles to the client's scope",
+            operationId = "addRealmScopeMappings"
+    )
     @APIResponse(responseCode = "204", description = "No Content")
     public void addRealmScopeMappings(List<RoleRepresentation> roles) {
         managePermission.require();
@@ -243,7 +259,10 @@ public class ScopeMappedResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.SCOPE_MAPPINGS)
-    @Operation(summary = "Remove a set of realm-level roles from the client's scope")
+    @Operation(
+            summary = "Remove a set of realm-level roles from the client's scope",
+            operationId = "deleteRealmScopeMappings"
+    )
     public void deleteRealmScopeMappings(List<RoleRepresentation> roles) {
         managePermission.require();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
@@ -71,7 +71,10 @@ public class UserProfileResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(description = "Get the configuration for the user profile")
+    @Operation(
+            description = "Get the configuration for the user profile",
+            operationId = "getConfiguration"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UPConfig.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -85,7 +88,10 @@ public class UserProfileResource {
     @Path("/metadata")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(description = "Get the UserProfileMetadata from the configuration")
+    @Operation(
+            description = "Get the UserProfileMetadata from the configuration",
+            operationId = "getMetadata"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UserProfileMetadata.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -100,7 +106,10 @@ public class UserProfileResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(description = "Set the configuration for the user profile")
+    @Operation(
+            description = "Set the configuration for the user profile",
+            operationId = "updateUserProfile"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UPConfig.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -180,7 +180,7 @@ public class UserResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Update the user")
+    @Operation(summary = "Update the user", operationId = "updateUser")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class))),
@@ -335,7 +335,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Get representation of the user")
+    @Operation(summary = "Get representation of the user", operationId = "getUser")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UserRepresentation.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -376,7 +376,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Impersonate the user")
+    @Operation(summary = "Impersonate the user", operationId = "impersonate")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class))),
@@ -441,7 +441,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Get sessions associated with the user")
+    @Operation(summary = "Get sessions associated with the user", operationId = "getSessions")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UserSessionRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -461,7 +461,10 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Get offline sessions associated with the user and client")
+    @Operation(
+            summary = "Get offline sessions associated with the user and client",
+            operationId = "getOfflineSessions"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UserSessionRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -488,7 +491,10 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Get social logins associated with the user")
+    @Operation(
+            summary = "Get social logins associated with the user",
+            operationId = "getFederatedIdentity"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = FederatedIdentityRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -515,7 +521,10 @@ public class UserResource {
     @POST
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Add a social login provider to the user")
+    @Operation(
+            summary = "Add a social login provider to the user",
+            operationId = "addFederatedIdentity"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -542,7 +551,10 @@ public class UserResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Remove a social login provider from user")
+    @Operation(
+            summary = "Remove a social login provider from user",
+            operationId = "removeFederatedIdentity"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -566,7 +578,10 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Get consents granted by the user")
+    @Operation(
+            summary = "Get consents granted by the user",
+            operationId = "getConsents"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -640,7 +655,10 @@ public class UserResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Revoke consent and offline tokens for particular client from user")
+    @Operation(
+            summary = "Revoke consent and offline tokens for particular client from user",
+            operationId = "revokeConsent"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -670,7 +688,10 @@ public class UserResource {
     @Path("logout")
     @POST
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Remove all user sessions associated with the user Also send notification to all clients that have an admin URL to invalidate the sessions for the particular user.")
+    @Operation(
+            summary = "Remove all user sessions associated with the user Also send notification to all clients that have an admin URL to invalidate the sessions for the particular user.",
+            operationId = "logout"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -695,7 +716,7 @@ public class UserResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Delete the user")
+    @Operation(summary = "Delete the user", operationId = "deleteUser")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class))),
@@ -729,7 +750,10 @@ public class UserResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Disable all credentials for a user of a specific type")
+    @Operation(
+            summary = "Disable all credentials for a user of a specific type",
+            operationId = "disableCredentialType"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -752,7 +776,10 @@ public class UserResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Set up a new password for the user.")
+    @Operation(
+            summary = "Set up a new password for the user.",
+            operationId = "resetPassword"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -803,7 +830,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(operationId = "credentials")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = CredentialRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -827,7 +854,10 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Return credential types, which are provided by the user storage where user is stored.", description = "Returned values can contain for example \"password\", \"otp\" etc. This will always return empty list for \"local\" users, which are not backed by any user storage")
+    @Operation(
+            summary = "Return credential types, which are provided by the user storage where user is stored.", description = "Returned values can contain for example \"password\", \"otp\" etc. This will always return empty list for \"local\" users, which are not backed by any user storage",
+            operationId = "getConfiguredUserStorageCredentialTypes"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -847,7 +877,7 @@ public class UserResource {
     @DELETE
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Remove a credential for a user")
+    @Operation(summary = "Remove a credential for a user", operationId = "removeCredential")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -872,7 +902,10 @@ public class UserResource {
     @Consumes(MediaType.TEXT_PLAIN)
     @Path("credentials/{credentialId}/userLabel")
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Update a credential label for a user")
+    @Operation(
+            summary = "Update a credential label for a user",
+            operationId = "setCredentialUserLabel"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -896,7 +929,10 @@ public class UserResource {
     @Path("credentials/{credentialId}/moveToFirst")
     @POST
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Move a credential to a first position in the credentials list of the user")
+    @Operation(
+            summary = "Move a credential to a first position in the credentials list of the user",
+            operationId = "moveCredentialToFirst"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -914,7 +950,10 @@ public class UserResource {
     @Path("credentials/{credentialId}/moveAfter/{newPreviousCredentialId}")
     @POST
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Move a credential to a position behind another credential")
+    @Operation(
+            summary = "Move a credential to a position behind another credential",
+            operationId = "moveCredentialAfter"
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -952,7 +991,9 @@ public class UserResource {
     @Operation(
             summary = "Send an email to the user with a link they can click to reset their password.",
             description = "The redirectUri and clientId parameters are optional. The default for the redirect is the account client. This endpoint has been deprecated.  Please use the execute-actions-email passing a list with UPDATE_PASSWORD within it.",
-            deprecated = true)
+            operationId = "resetPasswordEmail",
+            deprecated = true
+    )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class))),
@@ -988,7 +1029,8 @@ public class UserResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
     @Operation(
             summary = "Send an email to the user with a link they can click to execute particular actions.",
-            description = "An email contains a link the user can click to perform a set of required actions. The redirectUri and clientId parameters are optional. If no redirect is given, then there will be no link back to click after actions have completed. Redirect uri must be a valid uri for the particular clientId."
+            description = "An email contains a link the user can click to perform a set of required actions. The redirectUri and clientId parameters are optional. If no redirect is given, then there will be no link back to click after actions have completed. Redirect uri must be a valid uri for the particular clientId.",
+            operationId = "executeActionsEmail"
     )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
@@ -1053,7 +1095,8 @@ public class UserResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
     @Operation(
             summary = "Send an email-verification email to the user An email contains a link the user can click to verify their email address.",
-            description = "The redirectUri, clientId and lifespan parameters are optional. The default for the redirect is the account client. The default for the lifespan is 12 hours"
+            description = "The redirectUri, clientId and lifespan parameters are optional. The default for the redirect is the account client. The default for the lifespan is 12 hours",
+            operationId = "sendVerifyEmail"
     )
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
@@ -1098,7 +1141,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(operationId = "groupMembership")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = GroupRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -1116,7 +1159,7 @@ public class UserResource {
     @Path("groups/count")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(operationId = "getGroupMembershipCount")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden")
@@ -1139,7 +1182,7 @@ public class UserResource {
     @Path("groups/{groupId}")
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(operationId = "removeMembership")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -1181,7 +1224,7 @@ public class UserResource {
     @Path("groups/{groupId}")
     @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(operationId = "joinGroup")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
@@ -1212,7 +1255,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation()
+    @Operation(operationId = "getUnmanagedAttributes")
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "403", description = "Forbidden")

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -136,7 +136,10 @@ public class UsersResource {
         @APIResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class)))
     })
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Create a new user Username must be unique.")
+    @Operation(
+            summary = "Create a new user Username must be unique.",
+            operationId = "createUser"
+    )
     public Response createUser(final UserRepresentation rep) {
         // first check if user has manage rights
         try {
@@ -269,7 +272,10 @@ public class UsersResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
-    @Operation(summary = "Get users Returns a stream of users, filtered according to query parameters.")
+    @Operation(
+            summary = "Get users Returns a stream of users, filtered according to query parameters.",
+            operationId = "getUsers"
+    )
     public Stream<UserRepresentation> getUsers(
             @Parameter(description = "A String contained in username, first or last name, or email. Default search behavior is prefix-based (e.g., foo or foo*). Use *foo* for infix search and \"foo\" for exact search.") @QueryParam("search") String search,
             @Parameter(description = "A String contained in lastName, or the complete lastName, if param \"exact\" is true") @QueryParam("lastName") String last,
@@ -396,7 +402,9 @@ public class UsersResource {
             description = "It can be called in three different ways. " +
                     "1. Don’t specify any criteria and pass {@code null}. The number of all users within that realm will be returned. <p> " +
                     "2. If {@code search} is specified other criteria such as {@code last} will be ignored even though you set them. The {@code search} string will be matched against the first and last name, the username and the email of a user. <p> " +
-                    "3. If {@code search} is unspecified but any of {@code last}, {@code first}, {@code email} or {@code username} those criteria are matched against their respective fields on a user entity. Combined with a logical and.")
+                    "3. If {@code search} is unspecified but any of {@code last}, {@code first}, {@code email} or {@code username} those criteria are matched against their respective fields on a user entity. Combined with a logical and.",
+            operationId = "getUsersCount"
+    )
     public Integer getUsersCount(
             @Parameter(description = "arbitrary search string for all the fields below. Default search behavior is prefix-based (e.g., foo or foo*). Use *foo* for infix search and \"foo\" for exact search.") @QueryParam("search") String search,
             @Parameter(description = "last name filter") @QueryParam("lastName") String last,


### PR DESCRIPTION
This PR adds `operationId` values to the Keycloak Admin REST API endpoints.  
These `operationId`s are included in the generated OpenAPI spec, which makes it easier for client generator tools (like OpenAPI Generator or Swagger Codegen) to produce readable and consistent method names.

### Motivation

- Improves developer experience when generating API clients from the OpenAPI spec.
- Allows for better naming consistency and predictability in generated code.
- Enables easier maintenance of custom clients or tooling relying on the OpenAPI spec.

Let me know if you’d like the naming scheme to follow a different convention, or if you'd prefer to limit this to a subset of endpoints.
