### PR TITLE
Make bootstrap admins temporary conditionally

### DIFF
--- a/docs/guides/server/bootstrap-admin-recovery.adoc
+++ b/docs/guides/server/bootstrap-admin-recovery.adoc
@@ -95,6 +95,13 @@ The `--no-prompt` parameter can be useful if the username or client ID should be
 
 This creates a temporary admin user with the default username without prompting for confirmation. For more information, see the <<Default values>> section above.
 
+== Treating the temporary admin account as a permanent one
+
+Both `bootstrap-admin user` and `bootstrap-admin service` commands support the `--is-temporary` parameter. This parameter allows you to treat the created admin account as a permanent one, meaning it will not be marked as temporary and will not be subject to the temporary account restrictions.
+
+A temporary admin account can also be created with the Welcome Screen that is displayed at the first start of {project_name}. In this case, the temporary account behavior is controlled by the `--bootstrap-admin-temporary` parameter. If the variable or setting is not defined, the account will be created as a temporary one.
+
+At the moment, a temporary account is reflected only in a form of visual warnings when using it, it does not actually expire the account. This might change with a future release.
 == Environment variables
 
 For the `bootstrap-admin user` command, both username and password can be optionally set as environment variables:

--- a/quarkus/config-api/src/main/java/org/keycloak/config/BootstrapAdminOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/BootstrapAdminOptions.java
@@ -5,17 +5,25 @@ public class BootstrapAdminOptions {
     public static final String DEFAULT_TEMP_ADMIN_USERNAME = "temp-admin";
     public static final String DEFAULT_TEMP_ADMIN_SERVICE = DEFAULT_TEMP_ADMIN_USERNAME;
     public static final int DEFAULT_TEMP_ADMIN_EXPIRATION = 120;
+    public static final boolean DEFAULT_TEMP_ADMIN_IS_TEMPORARY = true;
     private static final String USED_ONLY_WHEN = " Used only when the master realm is created.";
     private static final String NON_CLI = " Use a non-CLI configuration option for this option if possible.";
 
+    // Since the Configuration object is not available in the WelcomeResource, we'll just pass it through a static
+    // handler. It's definitely a suboptimal approach but the alternatives are to either put it in the Profile
+    // (which doesn't feel right) or RealmModel (which seems like too much).
+    // There have been some other attempts to handle this better (https://github.com/keycloak/keycloak/pull/39123)
+    // but they didn't get too much traction.
+    private static boolean isTemporaryRuntimeAdmin = true;
+
     public static final Option<String> PASSWORD = new OptionBuilder<>("bootstrap-admin-password", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Temporary bootstrap admin password." + USED_ONLY_WHEN + NON_CLI)
+            .description("Bootstrap admin password." + USED_ONLY_WHEN + NON_CLI)
             .build();
 
     public static final Option<String> USERNAME = new OptionBuilder<>("bootstrap-admin-username", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Temporary bootstrap admin username." + USED_ONLY_WHEN)
+            .description("Bootstrap admin username." + USED_ONLY_WHEN)
             .defaultValue(DEFAULT_TEMP_ADMIN_USERNAME)
             .build();
 
@@ -27,13 +35,28 @@ public class BootstrapAdminOptions {
 
     public static final Option<String> CLIENT_ID = new OptionBuilder<>("bootstrap-admin-client-id", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Client id for the temporary bootstrap admin service account." + USED_ONLY_WHEN)
+            .description("Client id for the bootstrap admin service account." + USED_ONLY_WHEN)
             .defaultValue(DEFAULT_TEMP_ADMIN_SERVICE)
             .build();
 
     public static final Option<String> CLIENT_SECRET = new OptionBuilder<>("bootstrap-admin-client-secret", String.class)
             .category(OptionCategory.BOOTSTRAP_ADMIN)
-            .description("Client secret for the temporary bootstrap admin service account." + USED_ONLY_WHEN + NON_CLI)
+            .description("Client secret for the bootstrap admin service account." + USED_ONLY_WHEN + NON_CLI)
             .build();
+
+    public static final Option<Boolean> IS_TEMPORARY = new OptionBuilder<>("bootstrap-admin-temporary", Boolean.class)
+            .category(OptionCategory.BOOTSTRAP_ADMIN)
+            .description("Indicates whether the admin user or service account is temporary." + USED_ONLY_WHEN)
+            .defaultValue(DEFAULT_TEMP_ADMIN_IS_TEMPORARY)
+            .build();
+
+    public static synchronized void setTemporaryRuntimeAdmin(boolean temporary) {
+        isTemporaryRuntimeAdmin = temporary;
+    }
+
+    public static synchronized boolean isTemporaryRuntimeAdmin() {
+        return isTemporaryRuntimeAdmin;
+    }
+
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminService.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminService.java
@@ -54,6 +54,9 @@ public class BootstrapAdminService extends AbstractNonServerCommand {
     @Option(paramLabel = "SECRET", names = { "--client-secret:env" }, description = "Environment variable name for the client secret")
     String clientSecretEnv;
 
+    @Option(names = { "--is-temporary" }, description = "Indicates whether this admin account is temporary, defaults to true", defaultValue = "true")
+    boolean isTemporary;
+
     String clientSecret;
     String clientId;
 
@@ -105,7 +108,7 @@ public class BootstrapAdminService extends AbstractNonServerCommand {
         //BootstrapAdmin bootstrap = spec.commandLine().getParent().getCommand();
         KeycloakSessionFactory sessionFactory = KeycloakApplication.getSessionFactory();
         KeycloakModelUtils.runJobInTransaction(sessionFactory, session -> application
-                .createTemporaryMasterRealmAdminService(clientId, clientSecret, /* bootstrap.expiration, */ session));
+                .createTemporaryMasterRealmAdminService(clientId, clientSecret, isTemporary, /* bootstrap.expiration, */ session));
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminUser.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/BootstrapAdminUser.java
@@ -54,6 +54,9 @@ public class BootstrapAdminUser extends AbstractNonServerCommand {
     @Option(paramLabel = "PASSWORD", names = { "--password:env" }, description = "Environment variable name for the admin user password")
     String passwordEnv;
 
+    @Option(names = { "--is-temporary" }, description = "Indicates whether this admin account is temporary, defaults to true", defaultValue = "true")
+    boolean isTemporary;
+
     String password;
     String username;
 
@@ -105,7 +108,7 @@ public class BootstrapAdminUser extends AbstractNonServerCommand {
         //BootstrapAdmin bootstrap = spec.commandLine().getParent().getCommand();
         KeycloakSessionFactory sessionFactory = KeycloakApplication.getSessionFactory();
         KeycloakModelUtils.runJobInTransaction(sessionFactory, session -> application
-                .createTemporaryMasterRealmAdminUser(username, password, /* bootstrap.expiration, */ session));
+                .createTemporaryMasterRealmAdminUser(username, password, isTemporary, /* bootstrap.expiration, */ session));
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
@@ -53,6 +53,8 @@ public final class BootstrapAdminPropertyMappers {
                         .paramLabel("client secret")
                         .isMasked(true)
                         .build(),
+                fromOption(BootstrapAdminOptions.IS_TEMPORARY)
+                        .build()
         };
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -63,7 +63,8 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
 
     @Override
     protected void loadConfig() {
-        // no need to load config provider because we force quarkus impl
+        var isTemporary = Boolean.parseBoolean(Configuration.getOptionalKcValue(BootstrapAdminOptions.IS_TEMPORARY.getKey()).orElse("true"));
+        BootstrapAdminOptions.setTemporaryRuntimeAdmin(isTemporary);
     }
 
     @Override
@@ -76,10 +77,10 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
 
         try {
             //Integer expiration = Configuration.getOptionalKcValue(BootstrapAdminOptions.EXPIRATION.getKey()).map(Integer::valueOf).orElse(null);
-            if (StringUtil.isNotBlank(adminPassword) && !createTemporaryMasterRealmAdminUser(adminUsername, adminPassword, /*expiration,*/ session)) {
+            if (StringUtil.isNotBlank(adminPassword) && !createTemporaryMasterRealmAdminUser(adminUsername, adminPassword, BootstrapAdminOptions.isTemporaryRuntimeAdmin(), /*expiration,*/ session)) {
                 throw new RuntimeException("Aborting startup and the creation of the master realm, because the temporary admin user account could not be created.");
             }
-            if (StringUtil.isNotBlank(clientSecret) && !createTemporaryMasterRealmAdminService(clientId, clientSecret, /*expiration,*/ session)) {
+            if (StringUtil.isNotBlank(clientSecret) && !createTemporaryMasterRealmAdminService(clientId, clientSecret, BootstrapAdminOptions.isTemporaryRuntimeAdmin(), /*expiration,*/ session)) {
                 throw new RuntimeException("Aborting startup and the creation of the master realm, because the temporary admin service account could not be created.");
             }
         } catch (NumberFormatException e) {
@@ -102,12 +103,12 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         }
     }
 
-    public boolean createTemporaryMasterRealmAdminUser(String adminUserName, String adminPassword, /*Integer adminExpiration,*/ KeycloakSession session) {
-        return new ApplianceBootstrap(session).createTemporaryMasterRealmAdminUser(adminUserName, adminPassword /*, adminExpiration*/, false);
+    public boolean createTemporaryMasterRealmAdminUser(String adminUserName, String adminPassword, boolean isTemporary, /*Integer adminExpiration,*/ KeycloakSession session) {
+        return new ApplianceBootstrap(session).createMasterRealmAdminUser(adminUserName, adminPassword, isTemporary /*, adminExpiration*/, false);
     }
 
-    public boolean createTemporaryMasterRealmAdminService(String clientId, String clientSecret, /*Integer adminExpiration,*/ KeycloakSession session) {
-        return new ApplianceBootstrap(session).createTemporaryMasterRealmAdminService(clientId, clientSecret /*, adminExpiration*/);
+    public boolean createTemporaryMasterRealmAdminService(String clientId, String clientSecret, boolean isTemporary, /*Integer adminExpiration,*/ KeycloakSession session) {
+        return new ApplianceBootstrap(session).createMasterRealmAdminService(clientId, clientSecret, isTemporary /*, adminExpiration*/);
     }
 
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BootstrapAdminDistTest.java
@@ -50,6 +50,7 @@ public class BootstrapAdminDistTest {
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }*/
 
+
     @Test
     @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD" })
     void failEnvNotSet(LaunchResult result) {
@@ -60,15 +61,16 @@ public class BootstrapAdminDistTest {
     @Test
     @WithEnvVars({"MY_PASSWORD", "admin123"})
     @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD" })
-    void createAdmin(LaunchResult result) {
+    void createTemporaryAdmin(LaunchResult result) {
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
+        assertTrue(result.getOutput().contains("Created temporary admin user with username admin"));
     }
 
     @Test
     @Launch({ "start-dev", "--bootstrap-admin-password=MY_PASSWORD" })
     void createAdminWithCliOptions(LaunchResult result) {
         assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
-        result.getOutput().contains("Created temporary admin user with username temp-admin");
+        assertTrue(result.getOutput().contains("Created temporary admin user with username temp-admin"));
     }
 
     @Test
@@ -76,6 +78,22 @@ public class BootstrapAdminDistTest {
     void failServiceAccountNoSecret(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("No client secret provided"),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
+    }
+
+    @Test
+    @WithEnvVars({"MY_SECRET", "admin123"})
+    @Launch({ "bootstrap-admin", "service", "--client-secret:env=MY_SECRET", "--is-temporary=false"})
+    void createAdminService(LaunchResult result) {
+        assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
+        assertTrue(result.getOutput().contains("Created admin service account with client id temp-admin"));
+    }
+
+    @Test
+    @WithEnvVars({"MY_PASSWORD", "admin123"})
+    @Launch({ "bootstrap-admin", "user", "--db=dev-file", "--username=admin", "--password:env=MY_PASSWORD", "--is-temporary=false" })
+    void createAdmin(LaunchResult result) {
+        assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
+        assertTrue(result.getOutput().contains("Created admin user with username admin"));
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -14,6 +14,8 @@ Options:
                      Environment variable name for the client secret
 -h, --help           This help message.
 --help-all           This same help message but with additional options.
+--is-temporary <isTemporary>
+                     Indicates whether this admin account is temporary, defaults to true
 --no-prompt          Run non-interactive without prompting
 --optimized          Use this option to achieve an optimal startup time if you have previously
                        built a server image using the 'build' command.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -10,6 +10,8 @@ Options:
 
 -h, --help           This help message.
 --help-all           This same help message but with additional options.
+--is-temporary <isTemporary>
+                     Indicates whether this admin account is temporary, defaults to true
 --no-prompt          Run non-interactive without prompting
 --optimized          Use this option to achieve an optimal startup time if you have previously
                        built a server image using the 'build' command.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -270,17 +270,20 @@ Export:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -438,17 +438,20 @@ Export:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -264,17 +264,20 @@ Import:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -432,17 +432,20 @@ Import:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -420,20 +420,23 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.
 
 Do NOT start the server using this command when deploying to production.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -664,20 +664,23 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.
 
 Do NOT start the server using this command when deploying to production.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -468,20 +468,23 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.
 
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -665,20 +665,23 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.
 
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -391,20 +391,23 @@ Truststore:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.
 
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -576,20 +576,23 @@ Truststore:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.
 
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -467,17 +467,20 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -664,17 +664,20 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -465,17 +465,20 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -662,17 +662,20 @@ Security:
 Bootstrap Admin:
 
 --bootstrap-admin-client-id <client id>
-                     Client id for the temporary bootstrap admin service account. Used only when
-                       the master realm is created. Available only when bootstrap admin client
-                       secret is set. Default: temp-admin.
+                     Client id for the bootstrap admin service account. Used only when the master
+                       realm is created. Available only when bootstrap admin client secret is set.
+                       Default: temp-admin.
 --bootstrap-admin-client-secret <client secret>
-                     Client secret for the temporary bootstrap admin service account. Used only
-                       when the master realm is created. Use a non-CLI configuration option for
-                       this option if possible.
+                     Client secret for the bootstrap admin service account. Used only when the
+                       master realm is created. Use a non-CLI configuration option for this option
+                       if possible.
 --bootstrap-admin-password <password>
-                     Temporary bootstrap admin password. Used only when the master realm is
-                       created. Use a non-CLI configuration option for this option if possible.
+                     Bootstrap admin password. Used only when the master realm is created. Use a
+                       non-CLI configuration option for this option if possible.
+--bootstrap-admin-temporary <true|false>
+                     Indicates whether the admin user or service account is temporary. Used only
+                       when the master realm is created. Use a non-CLI configuration option for
+                       this option if possible. Default: true.
 --bootstrap-admin-username <username>
-                     Temporary bootstrap admin username. Used only when the master realm is
-                       created. Available only when bootstrap admin password is set. Default:
-                       temp-admin.
+                     Bootstrap admin username. Used only when the master realm is created.
+                       Available only when bootstrap admin password is set. Default: temp-admin.

--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -469,4 +469,12 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=110, value="Environment variable '%s' is deprecated, use '%s' instead")
     void usingDeprecatedEnvironmentVariable(String deprecated, String supported);
 
+    @LogMessage(level = INFO)
+    @Message(id=111, value="Created admin user with username %s")
+    void createdAdminUser(String userName);
+
+    @LogMessage(level = INFO)
+    @Message(id=112, value="Created admin service account with client id %s")
+    void createdAdminService(String clientId);
+
 }

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -97,6 +97,7 @@ public class ApplianceBootstrap {
         realm.setRegistrationAllowed(false);
         realm.setRegistrationEmailAsUsername(false);
 
+
         session.getContext().setRealm(realm);
         DefaultKeyProviders.createProviders(realm);
 
@@ -121,7 +122,7 @@ public class ApplianceBootstrap {
      * @param initialUser if true only create the user if no other users exist
      * @return false if the user could not be created
      */
-    public boolean createTemporaryMasterRealmAdminUser(String username, String password, /*Integer expriationMinutes,*/ boolean initialUser) {
+    public boolean createMasterRealmAdminUser(String username, String password, boolean isTemporary, /*Integer expriationMinutes,*/ boolean initialUser) {
         RealmModel realm = session.realms().getRealmByName(Config.getAdminRealm());
         session.getContext().setRealm(realm);
 
@@ -136,8 +137,10 @@ public class ApplianceBootstrap {
         try {
             UserModel adminUser = session.users().addUser(realm, username);
             adminUser.setEnabled(true);
-            adminUser.setSingleAttribute(IS_TEMP_ADMIN_ATTR_NAME, Boolean.TRUE.toString());
-            // also set the expiration - could be relative to a creation timestamp, or computed
+            if (isTemporary) {
+                adminUser.setSingleAttribute(IS_TEMP_ADMIN_ATTR_NAME, Boolean.TRUE.toString());
+                // also set the expiration - could be relative to a creation timestamp, or computed
+            }
 
             UserCredentialModel usrCredModel = UserCredentialModel.password(password);
             adminUser.credentialManager().updateCredential(usrCredModel);
@@ -145,7 +148,10 @@ public class ApplianceBootstrap {
             RoleModel adminRole = realm.getRole(AdminRoles.ADMIN);
             adminUser.grantRole(adminRole);
 
-            ServicesLogger.LOGGER.createdTemporaryAdminUser(username);
+            if (isTemporary)
+                ServicesLogger.LOGGER.createdTemporaryAdminUser(username);
+            else
+                ServicesLogger.LOGGER.createdAdminUser(username);
         } catch (ModelDuplicateException e) {
             ServicesLogger.LOGGER.addUserFailedUserExists(username, Config.getAdminRealm());
             return false;
@@ -155,11 +161,13 @@ public class ApplianceBootstrap {
 
     /**
      * Create a temporary admin service account
-     * @param clientId the client ID
+     *
+     * @param clientId     the client ID
      * @param clientSecret the client secret
+     * @param isTemporary
      * @return false if the service account could not be created
      */
-    public boolean createTemporaryMasterRealmAdminService(String clientId, String clientSecret /*, Integer expriationMinutes*/) {
+    public boolean createMasterRealmAdminService(String clientId, String clientSecret, boolean isTemporary/*, Integer expriationMinutes*/) {
         RealmModel realm = session.realms().getRealmByName(Config.getAdminRealm());
         session.getContext().setRealm(realm);
 
@@ -183,10 +191,15 @@ public class ApplianceBootstrap {
             serviceAccount.grantRole(adminRole);
 
             adminClientModel.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, Boolean.TRUE.toString());
-            adminClientModel.setAttribute(IS_TEMP_ADMIN_ATTR_NAME, Boolean.TRUE.toString());
-            // also set the expiration - could be relative to a creation timestamp, or computed
+            if (isTemporary) {
+                adminClientModel.setAttribute(IS_TEMP_ADMIN_ATTR_NAME, Boolean.TRUE.toString());
+                // also set the expiration - could be relative to a creation timestamp, or computed
+            }
 
-            ServicesLogger.LOGGER.createdTemporaryAdminService(clientId);
+            if (isTemporary)
+                ServicesLogger.LOGGER.createdTemporaryAdminService(clientId);
+            else
+                ServicesLogger.LOGGER.createdAdminService(clientId);
         } catch (ModelDuplicateException e) {
             ServicesLogger.LOGGER.addClientFailedClientExists(clientId, Config.getAdminRealm());
             return false;
@@ -194,8 +207,8 @@ public class ApplianceBootstrap {
         return true;
     }
 
-    public void createMasterRealmUser(String username, String password) {
-        createTemporaryMasterRealmAdminUser(username, password, true);
+    public void createMasterRealmUser(String username, String password, boolean isTemporary) {
+        createMasterRealmAdminUser(username, password, isTemporary, true);
     }
 
 }

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/KeycloakOnUndertow.java
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/KeycloakOnUndertow.java
@@ -226,7 +226,7 @@ public class KeycloakOnUndertow implements DeployableContainer<KeycloakOnUnderto
         try (KeycloakSession session = sessionFactory.create()) {
             session.getTransactionManager().begin();
             if (new ApplianceBootstrap(session).isNoMasterUser()) {
-                new ApplianceBootstrap(session).createMasterRealmUser("admin", "admin");
+                new ApplianceBootstrap(session).createMasterRealmUser("admin", "admin", true);
             }
         }
     }

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
@@ -397,7 +397,7 @@ public class KeycloakServer {
             try (KeycloakSession session = sessionFactory.create()) {
                 session.getTransactionManager().begin();
                 if (new ApplianceBootstrap(session).isNoMasterUser()) {
-                    new ApplianceBootstrap(session).createMasterRealmUser("admin", "admin");
+                    new ApplianceBootstrap(session).createMasterRealmUser("admin", "admin", true);
                     log.info("Created master user with credentials admin:admin");
                 }
             }

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -50,13 +50,26 @@
           <main class="pf-v5-c-login__main">
             <header class="pf-v5-c-login__main-header">
               <#if localUser>
+                <#if isTemporaryAdmin == true>
                 <h1 class="pf-v5-c-title pf-m-2xl">Create a temporary administrative user</h1>
+                <#else>
+                  <h1 class="pf-v5-c-title pf-m-2xl">Create an administrative user</h1>
+                </#if>
                 <#if !successMessage?has_content>
+                  <#if isTemporaryAdmin == true>
                   <p class="pf-v5-c-login__main-header-desc">To get started with ${productName}, you first create a temporary administrative user.  Later, to harden security, create a new permanent administrative user and delete the temporary user that was created during this setup.</p>
+                  <#else>
+                    <p class="pf-v5-c-login__main-header-desc">To get started with ${productName}, you first create an administrative user.</p>
+                  </#if>
                 </#if>
               <#else>
+                <#if isTemporaryAdmin == true>
                 <h1 class="pf-v5-c-title pf-m-3xl">Local access required</h1>
                 <p class="pf-v5-c-login__main-header-desc">You will need local access to create the temporary administrative user.</p>
+                <#else>
+                  <h1 class="pf-v5-c-title pf-m-3xl">Local access required</h1>
+                  <p class="pf-v5-c-login__main-header-desc">You will need local access to create the administrative user.</p>
+                </#if>
               </#if>
             </header>
             <div class="pf-v5-c-login__main-body">
@@ -132,7 +145,11 @@
                     </div>
                   </form>
                 <#else>
+                  <#if isTemporaryAdmin == true>
                   <p>To create the temporary administrative user, access the Administration Console over localhost, or use a <code>bootstrap-admin</code> command.</p>
+                  <#else>
+                    <p>To create the administrative user, access the Administration Console over localhost, or use a <code>bootstrap-admin</code> command.</p>
+                  </#if>
                 </#if>
               </#if>
             </div>


### PR DESCRIPTION
This Pull Request introduces a flag to make the Bootstrap Admin temporary or permanent. 

Closes #40305
