### PR TITLE
Rename "Browser - Conditional OTP" to "Browser - Conditional 2FA" in default browser flow

### DIFF
--- a/js/apps/admin-ui/test/autentication/flows.spec.ts
+++ b/js/apps/admin-ui/test/autentication/flows.spec.ts
@@ -111,7 +111,7 @@ test.describe("Authentication test", () => {
 
       await addCondition(
         page,
-        flowName + " Browser - Conditional OTP",
+        flowName + " Browser - Conditional 2FA",
         "conditional-user-role",
       );
 
@@ -122,7 +122,7 @@ test.describe("Authentication test", () => {
       await clickTableRowItem(page, flowName);
 
       const name = "SubFlow";
-      await addSubFlow(page, flowName + " Browser - Conditional OTP", name);
+      await addSubFlow(page, flowName + " Browser - Conditional 2FA", name);
 
       await assertNotificationMessage(page, "Flow successfully updated");
       await assertRowExists(page, name);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -351,8 +351,8 @@ public class DefaultAuthenticationFlows {
         AuthenticationFlowModel conditionalOTP = new AuthenticationFlowModel();
         conditionalOTP.setTopLevel(false);
         conditionalOTP.setBuiltIn(true);
-        conditionalOTP.setAlias("Browser - Conditional OTP");
-        conditionalOTP.setDescription("Flow to determine if the OTP is required for the authentication");
+        conditionalOTP.setAlias("Browser - Conditional 2FA");
+        conditionalOTP.setDescription("Flow to determine if any 2FA is required for the authentication");
         conditionalOTP.setProviderId("basic-flow");
         conditionalOTP = realm.addAuthenticationFlow(conditionalOTP);
         execution = new AuthenticationExecutionModel();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
@@ -141,7 +141,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "Organization Identity-First Login", "organization", true, 2, 1, ALTERNATIVE, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
         addExecInfo(execs, "forms", null, false, 0, 4, ALTERNATIVE, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 30);
         addExecInfo(execs, "Username Password Form", "auth-username-password-form", false, 1, 0, REQUIRED, null, new String[]{REQUIRED}, 10);
-        addExecInfo(execs, "Browser - Conditional OTP", null, false, 1, 1, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
+        addExecInfo(execs, "Browser - Conditional 2FA", null, false, 1, 1, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
         addExecInfo(execs, "Condition - user configured", "conditional-user-configured", false, 2, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED}, 10);
         addExecInfo(execs, "OTP Form", "auth-otp-form", false, 2, 1, ALTERNATIVE, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
         addExecInfo(execs, "WebAuthn Authenticator", "webauthn-authenticator", false, 2, 2, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 30);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -912,7 +912,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
 
         // Disable parent subflow - that should treat OTP execution as disabled too
         AuthenticationExecutionModel.Requirement currentBrowserReq = setExecutionRequirement(DefaultAuthenticationFlows.BROWSER_FLOW,
-                "Browser - Conditional OTP", AuthenticationExecutionModel.Requirement.DISABLED);
+                "Browser - Conditional 2FA", AuthenticationExecutionModel.Requirement.DISABLED);
 
         // Disable OTP directly in first-broker-login and direct-grant
         AuthenticationExecutionModel.Requirement currentFBLReq = setExecutionRequirement(DefaultAuthenticationFlows.FIRST_BROKER_LOGIN_FLOW,
@@ -928,14 +928,14 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
 
             // Enable browser subflow. OTP should be available then
             setExecutionRequirement(DefaultAuthenticationFlows.BROWSER_FLOW,
-                    "Browser - Conditional OTP", currentBrowserReq);
+                    "Browser - Conditional 2FA", currentBrowserReq);
             credentials = getCredentials();
             Assert.assertEquals(2, credentials.size());
             Assert.assertEquals(OTPCredentialModel.TYPE, credentials.get(1).getType());
 
             // Disable browser subflow and enable FirstBrokerLogin. OTP should be available then
             setExecutionRequirement(DefaultAuthenticationFlows.BROWSER_FLOW,
-                    "Browser - Conditional OTP", AuthenticationExecutionModel.Requirement.DISABLED);
+                    "Browser - Conditional 2FA", AuthenticationExecutionModel.Requirement.DISABLED);
             setExecutionRequirement(DefaultAuthenticationFlows.FIRST_BROKER_LOGIN_FLOW,
                     "OTP Form", currentFBLReq);
             credentials = getCredentials();
@@ -944,7 +944,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         } finally {
             // Revert flows
             setExecutionRequirement(DefaultAuthenticationFlows.BROWSER_FLOW,
-                    "Browser - Conditional OTP", currentBrowserReq);
+                    "Browser - Conditional 2FA", currentBrowserReq);
             setExecutionRequirement(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW,
                     "Direct Grant - Conditional OTP", currentDirectGrantReq);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowOTPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowOTPTest.java
@@ -126,8 +126,8 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         realm.setBrowserFlow("browser");
         testRealmResource().update(realm);
 
-        updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional OTP"));
-        updateRequirement("Browser - Conditional OTP", OTPFormAuthenticatorFactory.PROVIDER_ID, Requirement.REQUIRED);
+        updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional 2FA"));
+        updateRequirement("Browser - Conditional 2FA", OTPFormAuthenticatorFactory.PROVIDER_ID, Requirement.REQUIRED);
         oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertTrue(loginConfigTotpPage.isCurrent());
@@ -161,8 +161,8 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
             realm.setBrowserFlow("browser");
             testRealmResource().update(realm);
 
-            updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional OTP"));
-            updateRequirement("Browser - Conditional OTP", OTPFormAuthenticatorFactory.PROVIDER_ID, Requirement.REQUIRED);
+            updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional 2FA"));
+            updateRequirement("Browser - Conditional 2FA", OTPFormAuthenticatorFactory.PROVIDER_ID, Requirement.REQUIRED);
             oauth.openLoginForm();
             testRealmLoginPage.form().login(testUser);
             assertTrue(loginConfigTotpPage.isCurrent());
@@ -565,7 +565,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         data.put("provider", provider);
         getAuthMgmtResource().addExecution(flowAlias, data);
         
-        //set Conditional OTP requirement to required
+        //set Conditional 2FA requirement to required
         updateRequirement(flowAlias, provider, Requirement.REQUIRED);
         
         //update realm browser flow

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
@@ -125,7 +125,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         try {
             // Emulate former (pre KEYCLOAK-11745 change) OPTIONAL requirement by:
             // * Disabling the CONFIGURE_TOTP required action on realm
-            // * Marking "Browser - Conditional OTP" authenticator as CONDITIONAL
+            // * Marking "Browser - Conditional 2FA" authenticator as CONDITIONAL
             // * Marking "Condition - user configured" authenticator as DISABLED, and
             // * Marking "OTP Form" authenticator as ALTERNATIVE
             preConfigureRealmForCancelSetupTotpTest();
@@ -145,7 +145,7 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         // Disable CONFIGURE_TOTP required action
         configureRealmEnableRequiredActionByAlias("CONFIGURE_TOTP", false);
         // Set "Browser - Conditional OTP" execution requirement to CONDITIONAL
-        configureRealmSetExecutionRequirementByDisplayName("browser", "Browser - Conditional OTP", AuthenticationExecutionModel.Requirement.CONDITIONAL);
+        configureRealmSetExecutionRequirementByDisplayName("browser", "Browser - Conditional 2FA", AuthenticationExecutionModel.Requirement.CONDITIONAL);
         // Set "Condition - user configured" execution requirement to DISABLED
         configureRealmSetExecutionRequirementByDisplayName("browser", "Condition - user configured", AuthenticationExecutionModel.Requirement.DISABLED);
         // Set "OTP Form" execution requirement to ALTERNATIVE
@@ -157,9 +157,9 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
         // Enable CONFIGURE_TOTP required action back (the default)
         configureRealmEnableRequiredActionByAlias("CONFIGURE_TOTP", true);
 
-        // Set requirement of "Browser - Conditional OTP", "Condition - user configured",
+        // Set requirement of "Browser - Conditional 2FA", "Condition - user configured",
         // and "OTP Form" browser flow executions back to REQUIRED (the default)
-        List<String> executionDisplayNames = Arrays.asList("Browser - Conditional OTP", "Condition - user configured", "OTP Form");
+        List<String> executionDisplayNames = Arrays.asList("Browser - Conditional 2FA", "Condition - user configured", "OTP Form");
         executionDisplayNames.stream().forEach(name -> configureRealmSetExecutionRequirementByDisplayName("browser", name, AuthenticationExecutionModel.Requirement.REQUIRED));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
@@ -94,12 +94,12 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
     private void setOTPAuthRequirement(AuthenticationExecutionModel.Requirement conditionalReq, AuthenticationExecutionModel.Requirement otpReq) {
         AuthenticationManagementResource authMgtRes = testRealm().flows();
         AuthenticationExecutionInfoRepresentation browserConditionalExecution = authMgtRes.getExecutions("browser").stream()
-                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
+                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional 2FA"))
                 .findAny()
                 .get();
         browserConditionalExecution.setRequirement(conditionalReq.name());
         authMgtRes.updateExecutions("browser", browserConditionalExecution);
-        AuthenticationExecutionInfoRepresentation otpExecution = authMgtRes.getExecutions("Browser - Conditional OTP").stream()
+        AuthenticationExecutionInfoRepresentation otpExecution = authMgtRes.getExecutions("Browser - Conditional 2FA").stream()
                 .filter(execution -> OTPFormAuthenticatorFactory.PROVIDER_ID.equals(execution.getProviderId()))
                 .findAny()
                 .get();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPReadOnlyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPReadOnlyTest.java
@@ -253,12 +253,12 @@ public class LDAPReadOnlyTest extends AbstractLDAPTest  {
     private void setTotpRequirementExecutionForRealm(AuthenticationExecutionModel.Requirement conditionalReq, AuthenticationExecutionModel.Requirement otpReq) {
         AuthenticationManagementResource authMgtRes = testRealm().flows();
         AuthenticationExecutionInfoRepresentation browserConditionalExecution = authMgtRes.getExecutions("browser").stream()
-                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional OTP"))
+                .filter(execution -> execution.getDisplayName().equals("Browser - Conditional 2FA"))
                 .findAny()
                 .get();
         browserConditionalExecution.setRequirement(conditionalReq.name());
         authMgtRes.updateExecutions("browser", browserConditionalExecution);
-        AuthenticationExecutionInfoRepresentation otpExecution = authMgtRes.getExecutions("Browser - Conditional OTP").stream()
+        AuthenticationExecutionInfoRepresentation otpExecution = authMgtRes.getExecutions("Browser - Conditional 2FA").stream()
                 .filter(execution -> OTPFormAuthenticatorFactory.PROVIDER_ID.equals(execution.getProviderId()))
                 .findAny()
                 .get();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/login/ConditionalSubFlowExecutedAuthenticatorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/login/ConditionalSubFlowExecutedAuthenticatorTest.java
@@ -75,7 +75,7 @@ public class ConditionalSubFlowExecutedAuthenticatorTest extends AbstractTestRea
 
     @Test
     public void testWithoutOtpConfiguredExecuted() {
-        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional OTP", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_EXECUTED);
+        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional 2FA", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_EXECUTED);
 
         oauth.doLogin("test-user@localhost", "password");
 
@@ -85,7 +85,7 @@ public class ConditionalSubFlowExecutedAuthenticatorTest extends AbstractTestRea
 
     @Test
     public void testWithoutOtpConfiguredNotExecuted() {
-        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional OTP", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_NOT_EXECUTED);
+        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional 2FA", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_NOT_EXECUTED);
 
         oauth.doLogin("test-user@localhost", "password");
 
@@ -95,7 +95,7 @@ public class ConditionalSubFlowExecutedAuthenticatorTest extends AbstractTestRea
 
     @Test
     public void testWithOtpConfiguredExecuted() {
-        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional OTP", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_EXECUTED);
+        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional 2FA", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_EXECUTED);
 
         oauth.doLogin("user-with-one-configured-otp", "password");
 
@@ -108,7 +108,7 @@ public class ConditionalSubFlowExecutedAuthenticatorTest extends AbstractTestRea
 
     @Test
     public void testWithOtpConfiguredNotExecuted() {
-        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional OTP", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_NOT_EXECUTED);
+        configureConditionalSubFlowExecutedAuthenticatorInFlow("test Browser - Conditional 2FA", ConditionalSubFlowExecutedAuthenticatorFactory.CHECK_RESULT_NOT_EXECUTED);
 
         oauth.doLogin("user-with-two-configured-otp", "password");
 


### PR DESCRIPTION
Closes #40281

Just renaming the name of the conditional flow. Fixed the tests that are failing after that. This change needs to be then referenced in the documentation because the name appears several times is docs too. Just a reminder for the documentation issue.