### PR TITLE
Add OpenAPI annotation to JSON object of ClientPolicycy representations

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ClientPolicyConditionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ClientPolicyConditionRepresentation.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -32,6 +34,9 @@ public class ClientPolicyConditionRepresentation {
     private String conditionProviderId;
 
     @JsonProperty("configuration")
+    @Schema(type= SchemaType.OBJECT,
+            description = "Configuration settings as a JSON object",
+            additionalProperties = Schema.True.class)
     private JsonNode configuration;
 
     public String getConditionProviderId() {

--- a/core/src/main/java/org/keycloak/representations/idm/ClientPolicyExecutorRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ClientPolicyExecutorRepresentation.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -32,6 +34,9 @@ public class ClientPolicyExecutorRepresentation {
     private String executorProviderId;
 
     @JsonProperty("configuration")
+    @Schema(type=SchemaType.OBJECT,
+            description = "Configuration settings as a JSON object",
+            additionalProperties = Schema.True.class)
     private JsonNode configuration;
 
     public String getExecutorProviderId() {


### PR DESCRIPTION
The OpenAPI specification error of missing items, which occurred because the variable configuration was an array type, has been resolved by making configuration an object type.

Closes #32600

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
