### PR TITLE
Make passkeys feature dependent on web_authn

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -124,7 +124,7 @@ public class Profile {
 
         ORGANIZATION("Organization support within realms", Type.DEFAULT),
 
-        PASSKEYS("Passkeys", Type.PREVIEW),
+        PASSKEYS("Passkeys", Type.PREVIEW, Feature.WEB_AUTHN),
 
         USER_EVENT_METRICS("Collect metrics based on user events", Type.DEFAULT),
 


### PR DESCRIPTION
Closes #40975

Adding `web_authn` dependency to `passkeys`. `passkeys` doesn't work  without `web_authn` so better add the dependency.
