### PR TITLE
Fix protocol validation in client scope creation

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -116,7 +116,7 @@ public class ClientScopesResource {
     public Response createClientScope(ClientScopeRepresentation rep) {
         auth.clients().requireManageClientScopes();
         ClientScopeResource.validateClientScopeName(rep.getName());
-        ClientScopeResource.validateClientScopeProtocol(rep.getProtocol());
+        ClientScopeResource.validateClientScopeProtocol(session, rep.getProtocol());
         ClientScopeResource.validateDynamicClientScope(rep);
         try {
             ClientScopeModel clientModel = RepresentationToModel.createClientScope(session, realm, rep);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTest.java
@@ -56,6 +56,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.keycloak.tests.utils.Assert.assertNames;
 
 /**
@@ -218,9 +219,27 @@ public class ClientScopeTest extends AbstractClientScopeTest {
 
     @Test
     public void testValidateClientScopeProtocol() {
-        org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol("saml");
-        org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol("openid-connect");
-        Assertions.assertThrows(RuntimeException.class, () -> org.keycloak.services.resources.admin.ClientScopeResource.validateClientScopeProtocol("other"));
+        ClientScopeRepresentation scopeRep1 = new ClientScopeRepresentation();
+        scopeRep1.setName("scope1");
+        scopeRep1.setProtocol("saml");
+        createClientScopeWithCleanup(scopeRep1);
+
+        ClientScopeRepresentation scopeRep2 = new ClientScopeRepresentation();
+        scopeRep2.setName("scope2");
+        scopeRep2.setProtocol("openid-connect");
+        createClientScopeWithCleanup(scopeRep2);
+
+        ClientScopeRepresentation scopeRep3 = new ClientScopeRepresentation();
+        scopeRep3.setName("scope3");
+        scopeRep3.setProtocol("other");
+
+        ErrorRepresentation error;
+        try (Response response = clientScopes().create(scopeRep3)) {
+            Assertions.assertEquals(400, response.getStatus());
+            error = response.readEntity(ErrorRepresentation.class);
+        }
+
+        assertThat(error.getErrorMessage(), startsWith("Unexpected protocol: other"));
     }
 
     @Test


### PR DESCRIPTION
Currently, only `openid-connect` and `saml` are allowed as valid protocols during client scope creation. This restriction was introduced in PR https://github.com/keycloak/keycloak/pull/29544.

When the experimental Docker registry v2 authentication feature is enabled using `--features=docker`, the `docker-v2` protocol should also be accepted. Similarly, enabling OpenID for Verifiable Credential Issuance with `--features=oid4vc-vci` should allow the `oid4vc` protocol.

This PR updates the validation logic to dynamically retrieve the list of valid protocols from the registered login protocol providers. This change ensures that the appropriate protocols are allowed when the experimental features are enabled, and also makes the validation remain up-to-date for any new protocols introduced later, including those introduced by extensions.

Fixes #40245, fixes #32281, fixes #36355
