### PR TITLE
UserInfo request fails by using an access token obtained in Hybrid fl…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -315,6 +315,12 @@ public class OIDCLoginProtocol implements LoginProtocol {
                 redirectUri.addParam(OAuth2Constants.TOKEN_TYPE, res.getTokenType());
                 redirectUri.addParam(OAuth2Constants.EXPIRES_IN, String.valueOf(res.getExpiresIn()));
             }
+
+            boolean offlineTokenRequested = clientSessionCtx.isOfflineTokenRequested();
+            if (!responseType.isImplicitFlow() && offlineTokenRequested) {
+                // Allow creating offline token early, so the tokens issued from authz-enpdpoint can lookup offline-user-session if used before code-to-token request
+                responseBuilder.createOrUpdateOfflineSession();
+            }
         }
 
         return buildRedirectUri(redirectUri, authSession, userSession, clientSessionCtx);

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -1167,17 +1167,11 @@ public class TokenManager {
             UserSessionModel userSession = clientSession.getUserSession();
             userSession.setLastSessionRefresh(refreshToken.getIat().intValue());
             if (offlineTokenRequested) {
-                UserSessionManager sessionManager = new UserSessionManager(session);
-                if (!sessionManager.isOfflineTokenAllowed(clientSessionCtx)) {
-                    event.detail(Details.REASON, "Offline tokens not allowed for the user or client");
-                    event.error(Errors.NOT_ALLOWED);
-                    throw new ErrorResponseException(Errors.NOT_ALLOWED, "Offline tokens not allowed for the user or client", Response.Status.BAD_REQUEST);
-                }
                 refreshToken.type(TokenUtil.TOKEN_TYPE_OFFLINE);
                 if (realm.isOfflineSessionMaxLifespanEnabled()) {
                     refreshToken.exp(getExpiration(true));
                 }
-                sessionManager.createOrUpdateOfflineSession(clientSessionCtx.getClientSession(), userSession);
+                createOrUpdateOfflineSession();
             } else {
                 refreshToken.exp(getExpiration(false));
             }
@@ -1187,6 +1181,16 @@ public class TokenManager {
                         .map(ClientModel::getClientId)
                         .collect(Collectors.toSet()));
             }
+        }
+
+        public void createOrUpdateOfflineSession() {
+            UserSessionManager sessionManager = new UserSessionManager(session);
+            if (!sessionManager.isOfflineTokenAllowed(clientSessionCtx)) {
+                event.detail(Details.REASON, "Offline tokens not allowed for the user or client");
+                event.error(Errors.NOT_ALLOWED);
+                throw new ErrorResponseException(Errors.NOT_ALLOWED, "Offline tokens not allowed for the user or client", Response.Status.BAD_REQUEST);
+            }
+            sessionManager.createOrUpdateOfflineSession(clientSessionCtx.getClientSession(), userSession);
         }
 
        /**


### PR DESCRIPTION
…ow with offline_access scope

closes #39037

**Problem:** When there is hybdrid flow requested (the request sent to OIDC authentication endpoint with something like `response_type=code token`) together with offline access requested (the `scope=offline_access`), there are access-tokens (and possibly ID tokens etc) issued from the OIDC authorization response. When these access-tokens are sent to KEycloak endpoints (like UserInfo endpoint or Introspection endpoint) before the `code` from authz response is exchanged for another set of tokens (in the code-to-token request),the requests fails.

**Cause:** Before OIDC authentication response is sent back to the client after successful authentication, Keycloak creates only regular "online" user session. Then during code-to-token request (processed by `AuthorizationCodeGrantType`), the online session is possibly removed and there is instead offline user session created. So when the request is sent to UserInfo endpoint with the token from OIDC authentication response, before the code-to-token request, the offline user session does not yet exists. With the changes from https://github.com/keycloak/keycloak/issues/37662, Keycloak is now more opinionated as it knows that access-tokens is associated with the offline-session and hence tries to lookup only offline-session (not "online" session). Which fails as offline session does not yet exists.

The approach I've used in the PR is to create offline session at the end of the OIDC authorization code flow in case that "hybrid" flow is used. In that case, UserInfo can be successfully invoked even before code-to-token request as offline session already exists.

The alternative approach I was considering was to create offline session still as before in the code-to-token request. But instead possibly introduce another type of `AccessTokenContext.SessionType`, which will allow to lookup both offline or online session. In that case, access-token will be able to fallback to lookup online session in case that offline session does not yet exists. Let me know if you prefer this approach. It would have advantage that does not need to create offline session earlier than needed (as it is really needed just when refresh offline token is going to be issued), but it would make a code a little bit more complicated than necessary.
