### PR TITLE
Add SMF to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -51,6 +51,7 @@ List of organization names below is based on information collected using Keycloa
 * Quest Software
 * Research Industrial Software Engineering (RISE)
 * [SICK AG](https://www.sick.com)
+* [SMF](https://www.smf.de)
 * Sportsbet.com.au
 * [Stacklok](https://stacklok.com/)
 * Stack Labs


### PR DESCRIPTION
At SMF, we use Keycloak as part of the digital solutions that we deliver to our public sector clients. We regularly attend Keycloak conferences and are looking forward to contributing to the project.