### PR TITLE
Adding a config to the UPDATE_EMAIL action to force users to verify email

### DIFF
--- a/docs/documentation/server_admin/topics/login-settings/update-email-workflow.adoc
+++ b/docs/documentation/server_admin/topics/login-settings/update-email-workflow.adoc
@@ -2,11 +2,39 @@
 
 == Update Email Workflow (UpdateEmail)
 
-With this workflow, users will have to use an UPDATE_EMAIL action to change their own email address.
+With this workflow, users will have to use an `UPDATE_EMAIL` action to change their own email address.
 
-The action is associated with a single email input form. If the realm has email verification disabled, this action will allow to update the email without verification. If the realm has email verification enabled, the action will send an email update action token to the new email address without changing the account email. Only the action token triggering will complete the email update.
+This action provides a more secure and consistent flow to update user emails because they will be forced to re-authenticate
+as well as verify their emails before any update to their account.
 
 Applications are able to send their users to the email update form by leveraging UPDATE_EMAIL as an <<con-aia_{context},AIA (Application Initiated Action)>>.
+
+=== Verifying Emails
+
+If the realm has email verification disabled, this action will allow to update the email without verification.
+
+If the realm has email verification enabled, the action will send an email with a link to the new email address without changing the account email.
+Only after following the link and confirming the email, the email will be updated.
+
+Under certain circumstances, you do not want to enable email verification at the realm level but only when users are updating their emails.
+For that, you can set the `Force Email Verification` setting on the `Update Email` required action to force users to verify their emails
+even though email verification is eventually disabled at the realm level. By default, email verification is not enabled.
+
+In case the user is updating the email during the authentication flow (e.g.: when running the `UPDATE_PROFILE` required action),
+the user will be forced to verify the email if any of the `Verify Email` or the `Force Email Verification` settings are enabled.
+In case the `Verify Email` is enabled at the realm level, the `VERIFY_EMAIL` required action will be automatically added to the user account.
+Otherwise, if only the `Force Email Verification` is enabled the `UPDATE_EMAIL` required
+action will be added instead.
+
+=== Updating the user email
+
+When the `Update Email` required action is enabled, the user can update their emails by:
+
+* Self-registering to a realm if this capability is enabled to realm
+* Accessing the account console and clicking the `Update email` link when at the `Personal info` section
+* Updating the profile during the authentication flow (e.g.: when running the `UPDATE_PROFILE` required action) if the email is not yet set.
+If an existing user does have an email set when updating the profile during the authentication flow, the email attribute will not be available.
+* Administrators when updating the user account through the administration console
 
 :tech_feature_name: UpdateEmail
 :tech_feature_id: update-email

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
@@ -40,6 +40,8 @@ import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.auth.page.login.UpdateEmailPage;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.pages.LoginUpdateProfilePage;
+import org.keycloak.testsuite.pages.VerifyEmailPage;
 import org.keycloak.testsuite.util.SecondBrowser;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.openqa.selenium.WebDriver;
@@ -56,7 +58,10 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 	@Page
 	protected UpdateEmailPage updateEmailPage;
 
-	@Page
+    @Page
+    protected LoginUpdateProfilePage updateProfilePage;
+
+    @Page
 	protected AppPage appPage;
 
         @Drone

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTestWithVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateEmailTestWithVerificationTest.java
@@ -18,6 +18,7 @@ package org.keycloak.testsuite.actions;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
@@ -30,16 +31,21 @@ import java.util.List;
 import java.util.UUID;
 
 import org.jboss.arquillian.graphene.page.Page;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.actiontoken.updateemail.UpdateEmailActionToken;
+import org.keycloak.authentication.requiredactions.UpdateEmail;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testsuite.pages.ErrorPage;
@@ -136,15 +142,15 @@ public class RequiredActionUpdateEmailTestWithVerificationTest extends AbstractR
 		assertFalse(user.getRequiredActions().contains(UserModel.RequiredAction.UPDATE_EMAIL.name()));
 	}
 
-        @Test
-        public void updateEmailLogoutSessionsChecked() throws Exception {
-                updateEmail(true);
-        }
+    @Test
+    public void updateEmailLogoutSessionsChecked() throws Exception {
+            updateEmail(true);
+    }
 
