### PR TITLE
Change Grafana dashboards guide title to plural

### DIFF
--- a/docs/guides/observability/grafana-dashboards.adoc
+++ b/docs/guides/observability/grafana-dashboards.adoc
@@ -2,8 +2,8 @@
 <#import "/templates/links.adoc" as links>
 
 <@tmpl.guide
-title="Visualizing activities in a dashboard"
-summary="Install the {project_name} Grafana dashboards to vitualize the metrics that capture the status and activities of your deployment.">
+title="Visualizing activities in dashboards"
+summary="Install the {project_name} Grafana dashboards to visualize the metrics that capture the status and activities of your deployment.">
 
 {project_name} provides metrics to observe what is happening inside the deployment.
 To understand how metrics evolve over time, it is helpful to collect them and visualize in graphs.


### PR DESCRIPTION
Closes #39057

@ahus1 While writing the blog post I found the name in singular a little odd to read. I think it makes more sense with plural. 

Let me know what you think and if it makes sense to you, I will create an issue for this.