### PR TITLE
Fix footer ftl snippet in documentation

### DIFF
--- a/docs/documentation/server_development/topics/themes.adoc
+++ b/docs/documentation/server_development/topics/themes.adoc
@@ -256,7 +256,7 @@ An example for a custom `footer.ftl` may look like this:
         <li><a href="#about">About</a></li>
         <li><a href="#contact">Contact</a></li>
     </ul>
-<div>
+</div>
 </#macro>
 ```
 


### PR DESCRIPTION
Closes #39442

There are two `<div>` where the second should close `</div>`.