### PR TITLE
Fix GrantTypeCondition config key mismatch

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.models.KeycloakSession;
@@ -47,6 +48,7 @@ public class GrantTypeCondition extends AbstractClientPolicyConditionProvider<Gr
 
     public static class Configuration extends ClientPolicyConditionConfigurationRepresentation {
 
+        @JsonAlias("grant_types")
         protected List<String> grantTypes;
 
         public List<String> getGrantTypes() {


### PR DESCRIPTION
Update GrantTypeConditionFactory to use "grantTypes" instead of "grant_types" to match the expected configuration key in GrantTypeCondition.

This ensures that the grant types are correctly read during evaluation, allowing the condition to trigger as intended when client policies are enforced.

Closes #39296
