### PR TITLE
Upgrade webauth4j to current release 0.29.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         </surefire.system.args>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.21.5.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.29.3.RELEASE</webauthn4j.version>
         <org.apache.kerby.kerby-asn1.version>2.0.3</org.apache.kerby.kerby-asn1.version>
 
         <!-- Used to test SAML Galleon feature-pack layers discovery -->

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnPasswordlessRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnPasswordlessRegister.java
@@ -18,7 +18,7 @@
 
 package org.keycloak.authentication.requiredactions;
 
-import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.CertPathTrustworthinessVerifier;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.credential.WebAuthnPasswordlessCredentialProviderFactory;
 import org.keycloak.models.KeycloakSession;
@@ -32,8 +32,8 @@ import org.keycloak.models.credential.WebAuthnCredentialModel;
  */
 public class WebAuthnPasswordlessRegister extends WebAuthnRegister {
 
-    public WebAuthnPasswordlessRegister(KeycloakSession session, CertPathTrustworthinessValidator certPathtrustValidator) {
-        super(session, certPathtrustValidator);
+    public WebAuthnPasswordlessRegister(KeycloakSession session, CertPathTrustworthinessVerifier certPathtrustVerifier) {
+        super(session, certPathtrustVerifier);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnPasswordlessRegisterFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnPasswordlessRegisterFactory.java
@@ -18,7 +18,7 @@
 
 package org.keycloak.authentication.requiredactions;
 
-import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.CertPathTrustworthinessVerifier;
 import org.keycloak.models.KeycloakSession;
 
 /**
@@ -29,8 +29,8 @@ public class WebAuthnPasswordlessRegisterFactory extends WebAuthnRegisterFactory
     public static final String PROVIDER_ID = "webauthn-register-passwordless";
 
     @Override
-    protected WebAuthnRegister createProvider(KeycloakSession session, CertPathTrustworthinessValidator trustValidator) {
-        return new WebAuthnPasswordlessRegister(session, trustValidator);
+    protected WebAuthnRegister createProvider(KeycloakSession session, CertPathTrustworthinessVerifier trustVerifier) {
+        return new WebAuthnPasswordlessRegister(session, trustVerifier);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -72,14 +72,14 @@ import com.webauthn4j.data.RegistrationData;
 import com.webauthn4j.data.RegistrationParameters;
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.exception.WebAuthnException;
-import com.webauthn4j.validator.attestation.statement.androidkey.AndroidKeyAttestationStatementValidator;
-import com.webauthn4j.validator.attestation.statement.androidsafetynet.AndroidSafetyNetAttestationStatementValidator;
-import com.webauthn4j.validator.attestation.statement.none.NoneAttestationStatementValidator;
-import com.webauthn4j.validator.attestation.statement.packed.PackedAttestationStatementValidator;
-import com.webauthn4j.validator.attestation.statement.tpm.TPMAttestationStatementValidator;
-import com.webauthn4j.validator.attestation.statement.u2f.FIDOU2FAttestationStatementValidator;
-import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
-import com.webauthn4j.validator.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessValidator;
+import com.webauthn4j.verifier.attestation.statement.androidkey.AndroidKeyAttestationStatementVerifier;
+import com.webauthn4j.verifier.attestation.statement.androidsafetynet.AndroidSafetyNetAttestationStatementVerifier;
+import com.webauthn4j.verifier.attestation.statement.none.NoneAttestationStatementVerifier;
+import com.webauthn4j.verifier.attestation.statement.packed.PackedAttestationStatementVerifier;
+import com.webauthn4j.verifier.attestation.statement.tpm.TPMAttestationStatementVerifier;
+import com.webauthn4j.verifier.attestation.statement.u2f.FIDOU2FAttestationStatementVerifier;
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.CertPathTrustworthinessVerifier;
+import com.webauthn4j.verifier.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessVerifier;
 
 import static org.keycloak.WebAuthnConstants.REG_ERR_DETAIL_LABEL;
 import static org.keycloak.WebAuthnConstants.REG_ERR_LABEL;
@@ -93,12 +93,12 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
     private static final String WEB_AUTHN_TITLE_ATTR = "webAuthnTitle";
     private static final Logger logger = Logger.getLogger(WebAuthnRegister.class);
 
-    private KeycloakSession session;
-    private CertPathTrustworthinessValidator certPathtrustValidator;
+    private final KeycloakSession session;
+    private final CertPathTrustworthinessVerifier certPathtrustVerifier;
 
-    public WebAuthnRegister(KeycloakSession session, CertPathTrustworthinessValidator certPathtrustValidator) {
+    public WebAuthnRegister(KeycloakSession session, CertPathTrustworthinessVerifier certPathtrustVerifier) {
         this.session = session;
-        this.certPathtrustValidator = certPathtrustValidator;
+        this.certPathtrustVerifier = certPathtrustVerifier;
     }
 
     @Override
@@ -269,7 +269,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
             // parse
             RegistrationData registrationData = webAuthnRegistrationManager.parse(registrationRequest);
             // validate
-            webAuthnRegistrationManager.validate(registrationData, registrationParameters);
+            webAuthnRegistrationManager.verify(registrationData, registrationParameters);
 
             showInfoAfterWebAuthnApiCreate(registrationData);
 
@@ -319,15 +319,15 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
     protected WebAuthnRegistrationManager createWebAuthnRegistrationManager() {
         return new WebAuthnRegistrationManager(
                 Arrays.asList(
-                        new NoneAttestationStatementValidator(),
-                        new PackedAttestationStatementValidator(),
-                        new TPMAttestationStatementValidator(),
-                        new AndroidKeyAttestationStatementValidator(),
-                        new AndroidSafetyNetAttestationStatementValidator(),
-                        new FIDOU2FAttestationStatementValidator()
-                ), this.certPathtrustValidator,
-                new DefaultSelfAttestationTrustworthinessValidator(),
-                Collections.emptyList(), // Custom Registration Validator is not supported
+                        new NoneAttestationStatementVerifier(),
+                        new PackedAttestationStatementVerifier(),
+                        new TPMAttestationStatementVerifier(),
+                        new AndroidKeyAttestationStatementVerifier(),
+                        new AndroidSafetyNetAttestationStatementVerifier(),
+                        new FIDOU2FAttestationStatementVerifier()
+                ), this.certPathtrustVerifier,
+                new DefaultSelfAttestationTrustworthinessVerifier(),
+                Collections.emptyList(), // Custom Registration Verifier is not supported
                 new ObjectConverter()
                 );
     }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegisterFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegisterFactory.java
@@ -16,7 +16,11 @@
 
 package org.keycloak.authentication.requiredactions;
 
-import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
+import com.webauthn4j.anchor.KeyStoreTrustAnchorRepository;
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.CertPathTrustworthinessVerifier;
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.DefaultCertPathTrustworthinessVerifier;
+import com.webauthn4j.verifier.attestation.trustworthiness.certpath.NullCertPathTrustworthinessVerifier;
+
 import org.keycloak.Config;
 import org.keycloak.Config.Scope;
 import org.keycloak.authentication.RequiredActionFactory;
@@ -27,11 +31,6 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.truststore.TruststoreProvider;
 
-import com.webauthn4j.anchor.KeyStoreTrustAnchorsProvider;
-import com.webauthn4j.anchor.TrustAnchorsResolverImpl;
-import com.webauthn4j.validator.attestation.trustworthiness.certpath.NullCertPathTrustworthinessValidator;
-import com.webauthn4j.validator.attestation.trustworthiness.certpath.TrustAnchorCertPathTrustworthinessValidator;
-
 public class WebAuthnRegisterFactory implements RequiredActionFactory, EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = "webauthn-register";
@@ -41,19 +40,17 @@ public class WebAuthnRegisterFactory implements RequiredActionFactory, Environme
         WebAuthnRegister webAuthnRegister = null;
         TruststoreProvider truststoreProvider = session.getProvider(TruststoreProvider.class);
         if (truststoreProvider == null || truststoreProvider.getTruststore() == null) {
-            webAuthnRegister = createProvider(session, new NullCertPathTrustworthinessValidator());
+            webAuthnRegister = createProvider(session, new NullCertPathTrustworthinessVerifier());
         } else {
-            KeyStoreTrustAnchorsProvider trustAnchorsProvider = new KeyStoreTrustAnchorsProvider();
-            trustAnchorsProvider.setKeyStore(truststoreProvider.getTruststore());
-            TrustAnchorsResolverImpl resolverImpl = new TrustAnchorsResolverImpl(trustAnchorsProvider);
-            TrustAnchorCertPathTrustworthinessValidator trustValidator = new TrustAnchorCertPathTrustworthinessValidator(resolverImpl);
-            webAuthnRegister = createProvider(session, trustValidator);
+            KeyStoreTrustAnchorRepository keyStoreTrustAnchorRepository = new KeyStoreTrustAnchorRepository(truststoreProvider.getTruststore());
+            DefaultCertPathTrustworthinessVerifier trustVerifier = new DefaultCertPathTrustworthinessVerifier(keyStoreTrustAnchorRepository);
+            webAuthnRegister = createProvider(session, trustVerifier);
         }
         return webAuthnRegister;
     }
 
-    protected WebAuthnRegister createProvider(KeycloakSession session, CertPathTrustworthinessValidator trustValidator) {
-         return new WebAuthnRegister(session, trustValidator);
+    protected WebAuthnRegister createProvider(KeycloakSession session, CertPathTrustworthinessVerifier trustVerifier) {
+         return new WebAuthnRegister(session, trustVerifier);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -31,8 +31,8 @@ import com.webauthn4j.data.client.Origin;
 import com.webauthn4j.server.ServerProperty;
 import com.webauthn4j.util.AssertUtil;
 import com.webauthn4j.util.exception.WebAuthnException;
-import com.webauthn4j.validator.OriginValidatorImpl;
-import com.webauthn4j.validator.exception.BadOriginException;
+import com.webauthn4j.verifier.OriginVerifierImpl;
+import com.webauthn4j.verifier.exception.BadOriginException;
 import jakarta.annotation.Nonnull;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
@@ -209,7 +209,7 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
                             authenticator,
                             context.getAuthenticationParameters().isUserVerificationRequired()
                     );
-                    webAuthnAuthenticationManager.validate(authenticationData, authenticationParameters);
+                    webAuthnAuthenticationManager.verify(authenticationData, authenticationParameters);
 
 
                     logger.debugv("response.getAuthenticatorData().getFlags() = {0}", authenticationData.getAuthenticatorData().getFlags());
@@ -246,9 +246,9 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
                 .map(Origin::new)
                 .collect(Collectors.toSet());
         WebAuthnAuthenticationManager webAuthnAuthenticationManager = new WebAuthnAuthenticationManager();
-        webAuthnAuthenticationManager.getAuthenticationDataValidator().setOriginValidator(new OriginValidatorImpl(){
+        webAuthnAuthenticationManager.getAuthenticationDataVerifier().setOriginVerifier(new OriginVerifierImpl() {
             @Override
-            protected void validate(@Nonnull CollectedClientData collectedClientData,
+            protected void verify(@Nonnull CollectedClientData collectedClientData,
                                     @Nonnull ServerProperty serverProperty) {
                 AssertUtil.notNull(collectedClientData, "collectedClientData must not be null");
                 AssertUtil.notNull(serverProperty, "serverProperty must not be null");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/registration/PubKeySignRegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/registration/PubKeySignRegisterTest.java
@@ -100,6 +100,7 @@ public class PubKeySignRegisterTest extends AbstractWebAuthnVirtualTest {
             }
 
             final String credentialType = getCredentialType();
+            final long selectedAlgorithmValue = selectedAlgorithm.getValue();
 
             getTestingClient().server(TEST_REALM_NAME).run(session -> {
                 final WebAuthnDataWrapper dataWrapper = new WebAuthnDataWrapper(session, USERNAME, credentialType);
@@ -111,7 +112,7 @@ public class PubKeySignRegisterTest extends AbstractWebAuthnVirtualTest {
                 final COSEKey pubKey = dataWrapper.getKey();
                 assertThat(pubKey, notNullValue());
                 assertThat(pubKey.getAlgorithm(), notNullValue());
-                assertThat(pubKey.getAlgorithm().getValue(), is(selectedAlgorithm.getValue()));
+                assertThat(pubKey.getAlgorithm().getValue(), is(selectedAlgorithmValue));
                 assertThat(pubKey.hasPublicKey(), is(true));
             });
         } catch (IOException e) {


### PR DESCRIPTION
Closes #40023

Upgrading the webauthn4j to current release 0.29.3. It needs some tweaks (mainly `validator` to `verifier` in several places) to accommodate the new version. I also restored the tests in the attestation conveyance that needs to disable the trust-store (the tests uses chrome and it seems that the certificate used in the attestation is a self-signed generated every time; so they cannot be added to the trust-store in the tests).

@pskopek Take a look when you have time.