### PR TITLE
Verification of external facebook token via "debug token" endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/social/facebook/FacebookIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/facebook/FacebookIdentityProvider.java
@@ -19,6 +19,9 @@ package org.keycloak.social.facebook;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import jakarta.ws.rs.core.Response;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
 import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
 import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
@@ -27,7 +30,11 @@ import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.broker.social.SocialIdentityProvider;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.TokenExchangeContext;
 import org.keycloak.saml.common.util.StringUtil;
+import org.keycloak.services.ErrorResponseException;
+
+import java.io.IOException;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -37,6 +44,7 @@ public class FacebookIdentityProvider extends AbstractOAuth2IdentityProvider<Fac
 	public static final String AUTH_URL = "https://graph.facebook.com/oauth/authorize";
 	public static final String TOKEN_URL = "https://graph.facebook.com/oauth/access_token";
 	public static final String PROFILE_URL = "https://graph.facebook.com/me?fields=id,name,email,first_name,last_name";
+    public static final String DEBUG_TOKEN_URL = "https://graph.facebook.com/debug_token";
 	public static final String DEFAULT_SCOPE = "email";
 	protected static final String PROFILE_URL_FIELDS_SEPARATOR = ",";
 
@@ -59,6 +67,29 @@ public class FacebookIdentityProvider extends AbstractOAuth2IdentityProvider<Fac
 			throw new IdentityBrokerException("Could not obtain user profile from facebook.", e);
 		}
 	}
+
+    private void verifyToken(String accessToken) throws IOException {
+        JsonNode response = SimpleHttp.doGet(DEBUG_TOKEN_URL, session)
+                .param("input_token", accessToken)
+                .param(OAuth2Constants.ACCESS_TOKEN, getConfig().getClientId() + "|" + getConfig().getClientSecret())
+                .asJson();
+
+        JsonNode errorNode = response.get("error");
+        if (errorNode != null) {
+            String errorMessage = getJsonProperty(errorNode, "message");
+            throw new RuntimeException("Error message:  " + errorMessage);
+        }
+
+        JsonNode dataNode = response.get("data");
+        if (dataNode == null || dataNode.isNull()) {
+            throw new RuntimeException("Invalid token debug response: 'data' field is missing.");
+        }
+
+        String appId = getJsonProperty(dataNode, "app_id");
+        if (!getConfig().getClientId().equals(appId)) {
+            throw new RuntimeException("Client ID does not match the app_id in the access token debug response.");
+        }
+    }
 
 	@Override
 	protected boolean supportsExternalExchange() {
@@ -108,7 +139,22 @@ public class FacebookIdentityProvider extends AbstractOAuth2IdentityProvider<Fac
 		return user;
 	}
 
-	@Override
+    @Override
+    protected BrokeredIdentityContext exchangeExternalTokenV2Impl(TokenExchangeContext tokenExchangeContext) {
+        String subjectToken = tokenExchangeContext.getFormParams().getFirst(OAuth2Constants.SUBJECT_TOKEN);
+        if (subjectToken == null) {
+            throw new ErrorResponseException(OAuthErrorException.INVALID_TOKEN, "token not set", Response.Status.BAD_REQUEST);
+        }
+        try {
+            verifyToken(subjectToken);
+            return doGetFederatedIdentity(subjectToken);
+        }
+        catch (Exception e) {
+            throw new ErrorResponseException(OAuthErrorException.INVALID_TOKEN, e.getMessage(), Response.Status.BAD_REQUEST);
+        }
+    }
+
+    @Override
 	protected String getDefaultScopes() {
 		return DEFAULT_SCOPE;
 	}


### PR DESCRIPTION
Closes #40163

Added a check to ensure that the `client_id` matches the `app_id` contained in the response from the custom Facebook `/debug_token` endpoint. To invoke the debug endpoint, an "app access token" is required, which can either be in the form `client_id|client_secret` or obtained via the client credentials grant. However, I noticed that with the default settings, the "app access token" is returned from client credential grant as `client_id|client_secret` in plain so I skipped this additional step. Since we don't have automated tests, I also added the option to disable this verification (enabled by default).


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
