### PR TITLE
Login[v2]: use field.checkbox in password-commons

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/password-commons.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/password-commons.ftl
@@ -1,12 +1,8 @@
+<#import "field.ftl" as field>
 <#macro logoutOtherSessions>
     <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-        <div class="${properties.kcFormOptionsWrapperClass!}">
-            <div class="pf-v5-c-check">
-                <input class="pf-v5-c-check__input" type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked>
-                <label class="pf-v5-c-check__label" for="logout-sessions">
-                    ${msg("logoutOtherSessions")}
-                </label>
-            </div>
+        <div class="${properties.kcFormOptionsWrapperClass!}"> 
+            <@field.checkbox name="logout-sessions" label=msg("logoutOtherSessions") value=true />
         </div>
     </div>
 </#macro>


### PR DESCRIPTION
This PR replaces the manually constructed checkbox field on i.e. the password reset page with the field.checkbox macro in the keycloak.v2 login theme.

Closes #39843

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
