### PR TITLE
Enable audience aliases during signed jwt authentication

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
@@ -283,6 +283,11 @@ public class JWTClientValidator {
         String tokenIntrospectUrl = OIDCLoginProtocolService.tokenIntrospectionUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
         String parEndpointUrl = ParEndpoint.parUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
         List<String> expectedAudiences = new ArrayList<>(Arrays.asList(issuerUrl, tokenUrl, tokenIntrospectUrl, parEndpointUrl));
+
+        String additionalAudiencesString = java.util.Objects.requireNonNullElse(realm.getAttribute("jwt_auth_additional_audiences"), "");
+        String[] additionalAudiences = additionalAudiencesString.split("\\s*,\\s*");
+        expectedAudiences.addAll(Arrays.asList(additionalAudiences));
+
         String backchannelAuthenticationUrl = CibaGrantType.authorizationUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
         expectedAudiences.add(backchannelAuthenticationUrl);
 


### PR DESCRIPTION
Due to changes in OAuth2 requirements during signed jwt authentication
(urn:ietf:params:oauth:client-assertion-type:jwt-bearer) where the JWT
token used can only have one item in the aud claim, we see a need to
allow the keycloak instance to accept multiple 'identities'.

This proposed change reads a string from Realm attribute
'jwt_auth_additional_audiences', then splits the string by
comma and adds the resulting items to the expectedAudiences
list, used by the JWTClientValidator. 

Closes #39648