### PR TITLE
Add missing javadocs to published artifacts to allow Maven Central Portal Publisher pass validation process.

### DIFF
--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -75,13 +75,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/distribution/maven-plugins/pom.xml
+++ b/distribution/maven-plugins/pom.xml
@@ -74,7 +74,6 @@
                                 <goal>addTestSources</goal>
                                 <goal>generateStubs</goal>
                                 <goal>compile</goal>
-                                <goal>removeStubs</goal>
                                 <goal>generateTestStubs</goal>
                                 <goal>compileTests</goal>
                                 <goal>removeTestStubs</goal>


### PR DESCRIPTION
Fix missing javadocs on two artifatcs.

Needs to be backported in #40825.