### PR TITLE
Added WebAuthn and recovery codes as disabled in the First Broker Login Flow

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -659,9 +659,30 @@ public class DefaultAuthenticationFlows {
 
         execution = new AuthenticationExecutionModel();
         execution.setParentFlow(conditionalOTP.getId());
-        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.ALTERNATIVE);
+        if (migrate && hasCredentialType(realm, RequiredCredentialModel.TOTP.getType())) {
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
+        }
         execution.setAuthenticator("auth-otp-form");
         execution.setPriority(20);
+        execution.setAuthenticatorFlow(false);
+        realm.addAuthenticatorExecution(execution);
+
+        // webauthn as disabled
+        execution = new AuthenticationExecutionModel();
+        execution.setParentFlow(conditionalOTP.getId());
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+        execution.setAuthenticator("webauthn-authenticator");
+        execution.setPriority(30);
+        execution.setAuthenticatorFlow(false);
+        realm.addAuthenticatorExecution(execution);
+
+        // recovery-codes as disabled
+        execution = new AuthenticationExecutionModel();
+        execution.setParentFlow(conditionalOTP.getId());
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+        execution.setAuthenticator("auth-recovery-authn-code-form");
+        execution.setPriority(40);
         execution.setAuthenticatorFlow(false);
         realm.addAuthenticatorExecution(execution);
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -618,8 +618,8 @@ public class DefaultAuthenticationFlows {
         AuthenticationFlowModel conditionalOTP = new AuthenticationFlowModel();
         conditionalOTP.setTopLevel(false);
         conditionalOTP.setBuiltIn(true);
-        conditionalOTP.setAlias("First broker login - Conditional OTP");
-        conditionalOTP.setDescription("Flow to determine if the OTP is required for the authentication");
+        conditionalOTP.setAlias("First broker login - Conditional 2FA");
+        conditionalOTP.setDescription("Flow to determine if any 2FA is required for the authentication");
         conditionalOTP.setProviderId("basic-flow");
         conditionalOTP = realm.addAuthenticationFlow(conditionalOTP);
         execution = new AuthenticationExecutionModel();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
@@ -197,7 +197,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "Verify existing account by Email", "idp-email-verification", false, 3, 0, ALTERNATIVE, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 10);
         addExecInfo(execs, "Verify Existing Account by Re-authentication", null, false, 3, 1, ALTERNATIVE, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
         addExecInfo(execs, "Username Password Form for identity provider reauthentication", "idp-username-password-form", false, 4, 0, REQUIRED, null, new String[]{REQUIRED}, 10);
-        addExecInfo(execs, "First broker login - Conditional OTP", null, false, 4, 1, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
+        addExecInfo(execs, "First broker login - Conditional 2FA", null, false, 4, 1, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
         addExecInfo(execs, "Condition - user configured", "conditional-user-configured", false, 5, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED}, 10);
         addExecInfo(execs, "OTP Form", "auth-otp-form", false, 5, 1, ALTERNATIVE, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
         addExecInfo(execs, "WebAuthn Authenticator", "webauthn-authenticator", false, 5, 2, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 30);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
@@ -199,7 +199,9 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "Username Password Form for identity provider reauthentication", "idp-username-password-form", false, 4, 0, REQUIRED, null, new String[]{REQUIRED}, 10);
         addExecInfo(execs, "First broker login - Conditional OTP", null, false, 4, 1, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 20);
         addExecInfo(execs, "Condition - user configured", "conditional-user-configured", false, 5, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED}, 10);
-        addExecInfo(execs, "OTP Form", "auth-otp-form", false, 5, 1, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
+        addExecInfo(execs, "OTP Form", "auth-otp-form", false, 5, 1, ALTERNATIVE, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
+        addExecInfo(execs, "WebAuthn Authenticator", "webauthn-authenticator", false, 5, 2, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 30);
+        addExecInfo(execs, "Recovery Authentication Code Form", "auth-recovery-authn-code-form", false, 5, 3, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 40);
         addExecInfo(execs, "First Broker Login - Conditional Organization", null, false, 0, 2, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 50);
         addExecInfo(execs, "Condition - user configured", "conditional-user-configured", false, 1, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED}, 10);
         addExecInfo(execs, "Organization Member Onboard", "idp-add-organization-member", false, 1, 1, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
@@ -345,8 +345,10 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
         testAccountConsoleClient(masterRealm);
         testAccountConsoleClient(migrationRealm);
         testAlwaysDisplayInConsole();
-        testFirstBrokerLoginFlowMigrated(masterRealm);
-        testFirstBrokerLoginFlowMigrated(migrationRealm);
+
+        // master realm is not imported from json
+        testFirstBrokerLoginFlowMigrated(masterRealm, false);
+        testFirstBrokerLoginFlowMigrated(migrationRealm, true);
         testAccountClient(masterRealm);
         testAccountClient(migrationRealm);
         testAdminClientPkce(masterRealm);
@@ -558,7 +560,7 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
         assertEquals("oidc-audience-resolve-mapper", mappers.get(0).getProtocolMapper());
     }
 
-    private void testFirstBrokerLoginFlowMigrated(RealmResource realm) {
+    private void testFirstBrokerLoginFlowMigrated(RealmResource realm, boolean imported) {
         log.infof("Test that firstBrokerLogin flow was migrated in new realm '%s'", realm.toRepresentation().getRealm());
 
         List<AuthenticationExecutionInfoRepresentation> authExecutions = realm.flows().getExecutions(DefaultAuthenticationFlows.FIRST_BROKER_LOGIN_FLOW);
@@ -597,8 +599,9 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
         testAuthenticationExecution(authExecutions.get(10), null,
                 ConditionalUserConfiguredAuthenticatorFactory.PROVIDER_ID, AuthenticationExecutionModel.Requirement.REQUIRED, 5, 0);
 
+        AuthenticationExecutionModel.Requirement requirement = imported ? AuthenticationExecutionModel.Requirement.REQUIRED : AuthenticationExecutionModel.Requirement.ALTERNATIVE;
         testAuthenticationExecution(authExecutions.get(11), null,
-                OTPFormAuthenticatorFactory.PROVIDER_ID, AuthenticationExecutionModel.Requirement.REQUIRED, 5, 1);
+                OTPFormAuthenticatorFactory.PROVIDER_ID, requirement, 5, 1);
     }
 
 


### PR DESCRIPTION
Closes #40000 

As with the browser flow, added WebAuthn and recovery codes as disabled in the First Broker Login Flow, changed the OTP Form to Alternative, and renamed the subflow from "First broker login - Conditional OTP" to "First broker login - Conditional 2FA".