### PR TITLE
Make user attribute option for SAML mappers required

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/UserProfileAttributeListComponent.tsx
@@ -46,6 +46,12 @@ export const UserProfileAttributeListComponent = ({
 
   if (!config) return null;
 
+  const getError = () => {
+    return convertedName
+      .split(".")
+      .reduce((record: any, key) => record?.[key], errors);
+  };
+
   return (
     <FormGroup
       label={t(label!)}
@@ -58,7 +64,7 @@ export const UserProfileAttributeListComponent = ({
         rules={required ? { required: true } : {}}
         selectItems={convert(config)}
       />
-      {errors[convertedName!] && <FormErrorText message={t("required")} />}
+      {getError() && <FormErrorText message={t("required")} />}
     </FormGroup>
   );
 };

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeNameIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeNameIdMapper.java
@@ -21,6 +21,8 @@ public class UserAttributeNameIdMapper extends AbstractSAMLProtocolMapper implem
         property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
         property.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
         property.setHelpText(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_HELP_TEXT);
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
+        property.setRequired(Boolean.TRUE);
         configProperties.add(property);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeStatementMapper.java
@@ -47,6 +47,7 @@ public class UserAttributeStatementMapper extends AbstractSAMLProtocolMapper imp
         property.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
         property.setHelpText(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_HELP_TEXT);
         property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
+        property.setRequired(Boolean.TRUE);
         configProperties.add(property);
         AttributeStatementHelper.setConfigProperties(configProperties);
 

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserPropertyAttributeStatementMapper.java
@@ -45,6 +45,7 @@ public class UserPropertyAttributeStatementMapper extends AbstractSAMLProtocolMa
         property.setLabel(ProtocolMapperUtils.USER_MODEL_PROPERTY_LABEL);
         property.setHelpText(ProtocolMapperUtils.USER_MODEL_PROPERTY_HELP_TEXT);
         property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
+        property.setRequired(Boolean.TRUE);
         configProperties.add(property);
         AttributeStatementHelper.setConfigProperties(configProperties);
 


### PR DESCRIPTION
Closes #37648

The PR just adds the `required` attribute and the user profile list type to the user attribute in the three SAML mappers. But I detected that the `⚠ Required field` error message was not displayed in the UI because the `errors` variable has an intermediate `config` key and it's not detected in the array `errors[convertedName!]`. I just fixed that doing a quick fix, please @keycloak/ui check if you see something better for this.
