### PR TITLE
Add webauthn and recovery codes to the default browser flow as disabled

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -377,9 +377,30 @@ public class DefaultAuthenticationFlows {
         // otp processing
         execution = new AuthenticationExecutionModel();
         execution.setParentFlow(conditionalOTP.getId());
-        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.ALTERNATIVE);
+        if (migrate && hasCredentialType(realm, RequiredCredentialModel.TOTP.getType())) {
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
+        }
         execution.setAuthenticator("auth-otp-form");
         execution.setPriority(20);
+        execution.setAuthenticatorFlow(false);
+        realm.addAuthenticatorExecution(execution);
+
+        // webauthn as disabled
+        execution = new AuthenticationExecutionModel();
+        execution.setParentFlow(conditionalOTP.getId());
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+        execution.setAuthenticator("webauthn-authenticator");
+        execution.setPriority(30);
+        execution.setAuthenticatorFlow(false);
+        realm.addAuthenticatorExecution(execution);
+
+        // recovery-codes as disabled
+        execution = new AuthenticationExecutionModel();
+        execution.setParentFlow(conditionalOTP.getId());
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+        execution.setAuthenticator("auth-recovery-authn-code-form");
+        execution.setPriority(40);
         execution.setAuthenticatorFlow(false);
         realm.addAuthenticatorExecution(execution);
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
@@ -143,7 +143,9 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "Username Password Form", "auth-username-password-form", false, 1, 0, REQUIRED, null, new String[]{REQUIRED}, 10);
         addExecInfo(execs, "Browser - Conditional OTP", null, false, 1, 1, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
         addExecInfo(execs, "Condition - user configured", "conditional-user-configured", false, 2, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED}, 10);
