### PR TITLE
Revert changes to exception handling in RealmsAdminResource#importRealm

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -176,6 +176,12 @@ public class RealmsAdminResource {
         } catch (PasswordPolicyNotMetException e) {
             logger.error("Password policy not met for user " + e.getUsername(), e);
             throw ErrorResponse.error("Password policy not met. See logs for details", Response.Status.BAD_REQUEST);
+        } catch (ModelIllegalStateException mise) {
+            logger.error(mise.getMessage(), mise);
+            throw ErrorResponse.error(mise.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+        } catch (ModelDuplicateException mde) {
+            logger.error("Conflict detected", mde);
+            throw ErrorResponse.exists(mde.getMessage());
         } catch (ModelException e) {
             throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
         }


### PR DESCRIPTION
- ModelDuplicateException and ModelIllegalException were wrongfully handled as ModelException, returning wrong status code

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>

Closes #39753

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
