### PR TITLE
fix: adding docs about h2 migration (#39159)

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_2_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_2_0.adoc
@@ -19,6 +19,17 @@ the `X-Forwarded-Port` header with the desired port.
 The required JAR for the Oracle JDBC driver that needs to be explicitly added to the distribution has changed.
 Instead of providing `ojdbc11` JAR, use `ojdbc17` JAR as stated in the https://www.keycloak.org/server/db#_installing_the_oracle_database_driver[Installing the Oracle Database driver] guide.
 
+=== H2 Credentials
+
+With this version, the default H2 based `dev-file` database changed its credentials. While migrating from an instance using this dev only database is not supported, you may be able to continue to use your existing H2 database if you explicitly provide the old defaults for the database username and password. For example in the `keycloak.conf` specify:
+
+[example]
+====
+db-username=sa
+
+db-password=password
+====
+
 === JWT Client authentication aligned with the latest OIDC specification
 
 The latest draft version of the link:https://openid.net/specs/openid-connect-core-1_0-36.html#rfc.section.9[OpenID Connect core specification] changed the rules for

--- a/docs/documentation/upgrading/topics/migrate_db.adoc
+++ b/docs/documentation/upgrading/topics/migrate_db.adoc
@@ -10,6 +10,11 @@ database is automatically migrated when you start the new installation for the f
 Before you migrate the database, shut down all {project_name} nodes running the old version of {project_name}.
 ====
 
+[NOTE]
+====
+Migration is not supported with the default H2 based `dev-file` database type.
+====
+
 === Automatic relational database migration
 
 To perform an automatic migration, start the server connected to the desired database.  If the database schema has changed for the new server version, the migration starts automatically unless the database has too many records.


### PR DESCRIPTION
* fix: adding docs about h2 migration

closes: #39046

Signed-off-by: Steve Hawkins <shawkins@redhat.com>

* Update docs/documentation/upgrading/topics/changes/changes-26_2_0.adoc

Co-authored-by: Václav Muzikář <vaclav@muzikari.cz>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>

* Update docs/documentation/upgrading/topics/migrate_db.adoc

Co-authored-by: Martin Bartoš <mabartos@redhat.com>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>

* Apply suggestions from code review

Co-authored-by: Václav Muzikář <vaclav@muzikari.cz>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>

---------

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>
Co-authored-by: Václav Muzikář <vaclav@muzikari.cz>
Co-authored-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit 837c2e25a23c5fa40c5b290c95a23b9d749f242b)
