### PR TITLE
Prevent a log-and-throw situation where errors appear in the log that are handled

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.logging;
+
+import io.quarkus.logging.LoggingFilter;
+
+import java.util.Objects;
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * @author Alexander Schwartz
+ */
+@LoggingFilter(name = "keycloak-filter")
+public final class KeycloakLogFilter implements Filter {
+    @Override
+    public boolean isLoggable(LogRecord record) {
+        // The ARJUNA012125 messages are logged and then thrown.
+        // As those messages might later be caught and handled, this is an antipattern so we prevent logging them.
+        // https://narayana.zulipchat.com/#narrow/channel/323714-users/topic/Message.20.22ARJUNA012125.22.20implements.20log-and-throw.20antipattern
+        if (Objects.equals(record.getLevel(), Level.WARNING) && record.getLoggerName().equals("com.arjuna.ats.arjuna") && record.getMessage().startsWith("ARJUNA012125:")) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -30,6 +30,15 @@ quarkus.log.category."io.quarkus.arc.processor.IndexClassLookupUtils".level=off
 quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
 quarkus.log.category."io.quarkus.deployment.steps.ReflectiveHierarchyStep".level=error
 
+# SqlExceptionHelper will log-and-throw error messages.
+# As those messages might later be caught and handled, this is an antipattern so we prevent logging them
+# https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/Feature.20Request.3A.20Disable.20logging.20of.20SqlExceptionHelper.20for
+quarkus.log.category."org.hibernate.engine.jdbc.spi.SqlExceptionHelper".level=off
+
+quarkus.log.console.filter=keycloak-filter
+quarkus.log.file.filter=keycloak-filter
+quarkus.log.syslog.filter=keycloak-filter
+
 # Enable logging for slow queries
 quarkus.log.category."org.hibernate.SQL_SLOW".level=info
 


### PR DESCRIPTION
Closes #39173

Example log messages that are suppressed by this filtering: 

```
2025-04-29 20:57:39,033 ERROR [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] (org.keycloak.models.sessions.infinispan.changes.PersistentSessionsWorker$BatchWorker) ERROR: duplicate key value violates unique constraint "constraint_offl_cl_ses_pk3"
  Detail: Key (user_session_id, client_id, client_storage_provider, external_client_id, offline_flag)=(f818bfcc-7ec4-4a77-815c-5709e56737d7, 5cb62d8a-49ac-41d2-b554-d3b6df03055e, local, local, 0) already exists.
2025-04-29 20:57:39,045 WARN  [com.arjuna.ats.arjuna] (org.keycloak.models.sessions.infinispan.changes.PersistentSessionsWorker$BatchWorker) ARJUNA012125: TwoPhaseCoordinator.beforeCompletion - failed for SynchronizationImple< 0:ffffc0a80156:96af:681120cd:43, org.hibernate.resource.transaction.backend.jta.internal.synchronization.RegisteredSynchronization@12b005ef >: org.hibernate.exception.ConstraintViolationException: could not execute batch [Batch entry 0 /* insert for org.keycloak.models.jpa.session.PersistentClientSessionEntity */insert into OFFLINE_CLIENT_SESSION (DATA,TIMESTAMP,VERSION,CLIENT_ID,CLIENT_STORAGE_PROVIDER,EXTERNAL_CLIENT_ID,OFFLINE_FLAG,USER_SESSION_ID) values (('{"authMethod":"openid-connect","redirectUri":"http://localhost:8080/admin/master/console/#/master/clients/5cb62d8a-49ac-41d2-b554-d3b6df03055e/sessions","notes":{"clientId":"5cb62d8a-49ac-41d2-b554-d3b6df03055e","iss":"http://localhost:8080/realms/master","startedAt":"1745952988","response_type":"code","level-of-authentication":"-1","code_challenge_method":"S256","nonce":"a660c5bc-e1ca-4275-95d5-6a9c9f4f36d8","response_mode":"query","scope":"openid","SSO_AUTH":"true","userSessionStartedAt":"1745951036","redirect_uri":"http://localhost:8080/admin/master/console/#/master/clients/5cb62d8a-49ac-41d2-b554-d3b6df03055e/sessions","state":"714e2aaa-e521-47ff-89e6-eb4a2a3a4df6","prompt":"none","code_challenge":"Ssevc0VDMW5S_YZDFWqQmSNyxv0sy-2lsNNj294uwaY"}}'),('1745952988'::int4),('0'::int4),('5cb62d8a-49ac-41d2-b554-d3b6df03055e'),('local'),('local'),('0'),('f818bfcc-7ec4-4a77-815c-5709e56737d7')) was aborted: ERROR: duplicate key value violates unique constraint "constraint_offl_cl_ses_pk3"
  Detail: Key (user_session_id, client_id, client_storage_provider, external_client_id, offline_flag)=(f818bfcc-7ec4-4a77-815c-5709e56737d7, 5cb62d8a-49ac-41d2-b554-d3b6df03055e, local, local, 0) already exists.  Call getNextException to see other errors in the batch.] [/* insert for org.keycloak.models.jpa.session.PersistentClientSessionEntity */insert into OFFLINE_CLIENT_SESSION (DATA,TIMESTAMP,VERSION,CLIENT_ID,CLIENT_STORAGE_PROVIDER,EXTERNAL_CLIENT_ID,OFFLINE_FLAG,USER_SESSION_ID) values (?,?,?,?,?,?,?,?)]
        at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:97)
        at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:58)
        at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108)
        at org.hibernate.engine.jdbc.batch.internal.BatchImpl.lambda$performExecution$2(BatchImpl.java:293)
        at org.hibernate.engine.jdbc.mutation.internal.PreparedStatementGroupSingleTable.forEachStatement(PreparedStatementGroupSingleTable.java:67)
        at org.hibernate.engine.jdbc.batch.internal.BatchImpl.performExecution(BatchImpl.java:264)
        at org.hibernate.engine.jdbc.batch.internal.BatchImpl.execute(BatchImpl.java:242)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.executeBatch(JdbcCoordinatorImpl.java:188)
        at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:674)
        at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:511)
        at org.hibernate.event.internal.AbstractFlushingEventListener.performExecutions(AbstractFlushingEventListener.java:414)
        at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:41)
        at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:127)
        at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1429)
        at org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:491)
        at org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:2354)
        at org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:1978)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:439)
        at org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorImpl.beforeCompletion(JtaTransactionCoordinatorImpl.java:336)
        at org.hibernate.resource.transaction.backend.jta.internal.synchronization.SynchronizationCallbackCoordinatorNonTrackingImpl.beforeCompletion(SynchronizationCallbackCoordinatorNonTrackingImpl.java:47)
        at org.hibernate.resource.transaction.backend.jta.internal.synchronization.RegisteredSynchronization.beforeCompletion(RegisteredSynchronization.java:37)
        at com.arjuna.ats.internal.jta.resources.arjunacore.SynchronizationImple.beforeCompletion(SynchronizationImple.java:52)
        at com.arjuna.ats.arjuna.coordinator.TwoPhaseCoordinator.beforeCompletion(TwoPhaseCoordinator.java:348)
        at com.arjuna.ats.arjuna.coordinator.TwoPhaseCoordinator.end(TwoPhaseCoordinator.java:66)
        at com.arjuna.ats.arjuna.AtomicAction.commit(AtomicAction.java:135)
        at com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple.commitAndDisassociate(TransactionImple.java:1307)
        at com.arjuna.ats.internal.jta.transaction.arjunacore.BaseTransaction.commit(BaseTransaction.java:104)
        at io.quarkus.narayana.jta.runtime.NotifyingTransactionManager.commit(NotifyingTransactionManager.java:70)
        at org.keycloak.transaction.JtaTransactionWrapper.commit(JtaTransactionWrapper.java:102)
        at org.keycloak.services.DefaultKeycloakTransactionManager.lambda$commitWithTracing$0(DefaultKeycloakTransactionManager.java:169)
        at org.keycloak.tracing.NoopTracingProvider.trace(NoopTracingProvider.java:59)
        at org.keycloak.tracing.NoopTracingProvider.trace(NoopTracingProvider.java:69)
        at org.keycloak.services.DefaultKeycloakTransactionManager.commitWithTracing(DefaultKeycloakTransactionManager.java:168)
        at org.keycloak.services.DefaultKeycloakTransactionManager.commit(DefaultKeycloakTransactionManager.java:136)
        at org.keycloak.services.DefaultKeycloakSession.closeTransactionManager(DefaultKeycloakSession.java:392)
        at org.keycloak.services.DefaultKeycloakSession.close(DefaultKeycloakSession.java:357)
        at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransactionWithResult(KeycloakModelUtils.java:467)
        at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransaction(KeycloakModelUtils.java:340)
        at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransaction(KeycloakModelUtils.java:330)
        at org.keycloak.models.sessions.infinispan.changes.PersistentSessionsWorker$BatchWorker.lambda$process$5(PersistentSessionsWorker.java:116)
        at org.keycloak.common.util.Retry.executeWithBackoff(Retry.java:102)
        at org.keycloak.common.util.Retry.executeWithBackoff(Retry.java:93)
        at org.keycloak.models.sessions.infinispan.changes.PersistentSessionsWorker$BatchWorker.lambda$process$7(PersistentSessionsWorker.java:113)
        at org.keycloak.models.utils.KeycloakModelUtils.lambda$runJobInTransaction$1(KeycloakModelUtils.java:341)
        at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransactionWithResult(KeycloakModelUtils.java:460)
        at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransaction(KeycloakModelUtils.java:340)
        at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransaction(KeycloakModelUtils.java:330)
        at org.keycloak.models.sessions.infinispan.changes.PersistentSessionsWorker$BatchWorker.process(PersistentSessionsWorker.java:97)
        at org.keycloak.models.sessions.infinispan.changes.PersistentSessionsWorker$BatchWorker.run(PersistentSessionsWorker.java:76)
Caused by: java.sql.BatchUpdateException: Batch entry 0 /* insert for org.keycloak.models.jpa.session.PersistentClientSessionEntity */insert into OFFLINE_CLIENT_SESSION (DATA,TIMESTAMP,VERSION,CLIENT_ID,CLIENT_STORAGE_PROVIDER,EXTERNAL_CLIENT_ID,OFFLINE_FLAG,USER_SESSION_ID) values (('{"authMethod":"openid-connect","redirectUri":"http://localhost:8080/admin/master/console/#/master/clients/5cb62d8a-49ac-41d2-b554-d3b6df03055e/sessions","notes":{"clientId":"5cb62d8a-49ac-41d2-b554-d3b6df03055e","iss":"http://localhost:8080/realms/master","startedAt":"1745952988","response_type":"code","level-of-authentication":"-1","code_challenge_method":"S256","nonce":"a660c5bc-e1ca-4275-95d5-6a9c9f4f36d8","response_mode":"query","scope":"openid","SSO_AUTH":"true","userSessionStartedAt":"1745951036","redirect_uri":"http://localhost:8080/admin/master/console/#/master/clients/5cb62d8a-49ac-41d2-b554-d3b6df03055e/sessions","state":"714e2aaa-e521-47ff-89e6-eb4a2a3a4df6","prompt":"none","code_challenge":"Ssevc0VDMW5S_YZDFWqQmSNyxv0sy-2lsNNj294uwaY"}}'),('1745952988'::int4),('0'::int4),('5cb62d8a-49ac-41d2-b554-d3b6df03055e'),('local'),('local'),('0'),('f818bfcc-7ec4-4a77-815c-5709e56737d7')) was aborted: ERROR: duplicate key value violates unique constraint "constraint_offl_cl_ses_pk3"
  Detail: Key (user_session_id, client_id, client_storage_provider, external_client_id, offline_flag)=(f818bfcc-7ec4-4a77-815c-5709e56737d7, 5cb62d8a-49ac-41d2-b554-d3b6df03055e, local, local, 0) already exists.  Call getNextException to see other errors in the batch.
        at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:165)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2421)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:580)
        at org.postgresql.jdbc.PgStatement.internalExecuteBatch(PgStatement.java:889)
        at org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:913)
        at org.postgresql.jdbc.PgPreparedStatement.executeBatch(PgPreparedStatement.java:1739)
        at io.agroal.pool.wrapper.StatementWrapper.executeBatch(StatementWrapper.java:340)
        at org.hibernate.engine.jdbc.batch.internal.BatchImpl.lambda$performExecution$2(BatchImpl.java:279)
        ... 45 more
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "constraint_offl_cl_ses_pk3"
  Detail: Key (user_session_id, client_id, client_storage_provider, external_client_id, offline_flag)=(f818bfcc-7ec4-4a77-815c-5709e56737d7, 5cb62d8a-49ac-41d2-b554-d3b6df03055e, local, local, 0) already exists.
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2733)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2420)
        ... 51 more

```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
