### PR TITLE
Ignore protoLock checks when building Keycloak with JDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
 
       - name: Build with JDK
         run:
-          ./mvnw install -e -DskipTests -DskipExamples
+          ./mvnw install -e -DskipTests -DskipExamples -DskipProtoLock=true
 
       - name: Upload JVM Heapdumps
         if: always()


### PR DESCRIPTION
Closes #39861

This was failing in recent GHA test runs and we don't need to check this here since it was already checked by the global build.

There may be other occurrences of 429 mentioned in #39861 but it seems it is pretty much stable in recent runs, therefore I think removing this is enough for now and we can reopen later if it happens again.

Let me know what you think.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
