### PR TITLE
Prevent Passkeys authenticator from being incorrectly sorted after non-credential authenticators in alternative flows

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java
@@ -174,11 +174,11 @@ class AuthenticationSelectionResolver {
         }
 
         Authenticator localAuthenticator = processor.getSession().getProvider(Authenticator.class, execution.getAuthenticator());
-        if (!(localAuthenticator instanceof CredentialValidator)) {
-            nonCredentialExecutions.add(execution);
-        } else {
+        if (localAuthenticator instanceof CredentialValidator && localAuthenticator.requiresUser()) {
             CredentialValidator<?> cv = (CredentialValidator<?>) localAuthenticator;
             typeAuthExecMap.put(cv.getType(processor.getSession()), execution);
+        } else {
+            nonCredentialExecutions.add(execution);
         }
     }
 


### PR DESCRIPTION
Closes #21140

Fix execution order of Passkeys authenticator in alternative flows