### PR TITLE
fix: moving build-time provider option validation to the quarkus side

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -41,7 +41,7 @@ import static org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourcePro
 
 public final class PropertyMappers {
 
-    public static final String KC_SPI_PREFIX = "kc.spi";
+    public static final String KC_SPI_PREFIX = "kc.spi-";
     public static String VALUE_MASK = "*******";
     private static MappersConfig MAPPERS;
     private static final Logger log = Logger.getLogger(PropertyMappers.class);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -69,7 +69,6 @@ public class StartCommandDistTest {
                 () -> "The Output:\n" + cliResult.getOutput() + "doesn't contains the expected string.");
     }
 
-    @DryRun
     @Test
     @RawDistOnly(reason = "Containers are immutable")
     void errorSpiBuildtimeAtRuntime(KeycloakDistribution dist) {


### PR DESCRIPTION
closes: #39063

@keycloak/cloud-native this is a rough-in of the middle option from https://github.com/keycloak/keycloak/issues/39063#issuecomment-2821054836

This has the drawback of additional complexity, but won't cost us much time.

Also updated https://github.com/keycloak/keycloak/discussions/38894 with the most simplistic option of not exposing any concept of reagumentation other than the build command.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
