### PR TITLE
Remove parent and children composite dependencies when removing roles

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -459,7 +459,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         // the alternative of clearing the persistence context is not either as we don't know if something currently present
         // in the context is not needed later.
 
-        roleEntity.getParentRoles().forEach(roleEntity1 -> roleEntity1.getCompositeRoles().remove(roleEntity));
+        roleEntity.getCompositeRoles().forEach(childRole -> childRole.getParentRoles().remove(roleEntity));
+        roleEntity.getParentRoles().forEach(parentRole -> parentRole.getCompositeRoles().remove(roleEntity));
 
         em.createNamedQuery("deleteClientScopeRoleMappingByRole").setParameter("role", roleEntity).executeUpdate();
 


### PR DESCRIPTION
Closes #39724

The problem was that if the composite role was deleted first the child role wanted to remove the same role from the parent, but it was already removed, and that created the issue. The roles should remove both types of dependencies (for children/composites, the role should be deleted as the parent; for parents, the role should be deleted as composite/child). Test added.

@mposolda @ahus1 Take a look if you can.
