### PR TITLE
Only include new fields for key generation if not useFile

### DIFF
--- a/js/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
@@ -93,25 +93,29 @@ export const KeyForm = ({
       {format !== CERT_PEM && (
         <StoreSettings hidePassword={useFile} isSaml={isSaml} />
       )}
-      <SelectControl
-        name="keySize"
-        label={t("keySize")}
-        labelIcon={t("keySizeHelp")}
-        controller={{
-          defaultValue: keySizes[0],
-        }}
-        menuAppendTo="parent"
-        options={keySizes}
-      />
-      <NumberControl
-        name="validity"
-        label={t("validity")}
-        labelIcon={t("validityHelp")}
-        controller={{
-          defaultValue: 3,
-          rules: { required: t("required"), min: 1, max: 10 },
-        }}
-      />
+      {!useFile && (
+        <>
+          <SelectControl
+            name="keySize"
+            label={t("keySize")}
+            labelIcon={t("keySizeHelp")}
+            controller={{
+              defaultValue: keySizes[0],
+            }}
+            menuAppendTo="parent"
+            options={keySizes}
+          />
+          <NumberControl
+            name="validity"
+            label={t("validity")}
+            labelIcon={t("validityHelp")}
+            controller={{
+              defaultValue: 3,
+              rules: { required: t("required"), min: 1, max: 10 },
+            }}
+          />
+        </>
+      )}
     </Form>
   );
 };


### PR DESCRIPTION
Closes #40860

I detected today that the component modified by #38620 is also used when importing keys in saml. The new fields make no sense in that case, when `useFile` is `true`. So the PR just shows them if `!useFile`. 
