### PR TITLE
Add missing artifact descriptions to allow Maven Portal Publisher Validation pass.

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Adapters</name>
-    <description/>
+    <description>Keycloak Adapters Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-adapters-pom</artifactId>

--- a/adapters/saml/core-public/pom.xml
+++ b/adapters/saml/core-public/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-saml-adapter-api-public</artifactId>
     <name>Keycloak SAML Client Adapter Public API</name>
-    <description/>
+    <description>Keycloak SAML Client Adapter Public API</description>
 
 
     <properties>

--- a/adapters/saml/core/pom.xml
+++ b/adapters/saml/core/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-saml-adapter-core</artifactId>
     <name>Keycloak SAML Client Adapter Core</name>
-    <description/>
+    <description>Keycloak SAML Client Adapter Core</description>
 
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>

--- a/adapters/saml/pom.xml
+++ b/adapters/saml/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Keycloak SAML Client Adapter Modules</name>
-    <description/>
+    <description>Keycloak SAML Client Adapter Wildfly Modules</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-saml-client-adapter-pom</artifactId>

--- a/adapters/saml/wildfly-elytron/pom.xml
+++ b/adapters/saml/wildfly-elytron/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-saml-wildfly-elytron-adapter</artifactId>
     <name>Keycloak WildFly Elytron SAML Adapter</name>
-    <description/>
+    <description>Keycloak WildFly Elytron SAML Adapter</description>
 
     <dependencies>
         <dependency>

--- a/adapters/saml/wildfly/pom.xml
+++ b/adapters/saml/wildfly/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Keycloak SAML Wildfly Integration</name>
-    <description/>
+    <description>Keycloak SAML Wildfly Integration Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-saml-wildfly-integration-pom</artifactId>

--- a/adapters/saml/wildfly/wildfly-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-saml-wildfly-subsystem</artifactId>
     <name>Keycloak Wildfly SAML Adapter Subsystem</name>
-    <description/>
+    <description>Keycloak Wildfly SAML Adapter Subsystem</description>
     <packaging>jar</packaging>
 
     <build>

--- a/adapters/spi/adapter-spi/pom.xml
+++ b/adapters/spi/adapter-spi/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-adapter-spi</artifactId>
     <name>Keycloak Adapter SPI</name>
-    <description/>
+    <description>Keycloak Adapter SPI</description>
 
     <properties>
         <!-- We still need to support EAP 8, set the Java version to 11. -->

--- a/adapters/spi/jboss-adapter-core/pom.xml
+++ b/adapters/spi/jboss-adapter-core/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-jboss-adapter-core</artifactId>
     <name>Common JBoss/Wildfly Core Classes</name>
-    <description/>
+    <description>Common JBoss/Wildfly Core Classes</description>
 
     <properties>
          <!-- We still need to support EAP 8, set the Java version to 11. -->

--- a/adapters/spi/pom.xml
+++ b/adapters/spi/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Keycloak Client Adapter SPI Modules</name>
-    <description/>
+    <description>Keycloak Client Adapter SPI Modules</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-client-adapter-spi-pom</artifactId>

--- a/authz/policy/pom.xml
+++ b/authz/policy/pom.xml
@@ -15,6 +15,7 @@
     <packaging>pom</packaging>
 
     <name>Keycloak AuthZ: Policy Provider Parent</name>
+    <description>Keycloak AuthZ: Policy Provider Parent</description>
 
     <modules>
         <module>common</module>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,8 +28,8 @@
 
     <artifactId>keycloak-core</artifactId>
     <name>Keycloak Core</name>
+    <description>Keycloak Core</description>
     <packaging>jar</packaging>
-    <description/>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/crypto/default/pom.xml
+++ b/crypto/default/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-crypto-default</artifactId>
     <name>Keycloak Crypto Default</name>
-    <description/>
+    <description>Keycloak Crypto Default</description>
 
     <dependencies>
         <dependency>

--- a/crypto/elytron/pom.xml
+++ b/crypto/elytron/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-crypto-elytron</artifactId>
     <name>Keycloak Crypto Wildfly Elytron Integration</name>
-    <description/>
+    <description>Keycloak Crypto Wildfly Elytron Integration</description>
 
     <dependencies>
         <dependency>

--- a/crypto/fips1402/pom.xml
+++ b/crypto/fips1402/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-crypto-fips1402</artifactId>
     <name>Keycloak Crypto FIPS 140-2 Integration</name>
