### PR TITLE
Do the re-hash of password in a spearate transaction to continue login in case of model exception

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/HttpClientUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/HttpClientUtils.java
@@ -1,6 +1,8 @@
 package org.keycloak.testsuite.util;
 
+import org.apache.http.client.RedirectStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 public class HttpClientUtils {
@@ -8,12 +10,16 @@ public class HttpClientUtils {
     private static final boolean SSL_REQUIRED = Boolean.parseBoolean(System.getProperty("auth.server.ssl.required"));
 
     public static CloseableHttpClient createDefault() {
+        return createDefault(DefaultRedirectStrategy.INSTANCE);
+    }
+
+    public static CloseableHttpClient createDefault(RedirectStrategy redirectStrategy) {
         if (SSL_REQUIRED) {
             String keyStorePath = System.getProperty("client.certificate.keystore");
             String keyStorePassword = System.getProperty("client.certificate.keystore.passphrase");
             String trustStorePath = System.getProperty("client.truststore");
             String trustStorePassword = System.getProperty("client.truststore.passphrase");
-            return MutualTLSUtils.newCloseableHttpClient(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword);
+            return MutualTLSUtils.newCloseableHttpClient(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword, redirectStrategy);
         }
         return HttpClientBuilder.create().build();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
@@ -36,7 +36,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
@@ -56,6 +55,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.common.util.Retry;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.ClientBuilder;
@@ -76,7 +77,6 @@ import org.keycloak.util.JsonSerialization;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
 /**
  * @author <a href="mailto:vramik@redhat.com">Vlastislav Ramik</a>
  */
@@ -139,13 +139,35 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
         }
     }
 
-    protected CloseableHttpClient getHttpsAwareClient() {
-        HttpClientBuilder builder = HttpClientBuilder.create()
-              .setRedirectStrategy(new LaxRedirectStrategy());
-        if (AUTH_SERVER_SSL_REQUIRED) {
-            builder.setSSLHostnameVerifier((s, sslSession) -> true);
+    @Test
+    public void concurrentLoginSingleUserSingleClientRehash() throws Throwable {
+        log.info("*********************************************");
+        final RealmRepresentation realmRep = testRealm().toRepresentation();
+
+        try {
+            realmRep.setPasswordPolicy("hashAlgorithm(pbkdf2-sha256)");
+            testRealm().update(realmRep);
+            // change the password of the test user to the same to force re-hashing
+            CredentialRepresentation rep = new CredentialRepresentation();
+            rep.setTemporary(Boolean.FALSE);
+            rep.setValue("password");
+            rep.setType(CredentialRepresentation.PASSWORD);
+            ApiUtil.findUserByUsernameId(testRealm(), "test-user@localhost").resetPassword(rep);
+        } finally {
+            realmRep.setPasswordPolicy("");
+            testRealm().update(realmRep);
         }
-        return builder.build();
+
+        // execute the login to re-hash in parallel
+        run(2, 10, (KeycloakRunnable) (int threadIndex, Keycloak keycloak, RealmResource realm) -> {
+            try (CloseableHttpClient httpClient = getHttpsAwareClient()) {
+                createHttpClientContextForUser(httpClient, "test-user@localhost", "password");
+            }
+        });
+    }
+
+    protected CloseableHttpClient getHttpsAwareClient() {
+        return HttpClientUtils.createDefault(LaxRedirectStrategy.INSTANCE);
     }
 
     protected HttpClientContext createHttpClientContextForUser(final CloseableHttpClient httpClient, String userName, String password) throws IOException {


### PR DESCRIPTION
Closes #38970

The previous change in #26106 does not allow concurrent changes for the credential. This is normally OK but it can happen that login perform a re-hash when the realm policy has changed (manually or via migration). This is not a common situation but doing parallel logins in that circumstance can lead to ModelException in the login. This PR performs the re-hash in a separate transaction.

@mposolda @ahus1 WDYT?