### PR TITLE
Do not show update email link if the email attribute is not writable

### DIFF
--- a/js/apps/account-ui/src/personal-info/PersonalInfo.tsx
+++ b/js/apps/account-ui/src/personal-info/PersonalInfo.tsx
@@ -119,11 +119,15 @@ export const PersonalInfo = () => {
             ((key: unknown, params) =>
               t(key as TFuncKey, params as any)) as TFunction
           }
-          renderer={(attribute) =>
-            attribute.name === "email" &&
-            updateEmailFeatureEnabled &&
-            updateEmailActionEnabled &&
-            (!isRegistrationEmailAsUsername || isEditUserNameAllowed) ? (
+          renderer={(attribute) => {
+            const annotations = attribute.annotations
+              ? attribute.annotations
+              : {};
+            return attribute.name === "email" &&
+              updateEmailFeatureEnabled &&
+              updateEmailActionEnabled &&
+              annotations["kc.required.action.supported"] &&
+              (!isRegistrationEmailAsUsername || isEditUserNameAllowed) ? (
               <Button
                 id="update-email-btn"
                 variant="link"
@@ -135,8 +139,8 @@ export const PersonalInfo = () => {
               >
                 {t("updateEmail")}
               </Button>
-            ) : undefined
-          }
+            ) : undefined;
+          }}
         />
         {!allFieldsReadOnly() && (
           <ActionGroup>

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -567,6 +567,19 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
         return unmanagedAttributes;
     }
 
+    @Override
+    public Map<String, Object> getAnnotations(String name) {
+        AttributeMetadata metadata = getMetadata(name);
+
+        if (metadata == null) {
+            return Collections.emptyMap();
+        }
+
+        AttributeContext context = createAttributeContext(metadata);
+
+        return metadata.getAnnotations(context);
+    }
+
     protected AttributeMetadata createUnmanagedAttributeMetadata(String name) {
         return new AttributeMetadata(name, Integer.MAX_VALUE) {
             final UnmanagedAttributePolicy unmanagedAttributePolicy = upConfig.getUnmanagedAttributePolicy();

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileUtil.java
@@ -155,12 +155,14 @@ public class UserProfileUtil {
             group = am.getAttributeGroupMetadata().getName();
         }
 
+        Attributes attributes = profile.getAttributes();
+
         return new UserProfileAttributeMetadata(am.getName(),
                 am.getAttributeDisplayName(),
-                profile.getAttributes().isRequired(am.getName()),
-                profile.getAttributes().isReadOnly(am.getName()),
+                attributes.isRequired(am.getName()),
+                attributes.isReadOnly(am.getName()),
                 group,
-                am.getAnnotations(),
+                attributes.getAnnotations(am.getName()),
                 toValidatorMetadata(am, session),
                 am.isMultivalued());
     }

--- a/server-spi/src/main/java/org/keycloak/userprofile/AttributeMetadata.java
+++ b/server-spi/src/main/java/org/keycloak/userprofile/AttributeMetadata.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -52,7 +53,7 @@ public class AttributeMetadata {
     private Map<String, Object> annotations;
     private int guiOrder;
     private boolean multivalued;
-
+    private Function<AttributeContext, Map<String, Object>> annotationDecorator = (c) -> c.getMetadata().getAnnotations();
 
     AttributeMetadata(String attributeName, int guiOrder) {
         this(attributeName, guiOrder, ALWAYS_TRUE, ALWAYS_TRUE, ALWAYS_TRUE, ALWAYS_TRUE);
@@ -225,6 +226,7 @@ public class AttributeMetadata {
             cloned.setAttributeGroupMetadata(attributeGroupMetadata.clone());
         }
         cloned.setMultivalued(multivalued);
+        cloned.setAnnotationDecorator(annotationDecorator);
         return cloned;
     }
 
@@ -268,6 +270,15 @@ public class AttributeMetadata {
 
     public AttributeMetadata setValidators(List<AttributeValidatorMetadata> validators) {
         this.validators = validators;
+        return this;
+    }
+
+    public Map<String, Object> getAnnotations(AttributeContext context) {
+        return annotationDecorator.apply(context);
+    }
+
+    public AttributeMetadata setAnnotationDecorator(Function<AttributeContext, Map<String, Object>> annotationDecorator) {
+        this.annotationDecorator = annotationDecorator;
         return this;
     }
 }

--- a/server-spi/src/main/java/org/keycloak/userprofile/Attributes.java
+++ b/server-spi/src/main/java/org/keycloak/userprofile/Attributes.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.keycloak.validate.ValidationError;
 
@@ -168,4 +169,24 @@ public interface Attributes {
      * @return a map with any unmanaged attribute
      */
     Map<String, List<String>> getUnmanagedAttributes();
+
+    /**
+     * <p>Returns the annotations for an attribute with the given {@code name}.
+     *
+     * <p>The annotations returned by this method might differ from those returned directly from
+     * the {@link AttributeMetadata#getAnnotations()} if the implementation supports annotations
+     * being resolved dynamically based on contextual data. See {@link AttributeMetadata#setAnnotationDecorator(Function)}.
+     *
+     * @param name the name of the attribute
+     * @return the annotations
+     */
+    default Map<String, Object> getAnnotations(String name) {
+        AttributeMetadata metadata = getMetadata(name);
+
+        if (metadata == null) {
+            return Collections.emptyMap();
+        }
+
+        return metadata.getAnnotations();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceWithUserProfileTest.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.testsuite.account;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
@@ -25,6 +28,8 @@ import static org.keycloak.testsuite.account.AccountRestServiceTest.getUserProfi
 import static org.keycloak.testsuite.util.userprofile.UserProfileUtil.PERMISSIONS_ALL;
 import static org.keycloak.testsuite.util.userprofile.UserProfileUtil.PERMISSIONS_ADMIN_EDITABLE;
 import static org.keycloak.testsuite.util.userprofile.UserProfileUtil.PERMISSIONS_ADMIN_ONLY;
+import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_ADMIN;
+import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_USER;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -32,10 +37,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.UserModel;
@@ -43,6 +51,10 @@ import org.keycloak.representations.idm.UserProfileAttributeMetadata;
 import org.keycloak.representations.idm.UserProfileMetadata;
 import org.keycloak.representations.account.UserRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
+import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.broker.util.SimpleHttpDefault;
 import org.keycloak.testsuite.util.userprofile.UserProfileUtil;
 import org.keycloak.userprofile.UserProfileContext;
@@ -155,6 +167,33 @@ public class AccountRestServiceWithUserProfileTest extends AbstractRestServiceTe
             RealmRepresentation realmRep = testRealm().toRepresentation();
             realmRep.setEditUsernameAllowed(true);
             testRealm().update(realmRep);
+        }
+    }
+
+    @EnableFeature(value = Profile.Feature.UPDATE_EMAIL, skipRestart = true)
+    @Test
+    public void testUpdateEmailLink() throws Exception {
+        RealmResource realm = adminClient.realm("test");
+        RealmRepresentation realmRep = realm.toRepresentation();
+
+        try {
+            realmRep.setEditUsernameAllowed(false);
+            realm.update(realmRep);
+
+            UserRepresentation user = getUser();
+            assertNotNull(user.getUserProfileMetadata());
+            assertThat(user.getUserProfileMetadata().getAttributeMetadata(UserModel.EMAIL).getAnnotations().get("kc.required.action.supported"), is(true));
+
+            UPConfig upConfig = realm.users().userProfile().getConfiguration();
+            UPAttribute attribute = upConfig.getAttribute(UserModel.EMAIL);
+            attribute.setPermissions(new UPAttributePermissions(Set.of(ROLE_USER), Set.of(ROLE_ADMIN)));
+            realm.users().userProfile().update(upConfig);
+            user = getUser();
+            assertNotNull(user.getUserProfileMetadata());
+            assertThat(user.getUserProfileMetadata().getAttributeMetadata(UserModel.EMAIL).getAnnotations().get("kc.required.action.supported"), is(nullValue()));
+        } finally {
+            realmRep.setEditUsernameAllowed(true);
+            realm.update(realmRep);
         }
     }
 


### PR DESCRIPTION
Closes #39669

* Certain attributes, like the `email`, might only be updated through an AIA. In this case, the UP configuration will allow setting a "annotation decorator" to dynamically resolve annotations based on contextual data so that UIs can check whether or not a link to initiate the action should be rendered.
* The reason why this issue is resolved using an annotation is because the attribute is indeed readonly when at the `ACCOUNT` context, and we can not rely on the `org.keycloak.representations.idm.UserProfileAttributeMetadata#readOnly` field to decide to show or hide the link. In addition to that, annotations serve as a hint to UIs about how to render attributes.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
