### PR TITLE
[26.2.x] Unable to configure TLS reloading in Keycloak version 26.2.0 or later

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -93,8 +93,7 @@ public final class HttpPropertyMappers {
                         .build(),
                 fromOption(HttpOptions.HTTPS_CERTIFICATES_RELOAD_PERIOD)
                         .to("quarkus.http.ssl.certificate.reload-period")
-                        // -1 means no reload
-                        .transformer((value, context) -> "-1".equals(value) ? null : value)
+                        .transformer(HttpPropertyMappers::transformNegativeReloadPeriod)
                         .paramLabel("reload period")
                         .build(),
                 fromOption(HttpOptions.HTTPS_CERTIFICATE_FILE)
@@ -172,6 +171,11 @@ public final class HttpPropertyMappers {
 
     private static String getHttpEnabledTransformer(String value, ConfigSourceInterceptorContext context) {
         return isHttpEnabled(value) ? "enabled" : "disabled";
+    }
+
+    static String transformNegativeReloadPeriod(String value, ConfigSourceInterceptorContext context) {
+        // -1 means no reload
+        return "-1".equals(value) ? null : value;
     }
 
     private static boolean isHttpEnabled(String value) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
@@ -74,8 +74,7 @@ public class ManagementPropertyMappers {
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATES_RELOAD_PERIOD)
                         .mapFrom(HttpOptions.HTTPS_CERTIFICATES_RELOAD_PERIOD)
                         .to("quarkus.management.ssl.certificate.reload-period")
-                        // -1 means no reload
-                        .transformer((value, context) -> "-1".equals(value) ? null : value)
+                        .transformer(HttpPropertyMappers::transformNegativeReloadPeriod)
                         .paramLabel("reload period")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_FILE)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -244,7 +244,8 @@ public class PropertyMapper<T> {
         String mappedValue = value;
 
         boolean mapped = false;
-        var theMapper = parentValue ? this.parentMapper : this.mapper;
+        // use parent mapper/transformer when no mapper is explicitly specified in .mapFrom()
+        var theMapper = parentValue && parentMapper != null ? this.parentMapper : this.mapper;
         if (theMapper != null && (!name.equals(getFrom()) || parentValue)) {
             mappedValue = theMapper.apply(value, context);
             mapped = true;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -244,7 +244,7 @@ public class PropertyMapper<T> {
         String mappedValue = value;
 
         boolean mapped = false;
-        // use parent mapper/transformer when no mapper is explicitly specified in .mapFrom()
+        // fall back to the transformer when no mapper is explicitly specified in .mapFrom()
         var theMapper = parentValue && parentMapper != null ? this.parentMapper : this.mapper;
         if (theMapper != null && (!name.equals(getFrom()) || parentValue)) {
             mappedValue = theMapper.apply(value, context);

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -124,10 +124,13 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertEquals("1h",
                 nonRunningPicocli.config.getConfigValue("quarkus.http.ssl.certificate.reload-period").getValue());
+        assertEquals("1h",
+                nonRunningPicocli.config.getConfigValue("quarkus.management.ssl.certificate.reload-period").getValue());
 
         nonRunningPicocli = pseudoLaunch("start-dev", "--https-certificates-reload-period=-1");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertNull(nonRunningPicocli.config.getConfigValue("quarkus.http.ssl.certificate.reload-period").getValue());
+        assertNull(nonRunningPicocli.config.getConfigValue("quarkus.management.ssl.certificate.reload-period").getValue());
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/AbstractConfigurationTest.java
@@ -19,6 +19,7 @@ package org.keycloak.quarkus.runtime.configuration.test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Field;
@@ -170,6 +171,19 @@ public abstract class AbstractConfigurationTest {
 
     protected void assertExternalConfig(Map<String, String> expectedValues) {
         expectedValues.forEach(this::assertExternalConfig);
+    }
+
+    protected void assertConfigNull(String key, boolean isExternal) {
+        Function<String, ConfigValue> getConfig = isExternal ? Configuration::getConfigValue : Configuration::getKcConfigValue;
+        assertThat(String.format("We expect that the value is null for key '%s'", key), getConfig.apply(key).getValue(), nullValue());
+    }
+
+    protected void assertConfigNull(String key) {
+        assertConfigNull(key, false);
+    }
+
+    protected void assertExternalConfigNull(String key) {
+        assertConfigNull(key, true);
     }
 
     protected static void addPersistedConfigValues(Map<String, String> values) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -497,11 +497,23 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void testReloadPeriod() {
         ConfigArgsConfigSource.setCliArgs("");
-        assertEquals("1h", createConfig().getConfigValue("quarkus.http.ssl.certificate.reload-period").getValue());
+        initConfig();
+        assertExternalConfig(Map.of(
+                "quarkus.http.ssl.certificate.reload-period", "1h",
+                "quarkus.management.ssl.certificate.reload-period", "1h"
+        ));
+
         ConfigArgsConfigSource.setCliArgs("--https-certificates-reload-period=-1");
-        assertNull(createConfig().getConfigValue("quarkus.http.ssl.certificate.reload-period").getValue());
+        initConfig();
+        assertExternalConfigNull("quarkus.http.ssl.certificate.reload-period");
+        assertExternalConfigNull("quarkus.management.ssl.certificate.reload-period");
+
         ConfigArgsConfigSource.setCliArgs("--https-certificates-reload-period=2h");
-        assertEquals("2h", createConfig().getConfigValue("quarkus.http.ssl.certificate.reload-period").getValue());
+        initConfig();
+        assertExternalConfig(Map.of(
+                "quarkus.http.ssl.certificate.reload-period", "2h",
+                "quarkus.management.ssl.certificate.reload-period", "2h"
+        ));
     }
 
     @Test


### PR DESCRIPTION
Closes #40713

PR to main: https://github.com/keycloak/keycloak/pull/40790

(cherry picked from 83c54b0c83dc97333a24bb9d4bd0336d3910de41)

@shawkins Could you please check this backport?