### PR TITLE
[26.0] Upgrade to Quarkus 3.15.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.15.4</quarkus.version>
-        <quarkus.build.version>3.15.4</quarkus.build.version>
+        <quarkus.version>3.15.5</quarkus.version>
+        <quarkus.build.version>3.15.5</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 


### PR DESCRIPTION
- Closes #39839

Executed script `./set-quarkus-version.sh 3.15.5`