### PR TITLE
case insensitive match on organization identity provider domain

### DIFF
--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -259,10 +259,10 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             return false;
         }
 
-        // first look for an IDP that matches exactly the specified domain
+        // first look for an IDP that matches exactly the specified domain (case-insensitive)
         IdentityProviderModel idp = organization.getIdentityProviders()
                 .filter(broker -> IdentityProviderRedirectMode.EMAIL_MATCH.isSet(broker) &&
-                    domain.equals(broker.getConfig().get(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE))).findFirst().orElse(null);
+                    domain.equalsIgnoreCase(broker.getConfig().get(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE))).findFirst().orElse(null);
 
         if (idp != null) {
             // redirect the user using the broker that matches the specified domain


### PR DESCRIPTION
Closes #40253 

Currently when matching on Identity Providers for an Organization, if a user enters the domain part of their email when trying to login as anything but lowercase, the specified IDP flow is unavailable.