### PR TITLE
V2 patch

### DIFF
--- a/core/src/main/java/org/keycloak/representations/admin/v2/BaseRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/BaseRepresentation.java
@@ -1,0 +1,31 @@
+package org.keycloak.representations.admin.v2;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public class BaseRepresentation {
+
+    @JsonIgnore
+    protected Map<String, Object> additionalFields = new LinkedHashMap<String, Object>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalFields() {
+        return additionalFields;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalFields(String name, Object value) {
+        this.additionalFields.put(name, value);
+    }
+
+    public void setAdditionalFields(Map<String, Object> additionalFields) {
+        this.additionalFields = additionalFields;
+    }
+
+}

--- a/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public class ClientRepresentation {
+
+    public static final String OIDC = "openid-connect";
 
     @JsonProperty(required = true)
     @JsonPropertyDescription("ID uniquely identifying this client")
@@ -19,8 +22,9 @@ public class ClientRepresentation {
     @JsonPropertyDescription("Human readable description of the client")
     private String description;
 
+    @JsonProperty(defaultValue = OIDC)
     @JsonPropertyDescription("The protocol used to communicate with the client")
-    private String protocol;
+    private String protocol = OIDC;
 
     @JsonPropertyDescription("Whether this client is enabled")
     private Boolean enabled;
@@ -28,21 +32,26 @@ public class ClientRepresentation {
     @JsonPropertyDescription("URL to the application's homepage that is represented by this client")
     private String appUrl;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("URLs that the browser can redirect to after login")
-    private Set<String> appRedirectUrls;
+    private Set<String> appRedirectUrls = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Login flows that are enabled for this client")
-    private Set<String> loginFlows;
+    private Set<String> loginFlows = new LinkedHashSet<String>();
 
     @JsonPropertyDescription("Authentication configuration for this client")
     private Auth auth;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Web origins that are allowed to make requests to this client")
-    private Set<String> webOrigins;
+    private Set<String> webOrigins = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Roles associated with this client")
-    private Set<String> roles;
+    private Set<String> roles = new LinkedHashSet<String>();
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Service account configuration for this client")
     private ServiceAccount serviceAccount;
 
@@ -148,7 +157,7 @@ public class ClientRepresentation {
         this.serviceAccount = serviceAccount;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public static class Auth {
 
         @JsonPropertyDescription("Whether authentication is enabled for this client")
@@ -196,14 +205,15 @@ public class ClientRepresentation {
         }
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public static class ServiceAccount {
 
         @JsonPropertyDescription("Whether the service account is enabled")
         private Boolean enabled;
 
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @JsonPropertyDescription("Roles assigned to the service account")
-        private Set<String> roles;
+        private Set<String> roles = new LinkedHashSet<String>();
 
         public Boolean getEnabled() {
             return enabled;

--- a/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
@@ -1,0 +1,225 @@
+package org.keycloak.representations.admin.v2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import java.util.Set;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ClientRepresentation {
+
+    @JsonProperty(required = true)
+    @JsonPropertyDescription("ID uniquely identifying this client")
+    private String clientId;
+
+    @JsonPropertyDescription("Human readable name of the client")
+    private String displayName;
+
+    @JsonPropertyDescription("Human readable description of the client")
+    private String description;
+
+    @JsonPropertyDescription("The protocol used to communicate with the client")
+    private String protocol;
+
+    @JsonPropertyDescription("Whether this client is enabled")
+    private Boolean enabled;
+
+    @JsonPropertyDescription("URL to the application's homepage that is represented by this client")
+    private String appUrl;
+
+    @JsonPropertyDescription("URLs that the browser can redirect to after login")
+    private Set<String> appRedirectUrls;
+
+    @JsonPropertyDescription("Login flows that are enabled for this client")
+    private Set<String> loginFlows;
+
+    @JsonPropertyDescription("Authentication configuration for this client")
+    private Auth auth;
+
+    @JsonPropertyDescription("Web origins that are allowed to make requests to this client")
+    private Set<String> webOrigins;
+
+    @JsonPropertyDescription("Roles associated with this client")
+    private Set<String> roles;
+
+    @JsonPropertyDescription("Service account configuration for this client")
+    private ServiceAccount serviceAccount;
+
+    public ClientRepresentation() {}
+
+    public ClientRepresentation(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getAppUrl() {
+        return appUrl;
+    }
+
+    public void setAppUrl(String appUrl) {
+        this.appUrl = appUrl;
+    }
+
+    public Set<String> getAppRedirectUrls() {
+        return appRedirectUrls;
+    }
+
+    public void setAppRedirectUrls(Set<String> appRedirectUrls) {
+        this.appRedirectUrls = appRedirectUrls;
+    }
+
+    public Set<String> getLoginFlows() {
+        return loginFlows;
+    }
+
+    public void setLoginFlows(Set<String> loginFlows) {
+        this.loginFlows = loginFlows;
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    public void setAuth(Auth auth) {
+        this.auth = auth;
+    }
+
+    public Set<String> getWebOrigins() {
+        return webOrigins;
+    }
+
+    public void setWebOrigins(Set<String> webOrigins) {
+        this.webOrigins = webOrigins;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    public ServiceAccount getServiceAccount() {
+        return serviceAccount;
+    }
+
+    public void setServiceAccount(ServiceAccount serviceAccount) {
+        this.serviceAccount = serviceAccount;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Auth {
+
+        @JsonPropertyDescription("Whether authentication is enabled for this client")
+        private Boolean enabled;
+
+        @JsonPropertyDescription("Which authentication method is used for this client")
+        private String method;
+
+        @JsonPropertyDescription("Secret used to authenticate this client with Secret authentication")
+        private String secret;
+
+        @JsonPropertyDescription("Public key used to authenticate this client with Signed JWT authentication")
+        private String certificate;
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public void setMethod(String method) {
+            this.method = method;
+        }
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+
+        public String getCertificate() {
+            return certificate;
+        }
+
+        public void setCertificate(String certificate) {
+            this.certificate = certificate;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class ServiceAccount {
+
+        @JsonPropertyDescription("Whether the service account is enabled")
+        private Boolean enabled;
+
+        @JsonPropertyDescription("Roles assigned to the service account")
+        private Set<String> roles;
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Set<String> getRoles() {
+            return roles;
+        }
+
+        public void setRoles(Set<String> roles) {
+            this.roles = roles;
+        }
+    }
+}
+

--- a/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
@@ -3,16 +3,16 @@ package org.keycloak.representations.admin.v2;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonInclude(JsonInclude.Include.NON_ABSENT)
-public class ClientRepresentation {
+public class ClientRepresentation extends BaseRepresentation {
 
     public static final String OIDC = "openid-connect";
 
-    @JsonProperty(required = true)
     @JsonPropertyDescription("ID uniquely identifying this client")
     private String clientId;
 
@@ -24,7 +24,7 @@ public class ClientRepresentation {
 
     @JsonProperty(defaultValue = OIDC)
     @JsonPropertyDescription("The protocol used to communicate with the client")
-    private String protocol = OIDC;
+    private String protocol;
 
     @JsonPropertyDescription("Whether this client is enabled")
     private Boolean enabled;
@@ -230,6 +230,17 @@ public class ClientRepresentation {
         public void setRoles(Set<String> roles) {
             this.roles = roles;
         }
+    }
+
+    public static void main(String[] args) throws JsonProcessingException {
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setAuth(new Auth());
+        ObjectMapper mapper = new ObjectMapper();
+        var reader = mapper.readerForUpdating(rep);
+        ClientRepresentation patch = new ClientRepresentation();
+        patch.getAdditionalFields().put("auth", null);
+        Object result = reader.readValue(mapper.writeValueAsString(patch));
+        System.out.println(mapper.writeValueAsString(result));
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,8 @@
         <!-- Used to test SAML Galleon feature-pack layers discovery -->
         <version.org.wildfly.glow>1.0.0.Alpha8</version.org.wildfly.glow>
 
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
+
         <!-- Galleon -->
         <galleon.fork.embedded>true</galleon.fork.embedded>
         <galleon.log.time>true</galleon.log.time>
@@ -383,6 +385,11 @@
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>xsom</artifactId>
                 <version>${org.glassfish.jaxb.xsom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct</artifactId>
+                <version>${org.mapstruct.version}</version>
             </dependency>
 
             <dependency>
@@ -1101,6 +1108,11 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-ui</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-admin-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -131,6 +131,11 @@
             <artifactId>rdf-urdna</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+
         <!-- SmallRye -->
         <dependency>
             <groupId>io.smallrye.config</groupId>
@@ -382,6 +387,17 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-rest-admin-ui-ext</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -57,6 +57,10 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-testdriver-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/rest/admin-api/pom.xml
+++ b/rest/admin-api/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-rest-parent</artifactId>
+        <version>999.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>keycloak-admin-api</artifactId>
+    <name>Keycloak Admin REST API v2</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminApi.java
@@ -1,0 +1,11 @@
+package org.keycloak.admin.api;
+
+import jakarta.ws.rs.Path;
+import org.keycloak.admin.api.realm.RealmsApi;
+import org.keycloak.provider.Provider;
+
+public interface AdminApi extends Provider {
+
+    @Path("realms")
+    RealmsApi realms();
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminRootV2.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminRootV2.java
@@ -1,0 +1,34 @@
+package org.keycloak.admin.api;
+
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resources.admin.AdminCorsPreflightService;
+
+@jakarta.ws.rs.ext.Provider
+@Path("admin/api")
+public class AdminRootV2 {
+
+    @Context
+    protected KeycloakSession session;
+
+    @Path("")
+    public AdminApi latestAdminApi() {
+        // we could return the latest Admin API if no version is specified
+        return new DefaultAdminApi(session);
+    }
+
+    @Path("v2")
+    public AdminApi adminApi() {
+        return new DefaultAdminApi(session);
+    }
+
+    @Path("{any:.*}")
+    @OPTIONS
+    @Operation(hidden = true)
+    public Object preFlight() {
+        return new AdminCorsPreflightService();
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/DefaultAdminApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/DefaultAdminApi.java
@@ -1,0 +1,25 @@
+package org.keycloak.admin.api;
+
+import jakarta.ws.rs.Path;
+import org.keycloak.admin.api.realm.DefaultRealmsApi;
+import org.keycloak.admin.api.realm.RealmsApi;
+import org.keycloak.models.KeycloakSession;
+
+public class DefaultAdminApi implements AdminApi {
+    private final KeycloakSession session;
+
+    public DefaultAdminApi(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Path("realms")
+    @Override
+    public RealmsApi realms() {
+        return new DefaultRealmsApi(session);
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/FieldValidation.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/FieldValidation.java
@@ -1,0 +1,7 @@
+package org.keycloak.admin.api;
+
+public enum FieldValidation {
+    Ignore,
+    Strict,
+    Warn
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -1,14 +1,31 @@
 package org.keycloak.admin.api.client;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.admin.api.FieldValidation;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public interface ClientApi {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     ClientRepresentation getClient();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation createOrUpdateClient(ClientRepresentation client, @PathParam("fieldValidation") FieldValidation fieldValidation);
+
+    @PUT
+    @Consumes("application/merge-patch+json")
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation patchClient(JsonNode patch, @PathParam("fieldValidation") FieldValidation fieldValidation);
+
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -1,0 +1,14 @@
+package org.keycloak.admin.api.client;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+
+public interface ClientApi {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation getClient(@QueryParam("runtime") Boolean isRuntime);
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -10,5 +10,5 @@ public interface ClientApi {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    ClientRepresentation getClient(@QueryParam("runtime") Boolean isRuntime);
+    ClientRepresentation getClient();
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
@@ -1,17 +1,18 @@
 package org.keycloak.admin.api.client;
 
+import java.util.stream.Stream;
+
+import org.keycloak.admin.api.FieldValidation;
+import org.keycloak.provider.Provider;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.keycloak.provider.Provider;
-import org.keycloak.representations.admin.v2.ClientRepresentation;
-
-import java.util.stream.Stream;
 
 public interface ClientsApi extends Provider {
 
@@ -20,15 +21,10 @@ public interface ClientsApi extends Provider {
     @Consumes(MediaType.APPLICATION_JSON)
     Stream<ClientRepresentation> getClients();
 
-    @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    ClientRepresentation createOrUpdateClient(ClientRepresentation client);
-
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    ClientRepresentation createClient(ClientRepresentation client);
+    ClientRepresentation createClient(ClientRepresentation client, @PathParam("fieldValidation") FieldValidation fieldValidation);
 
     @Path("{id}")
     ClientApi client(@PathParam("id") String id);

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
@@ -1,0 +1,36 @@
+package org.keycloak.admin.api.client;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.keycloak.provider.Provider;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+
+import java.util.stream.Stream;
+
+public interface ClientsApi extends Provider {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Stream<ClientRepresentation> getClients();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation createOrUpdateClient(ClientRepresentation client);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation createClient(ClientRepresentation client);
+
+    @Path("{id}")
+    ClientApi client(@PathParam("id") String id);
+}
+

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -26,8 +26,8 @@ public class DefaultClientApi implements ClientApi {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Override
-    public ClientRepresentation getClient(@QueryParam("runtime") Boolean isRuntime) {
-        return clientService.getClient(realm, clientId, isRuntime)
+    public ClientRepresentation getClient() {
+        return clientService.getClient(realm, clientId, null)
                 .orElseThrow(() -> new NotFoundException("Cannot find the specified client"));
     }
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -1,0 +1,33 @@
+package org.keycloak.admin.api.client;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.client.ClientService;
+
+public class DefaultClientApi implements ClientApi {
+    private final KeycloakSession session;
+    private final RealmModel realm;
+    private final String clientId;
+    private final ClientService clientService;
+
+    public DefaultClientApi(KeycloakSession session, String clientId) {
+        this.session = session;
+        this.clientId = clientId;
+        this.realm = session.getContext().getRealm();
+        this.clientService = session.services().clients();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Override
+    public ClientRepresentation getClient(@QueryParam("runtime") Boolean isRuntime) {
+        return clientService.getClient(realm, clientId, isRuntime)
+                .orElseThrow(() -> new NotFoundException("Cannot find the specified client"));
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -1,33 +1,83 @@
 package org.keycloak.admin.api.client;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
+import java.io.IOException;
+
+import org.keycloak.admin.api.FieldValidation;
+import org.keycloak.http.HttpResponse;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.ErrorResponse;
+import org.keycloak.services.ServiceException;
 import org.keycloak.services.client.ClientService;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
 public class DefaultClientApi implements ClientApi {
     private final KeycloakSession session;
     private final RealmModel realm;
     private final String clientId;
     private final ClientService clientService;
+    private HttpResponse response;
 
     public DefaultClientApi(KeycloakSession session, String clientId) {
         this.session = session;
         this.clientId = clientId;
         this.realm = session.getContext().getRealm();
         this.clientService = session.services().clients();
+        this.response = session.getContext().getHttpResponse();
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
     @Override
     public ClientRepresentation getClient() {
         return clientService.getClient(realm, clientId, null)
                 .orElseThrow(() -> new NotFoundException("Cannot find the specified client"));
+    }
+
+    @Override
+    public ClientRepresentation createOrUpdateClient(ClientRepresentation client, FieldValidation fieldValidation) {
+        try {
+            var result = clientService.createOrUpdate(realm, client, true);
+            if (result.created()) {
+                response.setStatus(Response.Status.CREATED.getStatusCode());
+            }
+            return result.representation();
+        } catch (ServiceException e) {
+            throw new WebApplicationException(e.getMessage(), e.getSuggestedResponseStatus().orElse(Response.Status.BAD_REQUEST));
+        }
+    }
+
+    @Override
+    public ClientRepresentation patchClient(JsonNode patch, FieldValidation fieldValidation) {
+        // patches don't yet allow for creating
+        ClientRepresentation client = getClient();
+        try {
+            // TODO: there should be a more centralized objectmapper
+            final ObjectReader objectReader = new ObjectMapper().readerForUpdating(client);
+            ClientRepresentation updated = objectReader.readValue(patch);
+
+            // TODO: reuse in the other methods
+            if (!updated.getAdditionalFields().isEmpty()) {
+                if (fieldValidation == null || fieldValidation == FieldValidation.Strict) {
+                    // validation failed
+                    throw new WebApplicationException("Payload contains unknown fields: " + updated.getAdditionalFields().keySet(), Response.Status.BAD_REQUEST);
+                } else if (fieldValidation == FieldValidation.Warn) {
+                    response.addHeader("WARNING", "Payload contains unknown fields: " + updated.getAdditionalFields().keySet());
+                }
+            }
+            return clientService.createOrUpdate(realm, updated, true).representation();
+        } catch (JsonProcessingException e) {
+            // TODO: kubernetes uses 422 instead
+            throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (IOException e) {
+            throw ErrorResponse.error("Unknown Error Occurred", Response.Status.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -1,15 +1,8 @@
 package org.keycloak.admin.api.client;
 
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import java.util.stream.Stream;
+
+import org.keycloak.admin.api.FieldValidation;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -17,7 +10,10 @@ import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.ServiceException;
 import org.keycloak.services.client.ClientService;
 
-import java.util.stream.Stream;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
 public class DefaultClientsApi implements ClientsApi {
     private final KeycloakSession session;
@@ -32,41 +28,22 @@ public class DefaultClientsApi implements ClientsApi {
         this.response = session.getContext().getHttpResponse();
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
     @Override
+    @GET
     public Stream<ClientRepresentation> getClients() {
         return clientService.getClients(realm, null, null, null);
     }
 
     @Override
-    @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public ClientRepresentation createOrUpdateClient(ClientRepresentation client) {
-        try {
-            // TODO return 200, or 201 if did not exist
-            response.setStatus(Response.Status.OK.getStatusCode());
-            return clientService.createOrUpdateClient(realm, client);
-        } catch (ServiceException e) {
-            throw new WebApplicationException(e.getMessage(), e.getSuggestedResponseStatus().orElse(Response.Status.BAD_REQUEST));
-        }
-    }
-
-    @Override
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public ClientRepresentation createClient(ClientRepresentation client) {
+    public ClientRepresentation createClient(ClientRepresentation client, FieldValidation fieldValidation) {
         try {
             response.setStatus(Response.Status.CREATED.getStatusCode());
-            return clientService.createClient(realm, client);
+            return clientService.createOrUpdate(realm, client, false).representation();
         } catch (ServiceException e) {
             throw new WebApplicationException(e.getMessage(), e.getSuggestedResponseStatus().orElse(Response.Status.BAD_REQUEST));
         }
     }
 
-    @Path("{id}")
     @Override
     public ClientApi client(@PathParam("id") String clientId) {
         return new DefaultClientApi(session, clientId);

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -1,0 +1,77 @@
+package org.keycloak.admin.api.client;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.http.HttpResponse;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.ServiceException;
+import org.keycloak.services.client.ClientService;
+
+import java.util.stream.Stream;
+
+public class DefaultClientsApi implements ClientsApi {
+    private final KeycloakSession session;
+    private final RealmModel realm;
+    private final HttpResponse response;
+    private final ClientService clientService;
+
+    public DefaultClientsApi(KeycloakSession session, RealmModel realm) {
+        this.session = session;
+        this.realm = realm;
+        this.clientService = session.services().clients();
+        this.response = session.getContext().getHttpResponse();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Override
+    public Stream<ClientRepresentation> getClients() {
+        return clientService.getClients(realm);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ClientRepresentation createOrUpdateClient(ClientRepresentation client) {
+        try {
+            // TODO return 200, or 201 if did not exist
+            response.setStatus(Response.Status.OK.getStatusCode());
+            return clientService.createOrUpdateClient(realm, client);
+        } catch (ServiceException e) {
+            throw new WebApplicationException(e.getMessage(), e.getSuggestedResponseStatus().orElse(Response.Status.BAD_REQUEST));
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ClientRepresentation createClient(ClientRepresentation client) {
+        try {
+            response.setStatus(Response.Status.CREATED.getStatusCode());
+            return clientService.createClient(realm, client);
+        } catch (ServiceException e) {
+            throw new WebApplicationException(e.getMessage(), e.getSuggestedResponseStatus().orElse(Response.Status.BAD_REQUEST));
+        }
+    }
+
+    @Path("{id}")
+    @Override
+    public ClientApi client(@PathParam("id") String clientId) {
+        return new DefaultClientApi(session, clientId);
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -36,9 +36,10 @@ public class DefaultClientsApi implements ClientsApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Stream<ClientRepresentation> getClients() {
-        return clientService.getClients(realm);
+        return clientService.getClients(realm, null, null, null);
     }
 
+    @Override
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -52,6 +53,7 @@ public class DefaultClientsApi implements ClientsApi {
         }
     }
 
+    @Override
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApi.java
@@ -1,0 +1,27 @@
+package org.keycloak.admin.api.realm;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import org.keycloak.admin.api.client.ClientsApi;
+import org.keycloak.admin.api.client.DefaultClientsApi;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.util.Optional;
+
+public class DefaultRealmApi implements RealmApi {
+    private final KeycloakSession session;
+    private final RealmModel realm;
+
+    public DefaultRealmApi(KeycloakSession session, String name) {
+        this.session = session;
+        this.realm = Optional.ofNullable(session.realms().getRealmByName(name)).orElseThrow(() -> new NotFoundException("Realm cannot be found"));
+        session.getContext().setRealm(realm);
+    }
+
+    @Path("clients")
+    @Override
+    public ClientsApi clients() {
+        return new DefaultClientsApi(session, realm);
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmsApi.java
@@ -1,0 +1,24 @@
+package org.keycloak.admin.api.realm;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import org.keycloak.models.KeycloakSession;
+
+public class DefaultRealmsApi implements RealmsApi {
+    private final KeycloakSession session;
+
+    public DefaultRealmsApi(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Path("{name}")
+    @Override
+    public RealmApi realm(@PathParam("name") String name) {
+        return new DefaultRealmApi(session, name);
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmApi.java
@@ -1,0 +1,10 @@
+package org.keycloak.admin.api.realm;
+
+import jakarta.ws.rs.Path;
+import org.keycloak.admin.api.client.ClientsApi;
+
+public interface RealmApi {
+
+    @Path("clients")
+    ClientsApi clients();
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmsApi.java
@@ -1,0 +1,12 @@
+package org.keycloak.admin.api.realm;
+
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import org.keycloak.provider.Provider;
+
+public interface RealmsApi extends Provider {
+
+    @Path("{name}")
+    RealmApi realm(@PathParam("name") String name);
+}

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -32,6 +32,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>admin-api</module>
         <module>admin-ui-ext</module>
     </modules>
 

--- a/server-spi-private/src/main/java/org/keycloak/models/mapper/ClientModelMapper.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/mapper/ClientModelMapper.java
@@ -1,0 +1,11 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+
+public interface ClientModelMapper {
+
+    ClientRepresentation fromModel(ClientModel model);
+
+    // ClientModel toModel(ClientModel baseModel, ClientRepresentation representation);
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/mapper/ClientModelMapper.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/mapper/ClientModelMapper.java
@@ -1,11 +1,12 @@
 package org.keycloak.models.mapper;
 
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 
 public interface ClientModelMapper {
 
     ClientRepresentation fromModel(ClientModel model);
 
-    // ClientModel toModel(ClientModel baseModel, ClientRepresentation representation);
+    void toModel(ClientModel model, ClientRepresentation rep, RealmModel realm);
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/mapper/ModelMapper.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/mapper/ModelMapper.java
@@ -1,0 +1,11 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.provider.Provider;
+
+public interface ModelMapper extends Provider {
+
+    ClientModelMapper clients();
+
+    default void close() {
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/mapper/ModelMapperFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/mapper/ModelMapperFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface ModelMapperFactory extends ProviderFactory<ModelMapper> {
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/mapper/ModelMapperSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/mapper/ModelMapperSpi.java
@@ -1,0 +1,28 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class ModelMapperSpi implements Spi {
+    public static final String NAME = "model-mapper";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends ModelMapper> getProviderClass() {
+        return ModelMapper.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<ModelMapper>> getProviderFactoryClass() {
+        return ModelMapperFactory.class;
+    }
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/KeycloakServicesFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/KeycloakServicesFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.services;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface KeycloakServicesFactory extends ProviderFactory<KeycloakServices> {
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/KeycloakServicesSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/KeycloakServicesSpi.java
@@ -1,0 +1,28 @@
+package org.keycloak.services;
+
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class KeycloakServicesSpi implements Spi {
+    public static final String NAME = "keycloak-services";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends KeycloakServices> getProviderClass() {
+        return KeycloakServices.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<KeycloakServices>> getProviderFactoryClass() {
+        return KeycloakServicesFactory.class;
+    }
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/client/ClientServiceFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/client/ClientServiceFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.services.client;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface ClientServiceFactory extends ProviderFactory<ClientService> {
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/client/ClientServiceSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/client/ClientServiceSpi.java
@@ -1,0 +1,28 @@
+package org.keycloak.services.client;
+
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class ClientServiceSpi implements Spi {
+    public static final String NAME = "client-service";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends ClientService> getProviderClass() {
+        return ClientService.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<ClientService>> getProviderFactoryClass() {
+        return ClientServiceFactory.class;
+    }
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+}

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -104,3 +104,6 @@ org.keycloak.health.LoadBalancerCheckSpi
 org.keycloak.cookie.CookieSpi
 org.keycloak.organization.OrganizationSpi
 org.keycloak.securityprofile.SecurityProfileSpi
+org.keycloak.services.KeycloakServicesSpi
+org.keycloak.services.client.ClientServiceSpi
+org.keycloak.models.mapper.ModelMapperSpi

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakSession.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakSession.java
@@ -20,6 +20,7 @@ package org.keycloak.models;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.provider.InvalidationHandler.InvalidableObjectType;
 import org.keycloak.provider.Provider;
+import org.keycloak.services.KeycloakServices;
 import org.keycloak.services.clientpolicy.ClientPolicyManager;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.vault.VaultTranscriber;
@@ -210,6 +211,8 @@ public interface KeycloakSession extends AutoCloseable {
      * @return the default IDP provider.
      */
     IdentityProviderStorageProvider identityProviders();
+
+    KeycloakServices services();
 
     @Override
     void close();

--- a/server-spi/src/main/java/org/keycloak/services/KeycloakServices.java
+++ b/server-spi/src/main/java/org/keycloak/services/KeycloakServices.java
@@ -1,0 +1,9 @@
+package org.keycloak.services;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.services.client.ClientService;
+
+public interface KeycloakServices extends Provider {
+
+    ClientService clients();
+}

--- a/server-spi/src/main/java/org/keycloak/services/Service.java
+++ b/server-spi/src/main/java/org/keycloak/services/Service.java
@@ -1,0 +1,9 @@
+package org.keycloak.services;
+
+import org.keycloak.provider.Provider;
+
+/**
+ * Service handling business logic for various user interfaces (REST API, GraphQL, GitOps,...)
+ */
+public interface Service extends Provider {
+}

--- a/server-spi/src/main/java/org/keycloak/services/ServiceException.java
+++ b/server-spi/src/main/java/org/keycloak/services/ServiceException.java
@@ -1,0 +1,27 @@
+package org.keycloak.services;
+
+import jakarta.ws.rs.core.Response;
+
+import java.util.Optional;
+
+public class ServiceException extends RuntimeException {
+    private Response.Status suggestedHttpResponseStatus;
+
+    public ServiceException(String message) {
+        super(message);
+    }
+
+    public ServiceException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public ServiceException(String message, Response.Status suggestedStatus) {
+        this(message);
+        this.suggestedHttpResponseStatus = suggestedStatus;
+    }
+
+    public Optional<Response.Status> getSuggestedResponseStatus() {
+        return Optional.ofNullable(suggestedHttpResponseStatus);
+    }
+
+}

--- a/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
@@ -5,18 +5,51 @@ import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.Service;
 import org.keycloak.services.ServiceException;
 
+import jakarta.ws.rs.core.Response.Status;
+
 import java.util.Optional;
 import java.util.stream.Stream;
 
 public interface ClientService extends Service {
 
-    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId);
+    public static class ClientSearchOptions {
+        // TODO
+    }
 
-    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation);
+    public static class ClientProjectionOptions {
+        // TODO
+    }
 
-    Stream<ClientRepresentation> getClients(RealmModel realm);
+    public static class ClientSortAndSliceOptions {
+        // order by
+        // offset
+        // limit
+        // NOTE: this is not always the most desirable way to do pagination
+    }
 
-    ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, ClientProjectionOptions projectionOptions);
+
+    Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions);
+
+    ClientRepresentation deleteClient(RealmModel realm, String clientId);
+
+    Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions);
+
+    default ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
+        // If we can paramertize the services, it makes sense to define default handling like this
+        // but this duplicate the existence check
+        try {
+            return createClient(realm, client);
+        } catch (ServiceException e) {
+            if (!e.getSuggestedResponseStatus().filter(Status.CONFLICT::equals).isPresent()) {
+                throw e;
+            }
+        }
+        return updateClient(realm, client);
+    }
+
+    ClientRepresentation updateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
 
     ClientRepresentation createClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+
 }

--- a/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
@@ -1,0 +1,22 @@
+package org.keycloak.services.client;
+
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.Service;
+import org.keycloak.services.ServiceException;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public interface ClientService extends Service {
+
+    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId);
+
+    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation);
+
+    Stream<ClientRepresentation> getClients(RealmModel realm);
+
+    ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+
+    ClientRepresentation createClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+}

--- a/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/server-spi/src/main/java/org/keycloak/services/client/ClientService.java
@@ -1,14 +1,12 @@
 package org.keycloak.services.client;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.Service;
 import org.keycloak.services.ServiceException;
-
-import jakarta.ws.rs.core.Response.Status;
-
-import java.util.Optional;
-import java.util.stream.Stream;
 
 public interface ClientService extends Service {
 
@@ -27,6 +25,8 @@ public interface ClientService extends Service {
         // NOTE: this is not always the most desirable way to do pagination
     }
 
+    public record CreateOrUpdateResult(ClientRepresentation representation, boolean created) {}
+
     Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, ClientProjectionOptions projectionOptions);
 
     Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions);
@@ -35,21 +35,6 @@ public interface ClientService extends Service {
 
     Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions);
 
-    default ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
-        // If we can paramertize the services, it makes sense to define default handling like this
-        // but this duplicate the existence check
-        try {
-            return createClient(realm, client);
-        } catch (ServiceException e) {
-            if (!e.getSuggestedResponseStatus().filter(Status.CONFLICT::equals).isPresent()) {
-                throw e;
-            }
-        }
-        return updateClient(realm, client);
-    }
-
-    ClientRepresentation updateClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
-
-    ClientRepresentation createClient(RealmModel realm, ClientRepresentation client) throws ServiceException;
+    CreateOrUpdateResult createOrUpdate(RealmModel realm, ClientRepresentation client, boolean allowUpdate) throws ServiceException;
 
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -81,7 +81,11 @@
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
@@ -270,6 +274,11 @@
                             <groupId>org.jboss.logging</groupId>
                             <artifactId>jboss-logging-processor</artifactId>
                             <version>${jboss-logging-annotations.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/services/src/main/java/org/keycloak/models/mapper/MapStructClientModelMapper.java
+++ b/services/src/main/java/org/keycloak/models/mapper/MapStructClientModelMapper.java
@@ -1,0 +1,46 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Mapper
+public interface MapStructClientModelMapper extends ClientModelMapper {
+    @Mapping(target = "displayName", source = "name")
+    @Mapping(target = "appUrl", source = "baseUrl")
+    @Mapping(target = "appRedirectUrls", source = "redirectUris")
+    @Mapping(target = "loginFlows", source = "authenticationFlowBindingOverrides", ignore = true)
+    @Mapping(target = "auth", ignore = true) // TODO
+    @Mapping(target = "roles", source = "rolesStream", qualifiedByName = "getRoleStrings")
+    @Mapping(target = "serviceAccount.enabled", source = "serviceAccountsEnabled")
+    @Mapping(target = "serviceAccount.roles", source = "rolesStream", qualifiedByName = "getServiceAccountRoles")
+    @Override
+    ClientRepresentation fromModel(ClientModel model);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void toModel(@MappingTarget ClientModel model, ClientRepresentation rep, @Context RealmModel realm);
+
+    @Named("getRoleStrings")
+    default Set<String> getRoleStrings(Stream<RoleModel> stream) {
+        return stream.map(RoleModel::getName).collect(Collectors.toSet());
+    }
+
+    @Named("getServiceAccountRoles")
+    default Set<String> getServiceAccountRoles(Stream<RoleModel> stream) {
+        return stream.filter(f -> true) //TODO check roles for SA
+                .map(RoleModel::getName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/services/src/main/java/org/keycloak/models/mapper/MapStructModelMapper.java
+++ b/services/src/main/java/org/keycloak/models/mapper/MapStructModelMapper.java
@@ -1,0 +1,16 @@
+package org.keycloak.models.mapper;
+
+import org.mapstruct.factory.Mappers;
+
+public class MapStructModelMapper implements ModelMapper {
+    private final MapStructClientModelMapper clientMapper;
+
+    public MapStructModelMapper() {
+        this.clientMapper = Mappers.getMapper(MapStructClientModelMapper.class);
+    }
+
+    @Override
+    public ClientModelMapper clients() {
+        return clientMapper;
+    }
+}

--- a/services/src/main/java/org/keycloak/models/mapper/MapStructModelMapperFactory.java
+++ b/services/src/main/java/org/keycloak/models/mapper/MapStructModelMapperFactory.java
@@ -1,0 +1,38 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class MapStructModelMapperFactory implements ModelMapperFactory {
+    public static final String PROVIDER_ID = "default";
+    private static ModelMapper SINGLETON;
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public ModelMapper create(KeycloakSession session) {
+        if (SINGLETON == null) {
+            SINGLETON = new MapStructModelMapper();
+        }
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakServices.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakServices.java
@@ -1,0 +1,26 @@
+package org.keycloak.services;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.client.ClientService;
+
+public class DefaultKeycloakServices implements KeycloakServices {
+    private final KeycloakSession session;
+    private ClientService clients;
+
+    public DefaultKeycloakServices(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public ClientService clients() {
+        if (clients == null) {
+            clients = session.getProvider(ClientService.class);
+        }
+        return clients;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakServicesFactory.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakServicesFactory.java
@@ -1,0 +1,34 @@
+package org.keycloak.services;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class DefaultKeycloakServicesFactory implements KeycloakServicesFactory {
+    public static final String PROVIDER_ID = "default";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public KeycloakServices create(KeycloakSession session) {
+        return new DefaultKeycloakServices(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
@@ -41,10 +41,10 @@ import org.keycloak.models.UserLoginFailureProvider;
 import org.keycloak.models.UserProvider;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
-import org.keycloak.provider.Provider;
-import org.keycloak.provider.ProviderFactory;
 import org.keycloak.provider.InvalidationHandler.InvalidableObjectType;
 import org.keycloak.provider.InvalidationHandler.ObjectType;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
 import org.keycloak.services.clientpolicy.ClientPolicyManager;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.storage.DatastoreProvider;
@@ -84,6 +84,7 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
     private TokenManager tokenManager;
     private VaultTranscriber vaultTranscriber;
     private ClientPolicyManager clientPolicyManager;
+    private KeycloakServices services;
     private boolean closed = false;
 
     public DefaultKeycloakSession(DefaultKeycloakSessionFactory factory) {
@@ -338,6 +339,14 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
             clientPolicyManager = getProvider(ClientPolicyManager.class);
         }
         return clientPolicyManager;
+    }
+
+    @Override
+    public KeycloakServices services() {
+        if (services == null) {
+            services = getProvider(KeycloakServices.class);
+        }
+        return services;
     }
 
     private static final Logger LOG = Logger.getLogger(DefaultKeycloakSession.class);

--- a/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -1,6 +1,8 @@
 package org.keycloak.services.client;
 
 import jakarta.ws.rs.core.Response;
+
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.mapper.ClientModelMapper;
@@ -22,24 +24,15 @@ public class DefaultClientService implements ClientService {
     }
 
     @Override
-    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId) {
+    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId,
+            ClientProjectionOptions projectionOptions) {
         return Optional.ofNullable(realm.getClientByClientId(clientId)).map(mapper::fromModel);
     }
 
     @Override
-    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation) {
-        // TODO reduced client rep
-        return fullRepresentation != null && fullRepresentation ? getClient(realm, clientId) : Optional.of(getTestReducedClientRep(clientId));
-    }
-
-    @Override
-    public Stream<ClientRepresentation> getClients(RealmModel realm) {
+    public Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions,
+            ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions) {
         return realm.getClientsStream().map(mapper::fromModel);
-    }
-
-    @Override
-    public ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
-        return null; // TODO
     }
 
     @Override
@@ -49,6 +42,30 @@ public class DefaultClientService implements ClientService {
         }
 
         var model = realm.addClient(client.getClientId());
+        // TODO: overlay model
+        return mapper.fromModel(model);
+    }
+
+    @Override
+    public ClientRepresentation deleteClient(RealmModel realm, String clientId) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ClientRepresentation updateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
+        ClientModel model = realm.getClientByClientId(client.getClientId());
+        if (model == null) {
+            throw new ServiceException("Client does not exist", Response.Status.NOT_FOUND);
+        }
+
+        // TODO: overlay model
         return mapper.fromModel(model);
     }
 
@@ -57,8 +74,4 @@ public class DefaultClientService implements ClientService {
 
     }
 
-    // TODO tested reduced client representation
-    private static ClientRepresentation getTestReducedClientRep(String clientId) {
-        return new ClientRepresentation(clientId);
-    }
 }

--- a/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -1,0 +1,64 @@
+package org.keycloak.services.client;
+
+import jakarta.ws.rs.core.Response;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.mapper.ClientModelMapper;
+import org.keycloak.models.mapper.ModelMapper;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.ServiceException;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+// TODO
+public class DefaultClientService implements ClientService {
+    private final KeycloakSession session;
+    private final ClientModelMapper mapper;
+
+    public DefaultClientService(KeycloakSession session) {
+        this.session = session;
+        this.mapper = session.getProvider(ModelMapper.class).clients();
+    }
+
+    @Override
+    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId) {
+        return Optional.ofNullable(realm.getClientByClientId(clientId)).map(mapper::fromModel);
+    }
+
+    @Override
+    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, Boolean fullRepresentation) {
+        // TODO reduced client rep
+        return fullRepresentation != null && fullRepresentation ? getClient(realm, clientId) : Optional.of(getTestReducedClientRep(clientId));
+    }
+
+    @Override
+    public Stream<ClientRepresentation> getClients(RealmModel realm) {
+        return realm.getClientsStream().map(mapper::fromModel);
+    }
+
+    @Override
+    public ClientRepresentation createOrUpdateClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
+        return null; // TODO
+    }
+
+    @Override
+    public ClientRepresentation createClient(RealmModel realm, ClientRepresentation client) throws ServiceException {
+        if (realm.getClientByClientId(client.getClientId()) != null) {
+            throw new ServiceException("Client already exists", Response.Status.CONFLICT);
+        }
+
+        var model = realm.addClient(client.getClientId());
+        return mapper.fromModel(model);
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    // TODO tested reduced client representation
+    private static ClientRepresentation getTestReducedClientRep(String clientId) {
+        return new ClientRepresentation(clientId);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/client/DefaultClientServiceFactory.java
+++ b/services/src/main/java/org/keycloak/services/client/DefaultClientServiceFactory.java
@@ -1,0 +1,34 @@
+package org.keycloak.services.client;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class DefaultClientServiceFactory implements ClientServiceFactory {
+    public static final String PROVIDER_ID = "default";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public ClientService create(KeycloakSession session) {
+        return new DefaultClientService(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.models.mapper.ModelMapperFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.models.mapper.ModelMapperFactory
@@ -1,0 +1,1 @@
+org.keycloak.models.mapper.MapStructModelMapperFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.KeycloakServicesFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.KeycloakServicesFactory
@@ -1,0 +1,1 @@
+org.keycloak.services.DefaultKeycloakServicesFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.client.ClientServiceFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.client.ClientServiceFactory
@@ -1,0 +1,1 @@
+org.keycloak.services.client.DefaultClientServiceFactory


### PR DESCRIPTION
also shows basic field validation

@vmuzikar @mabartos @Pepo48 this shows roughly what json merge patch support looks like - there is very little we need to do as Jackson has support already baked in. There are several TODOs - moving field validation to a common spot, using a common objectmapper, agreeing on the response codes, etc.

The server side method to allow for other patch types has the payload typed as JsonNode (if that doesn't work, then we'd just use String). 

From a rest client perspective you could have a typed method. Tthe user will do something like:

```
ClientRepresentation rep = new ClientRepresentation();
rep.setEnabled(false);
rep.getAdditionalField().put("description", null); // remove description

clients.getClient("id").patchClient(rep, FieldValidation.Strict);
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
