### PR TITLE
implementing json patch

### DIFF
--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -408,6 +408,10 @@
 
         <!-- Keycloak Dependencies-->
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>zjsonpatch</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>

--- a/rest/admin-api/pom.xml
+++ b/rest/admin-api/pom.xml
@@ -36,5 +36,9 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>zjsonpatch</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public interface ClientApi {
 
+    // TODO move these
+    public static final String CONENT_TYPE_MERGE_PATCH = "application/merge-patch+json";
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     ClientRepresentation getClient();
@@ -25,7 +28,7 @@ public interface ClientApi {
     ClientRepresentation createOrUpdateClient(ClientRepresentation client, @PathParam("fieldValidation") FieldValidation fieldValidation);
 
     @PATCH
-    @Consumes("application/merge-patch+json")
+    @Consumes({MediaType.APPLICATION_JSON_PATCH_JSON, CONENT_TYPE_MERGE_PATCH})
     @Produces(MediaType.APPLICATION_JSON)
     ClientRepresentation patchClient(JsonNode patch, @PathParam("fieldValidation") FieldValidation fieldValidation);
 

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -17,8 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import io.fabric8.zjsonpatch.JsonPatch;
-import jakarta.json.Json;
-import jakarta.json.stream.JsonParser;
+import io.fabric8.zjsonpatch.JsonPatchException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -88,8 +87,10 @@ public class DefaultClientApi implements ClientApi {
                 }
             }
             return clientService.createOrUpdate(realm, updated, true).representation();
-        } catch (JsonProcessingException e) {
+        } catch (JsonPatchException e) {
             // TODO: kubernetes uses 422 instead
+            throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (JsonProcessingException e) {
             throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
         } catch (IOException e) {
             throw ErrorResponse.error("Unknown Error Occurred", Response.Status.INTERNAL_SERVER_ERROR);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AdminV2Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AdminV2Test.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.api.client.ClientApi;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+@KeycloakIntegrationTest()
+public class AdminV2Test {
+
+    private static final String HOSTNAME_LOCAL_ADMIN = "http://localhost:8080/admin/api/v2";
+
+    @InjectHttpClient
+    private HttpClient client;
+
+    @Test
+    public void testGetClient() throws Exception {
+        HttpGet request = new HttpGet(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/account");
+        HttpResponse response = client.execute(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        ObjectMapper mapper = new ObjectMapper();
+        ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
+        assertEquals("account", client.getClientId());
+    }
+
+    @Test
+    public void testJsonPatchClient() throws Exception {
+        HttpPatch request = new HttpPatch(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/account");
+        request.setEntity(new StringEntity("not json"));
+        request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_PATCH_JSON);
+        HttpResponse response = client.execute(request);
+        EntityUtils.consumeQuietly(response.getEntity());
+        assertEquals(400, response.getStatusLine().getStatusCode());
+
+        request.setEntity(new StringEntity(
+                """
+                [{"op": "add", "path": "/description", "value": "I'm a description"}]
+                """));
+
+        response = client.execute(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        ObjectMapper mapper = new ObjectMapper();
+        ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
+        assertEquals("I'm a description", client.getDescription());
+    }
+
+    @Disabled
+    @Test
+    public void testJsonMergePatchClient() throws Exception {
+        HttpPatch request = new HttpPatch(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/account");
+        request.setHeader(HttpHeaders.CONTENT_TYPE, ClientApi.CONENT_TYPE_MERGE_PATCH);
+
+        ClientRepresentation patch = new ClientRepresentation();
+        patch.setDescription("I'm also a description");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        request.setEntity(new StringEntity(mapper.writeValueAsString(patch)));
+
+        HttpResponse response = client.execute(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
+        assertEquals("I'm also a description", client.getDescription());
+    }
+
+}


### PR DESCRIPTION
@keycloak/cloud-native this is roughly what json patch support looks like. We would also need to put the fabric8 zjsonpatch dependency in the lib. 

If we don't want the additional dependency, the alternative is to support jakarta.json / parsson (coming from Quarkus) - that seems slightly less efficient as we'll need to convert back and forth from the   JsonValue representation.

Let me know what you think.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
