### PR TITLE
added a non-null check to check whether the to be exported realm exists

### DIFF
--- a/model/storage-services/src/main/java/org/keycloak/exportimport/util/MultipleStepsExportProvider.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/util/MultipleStepsExportProvider.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -102,6 +103,7 @@ public abstract class MultipleStepsExportProvider<T extends MultipleStepsExportP
             @Override
             protected void runExportImportTask(KeycloakSession session) throws IOException {
                 RealmModel realm = session.realms().getRealmByName(realmName);
+                Objects.requireNonNull(realm, "realm not found by realm name '" + realmName + "'");
                 session.getContext().setRealm(realm);
                 RealmRepresentation rep = ExportUtils.exportRealm(session, realm, exportUsersIntoRealmFile, true);
                 writeRealm(realmName + "-realm.json", rep);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -71,4 +71,13 @@ public class ExportDistTest {
         cliResult.assertMessage("Export of realm 'fgap' requested.");
         cliResult.assertMessage("Export finished successfully");
     }
+
+    @Test
+    void testExportNonExistent(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("build");
+
+        cliResult = dist.run("export", "--realm=non-existent-realm", "--dir=.");
+        cliResult.assertMessage("realm not found by realm name 'non-existent-realm'");
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -22,15 +22,20 @@ import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.junit.After;
 import org.junit.Test;
+import org.keycloak.Config;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.exportimport.ExportImportConfig;
+import org.keycloak.exportimport.ExportProvider;
+import org.keycloak.exportimport.ExportProviderFactory;
 import org.keycloak.exportimport.Strategy;
 import org.keycloak.exportimport.dir.DirExportProvider;
 import org.keycloak.exportimport.dir.DirExportProviderFactory;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
 import org.keycloak.exportimport.util.ImportUtils;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.ComponentRepresentation;
@@ -41,6 +46,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.services.resources.KeycloakApplication;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
@@ -56,6 +62,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -183,6 +190,49 @@ public class ExportImportTest extends AbstractKeycloakTest {
 
         // There should be 6 files in target directory (3 realm, 3 user)
         assertEquals(6, new File(targetDirPath).listFiles().length);
+    }
+
+    @Test
+    public void checkForRealmNotFoundExceptionWhenDirExportingNonExistentRealm() throws IOException {
+        String realmName = "non-existent-realm";
+
+        try {
+            exportNonExistentRealm(new DirExportProviderFactory(), realmName, "dirRealmExport");
+        } catch (NullPointerException e) {
+            assertEquals(String.format("realm not found by realm name '%s'", realmName), e.getMessage());
+        }
+    }
+
+    @Test
+    public void checkForRealmNotFoundExceptionWhenFileExportingNonExistentRealm() throws IOException {
+        String realmName = "non-existent-realm";
+
+        try {
+            exportNonExistentRealm(new SingleFileExportProviderFactory(), realmName, "singleFile-full.json");
+        } catch (NullPointerException e) {
+            assertEquals(String.format("realm not found by realm name '%s'", realmName), e.getMessage());
+        }
+    }
+
+    private void exportNonExistentRealm(ExportProviderFactory exportProviderFactory,
+                                        String realmName, String targetDirSuffix) throws IOException {
+
+        String targetDirPath = Files.createTempDirectory("kc-tests").toAbsolutePath() + File.separator + targetDirSuffix;
+
+        if (exportProviderFactory instanceof DirExportProviderFactory) {
+            ExportImportConfig.setDir(targetDirPath);
+        } else if (exportProviderFactory instanceof SingleFileExportProviderFactory) {
+            ExportImportConfig.setFile(targetDirPath);
+        }
+
+        ExportImportConfig.setRealmName(realmName);
+        Config.Scope config = new Config.SystemPropertiesScope("");
+
+        exportProviderFactory.init(config);
+        KeycloakSessionFactory keycloakSessionFactory = KeycloakApplication.getSessionFactory();
+        KeycloakSession keycloakSession = keycloakSessionFactory.create();
+        ExportProvider exportProvider = exportProviderFactory.create(keycloakSession);
+        exportProvider.exportModel();
     }
 
     @Test


### PR DESCRIPTION
In the `SingleFileExportProvider.exportRealm(...)` (used when exporting to a single file) we are checking if the realm exists. In case it does not, we throw a proper error message:

> 2025-06-19 21:41:40,483 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) Error details:: java.lang.NullPointerException: realm not found by realm name 'non-existent-realm'
at java.base/java.util.Objects.requireNonNull(Objects.java:235)
at org.keycloak.exportimport.singlefile.SingleFileExportProvider.exportRealm(SingleFileExportProvider.java:88)

I copied this non-null check to the `MultipleStepsExportProvider.runExportImportTask(...)` (used when exporting multiple files to a directory) to have the same check and proper error message if the realm does not exist.

Closes #39122

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
