### PR TITLE
fix: don't treat quarkus property changes as hard errors

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -357,7 +357,9 @@ public class Picocli {
                         throw new PropertyException("A provider JAR was updated since the last build, please rebuild for this to be fully utilized.");
                     }
                 } else if (newValue != null && !isIgnoredPersistedOption(key)
-                        && isUserModifiable(Configuration.getConfigValue(key))) {
+                        && isUserModifiable(Configuration.getConfigValue(key))
+                        // let quarkus handle this - it's unsupported for direct usage in keycloak
+                        && !key.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX)) {
                     ignoredBuildTime.add(key);
                 }
             });

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -26,13 +26,18 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.keycloak.config.LoggingOptions;
@@ -682,6 +687,23 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertTrue(Picocli.timestampChanged("12000", "12346"));
         // new is truncated - should not be a change
         assertFalse(Picocli.timestampChanged("12345", "12000"));
+    }
+
+    @Test
+    public void quarkusRuntimeChangeNoError() throws IOException {
+        Path conf = Paths.get("src/test/resources/");
+        Path tmp = Paths.get("target/home-tmp");
+        FileUtils.copyDirectory(conf.toFile(), tmp.toFile());
+        Files.delete(tmp.resolve("conf/quarkus.properties"));
+        Environment.setHomeDir(tmp);
+        try {
+            build("build", "--db=dev-file");
+        } finally {
+            Environment.setHomeDir(conf);
+        }
+
+        var nonRunningPicocli = pseudoLaunch("start", "--optimized", "--http-enabled=true", "--hostname=foo");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
     }
 
     protected void assertLogAsyncHandlerInvalidValues(LoggingOptions.Handler handler) {


### PR DESCRIPTION
closes: #39450

It would be better to not directly modify the test resources conf diretory, but this change was a little more straight-forward than always creating / using a copy in the target directory.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
