### PR TITLE
fix: WebAuthNPasswordless authenticator is incorrectly sorted after all other authenticators in alternative flows

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java
@@ -62,7 +62,6 @@ class AuthenticationSelectionResolver {
      */
     static List<AuthenticationSelectionOption> createAuthenticationSelectionList(AuthenticationProcessor processor, AuthenticationExecutionModel model) {
         List<AuthenticationSelectionOption> authenticationSelectionList = new ArrayList<>();
-        List<AuthenticationSelectionOption> userlessCredBasedAuthenticationSelectionList = new ArrayList<>();
 
         if (processor.getAuthenticationSession() != null) {
             Map<String, AuthenticationExecutionModel> typeAuthExecMap = new HashMap<>();
@@ -89,24 +88,11 @@ class AuthenticationSelectionResolver {
                         .map(credentialType -> new AuthenticationSelectionOption(processor.getSession(), typeAuthExecMap.get(credentialType)))
                         .collect(Collectors.toList());
             }
-            else {
-                // No user associated with session. Check if this flow contains executions linked to authenticators that don't require a user
-                typeAuthExecMap.forEach((key, value) -> {
-                    AuthenticatorFactory credbasedAuthenticatorFactory = (AuthenticatorFactory) processor.getSession().getKeycloakSessionFactory().getProviderFactory(Authenticator.class, value.getAuthenticator());
-                    Authenticator credbasedAuthenticator = credbasedAuthenticatorFactory.create(processor.getSession());
-                    if (!credbasedAuthenticator.requiresUser()) {
-                        userlessCredBasedAuthenticationSelectionList.add(new AuthenticationSelectionOption(processor.getSession(), value));
-                    }
-                });
-            }
 
             //add all other authenticators
             for (AuthenticationExecutionModel exec : nonCredentialExecutions) {
                 authenticationSelectionList.add(new AuthenticationSelectionOption(processor.getSession(), exec));
             }
-
-            // Add options for userless credential based authenticators AFTER regular authenticators options
-            authenticationSelectionList.addAll(userlessCredBasedAuthenticationSelectionList);
         }
 
         logger.debugf("Selections when trying execution '%s' : %s", model.getAuthenticator(), authenticationSelectionList);
@@ -174,11 +160,11 @@ class AuthenticationSelectionResolver {
         }
 
         Authenticator localAuthenticator = processor.getSession().getProvider(Authenticator.class, execution.getAuthenticator());
-        if (!(localAuthenticator instanceof CredentialValidator)) {
-            nonCredentialExecutions.add(execution);
-        } else {
+        if (localAuthenticator instanceof CredentialValidator && (localAuthenticator.requiresUser() || processor.getAuthenticationSession().getAuthenticatedUser() != null)) {
             CredentialValidator<?> cv = (CredentialValidator<?>) localAuthenticator;
             typeAuthExecMap.put(cv.getType(processor.getSession()), execution);
+        } else {
+            nonCredentialExecutions.add(execution);
         }
     }
 


### PR DESCRIPTION
Closes #21140

The AuthenticationSelectionResolver currently sorts the WebAuthNPasswordless authenticator after all other alternative executions. As a result, it cannot be the first login option if, for example, a "UsernamePasswordForm" is also present in the flow.

To fix this behavior, I ensure that the WebAuthNPasswordless authenticator is added to the typeAuthExecMap if a user context is available, or to nonCredentialExecutions if not.
This means that:
- When a user context is present, the execution order will follow the user's credential preferences.
- In a userless scenario, the authenticator will be sorted according to the configuration order of the flow.