### PR TITLE
Fix account console for usage with secure-session client-policy (#37447)

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -266,6 +266,9 @@ public class AccountConsole implements AccountResourceProvider {
         UriBuilder uriBuilder = UriBuilder.fromUri(OIDCLoginProtocolService.authUrl(session.getContext().getUri()).build(realm.getName()).toString())
                 .queryParam(OAuth2Constants.CLIENT_ID, Constants.ACCOUNT_CONSOLE_CLIENT_ID)
                 .queryParam(OAuth2Constants.REDIRECT_URI, targetUri)
+                // dummy state param to make it usable with secure-session client policy.
+                // Once bootstrapped the account-console frontend will send the actual state with the authorize request.
+                .queryParam(OAuth2Constants.STATE, UUID.randomUUID().toString())
                 .queryParam(OAuth2Constants.RESPONSE_TYPE, OAuth2Constants.CODE)
                 .queryParam(OAuth2Constants.CODE_CHALLENGE, pkceChallenge)
                 .queryParam(OAuth2Constants.CODE_CHALLENGE_METHOD, OAuth2Constants.PKCE_METHOD_S256);

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -276,10 +276,20 @@ public class AccountConsole implements AccountResourceProvider {
         if (!queryParameters.isEmpty()) {
             String error = queryParameters.getFirst(OAuth2Constants.ERROR);
             if (error != null) {
-                try {
-                    return renderAccountConsole();
-                } catch (IOException | FreeMarkerException e) {
-                    throw new ServerErrorException(Status.INTERNAL_SERVER_ERROR);
+                String state = queryParameters.getFirst(OAuth2Constants.STATE);
+                if (state != null) {
+                    // Omit the "state" parameter to make sure that account console displays the error (it may not be shown due the keycloak.js, which will not be able to find the "callback data" in the browser callbackStorage)
+                    URI url = session.getContext().getUri(UrlType.FRONTEND)
+                            .getRequestUriBuilder()
+                            .replaceQueryParam(OAuth2Constants.STATE, null)
+                            .build();
+                    return Response.status(302).location(url).build();
+                } else {
+                    try {
+                        return renderAccountConsole();
+                    } catch (IOException | FreeMarkerException e) {
+                        throw new ServerErrorException(Status.INTERNAL_SERVER_ERROR);
+                    }
                 }
             }
             String scope = queryParameters.getFirst(OIDCLoginProtocol.SCOPE_PARAM);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/TermsAndConditionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/TermsAndConditionsTest.java
@@ -186,14 +186,8 @@ public class TermsAndConditionsTest extends AbstractChangeImportedUserPasswordsT
             assertNull("expected null for terms acceptance user attribute " + TermsAndConditions.USER_ATTRIBUTE,
                     attributes.get(TermsAndConditions.USER_ATTRIBUTE));
         }
-        assertThat(DroneUtils.getCurrentDriver().getTitle(), equalTo("Account Management"));
-        Assert.assertTrue(DroneUtils.getCurrentDriver().getPageSource().contains("You need to accept the Terms and Conditions to continue"));
-        Assert.assertFalse(DroneUtils.getCurrentDriver().getPageSource().contains("An unexpected error occurred"));
 
-        WebElement tryAgainButton = DroneUtils.getCurrentDriver().findElement(By.tagName("button"));
-        assertThat(tryAgainButton.getText(), equalTo("Try again"));
-        UIUtils.click(tryAgainButton);
-
+        // Redirect error to account-console, which starts authentication again
         loginPage.assertCurrent();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/TermsAndConditionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/TermsAndConditionsTest.java
@@ -186,8 +186,14 @@ public class TermsAndConditionsTest extends AbstractChangeImportedUserPasswordsT
             assertNull("expected null for terms acceptance user attribute " + TermsAndConditions.USER_ATTRIBUTE,
                     attributes.get(TermsAndConditions.USER_ATTRIBUTE));
         }
+        assertThat(DroneUtils.getCurrentDriver().getTitle(), equalTo("Account Management"));
+        Assert.assertTrue(DroneUtils.getCurrentDriver().getPageSource().contains("You need to accept the Terms and Conditions to continue"));
+        Assert.assertFalse(DroneUtils.getCurrentDriver().getPageSource().contains("An unexpected error occurred"));
 
-        // Redirect error to account-console, which starts authentication again
+        WebElement tryAgainButton = DroneUtils.getCurrentDriver().findElement(By.tagName("button"));
+        assertThat(tryAgainButton.getText(), equalTo("Try again"));
+        UIUtils.click(tryAgainButton);
+
         loginPage.assertCurrent();
     }
 


### PR DESCRIPTION
Fixes #37447


(cherry picked from commit a4654167328842a4a5659468e2659c8478101b59)

This is an extension of the PR https://github.com/keycloak/keycloak/pull/38476 , which fixes `TermsAndConditionsTest` (as after the error after user rejects terms-and-conditions, there is another request sent automatically and hence login page is displayed) .

Also added the automated test in `ClientPoliciesExecutorTest` for the scenario from the report.