-        addExecInfo(execs, "OTP Form", "auth-otp-form", false, 2, 1, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
+        addExecInfo(execs, "OTP Form", "auth-otp-form", false, 2, 1, ALTERNATIVE, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
+        addExecInfo(execs, "WebAuthn Authenticator", "webauthn-authenticator", false, 2, 2, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 30);
+        addExecInfo(execs, "Recovery Authentication Code Form", "auth-recovery-authn-code-form", false, 2, 3, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 40);
         expected.add(new FlowExecutions(flow, execs));
 
         flow = newFlow("clients", "Base authentication for clients", "client-flow", true, true);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowOTPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowOTPTest.java
@@ -20,6 +20,7 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.UserProfileResource;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticatorFactory;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.models.utils.TimeBasedOTP;
@@ -126,6 +127,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().update(realm);
 
         updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional OTP"));
+        updateRequirement("Browser - Conditional OTP", OTPFormAuthenticatorFactory.PROVIDER_ID, Requirement.REQUIRED);
         oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertTrue(loginConfigTotpPage.isCurrent());
@@ -160,6 +162,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
             testRealmResource().update(realm);
 
             updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional OTP"));
+            updateRequirement("Browser - Conditional OTP", OTPFormAuthenticatorFactory.PROVIDER_ID, Requirement.REQUIRED);
             oauth.openLoginForm();
             testRealmLoginPage.form().login(testUser);
             assertTrue(loginConfigTotpPage.isCurrent());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
@@ -66,14 +66,6 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
 
     @Before
     public void setOTPAuthRequired() {
-        adminClient.realm("test").flows().getExecutions("browser")
-                .stream()
-                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
-                .forEach(execution -> {
-                        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
-                        adminClient.realm("test").flows().updateExecutions("browser", execution);
-                });
-
         ApiUtil.removeUserByUsername(testRealm(), "test-user@localhost");
         UserRepresentation user = UserBuilder.create().enabled(true)
                 .username("test-user@localhost")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
@@ -24,8 +24,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticatorFactory;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -33,6 +35,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.utils.HmacOTP;
 import org.keycloak.models.utils.TimeBasedOTP;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
@@ -88,13 +91,20 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
         testRealm.setResetPasswordAllowed(Boolean.TRUE);
     }
 
-    private void setOTPAuthRequirement(AuthenticationExecutionModel.Requirement requirement) {
-        adminClient.realm(TEST_REALM_NAME).flows().getExecutions("browser").
-                stream().filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
-                .forEach(execution -> {
-                    execution.setRequirement(requirement.name());
-                    adminClient.realm("test").flows().updateExecutions("browser", execution);
-                });
+    private void setOTPAuthRequirement(AuthenticationExecutionModel.Requirement conditionalReq, AuthenticationExecutionModel.Requirement otpReq) {
+        AuthenticationManagementResource authMgtRes = testRealm().flows();
+        AuthenticationExecutionInfoRepresentation browserConditionalExecution = authMgtRes.getExecutions("browser").stream()
+                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
+                .findAny()
+                .get();
+        browserConditionalExecution.setRequirement(conditionalReq.name());
+        authMgtRes.updateExecutions("browser", browserConditionalExecution);
+        AuthenticationExecutionInfoRepresentation otpExecution = authMgtRes.getExecutions("Browser - Conditional OTP").stream()
+                .filter(execution -> OTPFormAuthenticatorFactory.PROVIDER_ID.equals(execution.getProviderId()))
+                .findAny()
+                .get();
+        otpExecution.setRequirement(otpReq.name());
+        authMgtRes.updateExecutions("browser", otpExecution);
     }
 
     private void configureRequiredActionsToUser(String username, String... actions) {
@@ -106,9 +116,6 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
 
     @Before
     public void setOTPAuthRequired() {
-
-        setOTPAuthRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
-
         ApiUtil.removeUserByUsername(testRealm(), "test-user@localhost");
         UserRepresentation user = UserBuilder.create().enabled(true)
                 .username("test-user@localhost")
@@ -426,107 +433,117 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
     //KEYCLOAK-15511
     @Test
     public void setupTotpEnforcedBySessionNotForUserInGeneral() {
-        String username = "test-user@localhost";
-        String configureTotp = UserModel.RequiredAction.CONFIGURE_TOTP.name();
+        setOTPAuthRequirement(AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.REQUIRED);
+        try {
+            String username = "test-user@localhost";
+            String configureTotp = UserModel.RequiredAction.CONFIGURE_TOTP.name();
 
-        // Remove required action from the user
-        UserResource user = ApiUtil.findUserByUsernameId(testRealm(), username);
-        UserRepresentation userRepresentation = user.toRepresentation();
-        userRepresentation.getRequiredActions().remove(configureTotp);
-        user.update(userRepresentation);
+            // Remove required action from the user
+            UserResource user = ApiUtil.findUserByUsernameId(testRealm(), username);
+            UserRepresentation userRepresentation = user.toRepresentation();
+            userRepresentation.getRequiredActions().remove(configureTotp);
+            user.update(userRepresentation);
 
-        // login
-        loginPage.open();
-        loginPage.login(username, "password");
+            // login
+            loginPage.open();
+            loginPage.login(username, "password");
 
-        // ensure TOTP configuration is enforced for current authentication session
-        totpPage.assertCurrent();
+            // ensure TOTP configuration is enforced for current authentication session
+            totpPage.assertCurrent();
 
-        // ensure TOTP configuration it is not enforced for the user in general
-        userRepresentation = user.toRepresentation();
-        assertFalse(userRepresentation.getRequiredActions().contains(configureTotp));
+            // ensure TOTP configuration it is not enforced for the user in general
+            userRepresentation = user.toRepresentation();
+            assertFalse(userRepresentation.getRequiredActions().contains(configureTotp));
+        } finally {
+            setOTPAuthRequirement(AuthenticationExecutionModel.Requirement.CONDITIONAL, AuthenticationExecutionModel.Requirement.ALTERNATIVE);
+        }
     }
 
     @Test
     public void setupTotpRegisteredAfterTotpRemoval() {
-        // Register new user
-        loginPage.open();
-        loginPage.clickRegister();
-        registerPage.register("firstName2", "lastName2", "email2@mail.com", "setupTotp2", "password2", "password2");
+        setOTPAuthRequirement(AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.REQUIRED);
+        try {
+            // Register new user
+            loginPage.open();
+            loginPage.clickRegister();
+            registerPage.register("firstName2", "lastName2", "email2@mail.com", "setupTotp2", "password2", "password2");
 
-        String userId = events.expectRegister("setupTotp2", "email2@mail.com").assertEvent().getUserId();
+            String userId = events.expectRegister("setupTotp2", "email2@mail.com").assertEvent().getUserId();
 
-        // Configure totp
-        totpPage.assertCurrent();
+            // Configure totp
+            totpPage.assertCurrent();
 
-        String totpCode = totpPage.getTotpSecret();
-        totpPage.configure(totp.generateTOTP(totpCode));
+            String totpCode = totpPage.getTotpSecret();
+            totpPage.configure(totp.generateTOTP(totpCode));
 
-        // After totp config, user should be on the app page
-        assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+            // After totp config, user should be on the app page
+            assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
-        events.expectRequiredAction(EventType.UPDATE_TOTP)
-                .user(userId)
-                .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
-                .detail(Details.USERNAME, "setuptotp2").assertEvent();
-        events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
-                .user(userId)
-                .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
-                .detail(Details.USERNAME, "setuptotp2").assertEvent();
+            events.expectRequiredAction(EventType.UPDATE_TOTP)
+                    .user(userId)
+                    .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
+                    .detail(Details.USERNAME, "setuptotp2").assertEvent();
+            events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
+                    .user(userId)
+                    .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
+                    .detail(Details.USERNAME, "setuptotp2").assertEvent();
 
-        EventRepresentation loginEvent = events.expectLogin().user(userId).detail(Details.USERNAME, "setuptotp2").assertEvent();
+            EventRepresentation loginEvent = events.expectLogin().user(userId).detail(Details.USERNAME, "setuptotp2").assertEvent();
 
-        // Logout
-        AccessTokenResponse tokenResponse = sendTokenRequestAndGetResponse(loginEvent);
-        oauth.logoutForm().idTokenHint(tokenResponse.getIdToken()).withRedirect().open();
-        events.expectLogout(loginEvent.getSessionId()).user(userId).assertEvent();
+            // Logout
+            AccessTokenResponse tokenResponse = sendTokenRequestAndGetResponse(loginEvent);
+            oauth.logoutForm().idTokenHint(tokenResponse.getIdToken()).withRedirect().open();
+            events.expectLogout(loginEvent.getSessionId()).user(userId).assertEvent();
 
-        setOtpTimeOffset(TimeBasedOTP.DEFAULT_INTERVAL_SECONDS, totp);
+            setOtpTimeOffset(TimeBasedOTP.DEFAULT_INTERVAL_SECONDS, totp);
 
-        // Try to login after logout
-        loginPage.open();
-        loginPage.login("setupTotp2", "password2");
+            // Try to login after logout
+            loginPage.open();
+            loginPage.login("setupTotp2", "password2");
 
-        // Totp is already configured, thus one-time password is needed, login page should be loaded
-        String uri = driver.getCurrentUrl();
-        String src = driver.getPageSource();
-        assertTrue(loginPage.isCurrent());
-        Assert.assertFalse(totpPage.isCurrent());
+            // Totp is already configured, thus one-time password is needed, login page should be loaded
+            String uri = driver.getCurrentUrl();
+            String src = driver.getPageSource();
+            assertTrue(loginPage.isCurrent());
+            Assert.assertFalse(totpPage.isCurrent());
 
-        // Login with one-time password
-        loginTotpPage.login(totp.generateTOTP(totpCode));
+            // Login with one-time password
+            loginTotpPage.login(totp.generateTOTP(totpCode));
 
-        loginEvent = events.expectLogin().user(userId).detail(Details.USERNAME, "setupTotp2").assertEvent();
+            loginEvent = events.expectLogin().user(userId).detail(Details.USERNAME, "setupTotp2").assertEvent();
 
-        // Remove google authenticator
-        Assert.assertTrue(AccountHelper.deleteTotpAuthentication(testRealm(),"setupTotp2"));
-        AccountHelper.logout(testRealm(),"setupTotp2");
+            // Remove google authenticator
+            Assert.assertTrue(AccountHelper.deleteTotpAuthentication(testRealm(), "setupTotp2"));
+            AccountHelper.logout(testRealm(), "setupTotp2");
 
-        setOtpTimeOffset(TimeBasedOTP.DEFAULT_INTERVAL_SECONDS, totp);
+            setOtpTimeOffset(TimeBasedOTP.DEFAULT_INTERVAL_SECONDS, totp);
 
-        // Try to login
-        loginPage.open();
-        loginPage.login("setupTotp2", "password2");
+            // Try to login
+            loginPage.open();
+            loginPage.login("setupTotp2", "password2");
 
-        // Since the authentificator was removed, it has to be set up again
-        totpPage.assertCurrent();
-        totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));
+            // Since the authentificator was removed, it has to be set up again
+            totpPage.assertCurrent();
+            totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));
 
-        String sessionId1 = events.expectRequiredAction(EventType.UPDATE_TOTP)
-                .user(userId)
-                .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
-                .detail(Details.USERNAME, "setupTotp2").assertEvent()
-                .getDetails().get(Details.CODE_ID);
-        String sessionId2 = events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
-                .user(userId)
-                .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
-                .detail(Details.USERNAME, "setupTotp2").assertEvent()
-                .getDetails().get(Details.CODE_ID);
+            String sessionId1 = events.expectRequiredAction(EventType.UPDATE_TOTP)
+                    .user(userId)
+                    .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
+                    .detail(Details.USERNAME, "setupTotp2").assertEvent()
+                    .getDetails().get(Details.CODE_ID);
+            String sessionId2 = events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
+                    .user(userId)
+                    .detail(Details.CREDENTIAL_TYPE, OTPCredentialModel.TYPE)
+                    .detail(Details.USERNAME, "setupTotp2").assertEvent()
+                    .getDetails().get(Details.CODE_ID);
 
-        assertEquals(sessionId1, sessionId2);
-        assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+            assertEquals(sessionId1, sessionId2);
+            assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
-        events.expectLogin().user(userId).session(sessionId1).detail(Details.USERNAME, "setupTotp2").assertEvent();
+            events.expectLogin().user(userId).session(sessionId1).detail(Details.USERNAME, "setupTotp2").assertEvent();
+        } finally {
+            setOTPAuthRequirement(AuthenticationExecutionModel.Requirement.CONDITIONAL, AuthenticationExecutionModel.Requirement.ALTERNATIVE);
+        }
     }
 
     @Test
@@ -689,8 +706,6 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
     }
 
     private void testTotpLogoutOtherSessions(boolean logoutOtherSessions) {
-        // allow login via password without OTP forced
-        setOTPAuthRequirement(AuthenticationExecutionModel.Requirement.CONDITIONAL);
         configureRequiredActionsToUser("test-user@localhost");
 
         // login with the user using the second driver

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPReadOnlyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPReadOnlyTest.java
@@ -27,7 +27,9 @@ import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
+import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticatorFactory;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.LDAPConstants;
@@ -35,6 +37,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.utils.TimeBasedOTP;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.storage.StorageId;
@@ -58,7 +61,6 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -122,7 +124,7 @@ public class LDAPReadOnlyTest extends AbstractLDAPTest  {
     @Test
     public void testReadOnlyWithTOTPEnabled() {
         // Set TOTP required
-        setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement.REQUIRED);
+        setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.REQUIRED);
 
         // Authenticate as the LDAP user and assert it works
         loginPage.open();
@@ -140,7 +142,7 @@ public class LDAPReadOnlyTest extends AbstractLDAPTest  {
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
 
         // Revert TOTP
-        setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement.CONDITIONAL);
+        setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement.CONDITIONAL, AuthenticationExecutionModel.Requirement.ALTERNATIVE);
         UserResource user = ApiUtil.findUserByUsernameId(testRealm(), "johnkeycloak");
         String totpCredentialId = user.credentials().stream()
                 .filter(credentialRep -> credentialRep.getType().equals(OTPCredentialModel.TYPE))
