### PR TITLE
Return user session started time when client note is missing for offline

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -39,8 +39,12 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
 
     default int getStarted() {
         String started = getNote(STARTED_AT_NOTE);
-        // Fallback to 0 if "started" note is not available. This can happen for the offline sessions migrated from old version where "startedAt" note was not yet available
-        return started == null ? 0 : Integer.parseInt(started);
+        if (started == null) {
+            // Note can be null for offline sessions migrated from old version where "startedAt" note was not yet available
+            // Fallback to user session started for offline or 0
+            return getUserSession().isOffline() ? getUserSessionStarted() : 0;
+        }
+        return Integer.parseInt(started);
     }
 
     default int getUserSessionStarted() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -101,7 +101,6 @@ import static org.keycloak.testsuite.util.oauth.OAuthClient.APP_ROOT;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -975,6 +974,22 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         }, Integer.class);
     }
 
+    private void removeClientSessionStartedAtNote(final String userSessionId, final String clientId, final String clientSessionId) {
+        testingClient.server().run(session -> {
+            RealmModel realmModel = session.realms().getRealmByName("test");
+            session.getContext().setRealm(realmModel);
+            ClientModel clientModel = realmModel.getClientByClientId(clientId);
+            UserSessionModel userSession = session.sessions().getOfflineUserSession(realmModel, userSessionId);
+            if (userSession != null) {
+                AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(clientModel.getId());
+                if (clientSession != null) {
+                    clientSession.removeNote(AuthenticatedClientSessionModel.STARTED_AT_NOTE);
+                    clientSession.removeNote(AuthenticatedClientSessionModel.USER_SESSION_STARTED_AT_NOTE);
+                }
+            }
+        });
+    }
+
     private void testOfflineSessionExpiration(int idleTime, int maxLifespan, int offsetHalf, int offset) {
         int prev[] = null;
         getTestingClient().testing().setTestingInfinispanTimeService();
@@ -1510,4 +1525,40 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         }
     }
 
+    @Test
+    public void offlineRefreshWhenNoStartedAtClientNote() throws Exception {
+        int prevOfflineSession[] = null;
+        try {
+            prevOfflineSession = changeOfflineSessionSettings(true, 3600, 3600, 0, 0);
+
+            // login to obtain a refresh token
+            oauth.scope("openid " + OAuth2Constants.OFFLINE_ACCESS);
+            oauth.client("offline-client", "secret1");
+            oauth.redirectUri(offlineClientAppUri);
+            oauth.doLogin("test-user@localhost", "password");
+            String code = oauth.parseLoginResponse().getCode();
+            AccessTokenResponse response = oauth.doAccessTokenRequest(code);
+
+            EventRepresentation loginEvent = events.expectLogin()
+                    .client("offline-client")
+                    .detail(Details.REDIRECT_URI, offlineClientAppUri)
+                    .assertEvent();
+
+            // remove the started notes that can be missed in previous versions
+            String clientSessionId = getOfflineClientSessionUuid(loginEvent.getSessionId(), loginEvent.getClientId());
+            removeClientSessionStartedAtNote(loginEvent.getSessionId(), loginEvent.getClientId(), clientSessionId);
+
+            // check refresh is successful
+            response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+            assertEquals(200, response.getStatusCode());
+            assertTrue("Invalid ExpiresIn", 0 < response.getRefreshExpiresIn() && response.getRefreshExpiresIn() <= 3600);
+
+            // check refresh a second time
+            response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+            assertEquals(200, response.getStatusCode());
+            assertTrue("Invalid ExpiresIn", 0 < response.getRefreshExpiresIn() && response.getRefreshExpiresIn() <= 3600);
+        } finally {
+            changeOfflineSessionSettings(false, prevOfflineSession[0], prevOfflineSession[1], prevOfflineSession[2], prevOfflineSession[3]);
+        }
+    }
 }


### PR DESCRIPTION
Closes #39021

For offline session the `getStarted` returns the user session created time instead of 0 when the note was null (migrated from old version). This cannot be tested in the migration class because the started note was added to the client session in keycloak 14, very long ago (2020). So an ad-hoc test is added that removes the two new notes in the offline class for this specific situation.