### PR TITLE
fix: adding a check for truncated last modified timestamps (#39340)

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -356,7 +356,9 @@ public class Picocli {
             // we have to ignore things like the profile properties because the commands set them at runtime
             checkChangesInBuildOptions((key, oldValue, newValue) -> {
                 if (key.startsWith(KC_PROVIDER_FILE_PREFIX)) {
-                    throw new PropertyException("A provider JAR was updated since the last build, please rebuild for this to be fully utilized.");
+                    if (timestampChanged(oldValue, newValue)) {
+                        throw new PropertyException("A provider JAR was updated since the last build, please rebuild for this to be fully utilized.");
+                    }
                 } else if (newValue != null && !isIgnoredPersistedOption(key)
                         && isUserModifiable(Configuration.getConfigValue(key))) {
                     ignoredBuildTime.add(key);
@@ -461,6 +463,16 @@ public class Picocli {
             DisabledMappersInterceptor.enable(disabledMappersInterceptorEnabled);
             PropertyMappingInterceptor.enable();
         }
+    }
+
+    static boolean timestampChanged(String oldValue, String newValue) {
+        if (newValue != null && oldValue != null) {
+            long longNewValue = Long.valueOf(newValue);
+            long longOldValue = Long.valueOf(oldValue);
+            // docker commonly truncates to the second at runtime, so we'll allow that special case
+            return ((longNewValue / 1000) * 1000) != longNewValue || ((longOldValue / 1000) * 1000) != longNewValue;
+        }
+        return true;
     }
 
     private void validateProperty(AbstractCommand abstractCommand, IncludeOptions options,

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -593,4 +593,13 @@ public class PicocliTest extends AbstractConfigurationTest {
         // second class kc form should not
         assertThat(nonRunningPicocli.getOutString(), not(containsString("kc.spi-events-listener-micrometer-user-event-metrics-enabled")));
     }
+
+    @Test
+    public void timestampChanged() {
+        assertTrue(Picocli.timestampChanged("12345", null));
+        assertTrue(Picocli.timestampChanged("12345", "12346"));
+        assertTrue(Picocli.timestampChanged("12000", "12346"));
+        // new is truncated - should not be a change
+        assertFalse(Picocli.timestampChanged("12345", "12000"));
+    }
 }


### PR DESCRIPTION
closes: #38893


(cherry picked from commit 0ff4cce3180d6441b5dfaa269a33cb3cab15dd5e)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