-        @Test
-        public void updateEmailLogoutSessionsNotChecked() throws Exception {
-                updateEmail(false);
-        }
+    @Test
+    public void updateEmailLogoutSessionsNotChecked() throws Exception {
+            updateEmail(false);
+    }
 
 	@Test
 	public void confirmEmailUpdateAfterThirdPartyEmailUpdate() throws MessagingException, IOException {
@@ -167,6 +173,154 @@ public class RequiredActionUpdateEmailTestWithVerificationTest extends AbstractR
 		assertEquals("The link you clicked is an old stale link and is no longer valid. Maybe you have already verified your email.", errorPage.getError());
 		assertTrue(ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost").getRequiredActions().contains(UserModel.RequiredAction.UPDATE_EMAIL.name()));
 	}
+
+    @Test
+    public void testForceEmailVerification() throws MessagingException, IOException {
+        // disables verify email at the realm level
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setVerifyEmail(false);
+        testRealm().update(realm);
+
+        // force email verification when updating the email
+        AuthenticationManagementResource authMgt = testRealm().flows();
+        RequiredActionProviderRepresentation requiredAction = authMgt.getRequiredActions().stream()
+                .filter(action -> RequiredAction.UPDATE_EMAIL.name().equals(action.getAlias()))
+                .findAny().get();
+        requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.TRUE.toString());
+        authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+
+        try {
+            loginPage.open();
+            loginPage.login("test-user@localhost", "password");
+            updateEmailPage.assertCurrent();
+            updateEmailPage.changeEmail("new@localhost");
+            String confirmationLink = fetchEmailConfirmationLink("new@localhost");
+            driver.navigate().to(confirmationLink);
+            infoPage.assertCurrent();
+        } finally {
+            realm.setVerifyEmail(true);
+            testRealm().update(realm);
+            requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.FALSE.toString());
+            authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+        }
+    }
+
+    @Test
+    public void testForceEmailVerificationWhenUpdatingEmailInUpdateProfileContext() throws MessagingException, IOException {
+        // disables verify email at the realm level
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setVerifyEmail(false);
+        testRealm().update(realm);
+
+        // force email verification when updating the email
+        AuthenticationManagementResource authMgt = testRealm().flows();
+        RequiredActionProviderRepresentation requiredAction = authMgt.getRequiredActions().stream()
+                .filter(action -> RequiredAction.UPDATE_EMAIL.name().equals(action.getAlias()))
+                .findAny().get();
+        requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.TRUE.toString());
+        authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+
+        try {
+            UserRepresentation user = testRealm().users().search("test-user@localhost").get(0);
+            user.setEmail("");
+            user.setRequiredActions(List.of(RequiredAction.UPDATE_PROFILE.name()));
+            testRealm().users().get(user.getId()).update(user);
+
+            loginPage.open();
+            loginPage.login("test-user@localhost", "password");
+            updateProfilePage.assertCurrent();
+            updateProfilePage.update("f", "l", "new-email@localhost");
+            String confirmationLink = fetchEmailConfirmationLink("new-email@localhost");
+            driver.navigate().to(confirmationLink);
+            infoPage.assertCurrent();
+
+            user = testRealm().users().search("test-user@localhost").get(0);
+            assertEquals("new-email@localhost", user.getEmail());
+        } finally {
+            realm.setVerifyEmail(true);
+            testRealm().update(realm);
+            requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.FALSE.toString());
+            authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+        }
+    }
+
+    @Test
+    public void testForceEmailVerificationWhenUpdatingEmailInUpdateProfileContextIfEmailNotConfirmed() throws MessagingException, IOException {
+        // disables verify email at the realm level
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setVerifyEmail(false);
+        testRealm().update(realm);
+
+        // force email verification when updating the email
+        AuthenticationManagementResource authMgt = testRealm().flows();
+        RequiredActionProviderRepresentation requiredAction = authMgt.getRequiredActions().stream()
+                .filter(action -> RequiredAction.UPDATE_EMAIL.name().equals(action.getAlias()))
+                .findAny().get();
+        requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.TRUE.toString());
+        authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+
+        try {
+            UserRepresentation user = testRealm().users().search("test-user@localhost").get(0);
+            user.setEmail("");
+            user.setRequiredActions(List.of(RequiredAction.UPDATE_PROFILE.name()));
+            testRealm().users().get(user.getId()).update(user);
+
+            loginPage.open();
+            loginPage.login("test-user@localhost", "password");
+            updateProfilePage.assertCurrent();
+            updateProfilePage.update("f", "l", "new-email@localhost");
+            String confirmationLink = fetchEmailConfirmationLink("new-email@localhost");
+            assertNotNull(confirmationLink);
+            // logout to check if update email required action will be executed
+            testRealm().users().get(user.getId()).logout();
+            loginPage.open();
+            loginPage.login("test-user@localhost", "password");
+            // user is forced to update the email because it was not yet confirmed
+            assertTrue(driver.getPageSource().contains("You need to update your email address to activate your account."));
+            updateEmailPage.clickSubmitAction();
+            confirmationLink = fetchEmailConfirmationLink("new-email@localhost", greenMail.getLastReceivedMessage());
+            driver.navigate().to(confirmationLink);
+            infoPage.assertCurrent();
+
+            user = testRealm().users().search("test-user@localhost").get(0);
+            assertEquals("new-email@localhost", user.getEmail());
+        } finally {
+            realm.setVerifyEmail(true);
+            testRealm().update(realm);
+            requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.FALSE.toString());
+            authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+        }
+    }
+
+    @Test
+    public void testForceEmailVerificationWhenUpdatingEmailInUpdateProfileContextWhenVerifyEmailEnabled() {
+        // force email verification when updating the email
+        AuthenticationManagementResource authMgt = testRealm().flows();
+        RequiredActionProviderRepresentation requiredAction = authMgt.getRequiredActions().stream()
+                .filter(action -> RequiredAction.UPDATE_EMAIL.name().equals(action.getAlias()))
+                .findAny().get();
+        requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.TRUE.toString());
+        authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+
+        try {
+            UserRepresentation user = testRealm().users().search("test-user@localhost").get(0);
+            user.setEmail("");
+            user.setRequiredActions(List.of(RequiredAction.UPDATE_PROFILE.name()));
+            testRealm().users().get(user.getId()).update(user);
+
+            loginPage.open();
+            loginPage.login("test-user@localhost", "password");
+            updateProfilePage.assertCurrent();
+            updateProfilePage.update("f", "l", "new-email@localhost");
+
+            user = testRealm().users().search("test-user@localhost").get(0);
+            assertEquals(1, user.getRequiredActions().size());
+            assertEquals(RequiredAction.VERIFY_EMAIL.name(), user.getRequiredActions().get(0));
+        } finally {
+            requiredAction.getConfig().put(UpdateEmail.CONFIG_VERIFY_EMAIL, Boolean.FALSE.toString());
+            authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+        }
+    }
 
 	@Test
 	public void confirmEmailAfterDuplicateEmailSetForThirdPartyAccount() throws MessagingException, IOException {
@@ -194,10 +348,14 @@ public class RequiredActionUpdateEmailTestWithVerificationTest extends AbstractR
 		MimeMessage[] receivedMessages = greenMail.getReceivedMessages();
 		assertEquals(1, receivedMessages.length);
 		MimeMessage message = receivedMessages[0];
-		Address[] recipients = message.getRecipients(Message.RecipientType.TO);
-		assertTrue(recipients.length >= 1);
-		assertEquals(emailRecipient, recipients[0].toString());
+        return fetchEmailConfirmationLink(emailRecipient, message);
+    }
 
-		return MailUtils.getPasswordResetEmailLink(message).trim();
-	}
+    private String fetchEmailConfirmationLink(String emailRecipient, MimeMessage message) throws MessagingException, IOException {
+        Address[] recipients = message.getRecipients(Message.RecipientType.TO);
+        assertTrue(recipients.length >= 1);
+        assertEquals(emailRecipient, recipients[0].toString());
+
+        return MailUtils.getPasswordResetEmailLink(message).trim();
+    }
 }


### PR DESCRIPTION
Closes #32569 

* Adds a `Force email verification` setting to the `UPDATE_EMAIL` required action to decide whether or not users should be asked to confirm their emails despite of the value set to the `Verify email` setting at the realm level.
* Make sure email verification is enforced through the `UPDATE_EMAIL` required action when updating the email during   `UPDATE_PROFILE` in case the `Force email verification` setting is enabled in the `UPDATE_EMAIL` required action. This only happens if `Verify email` is not set at the realm level.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
