### PR TITLE
Fix for "Account UI ignores identity provider display order"

### DIFF
--- a/core/src/main/java/org/keycloak/representations/account/LinkedAccountRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/account/LinkedAccountRepresentation.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.representations.account;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  *
@@ -29,8 +28,6 @@ public class LinkedAccountRepresentation implements Comparable<LinkedAccountRepr
     private String providerName;
     private String displayName;
     private String linkedUsername;
-
-    @JsonIgnore
     private String guiOrder;
 
     public String getLinkedUsername() {

--- a/js/apps/account-ui/src/account-security/LinkedAccounts.tsx
+++ b/js/apps/account-ui/src/account-security/LinkedAccounts.tsx
@@ -86,7 +86,9 @@ export const LinkedAccounts = () => {
           />
           <DataList id="linked-idps" aria-label={t("linkedLoginProviders")}>
             {linkedAccounts.length > 0 ? (
-              linkedAccounts.map(
+              linkedAccounts.sort(
+                  (firstIdp, secondIdp) => Number(firstIdp.guiOrder ?? Number.MAX_SAFE_INTEGER) - Number(secondIdp.guiOrder ?? Number.MAX_SAFE_INTEGER)
+                  ).map(
                 (account, index) =>
                   index !== paramsLinked.max - 1 && (
                     <AccountRow
@@ -140,7 +142,9 @@ export const LinkedAccounts = () => {
           />
           <DataList id="unlinked-idps" aria-label={t("unlinkedLoginProviders")}>
             {unlinkedAccounts.length > 0 ? (
-              unlinkedAccounts.map(
+              unlinkedAccounts.sort(
+                  (firstIdp, secondIdp) => Number(firstIdp.guiOrder ?? Number.MAX_SAFE_INTEGER) - Number(secondIdp.guiOrder ?? Number.MAX_SAFE_INTEGER)
+              ).map(
                 (account, index) =>
                   index !== paramsUnlinked.max - 1 && (
                     <AccountRow

--- a/js/apps/account-ui/src/api/representations.ts
+++ b/js/apps/account-ui/src/api/representations.ts
@@ -66,6 +66,7 @@ export interface LinkedAccountRepresentation {
   displayName: string;
   linkedUsername: string;
   social: boolean;
+  guiOrder: string;
 }
 
 export interface SessionRepresentation {


### PR DESCRIPTION
Fix identity provider UI order bug

Ensures identity providers are displayed in the correct order
by GUI priority fetched in API when rendering the Account UI list.

Closes #40461 