-    <description/>
+    <description>Keycloak Crypto FIPS 140-2 Integration</description>
 
     <dependencies>
         <dependency>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Crypto Parent</name>
-    <description/>
+    <description>Keycloak Crypto Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-crypto-parent</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>keycloak-dependencies-parent</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Dependencies Parent</name>
-    <description/>
+    <description>Keycloak Dependencies Parent</description>
 
     <modules>
         <module>server-min</module>

--- a/dependencies/server-all/pom.xml
+++ b/dependencies/server-all/pom.xml
@@ -28,7 +28,7 @@
 	<artifactId>keycloak-dependencies-server-all</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Dependencies Server All</name>
-	<description />
+    <description>Keycloak Dependencies Server All</description>
 
     <dependencies>
         <dependency>

--- a/dependencies/server-min/pom.xml
+++ b/dependencies/server-min/pom.xml
@@ -28,7 +28,7 @@
 	<artifactId>keycloak-dependencies-server-min</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Dependencies Server Min</name>
-	<description />
+    <description>Keycloak Dependencies Server Min</description>
 
     <dependencies>
         <dependency>

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>keycloak-api-docs-dist</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Docs Distribution</name>
-    <description/>
+    <description>Keycloak Docs Distribution</description>
 
     <properties>
         <javadoc.branding>Keycloak ${project.version}</javadoc.branding>

--- a/distribution/downloads/pom.xml
+++ b/distribution/downloads/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>keycloak-dist-downloads</artifactId>
     <packaging>jar</packaging>
     <name>Keycloak Release Downloads</name>
-    <description/>
+    <description>Keycloak Release Downloads</description>
 
     <build>
         <plugins>

--- a/distribution/galleon-feature-packs/pom.xml
+++ b/distribution/galleon-feature-packs/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <name>Galleon Feature Pack Builds</name>
-    <description/>
+    <description>Galleon Feature Pack Builds</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>galleon-feature-packs-parent</artifactId>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
@@ -28,6 +28,7 @@
     <artifactId>keycloak-saml-adapter-galleon-pack-layers-metadata-tests</artifactId>
 
     <name>Keycloak Galleon Feature Pack: SAML Adapter Layer Metadata Tests</name>
+    <description>Keycloak Galleon Feature Pack: SAML Adapter Layer Metadata Tests</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
@@ -28,6 +28,7 @@
     <artifactId>keycloak-saml-adapter-galleon-pack</artifactId>
 
     <name>Keycloak Galleon Feature Pack: SAML Adapter</name>
+    <description>Keycloak Galleon Feature Pack: SAML Adapter</description>
     <packaging>pom</packaging>
 
     <properties>

--- a/distribution/licenses-common/pom.xml
+++ b/distribution/licenses-common/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>keycloak-distribution-licenses-common</artifactId>
     <packaging>jar</packaging>
     <name>Keycloak Distribution Licenses Common</name>
+    <description>Keycloak Distribution Licenses Common</description>
 
     <build>
         <resources>

--- a/distribution/maven-plugins/pom.xml
+++ b/distribution/maven-plugins/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>keycloak-distribution-maven-plugins-parent</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Distribution Maven Plugins Parent</name>
+    <description>Keycloak Distribution Maven Plugins Parent</description>
 
     <dependencies>
         <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <name>Distribution Parent</name>
-    <description/>
+    <description>Distribution Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-distribution-parent</artifactId>

--- a/distribution/saml-adapters/pom.xml
+++ b/distribution/saml-adapters/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <name>SAML Adapters Distribution Parent</name>
-    <description/>
+    <description>SAML Adapters Distribution Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-saml-adapters-distribution-parent</artifactId>

--- a/distribution/saml-adapters/wildfly-adapter/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Keycloak Wildfly SAML Adapter</name>
-    <description/>
+    <description>Keycloak Wildfly SAML Adapter</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-saml-wildfly-adapter-dist-pom</artifactId>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>keycloak-saml-wildfly-adapter-dist</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak SAML Wildfly Adapter Distro</name>
-    <description/>
+    <description>Keycloak SAML Wildfly Adapter Distro</description>
 
     <dependencies>
         <dependency>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
@@ -32,6 +32,7 @@
     <artifactId>keycloak-saml-wildfly-modules</artifactId>
 
     <name>Keycloak SAML Wildfly Modules</name>