@@ -248,14 +250,21 @@ public class LDAPReadOnlyTest extends AbstractLDAPTest  {
         MatcherAssert.assertThat((Integer) userAttackInfo.get("numFailures"), is(numberOfFailures));
     }
 
-    private void setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement requirement) {
-        adminClient.realm("test").flows().getExecutions("browser").
-                stream().filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
-                .forEach(execution ->
-                {execution.setRequirement(requirement.name());
-                    adminClient.realm("test").flows().updateExecutions("browser", execution);});
+    private void setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement conditionalReq, AuthenticationExecutionModel.Requirement otpReq) {
+        AuthenticationManagementResource authMgtRes = testRealm().flows();
+        AuthenticationExecutionInfoRepresentation browserConditionalExecution = authMgtRes.getExecutions("browser").stream()
+                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
+                .findAny()
+                .get();
+        browserConditionalExecution.setRequirement(conditionalReq.name());
+        authMgtRes.updateExecutions("browser", browserConditionalExecution);
+        AuthenticationExecutionInfoRepresentation otpExecution = authMgtRes.getExecutions("Browser - Conditional OTP").stream()
+                .filter(execution -> OTPFormAuthenticatorFactory.PROVIDER_ID.equals(execution.getProviderId()))
+                .findAny()
+                .get();
+        otpExecution.setRequirement(otpReq.name());
+        authMgtRes.updateExecutions("browser", otpExecution);
     }
-
 
     protected void assertFederatedUserLink(UserRepresentation user) {
         Assert.assertTrue(StorageId.isLocalStorage(user.getId()));


### PR DESCRIPTION
Closes #39999

Adding webauthn and recovery codes in the conditional OTP flow as disabled. PR adds the normal webauthn (not passwordless), as I suppose the passwordless is going to be integrated using the passkeys feature and passwordless is more a primary than a 2FA (let me know if I'm wrong). I have not detected important issues except that now to force OTP as required you need to modify two things (flow from conditional to required, otp authenticator from alternative to required). I maintained the `requiredCredentials` differentiation although I think this is not used anymore.