### PR TITLE
BACKPORT: use onDataChange instead of text changed (#38771)

### DIFF
--- a/js/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
@@ -96,10 +96,12 @@ export const KeyForm = ({
             render={({ field }) => (
               <FileUpload
                 id="importFile"
+                type="text"
                 value={field.value}
+                hideDefaultPreview
                 filename={filename}
                 browseButtonText={t("browse")}
-                onTextChange={(value) => {
+                onDataChange={(_, value) => {
                   field.onChange(value);
                 }}
                 onFileInputChange={(_, file) => setFilename(file.name)}


### PR DESCRIPTION
fixes: #38482
backport: #38771
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 014de8064d8ce799c57bed4c4a685e25afc13518)
