### PR TITLE
Hardcode nip.io test hosts to `/etc/hosts`

### DIFF
--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -14,6 +14,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: update-hosts
+      name: Update /etc/hosts
+      uses: ./.github/actions/update-hosts
+
     - id: setup-java
       name: Setup Java
       uses: ./.github/actions/java-setup

--- a/.github/actions/update-hosts/action.yml
+++ b/.github/actions/update-hosts/action.yml
@@ -1,0 +1,21 @@
+name: Update /etc/hosts
+description: Update /etc/hosts file to hardcode known nip.io hostnames. This is to avoid test instability due to DNS resolution issues.
+
+runs:
+  using: composite
+  steps:
+
+    - id: update-hosts-linux
+      name: Update /etc/hosts
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        printf "\n\n$(cat .github/actions/update-hosts/nipio-hosts)" | sudo tee -a /etc/hosts
+
+    - id: update-hosts-windows
+      name: Update C:\Windows\System32\drivers\etc\hosts
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        "`n`n" | Add-Content C:\Windows\System32\drivers\etc\hosts
+        Get-Content .github/actions/update-hosts/nipio-hosts | Add-Content C:\Windows\System32\drivers\etc\hosts

--- a/.github/actions/update-hosts/nipio-hosts
+++ b/.github/actions/update-hosts/nipio-hosts
@@ -1,0 +1,1 @@
+127.0.0.1 127.0.0.1.nip.io admin.127.0.0.1.nip.io localhost-myapp.127.0.0.1.nip.io localhost-sso.127.0.0.1.nip.io realmFrontend.127.0.0.1.nip.io proxy.kc.127.0.0.1.nip.io

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/DefaultCookieProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/DefaultCookieProviderTest.java
@@ -67,7 +67,7 @@ public class DefaultCookieProviderTest extends AbstractKeycloakTest {
 
     @Test
     public void testCookieDefaultsWithInsecureContext() {
-        KeycloakTestingClient testingInsecure = KeycloakTestingClient.getInstance("http://0.0.0.0:8180/auth");
+        KeycloakTestingClient testingInsecure = KeycloakTestingClient.getInstance("http://127.0.0.1.nip.io:8180/auth");
 
         Response response = testingInsecure.server("master").runWithResponse(session -> {
             CookieProvider cookies = session.getProvider(CookieProvider.class);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ReverseProxy.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ReverseProxy.java
@@ -11,7 +11,7 @@ import org.keycloak.testsuite.arquillian.undertow.lb.SimpleUndertowLoadBalancer;
 
 public class ReverseProxy implements TestRule {
 
-    public static String DEFAULT_PROXY_HOST = "127.0.0.1";
+    public static String DEFAULT_PROXY_HOST = "proxy.kc.127.0.0.1.nip.io";
     public static final int DEFAULT_HTTP_PORT = 8666;
     public static final int DEFAULT_HTTPS_PORT = 8667;
 


### PR DESCRIPTION
Closes #38104

Partially reverts 9eb336ae4164b717fd26b218407af4c0ce162187 to be on the safe side that real hostnames are used.

The hostnames are right now manually managed in the GH Action. We could of course automate this but greping the whole code base for nip.io hosts before each CI run seemed like too much overhead and unnecessary overengineering. It might not also capture all hostnames as some are programmatically specified in the tests – so it would require human interaction (to avoid stuff like [this](https://github.com/keycloak/keycloak/blob/b545339e2c924263a498653f348610de0c09059c/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSamlIdPInitiatedVaryingLetterCaseTest.java#L91-L92)) anyway. Given it's just a handful of hostnames I went for the manual approach. Let me know if that works for you.

A [test run](https://github.com/vmuzikar/keycloak/actions/runs/14499607403) of 2x100 `DefaultCookieProviderTest` seems stable.