### PR TITLE
Oracle driver problems in Keycloak 26.2.1

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -210,8 +210,8 @@ public final class Database {
                 "mssql"
         ),
         ORACLE("oracle",
-                "oracle.jdbc.datasource.OracleXADataSource",
-                "oracle.jdbc.OracleDriver",
+                "oracle.jdbc.xa.client.OracleXADataSource",
+                "oracle.jdbc.driver.OracleDriver",
                 "org.hibernate.dialect.OracleDialect",
                 "jdbc:oracle:thin:@//${kc.db-url-host:localhost}:${kc.db-url-port:1521}/${kc.db-url-database:keycloak}",
                 asList("liquibase.database.core.OracleDatabase")


### PR DESCRIPTION
Closes #39182

![image](https://github.com/user-attachments/assets/93cae582-af22-43d1-ad4b-82d9c317a7a1)

Based on Quarkus reference: https://quarkus.io/version/3.20/guides/datasource#extensions-and-database-drivers-reference

@shawkins Could you please check it? Thanks!

We should consider having some tests for XA.
