### PR TITLE
Remove redundant username error display logic

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
@@ -19,12 +19,6 @@
                                     <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
                                 </#assign>
                                 <@field.input name="username" label=label value=login.username!'' autofocus=true autocomplete="username" />
-
-                                <#if messagesPerField.existsError('username')>
-                                    <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                                        ${kcSanitize(messagesPerField.get('username'))?no_esc}
-                                    </span>
-                                </#if>
                             </div>
                         </#if>
 


### PR DESCRIPTION
Back port to 26.2  

Closes #39663 

The error message rendering for the username field was removed as it is already handled in @field.input macro

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
