### PR TITLE
Create client passwords calculating the entropy size for JWT with cli…

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
+++ b/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
@@ -56,6 +56,7 @@ public class SecretGenerator {
 
         return new String(buf);
     }
+
     public byte[] randomBytes() {
         return randomBytes(SECRET_LENGTH_256_BITS);
     }
@@ -70,4 +71,28 @@ public class SecretGenerator {
         return buf;
     }
 
+    /**
+     * Returns the equivalent length for a destination alphabet to have the same
+     * entropy bits than a byte array random generated.
+     *
+     * @param byteLengthEntropy The desired entropy in bytes
+     * @param dstAlphabetLeng The length of the destination alphabet
+     * @return The equivalent length in destination alphabet to have the same entropy bits
+     */
+    public static int equivalentEntropySize(int byteLengthEntropy, int dstAlphabetLeng) {
+        return equivalentEntropySize(byteLengthEntropy, 256, dstAlphabetLeng);
+    }
+
+    /**
+     * Returns the equivalent length for a destination alphabet to have the same
+     * entropy bits than another source alphabet.
+     *
+     * @param length The length of the string encoded in source alphabet
+     * @param srcAlphabetLength The length of the source alphabet
+     * @param dstAlphabetLeng The length of the destination alphabet
+     * @return The equivalent length (same entropy) in destination alphabet for a string of length in source alphabet
+     */
+    public static int equivalentEntropySize(int length, int srcAlphabetLength, int dstAlphabetLeng) {
+        return (int) Math.ceil(length * ((Math.log(srcAlphabetLength)) / (Math.log(dstAlphabetLeng))));
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -1167,8 +1167,12 @@ public final class KeycloakModelUtils {
         if (clientAuthenticatorType != null)
             switch (clientAuthenticatorType) {
                 case AUTH_TYPE_CLIENT_SECRET_JWT: {
-                    if (Algorithm.HS384.equals(signingAlg)) return SecretGenerator.SECRET_LENGTH_384_BITS;
-                    if (Algorithm.HS512.equals(signingAlg)) return SecretGenerator.SECRET_LENGTH_512_BITS;
+                    if (Algorithm.HS384.equals(signingAlg))
+                        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_384_BITS, SecretGenerator.ALPHANUM.length);
+                    else if (Algorithm.HS512.equals(signingAlg))
+                        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_512_BITS, SecretGenerator.ALPHANUM.length);
+                    else
+                        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_256_BITS, SecretGenerator.ALPHANUM.length);
                 }
             }
         return SecretGenerator.SECRET_LENGTH_256_BITS;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
@@ -290,16 +290,16 @@ public class ClientAuthSecretSignedJWTTest extends AbstractKeycloakTest {
         configureDefaultProfileAndPolicy();
 
         String firstSecret = clientResource.generateNewSecret().getValue(); //clientResource.getSecret().getValue();
-        assertThat(firstSecret.length(),is(secretLength));
+        assertThat(firstSecret.length(), is(SecretGenerator.equivalentEntropySize(secretLength, SecretGenerator.ALPHANUM.length)));
 
         //generate new secret, rotate the secret
         String newSecret = clientResource.generateNewSecret().getValue();
         assertThat(firstSecret, not(equalTo(newSecret)));
-        assertThat(newSecret.length(),is(secretLength));
+        assertThat(newSecret.length(), is(SecretGenerator.equivalentEntropySize(secretLength, SecretGenerator.ALPHANUM.length)));
 
         oauth.clientId("jwt-client");
         oauth.doLogin("test-user@localhost", "password");
-        EventRepresentation loginEvent = events.expectLogin().client("jwt-client").assertEvent();
+        events.expectLogin().client("jwt-client").assertEvent();
         String code = oauth.parseLoginResponse().getCode();
         AccessTokenResponse response = doAccessTokenRequest(code, getClientSignedJWT(firstSecret, 20, algorithm));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));


### PR DESCRIPTION
Closes #38621

The idea of the PR is that the password calculates the needed length using the selected alphabet (ALPHANUM, 62 characters) to have the same entropy bits. This way the password is created larger with the correct entropy (for example 32bit, 8 bytes are 43 length now).

Other things we can think about:

* Use another alphabet that has more symbols (for example ASCII85) to reduce the password length (but it's just a bit, for example 43 to 40 for 256bits entropy).
* Create the password using random bytes and then encode them into a printable password (it can be using base64url for example or any other encoding). But it generates the same length than alphanum (just two more characters, 64 instead of 62 for base64).
* The PR just generates longer passwords when JWT with Client Secret is selected. I hesitated to do this for all the passwords but finally I decided to only do this when the JWT authentication is used.