### PR TITLE
fix: updating the examples to bind docker/podman 8080 only to localhost

### DIFF
--- a/docs/guides/getting-started/templates/start-keycloak-container.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-container.adoc
@@ -4,7 +4,7 @@ From a terminal, enter the following command to start {project_name}:
 
 [source,bash,subs="attributes+"]
 ----
-{containerCommand} run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:{version} start-dev
+{containerCommand} run -p 127.0.0.1:8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:{version} start-dev
 ----
 
 This command starts {project_name} exposed on the local port 8080 and creates an initial admin user with the username `admin`

--- a/docs/guides/server/containers.adoc
+++ b/docs/guides/server/containers.adoc
@@ -202,7 +202,7 @@ You use the `start-dev` command:
 
 [source,bash,subs="attributes+"]
 ----
-podman|docker run --name mykeycloak -p 8080:8080 \
+podman|docker run --name mykeycloak -p 127.0.0.1:8080:8080 \
         -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=change_me \
         quay.io/keycloak/keycloak:{containerlabel} \
         start-dev
@@ -221,10 +221,11 @@ For example:
 
 [source,bash,subs="attributes+"]
 ----
-podman|docker run --name mykeycloak -p 8080:8080 \
+podman|docker run --name mykeycloak -p 127.0.0.1:8080:8080 \
         -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=change_me \
         quay.io/keycloak/keycloak:{containerlabel} \
         start \
+        --hostname=localhost --http-enabled=true
         --db=postgres --features=token-exchange \
         --db-url=<JDBC-URL> --db-username=<DB-USER> --db-password=<DB-PASSWORD> \
         --https-key-store-file=<file> --https-key-store-password=<password>
@@ -254,7 +255,7 @@ The {project_name} containers have a directory `/opt/keycloak/data/import`. If y
 
 [source,bash,subs="attributes+"]
 ----
-podman|docker run --name keycloak_unoptimized -p 8080:8080 \
+podman|docker run --name keycloak_unoptimized -p 127.0.0.1:8080:8080 \
         -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=change_me \
         -v /path/to/realm/data:/opt/keycloak/data/import \
         quay.io/keycloak/keycloak:{containerlabel} \
@@ -283,7 +284,7 @@ For example, you can specify the environment variable and memory limit as follow
 
 [source,bash,subs="attributes+"]
 ----
-podman|docker run --name mykeycloak -p 8080:8080 -m 1g \
+podman|docker run --name mykeycloak -p 127.0.0.1:8080:8080 -m 1g \
         -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=change_me \
         -e JAVA_OPTS_KC_HEAP="-XX:MaxHeapFreeRatio=30 -XX:MaxRAMPercentage=65" \
         quay.io/keycloak/keycloak:{containerlabel} \


### PR DESCRIPTION
closes: #39144

This also assumes users are directly using the container locally.

Other considerations: the example could also be shown as as ipv6. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
