### PR TITLE
Initialize the supported locales to empty set in RealmAttributeUpdater to revert back OK

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
@@ -4,6 +4,7 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -148,6 +149,9 @@ public class RealmAttributeUpdater extends ServerResourceUpdater<RealmAttributeU
     }
 
     public RealmAttributeUpdater addSupportedLocale(String locale) {
+        if (origRep.getSupportedLocales() == null) {
+            origRep.setSupportedLocales(Collections.emptySet());
+        }
         rep.addSupportedLocales(locale);
         return this;
     }


### PR DESCRIPTION
Closes #40049

I created this flaky test was created in #39934. Sorry! It was not detected because the test runs OK in the second try (and initially it seems to be non-related).

Now the `supportedLocales` is null when empty and it was not reverted OK in the updater at close (null was send, which is discarded in the update at close, and the locales remain there). Now we need to manually initialize the orig representation to empty in the updater to force the update at close.