### PR TITLE
Adapt fake_fips for kernel 6.11

### DIFF
--- a/.github/actions/conditional/conditions
+++ b/.github/actions/conditional/conditions
@@ -3,6 +3,7 @@
 # To test a pattern run '.github/actions/conditional/conditional.sh <remote name> <branch>'
 
 .github/actions/                            ci ci-quarkus ci-store ci-sssd operator js codeql-java codeql-javascript codeql-typescript guides documentation
+.github/fake_fips/                          ci
 .github/scripts/                            ci ci-quarkus ci-sssd
 .github/scripts/ansible/                    ci-store
 .github/scripts/aws/                        ci-store

--- a/.github/fake_fips/fake_fips.c
+++ b/.github/fake_fips/fake_fips.c
@@ -34,7 +34,9 @@ static struct ctl_table crypto_sysctl_table[] = {
 		.mode		= 0444,
 		.proc_handler	= proc_dointvec
 	},
-        {}
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0))
+	{}
+#endif
 };
 static struct ctl_table crypto_dir_table[] = {
 	{
@@ -44,7 +46,9 @@ static struct ctl_table crypto_dir_table[] = {
 		.child          = crypto_sysctl_table
 #endif
 	},
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0))
 	{}
+#endif
 };
 
 static struct ctl_table_header *crypto_sysctls;


### PR DESCRIPTION
Closes #39125

Just adapting the fake_fips kernel module for 6.11 kernel. It seems that the end mark for the structure is not needed now.
