### PR TITLE
BACKPORT: use scroll into view instead of hash override (#39702)

### DIFF
--- a/js/libs/ui-shared/src/scroll-form/ScrollForm.tsx
+++ b/js/libs/ui-shared/src/scroll-form/ScrollForm.tsx
@@ -80,10 +80,17 @@ export const ScrollForm = ({
               const scrollId = spacesToHyphens(title.toLowerCase());
 
               return (
-                // note that JumpLinks currently does not work with spaces in the href
                 <JumpLinksItem
                   key={title}
-                  href={`#${scrollId}`}
+                  onClick={() => {
+                    const element = document.getElementById(scrollId);
+                    if (element) {
+                      element.scrollIntoView({
+                        behavior: "smooth",
+                        block: "start",
+                      });
+                    }
+                  }}
                   data-testid={`jump-link-${scrollId}`}
                 >
                   {title}


### PR DESCRIPTION
fixes: #39693
backport: #39702

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 5a992e3f5407804e94858044f8c83aaf59917336)
