### PR TITLE
Better locale management in the admin console

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2888,6 +2888,7 @@ emptyPermissionInstructions=If you want to create a permission, please click the
 webAuthnPolicyAvoidSameAuthenticatorRegisterHelp=Avoid registering an authenticator that has already been registered.
 memberofLdapAttribute=Member-of LDAP attribute
 supportedLocales=Supported locales
+invalidLocale=Invalid locale selected
 showPasswordDataValue=Value
 webAuthnPolicyAttestationConveyancePreference=Attestation conveyance preference
 copyOf=Copy of {{name}}

--- a/js/apps/admin-ui/src/realm-settings/localization/LocalizationTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/localization/LocalizationTab.tsx
@@ -98,8 +98,15 @@ export const LocalizationTab = ({
                   name="supportedLocales"
                   isScrollable
                   label={t("supportedLocales")}
+                  labelIcon={t("supportedLocalesHelp")}
                   controller={{
                     defaultValue: defaultSupportedLocales,
+                    rules: {
+                      required: t("required"),
+                      validate: (value: string[]) =>
+                        value.every((v) => allLocales.includes(v)) ||
+                        t("invalidLocale"),
+                    },
                   }}
                   variant="typeaheadMulti"
                   placeholderText={t("selectLocales")}
@@ -111,8 +118,14 @@ export const LocalizationTab = ({
                 <SelectControl
                   name="defaultLocale"
                   label={t("defaultLocale")}
+                  labelIcon={t("defaultLocaleHelp")}
                   controller={{
                     defaultValue: DEFAULT_LOCALE,
+                    rules: {
+                      required: t("required"),
+                      validate: (value: string) =>
+                        watchSupportedLocales?.includes(value) || t("required"),
+                    },
                   }}
                   data-testid="select-default-locale"
                   options={watchSupportedLocales!.map((l) => ({

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -564,7 +564,10 @@ public class ModelToRepresentation {
         }
 
         rep.setInternationalizationEnabled(realm.isInternationalizationEnabled());
-        rep.setSupportedLocales(realm.getSupportedLocalesStream().collect(Collectors.toSet()));
+        Set<String> supportedLocales = realm.getSupportedLocalesStream().collect(Collectors.toSet());
+        if (!supportedLocales.isEmpty()) {
+            rep.setSupportedLocales(supportedLocales);
+        }
         rep.setDefaultLocale(realm.getDefaultLocale());
         if (internal) {
             exportAuthenticationFlows(session, realm, rep);


### PR DESCRIPTION
Closes #39934

The PR just improves a little the locale settings tab for realms:

1. The `supportedLocales` attribute is not added if the array is empty. This is the standard for other arrays so it's OK and it seems that the UI does not manage OK an empty array.
2. The help icons are added to both fields (I don not know why, it was not there).
3. Both are set as required because the two options depends in other values and the user can start adding/removing values until on field are empty or invalid. This way it is ensure that both options has a value.
4. Both fields validate the locale with the options passed to not allow assigning values that are not in the options. As commented the options can change.

@keycloak/ui Please take a look, maybe there is a better way of doing this.

Regards!
