### PR TITLE
Additional Quarkus devtools dependencies in distribution

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -34,6 +34,10 @@
                     <groupId>org.eclipse.sisu</groupId>
                     <artifactId>org.eclipse.sisu.inject</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devtools-utilities</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -76,6 +80,36 @@
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-devtools-codestarts</artifactId>
                 </exclusion>
+                <!-- Exclude transitive dependencies for 'io.quarkus:quarkus-devtools-common' BEGIN -->
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devtools-registry-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devtools-utilities</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devtools-base-codestarts</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codejive</groupId>
+                    <artifactId>java-properties</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-version</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <!-- Exclude transitive dependencies for 'io.quarkus:quarkus-devtools-common' END -->
             </exclusions>
         </dependency>
         <dependency>
@@ -97,6 +131,10 @@
                 <exclusion>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-devservices-deployment</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal-dev</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -195,6 +233,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devtools-utilities</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus/dist/check-dev-dependencies.sh
+++ b/quarkus/dist/check-dev-dependencies.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+if mvn dependency:tree -Dverbose | grep -E '(-dev:|-devtools-)'; then
+  echo "[WARNING] Detected development dependencies in the build tree."
+fi

--- a/quarkus/dist/pom.xml
+++ b/quarkus/dist/pom.xml
@@ -111,4 +111,35 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>check-dev-dependencies</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>warn-on-dev-dependencies</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${project.basedir}/check-dev-dependencies.sh</executable>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Closes #39227

- As we are not currently able to exclude dev dependencies completely, we need to be more selective here: https://github.com/quarkusio/quarkus/issues/47210
- Some basic approaches on how to exclude these dev dependencies will be part of Quarkus 3.23.x, and some other changes later: https://github.com/quarkusio/quarkus/pull/45053
- The only `io.quarkus:quarkus-devtools-common` cannot be excluded from the distribution, but its transitive dependencies can
- Create script that checks the distribution dependency tree and warn us if there are some more - which might be useful even for Quarkus upgrades
![Screenshot From 2025-06-12 17-25-30](https://github.com/user-attachments/assets/daa6bf36-ed2c-4e95-a9b1-b0e5aca27333)
- I'll create a follow-up issue to track progress on Quarkus side and then removing all these additional excludes

@shawkins @vmuzikar Could you please check it? Thanks!
