### PR TITLE
Return user session started time when client note is missing for offline (26.0)

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -39,8 +39,12 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
 
     default int getStarted() {
         String started = getNote(STARTED_AT_NOTE);
-        // Fallback to 0 if "started" note is not available. This can happen for the offline sessions migrated from old version where "startedAt" note was not yet available
-        return started == null ? 0 : Integer.parseInt(started);
+        if (started == null) {
+            // Note can be null for offline sessions migrated from old version where "startedAt" note was not yet available
+            // Fallback to user session started for offline or 0
+            return getUserSession().isOffline() ? getUserSessionStarted() : 0;
+        }
+        return Integer.parseInt(started);
     }
 
     default int getUserSessionStarted() {


### PR DESCRIPTION
Closes #39021

PR:             https://github.com/keycloak/keycloak/pull/39449
Commit:         https://github.com/keycloak/keycloak/commit/11b032f9cd5b336c1002ccb19e4977b1699f8ffa
PR branch:      backport-39449-26.0
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.0

Modified to adapt to old OAuthClient...