### PR TITLE
Do not add steps if feature disabled in default flows

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -387,22 +387,26 @@ public class DefaultAuthenticationFlows {
         realm.addAuthenticatorExecution(execution);
 
         // webauthn as disabled
-        execution = new AuthenticationExecutionModel();
-        execution.setParentFlow(conditionalOTP.getId());
-        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
-        execution.setAuthenticator("webauthn-authenticator");
-        execution.setPriority(30);
-        execution.setAuthenticatorFlow(false);
-        realm.addAuthenticatorExecution(execution);
+        if (Profile.isFeatureEnabled(Profile.Feature.WEB_AUTHN)) {
+            execution = new AuthenticationExecutionModel();
+            execution.setParentFlow(conditionalOTP.getId());
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+            execution.setAuthenticator("webauthn-authenticator");
+            execution.setPriority(30);
+            execution.setAuthenticatorFlow(false);
+            realm.addAuthenticatorExecution(execution);
+        }
 
         // recovery-codes as disabled
-        execution = new AuthenticationExecutionModel();
-        execution.setParentFlow(conditionalOTP.getId());
-        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
-        execution.setAuthenticator("auth-recovery-authn-code-form");
-        execution.setPriority(40);
-        execution.setAuthenticatorFlow(false);
-        realm.addAuthenticatorExecution(execution);
+        if (Profile.isFeatureEnabled(Profile.Feature.RECOVERY_CODES)) {
+            execution = new AuthenticationExecutionModel();
+            execution.setParentFlow(conditionalOTP.getId());
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+            execution.setAuthenticator("auth-recovery-authn-code-form");
+            execution.setPriority(40);
+            execution.setAuthenticatorFlow(false);
+            realm.addAuthenticatorExecution(execution);
+        }
 
         addOrganizationBrowserFlowStep(realm, browser);
     }
@@ -669,22 +673,26 @@ public class DefaultAuthenticationFlows {
         realm.addAuthenticatorExecution(execution);
 
         // webauthn as disabled
-        execution = new AuthenticationExecutionModel();
-        execution.setParentFlow(conditionalOTP.getId());
-        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
-        execution.setAuthenticator("webauthn-authenticator");
-        execution.setPriority(30);
-        execution.setAuthenticatorFlow(false);
-        realm.addAuthenticatorExecution(execution);
+        if (Profile.isFeatureEnabled(Profile.Feature.WEB_AUTHN)) {
+            execution = new AuthenticationExecutionModel();
+            execution.setParentFlow(conditionalOTP.getId());
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+            execution.setAuthenticator("webauthn-authenticator");
+            execution.setPriority(30);
+            execution.setAuthenticatorFlow(false);
+            realm.addAuthenticatorExecution(execution);
+        }
 
         // recovery-codes as disabled
-        execution = new AuthenticationExecutionModel();
-        execution.setParentFlow(conditionalOTP.getId());
-        execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
-        execution.setAuthenticator("auth-recovery-authn-code-form");
-        execution.setPriority(40);
-        execution.setAuthenticatorFlow(false);
-        realm.addAuthenticatorExecution(execution);
+        if (Profile.isFeatureEnabled(Profile.Feature.RECOVERY_CODES)) {
+            execution = new AuthenticationExecutionModel();
+            execution.setParentFlow(conditionalOTP.getId());
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+            execution.setAuthenticator("auth-recovery-authn-code-form");
+            execution.setPriority(40);
+            execution.setAuthenticatorFlow(false);
+            realm.addAuthenticatorExecution(execution);
+        }
 
         addOrganizationFirstBrokerFlowStep(realm, firstBrokerLogin);
     }

--- a/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
@@ -357,7 +357,8 @@ public class DefaultAuthenticationFlow implements AuthenticationFlow {
     }
 
     private boolean isConditionalAuthenticator(AuthenticationExecutionModel model) {
-        return !model.isAuthenticatorFlow() && model.getAuthenticator() != null && createAuthenticator(getAuthenticatorFactory(model)) instanceof ConditionalAuthenticator;
+        return !model.isAuthenticatorFlow() && model.getAuthenticator() != null && model.isEnabled()
+                && createAuthenticator(getAuthenticatorFactory(model)) instanceof ConditionalAuthenticator;
     }
 
     private AuthenticatorFactory getAuthenticatorFactory(AuthenticationExecutionModel model) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -1006,6 +1006,19 @@ public class LoginTest extends AbstractChangeImportedUserPasswordsTest {
     }
 
     @Test
+    public void loginSuccessfulWithoutWebAuthn() {
+        testingClient.disableFeature(Profile.Feature.WEB_AUTHN);
+        try {
+            loginPage.open();
+            loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
+            Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+            events.expectLogin().assertEvent();
+        } finally {
+            testingClient.enableFeature(Profile.Feature.WEB_AUTHN);
+        }
+    }
+
+    @Test
     public void testExecuteActionIfSessionExists() {
         loginPage.open();
         loginPage.login("test-user@localhost", getPassword("test-user@localhost"));


### PR DESCRIPTION
Allow login if a step is disabled even the authenticator is not enabled by profile
Closes #40954

When webauthn and recovery-codes were added to the default forms we didn't think that the features could be disabled. The PR just adds two things:

1. The steps are just added if the features are enabled.
2. The `DefaultAuthenticationFlow.isConditionalAuthenticator` checks the `isEnabled` before loading the authenticator. This way even having the steps disabled the login is allowed. Test added for this point.