### PR TITLE
Fix missing background color for dropdown panels in keycloak.v2 theme

### DIFF
--- a/js/apps/admin-ui/src/components/dropdown-panel/dropdown-panel.css
+++ b/js/apps/admin-ui/src/components/dropdown-panel/dropdown-panel.css
@@ -37,7 +37,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .kc-dropdown-panel-content {
+  .pf-v5-theme-dark .kc-dropdown-panel-content {
     background-color: var(--pf-v5-global--BackgroundColor--300);
   }
 }


### PR DESCRIPTION
## Description
Fixes missing background color for dropdown filter panels in Admin UI when using keycloak.v2 theme.

## Problem
When OS color scheme is set to `prefers-color-scheme: dark`, dropdown panels in Admin > Events > Search events form show transparent/unreadable background. This occurs because:

1. CSS media query applies `var(--pf-v5-global--BackgroundColor--300)` when OS prefers dark mode
2. This CSS variable is only defined within `.pf-v5-theme-dark` scope  
3. When Keycloak uses light theme but OS prefers dark mode, the variable is undefined

## Solution
Added `.pf-v5-theme-dark` selector to scope the media query properly:

```css
@media (prefers-color-scheme: dark) {
  .pf-v5-theme-dark .kc-dropdown-panel-content {
    background-color: var(--pf-v5-global--BackgroundColor--300);
  }
}
```

This ensures the CSS rule only applies when both OS and Keycloak theme are dark, preventing reference to undefined CSS variables.

## Testing
- [x] Tested with OS dark mode + Keycloak light theme (no longer shows transparent background)
- [x] Tested with OS dark mode + Keycloak dark theme (works as expected)  
- [x] Tested with OS light mode (no regression)
- [x] Verified dropdown panel text remains readable in all scenarios

## Files Changed
- `js/apps/admin-ui/src/components/dropdown-panel/dropdown-panel.css`

Closes #40135