### PR TITLE
MigrationModel duplicate entry

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion.java
@@ -33,8 +33,6 @@ public class JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion extends Custom
         final String colVersion = database.correctObjectName("VERSION", Column.class);
         final String colUpdateTime = database.correctObjectName("UPDATE_TIME", Column.class);
 
-        database.getConcatSql();
-
         //noinspection SqlSourceToSinkFlow
         try (PreparedStatement ps = connection.prepareStatement(getOlderDuplicatedRecords(tableName, colId, colVersion, colUpdateTime))) {
             ResultSet resultSet = ps.executeQuery();

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion.java
@@ -1,0 +1,71 @@
+package org.keycloak.connections.jpa.updater.liquibase.custom;
+
+import liquibase.exception.CustomChangeException;
+import liquibase.statement.core.DeleteStatement;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.Schema;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Cleanup script for removing duplicated migration model versions in the MIGRATION_MODEL table
+ * See: <a href="https://github.com/keycloak/keycloak/issues/39866">keycloak#39866</a>
+ */
+public class JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion extends CustomKeycloakTask {
+
+    @Override
+    protected String getTaskId() {
+        return "Delete duplicated records for DB version in MIGRATION_MODEL table";
+    }
+
+    @Override
+    protected void generateStatementsImpl() throws CustomChangeException {
+        Set<String> idsToDelete = new HashSet<>();
+
+        final String catalog = database.escapeObjectName(database.getDefaultCatalogName(), Catalog.class);
+        final String schema = getSchema();
+        final String tableName = getTableName("MIGRATION_MODEL");
+        final String colId = database.correctObjectName("ID", Column.class);
+
+        final String GET_OLDER_DUPLICATED_RECORDS = """
+                SELECT m1.ID
+                FROM %sMIGRATION_MODEL m1
+                WHERE EXISTS (
+                    SELECT m2.ID
+                    FROM %sMIGRATION_MODEL m2
+                    WHERE m2.VERSION = m1.VERSION AND m2.UPDATE_TIME > m1.UPDATE_TIME
+                )
+                """.formatted(schema, schema);
+
+        try (PreparedStatement ps = connection.prepareStatement(GET_OLDER_DUPLICATED_RECORDS)) {
+            ResultSet resultSet = ps.executeQuery();
+            while (resultSet.next()) {
+                idsToDelete.add(resultSet.getString(1));
+            }
+        } catch (Exception e) {
+            throw new CustomChangeException(getTaskId() + ": Failed to detect duplicate MIGRATION_MODEL rows", e);
+        }
+
+        AtomicInteger i = new AtomicInteger();
+        idsToDelete.stream()
+                .collect(Collectors.groupingByConcurrent(id -> i.getAndIncrement() / 20, Collectors.toList())) // Split into chunks of at most 20 items
+                .values().stream()
+                .map(ids -> new DeleteStatement(catalog, schema, tableName)
+                        .setWhere(":name IN (" + ids.stream().map(id -> "?").collect(Collectors.joining(",")) + ")")
+                        .addWhereColumnName(colId)
+                        .addWhereParameters(ids.toArray())
+                )
+                .forEach(statements::add);
+    }
+
+    private String getSchema() {
+        String schema = database.escapeObjectName(database.getDefaultSchemaName(), Schema.class);
+        return schema == null ? "" : schema + ".";
+    }
+}

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.2.6.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.2.6.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="26.2.6-39866-duplicate">
+        <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate26_2_6_RemoveDuplicateMigrationModelVersion"/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.2.6-39866-uk">
+        <addUniqueConstraint tableName="MIGRATION_MODEL" columnNames="VERSION" constraintName="UK_MIGRATION_VERSION"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -86,6 +86,7 @@
     <include file="META-INF/jpa-changelog-26.0.0.xml"/>
     <include file="META-INF/jpa-changelog-26.1.0.xml"/>
     <include file="META-INF/jpa-changelog-26.2.0.xml"/>
+    <include file="META-INF/jpa-changelog-26.2.6.xml"/>
     <include file="META-INF/jpa-changelog-26.3.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Closes: #39866

- Cleanup for duplicated old records in MIGRATION_MODEL table
- Unique constraint on the VERSION col in MIGRATION_MODEL table
- Advanced lock mechanism will be done in a follow-up issues as this might be backported to 26.2.x


I've reproduced the issue before:
![Screenshot From 2025-05-27 14-05-52](https://github.com/user-attachments/assets/63efb34b-c4d9-4da0-a616-1f67d3bc3172)

After these changes, everything should be good:
![Screenshot From 2025-05-27 15-43-50](https://github.com/user-attachments/assets/c782b205-9d22-4bb4-b35c-72e38a3b5f23)

## Testing approach

- Included these changes into distribution and built custom image `mabartos/keycloak:26.3.0`
- Having Deployment config with 5 replicas
- Initial version Keycloak 26.1.3
- Then upgraded to the `mabartos/keycloak/26.3.0`
- Change sets were propagated (cleanup + unique constraint)
- Table contains only 2 records with versions (26.1.3 and 26.3.0)

<details>
<summary>Used Testing Deployment</summary>

```yaml
apiVersion: v1
kind: Service
metadata:
  name: keycloak
  labels:
    app: keycloak
spec:
  ports:
    - protocol: TCP
      port: 8080
      targetPort: http
      name: http
  selector:
    app: keycloak
  type: ClusterIP
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: keycloak
  # Used to
  name: keycloak-discovery
spec:
  selector:
    app: keycloak
  # Allow not-yet-ready Pods to be visible to ensure the forming of a cluster if Pods come up concurrently
  # publishNotReadyAddresses: true
  clusterIP: None
  type: ClusterIP
---
apiVersion: apps/v1
# Use a stateful setup to ensure that for a rolling update Pods are restarted with a rolling strategy one-by-one.
# This prevents losing in-memory information stored redundantly in two Pods.
#kind: StatefulSet
kind: Deployment
metadata:
  name: keycloak
  labels:
    app: keycloak
spec:
  #serviceName: keycloak-discovery
  # Run with one replica to save resources, or with two replicas to allow for rolling updates for configuration changes
  replicas: 5
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app: keycloak
  template:
    metadata:
      labels:
        app: keycloak
    spec:
      containers:
        - name: keycloak
          image: quay.io/keycloak/keycloak:26.1.3
          args: ["start"]
          env:
            - name: KC_BOOTSTRAP_ADMIN_USERNAME
              value: "admin"
            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
              value: "admin"
            # In a production environment, add a TLS certificate to Keycloak to either end-to-end encrypt the traffic between
            # the client or Keycloak, or to encrypt the traffic between your proxy and Keycloak.
            # Respect the proxy headers forwarded by the reverse proxy
            # In a production environment, verify which proxy type you are using, and restrict access to Keycloak
            # from other sources than your proxy if you continue to use proxy headers.
            - name: KC_PROXY_HEADERS
              value: "xforwarded"
            - name: KC_HTTP_ENABLED
              value: "true"
            # In this explorative setup, no strict hostname is set.
            # For production environments, set a hostname for a secure setup.
            - name: KC_HOSTNAME_STRICT
              value: "false"
            - name: KC_HEALTH_ENABLED
              value: "true"
            - name: 'KC_CACHE'
              value: 'ispn'
            # Use the Kubernetes configuration for distributed caches which is based on DNS
            - name: 'KC_CACHE_STACK'
              value: 'kubernetes'
            # Passing the Pod's IP primary address to the JGroups clustering as this is required in IPv6 only setups
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            # Instruct JGroups which DNS hostname to use to discover other Keycloak nodes
            # Needs to be unique for each Keycloak cluster
            - name: JAVA_OPTS_APPEND
              value: '-Djgroups.dns.query="keycloak-discovery" -Djgroups.bind.address=$(POD_IP)'
            - name: 'KC_DB_URL_DATABASE'
              value: 'keycloak'
            - name: 'KC_DB_URL_HOST'
              value: 'postgres'
            - name: 'KC_DB'
              value: 'postgres'
            # In a production environment, use a secret to store username and password to the database
            - name: 'KC_DB_PASSWORD'
              value: 'keycloak'
            - name: 'KC_DB_USERNAME'
              value: 'keycloak'
          ports:
            - name: http
              containerPort: 8080
            - name: management
              containerPort: 9000  
          startupProbe:
            httpGet:
              path: /health/started
              port: 9000
            failureThreshold: 15
          readinessProbe:
            httpGet:
              path: /health/ready
              port: 9000
          livenessProbe:
            httpGet:
              path: /health/live
              port: 9000
          resources:
            limits:
              cpu: 2000m
              memory: 4000Mi
            requests:
              cpu: 1500m
              memory: 3500Mi
---
# This is deployment of PostgreSQL with an ephemeral storage for testing: Once the Pod stops, the data is lost.
# For a production setup, replace it with a database setup that persists your data.
apiVersion: apps/v1
kind: Deployment
metadata:
  name: postgres
  labels:
    app: postgres
spec:
  
  replicas: 1
  selector:
    matchLabels:
      app: postgres
  template:
    metadata:
      labels:
        app: postgres
    spec:
      containers:
        - name: postgres
          image: mirror.gcr.io/postgres:17
          env:
            - name: POSTGRES_USER
              value: "keycloak"
            - name: POSTGRES_PASSWORD
              value: "keycloak"
            - name: POSTGRES_DB
              value: "keycloak"
            - name: POSTGRES_LOG_STATEMENT
              value: "all"
          ports:
            - name: postgres
              containerPort: 5432
          volumeMounts:
            # Using volume mount for PostgreSQL's data folder as it is otherwise not writable
            - name: postgres-data
              mountPath: /var/lib/postgresql
      volumes:
        - name: postgres-data
          emptyDir: {}
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: postgres
  name: postgres
spec:
  selector:
    app: postgres
  ports:
    - protocol: TCP
      port: 5432
      targetPort: 5432
  type: ClusterIP
```
</details>

We might probably even update the MigrationModelAdapter to only update fields instead of trying to create a new record.