### PR TITLE
Introduce ExternalToInternalTokenExchangeProvider. Make it working wi…

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -75,6 +75,7 @@ public class Profile {
 
         TOKEN_EXCHANGE("Token Exchange Service", Type.PREVIEW, 1),
         TOKEN_EXCHANGE_STANDARD_V2("Standard Token Exchange version 2", Type.DEFAULT, 2),
+        TOKEN_EXCHANGE_EXTERNAL_INTERNAL_V2("External to Internal Token Exchange version 2", Type.EXPERIMENTAL, 2),
 
         WEB_AUTHN("W3C Web Authentication (WebAuthn)", Type.DEFAULT),
 

--- a/core/src/main/java/org/keycloak/representations/JsonWebToken.java
+++ b/core/src/main/java/org/keycloak/representations/JsonWebToken.java
@@ -41,6 +41,7 @@ import java.util.Map;
  */
 public class JsonWebToken implements Serializable, Token {
     public static final String AZP = "azp";
+    public static final String AUD = "aud";
     public static final String SUBJECT = "sub";
 
     @JsonProperty("jti")
@@ -52,7 +53,7 @@ public class JsonWebToken implements Serializable, Token {
 
     @JsonProperty("iss")
     protected String issuer;
-    @JsonProperty("aud")
+    @JsonProperty(AUD)
     @JsonSerialize(using = StringOrArraySerializer.class)
     @JsonDeserialize(using = StringOrArrayDeserializer.class)
     protected String[] audience;

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/ExchangeExternalToken.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/ExchangeExternalToken.java
@@ -16,11 +16,11 @@
  */
 package org.keycloak.broker.provider;
 
-import org.keycloak.broker.provider.BrokeredIdentityContext;
-import org.keycloak.events.EventBuilder;
 import org.keycloak.models.UserSessionModel;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import org.keycloak.protocol.oidc.TokenExchangeContext;
+import org.keycloak.protocol.oidc.TokenExchangeProvider;
 
 /**
  * Exchange a token crafted by this provider for a local realm token.
@@ -30,7 +30,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
  */
 public interface ExchangeExternalToken {
     boolean isIssuer(String issuer, MultivaluedMap<String, String> params);
-    BrokeredIdentityContext exchangeExternal(EventBuilder event, MultivaluedMap<String, String> params);
+    BrokeredIdentityContext exchangeExternal(TokenExchangeProvider tokenExchangeProvider, TokenExchangeContext tokenExchangeContext);
 
     void exchangeExternalComplete(UserSessionModel userSession, BrokeredIdentityContext context, MultivaluedMap<String, String> params);
 }

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/TokenExchangeProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/TokenExchangeProvider.java
@@ -44,4 +44,10 @@ public interface TokenExchangeProvider extends Provider {
      */
     Response exchange(TokenExchangeContext context);
 
+    /**
+     * @return version of the token-exchange provider. Could be useful by various components (like for example identity-providers), which need to interact with the token-exchange provider
+     * to doublecheck if it should have a "legacy" behaviour (for older version of token-exchange provider) or a "new" behaviour
+     */
+    int getVersion();
+
 }

--- a/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
@@ -138,7 +138,7 @@ public class KeycloakOIDCIdentityProvider extends OIDCIdentityProvider {
     }
 
     @Override
-    protected BrokeredIdentityContext exchangeExternalImpl(EventBuilder event, MultivaluedMap<String, String> params) {
+    protected BrokeredIdentityContext exchangeExternalTokenV1Impl(EventBuilder event, MultivaluedMap<String, String> params) {
         String subjectToken = params.getFirst(OAuth2Constants.SUBJECT_TOKEN);
         if (subjectToken == null) {
             event.detail(Details.REASON, OAuth2Constants.SUBJECT_TOKEN + " param unset");

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -933,7 +933,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     }
 
     @Override
-    protected BrokeredIdentityContext exchangeExternalImpl(EventBuilder event, MultivaluedMap<String, String> params) {
+    protected BrokeredIdentityContext exchangeExternalTokenV1Impl(EventBuilder event, MultivaluedMap<String, String> params) {
         if (!supportsExternalExchange()) return null;
         String subjectToken = params.getFirst(OAuth2Constants.SUBJECT_TOKEN);
         if (subjectToken == null) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -288,7 +288,7 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
             event.error(Errors.NOT_ALLOWED);
             throw new CorsErrorResponseException(cors, OAuthErrorException.ACCESS_DENIED, "Client not allowed to exchange", Response.Status.FORBIDDEN);
         }
-        BrokeredIdentityContext context = externalExchangeContext.provider().exchangeExternal(event, formParams);
+        BrokeredIdentityContext context = externalExchangeContext.provider().exchangeExternal(this, this.context);
         if (context == null) {
             event.error(Errors.INVALID_ISSUER);
             throw new CorsErrorResponseException(cors, Errors.INVALID_ISSUER, "Invalid " + OAuth2Constants.SUBJECT_ISSUER + " parameter", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/ExternalToInternalTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/ExternalToInternalTokenExchangeProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.protocol.oidc.tokenexchange;
+
+import jakarta.ws.rs.core.Response;
+import org.keycloak.protocol.oidc.TokenExchangeContext;
+
+/**
+ * Provider for external-internal token exchange
+ *
+ * TODO Should not extend from V1TokenExchangeProvider, but rather AbstractTokenExchangeProvider or from StandardTokenExchangeProvider (as issuing internal tokens might be done in a same/similar way like for standard V2 provider)
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ExternalToInternalTokenExchangeProvider extends V1TokenExchangeProvider {
+
+    @Override
+    public boolean supports(TokenExchangeContext context) {
+        return (isExternalInternalTokenExchangeRequest(context));
+    }
+
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+
+    @Override
+    protected Response tokenExchange() {
+        String subjectToken = context.getParams().getSubjectToken();
+        String subjectTokenType = context.getParams().getSubjectTokenType();
+        String subjectIssuer = getSubjectIssuer(this.context, subjectToken, subjectTokenType);
+        return exchangeExternalToken(subjectIssuer, subjectToken);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/ExternalToInternalTokenExchangeProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/ExternalToInternalTokenExchangeProviderFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.protocol.oidc.tokenexchange;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.protocol.oidc.TokenExchangeProvider;
+import org.keycloak.protocol.oidc.TokenExchangeProviderFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+/**
+ * Provider factory for external-internal token exchange
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ExternalToInternalTokenExchangeProviderFactory implements TokenExchangeProviderFactory, EnvironmentDependentProviderFactory {
+
+    @Override
+    public TokenExchangeProvider create(KeycloakSession session) {
+        return new ExternalToInternalTokenExchangeProvider();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return "external-internal";
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_EXTERNAL_INTERNAL_V2);
+    }
+
+    @Override
+    public int order() {
+        // Bigger priority than V1, so it has preference if both V1 and V2 enabled. Also bigger priority than "standard", so it can verify if request is from external-token
+        return 20;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -63,6 +63,11 @@ import org.keycloak.util.TokenUtil;
 public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider {
 
     @Override
+    public int getVersion() {
+        return 2;
+    }
+
+    @Override
     public boolean supports(TokenExchangeContext context) {
         // Subject impersonation request
         String requestedSubject = context.getFormParams().getFirst(OAuth2Constants.REQUESTED_SUBJECT);

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
@@ -79,6 +79,11 @@ public class V1TokenExchangeProvider extends AbstractTokenExchangeProvider {
     private static final Logger logger = Logger.getLogger(V1TokenExchangeProvider.class);
 
     @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
     public boolean supports(TokenExchangeContext context) {
         return true;
     }

--- a/services/src/main/java/org/keycloak/social/gitlab/GitLabIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/gitlab/GitLabIdentityProvider.java
@@ -90,7 +90,7 @@ public class GitLabIdentityProvider extends OIDCIdentityProvider  implements Soc
 
 
 	@Override
-	protected BrokeredIdentityContext exchangeExternalImpl(EventBuilder event, MultivaluedMap<String, String> params) {
+	protected BrokeredIdentityContext exchangeExternalTokenV1Impl(EventBuilder event, MultivaluedMap<String, String> params) {
 		return exchangeExternalUserInfoValidationOnly(event, params);
 	}
 

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.TokenExchangeProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.TokenExchangeProviderFactory
@@ -1,3 +1,3 @@
 org.keycloak.protocol.oidc.tokenexchange.V1TokenExchangeProviderFactory
 org.keycloak.protocol.oidc.tokenexchange.StandardTokenExchangeProviderFactory
-
+org.keycloak.protocol.oidc.tokenexchange.ExternalToInternalTokenExchangeProviderFactory


### PR DESCRIPTION
…th Google IDP using token-info endpoint instead of user-info endpoint

closes #40146
closes #40133

- PR introduces provider `ExternalToInternalTokenExchangeProvider` and the feature `TOKEN_EXCHANGE_EXTERNAL_INTERNAL_V2` . See https://github.com/keycloak/keycloak/issues/40146 for some reasoning for using "external internal" only for now and make it separated from "internal external" .

- Similarly like we did for "standard token exchange", we may want to develop supported "external internal" and at the same time make the token-exchange:v1 works the same as before. This means also that Identity providers may need to behave differently for V1 and V2. Due to this, I've added the method `getVersion` on the `TokenExchangeProvider` and methods like `exchangeExternalTokenV1Impl` and `exchangeExternalTokenV2Impl` on the Identity provider.

- The `exchangeExternalTokenV1Impl` works the same as before for V1 token exchange.

- The `exchangeExternalTokenV2Impl` is implemented only for Google provider now. So Google is the only provider, which works with `ExternalToInternalTokenExchangeProvider` right now. Instead of using only user-info endpoint for the verification (like V1 is doing), The V2 uses token-verification, which works with Google token-info endpoint and checks that token has expected audience. See some details in the GH issue https://github.com/keycloak/keycloak/issues/40133 and in the [google doc](https://docs.google.com/document/d/1hmUpMfvAwyRBvUhCD01IEGNjx1yIh9a8FpGCQlmrOno/edit?tab=t.0#heading=h.ptu7z1gumjz) regarding this.

Other providers (OIDC, other social providers) can hopefully be done in a follow-up PRs. Created some subtasks of https://github.com/keycloak/keycloak/issues/40132 for this.
