### PR TITLE
fix: prevent quarkus from persisting logging runtime defaults

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -41,6 +41,7 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.TruststoreOptions;
 import org.keycloak.marshalling.Marshalling;
 import org.keycloak.provider.Provider;
@@ -130,7 +131,7 @@ public class KeycloakRecorder {
     }
 
     public HibernateOrmIntegrationRuntimeInitListener createDefaultUnitListener() {
-        return propertyCollector -> propertyCollector.accept(AvailableSettings.DEFAULT_SCHEMA, Configuration.getRawValue("kc.db-schema"));
+        return propertyCollector -> propertyCollector.accept(AvailableSettings.DEFAULT_SCHEMA, Configuration.getConfigValue(DatabaseOptions.DB_SCHEMA).getValue());
     }
 
     public void setCryptoProvider(FipsMode fipsMode) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/QuarkusProfileConfigResolver.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/QuarkusProfileConfigResolver.java
@@ -11,7 +11,7 @@ public class QuarkusProfileConfigResolver extends CommaSeparatedListProfileConfi
 
     static String getConfig(String key) {
         return Configuration.getRawPersistedProperty(key)
-                .orElse(Configuration.getRawValue(key));
+                .orElse(Configuration.getConfigValue(key).getValue());
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -86,7 +86,17 @@ public final class ShowConfig extends AbstractCommand {
             }
 
             if (mapper != null) {
-                property = mapper.forKey(property).getFrom();
+                String from = mapper.forKey(property).getFrom();
+
+                // only report from when it exists
+                if (!property.equals(from)) {
+                    ConfigValue value = getConfigValue(from);
+                    if (value.getValue() != null) {
+                        return;
+                    }
+                    configValue = value;
+                    property = from;
+                }
             }
 
             if (!uniqueNames.add(property)) {
@@ -115,11 +125,7 @@ public final class ShowConfig extends AbstractCommand {
 
     private void printProperty(String property, PropertyMapper<?> mapper, ConfigValue configValue) {
         String sourceName = configValue.getConfigSourceName();
-        String value = configValue.getRawValue();
-
-        if (value == null) {
-            value = configValue.getValue();
-        }
+        String value = configValue.getValue();
 
         value = maskValue(value, sourceName, mapper);
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -115,10 +115,6 @@ public final class Configuration {
         return PersistedConfigSource.getInstance().getProperties();
     }
 
-    public static String getRawValue(String propertyName) {
-        return getConfig().getRawValue(propertyName);
-    }
-
     public static Iterable<String> getPropertyNames() {
         return getPropertyNames(false);
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -102,7 +102,10 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
             }
             allMappers.remove(mapper);
 
-            if (!mapper.hasWildcard()) {
+            // include additional mappings if we're on the from side of the mapping
+            // as the mapping may not be bi-directional
+
+            if (!mapper.hasWildcard() && name.equals(mapper.getFrom())) {
                 // this is not a wildcard value, but may map to wildcards
                 // the current example is something like log-level=wildcardCat1:level,wildcardCat2:level
                 var wildCard = PropertyMappers.getWildcardMappedFrom(mapper.getOption());
@@ -116,9 +119,12 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
             mapper = mapper.forKey(name);
 
-            // there is a corner case here: -1 for the reload period has no 'to' value.
-            // if that becomes an issue we could use more metadata to perform a full mapping
-            return toDistinctStream(name, mapper.getTo());
+            if (name.equals(mapper.getFrom())) {
+                // there is a corner case here: -1 for the reload period has no 'to' value.
+                // if that becomes an issue we could use more metadata to perform a full mapping
+                return toDistinctStream(name, mapper.getTo());
+            }
+            return Stream.of(name);
         });
 
         // include anything remaining that has a default value

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import org.keycloak.config.DeprecatedMetadata;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionCategory;
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.ShortErrorMessageHandler;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
@@ -278,6 +279,10 @@ public class PropertyMapper<T> {
 
         if (!mapped && name.equals(configValue.getName())) {
             return configValue;
+        }
+
+        if (!isBuildTime() && Environment.isRebuild()) {
+            value = null; // prevent quarkus from recording these raw values as runtime defaults
         }
 
         // by unsetting the ordinal this will not be seen as directly modified by the user

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/DebugHostnameSettingsResource.java
@@ -173,10 +173,7 @@ public class DebugHostnameSettingsResource {
     }
 
     private void addOption(String key) {
-        String rawValue = Configuration.getRawValue("kc." + key);
-        if (rawValue != null && !rawValue.isEmpty()) {
-            this.allConfigPropertiesMap.put(key, rawValue);
-        }
+        Configuration.getOptionalKcValue(key).ifPresent(value -> this.allConfigPropertiesMap.put(key, value));
     }
 
     private Map<String, String> getHeaders() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
@@ -28,6 +28,7 @@ import jakarta.persistence.FlushModeType;
 import jakarta.persistence.SynchronizationType;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.keycloak.Config;
+import org.keycloak.config.DatabaseOptions;
 import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
 import org.keycloak.connections.jpa.support.EntityManagerProxy;
 import org.keycloak.models.KeycloakSession;
@@ -59,7 +60,7 @@ public abstract class AbstractJpaConnectionProviderFactory implements JpaConnect
 
     @Override
     public String getSchema() {
-        String schema = Configuration.getRawValue("kc.db-schema");
+        String schema = Configuration.getConfigValue(DatabaseOptions.DB_SCHEMA).getValue();
         if (schema != null && schema.contains("-") && ! Boolean.parseBoolean(System.getProperty(GlobalConfiguration.PRESERVE_SCHEMA_CASE.getKey()))) {
             System.setProperty(GlobalConfiguration.PRESERVE_SCHEMA_CASE.getKey(), "true");
             logger.warnf("The passed schema '%s' contains a dash. Setting liquibase config option PRESERVE_SCHEMA_CASE to true. See https://github.com/keycloak/keycloak/issues/20870 for more information.", schema);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/FilesKeystoreVaultProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/FilesKeystoreVaultProviderFactory.java
@@ -18,6 +18,7 @@
 package org.keycloak.quarkus.runtime.vault;
 
 import org.keycloak.Config;
+import org.keycloak.config.VaultOptions;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
@@ -33,6 +34,6 @@ public class FilesKeystoreVaultProviderFactory extends org.keycloak.vault.FilesK
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return getId().equals(Configuration.getRawValue("kc.vault"));
+        return getId().equals(Configuration.getConfigValue(VaultOptions.VAULT).getValue());
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/FilesPlainTextVaultProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/FilesPlainTextVaultProviderFactory.java
@@ -18,6 +18,7 @@
 package org.keycloak.quarkus.runtime.vault;
 
 import org.keycloak.Config;
+import org.keycloak.config.VaultOptions;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
@@ -33,6 +34,6 @@ public class FilesPlainTextVaultProviderFactory extends org.keycloak.vault.Files
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return getId().equals(Configuration.getRawValue("kc.vault"));
+        return getId().equals(Configuration.getConfigValue(VaultOptions.VAULT).getValue());
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -471,6 +471,9 @@ public class PicocliTest extends AbstractConfigurationTest {
         var value = nonRunningPicocli.config.getConfigValue("quarkus.log.category.\"org.keycloak\".level");
         assertEquals("quarkus.log.category.\"org.keycloak\".level", value.getName());
         assertEquals("WARN", value.getValue());
+        value = nonRunningPicocli.config.getConfigValue("quarkus.log.category.\"org.keycloak1\".level");
+        assertEquals("quarkus.log.category.\"org.keycloak1\".level", value.getName());
+        assertNull(value.getValue());
     }
 
     @Test
@@ -480,6 +483,9 @@ public class PicocliTest extends AbstractConfigurationTest {
         var value = nonRunningPicocli.config.getConfigValue("quarkus.log.category.\"org.keycloak\".level");
         assertEquals("quarkus.log.category.\"org.keycloak\".level", value.getName());
         assertEquals("WARN", value.getValue());
+        value = nonRunningPicocli.config.getConfigValue("quarkus.log.category.\"org.keycloak1\".level");
+        assertEquals("quarkus.log.category.\"org.keycloak1\".level", value.getName());
+        assertNull(value.getValue());
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -289,6 +289,13 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void testShowConfigDisplaysPrimaryValue() {
+        build("build", "--db=postgres");
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("show-config");
+        assertThat(nonRunningPicocli.getOutString(), containsString("postgres (Persisted)"));
+    }
+
+    @Test
     public void failSingleParamWithSpace() {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--db postgres");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -149,4 +149,46 @@ public class StartAutoBuildDistTest {
         cliResult.assertStartedDevMode();
     }
 
+    @Test
+    @Order(11)
+    void testLogging(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("start-dev", "--log-level=WARN,org.hibernate.SQL:debug");
+        cliResult.assertMessage("DEBUG [org.hibernate.SQL]");
+        cliResult.assertStartedDevMode();
+        dist.stop();
+
+        // logging runtime defaults should not be used
+        cliResult = dist.run("start-dev");
+        cliResult.assertNoMessage("DEBUG [org.hibernate.SQL]");
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @Order(11)
+    void testLogLevelNotPeristed(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("start", "--log-level=WARN,org.hibernate.SQL:debug", "--http-enabled=true", "--hostname-strict=false");
+        cliResult.assertMessage("DEBUG [org.hibernate.SQL]");
+        cliResult.assertStartedDevMode();
+        dist.stop();
+
+        // logging runtime defaults should not be used
+        cliResult = dist.run("start", "--http-enabled=true", "--hostname-strict=false");
+        cliResult.assertNoMessage("DEBUG [org.hibernate.SQL]");
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @Order(12)
+    void testLogLevelWildcardNotPeristed(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("start-dev", "--log-level-org.hibernate.SQL=debug");
+        cliResult.assertMessage("DEBUG [org.hibernate.SQL]");
+        cliResult.assertStartedDevMode();
+        dist.stop();
+
+        // logging runtime defaults should not be used
+        cliResult = dist.run("start-dev");
+        cliResult.assertNoMessage("DEBUG [org.hibernate.SQL]");
+        cliResult.assertStartedDevMode();
+    }
+
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -152,15 +152,15 @@ public class StartAutoBuildDistTest {
     @Test
     @Order(11)
     void testLogLevelNotPeristed(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("start", "--log-level=WARN,org.hibernate.SQL:debug", "--http-enabled=true", "--hostname-strict=false");
+        CLIResult cliResult = dist.run("start", "--db=dev-file", "--log-level=org.hibernate.SQL:debug", "--http-enabled=true", "--hostname-strict=false");
         cliResult.assertMessage("DEBUG [org.hibernate.SQL]");
-        cliResult.assertStartedDevMode();
+        cliResult.assertStarted();
         dist.stop();
 
         // logging runtime defaults should not be used
-        cliResult = dist.run("start", "--http-enabled=true", "--hostname-strict=false");
+        cliResult = dist.run("start", "--db=dev-file", "--http-enabled=true", "--hostname-strict=false");
         cliResult.assertNoMessage("DEBUG [org.hibernate.SQL]");
-        cliResult.assertStartedDevMode();
+        cliResult.assertStarted();
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -151,20 +151,6 @@ public class StartAutoBuildDistTest {
 
     @Test
     @Order(11)
-    void testLogging(KeycloakDistribution dist) {
-        CLIResult cliResult = dist.run("start-dev", "--log-level=WARN,org.hibernate.SQL:debug");
-        cliResult.assertMessage("DEBUG [org.hibernate.SQL]");
-        cliResult.assertStartedDevMode();
-        dist.stop();
-
-        // logging runtime defaults should not be used
-        cliResult = dist.run("start-dev");
-        cliResult.assertNoMessage("DEBUG [org.hibernate.SQL]");
-        cliResult.assertStartedDevMode();
-    }
-
-    @Test
-    @Order(11)
     void testLogLevelNotPeristed(KeycloakDistribution dist) {
         CLIResult cliResult = dist.run("start", "--log-level=WARN,org.hibernate.SQL:debug", "--http-enabled=true", "--hostname-strict=false");
         cliResult.assertMessage("DEBUG [org.hibernate.SQL]");


### PR DESCRIPTION
closes: #40977

@mabartos this may address the datasource issue as well.

There are two things happening here:
1. when there's a value to transform we assume that the default won't apply - this is not always true, especially with wildcards.
2. when the transform returns null, do we mean "unset", or use default? The http reload issue fixed the meaning as "unset", but that's also not generally true.

EDIT: none of the above is correct. The change here is to just prevent quarkus from persisting our runtime values.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
