### PR TITLE
Fix NPE when client is not set in context during token encoding

### DIFF
--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -244,7 +244,7 @@ public class DefaultTokenManager implements TokenManager {
         switch (category) {
             case ACCESS:
                 ClientModel client = session.getContext().getClient();
-                return OIDCAdvancedConfigWrapper.fromClientModel(client).isUseRfc9068AccessTokenHeaderType()
+                return client != null && OIDCAdvancedConfigWrapper.fromClientModel(client).isUseRfc9068AccessTokenHeaderType()
                     ? TokenUtil.TOKEN_TYPE_JWT_ACCESS_TOKEN
                     : "JWT";
             case LOGOUT:


### PR DESCRIPTION
This commit fixes an issue throwing an NPE when trying to encode a token without having a client set in the session context. In other places in this class (like getSignatureAlgorithm(String)) this is checked. But in the type(TokenCategory) it was forgotten to check.

Fixes #40935