### PR TITLE
feat: organization authenticator : bypass username form when login_hint is set

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
@@ -205,10 +205,9 @@ public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
         String expectedUsername = URLEncoder.encode(member.getEmail(), StandardCharsets.UTF_8);
         oauth.realm(bc.consumerRealmName());
         oauth.loginForm().loginHint(expectedUsername).open();
-        assertThat(loginPage.getUsername(), Matchers.equalTo(URLDecoder.decode(expectedUsername, StandardCharsets.UTF_8)));
+        assertThat(loginPage.getAttemptedUsername(), Matchers.equalTo(URLDecoder.decode(expectedUsername, StandardCharsets.UTF_8)));
 
         // continue authenticating without setting the username
-        loginPage.clickSignIn();
         loginPage.login(memberPassword);
         appPage.assertCurrent();
     }


### PR DESCRIPTION
fixes #38228

when using organization authenticator, if login_hint is set, the username form should be auto submitted.