+    <description>Keycloak SAML Wildfly Modules</description>
     <packaging>pom</packaging>
     <dependencies>
         <dependency>

--- a/docs/documentation/aggregation/pom.xml
+++ b/docs/documentation/aggregation/pom.xml
@@ -9,7 +9,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <name>Aggregation</name>
+    <name>Documentation Aggregation</name>
+    <description>Documentation Aggregation</description>
+
     <artifactId>aggregation</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/api_documentation/pom.xml
+++ b/docs/documentation/api_documentation/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <name>API Documentation</name>
+    <description>API Documentation</description>
+
     <artifactId>api-documentation</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/authorization_services/pom.xml
+++ b/docs/documentation/authorization_services/pom.xml
@@ -9,7 +9,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <name>Authorization Services</name>
+    <name>Authorization Services Documentation</name>
+    <description>Authorization Services Documentation</description>
+
     <artifactId>authorization-services</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/dist/pom.xml
+++ b/docs/documentation/dist/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <name>Keycloak Documentation dist</name>
+    <description>Keycloak Documentation dist</description>
+
     <artifactId>keycloak-documentation</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/header-maven-plugin/pom.xml
+++ b/docs/documentation/header-maven-plugin/pom.xml
@@ -13,7 +13,8 @@
     <version>999.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
-    <name>github-maven-plugin</name>
+    <name>header-maven-plugin</name>
+    <description>header-maven-plugin</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/docs/documentation/pom.xml
+++ b/docs/documentation/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <name>Keycloak Documentation Parent</name>
+    <description>Keycloak Documentation Parent</description>
+
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
     <version>999.0.0-SNAPSHOT</version>

--- a/docs/documentation/release_notes/pom.xml
+++ b/docs/documentation/release_notes/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <name>Release Notes</name>
+    <description>Release Notes</description>
+
     <artifactId>release-notes</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/server_admin/pom.xml
+++ b/docs/documentation/server_admin/pom.xml
@@ -9,7 +9,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <name>Server Administration</name>
+    <name>Server Administration Guide</name>
+    <description>Server Administration Guide</description>
+
     <artifactId>server-admin</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/server_development/pom.xml
+++ b/docs/documentation/server_development/pom.xml
@@ -9,7 +9,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <name>Server Developer</name>
+    <name>Server Developer Guide</name>
+    <description>Server Developer Guide</description>
+
     <artifactId>server-development</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/documentation/tests/pom.xml
+++ b/docs/documentation/tests/pom.xml
@@ -65,6 +65,8 @@
     </parent>
 
     <name>Keycloak Documentation tests</name>
+    <description>Keycloak Documentation tests</description>
+
     <artifactId>tests</artifactId>
     <packaging>jar</packaging>
 

--- a/docs/documentation/upgrading/pom.xml
+++ b/docs/documentation/upgrading/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <name>Upgrading Guide</name>
+    <description>Upgrading Guide</description>
+
     <artifactId>upgrading</artifactId>
     <packaging>pom</packaging>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Docs Parent</name>
-    <description/>
+    <description>Keycloak Docs Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-docs-parent</artifactId>

--- a/federation/ipatuura/pom.xml
+++ b/federation/ipatuura/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-ipatuura-federation</artifactId>
     <name>Keycloak Ipatuura Federation</name>
-    <description />
+    <description>Keycloak Ipatuura Federation</description>
 
     <dependencies>
         <dependency>

--- a/federation/kerberos/pom.xml
+++ b/federation/kerberos/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-kerberos-federation</artifactId>
     <name>Keycloak Kerberos Federation</name>
-    <description />
+    <description>Keycloak Kerberos Federation</description>
 
     <dependencies>
         <dependency>

--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-ldap-federation</artifactId>
     <name>Keycloak LDAP UserStoreProvider</name>
-    <description />
+    <description>Keycloak LDAP UserStoreProvider</description>
 
     <dependencies>
         <dependency>

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -30,7 +30,7 @@
 
     <artifactId>keycloak-federation-parent</artifactId>
     <name>Keycloak Federation</name>
-    <description />
+    <description>Keycloak Federation Parent</description>
 
     <modules>
         <module>kerberos</module>

--- a/federation/sssd/pom.xml
+++ b/federation/sssd/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>keycloak-sssd-federation</artifactId>
     <name>Keycloak SSSD Federation</name>
-    <description/>
+    <description>Keycloak SSSD Federation</description>
 
     <build>
         <plugins>

