### PR TITLE
JGroups: Switch to "per-destination" bundler for jdbc-ping

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
@@ -20,6 +20,7 @@ package org.keycloak.spi.infinispan.impl.embedded;
 import java.lang.invoke.MethodHandles;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,6 +33,7 @@ import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.jboss.logging.Logger;
 import org.jgroups.conf.ClassConfigurator;
 import org.jgroups.conf.ProtocolConfiguration;
+import org.jgroups.protocols.TCP;
 import org.jgroups.protocols.TCP_NIO2;
 import org.jgroups.protocols.UDP;
 import org.jgroups.stack.Protocol;
@@ -43,6 +45,7 @@ import org.keycloak.connections.infinispan.InfinispanConnectionSpi;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
 import org.keycloak.connections.jpa.util.JpaUtils;
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.jgroups.protocol.KEYCLOAK_JDBC_PING2;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.spi.infinispan.JGroupsCertificateProvider;
@@ -193,7 +196,7 @@ public final class JGroupsConfigurator {
         var stackName = transportStackOf(holder).get();
         var isUdp = stackName.endsWith("udp");
         var tableName = JpaUtils.getTableNameForNativeQuery("JGROUPS_PING", em);
-        var stack = getProtocolConfigurations(tableName, isUdp ? "PING" : "MPING");
+        var stack = getProtocolConfigurations(tableName, isUdp);
         var connectionFactory = (JpaConnectionProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(JpaConnectionProvider.class);
         holder.addJGroupsStack(new JpaFactoryAwareJGroupsChannelConfigurator(stackName, stack, connectionFactory, isUdp), null);
 
@@ -201,22 +204,29 @@ public final class JGroupsConfigurator {
         JGroupsConfigurator.logger.info("JGroups JDBC_PING discovery enabled.");
     }
 
-    private static List<ProtocolConfiguration> getProtocolConfigurations(String tableName, String discoveryProtocol) {
-        var attributes = Map.of(
-                // Leave initialize_sql blank as table is already created by Keycloak
-                "initialize_sql", "",
-                // Explicitly specify clear and select_all SQL to ensure "cluster_name" column is used, as the default
-                // "cluster" cannot be used with Oracle DB as it's a reserved word.
-                "clear_sql", String.format("DELETE from %s WHERE cluster_name=?", tableName),
-                "delete_single_sql", String.format("DELETE from %s WHERE address=?", tableName),
-                "insert_single_sql", String.format("INSERT INTO %s values (?, ?, ?, ?, ?)", tableName),
-                "select_all_pingdata_sql", String.format("SELECT address, name, ip, coord FROM %s WHERE cluster_name=?", tableName),
-                "remove_all_data_on_view_change", "true",
-                "register_shutdown_hook", "false",
-                "stack.combine", "REPLACE",
-                "stack.position", discoveryProtocol
+    private static List<ProtocolConfiguration> getProtocolConfigurations(String tableName, boolean udp) {
+        var list = new ArrayList<ProtocolConfiguration>(udp ? 1 : 2);
+        list.add(new ProtocolConfiguration(KEYCLOAK_JDBC_PING2.class.getName(),
+              Map.of(
+                    // Leave initialize_sql blank as table is already created by Keycloak
+                    "initialize_sql", "",
+                    // Explicitly specify clear and select_all SQL to ensure "cluster_name" column is used, as the default
+                    // "cluster" cannot be used with Oracle DB as it's a reserved word.
+                    "clear_sql", String.format("DELETE from %s WHERE cluster_name=?", tableName),
+                    "delete_single_sql", String.format("DELETE from %s WHERE address=?", tableName),
+                    "insert_single_sql", String.format("INSERT INTO %s values (?, ?, ?, ?, ?)", tableName),
+                    "select_all_pingdata_sql", String.format("SELECT address, name, ip, coord FROM %s WHERE cluster_name=?", tableName),
+                    "remove_all_data_on_view_change", "true",
+                    "register_shutdown_hook", "false",
+                    "stack.combine", "REPLACE",
+                    "stack.position", udp ? "PING" : "MPING"
+              ))
         );
-        return List.of(new ProtocolConfiguration(KEYCLOAK_JDBC_PING2.class.getName(), attributes));
+
+        if (!udp && InfinispanUtils.isVirtualThreadsEnabled())
+            list.add(new ProtocolConfiguration(TCP.class.getSimpleName(), Map.of("bundler_type", "per-destination")));
+
+        return list;
     }
 
     private static void warnDeprecatedStack(ConfigurationBuilderHolder holder) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ForkJoinPool;
 import jakarta.enterprise.context.ApplicationScoped;
 import picocli.CommandLine;
 
+import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
 import io.quarkus.bootstrap.runner.RunnerClassLoader;
@@ -53,20 +54,13 @@ import io.quarkus.runtime.annotations.QuarkusMain;
 @ApplicationScoped
 public class KeycloakMain implements QuarkusApplication {
 
-    private static final String INFINISPAN_VIRTUAL_THREADS_PROP = "org.infinispan.threads.virtual";
-
-    public static final int MIN_VT_POOL_SIZE = 2;
-
     static {
-        // enable Infinispan and JGroups virtual threads by default
-        if (System.getProperty(INFINISPAN_VIRTUAL_THREADS_PROP) == null && getParallelism() >= MIN_VT_POOL_SIZE) {
-            System.setProperty(INFINISPAN_VIRTUAL_THREADS_PROP, "true");
-        }
+        InfinispanUtils.configureVirtualThreads();
     }
 
     public static void main(String[] args) {
         ensureForkJoinPoolThreadFactoryHasBeenSetToQuarkus();
-        ensureVirtualThreadsParallelism();
+        InfinispanUtils.ensureVirtualThreadsParallelism();
 
         System.setProperty("kc.version", Version.VERSION);
 
@@ -82,25 +76,6 @@ public class KeycloakMain implements QuarkusApplication {
             picocli = new Picocli();
         }
         main(args, picocli);
-    }
-
-    private static void ensureVirtualThreadsParallelism() {
-        if (Boolean.parseBoolean(System.getProperty(INFINISPAN_VIRTUAL_THREADS_PROP))) {
-            if (getParallelism() < MIN_VT_POOL_SIZE) {
-                throw new RuntimeException("To be able to use Infinispan/JGroups virtual threads, you need to set the Java system property jdk.virtualThreadScheduler.parallelism to at least " + MIN_VT_POOL_SIZE);
-            }
-        }
-    }
-
-    private static int getParallelism() {
-        int parallelism;
-        String parallelismValue = System.getProperty("jdk.virtualThreadScheduler.parallelism");
-        if (parallelismValue != null) {
-            parallelism = Integer.parseInt(parallelismValue);
-        } else {
-            parallelism = Runtime.getRuntime().availableProcessors();
-        }
-        return parallelism;
     }
 
     public static void main(String[] args, Picocli picocli) {


### PR DESCRIPTION
Closes #39545

I have manually tested that the per-destination bundler gets applied via the remote debugger. Do we have any existing tests that allows us to extract the Infinispan `DefaultCacheManager` and verify the applied settings are correct for a given user config?

I looked in `model/infinispan`, but all I could find were outdated tests which I propose we remove: https://github.com/keycloak/keycloak/issues/40203

I'm also aware of the `src/test/java/org/keycloak/it/cli/dist` tests, however AFAIK they only allow verification of logs unless a `TestProvider` implementation is specified.