### PR TITLE
Lazily process sessions from ISPN to avoid fetching client sessions

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -81,6 +81,7 @@ import org.keycloak.models.sessions.infinispan.stream.UserSessionPredicate;
 import org.keycloak.models.sessions.infinispan.util.FuturesHelper;
 import org.keycloak.models.sessions.infinispan.util.InfinispanKeyGenerator;
 import org.keycloak.models.sessions.infinispan.util.SessionTimeouts;
+import org.keycloak.utils.StreamsUtil;
 
 import static org.keycloak.models.Constants.SESSION_NOTE_LIGHTWEIGHT_USER;
 import static org.keycloak.utils.StreamsUtil.paginatedStream;
@@ -452,8 +453,10 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
         UserSessionPredicate predicate = UserSessionPredicate.create(realm.getId()).client(client.getId());
 
-        return paginatedStream(getUserSessionsStream(realm, predicate, offline)
-                .sorted(Comparator.comparing(UserSessionModel::getLastSessionRefresh)), firstResult, maxResults);
+        // If the sorted stream is used within a flatMap (like in SessionsResource), it will not terminate early unless wrapped with
+        // StreamsUtil.prepareSortedStreamToWorkInsideOfFlatMapWithTerminalOperations causing unnecessary operations.
+        return paginatedStream(StreamsUtil.prepareSortedStreamToWorkInsideOfFlatMapWithTerminalOperations(getUserSessionsStream(realm, predicate, offline)
+                .sorted(Comparator.comparing(UserSessionModel::getLastSessionRefresh))), firstResult, maxResults);
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
@@ -142,4 +142,19 @@ public class StreamsUtil {
             }
         }, false);
     }
+
+    /**
+     * This works around a bug in JDK 21 (but no longer in JDK 24) where a sorted stream has all its elements processed
+     * when used inside of a flatmap and a terminal operation like limit() is used outside of it.
+     * See StreamUtilTests.testSortedInsideOfFlatMapShouldRespectTerminalOperation for an example.
+     * Possible <a href="https://bugs.openjdk.org/browse/JDK-8196106">JDK-8196106</a> as the reference to the bug.
+     *
+     * @param <T> The type of the stream
+     * @param originalStream The original stream
+     * @return The stream that is lazily evaluating
+     */
+    public static <T> Stream<T> prepareSortedStreamToWorkInsideOfFlatMapWithTerminalOperations(Stream<T> originalStream) {
+        return StreamSupport.stream(originalStream.spliterator(), false);
+    }
+
 }


### PR DESCRIPTION
Closes #39638

How I tested this: 
* Start KC with persistent sessions disabled (`--features-disabled=persistent-user-sessions`)
* Create a set of sessions (~15)
* Go to the session overview in the admin UI
* Change the number of entry to 10 per page
* Set a breaking that logs each `toRepresentation` 
* Trigger the refresh button

What I see before the change: 
* All entries are mapped

What I see after the change: 
* 11 entries are mapped (page size + 1 so the frontend knows to show the "next" button)



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
