### PR TITLE
Throw a ProviderConfigPropertyNameNotUniqueException in case of a duplicate ProviderConfigProperty.

### DIFF
--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigPropertyNameNotUniqueException.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigPropertyNameNotUniqueException.java
@@ -1,0 +1,15 @@
+package org.keycloak.provider;
+
+import org.keycloak.models.ModelException;
+
+/**
+ * Exception thrown when a provider configuration property name is not unique.
+ * This is used to indicate that a property with the same name already exists
+ * in the configuration, which violates the uniqueness constraint.
+ */
+public class ProviderConfigPropertyNameNotUniqueException extends ModelException {
+
+  public ProviderConfigPropertyNameNotUniqueException(String message) {
+    super(message);
+  }
+}

--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigurationBuilder.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigurationBuilder.java
@@ -18,8 +18,10 @@
 package org.keycloak.provider;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Builds a list of ProviderConfigProperty instances.
@@ -30,6 +32,7 @@ import java.util.List;
 public class ProviderConfigurationBuilder {
 
     private List<ProviderConfigProperty> properties = new LinkedList<>();
+    private Set<String> propertyNames = new HashSet<>();
 
     private ProviderConfigurationBuilder() {
     }
@@ -43,7 +46,7 @@ public class ProviderConfigurationBuilder {
     }
 
     public ProviderConfigurationBuilder property(ProviderConfigProperty property) {
-        properties.add(property);
+        add(property);
         return this;
     }
 
@@ -51,13 +54,13 @@ public class ProviderConfigurationBuilder {
         ProviderConfigProperty property = new ProviderConfigProperty(name, label, helpText, type, defaultValue);
         property.setOptions(options);
         property.setSecret(secret);
-        properties.add(property);
+        add(property);
         return this;
     }
     public ProviderConfigurationBuilder property(String name, String label, String helpText, String type, Object defaultValue, List<String> options) {
         ProviderConfigProperty property = new ProviderConfigProperty(name, label, helpText, type, defaultValue);
         property.setOptions(options);
-        properties.add(property);
+        add(property);
         return this;
     }
 
@@ -195,10 +198,18 @@ public class ProviderConfigurationBuilder {
             property.setOptions(options);
             property.setSecret(secret);
             property.setRequired(required);
-            ProviderConfigurationBuilder.this.properties.add(property);
+            ProviderConfigurationBuilder.this.add(property);
             return ProviderConfigurationBuilder.this;
         }
 
     }
+
+  private boolean add(ProviderConfigProperty property) {
+    String name = property.getName();
+    if (!propertyNames.add(name)) {
+      throw new ProviderConfigPropertyNameNotUniqueException("ProviderConfigProperty with name '" + name + "' already exists.");
+    }
+    return properties.add(property);
+  }
 
 }

--- a/server-spi/src/test/java/org/keycloak/provider/ProviderConfigurationBuilderTest.java
+++ b/server-spi/src/test/java/org/keycloak/provider/ProviderConfigurationBuilderTest.java
@@ -1,0 +1,65 @@
+package org.keycloak.provider;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProviderConfigurationBuilderTest {
+
+  @Test
+  public void testAddProperty() {
+    ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+
+    builder.property()
+        .name("property1")
+        .label("Property 1")
+        .helpText("Help text for property 1")
+        .type("string")
+        .defaultValue("default1")
+        .add();
+
+    builder.property()
+        .name("property2")
+        .label("Property 2")
+        .helpText("Help text for property 2")
+        .type("int")
+        .defaultValue(10)
+        .add();
+
+    List<ProviderConfigProperty> properties = builder.build();
+
+    Assert.assertEquals(2, properties.size());
+    Assert.assertEquals("property1", properties.get(0).getName());
+    Assert.assertEquals("Property 1", properties.get(0).getLabel());
+    Assert.assertEquals("default1", properties.get(0).getDefaultValue());
+
+    Assert.assertEquals("property2", properties.get(1).getName());
+    Assert.assertEquals(10, properties.get(1).getDefaultValue());
+  }
+
+  @Test
+  public void testDuplicatePropertyNameThrowsException() {
+    ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+
+    builder.property()
+        .name("property1")
+        .label("Property 1")
+        .helpText("Help text for property 1")
+        .type("string")
+        .defaultValue("default1")
+        .add();
+
+    ProviderConfigPropertyNameNotUniqueException exception = Assert.assertThrows(
+        ProviderConfigPropertyNameNotUniqueException.class,
+        () -> builder.property()
+            .name("property1")
+            .label("Duplicate Property 1")
+            .helpText("Help text for duplicate property 1")
+            .type("string")
+            .defaultValue("default2")
+            .add()
+    );
+
+    Assert.assertEquals("ProviderConfigProperty with name 'property1' already exists.", exception.getMessage());
+  }
+}


### PR DESCRIPTION
See https://github.com/keycloak/keycloak/issues/40233