### PR TITLE
Redirect using client data when the session has expired

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -43,6 +43,8 @@ import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.ClientData;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.RestartLoginCookie;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.AuthenticationManager;
@@ -448,10 +450,15 @@ public class SessionCodeChecks {
                 flowPath = LoginActionsService.AUTHENTICATE_PATH;
             }
 
-            //set redirect uri from client data parameter
+            //set redirect uri and other notes from client data parameter
             try {
                 ClientData clientData = ClientData.decodeClientDataFromParameter(clientDataString);
-                authSession.setRedirectUri(clientData.getRedirectUri());
+                if (RedirectUtils.verifyRedirectUri(session, clientData.getRedirectUri(), authSession.getClient()) != null) {
+                    authSession.setRedirectUri(clientData.getRedirectUri());
+                    authSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, clientData.getResponseType());
+                    authSession.setClientNote(OIDCLoginProtocol.RESPONSE_MODE_PARAM, clientData.getResponseMode());
+                    authSession.setClientNote(OIDCLoginProtocol.STATE_PARAM, clientData.getState());
+                }
             } catch (Exception e) {
                 logger.debugf(e, "ClientData parameter in invalid format. ClientData parameter was %s", clientDataString);
             }

--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -448,6 +448,14 @@ public class SessionCodeChecks {
                 flowPath = LoginActionsService.AUTHENTICATE_PATH;
             }
 
+            //set redirect uri from client data parameter
+            try {
+                ClientData clientData = ClientData.decodeClientDataFromParameter(clientDataString);
+                authSession.setRedirectUri(clientData.getRedirectUri());
+            } catch (Exception e) {
+                logger.debugf(e, "ClientData parameter in invalid format. ClientData parameter was %s", clientDataString);
+            }
+
             String clientData = AuthenticationProcessor.getClientData(session, authSession);
             URI redirectUri = getLastExecutionUrl(flowPath, null, authSession.getTabId(), clientData);
             logger.debugf("Authentication session restart from cookie succeeded. Redirecting to %s", redirectUri);


### PR DESCRIPTION
Closes #36150

When the authentication session doesn't exist and it's restarted using the `KC_RESTART` cookie, with this PR the `redirect_uri` is taken from the `client_data` parameter of the restart endpoint (which belongs to the tab) instead of from the value inside the `KC_RESTART` cookie, which is shared across tabs.

I'm not sure if there are any security implications with this approach, since `KC_RESTART` is encrypted and not accessible from javascript, instead `client_data` is only Base64-encoded and accessible via javascript so the `redirect_uri` could potentially be injected but it still needs to be one of the allowed values.



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
