### PR TITLE
Deprecate the original Passkeys Conditional UI Authenticator

### DIFF
--- a/docs/documentation/release_notes/topics/26_3_0.adoc
+++ b/docs/documentation/release_notes/topics/26_3_0.adoc
@@ -77,4 +77,4 @@ Read more on how to enable this feature in https://www.keycloak.org/server/updat
 
 = Deprecation of the Passkeys Conditional UI Authenticator
 
-The preview feature *Passkeys* introduced recently a new *Passkeys Conditional UI Authenticator* that allowed to integrate the passkey auto-fill or conditional UI feature in your login flow. Passkeys are now going to be integrated into {project_name} seamlessly inside the default username forms. Therefore, the old authenticator makes no sense and, since this release, it is deprecated. The factory and implementation classes will be finally removed when *Passkeys* are supported in {project_name}.
+The preview feature *Passkeys* recently introduced a new *Passkeys Conditional UI Authenticator* that you can use to integrate the passkey auto-fill or conditional UI feature in your login flow. Passkeys are now being seamlessly integrated into {project_name} inside the default username forms. Therefore, the old authenticator is invalid and it is deprecated in this release. The factory and implementation classes will be removed when *Passkeys* are supported in {project_name}.

--- a/docs/documentation/release_notes/topics/26_3_0.adoc
+++ b/docs/documentation/release_notes/topics/26_3_0.adoc
@@ -74,3 +74,7 @@ In this release, we extended this to perform rolling update when the new image c
 This can reduce the service's downtime even further, as downtime is only needed when upgrading from a different minor or major version.
 
 Read more on how to enable this feature in https://www.keycloak.org/server/update-compatibility#rolling-updates-for-patch-releases[update compatibility command].
+
+= Deprecation of the Passkeys Conditional UI Authenticator
+
+The preview feature *Passkeys* introduced recently a new *Passkeys Conditional UI Authenticator* that allowed to integrate the passkey auto-fill or conditional UI feature in your login flow. Passkeys are now going to be integrated into {project_name} seamlessly inside the default username forms. Therefore, the old authenticator makes no sense and, since this release, it is deprecated. The factory and implementation classes will be finally removed when *Passkeys* are supported in {project_name}.

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasskeysConditionalUIAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasskeysConditionalUIAuthenticator.java
@@ -26,6 +26,7 @@ import org.keycloak.models.KeycloakSession;
 
 import jakarta.ws.rs.core.Response;
 
+@Deprecated(since = "26.3", forRemoval = true)
 public class PasskeysConditionalUIAuthenticator extends WebAuthnPasswordlessAuthenticator {
 
     public PasskeysConditionalUIAuthenticator(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasskeysConditionalUIAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasskeysConditionalUIAuthenticatorFactory.java
@@ -26,7 +26,11 @@ import org.keycloak.provider.EnvironmentDependentProviderFactory;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ * @deprecated Factory is deprecated as passkeys are now integrated with the
+ * default username authenticators. It will be removed in future versions
+ * when the passkeys feature become supported.
  */
+@Deprecated(since = "26.3", forRemoval = true)
 public class PasskeysConditionalUIAuthenticatorFactory extends WebAuthnPasswordlessAuthenticatorFactory implements EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = "passkeys-authenticator";


### PR DESCRIPTION
Closes #40033

Deprecation of the previous Passkeys Conditional UI Authenticator. Note added into the release. It would be good to add this one before 26.3 and, this way, we can definitely remove the class when supported in 26.4.
