### PR TITLE
fix: relaxes the admin root redirect check

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_2_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_2_2.adoc
@@ -1,0 +1,7 @@
+== Notable changes
+
+Notable changes where an internal behavior changed to prevent common misconfigurations, fix bugs or simplify running {project_name}.
+
+=== local admin deprecation
+
+`UrlType.LOCAL_ADMIN` and the corresponding welcome theme variable `localAdminUrl` have been deprecated for eventual removal. The default welcome resource will now simply mention localhost rather than providing a URL when an admin user has yet to be created.

--- a/docs/documentation/upgrading/topics/changes/changes-26_2_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_2_2.adoc
@@ -1,7 +1,0 @@
-== Notable changes
-
-Notable changes where an internal behavior changed to prevent common misconfigurations, fix bugs or simplify running {project_name}.
-
-=== local admin deprecation
-
-`UrlType.LOCAL_ADMIN` and the corresponding welcome theme variable `localAdminUrl` have been deprecated for eventual removal. The default welcome resource will now simply mention localhost rather than providing a URL when an admin user has yet to be created.

--- a/docs/documentation/upgrading/topics/changes/changes-26_3_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_3_0.adoc
@@ -2,6 +2,10 @@
 
 Breaking changes are identified as requiring changes from existing users to their configurations.
 
+=== local admin deprecated for removal
+
+`UrlType.LOCAL_ADMIN` and the corresponding welcome theme variable `localAdminUrl` have been deprecated for eventual removal. The default welcome resource will now simply mention localhost rather than providing a URL when an admin user has yet to be created.
+
 === Deprecated for removal the Instagram Identity Broker
 
 In this release, the Instagram Identity Broker is deprecated for removal and is not enabled by default.

--- a/server-spi/src/main/java/org/keycloak/urls/UrlType.java
+++ b/server-spi/src/main/java/org/keycloak/urls/UrlType.java
@@ -2,6 +2,11 @@ package org.keycloak.urls;
 
 public enum UrlType {
 
-    FRONTEND, BACKEND, ADMIN, LOCAL_ADMIN
+    FRONTEND, BACKEND, ADMIN,
+    /**
+     * @deprecated to be removed
+     */
+    @Deprecated
+    LOCAL_ADMIN
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -106,7 +106,7 @@ public class WelcomeResource {
         if (!shouldBootstrap()) {
             return createWelcomePage(null, null);
         } else {
-            if (!isLocal()) {
+            if (!isLocal(session)) {
                 ServicesLogger.LOGGER.rejectedNonLocalAttemptToCreateInitialUser(session.getContext().getConnection().getRemoteHost());
                 throw new WebApplicationException(Response.Status.BAD_REQUEST);
             }
@@ -210,7 +210,7 @@ public class WelcomeResource {
             map.put("resourcesPath", "resources/" + Version.RESOURCES_VERSION + "/" + theme.getType().toString().toLowerCase() +"/" + theme.getName());
             map.put("resourcesCommonPath", "resources/" + Version.RESOURCES_VERSION + "/" + commonPath);
 
-            boolean isLocal = isLocal();
+            boolean isLocal = isLocal(session);
             map.put("localUser", isLocal);
 
             if (bootstrap) {
@@ -269,7 +269,7 @@ public class WelcomeResource {
         return shouldBootstrap.get();
     }
 
-    private boolean isLocal() {
+    public static boolean isLocal(KeycloakSession session) {
         ClientConnection clientConnection = session.getContext().getConnection();
         String remoteAddress = clientConnection.getRemoteAddr();
         String localAddress = clientConnection.getLocalAddr();
@@ -277,7 +277,7 @@ public class WelcomeResource {
         HttpHeaders headers = request.getHttpHeaders();
         String xForwardedFor = headers.getHeaderString("X-Forwarded-For");
         String forwarded = headers.getHeaderString("Forwarded");
-        logger.debugf("Checking WelcomePage. Remote address: %s, Local address: %s, X-Forwarded-For header: %s, Forwarded header: %s", remoteAddress, localAddress, xForwardedFor, forwarded);
+        logger.debugf("Checking isLocal. Remote address: %s, Local address: %s, X-Forwarded-For header: %s, Forwarded header: %s", remoteAddress, localAddress, xForwardedFor, forwarded);
 
         // Consider that welcome page accessed locally just if it was accessed really through "localhost" URL and without loadbalancer (x-forwarded-for and forwarded header is empty).
         return xForwardedFor == null && forwarded == null && SecureContextResolver.isLocalAddress(remoteAddress) && SecureContextResolver.isLocalAddress(localAddress);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AdminRootEdgeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AdminRootEdgeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+@KeycloakIntegrationTest(config = AdminRootEdgeTest.AdminUrlConfig.class)
+public class AdminRootEdgeTest {
+    // full url with https, with default hostname-admin
+    private static final String HOSTNAME = "https://127.0.0.1.nip.io:8080";
+
+    @InjectHttpClient(followRedirects = false)
+    private HttpClient client;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http://127.0.0.1:8080", "http://127.0.0.1.nip.io:8080"})
+    public void testRedirect(String hostname) throws Exception {
+        HttpResponse response = client.execute(new HttpGet(hostname + "/admin"));
+
+        assertEquals(302, response.getStatusLine().getStatusCode());
+        assertThat(response.getFirstHeader("Location").getValue(), startsWith(HOSTNAME + "/admin/master/console"));
+    }
+
+    public static class AdminUrlConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.options(Map.of(
+                    "hostname", HOSTNAME
+            ));
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AdminRootTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AdminRootTest.java
@@ -63,7 +63,10 @@ public class AdminRootTest {
 
     @Test
     public void testNoRedirectWithFrontendUrl() throws Exception {
-        HttpResponse response = client.execute(new HttpGet(HOSTNAME + "/admin"));
+        HttpGet request = new HttpGet(HOSTNAME + "/admin");
+        // make the request seem like it's coming from a proxy so that it won't seem local
+        request.addHeader("Forwarded", "for=192.0.2.60");
+        HttpResponse response = client.execute(request);
 
         assertEquals(404, response.getStatusLine().getStatusCode());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/HostnameV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/HostnameV2Test.java
@@ -149,7 +149,7 @@ public class HostnameV2Test extends AbstractKeycloakTest {
                 SimpleHttp get = SimpleHttpDefault.doGet(getDynamicBaseUrl("127.0.0.1.nip.io"), client).header("X-Forwarded-For", "127.0.0.1");
 
                 String welcomePage = get.asString();
-                assertThat(welcomePage, containsString("<a href=\"" + getDynamicBaseUrl("localhost") + "/\">"));
+                assertThat(welcomePage, containsString("localhost"));
             }
         }
         finally {

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -132,7 +132,7 @@
                     </div>
                   </form>
                 <#else>
-                  <p>To create the temporary administrative user open <a href="${localAdminUrl}">${localAdminUrl}</a>, or use a <code>bootstrap-admin</code> command.</p>
+                  <p>To create the temporary administrative user, access the Administration Console over localhost, or use a <code>bootstrap-admin</code> command.</p>
                 </#if>
               </#if>
             </div>


### PR DESCRIPTION
closes: #39085

@vmuzikar @russau this relaxes the check in two ways 
- if there is no separate hostname-admin configured, then we'll always redirect. 
- the local admin check was exanded to any secure context localhost host - that will continue to allow dev scenarios using not just localhost, but 127.0.0.1, etc.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
