### PR TITLE
docs(caching): clarified wording for the jgroups fd port offset

### DIFF
--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -350,6 +350,7 @@ m|jgroups.fd.port-offset
 |Failure detection by protocol `FD_SOCK2`.
 It listens to the abrupt closing of a socket to suspect a {project_name} server failure.
 The `jgroups.fd.port-offset` property defines the offset from the `jgroups.bind.port`.
+By default, the offset is set to 50000, making the failure detection port 57800.
 
 |===
 


### PR DESCRIPTION
This change updates the documentation for caching to better explain the relationship between the default jgroups failure detection port offset and the actual port.

Closes #40564

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
