### PR TITLE
Update command for linking Maven repository on Windows

### DIFF
--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -42,7 +42,7 @@ runs:
         mkdir -p ..\..\..\.m2
         mkdir -p D:\.m2\repository
         cmd /c mklink /d $HOME\.m2\repository D:\.m2\repository
-        cmd /c mklink /d $PWD\..\..\..\.m2\repository D:\.m2\repository
+        cmd /c "rmdir /s /q $PWD\..\..\..\.m2\repository & mklink /d $PWD\..\..\..\.m2\repository D:\.m2\repository"
 
     - id: restore-maven-repository
       name: Maven cache


### PR DESCRIPTION
Closes #40543

removes the repository directory if it exists, prevents failure if it does not

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
