### PR TITLE
fix: switching to the registry addon for olm testing

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -143,7 +143,7 @@ jobs:
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
-          start args: --memory=${{ env.MINIKUBE_MEMORY }}
+          start args: --memory=${{ env.MINIKUBE_MEMORY }} --addons=registry --insecure-registry=192.168.49.2:5000
 
       - name: Install OPM
         uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
@@ -169,7 +169,7 @@ jobs:
         working-directory: operator
         run: |
           eval $(minikube -p minikube docker-env)
-          ./scripts/olm-testing.sh ${GITHUB_SHA::6}
+          REGISTRY=192.168.49.2:5000 ./scripts/olm-testing.sh ${GITHUB_SHA::6}
 
       - name: Deploy an example Keycloak and wait for it to be ready
         working-directory: operator

--- a/operator/scripts/create-olm-test-catalog.sh
+++ b/operator/scripts/create-olm-test-catalog.sh
@@ -19,7 +19,7 @@ mkdir -p $SCRIPT_DIR/../olm/catalog/test-catalog
     --output yaml > test-catalog/operator.yaml
 
   opm render $BUNDLE_IMAGE:$VERSION \
-    --output=yaml >> test-catalog/operator.yaml
+    --output=yaml --skip-tls >> test-catalog/operator.yaml
 
   cat << EOF >> test-catalog/operator.yaml
 ---

--- a/operator/scripts/olm-testing.sh
+++ b/operator/scripts/olm-testing.sh
@@ -10,14 +10,15 @@ TARGET_NAMESPACES=${3-$INSTALL_NAMESPACE}
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # This version translates to one day for ttl.sh
+REGISTRY=${REGISTRY:-ttl.sh}
 VERSION="86400000.0.0"
 
 # Build Keycloak Docker image (the keycloak tar.gz should already be in the container folder)
 (
   cd $SCRIPT_DIR/../../quarkus/container
   
-  docker build --build-arg KEYCLOAK_DIST=$(ls keycloak-*.tar.gz) . -t "ttl.sh/${UUID}keycloak:${VERSION}"
-  docker push "ttl.sh/${UUID}keycloak:${VERSION}"
+  docker build --build-arg KEYCLOAK_DIST=$(ls keycloak-*.tar.gz) . -t "$REGISTRY/${UUID}keycloak:${VERSION}"
+  docker push "$REGISTRY/${UUID}keycloak:${VERSION}"
 )
 
 # Build the operator Docker image
@@ -25,13 +26,13 @@ VERSION="86400000.0.0"
   cd $SCRIPT_DIR/../../
   ./mvnw clean package -Poperator -pl :keycloak-operator -am \
     -Dquarkus.container-image.build=true \
-    -Dquarkus.container-image.image="ttl.sh/${UUID}keycloak-operator:${VERSION}" \
-    -Dkc.operator.keycloak.image="ttl.sh/${UUID}keycloak:${VERSION}" \
+    -Dquarkus.container-image.image="$REGISTRY/${UUID}keycloak-operator:${VERSION}" \
+    -Dkc.operator.keycloak.image="$REGISTRY/${UUID}keycloak:${VERSION}" \
     -DskipTests
   # JIB patching on images doesn't work reliably with ttl.sh
-  docker push "ttl.sh/${UUID}keycloak-operator:${VERSION}"
+  docker push "$REGISTRY/${UUID}keycloak-operator:${VERSION}"
 )
 
-$SCRIPT_DIR/prepare-olm-test.sh ttl.sh ${VERSION} NONE ${UUID} $TARGET_NAMESPACES
+$SCRIPT_DIR/prepare-olm-test.sh $REGISTRY ${VERSION} NONE ${UUID} $TARGET_NAMESPACES
 
 $SCRIPT_DIR/install-keycloak-operator.sh $INSTALL_NAMESPACE


### PR DESCRIPTION
Just relying upon the docker daemon is not possible - while you can workaround several opm / olm issues, you can't install the CatalogSource with an imagepullpolicy of IfNotPresent unless you have an image digest - and those are only created by a registry.

So the approach here is to use the registry addon. However I do see that it doesn't always work as expected with minikube (1.32.0 seems fine, but locally minikube 1.35.0 won't start with registry addon enabled). Hopefully we can stick to minikube / kubernetes combinations where all is good, but if not we'll then have to deploy or run an external registry, which has a couple of extra steps.

closes: #40099

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
