### PR TITLE
Allow passkeys login when user has no password credential

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordForm.java
@@ -53,7 +53,8 @@ public class PasswordForm extends UsernamePasswordForm implements CredentialVali
 
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        return user.credentialManager().isConfiguredFor(getCredentialProvider(session).getType());
+        return user.credentialManager().isConfiguredFor(getCredentialProvider(session).getType())
+                || alreadyAuthenticatedUsingPasswordlessCredential(session.getContext().getAuthenticationSession());
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -26,6 +26,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.managers.AuthenticationManager;
 
@@ -72,9 +73,13 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
     }
 
     protected boolean alreadyAuthenticatedUsingPasswordlessCredential(AuthenticationFlowContext context) {
+        return alreadyAuthenticatedUsingPasswordlessCredential(context.getAuthenticationSession());
+    }
+
+    protected boolean alreadyAuthenticatedUsingPasswordlessCredential(AuthenticationSessionModel authSession) {
         // check if the authentication was already done using passwordless via passkeys
         return webauthnAuth != null && webauthnAuth.isPasskeysEnabled() && webauthnAuth.getCredentialType().equals(
-                context.getAuthenticationSession().getAuthNote(AuthenticationProcessor.LAST_AUTHN_CREDENTIAL));
+                authSession.getAuthNote(AuthenticationProcessor.LAST_AUTHN_CREDENTIAL));
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysUsernameFormTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysUsernameFormTest.java
@@ -31,9 +31,11 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.models.credential.WebAuthnCredentialModel;
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
@@ -125,6 +127,15 @@ public class PasskeysUsernameFormTest extends AbstractWebAuthnVirtualTest {
             MatcherAssert.assertThat(user, Matchers.notNullValue());
 
             logout();
+
+            // remove the password, so passkeys are the only credential in the user
+            final CredentialRepresentation passwordCredRep = userResource().credentials().stream()
+                    .filter(cred -> PasswordCredentialModel.TYPE.equals(cred.getType()))
+                    .findAny()
+                    .orElse(null);
+            Assert.assertNotNull("User has no password credential", passwordCredRep);
+            userResource().removeCredential(passwordCredRep.getId());
+
             events.clear();
 
             // the user should be automatically logged in using the discoverable key


### PR DESCRIPTION
Closes #40717

Just adding the `alreadyAuthenticatedUsingPasswordlessCredential` to the `configuredFor` method of the `PassworfForm` authenticator. If not a user was not able to login when no password credential set in the account. I have removed the password credential in one of the tests.
