### PR TITLE
Issue 39310

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.ws.rs.core.UriInfo;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
@@ -47,7 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * {@link  WellKnownProvider} implementation to provide the .well-known/openid-credential-issuer endpoint, offering
+ * {@link WellKnownProvider} implementation to provide the .well-known/openid-credential-issuer endpoint, offering
  * the Credential Issuer Metadata as defined by the OID4VCI protocol
  * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2.2}
  *
@@ -72,8 +73,10 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                 .setCredentialIssuer(getIssuer(keycloakSession.getContext()))
                 .setCredentialEndpoint(getCredentialsEndpoint(keycloakSession.getContext()))
                 .setCredentialsSupported(getSupportedCredentials(keycloakSession))
-                .setAuthorizationServers(List.of(getIssuer(keycloakSession.getContext())));
-
+                .setAuthorizationServers(List.of(getIssuer(keycloakSession.getContext())))
+                .setCredentialResponseEncryption(new CredentialIssuer.CredentialResponseEncryption()
+                        .setAlgValuesSupported(List.of("RSA-OAEP"))
+                        .setEncValuesSupported(List.of("A256GCM")));
     }
 
     /**
@@ -103,7 +106,6 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                 .distinct()
                 .peek(sc -> sc.setCredentialSigningAlgValuesSupported(supportedAlgorithms))
                 .collect(Collectors.toMap(SupportedCredentialConfiguration::getId, sc -> sc, (sc1, sc2) -> sc1));
-
 
         // Retrieving attributes from the realm
         Map<String, SupportedCredentialConfiguration> realmAttr = fromRealmAttributes(realm.getAttributes())

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -76,7 +76,8 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                 .setAuthorizationServers(List.of(getIssuer(keycloakSession.getContext())))
                 .setCredentialResponseEncryption(new CredentialIssuer.CredentialResponseEncryption()
                         .setAlgValuesSupported(List.of("RSA-OAEP"))
-                        .setEncValuesSupported(List.of("A256GCM")));
+                        .setEncValuesSupported(List.of("A256GCM"))
+                        .setEncryptionRequired(false));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/CredentialSigner.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/CredentialSigner.java
@@ -22,22 +22,32 @@ import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
 import org.keycloak.provider.Provider;
 
 /**
- * Interface to be used for signing verifiable credentials.
+ * Interface for signing verifiable credentials in the OID4VCI protocol.
+ * Implementations must produce a signed credential representation based on the provided
+ * credential body and configuration.
+ *
+ * @param <T> the type of the signed credential representation (e.g., String for JWT, Map for LD-Proof)
  */
 public interface CredentialSigner<T> extends Provider {
 
+    /**
+     * Default implementation for closing resources. Implementations should override
+     * if they hold resources that need to be released.
+     */
     @Override
     default void close() {
+        // No resources to close by default
     }
 
     /**
-     * Takes a verifiable credential and signs it according to the implementation.
-     * Depending on the type of the CredentialSigner, it will return a signed representation
-     * of the credential that be returned at the credential request endpoint.
+     * Signs a verifiable credential using the provided credential body and configuration.
      *
-     * @param credentialBody        a partially built credential representation, awaiting to be signed
-     * @param credentialBuildConfig additional configurations for building the credential
-     * @return a signed representation
+     * @param credentialBody        the partially built credential representation to be signed
+     * @param credentialBuildConfig additional configurations for building and signing the credential
+     * @return a signed credential representation
+     * @throws CredentialSignerException if signing fails due to invalid inputs, configuration errors,
+     *                                   or cryptographic issues
+     * @throws IllegalArgumentException if credentialBody or credentialBuildConfig is null
      */
     T signCredential(CredentialBody credentialBody, CredentialBuildConfig credentialBuildConfig)
             throws CredentialSignerException;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialIssuer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialIssuer.java
@@ -20,13 +20,12 @@ package org.keycloak.protocol.oid4vc.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Represents a credentials issuer according to the OID4VCI Credentials Issuer Metadata
- * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata}
+ * Represents the Credential Issuer Metadata as per OID4VCI spec
+ * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2.2}
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */
@@ -39,19 +38,14 @@ public class CredentialIssuer {
     @JsonProperty("credential_endpoint")
     private String credentialEndpoint;
 
+    @JsonProperty("credentials_supported")
+    private Map<String, SupportedCredentialConfiguration> credentialsSupported;
+
     @JsonProperty("authorization_servers")
     private List<String> authorizationServers;
 
-    @JsonProperty("batch_credential_endpoint")
-    private String batchCredentialEndpoint;
-
-    @JsonProperty("notification_endpoint")
-    private String notificationEndpoint;
-
-    @JsonProperty("credential_configurations_supported")
-    private Map<String, SupportedCredentialConfiguration> credentialsSupported;
-
-    private DisplayObject display;
+    @JsonProperty("credential_response_encryption")
+    private CredentialResponseEncryption credentialResponseEncryption;
 
     public String getCredentialIssuer() {
         return credentialIssuer;
@@ -71,30 +65,12 @@ public class CredentialIssuer {
         return this;
     }
 
-    public String getBatchCredentialEndpoint() {
-        return batchCredentialEndpoint;
-    }
-
-    public CredentialIssuer setBatchCredentialEndpoint(String batchCredentialEndpoint) {
-        this.batchCredentialEndpoint = batchCredentialEndpoint;
-        return this;
-    }
-
     public Map<String, SupportedCredentialConfiguration> getCredentialsSupported() {
         return credentialsSupported;
     }
 
     public CredentialIssuer setCredentialsSupported(Map<String, SupportedCredentialConfiguration> credentialsSupported) {
-        this.credentialsSupported = Collections.unmodifiableMap(credentialsSupported);
-        return this;
-    }
-
-    public DisplayObject getDisplay() {
-        return display;
-    }
-
-    public CredentialIssuer setDisplay(DisplayObject display) {
-        this.display = display;
+        this.credentialsSupported = credentialsSupported;
         return this;
     }
 
@@ -107,13 +83,43 @@ public class CredentialIssuer {
         return this;
     }
 
-    public String getNotificationEndpoint() {
-        return notificationEndpoint;
+    public CredentialResponseEncryption getCredentialResponseEncryption() {
+        return credentialResponseEncryption;
     }
 
-    public CredentialIssuer setNotificationEndpoint(String notificationEndpoint) {
-        this.notificationEndpoint = notificationEndpoint;
+    public CredentialIssuer setCredentialResponseEncryption(CredentialResponseEncryption credentialResponseEncryption) {
+        this.credentialResponseEncryption = credentialResponseEncryption;
         return this;
     }
-}
 
+    /**
+     * Represents the credential_response_encryption metadata as per OID4VCI spec
+     * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2.2}
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CredentialResponseEncryption {
+        @JsonProperty("alg_values_supported")
+        private List<String> algValuesSupported;
+
+        @JsonProperty("enc_values_supported")
+        private List<String> encValuesSupported;
+
+        public List<String> getAlgValuesSupported() {
+            return algValuesSupported;
+        }
+
+        public CredentialResponseEncryption setAlgValuesSupported(List<String> algValuesSupported) {
+            this.algValuesSupported = algValuesSupported;
+            return this;
+        }
+
+        public List<String> getEncValuesSupported() {
+            return encValuesSupported;
+        }
+
+        public CredentialResponseEncryption setEncValuesSupported(List<String> encValuesSupported) {
+            this.encValuesSupported = encValuesSupported;
+            return this;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialIssuer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialIssuer.java
@@ -93,16 +93,18 @@ public class CredentialIssuer {
     }
 
     /**
-     * Represents the credential_response_encryption metadata as per OID4VCI spec
+     * Represents the credential_response_encryption metadata
      * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2.2}
      */
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class CredentialResponseEncryption {
         @JsonProperty("alg_values_supported")
         private List<String> algValuesSupported;
 
         @JsonProperty("enc_values_supported")
         private List<String> encValuesSupported;
+
+        @JsonProperty("encryption_required")
+        private Boolean encryptionRequired;
 
         public List<String> getAlgValuesSupported() {
             return algValuesSupported;
@@ -119,6 +121,15 @@ public class CredentialIssuer {
 
         public CredentialResponseEncryption setEncValuesSupported(List<String> encValuesSupported) {
             this.encValuesSupported = encValuesSupported;
+            return this;
+        }
+
+        public Boolean getEncryptionRequired() {
+            return encryptionRequired;
+        }
+
+        public CredentialResponseEncryption setEncryptionRequired(Boolean encryptionRequired) {
+            this.encryptionRequired = encryptionRequired;
             return this;
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
@@ -22,8 +22,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Map;
+
 /**
- * Represents a  CredentialRequest according to OID4VCI
+ * Represents a CredentialRequest according to OID4VCI
  * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
@@ -51,6 +53,11 @@ public class CredentialRequest {
     // See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-format-identifier-3
     @JsonProperty("credential_definition")
     private CredentialDefinition credentialDefinition;
+
+    // Adding support for credential_response_encryption as per OID4VCI spec
+    // {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
+    @JsonProperty("credential_response_encryption")
+    private CredentialResponseEncryption credentialResponseEncryption;
 
     public String getFormat() {
         return format;
@@ -95,5 +102,52 @@ public class CredentialRequest {
     public CredentialRequest setCredentialDefinition(CredentialDefinition credentialDefinition) {
         this.credentialDefinition = credentialDefinition;
         return this;
+    }
+
+    public CredentialResponseEncryption getCredentialResponseEncryption() {
+        return credentialResponseEncryption;
+    }
+
+    public CredentialRequest setCredentialResponseEncryption(CredentialResponseEncryption credentialResponseEncryption) {
+        this.credentialResponseEncryption = credentialResponseEncryption;
+        return this;
+    }
+
+    /**
+     * Represents the credential_response_encryption object as per OID4VCI spec
+     * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CredentialResponseEncryption {
+        private String alg;
+        private String enc;
+        private Map<String, Object> jwk;
+
+        public String getAlg() {
+            return alg;
+        }
+
+        public CredentialResponseEncryption setAlg(String alg) {
+            this.alg = alg;
+            return this;
+        }
+
+        public String getEnc() {
+            return enc;
+        }
+
+        public CredentialResponseEncryption setEnc(String enc) {
+            this.enc = enc;
+            return this;
+        }
+
+        public Map<String, Object> getJwk() {
+            return jwk;
+        }
+
+        public CredentialResponseEncryption setJwk(Map<String, Object> jwk) {
+            this.jwk = jwk;
+            return this;
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
@@ -22,8 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import java.util.Map;
-
 /**
  * Represents a CredentialRequest according to OID4VCI
  * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
@@ -54,8 +52,6 @@ public class CredentialRequest {
     @JsonProperty("credential_definition")
     private CredentialDefinition credentialDefinition;
 
-    // Adding support for credential_response_encryption as per OID4VCI spec
-    // {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
     @JsonProperty("credential_response_encryption")
     private CredentialResponseEncryption credentialResponseEncryption;
 
@@ -113,41 +109,4 @@ public class CredentialRequest {
         return this;
     }
 
-    /**
-     * Represents the credential_response_encryption object as per OID4VCI spec
-     * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
-     */
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class CredentialResponseEncryption {
-        private String alg;
-        private String enc;
-        private Map<String, Object> jwk;
-
-        public String getAlg() {
-            return alg;
-        }
-
-        public CredentialResponseEncryption setAlg(String alg) {
-            this.alg = alg;
-            return this;
-        }
-
-        public String getEnc() {
-            return enc;
-        }
-
-        public CredentialResponseEncryption setEnc(String enc) {
-            this.enc = enc;
-            return this;
-        }
-
-        public Map<String, Object> getJwk() {
-            return jwk;
-        }
-
-        public CredentialResponseEncryption setJwk(Map<String, Object> jwk) {
-            this.jwk = jwk;
-            return this;
-        }
-    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialResponse.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialResponse.java
@@ -29,7 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CredentialResponse {
 
-    // concrete type depends on the format
+    // Concrete type depends on the format; may be a JWE string if encrypted
+    // as per https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-response
     private Object credential;
 
     @JsonProperty("notification_id")

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialResponseEncryption.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialResponseEncryption.java
@@ -1,0 +1,44 @@
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.keycloak.jose.jwk.JWK;
+
+/**
+ * Represents the credential_response_encryption object
+ * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request}
+ *
+ * @author <a href="mailto:Bertrand.Ogen@adorsys.com">Bertrand Ogen</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CredentialResponseEncryption {
+    private String alg;
+    private String enc;
+    private JWK jwk;
+
+    public String getAlg() {
+        return alg;
+    }
+
+    public CredentialResponseEncryption setAlg(String alg) {
+        this.alg = alg;
+        return this;
+    }
+
+    public String getEnc() {
+        return enc;
+    }
+
+    public CredentialResponseEncryption setEnc(String enc) {
+        this.enc = enc;
+        return this;
+    }
+
+    public JWK getJwk() {
+        return jwk;
+    }
+
+    public CredentialResponseEncryption setJwk(JWK jwk) {
+        this.jwk = jwk;
+        return this;
+    }
+}


### PR DESCRIPTION
This PR aims at supporting credential_response_encryption during the issuing of credentials request. If the Client requested an encrypted response by including the credential_response_encryption object in the request, the Credential Issuer MUST encode the information in the Credential Response as a JWT using the parameters from the credential_response_encryption object. If the Credential Response is encrypted, the media type of the response MUST be set to application/jwt. If encryption was requested in the Credential Request and the Credential Response is not encrypted, the Client SHOULD reject the Credential Response.

See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request