### PR TITLE
Make the checkbox "Sign out from other devices" unchecked by default

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_3_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_3_0.adoc
@@ -100,11 +100,13 @@ Consider one of the following cases and recommended migration steps:
 * With the feature `persistent-user-session` feature enabled, the remote store configuration is ignored and {project_name} will print a warning.
 ====
 
+=== Signing out from other devices now disabled by default
+
+Previously, when a user updated their credentials, like changing their password or adding another factor like an OTP or Passkey, they had a checkbox *Sign out from other devices* which was checked by default. Since this release, {project_name} displays the checkbox *Sign out from other devices* not checked by default. This checkbox should now be intentionally enabled by the user to logout all the other related sessions associated to the same user.
+
 === Signing out from other devices will log out offline sessions
 
-When a user updates their credentials, like changing their password or adding another factor like an OTP or Passkey, they have a checkbox *Sign out from other devices* which is checked by default.
-
-In previous versions, this logged out only regular sessions.
+Related to the previous point, in previous versions, the *Sign out from other devices* checkbox logged out only regular sessions.
 Starting with this release, it logs out also offline sessions as this is what users would expect to happen given the current screen design.
 
 To revert to the old behavior, enable the deprecated feature `logout-all-sessions:v1`.

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
@@ -421,7 +421,7 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
         doAIA();
 
         changePasswordPage.assertCurrent();
-        assertTrue("Logout sessions is checked by default", changePasswordPage.isLogoutSessionsChecked());
+        changePasswordPage.checkLogoutSessions();
         changePasswordPage.changePassword("All Right Then, Keep Your Secrets", "All Right Then, Keep Your Secrets");
         events.expectLogout(event2.getSessionId()).detail(Details.LOGOUT_TRIGGERED_BY_REQUIRED_ACTION, UserModel.RequiredAction.UPDATE_PASSWORD.name()).assertEvent();
         events.expectRequiredAction(EventType.UPDATE_PASSWORD).assertEvent();
@@ -450,7 +450,7 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
         doAIA();
 
         changePasswordPage.assertCurrent();
-        changePasswordPage.uncheckLogoutSessions();
+        assertFalse("Logout other sessions was ticked", changePasswordPage.isLogoutSessionsChecked());
         changePasswordPage.changePassword("All Right Then, Keep Your Secrets", "All Right Then, Keep Your Secrets");
         events.expectRequiredAction(EventType.UPDATE_PASSWORD).assertEvent();
         events.expectRequiredAction(EventType.UPDATE_CREDENTIAL).detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE).assertEvent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
@@ -164,9 +164,9 @@ public class RequiredActionResetPasswordTest extends AbstractTestRealmKeycloakTe
         loginPage.login("test-user@localhost", "password");
         changePasswordPage.assertCurrent();
         assertTrue(changePasswordPage.isLogoutSessionDisplayed());
