### PR TITLE
Fix realm attributes example and correct HTTP method in OID4VCI docs

### DIFF
--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -130,9 +130,9 @@ Create a JSON file (e.g., `realm-attributes.json`) with the following content:
 {
   "realm": "oid4vc-vci",
   "enabled": true,
-  "preAuthorizedCodeLifespanS": 120,
-  "issuerDid": "https://localhost:8443/realms/oid4vc-vci",
   "attributes": {
+    "preAuthorizedCodeLifespanS": 120,
+    "issuerDid": "https://localhost:8443/realms/oid4vc-vci",
     "vc.IdentityCredential.expiry_in_s": "31536000",
     "vc.IdentityCredential.format": "vc+sd-jwt",
     "vc.IdentityCredential.scope": "identity_credential",
@@ -156,9 +156,9 @@ This is a **sample configuration**. You can define **additional attributes** dep
 
 ==== Attribute Breakdown
 
+The attributes section contains issuer-specific and credential-specific metadata:
 - **preAuthorizedCodeLifespanS** – Defines how long pre-authorized codes remain valid (in seconds).
 - **issuerDid** – The Decentralized Identifier (DID) of the issuer.
-- **attributes** – Contains VC-specific metadata, which can be **expanded** as needed:
 - **expiry_in_s** – Credential expiration time (in seconds).
 - **format** – Defines the VC format (e.g., `vc+sd-jwt`).
 - **scope** – Identifies the credential’s scope.
@@ -171,7 +171,7 @@ Use the following `curl` command to import the attributes into {project_name}:
 
 [source,bash]
 ----
-curl -X POST "https://localhost:8443/admin/realms/oid4vc-vci" \
+curl -X PUT "https://localhost:8443/admin/realms/oid4vc-vci" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d @realm-attributes.json
@@ -181,7 +181,6 @@ curl -X POST "https://localhost:8443/admin/realms/oid4vc-vci" \
 ====
 - Replace `$ACCESS_TOKEN` with a valid **{project_name} Admin API access token**.
 - **Avoid using `-k` in production**; instead, configure a **trusted TLS certificate**.
-- If updating an existing realm, use `PUT` instead of `POST`.
 ====
 
 === Create Client Scopes with Mappers


### PR DESCRIPTION
This PR fixes outdated documentation in the OID4VCI configuration guide:
- Moves `preAuthorizedCodeLifespanS` and `issuerDid` under the attributes section as required by the current schema.
- Updates the curl command to use the correct HTTP method (PUT) for updating existing realms.

Closes #39264 