### PR TITLE
Remove duplicate definition of WebAuthnErrorPage in AbstractWebAuthnAccountTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
@@ -34,7 +34,6 @@ import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentati
 import org.keycloak.testsuite.AbstractAuthTest;
 import org.keycloak.testsuite.page.AbstractPatternFlyAlert;
 import org.keycloak.testsuite.webauthn.pages.SigningInPage;
-import org.keycloak.testsuite.webauthn.pages.WebAuthnErrorPage;
 import org.keycloak.testsuite.webauthn.utils.SigningInPageUtils;
 import org.keycloak.testsuite.pages.DeleteCredentialPage;
 import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
@@ -75,9 +74,6 @@ public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest imple
 
     @Page
     private DeleteCredentialPage deleteCredentialPage;
-
-    @Page
-    protected WebAuthnErrorPage webAuthnErrorPage;
 
     private VirtualAuthenticatorManager webAuthnManager;
     protected SigningInPage.CredentialType webAuthnCredentialType;


### PR DESCRIPTION
Closes #40451

Just removing the page that is duplicated. The problem is that two different PRs added the same page with the same name at the same time.