### PR TITLE
fix: enabling property mapping during validation

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -522,7 +522,12 @@ public class Picocli {
             return;
         }
 
-        mapper.validate(configValue);
+        PropertyMappingInterceptor.enable();
+        try {
+            mapper.validate(configValue);
+        } finally {
+            PropertyMappingInterceptor.disable();
+        }
 
         mapper.getDeprecatedMetadata().ifPresent(metadata -> handleDeprecated(deprecatedInUse, mapper, configValueStr, metadata));
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -75,11 +75,12 @@ public final class Build extends AbstractCommand implements Runnable {
         }
         checkProfileAndDb();
 
-        System.setProperty("quarkus.launch.rebuild", "true");
+        // validate before setting that we're rebuilding so that runtime options are still seen
         PersistedConfigSource.getInstance().runWithDisabled(() -> {
             validateConfig();
             return null;
         });
+        System.setProperty("quarkus.launch.rebuild", "true");
 
         println(spec.commandLine(), "Updating the configuration and installing your custom providers, if any. Please wait.");
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
@@ -20,8 +20,6 @@ import org.keycloak.config.HealthOptions;
 import org.keycloak.config.HttpOptions;
 import org.keycloak.config.ManagementOptions;
 import org.keycloak.config.MetricsOptions;
-import org.keycloak.quarkus.runtime.Messages;
-import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.config.ManagementOptions.LEGACY_OBSERVABILITY_INTERFACE;
@@ -81,25 +79,21 @@ public class ManagementPropertyMappers {
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_FILE)
                         .mapFrom(HttpOptions.HTTPS_CERTIFICATE_FILE)
                         .to("quarkus.management.ssl.certificate.files")
-                        .validator(value -> validateTlsProperties())
                         .paramLabel("file")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_KEY_FILE)
                         .mapFrom(HttpOptions.HTTPS_CERTIFICATE_KEY_FILE)
                         .to("quarkus.management.ssl.certificate.key-files")
-                        .validator(value -> validateTlsProperties())
                         .paramLabel("file")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_FILE)
                         .mapFrom(HttpOptions.HTTPS_KEY_STORE_FILE)
                         .to("quarkus.management.ssl.certificate.key-store-file")
-                        .validator(value -> validateTlsProperties())
                         .paramLabel("file")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_PASSWORD)
                         .mapFrom(HttpOptions.HTTPS_KEY_STORE_PASSWORD)
                         .to("quarkus.management.ssl.certificate.key-store-password")
-                        .validator(value -> validateTlsProperties())
                         .paramLabel("password")
                         .isMasked(true)
                         .build(),
@@ -126,16 +120,12 @@ public class ManagementPropertyMappers {
     public static boolean isManagementTlsEnabled() {
         var key = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_KEY_FILE.getKey());
         var cert = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_FILE.getKey());
-        if (key.isPresent() && cert.isPresent()) return true;
+        if (key.isPresent() && cert.isPresent()) {
+            return true;
+        }
 
         var keystore = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_FILE.getKey());
         return keystore.isPresent();
     }
 
-    private static void validateTlsProperties() {
-        var isHttpEnabled = Configuration.isTrue(HttpOptions.HTTP_ENABLED);
-        if (!isHttpEnabled && !isManagementTlsEnabled()) {
-            throw new PropertyException(Messages.httpsConfigurationNotSet());
-        }
-    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -85,7 +85,7 @@ public final class PropertyMappers {
         // The special handling of log properties is because some logging runtime properties are requested during build time
         // and we need to resolve them. That should be fine as they are generally not considered security sensitive.
         // See https://github.com/quarkusio/quarkus/pull/42157
-        if ((isRebuild() || Environment.isRebuildCheck()) && isKeycloakRuntime(name, mapper)
+        if (isRebuild() && isKeycloakRuntime(name, mapper)
                 && !NestedPropertyMappingInterceptor.getResolvingRoot().orElse(name).startsWith("quarkus.log.")) {
             return ConfigValue.builder().withName(name).build();
         }


### PR DESCRIPTION
closes: #40095

I was enabling property mapping to refine the validation of tls related management properties as noticed on #40044

However after reviewing again, it seems like we should just remove this validation. The problems with the logic:
- http and https can be enabled simultaneously, but the validation is effectively disabled if http is enabled
- it doesn't match what is being done for the main interface, where we just rely upon the TlsUtil failure to produce a message. If we remove the validation let TlsUtil handling determine if the config is valid.
- the message doesn't distingish that it's a problem related to the management https. The default handling also doesn't do a good job at distinguishing that it's the management interface - but that should be ideally be improved in quarkus, and we can add logic to report a more specific keycloak message.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
