### PR TITLE
fix: performing inline user import for multi-file

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
@@ -191,7 +191,7 @@ public class DefaultExportImportManager implements ExportImportManager {
     }
 
     @Override
-    public void importRealm(RealmRepresentation rep, RealmModel newRealm, boolean skipUserDependent) {
+    public void importRealm(RealmRepresentation rep, RealmModel newRealm, Runnable userImport) {
         convertDeprecatedSocialProviders(rep);
         convertDeprecatedApplications(session, rep);
         convertDeprecatedClientTemplates(rep);
@@ -481,7 +481,8 @@ public class DefaultExportImportManager implements ExportImportManager {
             }, true);
         }
 
-        if (!skipUserDependent) {
+        if (userImport != null) {
+            userImport.run();
             importRealmAuthorizationSettings(rep, newRealm, session);
         }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -140,8 +140,8 @@ public class RepresentationToModel {
     public static final String OIDC = "openid-connect";
 
 
-    public static void importRealm(KeycloakSession session, RealmRepresentation rep, RealmModel newRealm, boolean skipUserDependent) {
-        session.getProvider(DatastoreProvider.class).getExportImportManager().importRealm(rep, newRealm, skipUserDependent);
+    public static void importRealm(KeycloakSession session, RealmRepresentation rep, RealmModel newRealm, Runnable userImport) {
+        session.getProvider(DatastoreProvider.class).getExportImportManager().importRealm(rep, newRealm, userImport);
     }
 
     public static void importRoles(RolesRepresentation realmRoles, RealmModel realm) {
@@ -1180,7 +1180,7 @@ public class RepresentationToModel {
             if (applyPolicies != null && !applyPolicies.isEmpty()) {
                 PolicyStore policyStore = storeFactory.getPolicyStore();
                 try {
-                    List<String> policies = (List<String>) JsonSerialization.readValue(applyPolicies, List.class);
+                    List<String> policies = JsonSerialization.readValue(applyPolicies, List.class);
                     Set<String> policyIds = new HashSet<>();
 
                     for (String policyName : policies) {

--- a/server-spi-private/src/main/java/org/keycloak/storage/ExportImportManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/ExportImportManager.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
  * @author Alexander Schwartz
  */
 public interface ExportImportManager {
-    void importRealm(RealmRepresentation rep, RealmModel newRealm, boolean skipUserDependent);
+    void importRealm(RealmRepresentation rep, RealmModel newRealm, Runnable userImport);
 
     PartialImportResults partialImportRealm(RealmModel realm, InputStream requestBody);
 

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -527,14 +527,24 @@ public class RealmManager {
     }
 
     public RealmModel importRealm(RealmRepresentation rep) {
-        return importRealm(rep, false);
+        return importRealm(rep, () -> {});
     }
 
 
     /**
      * if "skipUserDependent" is true, then import of any models, which needs users already imported in DB, will be skipped. For example authorization
+     * @deprecated use {@link #importRealm(RealmRepresentation, Runnable)}
      */
+    @Deprecated
     public RealmModel importRealm(RealmRepresentation rep, boolean skipUserDependent) {
+        return importRealm(rep, skipUserDependent ? null : () -> {});
+    }
+
+    /**
+     * @param userImport if null, then import of any models, which needs users already imported in DB, will be skipped. For example authorization
+     */
+    public RealmModel importRealm(RealmRepresentation rep, Runnable userImport) {
+        boolean skipUserDependent = userImport == null;
         String id = rep.getId();
         if (id == null || id.trim().isEmpty()) {
             id = KeycloakModelUtils.generateId();
@@ -612,7 +622,7 @@ public class RealmManager {
                 createDefaultClientScopes(realm);
             }
 
-            RepresentationToModel.importRealm(session, rep, realm, skipUserDependent);
+            RepresentationToModel.importRealm(session, rep, realm, userImport);
 
             setupClientServiceAccountsAndAuthorizationOnImport(rep, skipUserDependent);
 


### PR DESCRIPTION
Moves the directory based import to be inline with the realm import so that we don't need separate post logic for directory imports.

This relies upon the newly introduced batching logic in that the partial realm import is flushed prior to proceeding with the user import.

If we don't care about preserving the skipUserDependent behavior, the logic can be cleaned up further.

@ahus1 as we were discussing on the other pr if this logic keeps getting refined, then we can end up with a single as memory-safe as possible approach to import.

closes: #38251

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