--- a/integration/client-cli/admin-cli/pom.xml
+++ b/integration/client-cli/admin-cli/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-admin-cli</artifactId>
     <name>Keycloak Admin CLI</name>
-    <description/>
+    <description>Keycloak Admin CLI</description>
 
     <dependencies>
         <dependency>

--- a/integration/client-cli/client-cli-dist/pom.xml
+++ b/integration/client-cli/client-cli-dist/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>keycloak-client-cli-dist</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Client CLI Distribution</name>
-    <description/>
+    <description>Keycloak Client CLI Distribution</description>
 
     <dependencies>
         <dependency>

--- a/integration/client-cli/pom.xml
+++ b/integration/client-cli/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <name>Keycloak Client CLI</name>
-    <description/>
+    <description>Keycloak Client CLI</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-client-cli-parent</artifactId>

--- a/integration/client-registration/pom.xml
+++ b/integration/client-registration/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-client-registration-api</artifactId>
     <name>Keycloak Client Registration API</name>
-    <description/>
+    <description>Keycloak Client Registration API</description>
 
     <dependencies>
         <dependency>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Integration</name>
-    <description/>
+    <description>Keycloak Integration</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-integration-parent</artifactId>

--- a/misc/theme-verifier/pom.xml
+++ b/misc/theme-verifier/pom.xml
@@ -32,6 +32,7 @@
     <version>999.0.0-SNAPSHOT</version>
 
     <name>Keycloak Theme verifier</name>
+    <description>Keycloak Theme verifier</description>
 
     <packaging>maven-plugin</packaging>
 

--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-model-infinispan</artifactId>
     <name>Keycloak Model Infinispan</name>
-    <description/>
+    <description>Keycloak Model Infinispan</description>
 
     <dependencies>
         <dependency>

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-model-jpa</artifactId>
     <name>Keycloak Model JPA</name>
-    <description/>
+    <description>Keycloak Model JPA</description>
 
     <properties>
         <keycloak.connectionsJpa.driver>org.h2.Driver</keycloak.connectionsJpa.driver>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Model Parent</name>
-    <description/>
+    <description>Keycloak Model Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-model-pom</artifactId>

--- a/model/storage-private/pom.xml
+++ b/model/storage-private/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>keycloak-model-storage-private</artifactId>
     <name>Keycloak Database Support - Private classes</name>
-    <description/>
+    <description>Keycloak Database Support - Private classes</description>
 
     <dependencies>
         <dependency>

--- a/model/storage-services/pom.xml
+++ b/model/storage-services/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>keycloak-model-storage-services</artifactId>
     <name>Keycloak Database Support - REST services</name>
-    <description/>
+    <description>Keycloak Database Support - REST services</description>
 
     <dependencies>
         <dependency>

--- a/model/storage/pom.xml
+++ b/model/storage/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>keycloak-model-storage</artifactId>
     <name>Keycloak Database Support</name>
-    <description/>
+    <description>Keycloak Database Support</description>
 
     <dependencies>
         <dependency>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <name>Keycloak Operator</name>
+    <description>Keycloak Operator</description>
     <artifactId>keycloak-operator</artifactId>
 
     <properties>

--- a/quarkus/config-api/pom.xml
+++ b/quarkus/config-api/pom.xml
@@ -28,8 +28,8 @@
 
     <artifactId>keycloak-config-api</artifactId>
     <name>Keycloak Configuration API</name>
+    <description>Keycloak Configuration API</description>
     <packaging>jar</packaging>
-    <description/>
 
     <dependencies>
         <dependency>

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -11,6 +11,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <name>Keycloak Quarkus Server Deployment</name>
+    <description>Keycloak Quarkus Server Deployment</description>
+
     <artifactId>keycloak-quarkus-server-deployment</artifactId>
 
     <dependencies>

--- a/quarkus/dist/pom.xml
+++ b/quarkus/dist/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>keycloak-quarkus-dist</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak Quarkus Server Distribution</name>
-    <description/>
+    <description>Keycloak Quarkus Server Distribution</description>
 
     <dependencies>
         <dependency>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Quarkus Parent</name>
-    <description/>
+    <description>Keycloak Quarkus Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-quarkus-parent</artifactId>

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -12,6 +12,8 @@
     </parent>
     
     <name>Keycloak Quarkus Server App</name>
