### PR TITLE
UserSession Offline removed from DB if not in cache

### DIFF
--- a/docs/documentation/server_admin/topics/sessions/offline.adoc
+++ b/docs/documentation/server_admin/topics/sessions/offline.adoc
@@ -24,20 +24,4 @@ Clients can request an offline token by adding the parameter `scope=offline_acce
 
 {project_name} will limit its internal cache for offline user and offline client sessions to 10000 entries by default, which will reduce the overall memory usage for offline sessions.
 Items which are evicted from memory will be loaded on-demand from the database when needed.
-To set different sizes for the caches, edit {project_name}'s cache config file to set a `+<memory max-count="..."/>+` for those caches.
-
-If you disabled feature `persistent-user-sessions`, it is possible to reduce memory requirements using a configuration option that shortens lifespan for imported offline sessions. Such sessions will be evicted from the Infinispan caches after the specified lifespan, but still available in the database. This will lower memory consumption, especially for deployments with a large number of offline sessions.
-
-To specify the lifespan override for offline user sessions, start {project_name} server with the following parameter:
-
-[source,bash]
-----
---spi-user-sessions--infinispan--offline-session-cache-entry-lifespan-override=<lifespan-in-seconds>
-----
-
-Similarly for offline client sessions:
-
-[source,bash]
-----
---spi-user-sessions--infinispan--offline-client-session-cache-entry-lifespan-override=<lifespan-in-seconds>
-----
+See the server configuration guide to change this default.

--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -42,6 +42,12 @@ configured directly via {project_name}: `cache-embedded-network-bind-address`, `
 `cache-embedded-network-external-address`, `cache-embedded-network-external-port`. Configuring ports using the old
 properties will still function as before, but we recommend to change to the CLI options as this may change in the future.
 
+=== Volatile user sessions affecting offline session memory requirements
+
+Starting with this release, {project_name} will cache by default only 10000 entries for offline user and client sessions in memory when volatile user sessions are enabled. This will greatly reduce memory usage.
+
+Use the options `cache-embedded-offline-sessions-max-count` and `cache-embedded-offline-client-sessions-max-count` to change size of the offline session caches.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 
@@ -52,6 +58,12 @@ The following sections provide details on deprecated features.
 The `displayTest` field in the `ConsentScopeRepresentation` class returned by the Account REST service has been deprecated due to a typo in its name.
 A new field `displayText` with the correct spelling has been added to replace it. The old field will be removed in {project_name} 27.0.
 The Typescript code `ConsentScopeRepresentation` for the Account Console already contains only the new field.
+
+=== Lifetime of offline session caches
+
+The options `--spi-user-sessions--infinispan--offline-session-cache-entry-lifespan-override` and `spi-user-sessions--infinispan--offline-client-session-cache-entry-lifespan-override` are now deprecated for removal.
+
+Instead use the options `cache-embedded-offline-sessions-max-count` and `cache-embedded-offline-client-sessions-max-count` to limit the memory usage if the default of 10000 cache offline user and client sessions does not work in your scenario.
 
 // ------------------------ Removed features ------------------------ //
 == Removed features

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -140,12 +140,6 @@ Since all the sessions in this setup are stored in-memory, there are two side ef
 When using volatile user sessions, the cache is the source of truth for user and client sessions.
 {project_name} automatically adjusts the number of entries that can be stored in memory, and increases the number of copies to prevent data loss.
 
-[WARNING]
-====
-It is not recommended to use volatile user sessions when using offline sessions extensively due to potentially high memory usage.
-For volatile sessions, the time offline sessions are cached in memory can be limited with the SPI options `spi-user-sessions--infinispan--offline-client-session-cache-entry-lifespan-override` and `spi-user-sessions--infinispan--offline-session-cache-entry-lifespan-override`.
-====
-
 Follow these steps to enable this setup:
 
 1. Disable `persistent-user-sessions` feature using the following command:

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.sessions.infinispan;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -29,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -37,9 +35,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.infinispan.Cache;
-import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.client.hotrod.exceptions.HotRodClientException;
-import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.infinispan.stream.CacheCollectors;
 import org.jboss.logging.Logger;
@@ -95,11 +90,6 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     protected final KeycloakSession session;
 
-    protected final Cache<String, SessionEntityWrapper<UserSessionEntity>> sessionCache;
-    protected final Cache<String, SessionEntityWrapper<UserSessionEntity>> offlineSessionCache;
-    protected final Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> clientSessionCache;
-    protected final Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> offlineClientSessionCache;
-
     protected final InfinispanChangelogBasedTransaction<String, UserSessionEntity> sessionTx;
     protected final InfinispanChangelogBasedTransaction<String, UserSessionEntity> offlineSessionTx;
     protected final InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionTx;
@@ -111,9 +101,9 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     protected final InfinispanKeyGenerator keyGenerator;
 
-    protected final SessionFunction offlineSessionCacheEntryLifespanAdjuster;
+    protected final SessionFunction<UserSessionEntity> offlineSessionCacheEntryLifespanAdjuster;
 
