### PR TITLE
Update documentation for Argon2 hash-key length to use the correct property.

### DIFF
--- a/crypto/default/src/main/java/org/keycloak/crypto/hash/Argon2PasswordHashProviderFactory.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/hash/Argon2PasswordHashProviderFactory.java
@@ -89,7 +89,7 @@ public class Argon2PasswordHashProviderFactory implements PasswordHashProviderFa
                 .add();
 
         builder.property()
-                .name(TYPE_KEY)
+                .name(HASH_LENGTH_KEY)
                 .type("int")
                 .helpText("Hash length")
                 .defaultValue(Argon2Parameters.DEFAULT_HASH_LENGTH)


### PR DESCRIPTION
Update the Argon2 documentation to use the correct property for the hash-length. 
See https://github.com/keycloak/keycloak/issues/40195