### PR TITLE
Disallow duplicate user federation display name (KEYCLOAK-39099)

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -565,6 +565,17 @@ public interface RealmModel extends RoleContainerModel {
      */
     ComponentModel importComponentModel(ComponentModel model);
 
+
+    /**
+     * Validates that no other component with the same name and provider type exists.
+     *
+     * @param model the component to validate
+     * @throws ModelDuplicateException if a duplicate is found
+     */
+    default void validateDuplicateComponentName(ComponentModel model) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
     /**
      * Updates component model. Will call onUpdate() method of ComponentFactory
      * @param component to be updated


### PR DESCRIPTION
#39099 

### Problem Addressed: Ensured that multiple user federation providers (e.g., LDAP) cannot be created with the same display name within the same realm.

### Validation Added:

Implemented a validation check during the creation and update of user federation providers to ensure that no other provider exists with the same display name in the same realm.

This check prevents the saving of providers with duplicate display names.

### Error Response:

If a duplicate display name is detected, a 409 Conflict response is returned, along with a clear error message explaining the issue to the user.

### Create :

![Screenshot 2025-05-11 124548](https://github.com/user-attachments/assets/7d3c4fb9-d0a1-4b64-ba40-14235f1b3099)



![Screenshot 2025-05-11 124629](https://github.com/user-attachments/assets/639907e2-e48b-4ed4-99e2-f735a8a1bc7c)



During Update:
![image](https://github.com/user-attachments/assets/559947fc-8444-4460-8c12-eb5c1b300ddf)