-    protected final SessionFunction offlineClientSessionCacheEntryLifespanAdjuster;
+    protected final SessionFunction<AuthenticatedClientSessionEntity> offlineClientSessionCacheEntryLifespanAdjuster;
 
     public InfinispanUserSessionProvider(KeycloakSession session,
                                          PersisterLastSessionRefreshStore persisterLastSessionRefreshStore,
@@ -129,11 +119,6 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
                                          SerializeExecutionsByKey<UUID> serializerClientSession,
                                          SerializeExecutionsByKey<UUID> serializerOfflineClientSession) {
         this.session = session;
-
-        this.sessionCache = sessionCache;
-        this.clientSessionCache = clientSessionCache;
-        this.offlineSessionCache = offlineSessionCache;
-        this.offlineClientSessionCache = offlineClientSessionCache;
 
         this.sessionTx = new InfinispanChangelogBasedTransaction<>(session, sessionCache, SessionTimeouts::getUserSessionLifespanMs, SessionTimeouts::getUserSessionMaxIdleMs, serializerSession);
         this.offlineSessionTx = new InfinispanChangelogBasedTransaction<>(session, offlineSessionCache, offlineSessionCacheEntryLifespanAdjuster, SessionTimeouts::getOfflineSessionMaxIdleMs, serializerOfflineSession);
@@ -155,7 +140,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     }
 
     protected Cache<String, SessionEntityWrapper<UserSessionEntity>> getCache(boolean offline) {
-        return offline ? offlineSessionCache : sessionCache;
+        return offline ? offlineSessionTx.getCache() : sessionTx.getCache();
     }
 
     protected InfinispanChangelogBasedTransaction<String, UserSessionEntity> getTransaction(boolean offline) {
@@ -163,7 +148,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     }
 
     protected Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> getClientSessionCache(boolean offline) {
-        return offline ? offlineClientSessionCache : clientSessionCache;
+        return offline ? offlineClientSessionTx.getCache() : clientSessionTx.getCache();
     }
 
     protected InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> getClientSessionTransaction(boolean offline) {
@@ -182,11 +167,10 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     @Override
     public AuthenticatedClientSessionModel createClientSession(RealmModel realm, ClientModel client, UserSessionModel userSession) {
-        final UUID clientSessionId = keyGenerator.generateKeyUUID(session, clientSessionCache);
+        InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionUpdateTx = clientSessionTx;
+        final UUID clientSessionId = keyGenerator.generateKeyUUID(session, clientSessionUpdateTx.getCache());
         var entity = AuthenticatedClientSessionEntity.create(clientSessionId, realm, client, userSession);
 
-        InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx = getTransaction(false);
-        InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionUpdateTx = getClientSessionTransaction(false);
         AuthenticatedClientSessionAdapter adapter = new AuthenticatedClientSessionAdapter(session, entity, client, userSession, clientSessionUpdateTx, false);
 
         // For now, the clientSession is considered transient in case that userSession was transient
@@ -196,8 +180,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         SessionUpdateTask<AuthenticatedClientSessionEntity> createClientSessionTask = Tasks.addIfAbsentSync();
         clientSessionUpdateTx.addTask(clientSessionId, createClientSessionTask, entity, persistenceState);
 
-        SessionUpdateTask registerClientSessionTask = new RegisterClientSessionTask(client.getId(), clientSessionId);
-        userSessionUpdateTx.addTask(userSession.getId(), registerClientSessionTask);
+        sessionTx.addTask(userSession.getId(), new RegisterClientSessionTask(client.getId(), clientSessionId));
 
         return adapter;
     }
@@ -206,7 +189,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     public UserSessionModel createUserSession(String id, RealmModel realm, UserModel user, String loginUsername, String ipAddress,
                                               String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId, UserSessionModel.SessionPersistenceState persistenceState) {
         if (id == null) {
-            id = keyGenerator.generateKeyString(session, sessionCache);
+            id = keyGenerator.generateKeyString(session, sessionTx.getCache());
         }
 
         UserSessionEntity entity = UserSessionEntity.create(id, realm, user, loginUsername, ipAddress, authMethod, rememberMe, brokerSessionId, brokerUserId);
@@ -214,7 +197,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         SessionUpdateTask<UserSessionEntity> createSessionTask = Tasks.addIfAbsentSync();
         sessionTx.addTask(id, createSessionTask, entity, persistenceState);
 
-        UserSessionAdapter adapter = user instanceof LightweightUserAdapter
+        UserSessionAdapter<?> adapter = user instanceof LightweightUserAdapter
           ? wrap(realm, entity, false, user)
           : wrap(realm, entity, false);
         adapter.setPersistenceState(persistenceState);
@@ -237,7 +220,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         }
     }
 
