### PR TITLE
Use direct path in windows for cache (link is problematic)

### DIFF
--- a/.github/actions/node-cache/action.yml
+++ b/.github/actions/node-cache/action.yml
@@ -13,6 +13,7 @@ runs:
 
     # Downloading Node.js often fails due to network issues, therefore we cache the artifacts downloaded by the frontend plugin.
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      if: runner.os != 'Windows'
       id: cache-binaries
       name: Cache Node.js and PNPM binaries
       with:
@@ -21,7 +22,17 @@ runs:
           ~/.m2/repository/com/github/eirslett/pnpm
         key: ${{ runner.os }}-frontend-plugin-artifacts-${{ steps.tooling-versions.outputs.node }}-${{ steps.tooling-versions.outputs.pnpm }}
 
+    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      if: runner.os == 'Windows'
+      id: cache-binaries-windows
+      name: Cache Node.js and PNPM binaries
+      with:
+        path: |
+          D:/.m2/repository/com/github/eirslett/node
+          D:/.m2/repository/com/github/eirslett/pnpm
+        key: ${{ runner.os }}-frontend-plugin-artifacts-${{ steps.tooling-versions.outputs.node }}-${{ steps.tooling-versions.outputs.pnpm }}
+
     - name: Download Node.js and PNPM
-      if: steps.cache-binaries.outputs.cache-hit != 'true'
+      if: steps.cache-binaries.outputs.cache-hit != 'true' && steps.cache-binaries-windows.outputs.cache-hit != 'true'
       shell: bash
-      run: ./.github/scripts/download-node-tooling.sh ${{ steps.tooling-versions.outputs.node }} ${{ steps.tooling-versions.outputs.pnpm }}
+      run: ./.github/scripts/download-node-tooling.sh ${{ steps.tooling-versions.outputs.node }} ${{ steps.tooling-versions.outputs.pnpm }} ${{ runner.os }}

--- a/.github/scripts/download-node-tooling.sh
+++ b/.github/scripts/download-node-tooling.sh
@@ -37,16 +37,24 @@ pnpm_url() {
 main() {
     local node_version=$1
     local pnpm_version=$2
+    local platform=$3
 
     if [ "$node_version" == "" ] || [ "$pnpm_version" == "" ]; then
         abort "Usage: download-node-tooling.sh <NODE_VERSION> <PNPM_VERSION>"
     fi
 
-    local target_directory=~/.m2/repository/com/github/eirslett
+    local target_directory
+    if [ "$platform" == "Windows" ]; then
+        target_directory=/d/.m2/repository/com/github/eirslett
+    elif [ "$platform" == "Linux" ]; then
+        target_directory=~/.m2/repository/com/github/eirslett
+    else
+        abort "Unsupported platform: $platform"
+    fi
 
     download_file "$(node_url "$node_version" "linux")" "$target_directory/node/$node_version/node-$node_version-linux-x64.tar.gz"
     download_file "$(node_url "$node_version" "windows")" "$target_directory/node/$node_version/node-$node_version-win-x64.exe"
     download_file "$(pnpm_url "$pnpm_version")" "$target_directory/pnpm/$pnpm_version/pnpm-$pnpm_version.tar.gz"
 }
 
-main "$1" "$2"
+main "$1" "$2" "$3"


### PR DESCRIPTION
Closes #40339

Draft for the moment. I think the problem with windows builds is the link. Don't know why but now the cache (tar) cannot work with the link. This PR uses direct path for windows (differentiating the cache in windows and linux).
