### PR TITLE
The transport stack defined in the cache XML should take precedence over internal jdbc-ping default

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/CachingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/CachingOptions.java
@@ -63,9 +63,9 @@ public class CachingOptions {
     public static final Option<Stack> CACHE_STACK = new OptionBuilder<>("cache-stack", Stack.class)
             .category(OptionCategory.CACHE)
             .strictExpectedValues(false)
-            .description("Define the default stack to use for cluster communication and node discovery.")
-            .defaultValue(Stack.jdbc_ping)
-            .deprecatedValues("Use 'jdbc-ping' instead", Stack.azure, Stack.ec2, Stack.google, Stack.tcp, Stack.udp, Stack.jdbc_ping_udp)
+            .description("Define the default stack to use for cluster communication and node discovery. Defaults to 'jdbc-ping' if not set.")
+            // Do not set a default value here as it would otherwise overwrite an explicit stack chosen in cache config XML
+            .deprecatedValues("Use 'jdbc-ping' instead by leaving it unset", Stack.azure, Stack.ec2, Stack.google, Stack.tcp, Stack.udp, Stack.jdbc_ping_udp)
             .build();
 
     public static final Option<File> CACHE_CONFIG_FILE = new OptionBuilder<>(CACHE_CONFIG_FILE_PROPERTY, File.class)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -117,6 +117,13 @@ public class ClusterConfigDistTest {
         result.assertMessage("ISPN000078: Starting JGroups channel `ISPN` with stack `encrypt-udp`");
     }
 
+    @Test
+    @BeforeStartDistribution(ConfigureCacheUsingAsyncEncryption.class)
+    @Launch({"start", "--cache-config-file=cache-ispn-asym-enc.xml", "--http-enabled=true", "--hostname-strict=false", "--cache-embedded-mtls-enabled=false"})
+    void testCustomCacheStackInConfigFileNotDev(CLIResult result) {
+        result.assertMessage("ISPN000078: Starting JGroups channel `ISPN` with stack `encrypt-udp`");
+    }
+
     public static class ConfigureCacheUsingAsyncEncryption implements Consumer<KeycloakDistribution> {
 
         @Override

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -102,10 +102,10 @@ Cache:
                        only when remote host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -83,10 +83,10 @@ Cache:
                        'clusterless' is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -103,10 +103,10 @@ Cache:
                        only when remote host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -83,10 +83,10 @@ Cache:
                        'clusterless' is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -103,10 +103,10 @@ Cache:
                        only when remote host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -82,10 +82,10 @@ Cache:
                        'clusterless' is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -102,10 +102,10 @@ Cache:
                        only when remote host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -80,10 +80,10 @@ Cache:
                        'clusterless' is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -100,10 +100,10 @@ Cache:
                        only when remote host is set.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
-                       Possible values are: jdbc-ping, kubernetes, jdbc-ping-udp (deprecated), tcp
-                       (deprecated), udp (deprecated), ec2 (deprecated), azure (deprecated), google
-                       (deprecated), or a custom one. Default: jdbc-ping. Available only when
-                       'cache' type is set to 'ispn'.
+                       Defaults to 'jdbc-ping' if not set. Possible values are: jdbc-ping,
+                       kubernetes, jdbc-ping-udp (deprecated), tcp (deprecated), udp (deprecated),
+                       ec2 (deprecated), azure (deprecated), google (deprecated), or a custom one.
+                       Available only when 'cache' type is set to 'ispn'.
 
 Config:
 


### PR DESCRIPTION
Closes #39614

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