-    protected UserSessionAdapter getUserSession(RealmModel realm, String id, boolean offline) {
+    protected UserSessionAdapter<InfinispanUserSessionProvider> getUserSession(RealmModel realm, String id, boolean offline) {
 
         UserSessionEntity userSessionEntityFromCache = getUserSessionEntity(realm, id, offline);
         if (userSessionEntityFromCache != null) {
@@ -250,63 +233,100 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
         // Try to recover from potentially lost offline-sessions by attempting to fetch and re-import
         // the offline session information from the PersistenceProvider.
-        UserSessionEntity userSessionEntityFromPersistenceProvider = getUserSessionEntityFromPersistenceProvider(realm, id, offline);
+        UserSessionEntity userSessionEntityFromPersistenceProvider = getUserSessionEntityFromPersistenceProvider(realm, id);
         if (userSessionEntityFromPersistenceProvider != null) {
             // we successfully recovered the offline session!
-            return wrap(realm, userSessionEntityFromPersistenceProvider, offline);
+            return wrap(realm, userSessionEntityFromPersistenceProvider, true);
         }
 
         // no luck, the session is really not there anymore
         return null;
     }
 
-    private UserSessionEntity getUserSessionEntityFromPersistenceProvider(RealmModel realm, String sessionId, boolean offline) {
-
+    private UserSessionEntity getUserSessionEntityFromPersistenceProvider(RealmModel realm, String sessionId) {
         log.debugf("Offline user-session not found in infinispan, attempting UserSessionPersisterProvider lookup for sessionId=%s", sessionId);
         UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
-        UserSessionModel persistentUserSession = persister.loadUserSession(realm, sessionId, offline);
+        UserSessionModel persistentUserSession = persister.loadUserSession(realm, sessionId, true);
 
         if (persistentUserSession == null) {
             log.debugf("Offline user-session not found in UserSessionPersisterProvider for sessionId=%s", sessionId);
             return null;
         }
 
-        UserSessionEntity sessionEntity = importUserSession(realm, offline, persistentUserSession);
+        UserSessionEntity sessionEntity = importUserSession(realm, persistentUserSession);
         if (sessionEntity == null) {
-            persister.removeUserSession(sessionId, offline);
+            // TODO session expired, remove or ignore?
+            persister.removeUserSession(sessionId, true);
         }
 
         return sessionEntity;
     }
 
-    private UserSessionEntity getUserSessionEntityFromCacheOrImportIfNecessary(RealmModel realm, boolean offline, UserSessionModel persistentUserSession) {
-
-        UserSessionEntity userSessionEntity = getUserSessionEntity(realm, persistentUserSession.getId(), offline);
+    private UserSessionEntity getUserSessionEntityFromCacheOrImportIfNecessary(RealmModel realm, UserSessionModel persistentUserSession) {
+        UserSessionEntity userSessionEntity = getUserSessionEntity(realm, persistentUserSession.getId(), true);
         if (userSessionEntity != null) {
             // user session present in cache, return existing session
             return userSessionEntity;
         }
 
-        return importUserSession(realm, offline, persistentUserSession);
+        return importUserSession(realm, persistentUserSession);
     }
 
-    private UserSessionEntity importUserSession(RealmModel realm, boolean offline, UserSessionModel persistentUserSession) {
-
+    private UserSessionEntity importUserSession(RealmModel realm, UserSessionModel persistentUserSession) {
         String sessionId = persistentUserSession.getId();
 
-        log.debugf("Attempting to import user-session for sessionId=%s offline=%s", sessionId, offline);
-        session.sessions().importUserSessions(Collections.singleton(persistentUserSession), offline);
-        log.debugf("user-session imported, trying another lookup for sessionId=%s offline=%s", sessionId, offline);
+        log.debugf("Attempting to import user-session for sessionId=%s offline=true", sessionId);
 
-        UserSessionEntity ispnUserSessionEntity = getUserSessionEntity(realm, sessionId, offline);
+        var userSessionEntityToImport = UserSessionEntity.createFromModel(persistentUserSession);
 
-        if (ispnUserSessionEntity != null) {
-            log.debugf("user-session found after import for sessionId=%s offline=%s", sessionId, offline);
-            return ispnUserSessionEntity;
+        long lifespan = offlineSessionCacheEntryLifespanAdjuster.apply(realm, null, userSessionEntityToImport);
+        long maxIdle = SessionTimeouts.getOfflineSessionMaxIdleMs(realm, null, userSessionEntityToImport);
+
+        if (lifespan == SessionTimeouts.ENTRY_EXPIRED_FLAG || maxIdle == SessionTimeouts.ENTRY_EXPIRED_FLAG) {
+            log.debugf("Session has expired. Do not import user-session for sessionId=%s offline=true", sessionId);
+            return null;
         }
 
-        log.debugf("user-session could not be found after import for sessionId=%s offline=%s", sessionId, offline);
-        return null;
+        UserSessionEntity existing = getTransaction(true)
+                .importSession(realm, userSessionEntityToImport.getId(), new SessionEntityWrapper<>(userSessionEntityToImport),
+                        lifespan, maxIdle);
+
+        if (existing != null) {
+            // skip import the client sessions, they should have been imported too.
+            log.debugf("The user-session already imported by another transaction for sessionId=%s offline=true", sessionId);
+            return existing;
+        }
+
+        // we need to import the client sessions too.
+        log.debugf("Attempting to import the client-sessions for user-session with sessionId=%s offline=true", sessionId);
+
+        var clientSessionsById = computeClientSessionsToImport(persistentUserSession, userSessionEntityToImport);
+        getClientSessionTransaction(true).importSessionsConcurrently(realm, clientSessionsById, offlineClientSessionCacheEntryLifespanAdjuster, SessionTimeouts::getOfflineClientSessionMaxIdleMs);
+
+        return userSessionEntityToImport;
+    }
+
+    private Map<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> computeClientSessionsToImport(UserSessionModel persistentUserSession, UserSessionEntity userSessionToImport) {
+        Map<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> clientSessionsById = new HashMap<>();
+        AuthenticatedClientSessionStore clientSessions = userSessionToImport.getAuthenticatedClientSessions();
+        int lastSessionRefresh = userSessionToImport.getLastSessionRefresh();
+        String realmId = userSessionToImport.getRealmId();
+        for (Map.Entry<String, AuthenticatedClientSessionModel> entry : persistentUserSession.getAuthenticatedClientSessions().entrySet()) {
+            String clientUUID = entry.getKey();
+            AuthenticatedClientSessionModel clientSession = entry.getValue();
+            AuthenticatedClientSessionEntity clientSessionToImport = createAuthenticatedClientSessionInstance(clientSession,
+                    realmId, clientUUID, true);
+
+            // Update timestamp to the same value as userSession.
+            // LastSessionRefresh of userSession from DB will have the correct value.
+            clientSessionToImport.setTimestamp(lastSessionRefresh);
+
+            clientSessionsById.put(clientSessionToImport.getId(), new SessionEntityWrapper<>(clientSessionToImport));
+
+            // Update userSession entity with the clientSession
+            clientSessions.put(clientUUID, clientSessionToImport.getId());
+        }
+        return clientSessionsById;
     }
 
     private UserSessionEntity getUserSessionEntity(RealmModel realm, String id, boolean offline) {
@@ -321,16 +341,6 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         }
         return entity;
     }
-
-    private Stream<UserSessionModel> getUserSessionsFromPersistenceProviderStream(RealmModel realm, UserModel user, boolean offline) {
-        UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
-        return persister.loadUserSessionsStream(realm, user, offline, 0, null)
-                .map(persistentUserSession -> getUserSessionEntityFromCacheOrImportIfNecessary(realm, offline, persistentUserSession))
-                .filter(Objects::nonNull)
-                .map(userSessionEntity -> (UserSessionModel) wrap(realm, userSessionEntity, offline))
-                .filter(Objects::nonNull);
-    }
-
 
     protected Stream<UserSessionModel> getUserSessionsStream(RealmModel realm, UserSessionPredicate predicate, boolean offline) {
 
@@ -365,8 +375,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
         // return a stream that 'wraps' the infinispan cache stream so that the cache stream's elements are read one by one
         // and then mapped locally to avoid serialization issues when trying to manipulate the cache stream directly.
-        return StreamSupport.stream(getCache(offline).entrySet().stream().filter(predicate).map(Mappers.userSessionEntity()).spliterator(), false)
-                .map(entity -> this.wrap(realm, entity, offline))
+        return StreamSupport.stream(getCache(false).entrySet().stream().filter(predicate).map(Mappers.userSessionEntity()).spliterator(), false)
+                .map(entity -> this.wrap(realm, entity, false))
                 .filter(Objects::nonNull).map(Function.identity());
     }
 
@@ -384,25 +394,25 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         // offline client session lookup in the persister
         if (offline) {
             log.debugf("Offline client session is not found in cache, try to load from db, userSession [%s] clientSessionId [%s] clientId [%s]", userSession.getId(), clientSessionId, client.getClientId());
-            return getClientSessionEntityFromPersistenceProvider(userSession, client, true);
+            return getClientSessionEntityFromPersistenceProvider(userSession, client);
         }
 
         return null;
     }
 
-    private AuthenticatedClientSessionAdapter getClientSessionEntityFromPersistenceProvider(UserSessionModel userSession, ClientModel client, boolean offline) {
+    private AuthenticatedClientSessionAdapter getClientSessionEntityFromPersistenceProvider(UserSessionModel userSession, ClientModel client) {
         UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
-        AuthenticatedClientSessionModel clientSession = persister.loadClientSession(session.getContext().getRealm(), client, userSession, offline);
+        AuthenticatedClientSessionModel clientSession = persister.loadClientSession(session.getContext().getRealm(), client, userSession, true);
 
         if (clientSession == null) {
             return null;
         }
 
-        AuthenticatedClientSessionAdapter clientAdapter = importClientSession((UserSessionAdapter) userSession, clientSession, getTransaction(offline),
-                getClientSessionTransaction(offline), offline, true);
+        AuthenticatedClientSessionAdapter clientAdapter = importClientSession((UserSessionAdapter<?>) userSession, clientSession, getTransaction(true),
+                getClientSessionTransaction(true), true);
 
         if (clientAdapter == null) {
-            persister.removeClientSession(userSession.getId(), client.getId(), offline);
+            persister.removeClientSession(userSession.getId(), client.getId(), true);
         }
         return clientAdapter;
     }
@@ -445,9 +455,9 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
             // fetch the actual offline user session count from the database
             UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
             return persister.loadUserSessionsStream(realm, client, true, firstResult, maxResults)
-                    .map(persistentUserSession -> getUserSessionEntityFromCacheOrImportIfNecessary(realm, offline, persistentUserSession))
+                    .map(persistentUserSession -> getUserSessionEntityFromCacheOrImportIfNecessary(realm, persistentUserSession))
                     .filter(Objects::nonNull)
-                    .map(userSessionEntity -> (UserSessionModel) wrap(realm, userSessionEntity, offline))
+                    .map(userSessionEntity -> (UserSessionModel) wrap(realm, userSessionEntity, true))
                     .filter(Objects::nonNull);
         }
 
@@ -455,7 +465,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
         // If the sorted stream is used within a flatMap (like in SessionsResource), it will not terminate early unless wrapped with
         // StreamsUtil.prepareSortedStreamToWorkInsideOfFlatMapWithTerminalOperations causing unnecessary operations.
-        return paginatedStream(StreamsUtil.prepareSortedStreamToWorkInsideOfFlatMapWithTerminalOperations(getUserSessionsStream(realm, predicate, offline)
+        return paginatedStream(StreamsUtil.prepareSortedStreamToWorkInsideOfFlatMapWithTerminalOperations(getUserSessionsStream(realm, predicate, false)
                 .sorted(Comparator.comparing(UserSessionModel::getLastSessionRefresh))), firstResult, maxResults);
     }
 
@@ -489,7 +499,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
             return persister.getUserSessionsCountsByClients(realm, true);
         }
 
-        return getCache(offline).entrySet().stream()
+        return getCache(false).entrySet().stream()
                 .filter(UserSessionPredicate.create(realm.getId()))
                 .map(Mappers.authClientSessionSetMapper())
                 .flatMap(CollectionToStreamMapper.getInstance())
@@ -504,7 +514,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
             return persister.getUserSessionsCount(realm, client, true);
         }
 
-        return getUserSessionsStream(realm, UserSessionPredicate.create(realm.getId()).client(client.getId()), offline).count();
+        return getUserSessionsStream(realm, UserSessionPredicate.create(realm.getId()).client(client.getId()), false).count();
     }
 
     @Override
@@ -535,7 +545,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     public void removeAllExpired() {
         // Rely on expiration of cache entries provided by infinispan. Just expire entries from persister is needed
         // TODO: Avoid iteration over all realms here (Details in the KEYCLOAK-16802)
-        session.realms().getRealmsStream().forEach(this::removeExpired);
+        UserSessionPersisterProvider provider = session.getProvider(UserSessionPersisterProvider.class);
+        session.realms().getRealmsStream().forEach(provider::removeExpired);
 
     }
 
@@ -562,10 +573,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     public void removeLocalUserSessions(String realmId, boolean offline) {
         FuturesHelper futures = new FuturesHelper();
 
-        Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
-        Cache<String, SessionEntityWrapper<UserSessionEntity>> localCache = CacheDecorators.localCache(cache);
-        Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> clientSessionCache = getClientSessionCache(offline);
-        Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> localClientSessionCache = CacheDecorators.localCache(clientSessionCache);
+        Cache<String, SessionEntityWrapper<UserSessionEntity>> localCache = CacheDecorators.localCache(getCache(offline));
+        Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> localClientSessionCache = CacheDecorators.localCache(getClientSessionCache(offline));
 
         final AtomicInteger userSessionsSize = new AtomicInteger();
 
@@ -573,22 +582,16 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
                 .entrySet()
                 .stream()
                 .filter(SessionWrapperPredicate.create(realmId))
-                .map(Mappers.userSessionEntity())
-                .forEach(new Consumer<UserSessionEntity>() {
+                .forEach(userSessionEntity -> {
+                    userSessionsSize.incrementAndGet();
 
-                    @Override
-                    public void accept(UserSessionEntity userSessionEntity) {
-                        userSessionsSize.incrementAndGet();
-
-                        // Remove session from remoteCache too. Use removeAsync for better perf
-                        Future future = localCache.removeAsync(userSessionEntity.getId());
-                        futures.addTask(future);
-                        userSessionEntity.getAuthenticatedClientSessions().forEach((clientUUID, clientSessionId) -> {
-                            Future f = localClientSessionCache.removeAsync(clientSessionId);
-                            futures.addTask(f);
-                        });
-                    }
-
+                    // Remove session from remoteCache too. Use removeAsync for better perf
+                    Future<?> future = localCache.removeAsync(userSessionEntity.getKey());
+                    futures.addTask(future);
+                    userSessionEntity.getValue().getEntity().getAuthenticatedClientSessions().forEach((clientUUID, clientSessionId) -> {
+                        Future<?> f = localClientSessionCache.removeAsync(clientSessionId);
+                        futures.addTask(f);
+                    });
                 });
 
 
@@ -617,9 +620,6 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     @Override
     public void onClientRemoved(RealmModel realm, ClientModel client) {
-//        clusterEventsSenderTx.addEvent(
-//                ClientRemovedSessionEvent.createEvent(ClientRemovedSessionEvent.class, InfinispanUserSessionProviderFactory.CLIENT_REMOVED_SESSION_EVENT, session, realm.getId(), true),
-//                ClusterProvider.DCNotify.LOCAL_DC_ONLY);
         UserSessionPersisterProvider sessionsPersister = session.getProvider(UserSessionPersisterProvider.class);
         if (sessionsPersister != null) {
             sessionsPersister.onClientRemoved(realm, client);
@@ -655,7 +655,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         userSessionUpdateTx.addTask(sessionEntity.getId(), removeTask);
     }
 
-    UserSessionAdapter wrap(RealmModel realm, UserSessionEntity entity, boolean offline, UserModel user) {
+    UserSessionAdapter<InfinispanUserSessionProvider> wrap(RealmModel realm, UserSessionEntity entity, boolean offline, UserModel user) {
         InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx = getTransaction(offline);
         InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionUpdateTx = getClientSessionTransaction(offline);
 
@@ -663,14 +663,13 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
             return null;
         }
 
-        return new UserSessionAdapter(session, user, this, userSessionUpdateTx, clientSessionUpdateTx, realm, entity, offline);
+        return new UserSessionAdapter<>(session, user, this, userSessionUpdateTx, clientSessionUpdateTx, realm, entity, offline);
     }
 
-    UserSessionAdapter wrap(RealmModel realm, UserSessionEntity entity, boolean offline) {
-        UserModel user = null;
+    UserSessionAdapter<InfinispanUserSessionProvider> wrap(RealmModel realm, UserSessionEntity entity, boolean offline) {
         if (Profile.isFeatureEnabled(Feature.TRANSIENT_USERS) && entity.getNotes().containsKey(SESSION_NOTE_LIGHTWEIGHT_USER)) {
             LightweightUserAdapter lua = LightweightUserAdapter.fromString(session, realm, entity.getNotes().get(SESSION_NOTE_LIGHTWEIGHT_USER));
-            final UserSessionAdapter us = wrap(realm, entity, offline, lua);
+            final UserSessionAdapter<InfinispanUserSessionProvider> us = wrap(realm, entity, offline, lua);
             lua.setUpdateHandler(lua1 -> {
                 if (lua == lua1) {  // Ensure there is no conflicting user model, only the latest lightweight user can be used
                     us.setNote(SESSION_NOTE_LIGHTWEIGHT_USER, lua1.serialize());
@@ -679,7 +678,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
             return us;
         }
 
-        user = session.users().getUserById(realm, entity.getUser());
+        UserModel user = session.users().getUserById(realm, entity.getUser());
 
         if (user == null) {
             // remove orphaned user session from the cache and from persister if the session is offline; also removes associated client sessions
@@ -699,11 +698,11 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     }
 
     UserSessionEntity getUserSessionEntity(RealmModel realm, UserSessionModel userSession, boolean offline) {
-        if (userSession instanceof UserSessionAdapter) {
-            if (!userSession.getRealm().equals(realm)) {
+        if (userSession instanceof UserSessionAdapter<?> usa) {
+            if (!usa.getRealm().equals(realm)) {
                 return null;
             }
-            return ((UserSessionAdapter) userSession).getEntity();
+            return usa.getEntity();
         } else {
             return getUserSessionEntity(realm, userSession.getId(), offline);
         }
@@ -712,7 +711,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     @Override
     public UserSessionModel createOfflineUserSession(UserSessionModel userSession) {
-        UserSessionAdapter offlineUserSession = importUserSession(userSession, true);
+        UserSessionAdapter<?> offlineUserSession = importUserSession(userSession);
 
         // started and lastSessionRefresh set to current time
         int currentTime = Time.currentTime();
@@ -725,7 +724,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     }
 
     @Override
-    public UserSessionAdapter getOfflineUserSession(RealmModel realm, String userSessionId) {
+    public UserSessionAdapter<InfinispanUserSessionProvider> getOfflineUserSession(RealmModel realm, String userSessionId) {
         return getUserSession(realm, userSessionId, true);
     }
 
@@ -745,12 +744,13 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     @Override
     public AuthenticatedClientSessionModel createOfflineClientSession(AuthenticatedClientSessionModel clientSession, UserSessionModel offlineUserSession) {
-        UserSessionAdapter userSessionAdapter = (offlineUserSession instanceof UserSessionAdapter) ? (UserSessionAdapter) offlineUserSession :
+        UserSessionAdapter<?> userSessionAdapter = (offlineUserSession instanceof UserSessionAdapter) ? (UserSessionAdapter<?>) offlineUserSession :
                 getOfflineUserSession(offlineUserSession.getRealm(), offlineUserSession.getId());
 
         InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx = getTransaction(true);
         InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionUpdateTx = getClientSessionTransaction(true);
-        AuthenticatedClientSessionAdapter offlineClientSession = importClientSession(userSessionAdapter, clientSession, userSessionUpdateTx, clientSessionUpdateTx, true, false);
+        AuthenticatedClientSessionAdapter offlineClientSession = importClientSession(userSessionAdapter, clientSession, userSessionUpdateTx, clientSessionUpdateTx, false);
+        assert offlineClientSession != null; // no expiration checked, it is never null
 
         // update timestamp to current time
         offlineClientSession.setTimestamp(Time.currentTime());
@@ -764,7 +764,12 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
     @Override
     public Stream<UserSessionModel> getOfflineUserSessionsStream(RealmModel realm, UserModel user) {
-        return getUserSessionsFromPersistenceProviderStream(realm, user, true);
+        UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+        return persister.loadUserSessionsStream(realm, user, true, 0, null)
+                .map(persistentUserSession -> getUserSessionEntityFromCacheOrImportIfNecessary(realm, persistentUserSession))
+                .filter(Objects::nonNull)
+                .map(userSessionEntity -> (UserSessionModel) wrap(realm, userSessionEntity, true))
+                .filter(Objects::nonNull);
     }
 
     @Override
@@ -778,7 +783,9 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     }
 
 
+    @SuppressWarnings("removal")
     @Override
+    @Deprecated(forRemoval = true, since = "25.0")
     public void importUserSessions(Collection<UserSessionModel> persistentUserSessions, boolean offline) {
         if (persistentUserSessions == null || persistentUserSessions.isEmpty()) {
             return;
@@ -821,9 +828,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
                     offline ? offlineSessionCacheEntryLifespanAdjuster : SessionTimeouts::getUserSessionLifespanMs,
                     offline ? SessionTimeouts::getOfflineSessionMaxIdleMs : SessionTimeouts::getUserSessionMaxIdleMs);
         } else {
-            Retry.executeWithBackoff((int iteration) -> {
-                cache.putAll(sessionsById);
-            }, 10, 10);
+            Retry.executeWithBackoff((int iteration) -> cache.putAll(sessionsById), 10, 10);
         }
 
         // Import client sessions
@@ -834,14 +839,12 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
                     offline ? offlineClientSessionCacheEntryLifespanAdjuster : SessionTimeouts::getClientSessionLifespanMs,
                     offline ? SessionTimeouts::getOfflineClientSessionMaxIdleMs : SessionTimeouts::getClientSessionMaxIdleMs);
         } else {
-            Retry.executeWithBackoff((int iteration) -> {
-                clientSessCache.putAll(clientSessionsById);
-            }, 10, 10);
+            Retry.executeWithBackoff((int iteration) -> clientSessCache.putAll(clientSessionsById), 10, 10);
         }
     }
 
-    private <T extends SessionEntity> void importSessionsWithExpiration(Map<? extends Object, SessionEntityWrapper<T>> sessionsById,
-                                                                        BasicCache cache, SessionFunction<T> lifespanMsCalculator,
+    private <K, T extends SessionEntity> void importSessionsWithExpiration(Map<K, SessionEntityWrapper<T>> sessionsById,
+                                                                        Cache<K, SessionEntityWrapper<T>> cache, SessionFunction<T> lifespanMsCalculator,
                                                                         SessionFunction<T> maxIdleTimeMsCalculator) {
         sessionsById.forEach((id, sessionEntityWrapper) -> {
 
@@ -853,61 +856,37 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
 
             if (lifespan != SessionTimeouts.ENTRY_EXPIRED_FLAG
                     && maxIdle != SessionTimeouts.ENTRY_EXPIRED_FLAG) {
-                if (cache instanceof RemoteCache) {
-                    Retry.executeWithBackoff((int iteration) -> {
-
-                        try {
-                            cache.put(id, sessionEntityWrapper, lifespan, TimeUnit.MILLISECONDS, maxIdle, TimeUnit.MILLISECONDS);
-                        } catch (HotRodClientException re) {
-                            if (log.isDebugEnabled()) {
-                                log.debugf(re, "Failed to put import %d sessions to remoteCache. Iteration '%s'. Will try to retry the task",
-                                        sessionsById.size(), iteration);
-                            }
-
-                            // Rethrow the exception. Retry will take care of handle the exception and eventually retry the operation.
-                            throw re;
-                        }
-
-                    }, 10, 10);
-                } else {
-                    cache.put(id, sessionEntityWrapper, lifespan, TimeUnit.MILLISECONDS, maxIdle, TimeUnit.MILLISECONDS);
-                }
+                cache.put(id, sessionEntityWrapper, lifespan, TimeUnit.MILLISECONDS, maxIdle, TimeUnit.MILLISECONDS);
             }
         });
     }
 
     // Imports just userSession without it's clientSessions
-    protected UserSessionAdapter importUserSession(UserSessionModel userSession, boolean offline) {
+    protected UserSessionAdapter<InfinispanUserSessionProvider> importUserSession(UserSessionModel userSession) {
         UserSessionEntity entity = UserSessionEntity.createFromModel(userSession);
 
-        InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx = getTransaction(offline);
+        InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx = getTransaction(true);
 
         SessionUpdateTask<UserSessionEntity> importTask = Tasks.addIfAbsentSync();
         userSessionUpdateTx.addTask(userSession.getId(), importTask, entity, UserSessionModel.SessionPersistenceState.PERSISTENT);
 
-        UserSessionAdapter importedSession = wrap(userSession.getRealm(), entity, offline);
-
-        return importedSession;
+        return wrap(userSession.getRealm(), entity, true);
     }
 
 
-    private AuthenticatedClientSessionAdapter importClientSession(UserSessionAdapter sessionToImportInto, AuthenticatedClientSessionModel clientSession,
+    private AuthenticatedClientSessionAdapter importClientSession(UserSessionAdapter<?> sessionToImportInto, AuthenticatedClientSessionModel clientSession,
                                                                   InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx,
                                                                   InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionUpdateTx,
-                                                                  boolean offline, boolean checkExpiration) {
+                                                                  boolean checkExpiration) {
         AuthenticatedClientSessionEntity entity = createAuthenticatedClientSessionInstance(clientSession,
-                sessionToImportInto.getRealm().getId(), clientSession.getClient().getId(), offline);
+                sessionToImportInto.getRealm().getId(), clientSession.getClient().getId(), true);
 
         // Update timestamp to same value as userSession. LastSessionRefresh of userSession from DB will have correct value
         entity.setTimestamp(sessionToImportInto.getLastSessionRefresh());
 
         if (checkExpiration) {
-            SessionFunction<AuthenticatedClientSessionEntity> lifespanChecker = offline
-                    ? offlineClientSessionCacheEntryLifespanAdjuster : SessionTimeouts::getClientSessionLifespanMs;
-            SessionFunction<AuthenticatedClientSessionEntity> idleTimeoutChecker = offline
-                    ? SessionTimeouts::getOfflineClientSessionMaxIdleMs : SessionTimeouts::getClientSessionMaxIdleMs;
-            if (idleTimeoutChecker.apply(sessionToImportInto.getRealm(), clientSession.getClient(), entity) == SessionTimeouts.ENTRY_EXPIRED_FLAG
-                    || lifespanChecker.apply(sessionToImportInto.getRealm(), clientSession.getClient(), entity) == SessionTimeouts.ENTRY_EXPIRED_FLAG) {
+            if (SessionTimeouts.getOfflineClientSessionMaxIdleMs(sessionToImportInto.getRealm(), clientSession.getClient(), entity) == SessionTimeouts.ENTRY_EXPIRED_FLAG
+                    || offlineClientSessionCacheEntryLifespanAdjuster.apply(sessionToImportInto.getRealm(), clientSession.getClient(), entity) == SessionTimeouts.ENTRY_EXPIRED_FLAG) {
                 return null;
             }
         }
@@ -920,10 +899,9 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         AuthenticatedClientSessionStore clientSessions = sessionToImportInto.getEntity().getAuthenticatedClientSessions();
         clientSessions.put(clientSession.getClient().getId(), clientSessionId);
 
-        SessionUpdateTask registerClientSessionTask = new RegisterClientSessionTask(clientSession.getClient().getId(), clientSessionId);
-        userSessionUpdateTx.addTask(sessionToImportInto.getId(), registerClientSessionTask);
+        userSessionUpdateTx.addTask(sessionToImportInto.getId(), new RegisterClientSessionTask(clientSession.getClient().getId(), clientSessionId));
 
-        return new AuthenticatedClientSessionAdapter(session, entity, clientSession.getClient(), sessionToImportInto, clientSessionUpdateTx, offline);
+        return new AuthenticatedClientSessionAdapter(session, entity, clientSession.getClient(), sessionToImportInto, clientSessionUpdateTx, true);
     }
 
 
@@ -944,15 +922,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
         return entity;
     }
 
-    private static class RegisterClientSessionTask implements SessionUpdateTask<UserSessionEntity> {
-
-        private final String clientUuid;
-        private final UUID clientSessionId;
-
-        public RegisterClientSessionTask(String clientUuid, UUID clientSessionId) {
-            this.clientUuid = clientUuid;
-            this.clientSessionId = clientSessionId;
-        }
+    private record RegisterClientSessionTask(String clientUuid, UUID clientSessionId)
+            implements SessionUpdateTask<UserSessionEntity> {
 
         @Override
         public void runUpdate(UserSessionEntity session) {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -148,7 +148,15 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
     public void init(Config.Scope config) {
         this.config = config;
         offlineSessionCacheEntryLifespanOverride = config.getInt(CONFIG_OFFLINE_SESSION_CACHE_ENTRY_LIFESPAN_OVERRIDE, -1);
+        if (offlineSessionCacheEntryLifespanOverride != -1) {
+            // to be removed in KC 27
+            log.warn("The option spi-user-sessions--infinispan--offline-session-cache-entry-lifespan-override is deprecated and will be removed in a future release");
+        }
         offlineClientSessionCacheEntryLifespanOverride = config.getInt(CONFIG_OFFLINE_CLIENT_SESSION_CACHE_ENTRY_LIFESPAN_OVERRIDE, -1);
+        if (offlineClientSessionCacheEntryLifespanOverride != -1) {
+            // to be removed in KC 27
+            log.warn("The option spi-user-sessions--infinispan--offline-client-session-cache-entry-lifespan-override is deprecated and will be removed in a future release");
+        }
         maxBatchSize = config.getInt(CONFIG_MAX_BATCH_SIZE, DEFAULT_MAX_BATCH_SIZE);
         // Do not use caches for sessions if explicitly disabled or if embedded caches are not used
         useCaches = config.getBoolean(CONFIG_USE_CACHES, DEFAULT_USE_CACHES) && InfinispanUtils.isEmbeddedInfinispan();
@@ -340,13 +348,13 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
         builder.property()
                 .name(CONFIG_OFFLINE_CLIENT_SESSION_CACHE_ENTRY_LIFESPAN_OVERRIDE)
                 .type("int")
-                .helpText("Override how long offline client sessions should be kept in memory in seconds")
+                .helpText("Override how long offline client sessions should be kept in memory in seconds (deprecated, to be removed in Keycloak 27)")
                 .add();
 
         builder.property()
                 .name(CONFIG_OFFLINE_SESSION_CACHE_ENTRY_LIFESPAN_OVERRIDE)
                 .type("int")
-                .helpText("Override how long offline user sessions should be kept in memory in seconds")
+                .helpText("Override how long offline user sessions should be kept in memory in seconds (deprecated, to be removed in Keycloak 27)")
                 .add();
 
         builder.property()

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/InfinispanChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/InfinispanChangelogBasedTransaction.java
@@ -19,10 +19,13 @@ package org.keycloak.models.sessions.infinispan.changes;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.jboss.logging.Logger;
+import org.keycloak.connections.infinispan.InfinispanUtil;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -30,7 +33,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.sessions.infinispan.CacheDecorators;
 import org.keycloak.models.sessions.infinispan.SessionFunction;
 import org.keycloak.models.sessions.infinispan.entities.SessionEntity;
-import org.keycloak.connections.infinispan.InfinispanUtil;
+import org.keycloak.models.sessions.infinispan.util.SessionTimeouts;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -137,11 +140,9 @@ public class InfinispanChangelogBasedTransaction<K, V extends SessionEntity> ext
             return wrappedEntity;
         } else {
             // If entity is scheduled for remove, we don't return it.
-            boolean scheduledForRemove = myUpdates.getUpdateTasks().stream().filter((SessionUpdateTask task) -> {
-
-                return task.getOperation() == SessionUpdateTask.CacheOperation.REMOVE;
-
-            }).findFirst().isPresent();
+            boolean scheduledForRemove = myUpdates.getUpdateTasks().stream()
+                    .map(SessionUpdateTask::getOperation)
+                    .anyMatch(SessionUpdateTask.CacheOperation.REMOVE::equals);
 
             return scheduledForRemove ? null : myUpdates.getEntityWrapper();
         }
@@ -258,7 +259,93 @@ public class InfinispanChangelogBasedTransaction<K, V extends SessionEntity> ext
     protected void rollbackImpl() {
     }
 
-    private SessionEntityWrapper<V> generateNewVersionAndWrapEntity(V entity, Map<String, String> localMetadata) {
+    /**
+     * @return The {@link Cache} backing up this transaction.
+     */
+    public Cache<K, SessionEntityWrapper<V>> getCache() {
+        return cache;
+    }
+
+    /**
+     * Imports a session from an external source into the {@link Cache}.
+     * <p>
+     * If a session already exists in the cache, this method does not insert the {@code session}. The invoker should use
+     * the session returned by this method invocation. When the session is successfully imported, this method returns
+     * null and the {@code session} can be used by the transaction.
+     * <p>
+     * This transaction will keep track of further changes in the session.
+     *
+     * @param realmModel The {@link RealmModel} where the session belong to.
+     * @param key        The cache's key.
+     * @param session    The session to import.
+     * @param lifespan   How long the session stays cached until it is expired and removed.
+     * @param maxIdle    How long the session can be idle (without reading or writing) before being removed.
+     * @return The existing cached session. If it returns {@code null}, it means the {@code session} used in the
+     * parameters was cached.
+     */
+    public V importSession(RealmModel realmModel, K key, SessionEntityWrapper<V> session, long lifespan, long maxIdle) {
+        SessionUpdatesList<V> updatesList = updates.get(key);
+        if (updatesList != null) {
+            // exists in transaction, avoid cache operation
+            return updatesList.getEntityWrapper().getEntity();
+        }
+        SessionEntityWrapper<V> existing = cache.putIfAbsent(key, session, lifespan, TimeUnit.MILLISECONDS, maxIdle, TimeUnit.MILLISECONDS);
+        if (existing == null) {
+            // keep track of the imported session for updates
+            updates.put(key, new SessionUpdatesList<>(realmModel, session));
+            return null;
+        }
+        updates.put(key, new SessionUpdatesList<>(realmModel, existing));
+        return existing.getEntity();
+    }
+
+    /**
+     * Imports multiple sessions from an external source into the {@link Cache}.
+     * <p>
+     * If the {@code lifespanFunction} or {@code maxIdleFunction} returns {@link SessionTimeouts#ENTRY_EXPIRED_FLAG},
+     * the session is considered expired and not stored in the cache.
+     * <p>
+     * Also, if one or more sessions already exist in the {@link Cache}, it will not be imported.
+     * <p>
+     * This transaction will keep track of further changes in the sessions.
+     *
+     * @param realmModel       The {@link RealmModel} where the sessions belong to.
+     * @param sessions         The {@link Map} with the cache's key/session mapping to be imported.
+     * @param lifespanFunction The {@link java.util.function.Function} to compute the lifespan of the session. It
+     *                         defines how long the session should be stored in the cache until it is removed.
+     * @param maxIdleFunction  The {@link java.util.function.Function} to compute the max-idle of the session. It
+     *                         defines how long the session will be idle before it is removed.
+     */
+    public void importSessionsConcurrently(RealmModel realmModel, Map<K, SessionEntityWrapper<V>> sessions, SessionFunction<V> lifespanFunction, SessionFunction<V> maxIdleFunction) {
+        if (sessions.isEmpty()) {
+            //nothing to import
+            return;
+        }
+        var stage = CompletionStages.aggregateCompletionStage();
+        var allSessions = new ConcurrentHashMap<K, SessionEntityWrapper<V>>();
+        sessions.forEach((key, session) -> {
+            if (updates.containsKey(key)) {
+                //nothing to import, already exists in transaction
+                return;
+            }
+            var clientModel = session.getClientIfNeeded(realmModel);
+            var sessionEntity = session.getEntity();
+            var lifespan = lifespanFunction.apply(realmModel, clientModel, sessionEntity);
+            var maxIdle = maxIdleFunction.apply(realmModel, clientModel, sessionEntity);
+            if (lifespan == SessionTimeouts.ENTRY_EXPIRED_FLAG || maxIdle == SessionTimeouts.ENTRY_EXPIRED_FLAG) {
+                //nothing to import, already expired
+                return;
+            }
+            var future = cache.putIfAbsentAsync(key, session, lifespan, TimeUnit.MILLISECONDS, maxIdle, TimeUnit.MILLISECONDS);
+            // write result into concurrent hash map because the consumer is invoked in a different thread each time.
+            stage.dependsOn(future.thenAccept(existing -> allSessions.put(key, existing == null ? session : existing)));
+        });
+
+        CompletionStages.join(stage.freeze());
+        allSessions.forEach((key, wrapper) -> updates.put(key, new SessionUpdatesList<>(realmModel, wrapper)));
+    }
+
+    private static <V extends SessionEntity> SessionEntityWrapper<V> generateNewVersionAndWrapEntity(V entity, Map<String, String> localMetadata) {
         return new SessionEntityWrapper<>(localMetadata, entity);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -232,6 +232,23 @@ public final class CacheConfigurator {
                 builder.clustering().hash().numOwners(2);
             }
         }
+
+        for (var name : Arrays.asList( OFFLINE_USER_SESSION_CACHE_NAME, OFFLINE_CLIENT_SESSION_CACHE_NAME)) {
+            var builder = holder.getNamedConfigurationBuilders().get(name);
+            if (builder == null) {
+                throw cacheNotFound(name);
+            }
+            if (builder.memory().maxCount() == -1) {
+                logger.infof("Offline sessions should have a max count set to avoid excessive memory usage. Setting a default cache limit of 10000 for cache %s.", name);
+                builder.memory().maxCount(10000);
+            }
+            if (builder.clustering().hash().attributes().attribute(HashConfiguration.NUM_OWNERS).get() != 1 &&
+                    builder.persistence().stores().stream().noneMatch(p -> p.attributes().attribute(AbstractStoreConfiguration.SHARED).get())
+            ) {
+                logger.infof("Setting a memory limit implies to have exactly one owne. Setting num_owners=1 to avoid data loss.", name);
+                builder.clustering().hash().numOwners(1);
+            }
+        }
     }
 
     // private methods below

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -216,7 +216,7 @@ public final class CacheConfigurator {
      */
     public static void configureSessionsCachesForVolatileSessions(ConfigurationBuilderHolder holder) {
         logger.debug("Configuring session cache (volatile user sessions)");
-        for (var name : Arrays.asList(USER_SESSION_CACHE_NAME, CLIENT_SESSION_CACHE_NAME, OFFLINE_USER_SESSION_CACHE_NAME, OFFLINE_CLIENT_SESSION_CACHE_NAME)) {
+        for (var name : Arrays.asList(USER_SESSION_CACHE_NAME, CLIENT_SESSION_CACHE_NAME)) {
             var builder = holder.getNamedConfigurationBuilders().get(name);
             if (builder == null) {
                 throw cacheNotFound(name);


### PR DESCRIPTION
Fixes #40754

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

The method `org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider#importUserSession(org.keycloak.models.RealmModel, org.keycloak.models.UserSessionModel)` was rewritten. The main differences are that I'm using `putIfAbsent` to import the session, and I'm importing all the client sessions in parallel.

I also took the opportunity to fix the code warnings (unused code, parameters with constant values, missing types, etc).