### PR TITLE
Expose tokens expiresIn in KeycloakAdminClient

### DIFF
--- a/js/libs/keycloak-admin-client/README.md
+++ b/js/libs/keycloak-admin-client/README.md
@@ -101,6 +101,14 @@ await kcAdminClient.auth(credentials);
 
 setInterval(() => kcAdminClient.auth(credentials), 58 * 1000); // 58 seconds
 ```
+Alternatively, if you don’t know the access token lifespan, you can read the access token `expiresIn` value (in seconds), for example :
+
+```js
+// Say the access token lifespan is set to 1 minute in the realm admin,
+// this will renew the token every 58 seconds:
+const timeout = (kcAdminClient.expiresIn - 2) * 1000;
+setInterval(() => kcAdminClient.auth(credentials), timeout);
+```
 
 ## Building and running the tests
 

--- a/js/libs/keycloak-admin-client/src/client.ts
+++ b/js/libs/keycloak-admin-client/src/client.ts
@@ -53,7 +53,9 @@ export class KeycloakAdminClient {
   public realmName: string;
   public scope?: string;
   public accessToken?: string;
+  public expiresIn?: number;
   public refreshToken?: string;
+  public refreshExpiresIn?: number;
 
   #requestOptions?: RequestInit;
   #globalRequestArgOptions?: Pick<RequestArgs, "catchNotFound">;
@@ -85,15 +87,18 @@ export class KeycloakAdminClient {
   }
 
   public async auth(credentials: Credentials) {
-    const { accessToken, refreshToken } = await getToken({
-      baseUrl: this.baseUrl,
-      realmName: this.realmName,
-      scope: this.scope,
-      credentials,
-      requestOptions: this.#requestOptions,
-    });
+    const { accessToken, expiresIn, refreshToken, refreshExpiresIn } =
+      await getToken({
+        baseUrl: this.baseUrl,
+        realmName: this.realmName,
+        scope: this.scope,
+        credentials,
+        requestOptions: this.#requestOptions,
+      });
     this.accessToken = accessToken;
+    this.expiresIn = expiresIn;
     this.refreshToken = refreshToken;
+    this.refreshExpiresIn = refreshExpiresIn;
   }
 
   public registerTokenProvider(provider: TokenProvider) {

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -27,7 +27,7 @@ export interface Settings {
 
 export interface TokenResponseRaw {
   access_token: string;
-  expires_in: string;
+  expires_in: number;
   refresh_expires_in: number;
   refresh_token: string;
   token_type: string;
@@ -39,7 +39,7 @@ export interface TokenResponseRaw {
 
 export interface TokenResponse {
   accessToken: string;
-  expiresIn: string;
+  expiresIn: number;
   refreshExpiresIn: number;
   refreshToken: string;
   tokenType: string;

--- a/js/libs/keycloak-admin-client/test/clients.spec.ts
+++ b/js/libs/keycloak-admin-client/test/clients.spec.ts
@@ -24,6 +24,9 @@ describe("Clients", () => {
     kcAdminClient = new KeycloakAdminClient();
     await kcAdminClient.auth(credentials);
 
+    expect(kcAdminClient.accessToken).to.be.a("string");
+    expect(kcAdminClient.expiresIn).to.be.a("number");
+
     // create client and also test it
     // NOTICE: to be clear, clientId stands for the property `clientId` of client
     // clientUniqueId stands for property `id` of client


### PR DESCRIPTION
- Add access token `expiresIn` and refresh token `refreshExpiresIn` properties in KeycloakAdminClient of @keycloak/keycloak-admin-client. 
- Fix internal `TokenResponser.expiresIn` type to `number` (seconds) instead of `string`.

Relates to #36825 #37084

