### PR TITLE
Icon for default role should have a separator to the role name

### DIFF
--- a/js/apps/admin-ui/src/components/roles-list/RolesList.tsx
+++ b/js/apps/admin-ui/src/components/roles-list/RolesList.tsx
@@ -43,7 +43,7 @@ const RoleDetailLink = ({
         </Link>
       ) : (
         <span>{role.name}</span>
-      )}
+      )}{" "}
       <HelpItem helpText={t("defaultRole")} fieldLabelId="defaultRole" />
     </>
   );


### PR DESCRIPTION
Closes #40191

New appearance: 

![image](https://github.com/user-attachments/assets/44d3d545-693e-490d-a117-4d15a26a96a9)


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
