### PR TITLE
Set window size instead of maximize because it fails in chrome 137

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
@@ -44,6 +44,7 @@ import org.keycloak.testsuite.webauthn.authenticators.UseVirtualAuthenticators;
 import org.keycloak.testsuite.webauthn.authenticators.VirtualAuthenticatorManager;
 import org.keycloak.testsuite.webauthn.pages.WebAuthnLoginPage;
 import org.keycloak.testsuite.webauthn.pages.WebAuthnRegisterPage;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
 
 import jakarta.ws.rs.ClientErrorException;
@@ -95,7 +96,7 @@ public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest imple
 
     @Before
     public void navigateBeforeTest() {
-        driver.manage().window().maximize();
+        driver.manage().window().setSize(new Dimension(1920, 1080));
 
         RealmRepresentation realm = testRealmResource().toRepresentation();
         assertThat(realm, notNullValue());


### PR DESCRIPTION
Closes #40402

Issue in chrome 137 when maximizing in headless mode, the window size is very small (probably 800x600): https://issues.chromium.org/issues/422844474

This PR just changes to fixed size of 1920x1080 instead of maximizing the browser.
