### PR TITLE
Use POST binding for logout when REDIRECT url is not set and forced POST

### DIFF
--- a/services/src/test/java/org/keycloak/protocol/saml/SamlProtocolTest.java
+++ b/services/src/test/java/org/keycloak/protocol/saml/SamlProtocolTest.java
@@ -124,7 +124,11 @@ public class SamlProtocolTest {
         String bindingType = SamlProtocol.getLogoutBindingTypeForClientSession(clientSession);
         assertEquals(SamlProtocol.SAML_REDIRECT_BINDING, bindingType);
 
+        // default to POST if forced with no url
+        client.setForcePostBinding(true);
+        assertEquals(SamlProtocol.SAML_REDIRECT_BINDING, bindingType);
 
+        client.setForcePostBinding(false);
         clientSession.setNote(SamlProtocol.SAML_BINDING, SamlProtocol.SAML_ARTIFACT_BINDING);
         client.defineSetLogoutUrls(false, false, true, false);
         bindingType = SamlProtocol.getLogoutBindingTypeForClientSession(clientSession);
@@ -143,9 +147,7 @@ public class SamlProtocolTest {
         client.defineSetLogoutUrls(false, false, true, false);
         bindingType = SamlProtocol.getLogoutBindingTypeForClientSession(clientSession);
         assertEquals(SamlProtocol.SAML_ARTIFACT_BINDING, bindingType);
-
     }
-
 
     @Test
     public void frontchannelLogoutSignsLogoutRequestsEvenThoughArtifactWasUsed() {


### PR DESCRIPTION
Closes #40637

A little regression created in 26.2 for SAML by #32262. Previously if just the admin URL (master SAML processing URL) was set, POST was used for frontchannel logout (see [this line in 26.1.5](https://github.com/keycloak/keycloak/blob/26.1.5/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java#L389)). After that issue the default is REDIRECT for that configuration, even if force POST is configured to ON in the client. I also changed that method to do a short-circuit evaluation (reversing the order and returning immediately). The meaningful change is `if (postUrlSet && !redirectUrlSet)` to `if (!redirectUrlSet && (postUrlSet || samlClient.forcePostBinding()))`. Created one integration test and modified the unitary test too.

Note that I didn't revert the functionality completely because IMHO it makes more sense like it is in the PR. The issue is only when there is only master saml processing URL, in that case previously it was always POST, currently is always REDIRECT, and with the PR its POST or REDIRECT depending the configuration of the `Force POST binding` switch. Normally the logout URLs are filled if you use a SP descriptor to create the client, and the `Force POST binding`  switch is by default set to true.