### PR TITLE
adding some notes about v2 default handling

### DIFF
--- a/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public class ClientRepresentation {
+
+    public static final String OIDC = "openid-connect";
 
     @JsonProperty(required = true)
     @JsonPropertyDescription("ID uniquely identifying this client")
@@ -19,8 +22,9 @@ public class ClientRepresentation {
     @JsonPropertyDescription("Human readable description of the client")
     private String description;
 
+    @JsonProperty(defaultValue = OIDC)
     @JsonPropertyDescription("The protocol used to communicate with the client")
-    private String protocol;
+    private String protocol = OIDC;
 
     @JsonPropertyDescription("Whether this client is enabled")
     private Boolean enabled;
@@ -28,21 +32,26 @@ public class ClientRepresentation {
     @JsonPropertyDescription("URL to the application's homepage that is represented by this client")
     private String appUrl;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("URLs that the browser can redirect to after login")
-    private Set<String> appRedirectUrls;
+    private Set<String> appRedirectUrls = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Login flows that are enabled for this client")
-    private Set<String> loginFlows;
+    private Set<String> loginFlows = new LinkedHashSet<String>();
 
     @JsonPropertyDescription("Authentication configuration for this client")
     private Auth auth;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Web origins that are allowed to make requests to this client")
-    private Set<String> webOrigins;
+    private Set<String> webOrigins = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Roles associated with this client")
-    private Set<String> roles;
+    private Set<String> roles = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Service account configuration for this client")
     private ServiceAccount serviceAccount;
 
@@ -81,6 +90,9 @@ public class ClientRepresentation {
     }
 
     public void setProtocol(String protocol) {
+        if (protocol == null) {
+            protocol = OIDC;
+        }
         this.protocol = protocol;
     }
 
@@ -148,7 +160,7 @@ public class ClientRepresentation {
         this.serviceAccount = serviceAccount;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public static class Auth {
 
         @JsonPropertyDescription("Whether authentication is enabled for this client")
@@ -196,14 +208,15 @@ public class ClientRepresentation {
         }
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public static class ServiceAccount {
 
         @JsonPropertyDescription("Whether the service account is enabled")
         private Boolean enabled;
 
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @JsonPropertyDescription("Roles assigned to the service account")
-        private Set<String> roles;
+        private Set<String> roles = new LinkedHashSet<String>();
 
         public Boolean getEnabled() {
             return enabled;

--- a/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
@@ -10,13 +10,26 @@ import java.util.stream.Stream;
 
 public interface ClientService extends Service {
 
-    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId);
+    public static class ClientSearchOptions {
+        // TODO
+    }
 
-    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation);
+    public static class ClientProjectionOptions {
+        Boolean fullRepresentation;
 
-    Stream<ClientRepresentation> getClients(RealmModel realm);
+        // TODO
+    }
 
-    ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, ClientProjectionOptions projectionOptions);
+
+    Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions);
+
+    ClientRepresentation deleteClient(RealmModel realm, String clientId);
+
+    Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions);
+
+    ClientRepresentation createOrUpdateClient(RealmModel realm, String clientId, ClientRepresentation client) throws ServiceException;
 
     ClientRepresentation createClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+
 }


### PR DESCRIPTION
Added a rough in of ClientService method refinements. In an ideal world this would all be pretty similar across types, possibly even allow for some generic base interfaces / classes.

Jackson notes:

I'd advocate for using NON_ABSENT at a top level to allow for "empty" values such an empty string. However this has the side effect that any possibly fully empty child objects or collections will need to be specifically marked as NON_EMPTY (fabric8 does this).

The usage of required or NON_ABSENT makes using the object model for creating JSON Merge patches difficult - the lack of a value will cause an exception when deserializing, or empty lists / arrays won't be serialized, or you can't use explicit nulls - which prevents some patching behavior. If we don't think that the representation classes will be used for this purpose, then we can ignore this concern.

Defaults:

Re-reading https://github.com/keycloak/keycloak/discussions/38551 there seems to be some intermixing of the ideas of what is a default and what is runtime state. If we are pursuing versioning, then these should be distinct concepts. That is for a given representation of a specific version, the same default values will always be the same. Changing the default values on a given version would likely be seen as a breaking change - although Kube does not prevent this. With this perspective I contend it doesn't matter if these then appear in the representations returned by Keycloak. The user is already maintaining their own representation with whatever defaults they want to be included - they don't have to overwrite that with what is returned by the server.

The other behaviors of always pruning defaults, or selectively trying to retain only those defaults that have been supplied in a PUT or POST have additional canonicalization (which we haven't addressed yet) or complexity (the v1  logic is setting defaults, so legacy exports / imports will introduce the defaults anyway) that don't seem to be needed.

With this in mind for "simple" defaults - those that can be specified in the OpenApi spec / json schema, I would propose using  JsonProperty.defaultValue. We'll have to ensure:
- that it's picked up by the schema generation (it is with fabric8 logic)
- since it is not used by serdes logic, we store these defaults and update the field / setter with the default (shown in this first commit). Granted that is not well encapsulated - you end up needing to put the default on the JsonProperty, the field, and handle null in the setter. However this also introduces a problem if we try to use the same representation class for patching purposes - as the default will always be present.

We can further describe what is set by the server as either:

Complex defaults / implied state: these may not be expressable as a static default, but are fully determinant based upon the rest of the representation - with no possibility of interpolating values from a changing source, such as server variables. Is there anything under the ClientRepresentation that would fall under this category? Assuming the model logic computes these already, we may not have to do any special handling other than needing the description to elaborate on what the default will be. However I do see there could be some complexity relying on the model layer computation if there could be a mismatch between the serving version and the storage version. 

or runtime state - which definitely should have separate handling. What is currently under the ClientRepresentation that would fall under this category?

The final thought would be around templating / expressions. We talked about this early on, but I'm not sure if it's still part of the conversation. Allowing for arbitrary expressions in what is sent to keycloak, similar to openshift templates, is difficult with a typed object model - that is if you have a boolean field and you want it to take the value of \$\{var\} - you have to parse something that is a string instead. You end up needing to have special deserialization logic (we have that in fabric8) or you have to parse generically, resolve the values, then parse as the representation. To understand what is not a default, or needs to be re-evaluated when variables change, you would end up needing to track both the "template" and the instanciation (just like openshift templates).

@keycloak/cloud-native WDYT?
