### PR TITLE
fix: don't treat quarkus property changes as hard errors (#39459)

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -360,7 +360,9 @@ public class Picocli {
                         throw new PropertyException("A provider JAR was updated since the last build, please rebuild for this to be fully utilized.");
                     }
                 } else if (newValue != null && !isIgnoredPersistedOption(key)
-                        && isUserModifiable(Configuration.getConfigValue(key))) {
+                        && isUserModifiable(Configuration.getConfigValue(key))
+                        // let quarkus handle this - it's unsupported for direct usage in keycloak
+                        && !key.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX)) {
                     ignoredBuildTime.add(key);
                 }
             });


### PR DESCRIPTION
closes: #39450


(cherry picked from commit 071accefe25488f568bca229b4febed6bb7bfee0)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
