### PR TITLE
39429/OfflineSessionPersistenceTest testPersistenceMultipleNodesClientSessionsAtRandomNode

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_3_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_3_0.adoc
@@ -83,6 +83,12 @@ Previously the default *browser* flow had a *Browser - Conditional OTP* conditio
 
 Upgraded realms will not be changed. The updated flow will only be available for new realms. Take this change into consideration if you have automated the realm creation.
 
+=== Volatile Session Cache Defaults
+
+If the `persistent-user-sessions` feature is disabled, i.e. volatile sessions are configured, {project_name} now prevents
+`num_owners=1` being configured unless a shared persistent store is also configured. This is to prevent data loss on cache
+rebalances.
+
 == Deprecated features
 
 The following sections provide details on deprecated features.

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.AbstractStoreConfiguration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.HashConfiguration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
@@ -227,8 +228,11 @@ public final class CacheConfigurator {
                 logger.warnf("Persistent user sessions disabled and memory limit is set to default value 10000. Ignoring cache limits to avoid losing sessions for cache %s.", name);
                 builder.memory().maxCount(-1);
             }
-            if (builder.clustering().hash().attributes().attribute(HashConfiguration.NUM_OWNERS).get() == 1 && builder.persistence().stores().isEmpty()) {
-                logger.warnf("Number of owners is one for cache %s, and no persistence is configured. This might be a misconfiguration as you will lose data when a single node is restarted!", name);
+            if (builder.clustering().hash().attributes().attribute(HashConfiguration.NUM_OWNERS).get() == 1 &&
+                  builder.persistence().stores().stream().noneMatch(p -> p.attributes().attribute(AbstractStoreConfiguration.SHARED).get())
+            ) {
+                logger.warnf("Persistent user sessions disabled with number of owners set to default value 1 for cache %s and no shared persistence store configured. Setting num_owners=2 to avoid data loss.", name);
+                builder.clustering().hash().numOwners(2);
             }
         }
     }


### PR DESCRIPTION
Closes #39429
Closes #40472

Test failures introduced by https://github.com/keycloak/keycloak/pull/39126

Previously `model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java` ensured that the caches were created with 2 owners if `sessionsOwners` was not explicitly configured. However, since those changes the `test-ispn.xml` configuration was loaded which utilises num_owners=1 for the `offlineSessions` cache.

When looking up a offlineSession not present in the cache, the `InfinispanUserSessionProvider` calls `getUserSessionEntityFromPersistenceProvider` which:

1. Load the persistent session from UserSessionPersisterProvider
2. Import it into memory using `importUserSession`
2a. Write to the cache via `session.sessions().importUserSessions`
2b. Retrieve the `UserSessionEntity` by reading from the cache and return

The test has become flaky as 2b is a cache miss if a rebalance occurs between 2a and 2b.

Sample log entries:

```
3131:10:00:33,666 DEBUG [org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction] (pool-4-thread-1) key c08a915e-41ba-414f-a3f4-26ed82e08e44 not found in updates
3134:10:00:33,666 DEBUG [org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction] (pool-4-thread-1) key c08a915e-41ba-414f-a3f4-26ed82e08e44 not found in cache
3135:10:00:33,666 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) getUserSessionEntity id=c08a915e-41ba-414f-a3f4-26ed82e08e44 entityWrapper==null
3136:10:00:33,666 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) Offline user-session not found in infinispan, attempting UserSessionPersisterProvider lookup for sessionId=c08a915e-41ba-414f-a3f4-26ed82e08e44
3145:10:00:33,668 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) Attempting to import user-session for sessionId=c08a915e-41ba-414f-a3f4-26ed82e08e44 offline=true
3147:10:00:33,668 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) importUserSession stream: c08a915e-41ba-414f-a3f4-26ed82e08e44 | true
3150:10:00:33,668 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) key=c08a915e-41ba-414f-a3f4-26ed82e08e44 value=SessionEntityWrapper{version=eab6587e-b99c-496a-bce7-ef8806826137, entity=UserSessionEntity [id=c08a915e-41ba-414f-a3f4-26ed82e08e44, realm=727c9dce-19ac-44d6-bc6c-468466451ba4, lastSessionRefresh=1749718831, clients=[]], localMetadata={}}
3151:10:00:33,668 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) importSessionsWithExpiration put id=c08a915e-41ba-414f-a3f4-26ed82e08e44
3155:10:00:33,669 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) importSessionsWithExpiration after id=c08a915e-41ba-414f-a3f4-26ed82e08e44
3158:10:00:33,669 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) after importUserSessions sessionId=c08a915e-41ba-414f-a3f4-26ed82e08e44 offline=true
3159:10:00:33,669 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) user-session imported, trying another lookup for sessionId=c08a915e-41ba-414f-a3f4-26ed82e08e44 offline=true
3160:10:00:33,670 DEBUG [org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction] (pool-4-thread-1) key c08a915e-41ba-414f-a3f4-26ed82e08e44 not found in updates
3162:10:00:33,670 WARN  [org.infinispan.CLUSTER] (pool-4-thread-2) [Context=offlineSessions] ISPN000312: Lost data because of graceful leaver node-3
3170:10:00:33,671 INFO  [org.infinispan.LIFECYCLE] () [Context=offlineSessions] ISPN100002: Starting rebalance with members [node-4, node-2], phase READ_OLD_WRITE_ALL, topology id 11
3171:10:00:33,671 INFO  [org.infinispan.LIFECYCLE] () [Context=offlineSessions] ISPN100002: Starting rebalance with members [node-4, node-2], phase READ_OLD_WRITE_ALL, topology id 11
3172:10:00:33,671 INFO  [org.infinispan.LIFECYCLE] (non-blocking-thread-node-2-p17-t17) [Context=offlineSessions] ISPN100010: Finished rebalance with members [node-4, node-2], topology id 11
3173:10:00:33,671 INFO  [org.infinispan.LIFECYCLE] (non-blocking-thread-node-4-p12-t38) [Context=offlineSessions] ISPN100010: Finished rebalance with members [node-4, node-2], topology id 11
3174:10:00:33,671 DEBUG [org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction] (pool-4-thread-1) key c08a915e-41ba-414f-a3f4-26ed82e08e44 not found in cache
3175:10:00:33,671 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) getUserSessionEntity id=c08a915e-41ba-414f-a3f4-26ed82e08e44 entityWrapper==null
3176:10:00:33,672 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (pool-4-thread-1) user-session could not be found after import for sessionId=c08a915e-41ba-414f-a3f4-26ed82e08e44 offline=true
```

The solution is to ensure that `num_owners=2` is always defined for `volatilesession` tests like we recommend for users in their configurations.

I have executed the test 100 times consecutively without failure locally, without the fix it would consistently fail before the 20th iteration.