### PR TITLE
Fix wrong dependent registering in Registry

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/AbstractInterceptorHelper.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/AbstractInterceptorHelper.java
@@ -22,9 +22,9 @@ public abstract class AbstractInterceptorHelper<I, V> {
             value = intercept(value, interception.supplier, interception.existingInstance);
             registry.getLogger().logIntercepted(value, interception.supplier);
             if (interception.existingInstance != null) {
-                interception.existingInstance.registerDependency(instanceContext);
+                interception.existingInstance.registerDependent(instanceContext);
             } else {
-                interception.requestedInstance.registerDependency(instanceContext);
+                interception.requestedInstance.registerDependent(instanceContext);
             }
         }
         return value;

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/InstanceContext.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/InstanceContext.java
@@ -12,7 +12,7 @@ public class InstanceContext<T, A extends Annotation> {
     private final Registry registry;
     private final Supplier<T, A> supplier;
     private final A annotation;
-    private final Set<InstanceContext<?, ?>> dependencies = new HashSet<>();
+    private final Set<InstanceContext<?, ?>> dependents = new HashSet<>();
     private T value;
     private Class<? extends T> requestedValueType;
     private LifeCycle lifeCycle;
@@ -73,12 +73,18 @@ public class InstanceContext<T, A extends Annotation> {
         return annotation;
     }
 
-    public Set<InstanceContext<?, ?>> getDependencies() {
-        return dependencies;
+    public Set<InstanceContext<?, ?>> getDependents() {
+        return dependents;
     }
 
-    public void registerDependency(InstanceContext<?, ?> instanceContext) {
-        dependencies.add(instanceContext);
+    /**
+     * This method registers dependents for this Instance contents.
+     * This makes sure whenever this instance is cleaned all of its dependents need to be cleaned first
+     *
+     * @param instanceContext dependent instance context
+     */
+    public void registerDependent(InstanceContext<?, ?> instanceContext) {
+        dependents.add(instanceContext);
     }
 
     public void addNote(String key, Object value) {

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/RegistryLogger.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/RegistryLogger.java
@@ -70,9 +70,20 @@ class RegistryLogger {
     }
 
     public void logCreatedInstance(RequestedInstance requestedInstance, InstanceContext instance) {
+        logCreatedInstanceForSupplier(requestedInstance.getSupplier(), instance);
+    }
+
+    public void logCreatedInstanceForSupplier(Supplier<?,?> supplier, InstanceContext instance) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debugv("Created instance: {0}#{1,number,#}",
-                    requestedInstance.getSupplier().getClass().getSimpleName(), instance.getInstanceId());
+                    supplier.getClass().getSimpleName(), instance.getInstanceId());
+        }
+    }
+
+    public void logDependentCleaning(InstanceContext<?, ?> cleanedInstance, InstanceContext instanceDependent) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugv("Before cleaning {0}#{1,number,#}, cleaning dependent {2}#{3,number,#}",
+                    cleanedInstance.getValue().getClass().getSimpleName(), cleanedInstance.getInstanceId(), instanceDependent.getValue().getClass().getSimpleName(), instanceDependent.getInstanceId());
         }
     }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/RequestedInstance.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/RequestedInstance.java
@@ -9,7 +9,7 @@ public class RequestedInstance<T, A extends Annotation> {
     private final int instanceId;
     private final Supplier<T, A> supplier;
     private final A annotation;
-    private final Set<InstanceContext<?, ?>> dependencies = new HashSet<>();
+    private final Set<InstanceContext<?, ?>> dependents = new HashSet<>();
     private final Class<? extends T> valueType;
     private final LifeCycle lifeCycle;
     private final String ref;
@@ -47,11 +47,11 @@ public class RequestedInstance<T, A extends Annotation> {
         return ref;
     }
 
-    public void registerDependency(InstanceContext<?, ?> instanceContext) {
-        dependencies.add(instanceContext);
+    public void registerDependent(InstanceContext<?, ?> instanceContext) {
+        dependents.add(instanceContext);
     }
 
-    public Set<InstanceContext<?, ?>> getDependencies() {
-        return dependencies;
+    public Set<InstanceContext<?, ?>> getDependents() {
+        return dependents;
     }
 }


### PR DESCRIPTION

Closes #40756

While looking into this:
https://github.com/keycloak/keycloak/pull/40623#discussion_r2161345556

I noticed there seems to be an inconsistency in Registry between:
https://github.com/keycloak/keycloak/blob/c01736a9cdf95ddc0c020abcd7b6550c3a94ed46/test-framework/core/src/main/java/org/keycloak/testframework/injection/Registry.java#L87

and
https://github.com/keycloak/keycloak/blob/c01736a9cdf95ddc0c020abcd7b6550c3a94ed46/test-framework/core/src/main/java/org/keycloak/testframework/injection/Registry.java#L188

The direction of registering dependency is different between these two calls. This was causing the issue in the discussion above, where with `BEFORE_REALM` it worked while with `BEFORE_KEYCLOAK_SERVER` it did not.

With these changes the cleaning is done in the correct order.

This PR is adding:
- switching the direction of registered dependency to be consistent
- changing the name from dependency to dependent as it seems to be more correct term
- adding a bunch of additional debug logging that helped me investigate this

Please let me know whether this is a relevant issue that we want to fix and if yes I will create a GHI

