### PR TITLE
Adds a KeycloakMdcLogFilter and MdcDefinitionSpi.

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -135,6 +135,8 @@ public class Profile {
         ROLLING_UPDATES_V1("Rolling Updates", Type.DEFAULT, 1),
         ROLLING_UPDATES_V2("Rolling Updates for patch releases", Type.PREVIEW, 2),
 
+        LOG_MDC("Mapped Diagnostic Context (MDC) information in logs", Type.PREVIEW),
+
         /**
          * @see <a href="https://github.com/keycloak/keycloak/issues/37967">Deprecate for removal the Instagram social broker</a>.
          */

--- a/docs/documentation/release_notes/topics/26_3_0.adoc
+++ b/docs/documentation/release_notes/topics/26_3_0.adoc
@@ -69,6 +69,13 @@ Asynchronous logging helps deployments that require high throughput and low late
 
 For more details on this opt-in feature, see the https://www.keycloak.org/server/logging[Logging guide].
 
+= Additional context information for log messages (preview)
+
+You can now add context information to each log message like the realm or the client that initiated the request.
+This helps you to track down a warning or error message in the log to a specific caller or environment
+
+For more details on this opt-in feature, see the https://www.keycloak.org/server/logging[Logging guide].
+
 = Rolling updates for patch releases for minimized downtime (preview)
 
 In the previous release, the Keycloak Operator was enhanced to support performing rolling updates of the Keycloak image if both images contain the same version.

--- a/docs/documentation/release_notes/topics/26_3_0.adoc
+++ b/docs/documentation/release_notes/topics/26_3_0.adoc
@@ -69,13 +69,6 @@ Asynchronous logging helps deployments that require high throughput and low late
 
 For more details on this opt-in feature, see the https://www.keycloak.org/server/logging[Logging guide].
 
-= Additional context information for log messages (preview)
-
-You can now add context information to each log message like the realm or the client that initiated the request.
-This helps you to track down a warning or error message in the log to a specific caller or environment
-
-For more details on this opt-in feature, see the https://www.keycloak.org/server/logging[Logging guide].
-
 = Rolling updates for patch releases for minimized downtime (preview)
 
 In the previous release, the Keycloak Operator was enhanced to support performing rolling updates of the Keycloak image if both images contain the same version.

--- a/docs/documentation/release_notes/topics/26_4_0.adoc
+++ b/docs/documentation/release_notes/topics/26_4_0.adoc
@@ -5,4 +5,11 @@ Read on to learn more about each new feature, and https://www.keycloak.org/docs/
 
 = Option to force management interface to use HTTP.
 
-There's a new option `http-management-scheme` that may be set to `http` to force the management interface to use HTTP rather than inheriting the HTTPS settings of the main interface. 
+There's a new option `http-management-scheme` that may be set to `http` to force the management interface to use HTTP rather than inheriting the HTTPS settings of the main interface.
+
+= Additional context information for log messages (preview)
+
+You can now add context information to each log message like the realm or the client that initiated the request.
+This helps you to track down a warning or error message in the log to a specific caller or environment
+
+For more details on this opt-in feature, see the https://www.keycloak.org/server/logging[Logging guide].

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -68,6 +68,32 @@ This example sets the following log levels:
 * The hibernate log level in general is set to debug.
 * To keep SQL abstract syntax trees from creating verbose log output, the specific subcategory `org.hibernate.hql.internal.ast` is set to info. As a result, the SQL abstract syntax trees are omitted instead of appearing at the `debug` level.
 
+=== Adding context for log messages
+
+:tech_feature_name: Log messages with Mapped Diagnostic Context (MDC)
+:tech_feature_id: log-mdc
+
+[NOTE]
+====
+{tech_feature_name} is
+*Preview*
+and is not fully supported. This feature is disabled by default.
+====
+
+You can enable additional context information for each log line like the current realm and client that is executing the request.
+
+Use the option `log-mdc-enable` to enable it.
+
+.Example configuration
+<@kc.start parameters="--features=log-mdc --log-mdc-enable=true"/>
+
+.Example output
+----
+2025-06-20 14:13:01,772 {kc.clientId=security-admin-console, kc.realm=master} INFO ...
+----
+
+Specify which keys to be added by setting the configuration option `log-mdc-keys`.
+
 ==== Configuring levels as individual options
 When configuring category-specific log levels, you can also set the log levels as individual `log-level-<category>` options instead of using the `log-level` option for that.
 This is useful when you want to set the log levels for selected categories without overwriting the previously set `log-level` option.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -322,6 +322,7 @@ public class LoggingOptions {
     public static final Option<Boolean> LOG_MDC_ENABLED = new OptionBuilder<>("log-mdc-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
             .defaultValue(false)
+            .buildTime(true)
             .description("Indicates whether to add information about the realm and other information to the mapped diagnostic context. All elements will be prefixed with 'kc.'")
             .build();
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -20,10 +20,9 @@ public class LoggingOptions {
     public static final String DEFAULT_LOG_PATH = "data" + File.separator + "log" + File.separator + DEFAULT_LOG_FILENAME;
 
     // Log format + tracing
-    private static final Function<String, String> DEFAULT_LOG_FORMAT_FUNC = (additionalFields) ->
+    public static final Function<String, String> DEFAULT_LOG_FORMAT_FUNC = (additionalFields) ->
             "%d{yyyy-MM-dd HH:mm:ss,SSS} " + additionalFields + "%-5p [%c] (%t) %s%e%n";
     public static final String DEFAULT_LOG_FORMAT = DEFAULT_LOG_FORMAT_FUNC.apply("");
-    public static final String DEFAULT_LOG_TRACING_FORMAT = DEFAULT_LOG_FORMAT_FUNC.apply("traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} ");
 
     public enum Handler {
         console,
@@ -125,6 +124,12 @@ public class LoggingOptions {
             .defaultValue(true)
             .build();
 
+    public static final Option<Boolean> LOG_CONSOLE_INCLUDE_MDC = new OptionBuilder<>("log-console-include-mdc", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .description(format("Include mdc information in the console log. If the '%s' option is specified, this option has no effect.", LOG_CONSOLE_FORMAT.getKey()))
+            .defaultValue(true)
+            .build();
+
     public static final Option<Boolean> LOG_CONSOLE_COLOR = new OptionBuilder<>("log-console-color", Boolean.class)
             .category(OptionCategory.LOGGING)
             .description("Enable or disable colors when logging to console.")
@@ -185,6 +190,12 @@ public class LoggingOptions {
     public static final Option<Boolean> LOG_FILE_INCLUDE_TRACE = new OptionBuilder<>("log-file-include-trace", Boolean.class)
             .category(OptionCategory.LOGGING)
             .description(format("Include tracing information in the file log. If the '%s' option is specified, this option has no effect.", LOG_FILE_FORMAT.getKey()))
+            .defaultValue(true)
+            .build();
+
+    public static final Option<Boolean> LOG_FILE_INCLUDE_MDC = new OptionBuilder<>("log-file-include-mdc", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .description(format("Include MDC information in the file log. If the '%s' option is specified, this option has no effect.", LOG_FILE_FORMAT.getKey()))
             .defaultValue(true)
             .build();
 
@@ -273,6 +284,12 @@ public class LoggingOptions {
             .defaultValue(true)
             .build();
 
+    public static final Option<Boolean> LOG_SYSLOG_INCLUDE_MDC = new OptionBuilder<>("log-syslog-include-mdc", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .description(format("Include MDC information in the Syslog. If the '%s' option is specified, this option has no effect.", LOG_SYSLOG_FORMAT.getKey()))
+            .defaultValue(true)
+            .build();
+
     public static final Option<Output> LOG_SYSLOG_OUTPUT = new OptionBuilder<>("log-syslog-output", Output.class)
             .category(OptionCategory.LOGGING)
             .defaultValue(DEFAULT_SYSLOG_OUTPUT)
@@ -301,4 +318,18 @@ public class LoggingOptions {
             .defaultValue(512)
             .description("The queue length to use before flushing writing when logging to Syslog.")
             .build();
+
+    public static final Option<Boolean> LOG_MDC_ENABLED = new OptionBuilder<>("log-mdc-enabled", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(false)
+            .description("Indicates whether to add information about the realm and other information to the mapped diagnostic context. All elements will be prefixed with 'kc.'")
+            .build();
+
+    public static final Option<List<String>> LOG_MDC_KEYS = OptionBuilder.listOptionBuilder("log-mdc-keys", String.class)
+            .category(OptionCategory.LOGGING)
+            .expectedValues(List.of("realm", "clientId", "userId", "ipAddress", "org"))
+            .defaultValue(List.of("realm", "org", "clientId"))
+            .description("Defines which information should be added to the mapped diagnostic context as a comma-separated list.")
+            .build();
+
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -81,6 +81,7 @@ import org.keycloak.common.util.StreamUtil;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.HttpOptions;
+import org.keycloak.config.LoggingOptions;
 import org.keycloak.config.ManagementOptions;
 import org.keycloak.config.MetricsOptions;
 import org.keycloak.config.SecurityOptions;
@@ -111,6 +112,7 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakHandlerChainCustomizer;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakTracingCustomizer;
+import org.keycloak.quarkus.runtime.logging.ClearMappedDiagnosticContextFilter;
 import org.keycloak.quarkus.runtime.services.health.KeycloakReadyHealthCheck;
 import org.keycloak.quarkus.runtime.storage.database.jpa.NamedJpaConnectionProviderFactory;
 import org.keycloak.quarkus.runtime.themes.FlatClasspathThemeResourceProviderFactory;
@@ -643,6 +645,16 @@ class KeycloakProcessor {
             // disables the single check we provide which depends on metrics enabled
             ClassInfo disabledBean = index.getIndex()
                     .getClassByName(DotName.createSimple(KeycloakReadyHealthCheck.class.getName()));
+            removeBeans.produce(new BuildTimeConditionBuildItem(disabledBean.asClass(), false));
+        }
+    }
+
+    @BuildStep
+    void disableMdcContextFilter(BuildProducer<BuildTimeConditionBuildItem> removeBeans, CombinedIndexBuildItem index) {
+        if (!Configuration.isTrue(LoggingOptions.LOG_MDC_ENABLED)) {
+            // disables the filter
+            ClassInfo disabledBean = index.getIndex()
+                    .getClassByName(DotName.createSimple(ClearMappedDiagnosticContextFilter.class.getName()));
             removeBeans.produce(new BuildTimeConditionBuildItem(disabledBean.asClass(), false));
         }
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/ClearMappedDiagnosticContextFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/ClearMappedDiagnosticContextFilter.java
@@ -1,0 +1,26 @@
+package org.keycloak.quarkus.runtime.logging;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.keycloak.logging.MappedDiagnosticContextUtil;
+
+import java.io.IOException;
+
+/**
+ * Response filter that clears custom properties from MDC.
+ *
+ * @author <a href="mailto:b.eicki@gmx.net">Björn Eickvonder</a>
+ */
+@Provider
+@Priority(0)
+public class ClearMappedDiagnosticContextFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+                       ContainerResponseContext responseContext) throws IOException {
+        MappedDiagnosticContextUtil.clearMdc();
+    }
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TracingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TracingConfigurationTest.java
@@ -147,42 +147,61 @@ public class TracingConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void consoleLogTraceOn() {
-        assertLogFormat(LoggingOptions.Handler.console, true, LoggingOptions.DEFAULT_LOG_TRACING_FORMAT);
+        assertLogFormat(LoggingOptions.Handler.console, true, false, LoggingOptions.DEFAULT_LOG_FORMAT_FUNC.apply("traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} "));
+    }
+
+    @Test
+    public void consoleLogMdcOn() {
+        assertLogFormat(LoggingOptions.Handler.console, true, true, LoggingOptions.DEFAULT_LOG_FORMAT_FUNC.apply("%X "));
     }
 
     @Test
     public void consoleLogTraceOff() {
-        assertLogFormat(LoggingOptions.Handler.console, false, LoggingOptions.DEFAULT_LOG_FORMAT);
+        assertLogFormat(LoggingOptions.Handler.console, false, false, LoggingOptions.DEFAULT_LOG_FORMAT);
     }
 
     @Test
     public void fileLogTraceOn() {
-        assertLogFormat(LoggingOptions.Handler.file, true, LoggingOptions.DEFAULT_LOG_TRACING_FORMAT);
+        assertLogFormat(LoggingOptions.Handler.file, true, false, LoggingOptions.DEFAULT_LOG_FORMAT_FUNC.apply("traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} "));
+    }
+
+    @Test
+    public void fileLogMdcOn() {
+        assertLogFormat(LoggingOptions.Handler.file, true, true, LoggingOptions.DEFAULT_LOG_FORMAT_FUNC.apply("%X "));
     }
 
     @Test
     public void fileLogTraceOff() {
-        assertLogFormat(LoggingOptions.Handler.file, false, LoggingOptions.DEFAULT_LOG_FORMAT);
+        assertLogFormat(LoggingOptions.Handler.file, false, false, LoggingOptions.DEFAULT_LOG_FORMAT);
     }
 
     @Test
     public void syslogLogTraceOn() {
-        assertLogFormat(LoggingOptions.Handler.syslog, true, LoggingOptions.DEFAULT_LOG_TRACING_FORMAT);
+        assertLogFormat(LoggingOptions.Handler.syslog, true, false, LoggingOptions.DEFAULT_LOG_FORMAT_FUNC.apply("traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} "));
+    }
+
+    @Test
+    public void syslogLogMdcOn() {
+        assertLogFormat(LoggingOptions.Handler.syslog, true, true, LoggingOptions.DEFAULT_LOG_FORMAT_FUNC.apply("%X "));
     }
 
     @Test
     public void syslogLogTraceOff() {
-        assertLogFormat(LoggingOptions.Handler.syslog, false, LoggingOptions.DEFAULT_LOG_FORMAT);
+        assertLogFormat(LoggingOptions.Handler.syslog, false, false, LoggingOptions.DEFAULT_LOG_FORMAT);
     }
 
     /**
      * Assert log format for individual log handlers with different `includeTrace` option.
      * It also checks the log format is unchanged despite the `includeTrace` option, when explicitly specified.
      */
-    protected void assertLogFormat(LoggingOptions.Handler loggerType, boolean includeTrace, String expectedFormat) {
+    protected void assertLogFormat(LoggingOptions.Handler loggerType, boolean includeTrace, boolean includeMdc, String expectedFormat) {
         var envVars = new HashMap<String, String>();
         envVars.put("KC_TRACING_ENABLED", "true");
+        if (includeMdc) {
+            envVars.put("KC_LOG_MDC_ENABLED", "true");
+        }
         envVars.put("KC_LOG_" + loggerType.name().toUpperCase() + "_INCLUDE_TRACE", Boolean.toString(includeTrace));
+        envVars.put("KC_LOG_" + loggerType.name().toUpperCase() + "_INCLUDE_MDC", Boolean.toString(includeMdc));
 
         putEnvVars(envVars);
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -214,6 +214,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -247,6 +251,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -274,6 +282,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -297,6 +314,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -214,6 +214,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -247,6 +251,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -274,6 +282,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -297,6 +314,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -445,6 +445,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -478,6 +482,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -505,6 +513,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -528,6 +545,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -446,6 +446,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -479,6 +483,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -506,6 +514,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -529,6 +546,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -384,6 +384,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -417,6 +421,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -444,6 +452,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -467,6 +484,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -452,10 +452,6 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
---log-mdc-enabled <true|false>
-                     Indicates whether to add information about the realm and other information to
-                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
-                       Default: false. Available only when log-mdc preview feature is enabled.
 --log-mdc-keys <keys>
                      Defines which information should be added to the mapped diagnostic context as
                        a comma-separated list. Possible values are: realm, clientId, userId,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -445,6 +445,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -478,6 +482,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -505,6 +513,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -528,6 +545,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -443,6 +443,10 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Console log handler is activated.
+--log-console-include-mdc <true|false>
+                     Include mdc information in the console log. If the 'log-console-format' option
+                       is specified, this option has no effect. Default: true. Available only when
+                       Console log handler and MDC logging are activated.
 --log-console-include-trace <true|false>
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
@@ -476,6 +480,10 @@ Logging:
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n. Available only when File log handler is
                        activated.
+--log-file-include-mdc <true|false>
+                     Include MDC information in the file log. If the 'log-file-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       File log handler and MDC logging are activated.
 --log-file-include-trace <true|false>
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
@@ -503,6 +511,15 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-mdc-enabled <true|false>
+                     Indicates whether to add information about the realm and other information to
+                       the mapped diagnostic context. All elements will be prefixed with 'kc.'
+                       Default: false. Available only when log-mdc preview feature is enabled.
+--log-mdc-keys <keys>
+                     Defines which information should be added to the mapped diagnostic context as
+                       a comma-separated list. Possible values are: realm, clientId, userId,
+                       ipAddress, org. Default: realm,org,clientId. Available only when MDC logging
+                       is enabled.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.
@@ -526,6 +543,10 @@ Logging:
 --log-syslog-format <format>
                      Set a format specific to Syslog entries. Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n. Available only when Syslog is activated.
+--log-syslog-include-mdc <true|false>
+                     Include MDC information in the Syslog. If the 'log-syslog-format' option is
+                       specified, this option has no effect. Default: true. Available only when
+                       Syslog handler and MDC logging are activated.
 --log-syslog-include-trace <true|false>
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when

--- a/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextProvider.java
@@ -1,0 +1,71 @@
+package org.keycloak.logging;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.provider.Provider;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * Provider interface for updating the Mapped Diagnostic Context (MDC) with key/value pairs based on the current keycloak context.
+ * All keys in the MDC will be prefixed with "kc." to avoid conflicts.
+ *
+ * @author <a href="mailto:b.eicki@gmx.net">Björn Eickvonder</a>
+ */
+public interface MappedDiagnosticContextProvider extends Provider {
+
+    String MDC_PREFIX = "kc.";
+
+    /**
+     * Updates the Mapped Diagnostic Context (MDC) with key/value pairs based on the current Keycloak context.
+     * This method is called when a Keycloak Session is set and when the authentication session property of the
+     * Keycloak context is updated.
+     *
+     * @param keycloakContext the current Keycloak context, never null
+     * @param session the authentication session
+     */
+    void update(KeycloakContext keycloakContext, AuthenticationSessionModel session);
+
+    /**
+     * Updates the Mapped Diagnostic Context (MDC) with key/value pairs based on the current Keycloak context.
+     * This method is called when a Keycloak Session is set and when the realm property of the Keycloak context
+     * is updated.
+     *
+     * @param keycloakContext the current Keycloak context, never null
+     * @param realm the realm
+     */
+    void update(KeycloakContext keycloakContext, RealmModel realm);
+
+    /**
+     * Updates the Mapped Diagnostic Context (MDC) with key/value pairs based on the current Keycloak context.
+     * This method is called when a Keycloak Session is set and when the client property of the Keycloak context
+     * is updated.
+     *
+     * @param keycloakContext the current Keycloak context, never null
+     * @param client the client
+     */
+    void update(KeycloakContext keycloakContext, ClientModel client);
+
+    /**
+     * Updates the Mapped Diagnostic Context (MDC) with key/value pairs based on the current Keycloak context.
+     * This method is called when a Keycloak Session is set and when the organization property of the Keycloak context
+     * is updated.
+     *
+     * @param keycloakContext the current Keycloak context, never null
+     * @param organization the organization
+     */
+    void update(KeycloakContext keycloakContext, OrganizationModel organization);
+
+    /**
+     * Updates the Mapped Diagnostic Context (MDC) with key/value pairs based on the current Keycloak context.
+     * This method is called when a Keycloak Session is set and when the user session property of the Keycloak context
+     * is updated.
+     *
+     * @param keycloakContext the current Keycloak context, never null
+     * @param userSession the user session
+     */
+    void update(KeycloakContext keycloakContext, UserSessionModel userSession);
+
+}

--- a/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextProviderFactory.java
@@ -1,0 +1,9 @@
+package org.keycloak.logging;
+
+import org.keycloak.provider.ProviderFactory;
+
+/**
+ * @author <a href="mailto:b.eicki@gmx.net">Björn Eickvonder</a>
+ */
+public interface MappedDiagnosticContextProviderFactory extends ProviderFactory<MappedDiagnosticContextProvider> {
+}

--- a/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextSpi.java
@@ -1,0 +1,31 @@
+package org.keycloak.logging;
+
+import org.keycloak.provider.Spi;
+
+/**
+ * This SPI is used to define the MDC keys and values that should be set for each request.
+ *
+ * @author <a href="mailto:b.eicki@gmx.net">Björn Eickvonder</a>
+ */
+public class MappedDiagnosticContextSpi implements Spi {
+
+    @Override
+    public boolean isInternal() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "mappedDiagnosticContext";
+    }
+
+    @Override
+    public Class<MappedDiagnosticContextProvider> getProviderClass() {
+        return MappedDiagnosticContextProvider.class;
+    }
+
+    @Override
+    public Class<MappedDiagnosticContextProviderFactory> getProviderFactoryClass() {
+        return MappedDiagnosticContextProviderFactory.class;
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextUtil.java
@@ -5,13 +5,14 @@ import org.jboss.logging.MDC;
 import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSession;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
 
 public final class MappedDiagnosticContextUtil {
 
     private static final Logger log = Logger.getLogger(MappedDiagnosticContextUtil.class);
     private static final MappedDiagnosticContextProvider NOOP_PROVIDER = new NoopMappedDiagnosticContextProvider();
-    private static volatile List<String> keysToClear = List.of();
+    private static volatile Collection<String> keysToClear = Collections.emptySet();
 
     public static MappedDiagnosticContextProvider getMappedDiagnosticContextProvider(KeycloakSession session) {
         if (!Profile.isFeatureEnabled(Profile.Feature.LOG_MDC)) {
@@ -28,7 +29,7 @@ public final class MappedDiagnosticContextUtil {
         return provider;
     }
 
-    public static void setKeysToClear(List<String> keys) {
+    public static void setKeysToClear(Collection<String> keys) {
         // As the MDC.getMap() clones the context and is possibly expensive, we instead iterate over the list of all known keys
         keysToClear = keys;
     }
@@ -38,9 +39,7 @@ public final class MappedDiagnosticContextUtil {
      */
     public static void clearMdc() {
         for (String key : keysToClear) {
-            if (key.startsWith(MappedDiagnosticContextProvider.MDC_PREFIX)) {
-                MDC.remove(key);
-            }
+            MDC.remove(key);
         }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/logging/MappedDiagnosticContextUtil.java
@@ -1,0 +1,43 @@
+package org.keycloak.logging;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+import org.keycloak.common.Profile;
+import org.keycloak.models.KeycloakSession;
+
+import java.util.ArrayList;
+
+public final class MappedDiagnosticContextUtil {
+
+    private static final Logger log = Logger.getLogger(MappedDiagnosticContextUtil.class);
+    private static final MappedDiagnosticContextProvider NOOP_PROVIDER = new NoopMappedDiagnosticContextProvider();
+
+    public static MappedDiagnosticContextProvider getMappedDiagnosticContextProvider(KeycloakSession session) {
+        if (!Profile.isFeatureEnabled(Profile.Feature.LOG_MDC)) {
+            return NOOP_PROVIDER;
+        }
+        if (session == null) {
+            log.warn("Cannot obtain session from thread to init MappedDiagnosticContextProvider. Return Noop provider.");
+            return NOOP_PROVIDER;
+        }
+        MappedDiagnosticContextProvider provider = session.getProvider(MappedDiagnosticContextProvider.class);
+        if (provider == null) {
+            return NOOP_PROVIDER;
+        }
+        return provider;
+    }
+
+    /**
+     * Clears the Mapped Diagnostic Context (MDC), but only clears the key/value pairs that were set by this provider.
+     */
+    public static void clearMdc() {
+        if (Profile.isFeatureEnabled(Profile.Feature.LOG_MDC)) {
+            // getMap() is relatively expensive as it actually copies the context, but just calling MDC.clear() is not an option because it might affect otel tracing.
+            for (String key : new ArrayList<>(MDC.getMap().keySet())) {
+                if (key.startsWith(MappedDiagnosticContextProvider.MDC_PREFIX)) {
+                    MDC.remove(key);
+                }
+            }
+        }
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/logging/NoopMappedDiagnosticContextProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/logging/NoopMappedDiagnosticContextProvider.java
@@ -1,0 +1,41 @@
+package org.keycloak.logging;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public class NoopMappedDiagnosticContextProvider implements MappedDiagnosticContextProvider {
+
+    @Override
+    public void update(KeycloakContext keycloakContext, AuthenticationSessionModel session) {
+        // no-op
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, RealmModel realm) {
+        // no-op
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, ClientModel client) {
+        // no-op
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, OrganizationModel organization) {
+        // no-op
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, UserSessionModel userSession) {
+        // no-op
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/scheduled/ScheduledTaskRunner.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/scheduled/ScheduledTaskRunner.java
@@ -18,6 +18,7 @@
 package org.keycloak.services.scheduled;
 
 import org.jboss.logging.Logger;
+import org.keycloak.logging.MappedDiagnosticContextUtil;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -76,6 +77,7 @@ public class ScheduledTaskRunner implements TaskRunner {
             logger.errorf(t, "Failed to run scheduled task %s", task.getTaskName());
         } finally {
             tracing.close();
+            MappedDiagnosticContextUtil.clearMdc();
         }
     }
 

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -104,3 +104,4 @@ org.keycloak.health.LoadBalancerCheckSpi
 org.keycloak.cookie.CookieSpi
 org.keycloak.organization.OrganizationSpi
 org.keycloak.securityprofile.SecurityProfileSpi
+org.keycloak.logging.MappedDiagnosticContextSpi

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -24,6 +24,8 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.locale.LocaleSelectorProvider;
+import org.keycloak.logging.MappedDiagnosticContextProvider;
+import org.keycloak.logging.MappedDiagnosticContextUtil;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
@@ -118,7 +120,8 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     public void setRealm(RealmModel realm) {
         this.realm = realm;
         this.uriInfo = null;
-        trace(this.realm);
+        trace(realm);
+        mdc().update(this, realm);
     }
 
     @Override
@@ -134,7 +137,8 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public void setClient(ClientModel client) {
         this.client = client;
-        trace(this.client);
+        trace(client);
+        mdc().update(this, client);
     }
 
     @Override
@@ -145,6 +149,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public void setOrganization(OrganizationModel organization) {
         this.organization = organization;
+        mdc().update(this, organization);
     }
 
     @Override
@@ -174,7 +179,8 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public void setAuthenticationSession(AuthenticationSessionModel authenticationSession) {
         this.authenticationSession = authenticationSession;
-        trace(this.authenticationSession);
+        trace(authenticationSession);
+        mdc().update(this, authenticationSession);
     }
 
     @Override
@@ -230,7 +236,8 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public void setUserSession(UserSessionModel userSession) {
         this.userSession = userSession;
-        trace(this.userSession);
+        trace(userSession);
+        mdc().update(this, userSession);
     }
 
     // Tracing
@@ -308,5 +315,9 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
         }
 
         return user;
+    }
+
+    private MappedDiagnosticContextProvider mdc() {
+        return MappedDiagnosticContextUtil.getMappedDiagnosticContextProvider(session);
     }
 }

--- a/services/src/main/java/org/keycloak/services/logging/DefaultMappedDiagnosticContextProviderFactory.java
+++ b/services/src/main/java/org/keycloak/services/logging/DefaultMappedDiagnosticContextProviderFactory.java
@@ -5,6 +5,7 @@ import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.logging.MappedDiagnosticContextProvider;
 import org.keycloak.logging.MappedDiagnosticContextProviderFactory;
+import org.keycloak.logging.MappedDiagnosticContextUtil;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
@@ -51,6 +52,7 @@ public class DefaultMappedDiagnosticContextProviderFactory implements MappedDiag
     @Override
     public void init(Config.Scope config) {
         this.mdcKeys = Arrays.stream(Objects.requireNonNullElse(config.getArray(MDC_KEYS), new String[] {})).map(s -> MDC_PREFIX + s).collect(Collectors.toSet());
+        MappedDiagnosticContextUtil.setKeysToClear(mdcKeys.stream().toList());
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/logging/DefaultMappedDiagnosticContextProviderFactory.java
+++ b/services/src/main/java/org/keycloak/services/logging/DefaultMappedDiagnosticContextProviderFactory.java
@@ -1,0 +1,133 @@
+package org.keycloak.services.logging;
+
+import org.jboss.logging.MDC;
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.logging.MappedDiagnosticContextProvider;
+import org.keycloak.logging.MappedDiagnosticContextProviderFactory;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The default provider factory can be configured via --spi-mapped-diagnostic-context-default-mdc-keys to define mdc
+ * keys to add as a comma-separated list. By default, "realm", "clientId", "userId", "ipAddress" and "org" are supported by the default provider implementation.
+ * If you need further keys, you need to extend the provider.
+ *
+ * @author <a href="mailto:b.eicki@gmx.net">Björn Eickvonder</a>
+ */
+public class DefaultMappedDiagnosticContextProviderFactory implements MappedDiagnosticContextProviderFactory, MappedDiagnosticContextProvider, EnvironmentDependentProviderFactory {
+
+    public static final String MDC_KEY_REALM = MDC_PREFIX + "realm";
+    public static final String MDC_KEY_CLIENT_ID = MDC_PREFIX + "clientId";
+    public static final String MDC_KEY_USER_ID = MDC_PREFIX + "userId";
+    public static final String MDC_KEY_IP_ADDRESS = MDC_PREFIX + "ipAddress";
+    public static final String MDC_KEY_ORGANIZATION = MDC_PREFIX + "org";
+
+    public static final String MDC_KEYS = "mdcKeys";
+    private Set<String> mdcKeys;
+
+    @Override
+    public MappedDiagnosticContextProvider create(KeycloakSession session) {
+        // not using session, thus implementing MappedDiagnosticContextProvider here and handling it as singleton is fine
+        return this;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        this.mdcKeys = Arrays.stream(Objects.requireNonNullElse(config.getArray(MDC_KEYS), new String[] {})).map(s -> MDC_PREFIX + s).collect(Collectors.toSet());
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // no-op
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+
+    @Override
+    public String getId() {
+        return "default";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+
+        builder.property()
+                .name(MDC_KEYS)
+                .type("string")
+                .helpText("Comma-separated list of MDC keys to add to the Mapped Diagnostic Context.")
+                .options(Stream.of(MDC_KEY_REALM, MDC_KEY_CLIENT_ID, MDC_KEY_USER_ID, MDC_KEY_IP_ADDRESS, MDC_KEY_ORGANIZATION).map(s -> s.substring(MDC_PREFIX.length())).collect(Collectors.toList()))
+                .add();
+
+        return builder.build();
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.LOG_MDC);
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, AuthenticationSessionModel session) {
+        // nothing of interest here
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, RealmModel realm) {
+        if (mdcKeys.contains(MDC_KEY_REALM)) {
+            putMdc(MDC_KEY_REALM, realm != null ? realm.getName() : null);
+        }
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, ClientModel client) {
+        if (mdcKeys.contains(MDC_KEY_CLIENT_ID)) {
+            putMdc(MDC_KEY_CLIENT_ID, client != null ? client.getClientId() : null);
+        }
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, OrganizationModel organization) {
+        if (mdcKeys.contains(MDC_KEY_ORGANIZATION)) {
+            putMdc(MDC_KEY_ORGANIZATION, organization != null ? organization.getAlias() : null);
+        }
+    }
+
+    @Override
+    public void update(KeycloakContext keycloakContext, UserSessionModel userSession) {
+        if (mdcKeys.contains(MDC_KEY_USER_ID)) {
+            putMdc(MDC_KEY_USER_ID, userSession != null && userSession.getUser() != null ? userSession.getUser().getId() : null);
+        }
+        if (mdcKeys.contains(MDC_KEY_IP_ADDRESS)) {
+            putMdc(MDC_KEY_IP_ADDRESS, userSession != null ? userSession.getIpAddress() : null);
+        }
+    }
+
+    protected void putMdc(String key, String value) {
+        if (value != null) {
+            MDC.put(key, value);
+        } else {
+            MDC.remove(key);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/logging/DefaultMappedDiagnosticContextProviderFactory.java
+++ b/services/src/main/java/org/keycloak/services/logging/DefaultMappedDiagnosticContextProviderFactory.java
@@ -52,7 +52,7 @@ public class DefaultMappedDiagnosticContextProviderFactory implements MappedDiag
     @Override
     public void init(Config.Scope config) {
         this.mdcKeys = Arrays.stream(Objects.requireNonNullElse(config.getArray(MDC_KEYS), new String[] {})).map(s -> MDC_PREFIX + s).collect(Collectors.toSet());
-        MappedDiagnosticContextUtil.setKeysToClear(mdcKeys.stream().toList());
+        MappedDiagnosticContextUtil.setKeysToClear(mdcKeys);
     }
 
     @Override

--- a/services/src/main/resources/META-INF/services/org.keycloak.logging.MappedDiagnosticContextProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.logging.MappedDiagnosticContextProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.services.logging.DefaultMappedDiagnosticContextProviderFactory


### PR DESCRIPTION
Closes #39812

Adds realm, clientId by default to MDC and optionally userId and ipAddress.

This feature has been shortly discussed with @ahus1 on keycloak-dev Slack channel.

I haven't yet added test cases and documentation (except for Javadoc). If you can show me where I can include that best, I will happily add that.
