### PR TITLE
Change to useRealm all the policies tabs

### DIFF
--- a/js/apps/admin-ui/src/authentication/policies/Policies.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/Policies.tsx
@@ -1,9 +1,6 @@
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import { useFetch } from "@keycloak/keycloak-ui-shared";
 import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useAdminClient } from "../../admin-client";
 import { KeycloakSpinner } from "@keycloak/keycloak-ui-shared";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { CibaPolicy } from "./CibaPolicy";
@@ -12,26 +9,9 @@ import { PasswordPolicy } from "./PasswordPolicy";
 import { WebauthnPolicy } from "./WebauthnPolicy";
 
 export const Policies = () => {
-  const { adminClient } = useAdminClient();
-
   const { t } = useTranslation();
   const [subTab, setSubTab] = useState(1);
-  const { realm: realmName } = useRealm();
-  const [realm, setRealm] = useState<RealmRepresentation>();
-
-  useFetch(
-    async () => {
-      const realm = await adminClient.realms.findOne({ realm: realmName });
-      if (!realm) {
-        throw new Error(t("notFound"));
-      }
-      return realm;
-    },
-    (realm) => {
-      setRealm(realm);
-    },
-    [],
-  );
+  const { realmRepresentation: realm, refresh } = useRealm();
 
   if (!realm) {
     return <KeycloakSpinner />;
@@ -50,7 +30,7 @@ export const Policies = () => {
         eventKey={1}
         title={<TabTitleText>{t("passwordPolicy")}</TabTitleText>}
       >
-        <PasswordPolicy realm={realm} realmUpdated={setRealm} />
+        <PasswordPolicy realm={realm} realmUpdated={refresh} />
       </Tab>
       <Tab
         id="otpPolicy"
@@ -58,7 +38,7 @@ export const Policies = () => {
         eventKey={2}
         title={<TabTitleText>{t("otpPolicy")}</TabTitleText>}
       >
-        <OtpPolicy realm={realm} realmUpdated={setRealm} />
+        <OtpPolicy realm={realm} realmUpdated={refresh} />
       </Tab>
       <Tab
         id="webauthnPolicy"
@@ -66,7 +46,7 @@ export const Policies = () => {
         eventKey={3}
         title={<TabTitleText>{t("webauthnPolicy")}</TabTitleText>}
       >
-        <WebauthnPolicy realm={realm} realmUpdated={setRealm} />
+        <WebauthnPolicy realm={realm} realmUpdated={refresh} />
       </Tab>
       <Tab
         id="webauthnPasswordlessPolicy"
@@ -74,14 +54,14 @@ export const Policies = () => {
         eventKey={4}
         title={<TabTitleText>{t("webauthnPasswordlessPolicy")}</TabTitleText>}
       >
-        <WebauthnPolicy realm={realm} realmUpdated={setRealm} isPasswordLess />
+        <WebauthnPolicy realm={realm} realmUpdated={refresh} isPasswordLess />
       </Tab>
       <Tab
         data-testid="tab-ciba-policy"
         eventKey={5}
         title={<TabTitleText>{t("cibaPolicy")}</TabTitleText>}
       >
-        <CibaPolicy realm={realm} realmUpdated={setRealm} />
+        <CibaPolicy realm={realm} realmUpdated={refresh} />
       </Tab>
     </Tabs>
   );


### PR DESCRIPTION
Closes #40284

Currently the policy tabs are using fetch/update over the realm. But it seems that other parts are using another `useRealm` call that saves the realm. So the realm is not updated in the `useRealm` and another part that uses it is going to revert the changes to the previous ones. I didn't think that the policy was reverted, so I spent long time to realize it was not an error in my new code.
