### PR TITLE
Integrate passkeys with separate username and password forms

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authentication/AbstractAuthenticationFlowContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/AbstractAuthenticationFlowContext.java
@@ -150,6 +150,15 @@ public interface AbstractAuthenticationFlowContext {
     void success();
 
     /**
+     * Mark the current execution as successful and the auth session sets the
+     * credential type in the authentication session as the last credential used
+     * to authenticate the user.
+     *
+     * @param credentialType The credential used to authenticate the user
+     */
+    void success(String credentialType);
+
+    /**
      * Aborts the current flow
      *
      * @param error

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -90,6 +90,7 @@ public class AuthenticationProcessor {
     public static final String LAST_PROCESSED_EXECUTION = "last.processed.execution";
     public static final String CURRENT_FLOW_PATH = "current.flow.path";
     public static final String FORKED_FROM = "forked.from";
+    public static final String LAST_AUTHN_CREDENTIAL = "last.authn.credential";
 
     public static final String BROKER_SESSION_ID = "broker.session.id";
     public static final String BROKER_USER_ID = "broker.user.id";
@@ -406,6 +407,14 @@ public class AuthenticationProcessor {
 
         @Override
         public void success() {
+            success(null);
+        }
+
+        @Override
+        public void success(String credentialType) {
+            if (credentialType != null) {
+                getAuthenticationSession().setAuthNote(LAST_AUTHN_CREDENTIAL, credentialType);
+            }
             this.status = FlowStatus.SUCCESS;
         }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/OTPFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/OTPFormAuthenticator.java
@@ -116,7 +116,7 @@ public class OTPFormAuthenticator extends AbstractUsernameFormAuthenticator impl
             context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
             return;
         }
-        context.success();
+        context.success(OTPCredentialModel.TYPE);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordForm.java
@@ -32,12 +32,21 @@ import jakarta.ws.rs.core.Response;
 
 public class PasswordForm extends UsernamePasswordForm implements CredentialValidator<PasswordCredentialProvider> {
 
+    public PasswordForm(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
     protected boolean validateForm(AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
         return validatePassword(context, context.getUser(), formData, false);
     }
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
+        if (alreadyAuthenticatedUsingPasswordlessCredential(context)) {
+            context.success();
+            return;
+        }
         Response challengeResponse = context.form().createLoginPassword();
         context.challenge(challengeResponse);
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordFormFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordFormFactory.java
@@ -35,11 +35,10 @@ import java.util.List;
 public class PasswordFormFactory implements AuthenticatorFactory {
 
     public static final String PROVIDER_ID = "auth-password-form";
-    public static final PasswordForm SINGLETON = new PasswordForm();
 
     @Override
     public Authenticator create(KeycloakSession session) {
-        return SINGLETON;
+        return new PasswordForm(session);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
@@ -45,7 +45,7 @@ public class RecoveryAuthnCodesFormAuthenticator implements Authenticator {
         context.getEvent().detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE)
                 .user(context.getUser());
         if (isRecoveryAuthnCodeInputValid(context)) {
-            context.success();
+            context.success(RecoveryAuthnCodesCredentialModel.TYPE);
         }
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java
@@ -105,7 +105,7 @@ public class SpnegoAuthenticator extends AbstractUsernameFormAuthenticator imple
                     context.getAuthenticationSession().setUserSessionNote(entry.getKey(), entry.getValue());
                 }
             }
-            context.success();
+            context.success(UserCredentialModel.KERBEROS);
         } else if (output.getAuthStatus() == CredentialValidationOutput.Status.CONTINUE) {
             String spnegoResponseToken = (String) output.getState().get(KerberosConstants.RESPONSE_TOKEN);
             Response challenge =  challengeNegotiation(context, spnegoResponseToken);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernameForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernameForm.java
@@ -34,6 +34,14 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 
 public final class UsernameForm extends UsernamePasswordForm {
 
+    public UsernameForm() {
+        super();
+    }
+
+    public UsernameForm(KeycloakSession session) {
+        super(session);
+    }
+
     @Override
     public void authenticate(AuthenticationFlowContext context) {
         if (context.getUser() != null) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernameFormFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernameFormFactory.java
@@ -17,13 +17,17 @@
 
 package org.keycloak.authentication.authenticators.browser;
 
+import java.util.Collections;
+import java.util.Set;
 import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.common.Profile;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.List;
@@ -35,11 +39,10 @@ import java.util.List;
 public class UsernameFormFactory implements AuthenticatorFactory {
 
     public static final String PROVIDER_ID = "auth-username-form";
-    public static final UsernameForm SINGLETON = new UsernameForm();
 
     @Override
     public Authenticator create(KeycloakSession session) {
-        return SINGLETON;
+        return new UsernameForm(session);
     }
 
     @Override
@@ -68,9 +71,17 @@ public class UsernameFormFactory implements AuthenticatorFactory {
     }
 
     @Override
+    public Set<String> getOptionalReferenceCategories() {
+        return Profile.isFeatureEnabled(Profile.Feature.PASSKEYS)
+                ? Collections.singleton(WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                : AuthenticatorFactory.super.getOptionalReferenceCategories();
+    }
+
+    @Override
     public boolean isConfigurable() {
         return false;
     }
+
     public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
             AuthenticationExecutionModel.Requirement.REQUIRED
     };

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -252,7 +252,7 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
             context.getEvent()
                 .detail(WebAuthnConstants.USER_VERIFICATION_CHECKED, isUVChecked)
                 .detail(WebAuthnConstants.PUBKEY_CRED_ID_ATTR, encodedCredentialID);
-            context.success();
+            context.success(getCredentialType());
         } else {
             context.getEvent()
                 .detail(WebAuthnConstants.AUTHENTICATED_USER_ID, userId)

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -34,6 +34,7 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.services.ServicesLogger;
@@ -179,7 +180,7 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
             }
             else {
                 // Bypass the confirmation page and log the user in
-                context.success();
+                context.success(UserCredentialModel.CLIENT_CERT);
             }
         }
         catch(Exception e) {
@@ -269,7 +270,7 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
         }
         if (context.getUser() != null) {
             recordX509CertificateAuditDataViaContextEvent(context);
-            context.success();
+            context.success(UserCredentialModel.CLIENT_CERT);
             return;
         }
         context.attempted();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysUsernameFormTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysUsernameFormTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.webauthn.passwordless;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.keycloak.WebAuthnConstants;
+import org.keycloak.authentication.authenticators.browser.PasswordFormFactory;
+import org.keycloak.authentication.authenticators.browser.UsernameFormFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventType;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
+import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.admin.AbstractAdminTest;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
+import org.keycloak.testsuite.util.WaitUtils;
+import org.keycloak.testsuite.webauthn.AbstractWebAuthnVirtualTest;
+import org.keycloak.testsuite.webauthn.authenticators.DefaultVirtualAuthOptions;
+import org.keycloak.testsuite.webauthn.utils.PropertyRequirement;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.firefox.FirefoxDriver;
+
+/**
+ *
+ * @author rmartinc
+ */
+@EnableFeature(value = Profile.Feature.PASSKEYS, skipRestart = true)
+@IgnoreBrowserDriver(FirefoxDriver.class) // See https://github.com/keycloak/keycloak/issues/10368
+public class PasskeysUsernameFormTest extends AbstractWebAuthnVirtualTest {
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realmRepresentation = AbstractAdminTest.loadJson(getClass().getResourceAsStream("/webauthn/testrealm-webauthn.json"), RealmRepresentation.class);
+
+        makePasswordlessRequiredActionDefault(realmRepresentation);
+        switchExecutionInBrowser(realmRepresentation);
+
+        testRealms.add(realmRepresentation);
+    }
+
+    private void switchExecutionInBrowser(RealmRepresentation realm) {
+        List<AuthenticationFlowRepresentation> flows = realm.getAuthenticationFlows();
+        MatcherAssert.assertThat(flows, Matchers.notNullValue());
+
+        AuthenticationFlowRepresentation browserForm = flows.stream()
+                .filter(f -> f.getAlias().equals("browser-webauthn-forms"))
+                .findFirst()
+                .orElse(null);
+        MatcherAssert.assertThat("Cannot find 'browser-webauthn-forms' flow", browserForm, Matchers.notNullValue());
+
+        flows.removeIf(f -> f.getAlias().equals(browserForm.getAlias()));
+
+        // set first the username form authenticator
+        AuthenticationExecutionExportRepresentation usernameForm = new AuthenticationExecutionExportRepresentation();
+        usernameForm.setAuthenticator(UsernameFormFactory.PROVIDER_ID);
+        usernameForm.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
+        usernameForm.setPriority(10);
+        usernameForm.setAuthenticatorFlow(false);
+        usernameForm.setUserSetupAllowed(false);
+
+        // second the password form
+        AuthenticationExecutionExportRepresentation passwordForm = new AuthenticationExecutionExportRepresentation();
+        passwordForm.setAuthenticator(PasswordFormFactory.PROVIDER_ID);
+        passwordForm.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
+        passwordForm.setPriority(20);
+        passwordForm.setAuthenticatorFlow(false);
+        passwordForm.setUserSetupAllowed(false);
+
+        browserForm.setAuthenticationExecutions(List.of(usernameForm, passwordForm));
+        flows.add(browserForm);
+
+        realm.setAuthenticationFlows(flows);
+    }
+
+    @Override
+    public boolean isPasswordless() {
+        return true;
+    }
+
+    @Test
+    public void webauthnLoginWithDiscoverableKey() throws IOException {
+        getVirtualAuthManager().useAuthenticator(DefaultVirtualAuthOptions.PASSKEYS.getOptions());
+
+        // set passwordless policy for discoverable keys
+        try (Closeable c = getWebAuthnRealmUpdater()
+                .setWebAuthnPolicyRpEntityName("localhost")
+                .setWebAuthnPolicyRequireResidentKey(PropertyRequirement.YES.getValue())
+                .setWebAuthnPolicyUserVerificationRequirement(WebAuthnConstants.OPTION_REQUIRED)
+                .setWebAuthnPolicyPasskeysEnabled(Boolean.TRUE)
+                .update()) {
+
+            checkWebAuthnConfiguration(PropertyRequirement.YES.getValue(), WebAuthnConstants.OPTION_REQUIRED);
+
+            registerDefaultUser();
+
+            UserRepresentation user = userResource().toRepresentation();
+            MatcherAssert.assertThat(user, Matchers.notNullValue());
+
+            logout();
+            events.clear();
+
+            // the user should be automatically logged in using the discoverable key
+            oauth.openLoginForm();
+            WaitUtils.waitForPageToLoad();
+
+            appPage.assertCurrent();
+
+            events.expectLogin()
+                    .user(user.getId())
+                    .detail(Details.USERNAME, user.getUsername())
+                    .detail(Details.CREDENTIAL_TYPE, WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                    .detail(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true")
+                    .assertEvent();
+
+            logout();
+        }
+    }
+
+    @Test
+    public void passwordLoginWithNonDiscoverableKey() throws IOException {
+        getVirtualAuthManager().useAuthenticator(DefaultVirtualAuthOptions.PASSKEYS.getOptions());
+
+        // set passwordless policy not specified, key will not be discoverable
+        try (Closeable c = getWebAuthnRealmUpdater()
+                .setWebAuthnPolicyRpEntityName("localhost")
+                .setWebAuthnPolicyRequireResidentKey(PropertyRequirement.NOT_SPECIFIED.getValue())
+                .setWebAuthnPolicyUserVerificationRequirement(WebAuthnConstants.OPTION_NOT_SPECIFIED)
+                .setWebAuthnPolicyPasskeysEnabled(Boolean.TRUE)
+                .update()) {
+            registerDefaultUser();
+
+            UserRepresentation user = userResource().toRepresentation();
+            MatcherAssert.assertThat(user, Matchers.notNullValue());
+
+            logout();
+
+            events.clear();
+
+            // login should be done manually but webauthn is enabled
+            oauth.openLoginForm();
+            WaitUtils.waitForPageToLoad();
+            loginPage.assertCurrent();
+            MatcherAssert.assertThat(loginPage.getUsernameAutocomplete(), Matchers.is("username webauthn"));
+            MatcherAssert.assertThat(loginPage.isPasswordInputPresent(), Matchers.is(false));
+            MatcherAssert.assertThat(driver.findElement(By.xpath("//form[@id='webauth']")), Matchers.notNullValue());
+
+            // invalid login first
+            loginPage.loginUsername("invalid-user");
+            loginPage.assertCurrent();
+            MatcherAssert.assertThat(loginPage.getUsernameAutocomplete(), Matchers.is("username webauthn"));
+            MatcherAssert.assertThat(loginPage.getUsernameInputError(), Matchers.is("Invalid username or email."));
+            events.expect(EventType.LOGIN_ERROR)
+                    .detail(Details.USERNAME, "invalid-user")
+                    .error(Errors.USER_NOT_FOUND)
+                    .user(Matchers.blankOrNullString())
+                    .assertEvent();
+
+            // login OK now
+            loginPage.loginUsername(USERNAME);
+            loginPage.assertCurrent();
+            MatcherAssert.assertThat(loginPage.getAttemptedUsername(), Matchers.is(USERNAME));
+            Assert.assertThrows(NoSuchElementException.class, () -> driver.findElement(By.xpath("//form[@id='webauth']")));
+            loginPage.login(getPassword(USERNAME));
+            appPage.assertCurrent();
+            events.expectLogin()
+                    .user(user.getId())
+                    .detail(Details.USERNAME, USERNAME)
+                    .detail(Details.CREDENTIAL_TYPE, Matchers.nullValue())
+                    .assertEvent();
+        }
+    }
+
+    @Test
+    public void passwordLoginWithExternalKey() throws Exception {
+        // use a default resident key which is not shown in conditional UI
+        getVirtualAuthManager().useAuthenticator(DefaultVirtualAuthOptions.DEFAULT_RESIDENT_KEY.getOptions());
+
+        // set passwordless policy for discoverable keys
+        try (Closeable c = getWebAuthnRealmUpdater()
+                .setWebAuthnPolicyRpEntityName("localhost")
+                .setWebAuthnPolicyRequireResidentKey(PropertyRequirement.YES.getValue())
+                .setWebAuthnPolicyUserVerificationRequirement(WebAuthnConstants.OPTION_REQUIRED)
+                .setWebAuthnPolicyPasskeysEnabled(Boolean.TRUE)
+                .update()) {
+
+            checkWebAuthnConfiguration(PropertyRequirement.YES.getValue(), WebAuthnConstants.OPTION_REQUIRED);
+
+            registerDefaultUser();
+
+            UserRepresentation user = userResource().toRepresentation();
+            MatcherAssert.assertThat(user, Matchers.notNullValue());
+
+            logout();
+            events.clear();
+
+            // open login page, the key is not internal so not opened by default
+            oauth.openLoginForm();
+            WaitUtils.waitForPageToLoad();
+
+            loginPage.assertCurrent();
+            MatcherAssert.assertThat(loginPage.getUsernameAutocomplete(), Matchers.is("username webauthn"));
+            MatcherAssert.assertThat(loginPage.isPasswordInputPresent(), Matchers.is(false));
+            MatcherAssert.assertThat(driver.findElement(By.xpath("//form[@id='webauth']")), Matchers.notNullValue());
+
+            // force login using webauthn link
+            webAuthnLoginPage.clickAuthenticate();
+            appPage.assertCurrent();
+
+            events.expectLogin()
+                    .user(user.getId())
+                    .detail(Details.USERNAME, user.getUsername())
+                    .detail(Details.CREDENTIAL_TYPE, WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                    .detail(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true")
+                    .assertEvent();
+            logout();
+        }
+    }
+}

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -1,4 +1,5 @@
 <#import "template.ftl" as layout>
+<#import "passkeys.ftl" as passkeys>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password && realm.registrationAllowed && !registrationDisabled??); section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
@@ -17,7 +18,8 @@
                                        aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
                                        class="${properties.kcInputClass!}" name="username"
                                        value="${(login.username!'')}"
-                                       type="text" autofocus autocomplete="username"
+                                       type="text" autofocus
+                                       autocomplete="${(enableWebAuthnConditionalUI?has_content)?then('username webauthn', 'username')}"
                                        dir="ltr"/>
 
                                 <#if messagesPerField.existsError('username')>
@@ -55,6 +57,7 @@
                 </#if>
             </div>
         </div>
+        <@passkeys.conditionalUIData />
 
     <#elseif section = "info" >
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
@@ -2,6 +2,7 @@
 <#import "field.ftl" as field>
 <#import "buttons.ftl" as buttons>
 <#import "social-providers.ftl" as identityProviders>
+<#import "passkeys.ftl" as passkeys>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password && realm.registrationAllowed && !registrationDisabled??); section>
 <!-- template: login-username.ftl -->
 
@@ -18,7 +19,7 @@
                                 <#assign label>
                                     <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
                                 </#assign>
-                                <@field.input name="username" label=label value=login.username!'' autofocus=true autocomplete="username" />
+                                <@field.input name="username" label=label value=login.username!'' autofocus=true autocomplete="${(enableWebAuthnConditionalUI?has_content)?then('username webauthn', 'username')}" />
                             </div>
                         </#if>
 
@@ -33,6 +34,7 @@
                 </#if>
             </div>
         </div>
+        <@passkeys.conditionalUIData />
 
     <#elseif section = "info" >
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>


### PR DESCRIPTION
Closes #40021

PR to add passkeys to the separate username and password form authenticators. This PR follows the same idea used in the previous issue but it needs two more things:

1. The flow context adds a new method `success(String)` to mark the authenticator succeeded and it was used the passed credetial (otp, webauthn, cert, password,...). That type is added to the auth session in an attribute `last.authn.credential`.
2. The password authenticator directly successes without waiting for input the password if the passkeys feature is enabled and the previous property is set to passwordless webauthn. That means the username form was authenticated using passkeys and the password step can be skipped.

Tests added in a similar way of the previous PRs.
