### PR TITLE
Partial backport of #34980 to upgrade creaper and https initialization for eap8 and wildfly

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -54,7 +54,7 @@
         <arquillian-infinispan-container.version>1.2.0.Beta3</arquillian-infinispan-container.version>
         <undertow.version>${undertow-jakarta.version}</undertow.version>
         <undertow-embedded.version>1.0.0.Final</undertow-embedded.version>
-        <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
+        <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <jakarta.persistence-legacy.version>2.2.3</jakarta.persistence-legacy.version>
         <smallrye.jandex.version>3.0.5</smallrye.jandex.version>
         <commons.validator.version>1.8.0</commons.validator.version>


### PR DESCRIPTION
Closes #39319

This is a partial backport of upstream PR #34980 (issue #34853) to upgrade the creaper dependency and update how the https is initialized for wildfly and eap8 (only elytron now). In upstream this was done for the strict cookie for firefox but it's also necessary to run the adapter tests using https (probably before this was executed in plain).
