### PR TITLE
Improve keyboard tab navigation in forms

### DIFF
--- a/js/libs/ui-shared/src/controls/HelpItem.tsx
+++ b/js/libs/ui-shared/src/controls/HelpItem.tsx
@@ -22,6 +22,7 @@ export const HelpItem = ({
       <>
         {!unWrap && (
           <button
+            tabIndex={-1}
             data-testid={`help-label-${fieldLabelId}`}
             aria-label={fieldLabelId}
             onClick={(e) => e.preventDefault()}

--- a/js/libs/ui-shared/src/scroll-form/FormPanel.tsx
+++ b/js/libs/ui-shared/src/scroll-form/FormPanel.tsx
@@ -19,7 +19,7 @@ export const FormPanel = ({
   return (
     <Card id={id} className={className} isFlat>
       <CardHeader className="kc-form-panel__header">
-        <CardTitle tabIndex={0}>
+        <CardTitle tabIndex={-1}>
           <FormTitle id={scrollId} title={title} />
         </CardTitle>
       </CardHeader>

--- a/js/libs/ui-shared/src/scroll-form/FormTitle.tsx
+++ b/js/libs/ui-shared/src/scroll-form/FormTitle.tsx
@@ -20,7 +20,7 @@ export const FormTitle = ({
     size={size}
     className={style.title}
     id={id}
-    tabIndex={0} // so that jumpLink sends focus to the section for a11y
+    tabIndex={-1} // so that jumpLink sends focus to the section for a11y
     {...rest}
   >
     {title}


### PR DESCRIPTION
Exclude help texts from tab navigation. Changed the tabIndex of form titles to -1 to remove them from the sequential keyboard focus order, while still allowing them to be programmatically focused for the jump links.

Closes #39769
