### PR TITLE
Make recovery codes supported

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -93,7 +93,7 @@ public class Profile {
         // Check if kerberos is available in underlying JVM and auto-detect if feature should be enabled or disabled by default based on that
         KERBEROS("Kerberos", Type.DEFAULT, 1, () -> KerberosJdkProvider.getProvider().isKerberosAvailable()),
 
-        RECOVERY_CODES("Recovery codes", Type.PREVIEW),
+        RECOVERY_CODES("Recovery codes", Type.DEFAULT),
 
         UPDATE_EMAIL("Update Email Action", Type.PREVIEW),
 

--- a/docs/documentation/release_notes/topics/26_3_0.adoc
+++ b/docs/documentation/release_notes/topics/26_3_0.adoc
@@ -25,3 +25,7 @@ https://github.com/keycloak/keycloak/issues/37967[Deprecate for removal the Inst
 In this release, the Instagram Identity Broker is deprecated for removal and is not enabled by default.
 If you are using this broker, it is recommended to use the Facebook Identity Broker instead. For more
 details, see link:{upgradingguide_link}[{upgradingguide_name}].
+
+= Recovery Codes supported
+
+In this release, the *Recovery Codes* two-factor authentication is promoted from preview to supported feature. For more information about the 2FA method, see the link:{adminguide_link}#_recovery-codes[Recovery Codes] chapter in the {adminguide_name}.

--- a/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
+++ b/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
@@ -6,10 +6,6 @@ The Recovery Codes are a number of sequential one-time passwords (currently 12) 
 
 Due to its nature, the Recovery Codes work normally as a backup for another 2FA methods. They can complement the `OTP Form` or the `WebAuthn Authenticator` to give a backing way to log inside {project_name}, for example, if the software or hardware device used for the previous 2FA methods is broken or unavailable.
 
-:tech_feature_name: RecoveryCodes
-:tech_feature_id: recovery-codes
-include::../templates/techpreview.adoc[]
-
 ==== Enable Recovery Codes required action
 
 Check the Recovery Codes action is enabled in {project_name}:

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultRequiredActions.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultRequiredActions.java
@@ -287,7 +287,7 @@ public class DefaultRequiredActions {
             recoveryCodes.setName("Recovery Authentication Codes");
             recoveryCodes.setProviderId(PROVIDER_ID);
             recoveryCodes.setDefaultAction(false);
-            recoveryCodes.setPriority(70);
+            recoveryCodes.setPriority(120);
             realm.addRequiredActionProvider(recoveryCodes);
         }
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
@@ -173,6 +173,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
                 "Will also set it if execution is OPTIONAL and the password is currently configured for it.");
         addProviderInfo(result, "webauthn-authenticator", "WebAuthn Authenticator", "Authenticator for WebAuthn. Usually used for WebAuthn two-factor authentication");
         addProviderInfo(result, "webauthn-authenticator-passwordless", "WebAuthn Passwordless Authenticator", "Authenticator for Passwordless WebAuthn authentication");
+        addProviderInfo(result, "auth-recovery-authn-code-form", "Recovery Authentication Code Form", "Validates a Recovery Authentication Code");
 
         addProviderInfo(result, "auth-username-form", "Username Form",
                 "Selects a user from his username.");

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/RequiredActionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/RequiredActionsTest.java
@@ -63,6 +63,7 @@ public class RequiredActionsTest extends AbstractAuthenticationTest {
         List<RequiredActionProviderRepresentation> result = authMgmtResource.getRequiredActions();
 
         List<RequiredActionProviderRepresentation> expected = new ArrayList<>();
+        addRequiredAction(expected, "CONFIGURE_RECOVERY_AUTHN_CODES", "Recovery Authentication Codes", true, false, null);
         addRequiredAction(expected, "CONFIGURE_TOTP", "Configure OTP", true, false, null);
         addRequiredAction(expected, "TERMS_AND_CONDITIONS", "Terms and Conditions", false, false, null);
         addRequiredAction(expected, "UPDATE_PASSWORD", "Update Password", true, false, null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/feature/RecoveryAuthnCodesFeatureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/feature/RecoveryAuthnCodesFeatureTest.java
@@ -22,7 +22,6 @@ import org.keycloak.authentication.AuthenticatorSpi;
 import org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticatorFactory;
 import org.keycloak.common.Profile;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 
 public class RecoveryAuthnCodesFeatureTest extends AbstractFeatureStateTest {
 
@@ -37,7 +36,6 @@ public class RecoveryAuthnCodesFeatureTest extends AbstractFeatureStateTest {
     }
 
     @Test
-    @EnableFeature(value = Profile.Feature.RECOVERY_CODES, skipRestart = true)
     public void featureEnabled() {
         testFeatureAvailability(true);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
@@ -45,7 +45,6 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.admin.ApiUtil;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.broker.util.SimpleHttpDefault;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.federation.BackwardsCompatibilityUserStorageFactory;
@@ -71,7 +70,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
 import static org.wildfly.common.Assert.assertTrue;
 
 /**
@@ -79,7 +77,6 @@ import static org.wildfly.common.Assert.assertTrue;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-@EnableFeature(value = RECOVERY_CODES, skipRestart = true)
 public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeycloakTest {
 
     private static final String BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES = "Browser with Recovery Authentication Codes";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -93,7 +93,6 @@ import org.keycloak.util.JsonSerialization;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
 import static org.keycloak.testsuite.actions.AppInitiatedActionDeleteCredentialTest.getKcActionParamForDeleteCredential;
 
 /**
@@ -101,7 +100,6 @@ import static org.keycloak.testsuite.actions.AppInitiatedActionDeleteCredentialT
  *
  * @author <a href="mailto:sebastian.zoescher@prime-sign.com">Sebastian Zoescher</a>
  */
-@EnableFeature(value = RECOVERY_CODES, skipRestart = true)
 public class LevelOfAssuranceFlowTest extends AbstractChangeImportedUserPasswordsTest {
 
     private final static String FLOW_ALIAS = "browser -  Level of Authentication FLow";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -41,7 +41,6 @@ import org.keycloak.services.resources.account.AccountCredentialResource;
 import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.broker.util.SimpleHttpDefault;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.pages.AppPage;
@@ -67,7 +66,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.authentication.requiredactions.RecoveryAuthnCodesAction.WARNING_THRESHOLD;
-import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
 
 /**
  * Backup Code Authentication test
@@ -75,7 +73,6 @@ import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
  * @author <a href="mailto:vnukala@redhat.com">Venkata Nukala</a>
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-@EnableFeature(value = RECOVERY_CODES, skipRestart = true)
 public class RecoveryAuthnCodesAuthenticatorTest extends AbstractChangeImportedUserPasswordsTest {
 
     private static final String BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES = "Browser with Recovery Authentication Codes";


### PR DESCRIPTION
Closes #38994

PR to make recovery codes supported. Added a note in the documentation, removed the preview warning in the server admin section and updated the tests to not enable the feature. I moved the priority to the next 110 as it seems that priorities are spaced by 10 (tests check that). Also updated the authenticator to add the action to the session is the user is read-only.
