### PR TITLE
Fix: Removed conditional check preventing use of custom attribute names

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/TranslatableField.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/TranslatableField.tsx
@@ -98,9 +98,7 @@ export const TranslatableField = ({
   const requiredTranslationName = `${translationPrefix}.0.value`;
 
   useEffect(() => {
-    if (isTranslationRequired(value, t, realm)) {
-      setValue(fieldName, `\${${prefix}.${value}}`);
-    }
+    setValue(fieldName, `\${${prefix}.${value}}`);
   }, [value]);
 
   return (


### PR DESCRIPTION
Removed conditional check preventing use of custom attribute names identical to built-in Keycloak attributes. Please review and provide your feedback.

Closes: [40497](https://github.com/keycloak/keycloak/issues/40497)

Thanks!