### PR TITLE
Avoid inefficient SQL when deleting a role

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -458,18 +458,15 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         // So in any case, native query is not an option. This is not optimal as it executes additional queries but
         // the alternative of clearing the persistence context is not either as we don't know if something currently present
         // in the context is not needed later.
-        Stream<RoleEntity> parentRoles = em.createNamedQuery("getParentRolesOfACompositeRole", RoleEntity.class).setParameter("compositeRole", roleEntity).getResultStream();
-        parentRoles.forEach(parentRole -> parentRole.getCompositeRoles().remove(roleEntity));
-        parentRoles.close();
+
+        roleEntity.getParentRoles().forEach(roleEntity1 -> roleEntity1.getCompositeRoles().remove(roleEntity));
 
         em.createNamedQuery("deleteClientScopeRoleMappingByRole").setParameter("role", roleEntity).executeUpdate();
 
-        em.flush();
         em.remove(roleEntity);
 
         session.getKeycloakSessionFactory().publish(roleRemovedEvent(role));
 
-        em.flush();
         return true;
 
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -65,7 +65,6 @@ import java.util.Set;
         @NamedQuery(name="searchForRealmRoles", query="select role from RoleEntity role where role.clientRole = false and role.realmId = :realm and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
         @NamedQuery(name="getRoleIdsFromIdList", query="select role.id from RoleEntity role where role.realmId = :realm and role.id in :ids order by role.name ASC"),
         @NamedQuery(name="getRoleIdsByNameContainingFromIdList", query="select role.id from RoleEntity role where role.realmId = :realm and lower(role.name) like lower(concat('%',:search,'%')) and role.id in :ids order by role.name ASC"),
-        @NamedQuery(name="getParentRolesOfACompositeRole", query = "select role from RoleEntity role where :compositeRole member of role.compositeRoles"),
 })
 
 public class RoleEntity {
@@ -98,6 +97,9 @@ public class RoleEntity {
     @ManyToMany(fetch = FetchType.LAZY, cascade = {})
     @JoinTable(name = "COMPOSITE_ROLE", joinColumns = @JoinColumn(name = "COMPOSITE"), inverseJoinColumns = @JoinColumn(name = "CHILD_ROLE"))
     private Set<RoleEntity> compositeRoles;
+
+    @ManyToMany(mappedBy = "compositeRoles", cascade = {})
+    private Set<RoleEntity> parentRoles;
 
     // Explicitly not using OrphanRemoval as we're handling the removal manually through HQL but at the same time we still
     // want to remove elements from the entity's collection in a manual way. Without this, Hibernate would do a duplicit
@@ -156,6 +158,17 @@ public class RoleEntity {
             compositeRoles = new HashSet<>();
         }
         return compositeRoles;
+    }
+
+    public Set<RoleEntity> getParentRoles() {
+        if (parentRoles == null) {
+            parentRoles = new HashSet<>();
+        }
+        return parentRoles;
+    }
+
+    public void setParentRoles(Set<RoleEntity> parentRoles) {
+        this.parentRoles = parentRoles;
     }
 
     public void setCompositeRoles(Set<RoleEntity> compositeRoles) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -98,7 +98,7 @@ public class RoleEntity {
     @JoinTable(name = "COMPOSITE_ROLE", joinColumns = @JoinColumn(name = "COMPOSITE"), inverseJoinColumns = @JoinColumn(name = "CHILD_ROLE"))
     private Set<RoleEntity> compositeRoles;
 
-    @ManyToMany(mappedBy = "compositeRoles", cascade = {})
+    @ManyToMany(mappedBy = "compositeRoles", fetch = FetchType.LAZY, cascade = {})
     private Set<RoleEntity> parentRoles;
 
     // Explicitly not using OrphanRemoval as we're handling the removal manually through HQL but at the same time we still


### PR DESCRIPTION
Closes #39237

This is now a lot more efficient as it allows PostgreSQL to use the existing keys

```
select pr1_0.CHILD_ROLE,pr1_1.ID,pr1_1.CLIENT,pr1_1.CLIENT_REALM_CONSTRAINT,pr1_1.CLIENT_ROLE,pr1_1.DESCRIPTION,pr1_1.NAME,pr1_1.REALM_ID 
from COMPOSITE_ROLE pr1_0 join KEYCLOAK_ROLE pr1_1 on pr1_1.ID=pr1_0.COMPOSITE where pr1_0.CHILD_ROLE=?
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->


