### PR TITLE
fix: relaxing the ready=false reason to make the test less flaky

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -599,7 +599,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
 
         var updateCondition = k8sclient.resource(kc).informOnCondition(kcs -> {
             try {
-                assertKeycloakStatusCondition(kcs.get(0), KeycloakStatusCondition.READY, false, "Performing Keycloak update");
+                assertKeycloakStatusCondition(kcs.get(0), KeycloakStatusCondition.READY, false, null);
                 return true;
             } catch (AssertionError e) {
                 return false;


### PR DESCRIPTION
closes: #39124

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit a39adf7b4fffa7fd8269324f7f7772ca9db62cc8)
