### PR TITLE
Improve realm search by name (#40793)

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -93,6 +93,8 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
  */
 public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientScopeProvider, GroupProvider, RoleProvider, DeploymentStateProvider {
     protected static final Logger logger = Logger.getLogger(JpaRealmProvider.class);
+    public static final String REALM_NAME_SEARCH_PREFIX = "name:";
+    public static final String DISPLAY_NAME_SEARCH_PREFIX = "displayName:";
     private final KeycloakSession session;
     protected EntityManager em;
     private Set<String> clientSearchableAttributes;
@@ -162,7 +164,16 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         if (search.trim().isEmpty()) {
             return getRealmsStream();
         }
-        TypedQuery<String> query = em.createNamedQuery("getRealmIdsWithNameContaining", String.class);
+        TypedQuery<String> query;
+        if (search.startsWith(REALM_NAME_SEARCH_PREFIX)) {
+            search = search.substring(REALM_NAME_SEARCH_PREFIX.length());
+            query = em.createNamedQuery("getRealmIdsWithNameContaining", String.class);
+        } else if (search.startsWith(DISPLAY_NAME_SEARCH_PREFIX)) {
+            search = search.substring(DISPLAY_NAME_SEARCH_PREFIX.length());
+            query = em.createNamedQuery("getRealmIdsWithDisplayNameContaining", String.class);
+        } else {
+            query = em.createNamedQuery("getRealmIdsWithNameOrDisplayNameContaining", String.class);
+        }
         query.setParameter("search", search);
         return getRealms(query);
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -50,6 +50,13 @@ import java.util.Set;
 @NamedQueries({
         @NamedQuery(name="getAllRealmIds", query="select realm.id from RealmEntity realm"),
         @NamedQuery(name="getRealmIdsWithNameContaining", query="select realm.id from RealmEntity realm where LOWER(realm.name) like CONCAT('%', LOWER(:search), '%')"),
+        @NamedQuery(name="getRealmIdsWithDisplayNameContaining", query="select distinct realm.id " +
+                                                                             "from RealmEntity realm left join realm.attributes attr " +
+                                                                             "where (attr.name = 'displayName' and LOWER(attr.value) like CONCAT('%', LOWER(:search), '%'))"),
+        @NamedQuery(name="getRealmIdsWithNameOrDisplayNameContaining", query="select distinct realm.id " +
+                                                                "from RealmEntity realm left join realm.attributes attr " +
+                                                                "where LOWER(realm.name) like CONCAT('%', LOWER(:search), '%')" +
+                                                                "or (attr.name = 'displayName' and LOWER(attr.value) like CONCAT('%', LOWER(:search), '%'))"),
         @NamedQuery(name="getRealmIdByName", query="select realm.id from RealmEntity realm where realm.name = :name"),
         @NamedQuery(name="getRealmIdsWithProviderType", query="select distinct c.realm.id from ComponentEntity c where c.providerType = :providerType"),
 })

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
@@ -38,7 +38,9 @@ public class UIRealmsResource {
     @Operation(
             summary = "Lists only the names and display names of the realms",
             description = "Returns a list of realms containing only their name and displayName" +
-                    " based on what the caller is allowed to view"
+                    " based on what the caller is allowed to view. Looks for name and displayName by default. " +
+                          "To search only by name use the prefix 'name:'." +
+                          "To search only by display name use the prefix 'displayName:'."
     )
     @APIResponse(
             responseCode = "200",


### PR DESCRIPTION
Default realm search now also considers realm displayName by name. To explicitly search by name or displayName we now support the prefixes "name:" and "displayName:".

We now also consider the realm display name if set in realm searches by name.

Fixes #40793

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