-        assertTrue(changePasswordPage.isLogoutSessionsChecked());
-        if (!logoutOtherSessions) {
-            changePasswordPage.uncheckLogoutSessions();
+        assertFalse(changePasswordPage.isLogoutSessionsChecked());
+        if (logoutOtherSessions) {
+            changePasswordPage.checkLogoutSessions();
         }
         changePasswordPage.changePassword("All Right Then, Keep Your Secrets", "All Right Then, Keep Your Secrets");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
@@ -707,8 +707,8 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
         totpPage.assertCurrent();
-        if (!logoutOtherSessions) {
-            totpPage.uncheckLogoutSessions();
+        if (logoutOtherSessions) {
+            totpPage.checkLogoutSessions();
         }
         Assert.assertEquals(logoutOtherSessions, totpPage.isLogoutSessionsChecked());
         totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTest.java
@@ -43,8 +43,8 @@ public class RequiredActionUpdateEmailTest extends AbstractRequiredActionUpdateE
 
         loginPage.login("test-user@localhost", "password");
         updateEmailPage.assertCurrent();
-        if (!logoutOtherSessions) {
-            updateEmailPage.uncheckLogoutSessions();
+        if (logoutOtherSessions) {
+            updateEmailPage.checkLogoutSessions();
         }
         Assert.assertEquals(logoutOtherSessions, updateEmailPage.isLogoutSessionsChecked());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTestWithVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTestWithVerificationTest.java
@@ -78,8 +78,8 @@ public class RequiredActionUpdateEmailTestWithVerificationTest extends AbstractR
 		loginPage.login("test-user@localhost", "password");
 
                 updateEmailPage.assertCurrent();
-                if (!logoutOtherSessions) {
-                        updateEmailPage.uncheckLogoutSessions();
+                if (logoutOtherSessions) {
+                        updateEmailPage.checkLogoutSessions();
                 }
                 Assert.assertEquals(logoutOtherSessions, updateEmailPage.isLogoutSessionsChecked());
                 updateEmailPage.changeEmail(newEmail);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
@@ -389,8 +389,8 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         testAppHelper.startLogin("otp1", "pass");
 
         configureTotpRequiredActionPage.assertCurrent();
-        if (!logoutOtherSessions) {
-            configureTotpRequiredActionPage.uncheckLogoutSessions();
+        if (logoutOtherSessions) {
+            configureTotpRequiredActionPage.checkLogoutSessions();
         }
         String totpSecret = configureTotpRequiredActionPage.getTotpSecret();
         configureTotpRequiredActionPage.configure(totp.generateTOTP(totpSecret));
@@ -417,8 +417,8 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         testAppHelper.startLogin("otp1", "pass");
 
         setupRecoveryAuthnCodesPage.assertCurrent();
-        if (!logoutOtherSessions) {
-            setupRecoveryAuthnCodesPage.uncheckLogoutSessions();
+        if (logoutOtherSessions) {
+            setupRecoveryAuthnCodesPage.checkLogoutSessions();
         }
         List<String> codes = setupRecoveryAuthnCodesPage.getRecoveryAuthnCodes();
         setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RecoveryAuthnCodesAuthenticatorTest.java
@@ -170,8 +170,8 @@ public class RecoveryAuthnCodesAuthenticatorTest extends AbstractChangeImportedU
         loginPage.open();
         loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
         setupRecoveryAuthnCodesPage.assertCurrent();
-        if (!logoutOtherSessions) {
-            setupRecoveryAuthnCodesPage.uncheckLogoutSessions();
+        if (logoutOtherSessions) {
+            setupRecoveryAuthnCodesPage.checkLogoutSessions();
         }
         Assert.assertEquals(logoutOtherSessions, setupRecoveryAuthnCodesPage.isLogoutSessionsChecked());
         setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -248,7 +248,9 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         updatePasswordPage.assertCurrent();
 
         if(userAuthenticated) {
-            updatePasswordPage.uncheckLogoutSessions();
+            assertFalse("Logout other sessions was ticked", updatePasswordPage.isLogoutSessionsChecked());
+        } else {
+            updatePasswordPage.checkLogoutSessions();
         }
 
         updatePasswordPage.changePassword("resetPassword", "resetPassword");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/AppInitiatedActionWebAuthnTest.java
@@ -207,8 +207,8 @@ public class AppInitiatedActionWebAuthnTest extends AbstractAppInitiatedActionTe
         final int credentialsCount = getCredentialCount.get();
 
         webAuthnRegisterPage.assertCurrent();
-        if (!logoutOtherSessions) {
-            webAuthnRegisterPage.uncheckLogoutSessions();
+        if (logoutOtherSessions) {
+            webAuthnRegisterPage.checkLogoutSessions();
         }
         assertThat(webAuthnRegisterPage.isLogoutSessionsChecked(), is(logoutOtherSessions));
         webAuthnRegisterPage.clickRegister();

--- a/themes/src/main/resources/theme/base/login/password-commons.ftl
+++ b/themes/src/main/resources/theme/base/login/password-commons.ftl
@@ -3,7 +3,7 @@
         <div class="${properties.kcFormOptionsWrapperClass!}">
             <div class="checkbox">
                 <label>
-                    <input type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked>
+                    <input type="checkbox" id="logout-sessions" name="logout-sessions" value="on">
                     ${msg("logoutOtherSessions")}
                 </label>
             </div>

--- a/themes/src/main/resources/theme/keycloak.v2/login/password-commons.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/password-commons.ftl
@@ -2,7 +2,7 @@
 <#macro logoutOtherSessions>
     <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
         <div class="${properties.kcFormOptionsWrapperClass!}"> 
-            <@field.checkbox name="logout-sessions" label=msg("logoutOtherSessions") value=true />
+            <@field.checkbox name="logout-sessions" label=msg("logoutOtherSessions") value=false />
         </div>
     </div>
 </#macro>


### PR DESCRIPTION
Closes #39975

Just changing the default to not checked. Tests should be tweaked to adapt to the new default. Adding a note in the upgrading guide together with the Alexander's previous note because they are related to the same `Sign out from other devices` checkbox.
