### PR TITLE
Create the links correctly for the maven repository in windows

### DIFF
--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -39,8 +39,10 @@ runs:
       # On Windows, the .m2 folder is in different location, so move all the contents to the right folder here.
       # Also, not using the C: drive will speed up the build, see https://github.com/actions/runner-images/issues/8755
       run: |
-        mkdir -p ../../../.m2/repository
+        mkdir -p ..\..\..\.m2
+        mkdir -p D:\.m2\repository
         cmd /c mklink /d $HOME\.m2\repository D:\.m2\repository
+        cmd /c mklink /d $PWD\..\..\..\.m2\repository D:\.m2\repository
 
     - id: restore-maven-repository
       name: Maven cache


### PR DESCRIPTION
Closes #40339

Finally I understood this. The problem is that the link in Windows is not done OK. I don't know how this worked before, but probably some upgrade broke it. The idea is the cache is extracted in `..\..\..\.m2\repository` and the final repo is wanted in the disk `d:`, because of performance. So we need to create the extracted parent folder `..\..\..\.m2` and the destination folder `d:\.m2\repository`. Then perform two soft links to the `d:\.m2\repository`, one for the user home folder ` $HOME\.m2\repository` (maven uses this folder) and another for the `$PWD\..\..\..\.m2\repository` (cache extracts into this folder). This way it works OK.
