### PR TITLE
More secure call of Facebook debug token

### DIFF
--- a/services/src/main/java/org/keycloak/social/facebook/FacebookIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/facebook/FacebookIdentityProvider.java
@@ -19,6 +19,7 @@ package org.keycloak.social.facebook;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
@@ -70,8 +71,8 @@ public class FacebookIdentityProvider extends AbstractOAuth2IdentityProvider<Fac
 
     private void verifyToken(String accessToken) throws IOException {
         JsonNode response = SimpleHttp.doGet(DEBUG_TOKEN_URL, session)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getConfig().getClientId() + "|" + getConfig().getClientSecret())
                 .param("input_token", accessToken)
-                .param(OAuth2Constants.ACCESS_TOKEN, getConfig().getClientId() + "|" + getConfig().getClientSecret())
                 .asJson();
 
         JsonNode errorNode = response.get("error");


### PR DESCRIPTION
closes #40926

Unfortunately POST method does not work, but at least it is possible to send the client credentials in the HTTP header, which is a bit more secure than using GET parameter.
