### PR TITLE
update in mariadb JDBC connector due to TLS 1.3 issue, see https://gi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <postgresql-jdbc.version>42.7.5</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.2</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->


### PR DESCRIPTION
Closes #39634

In MariaDB connector 3.5.2 it is not possible to use TLS 1.3. See https://jira.mariadb.org/browse/CONJ-1240. This PR simply updates the MariaDB connector version. A direct test on our side (without keycloak) using the 3.5.2. version confirmed the issue, and a test with the 3.5.3 version showed that the issue has been resolved.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
