### PR TITLE
refinements related to service methods, serdes

### DIFF
--- a/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public class ClientRepresentation {
+
+    public static final String OIDC = "openid-connect";
 
     @JsonProperty(required = true)
     @JsonPropertyDescription("ID uniquely identifying this client")
@@ -19,8 +22,9 @@ public class ClientRepresentation {
     @JsonPropertyDescription("Human readable description of the client")
     private String description;
 
+    @JsonProperty(defaultValue = OIDC)
     @JsonPropertyDescription("The protocol used to communicate with the client")
-    private String protocol;
+    private String protocol = OIDC;
 
     @JsonPropertyDescription("Whether this client is enabled")
     private Boolean enabled;
@@ -28,21 +32,26 @@ public class ClientRepresentation {
     @JsonPropertyDescription("URL to the application's homepage that is represented by this client")
     private String appUrl;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("URLs that the browser can redirect to after login")
-    private Set<String> appRedirectUrls;
+    private Set<String> appRedirectUrls = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Login flows that are enabled for this client")
-    private Set<String> loginFlows;
+    private Set<String> loginFlows = new LinkedHashSet<String>();
 
     @JsonPropertyDescription("Authentication configuration for this client")
     private Auth auth;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Web origins that are allowed to make requests to this client")
-    private Set<String> webOrigins;
+    private Set<String> webOrigins = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Roles associated with this client")
-    private Set<String> roles;
+    private Set<String> roles = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Service account configuration for this client")
     private ServiceAccount serviceAccount;
 
@@ -148,7 +157,7 @@ public class ClientRepresentation {
         this.serviceAccount = serviceAccount;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public static class Auth {
 
         @JsonPropertyDescription("Whether authentication is enabled for this client")
@@ -196,14 +205,15 @@ public class ClientRepresentation {
         }
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public static class ServiceAccount {
 
         @JsonPropertyDescription("Whether the service account is enabled")
         private Boolean enabled;
 
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @JsonPropertyDescription("Roles assigned to the service account")
-        private Set<String> roles;
+        private Set<String> roles = new LinkedHashSet<String>();
 
         public Boolean getEnabled() {
             return enabled;

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -10,5 +10,5 @@ public interface ClientApi {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    ClientRepresentation getClient(@QueryParam("runtime") Boolean isRuntime);
+    ClientRepresentation getClient();
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -26,8 +26,8 @@ public class DefaultClientApi implements ClientApi {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Override
-    public ClientRepresentation getClient(@QueryParam("runtime") Boolean isRuntime) {
-        return clientService.getClient(realm, clientId, isRuntime)
+    public ClientRepresentation getClient() {
+        return clientService.getClient(realm, clientId, null)
                 .orElseThrow(() -> new NotFoundException("Cannot find the specified client"));
     }
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -36,9 +36,10 @@ public class DefaultClientsApi implements ClientsApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Stream<ClientRepresentation> getClients() {
-        return clientService.getClients(realm);
+        return clientService.getClients(realm, null, null, null);
     }
 
+    @Override
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -52,6 +53,7 @@ public class DefaultClientsApi implements ClientsApi {
         }
     }
 
+    @Override
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
@@ -5,18 +5,51 @@ import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.Service;
 import org.keycloak.services.ServiceException;
 
+import jakarta.ws.rs.core.Response.Status;
+
 import java.util.Optional;
 import java.util.stream.Stream;
 
 public interface ClientService extends Service {
 
-    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId);
+    public static class ClientSearchOptions {
+        // TODO
+    }
 
-    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation);
+    public static class ClientProjectionOptions {
+        // TODO
+    }
 
-    Stream<ClientRepresentation> getClients(RealmModel realm);
+    public static class ClientSortAndSliceOptions {
+        // order by
+        // offset
+        // limit
+        // NOTE: this is not always the most desirable way to do pagination
+    }
 
-    ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, ClientProjectionOptions projectionOptions);
+
+    Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions);
+
+    ClientRepresentation deleteClient(RealmModel realm, String clientId);
+
+    Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions);
+
+    default ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
+        // If we can paramertize the services, it makes sense to define default handling like this
+        // but this duplicate the existence check
+        try {
+            return createClient(realm, client);
+        } catch (ServiceException e) {
+            if (!e.getSuggestedResponseStatus().filter(Status.CONFLICT::equals).isPresent()) {
+                throw e;
+            }
+        }
+        return updateClient(realm, client);
+    }
+
+    ClientRepresentation updateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
 
     ClientRepresentation createClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+
 }

--- a/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -1,6 +1,8 @@
 package org.keycloak.services.client;
 
 import jakarta.ws.rs.core.Response;
+
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.mapper.ClientModelMapper;
@@ -22,24 +24,15 @@ public class DefaultClientService implements ClientService {
     }
 
     @Override
-    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId) {
+    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId,
+            ClientProjectionOptions projectionOptions) {
         return Optional.ofNullable(realm.getClientByClientId(clientId)).map(mapper::fromModel);
     }
 
     @Override
-    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation) {
-        // TODO reduced client rep
-        return fullRepresentation != null && fullRepresentation ? getClient(realm, clientId) : Optional.of(getTestReducedClientRep(clientId));
-    }
-
-    @Override
-    public Stream<ClientRepresentation> getClients(RealmModel realm) {
+    public Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions,
+            ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions) {
         return realm.getClientsStream().map(mapper::fromModel);
-    }
-
-    @Override
-    public ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
-        return null; // TODO
     }
 
     @Override
