### PR TITLE
The spans created should be made current and then later closed

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/tracing/OTelTracingProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/tracing/OTelTracingProviderTest.java
@@ -43,7 +43,6 @@ import java.io.Serializable;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -110,8 +109,9 @@ public class OTelTracingProviderTest extends AbstractTestRealmKeycloakTest {
 
             assertThat(current instanceof ReadableSpan, is(true));
             ReadableSpan readableSpan = (ReadableSpan) current;
-            assertThat(readableSpan.getAttribute(AttributeKey.stringKey("server.address")), is("localhost"));
-            assertThat(readableSpan.getAttribute(AttributeKey.stringKey("url.path")), containsString("run-on-server"));
+            assertThat(readableSpan.getAttribute(AttributeKey.stringKey("code.function")), is("runOnServer"));
+            assertThat(readableSpan.getAttribute(AttributeKey.stringKey("code.namespace")), is("org.keycloak.testsuite.rest.TestingResourceProvider"));
+            assertThat(readableSpan.getName(), is("TestingResourceProvider.runOnServer"));
         });
     }
 


### PR DESCRIPTION
Closes #39619

New view: 

![image](https://github.com/user-attachments/assets/c08e6024-a9fb-4aaa-982f-4ba69f6df3c5)

The SQL and other calls that happen when streaming a response are still outside the wrapped REST resource and this is expected: They are only executed after the call to the rest response returns and the stream is processed later.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
