### PR TITLE
BACKPORT: remove delete button when flow is in use (#38861)

### DIFF
--- a/js/apps/admin-ui/src/authentication/FlowDetails.tsx
+++ b/js/apps/admin-ui/src/authentication/FlowDetails.tsx
@@ -296,6 +296,10 @@ export default function FlowDetails() {
           >
             {t("editInfo")}
           </DropdownItem>,
+        ]
+      : []),
+    ...(!builtIn && !usedBy
+      ? [
           <DropdownItem
             data-testid="delete-flow"
             key="delete"


### PR DESCRIPTION
partially fixes: #38145
backport: #38861
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 21c0be3c6c874b230dc65f54cbdf643f33b36bb9)
