### PR TITLE
Patch kubernetes stack with port_range=0

### DIFF
--- a/.github/actions/install-chrome/action.yml
+++ b/.github/actions/install-chrome/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: The version of Chrome and Chromedriver to install. By default none is installed.
     required: false
-    default: default # E.g. 135.0.7049.84 (fixed version), default (chrome provided by GHA box)
+    default: "135.0.7049.114" # E.g. 135.0.7049.84 (fixed version), default (chrome provided by GHA box)
 
 runs:
   using: composite
@@ -29,3 +29,11 @@ runs:
         unzip -j /tmp/chromedriver.zip -d /tmp
         sudo mv -f /tmp/chromedriver $CHROMEWEBDRIVER/chromedriver
         sudo chmod +x $CHROMEWEBDRIVER/chromedriver
+
+    - id: show-version
+      name: Show Version
+      if: inputs.version == 'default'
+      shell: bash
+      run: |
+        google-chrome --version
+        $CHROMEWEBDRIVER/chromedriver --version


### PR DESCRIPTION
Fixes #39023

Fixes #39454

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Locally tested.

**Patch log entry**
```
$ ./keycloak-999.0.0-SNAPSHOT/bin/kc.sh start-dev --cache=ispn --cache-stack=kubernetes -Djgroups.diag.enabled=true -Djgroups.dns.query=localhost -Djgroups.bind.address=127.0.0.1
Running the server in development mode. DO NOT use this configuration in production.
2025-05-07 14:46:58,344 INFO  [org.keycloak.spi.infinispan.impl.embedded.JGroupsConfigurator] (main) JGroups Encryption enabled (mTLS).
2025-05-07 14:46:58,344 INFO  [org.keycloak.spi.infinispan.impl.embedded.JGroupsConfigurator] (main) [PATCH] Patching kubernetes stack.
...
2025-05-07 14:46:58,724 INFO  [org.infinispan.CLUSTER] (main) ISPN000078: Starting JGroups channel `ISPN` with stack `kubernetes-patched`
2025-05-07 14:46:58,725 INFO  [org.jgroups.JChannel] (main) local_addr: f42a4ec1-1fbb-4736-a6c1-b7b2d77b866c, name: pedro-desktop-60223
```

**Confirm port range set to zero**
```
$ java -cp keycloak-999.0.0-SNAPSHOT/lib/lib/main/org.jgroups.jgroups-5.3.15.Final.jar org.jgroups.tests.Probe -tcp true jmx=TCP.port_range
#1 (138 bytes):
pedro-desktop-60223 [ip=127.0.0.1:7800, 1 mbr(s), cluster=ISPN, version=5.3.15.Final (Zoncolan) (java 21.0.5+11-LTS)]
TCP={port_range=0}

1 responses (1 matches, 0 non matches)
```