### PR TITLE
Use previous password in SMTP when the the authType defaults to basic (26.2)

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
@@ -863,8 +863,16 @@ public class DefaultExportImportManager implements ExportImportManager {
 
             Map<String, String> config = new HashMap<>(rep.getSmtpServer());
 
-            if(rep.getSmtpServer().containsKey("authType") && "basic".equals(rep.getSmtpServer().get("authType"))) {
-                if (rep.getSmtpServer().containsKey("password") && ComponentRepresentation.SECRET_VALUE.equals(rep.getSmtpServer().get("password"))) {
+            if (!Boolean.parseBoolean(config.get("auth"))) {
+                config.remove("authTokenUrl");
+                config.remove("authTokenScope");
+                config.remove("authTokenClientId");
+                config.remove("authTokenClientSecret");
+                config.remove("password");
+                config.remove("user");
+                config.remove("authType");
+            } else if (config.get("authType") == null || "basic".equals(config.get("authType"))) {
+                if (ComponentRepresentation.SECRET_VALUE.equals(config.get("password"))) {
                     String passwordValue = realm.getSmtpConfig() != null ? realm.getSmtpConfig().get("password") : null;
                     config.put("password", passwordValue);
                 }
@@ -872,10 +880,8 @@ public class DefaultExportImportManager implements ExportImportManager {
                 config.remove("authTokenScope");
                 config.remove("authTokenClientId");
                 config.remove("authTokenClientSecret");
-            }
-
-            if(rep.getSmtpServer().containsKey("authType") && "token".equals(rep.getSmtpServer().get("authType"))) {
-                if (rep.getSmtpServer().containsKey("authTokenClientSecret") && ComponentRepresentation.SECRET_VALUE.equals(rep.getSmtpServer().get("authTokenClientSecret"))) {
+            } else if ("token".equals(config.get("authType"))) {
+                if (ComponentRepresentation.SECRET_VALUE.equals(config.get("authTokenClientSecret"))) {
                     String authTokenClientSecretValue = realm.getSmtpConfig() != null ? realm.getSmtpConfig().get("authTokenClientSecret") : null;
                     config.put("authTokenClientSecret", authTokenClientSecretValue);
                 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
@@ -436,6 +436,7 @@ public class RealmTest extends AbstractAdminTest {
     public void smtpPasswordSecret() {
         RealmRepresentation rep = RealmBuilder.create().testEventListener().testMail().build();
         rep.setRealm("realm-with-smtp");
+        rep.getSmtpServer().put("auth", "true");
         rep.getSmtpServer().put("user", "user");
         rep.getSmtpServer().put("password", "secret");
 
@@ -461,6 +462,19 @@ public class RealmTest extends AbstractAdminTest {
         assertEquals("secret", internalRep.getSmtpServer().get("password"));
 
         RealmRepresentation realm = adminClient.realms().findAll().stream().filter(r -> r.getRealm().equals("realm-with-smtp")).findFirst().get();
+        assertEquals(ComponentRepresentation.SECRET_VALUE, realm.getSmtpServer().get("password"));
+
+        // updating setting the secret value with asterisks
+        rep.getSmtpServer().put("password", ComponentRepresentation.SECRET_VALUE);
+        adminClient.realm("realm-with-smtp").update(rep);
+
+        event = testingClient.testing().pollAdminEvent();
+        assertTrue(event.getRepresentation().contains(ComponentRepresentation.SECRET_VALUE));
+
+        internalRep = serverClient.fetch(RunHelpers.internalRealm());
+        assertEquals("secret", internalRep.getSmtpServer().get("password"));
+
+        realm = adminClient.realm("realm-with-smtp").toRepresentation();
         assertEquals(ComponentRepresentation.SECRET_VALUE, realm.getSmtpServer().get("password"));
     }
 


### PR DESCRIPTION
Closes #39781

PR:             https://github.com/keycloak/keycloak/pull/40065
Commit:         https://github.com/keycloak/keycloak/commit/669cc2533ce8849c0f8ea48dd813db874e586269
PR branch:      backport-40065-26.2
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.2