@@ -49,6 +42,30 @@ public class DefaultClientService implements ClientService {
         }
 
         var model = realm.addClient(client.getClientId());
+        // TODO: overlay model
+        return mapper.fromModel(model);
+    }
+
+    @Override
+    public ClientRepresentation deleteClient(RealmModel realm, String clientId) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ClientRepresentation updateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
+        ClientModel model = realm.getClientByClientId(client.getClientId());
+        if (model == null) {
+            throw new ServiceException("Client does not exist", Response.Status.NOT_FOUND);
+        }
+
+        // TODO: overlay model
         return mapper.fromModel(model);
     }
 
@@ -57,8 +74,4 @@ public class DefaultClientService implements ClientService {
 
     }
 
-    // TODO tested reduced client representation
-    private static ClientRepresentation getTestReducedClientRep(String clientId) {
-        return new ClientRepresentation(clientId);
-    }
 }


### PR DESCRIPTION
Took the liberty of rebasing to main since I don't believe there is other pending work.

Re-opening the prior pull request, but this time it won't be a discussion about defaults.

Added a rough in of ClientService method refinements. In an ideal world this would all be pretty similar across types, possibly even allow for some generic base interfaces / classes.

**Jackson notes**:

I'd advocate for using NON_ABSENT (or NON_NULL) at a top level to allow for "empty" values such an empty string. However this has the side effect that any possibly fully empty child objects or collections will need to be specifically marked as NON_EMPTY (fabric8 does this).

**Nullability**:

Using not null / non absent heavily implies we will avoid using null as a value. If we want to use the existing representation classes for our own tests for example you can't do something like:

var client = new ClientRepresentation();
client.setSomeField(null);

Then call the endpoint and expect the serialized form to contain

"someField":null

This is how things are with the fabric8 kubernetes client built-in classes as well - and I don't think we've come across a case yet for simple put or post operations where this is a problem. 

Kubernetes explains the relationship between their metadata, defaults, and nullability here: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting-and-nullable - basically if a field is not explicitly nullable, then a null value or omitting the field are the same thing.

If we do need allow for some fields having explicit null values in get / put operations - and want to use our representation classes for that (which will be handy for our own tests), we'll need to be able to differentiate between null and unset. That could done internally with a wrapper, or a map. For example if wanted appUrl to be explicitly nullable:

```
@JsonInclude(JsonInclude.Include.NON_ABSENT)
public class ClientRepresentation {
    protected final Map<String, Object> state = new LinkedHashMap<>();

    @JsonPropertyDescription("URL to the application's homepage that is represented by this client")
    public String getAppUrl() {
        return state.get("appUrl");
    }

    public void setAppUrl(String appUrl) {
        state.put("appUrl", state);
    }

    public void unsetAppUrl() {
        state.remove("appUrl"); 
    }

    @JsonAnyGetter
    Map<String,String> getMap() {
        return Collections.unmodifiableMap(state);
    }

    ...

}
```

We may end up wanting a map like this in general if we want to capture additionalProperties like we do in fabric8.

To be useful for creating patches, you have to do something like the above for all field, so I'll probably just show how we can approach patching (json patch and json merge) in the next pr by just avoiding using the representation class to deserialize / create json merge patches.

**Defaults**:

Added just one default, which is in ClientRepresentation / Jackson annotation, which is the protocol defaulting to OIDC - if that's not appropriate, I'll remove it.

@keycloak/cloud-native WDYT?