### PR TITLE
fix: adding a check for truncated last modified timestamps

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -65,7 +65,6 @@ import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.DisabledMappersInterceptor;
 import org.keycloak.quarkus.runtime.configuration.KcUnmatchedArgumentException;
-import org.keycloak.quarkus.runtime.configuration.KeycloakPropertiesConfigSource;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor;
 import org.keycloak.quarkus.runtime.configuration.QuarkusPropertiesConfigSource;
@@ -354,7 +353,9 @@ public class Picocli {
             // we have to ignore things like the profile properties because the commands set them at runtime
             checkChangesInBuildOptions((key, oldValue, newValue) -> {
                 if (key.startsWith(KC_PROVIDER_FILE_PREFIX)) {
-                    throw new PropertyException("A provider JAR was updated since the last build, please rebuild for this to be fully utilized.");
+                    if (timestampChanged(oldValue, newValue)) {
+                        throw new PropertyException("A provider JAR was updated since the last build, please rebuild for this to be fully utilized.");
+                    }
                 } else if (newValue != null && !isIgnoredPersistedOption(key)
                         && isUserModifiable(Configuration.getConfigValue(key))) {
                     ignoredBuildTime.add(key);
@@ -459,6 +460,16 @@ public class Picocli {
             DisabledMappersInterceptor.enable(disabledMappersInterceptorEnabled);
             PropertyMappingInterceptor.enable();
         }
+    }
+
+    static boolean timestampChanged(String oldValue, String newValue) {
+        if (newValue != null && oldValue != null) {
+            long longNewValue = Long.valueOf(newValue);
+            long longOldValue = Long.valueOf(oldValue);
+            // docker commonly truncates to the second at runtime, so we'll allow that special case
+            return ((longNewValue / 1000) * 1000) != longNewValue || ((longOldValue / 1000) * 1000) != longNewValue;
+        }
+        return true;
     }
 
     private void validateProperty(AbstractCommand abstractCommand, IncludeOptions options,

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -675,6 +675,15 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertLogAsyncHandlerInvalidValues(LoggingOptions.Handler.syslog);
     }
 
+    @Test
+    public void timestampChanged() {
+        assertTrue(Picocli.timestampChanged("12345", null));
+        assertTrue(Picocli.timestampChanged("12345", "12346"));
+        assertTrue(Picocli.timestampChanged("12000", "12346"));
+        // new is truncated - should not be a change
+        assertFalse(Picocli.timestampChanged("12345", "12000"));
+    }
+
     protected void assertLogAsyncHandlerInvalidValues(LoggingOptions.Handler handler) {
         var handlerName = handler.toString();
 


### PR DESCRIPTION
After more discussion it seems best to proactively address some of the docker trucation problem on our side to keep the usage of workarounds to a minimum.

This pr adds a check for truncated timestamps. This will automatically address situations like this https://github.com/keycloak/keycloak/issues/38893#issuecomment-2827604586 when the truncation occurs after the build due to push / pull or save / load.

Obviously this weakens our check a little - but it would be strange to see a last modified timestamp going backwards like this otherwise.

closes: #38893

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
