### PR TITLE
Improve metadata for Recovery Codes

### DIFF
--- a/js/apps/admin-ui/src/user/user-credentials/CredentialDataDialog.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/CredentialDataDialog.tsx
@@ -11,11 +11,13 @@ import {
 } from "@patternfly/react-table";
 
 type CredentialDataDialogProps = {
+  title: string;
   credentialData: [string, string][];
   onClose: () => void;
 };
 
 export const CredentialDataDialog = ({
+  title,
   credentialData,
   onClose,
 }: CredentialDataDialogProps) => {
@@ -23,13 +25,13 @@ export const CredentialDataDialog = ({
   return (
     <Modal
       variant={ModalVariant.medium}
-      title={t("passwordDataTitle")}
+      title={title}
       data-testid="passwordDataDialog"
       isOpen
       onClose={onClose}
     >
       <Table
-        aria-label={t("passwordDataTitle")}
+        aria-label={title}
         data-testid="password-data-dialog"
         variant={TableVariant.compact}
       >

--- a/js/apps/admin-ui/src/user/user-credentials/CredentialRow.tsx
+++ b/js/apps/admin-ui/src/user/user-credentials/CredentialRow.tsx
@@ -57,6 +57,7 @@ export const CredentialRow = ({
     <>
       {showData && Object.keys(credential).length !== 0 && (
         <CredentialDataDialog
+          title={credential.userLabel || t("passwordDataTitle")}
           credentialData={rows}
           onClose={() => {
             toggleShow();

--- a/server-spi/src/main/java/org/keycloak/models/credential/RecoveryAuthnCodesCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/credential/RecoveryAuthnCodesCredentialModel.java
@@ -68,7 +68,7 @@ public class RecoveryAuthnCodesCredentialModel extends CredentialModel {
                             Base64.encodeBytes(RecoveryAuthnCodesUtils.hashRawCode(originalGeneratedCodes.get(i)))))
                     .collect(Collectors.toList());
             secretData = new RecoveryAuthnCodesSecretData(recoveryCodes);
-            credentialData = new RecoveryAuthnCodesCredentialData(RecoveryAuthnCodesUtils.NUM_HASH_ITERATIONS,
+            credentialData = new RecoveryAuthnCodesCredentialData(null,
                     RecoveryAuthnCodesUtils.NOM_ALGORITHM_TO_HASH, recoveryCodes.size(), recoveryCodes.size());
             model = new RecoveryAuthnCodesCredentialModel(credentialData, secretData);
             model.setCredentialData(JsonSerialization.writeValueAsString(credentialData));

--- a/server-spi/src/main/java/org/keycloak/models/credential/dto/RecoveryAuthnCodesCredentialData.java
+++ b/server-spi/src/main/java/org/keycloak/models/credential/dto/RecoveryAuthnCodesCredentialData.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class RecoveryAuthnCodesCredentialData {
 
-    private final int hashIterations;
+    private final Integer hashIterations;
     private final String algorithm;
 
     private int totalCodes;
     private int remainingCodes;
 
     @JsonCreator
-    public RecoveryAuthnCodesCredentialData(@JsonProperty("hashIterations") int hashIterations,
+    public RecoveryAuthnCodesCredentialData(@JsonProperty("hashIterations") Integer hashIterations,
             @JsonProperty("algorithm") String algorithm, @JsonProperty("remaining") int remainingCodes,
                                             @JsonProperty("total") int totalCodes) {
         this.hashIterations = hashIterations;
@@ -21,7 +21,7 @@ public class RecoveryAuthnCodesCredentialData {
         this.totalCodes = totalCodes;
     }
 
-    public int getHashIterations() {
+    public Integer getHashIterations() {
         return hashIterations;
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/utils/RecoveryAuthnCodesUtils.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/RecoveryAuthnCodesUtils.java
@@ -29,16 +29,15 @@ public class RecoveryAuthnCodesUtils {
     private static final int CODE_LENGTH = 12;
     public static final char[] UPPERNUM = "ABCDEFGHIJKLMNPQRSTUVWXYZ123456789".toCharArray();
     private static final SecretGenerator SECRET_GENERATOR = SecretGenerator.getInstance();
-    public static final String NOM_ALGORITHM_TO_HASH = Algorithm.RS512;
-    public static final int NUM_HASH_ITERATIONS = 1;
+    public static final String NOM_ALGORITHM_TO_HASH = JavaAlgorithm.SHA512;
     public static final String RECOVERY_AUTHN_CODES_INPUT_DEFAULT_ERROR_MESSAGE = "recovery-codes-error-invalid";
     public static final String FIELD_RECOVERY_CODE_IN_BROWSER_FLOW = "recoveryCodeInput";
 
     public static byte[] hashRawCode(String rawGeneratedCode) {
         Objects.requireNonNull(rawGeneratedCode, "rawGeneratedCode cannot be null");
-
-        return HashUtils.hash(JavaAlgorithm.getJavaAlgorithmForHash(NOM_ALGORITHM_TO_HASH),
-                rawGeneratedCode.getBytes(StandardCharsets.UTF_8));
+        // If we allow the algorithm to be truly configurable, we should make sure that it works
+        // with both `SHA-512` as well as `RS512` (which was used in the versions prior to 26.2)
+        return HashUtils.hash(NOM_ALGORITHM_TO_HASH, rawGeneratedCode.getBytes(StandardCharsets.UTF_8));
     }
 
     public static boolean verifyRecoveryCodeInput(String rawInputRecoveryCode, String hashedSavedRecoveryCode) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -20,6 +20,7 @@ import org.keycloak.authentication.authenticators.browser.PasswordFormFactory;
 import org.keycloak.authentication.authenticators.browser.UsernameFormFactory;
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialModel;
+import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
@@ -28,6 +29,7 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
+import org.keycloak.models.credential.dto.RecoveryAuthnCodesCredentialData;
 import org.keycloak.models.utils.RecoveryAuthnCodesUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.account.CredentialMetadataRepresentation;
@@ -55,6 +57,7 @@ import org.keycloak.testsuite.util.FlowUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.SecondBrowser;
+import org.keycloak.util.JsonSerialization;
 import org.openqa.selenium.WebDriver;
 
 import java.util.Arrays;
@@ -505,6 +508,13 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractChangeImportedU
             CredentialMetadataRepresentation recoveryCodesMetadata = getRecoveryCodeCredentialFromAccountRestApi(httpClient, response.getAccessToken());
             Assert.assertNull("Expected not warning", recoveryCodesMetadata.getWarningMessageTitle());
             Assert.assertEquals("0/12", recoveryCodesMetadata.getInfoMessage().getParameters()[0]);
+            Assert.assertNotNull(recoveryCodesMetadata.getCredential().getCredentialData());
+            RecoveryAuthnCodesCredentialData data = JsonSerialization.readValue(
+                    recoveryCodesMetadata.getCredential().getCredentialData(), RecoveryAuthnCodesCredentialData.class);
+            Assert.assertEquals(12, data.getTotalCodes());
+            Assert.assertEquals(12, data.getRemainingCodes());
+            Assert.assertEquals(JavaAlgorithm.SHA512, data.getAlgorithm());
+            Assert.assertNull(data.getHashIterations());
 
             // Re-authenticate with recovery codes
             oauth.loginForm().prompt(OIDCLoginProtocol.PROMPT_VALUE_LOGIN).open();


### PR DESCRIPTION
Closes #39243

Improvements to the recovery codes data commented in #39243:

1. The algorithm is now SHA-512.
2. Iterations is set to null to not be returned.
3. The title is using `Data for credential {{label}}`.

Image for a new recovery codes credential:
![Screenshot From 2025-04-29 08-34-00](https://github.com/user-attachments/assets/6d1099d3-98e2-4068-bec8-607add872471)

Image for an old recovery codes credential:
![Screenshot From 2025-04-29 08-34-19](https://github.com/user-attachments/assets/56cbd5b6-d1a9-4d0e-8b36-1d41b3d4c2ca)



