### PR TITLE
Fix NPE in LDAPUtils.loadAllLDAPObjects when batch size is set to val…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -310,8 +310,8 @@ public class LDAPUtils {
      * @return
      */
     public static List<LDAPObject> loadAllLDAPObjects(LDAPQuery ldapQuery, LDAPConfig ldapConfig) {
-        boolean pagination = ldapConfig.isPagination();
-        if (pagination) {
+
+        if (ldapConfig.isPagination() && ldapConfig.getBatchSizeForSync() > 0) {
             // For now reuse globally configured batch size in LDAP provider page
             int pageSize = ldapConfig.getBatchSizeForSync();
 


### PR DESCRIPTION
…ue <= 0

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>

Closes #39022

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