+    <description>Keycloak Quarkus Server App</description>
+
     <artifactId>keycloak-quarkus-server-app</artifactId>
 
     <dependencies>

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -29,6 +29,8 @@
     </parent>
 
     <name>Keycloak Quarkus Server Integration tests</name>
+    <description>Keycloak Quarkus Server Integration tests</description>
+
     <artifactId>keycloak-quarkus-integration-tests</artifactId>
     <packaging>jar</packaging>
 

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -29,6 +29,8 @@
     </parent>
 
     <name>Keycloak Quarkus Server JUnit 5 Internal Test Framework</name>
+    <description>Keycloak Quarkus Server JUnit 5 Internal Test Framework</description>
+
     <artifactId>keycloak-junit5</artifactId>
     <packaging>jar</packaging>
 

--- a/quarkus/tests/pom.xml
+++ b/quarkus/tests/pom.xml
@@ -29,6 +29,8 @@
     </parent>
     
     <name>Keycloak Quarkus Test Parent</name>
+    <description>Keycloak Quarkus Test Parent</description>
+
     <artifactId>keycloak-quarkus-test-parent</artifactId>
     <packaging>pom</packaging>
 

--- a/saml-core-api/pom.xml
+++ b/saml-core-api/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-saml-core-public</artifactId>
     <name>Keycloak SAML Core Public API</name>
-    <description/>
+    <description>Keycloak SAML Core Public API</description>
 
     <properties>
         <!-- We still need to support EAP 8, set the Java version to 11. -->

--- a/saml-core/pom.xml
+++ b/saml-core/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-saml-core</artifactId>
     <name>Keycloak SAML Core</name>
-    <description/>
+    <description>Keycloak SAML Core</description>
 
     <properties>
         <!-- We still need to support EAP 8, set the Java version to 11. -->

--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-server-spi-private</artifactId>
     <name>Keycloak Server Private SPI</name>
-    <description/>
+    <description>Keycloak Server Private SPI</description>
 
     <dependencies>
         <dependency>

--- a/server-spi/pom.xml
+++ b/server-spi/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-server-spi</artifactId>
     <name>Keycloak Server SPI</name>
-    <description/>
+    <description>Keycloak Server SPI</description>
 
     <dependencies>
         <dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-services</artifactId>
     <name>Keycloak REST Services</name>
-    <description/>
+    <description>Keycloak REST Services</description>
 
     <properties>
         <version.swagger.doclet>1.1.2</version.swagger.doclet>

--- a/test-framework/clustering/pom.xml
+++ b/test-framework/clustering/pom.xml
@@ -10,6 +10,9 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>Keycloak Test Framework Clustering</name>
+    <description>Keycloak Test Framework Clustering</description>
+
     <artifactId>keycloak-test-framework-clustering</artifactId>
 
     <dependencies>

--- a/tests/clustering/pom.xml
+++ b/tests/clustering/pom.xml
@@ -10,6 +10,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <name>Keycloak Clustering Tests</name>
+    <description>Keycloak Clustering Tests</description>
+
     <artifactId>keycloak-tests-clustering</artifactId>
 
     <dependencyManagement>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>keycloak-testsuite-pom</artifactId>
     <packaging>pom</packaging>
     <name>Keycloak TestSuite</name>
-    <description />
+    <description>Keycloak TestSuite</description>
 
     <build>
         <plugins>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>keycloak-testsuite-utils</artifactId>
     <name>Keycloak TestSuite Utils</name>
-    <description />
+    <description>Keycloak TestSuite Utils</description>
 
     <properties>
         <keycloak.additionalClasspathElement>NON_EXISTENT_PATH_OVERRIDE_ON_COMMAND_LINE</keycloak.additionalClasspathElement>

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>keycloak-themes</artifactId>
     <name>Keycloak Themes</name>
-    <description />
+    <description>Keycloak Themes</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -28,7 +28,7 @@
 
     <artifactId>keycloak-util-embedded-ldap</artifactId>
     <name>Keycloak Util Embedded LDAP</name>
-    <description/>
+    <description>Keycloak Util Embedded LDAP</description>
 
     <dependencies>
         <dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <name>Keycloak Util Parent</name>
-    <description/>
+    <description>Keycloak Util Parent</description>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.keycloak</groupId>


### PR DESCRIPTION
Maven Central Portal Publisher fails in validation process.
It complains about missing artifacts descriptions.
It needs to be fix to perform release (maven deploy part).