### PR TITLE
fix(i18n): add missing comma before 'a' in Polish password reset message

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
@@ -132,7 +132,7 @@ emailLinkIdp5=aby kontynuować.
 
 backToLogin=&laquo; Powrót do logowania
 
-emailInstruction=Wpisz swój adres e-mail lub nazwę użytkownika a wyślemy do Ciebie instrukcje, jak utworzyć nowe hasło.
+emailInstruction=Wpisz swój adres e-mail lub nazwę użytkownika, a wyślemy do Ciebie instrukcje, jak utworzyć nowe hasło.
 
 copyCodeInstruction=Proszę skopiować ten kod i wklej go do aplikacji\:
 


### PR DESCRIPTION
Closes #40485

Corrected punctuation in the UI string to follow proper Polish grammar rules.

