### PR TITLE
fix: refinements for ipv6 only testing

### DIFF
--- a/.github/actions/update-hosts/nipio-hosts
+++ b/.github/actions/update-hosts/nipio-hosts
@@ -1,1 +1,2 @@
-127.0.0.1 127.0.0.1.nip.io admin.127.0.0.1.nip.io localhost-myapp.127.0.0.1.nip.io localhost-sso.127.0.0.1.nip.io realmFrontend.127.0.0.1.nip.io proxy.kc.127.0.0.1.nip.io
+127.0.0.1 localtest.me 127.0.0.1.nip.io admin.127.0.0.1.nip.io localhost-myapp.127.0.0.1.nip.io localhost-sso.127.0.0.1.nip.io realmFrontend.127.0.0.1.nip.io proxy.kc.127.0.0.1.nip.io
+::1 localtest.me 127.0.0.1.nip.io admin.127.0.0.1.nip.io localhost-myapp.127.0.0.1.nip.io localhost-sso.127.0.0.1.nip.io realmFrontend.127.0.0.1.nip.io proxy.kc.127.0.0.1.nip.io

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -45,6 +45,7 @@
         <mvel.version>2.5.2.Final</mvel.version>
         <systemrules.version>1.19.0</systemrules.version>
         <common.resources>${basedir}/../../servers/auth-server/common</common.resources>
+        <auth.server.ipv6>false</auth.server.ipv6>
     </properties>
     
     <dependencies>
@@ -433,7 +434,20 @@
     </build>
 
     <profiles>
-
+    
+        <profile>
+            <id>ipv6</id>
+            <activation>
+                <property>
+                    <name>java.net.preferIPv6Addresses</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <auth.server.ipv6>true</auth.server.ipv6>
+            </properties>
+        </profile>
+        
         <profile>
             <id>app-server-wildfly</id>
             <activation>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/SessionRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/SessionRestServiceTest.java
@@ -164,7 +164,7 @@ public class SessionRestServiceTest extends AbstractRestServiceTest {
         List<SessionRepresentation> sessions = device.getSessions();
         assertEquals(1, sessions.size());
         SessionRepresentation session = sessions.get(0);
-        assertEquals("127.0.0.1", session.getIpAddress());
+        assertThat(session.getIpAddress(), anyOf(equalTo("127.0.0.1"), equalTo("0:0:0:0:0:0:0:1")));
         assertTrue(device.getLastAccess() == session.getLastAccess());
 
         List<ClientRepresentation> clients = session.getClients();
@@ -372,7 +372,7 @@ public class SessionRestServiceTest extends AbstractRestServiceTest {
         List<SessionRepresentation> sessions = device.getSessions();
         assertEquals(1, sessions.size());
         SessionRepresentation session = sessions.get(0);
-        assertEquals("127.0.0.1", session.getIpAddress());
+        assertThat(session.getIpAddress(), anyOf(equalTo("127.0.0.1"), equalTo("0:0:0:0:0:0:0:1")));
         assertEquals(device.getLastAccess(), session.getLastAccess());
 
         assertEquals(1, session.getClients().size());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AttributeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AttributeTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.net.InetAddress;
+import java.net.Inet4Address;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
@@ -68,7 +68,7 @@ public class AttributeTest {
 
         assertEquals(new SimpleDateFormat("dd/MM/yyyy").parse("12/12/2016"), attributes.getValue("date").asDate(0, "dd/MM/yyyy"));
 
-        assertEquals(InetAddress.getLoopbackAddress(), attributes.getValue("ip_network_address").asInetAddress(0));
-        assertEquals(InetAddress.getLoopbackAddress(), attributes.getValue("host_network_address").asInetAddress(0));
+        assertEquals("127.0.0.1", attributes.getValue("ip_network_address").asInetAddress(0).getHostAddress());
+        assertEquals("localhost", attributes.getValue("host_network_address").asInetAddress(0).getHostName());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -288,7 +288,7 @@
             </property>
             <property name="bindHttpPortOffset">${auth.server.port.offset}</property>
             <property name="javaOpts">-Xms512m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m
-                -Dauth.server.db.host=some
+                -Dauth.server.db.host=some -Djava.net.preferIPv6Addresses=${auth.server.ipv6}
             </property>
             <property name="enabledFeatures">${auth.server.feature}</property>
             <property name="disabledFeatures">${auth.server.feature.disable}</property>


### PR DESCRIPTION
With these changes and running maven with -Djava.net.preferIPv6Addresses, the tests should run successfully. 

As part of this PR, or a seperate task we can see about creating a smaller ipv6 test run like we discussed initially.

closes: #21277

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
