### PR TITLE
Generate a UUID to be the JTI instead of reusing the nonce.

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.keycloak.TokenVerifier.Predicate;
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Time;
 import org.keycloak.models.SingleUseObjectValueModel;
 import org.keycloak.models.DefaultActionTokenKey;
 import org.keycloak.models.KeycloakSession;
@@ -159,7 +158,7 @@ public class DefaultActionToken extends DefaultActionTokenKey implements SingleU
 
         this
           .issuedNow()
-          .id(getActionVerificationNonce().toString())
+          .id(UUID.randomUUID().toString())
           .issuer(issuerUri)
           .audience(issuerUri);
 


### PR DESCRIPTION
Fixes https://github.com/keycloak/keycloak/issues/40160