### PR TITLE
Copy restored maven repo to home folder in Windows

### DIFF
--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -31,23 +31,6 @@ runs:
         # Enable cross-os archive use the cache on both Linux and Windows
         enableCrossOsArchive: true
 
-# There have been recent changes on the build images about C/D drives, see https://github.com/actions/runner-images/issues/12386
-# As a temporary measure, disabling this optimization
-# This should be revisited to speed up the builds in a future issue
-#
-#    - shell: powershell
-#      name: Link the cached Maven repository to the OS-dependent location
-#      if: inputs.create-cache-if-it-doesnt-exist == 'false' && runner.os == 'Windows'
-#      # The cache restore in the next step uses the relative path which was valid on Linux and that is part of the archive it downloads.
-#      # You'll see that path when you enable debugging for the GitHub workflow on Windows.
-#      # On Windows, the .m2 folder is in different location, so move all the contents to the right folder here.
-#      # Also, not using the C: drive will speed up the build, see https://github.com/actions/runner-images/issues/8755
-#      run: |
-#        mkdir -p ..\..\..\.m2
-#        mkdir -p D:\.m2\repository
-#        cmd /c mklink /d $HOME\.m2\repository D:\.m2\repository
-#        cmd /c "rmdir /s /q $PWD\..\..\..\.m2\repository & mklink /d $PWD\..\..\..\.m2\repository D:\.m2\repository"
-
     - id: restore-maven-repository
       name: Maven cache
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -59,6 +42,15 @@ runs:
           !~/.m2/repository/org/keycloak
         key: ${{ steps.weekly-cache-key.outputs.key }}
         enableCrossOsArchive: true
+
+    - shell: bash
+      name: Copy restored maven repo to home folder in Windows
+      if: (steps.cache-maven-repository.outputs.cache-hit == 'true' || steps.restore-maven-repository.outputs.cache-hit == 'true') && runner.os == 'Windows'
+      run: |
+        if [ -d ../../../.m2/repository ]; then
+          cp -r ../../../.m2/repository ~/.m2
+          rm -r ../../../.m2/repository
+        fi
 
     - id: node-cache
       name: Node cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,15 +831,15 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - id: unit-test-setup
+        name: Unit test setup
+        uses: ./.github/actions/unit-test-setup
+
       - name: Fake fips
         run: |
           cd .github/fake_fips
           make
           sudo insmod fake_fips.ko
-
-      - id: unit-test-setup
-        name: Unit test setup
-        uses: ./.github/actions/unit-test-setup
 
       - name: Run crypto tests
         run: docker run --rm --workdir /github/workspace -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-ut.sh
@@ -866,17 +866,17 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Fake fips
-        run: |
-          cd .github/fake_fips
-          make
-          sudo insmod fake_fips.ko
-
       - id: integration-test-setup
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
         with:
           jdk-version: 21
+
+      - name: Fake fips
+        run: |
+          cd .github/fake_fips
+          make
+          sudo insmod fake_fips.ko
 
       - name: Run base tests
         run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi8/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}


### PR DESCRIPTION
Closes #40593

Copying the repository from the download folder to the correct user maven folder. I used copy to avoid any issue if the repo is already created. I checked that it works with and without cache.
