### PR TITLE
Refresh back button for chrome 136

### DIFF
--- a/.github/actions/install-chrome/action.yml
+++ b/.github/actions/install-chrome/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: The version of Chrome and Chromedriver to install. By default none is installed.
     required: false
-    default: "135.0.7049.114" # E.g. 135.0.7049.84 (fixed version), default (chrome provided by GHA box)
+    default: default # E.g. 135.0.7049.84 (fixed version), default (chrome provided by GHA box)
 
 runs:
   using: composite

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -3,6 +3,7 @@ package org.keycloak.testsuite.util;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.keycloak.testsuite.page.AbstractPatternFlyAlert;
+import org.keycloak.testsuite.pages.AbstractPage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
@@ -310,5 +311,23 @@ public final class UIUtils {
 
     public static String getRawPageSource() {
         return getRawPageSource(getCurrentDriver());
+    }
+
+    /**
+     * Navigates the driver back but it refreshes the page if it is not the expected one for
+     * chrome. Chrome 136 does not respect cache-control and refresh is needed
+     * to reach the server again (the page is cached no matter the cache-control
+     * directive returned).
+     * See https://issues.chromium.org/issues/415773538
+     *
+     * @param driver The driver used
+     * @param expectedPage The expected page
+     */
+    public static void navigateBackWithRefresh(WebDriver driver, AbstractPage expectedPage) {
+        driver.navigate().back();
+        if (!expectedPage.isCurrent() && BrowserDriverUtil.isDriverChrome(driver)) {
+            driver.navigate().refresh();
+        }
+        expectedPage.assertCurrent();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
@@ -44,6 +44,7 @@ import org.keycloak.testsuite.pages.RegisterPage;
 import org.keycloak.testsuite.pages.VerifyEmailPage;
 import org.keycloak.testsuite.util.GreenMailRule;
 import org.keycloak.testsuite.util.MailUtils;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.UserBuilder;
 
 /**
@@ -150,8 +151,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         updateProfilePage.assertCurrent();
 
         // Click browser back. Assert on "Page expired" page
-        driver.navigate().back();
-        loginExpiredPage.assertCurrent();
+        UIUtils.navigateBackWithRefresh(driver, loginExpiredPage);
 
         // Click browser forward. Assert on "updateProfile" page again
         driver.navigate().forward();
@@ -182,8 +182,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         updateProfilePage.assertCurrent();
 
         // Click browser back. Assert on "Page expired" page
-        driver.navigate().back();
-        loginExpiredPage.assertCurrent();
+        UIUtils.navigateBackWithRefresh(driver, loginExpiredPage);
 
         // Click browser refresh. Assert still on "Page expired" page
         driver.navigate().refresh();
@@ -198,8 +197,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         updateProfilePage.assertCurrent();
 
         // Click browser back. Assert on "Page expired" page
-        driver.navigate().back();
-        loginExpiredPage.assertCurrent();
+        UIUtils.navigateBackWithRefresh(driver, loginExpiredPage);
 
         // Click "login continue" and assert on updateProfile page
         loginExpiredPage.clickLoginContinueLink();
@@ -226,8 +224,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         grantPage.assertCurrent();
 
         // Click browser back. Assert on "page expired"
-        driver.navigate().back();
-        loginExpiredPage.assertCurrent();
+        UIUtils.navigateBackWithRefresh(driver, loginExpiredPage);
 
         // Click continue login. Assert on consent screen again
         loginExpiredPage.clickLoginContinueLink();
@@ -363,8 +360,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         updatePasswordPage.assertCurrent();
 
         // Click browser back. Should be on 'page expired'
-        driver.navigate().back();
-        loginExpiredPage.assertCurrent();
+        UIUtils.navigateBackWithRefresh(driver, loginExpiredPage);
 
         // Click 'continue' should be on updatePasswordPage
         loginExpiredPage.clickLoginContinueLink();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -56,6 +56,7 @@ import org.keycloak.testsuite.util.MailUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.testsuite.util.AccountHelper;
+import org.keycloak.testsuite.util.UIUtils;
 
 import jakarta.mail.internet.MimeMessage;
 import jakarta.ws.rs.core.Response;
@@ -904,9 +905,8 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         driver.navigate().back();
         driver.navigate().back();
         events.clear();
-        driver.navigate().back();
 
-        errorPage.assertCurrent();
+        UIUtils.navigateBackWithRefresh(driver, errorPage);
         Assert.assertEquals("Action expired. Please continue with login now.", errorPage.getError());
 
         events.expectRegister("registerUserMissingTermsAcceptance", "registerUserMissingTermsAcceptance@email")


### PR DESCRIPTION
Closes #39540

Since 136 chrome does not respect `cache-control: no-store` anymore (see [issue](https://issues.chromium.org/issues/415773538)). The pages are cached anyway. It seems that chrome checks now cookies (and other things) to decide if the page can be cached or not by default. There is also an API to specify what changes (cookies, storage entries,...) triggers the the eviction of the cache (but it's not standard). For the moment the PR changes the tests to do a refresh when needed for the back. It's only added for chrome by now (maybe other browsers will follow this idea).
