### PR TITLE
Wildcard mappers should be implicitly handled and value propagated

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -112,99 +112,104 @@ public class DatabaseOptions {
             .hidden()
             .build();
 
-    /**
-     * Options that have their sibling for a named datasource
-     * Example: for `db-dialect`, `db-dialect-<datasource>` is created
-     */
-    public static final List<Option<?>> OPTIONS_DATASOURCES = List.of(
-            DB_DIALECT,
-            DB_DRIVER,
-            DB,
-            DB_URL,
-            DB_URL_HOST,
-            DB_URL_DATABASE,
-            DB_URL_PORT,
-            DB_URL_PROPERTIES,
-            DB_USERNAME,
-            DB_PASSWORD,
-            DB_SCHEMA,
-            DB_POOL_INITIAL_SIZE,
-            DB_POOL_MIN_SIZE,
-            DB_POOL_MAX_SIZE,
-            DB_SQL_JPA_DEBUG,
-            DB_SQL_LOG_SLOW_QUERIES
-            );
+    public static final class Datasources {
+        /**
+         * Options that have their sibling for a named datasource
+         * Example: for `db-dialect`, `db-dialect-<datasource>` is created
+         */
+        public static final List<Option<?>> OPTIONS_DATASOURCES = List.of(
+                DB_DIALECT,
+                DB_DRIVER,
+                DB,
+                DB_URL,
+                DB_URL_HOST,
+                DB_URL_DATABASE,
+                DB_URL_PORT,
+                DB_URL_PROPERTIES,
+                DB_USERNAME,
+                DB_PASSWORD,
+                DB_SCHEMA,
+                DB_POOL_INITIAL_SIZE,
+                DB_POOL_MIN_SIZE,
+                DB_POOL_MAX_SIZE,
+                DB_SQL_JPA_DEBUG,
+                DB_SQL_LOG_SLOW_QUERIES
+        );
 
-    /**
-     * In order to avoid ambiguity, we need to have unique option names for wildcard options.
-     * This map controls overriding option name to be unique for wildcard option.
-     */
-    private static final Map<String, String> DATASOURCES_OVERRIDES_SUFFIX = Map.of(
-            DatabaseOptions.DB.getKey(), "-kind", // db-kind
-            DatabaseOptions.DB_URL.getKey(), "-full"  // db-url-full
-    );
+        /**
+         * In order to avoid ambiguity, we need to have unique option names for wildcard options.
+         * This map controls overriding option name to be unique for wildcard option.
+         */
+        private static final Map<String, String> DATASOURCES_OVERRIDES_SUFFIX = Map.of(
+                DatabaseOptions.DB.getKey(), "-kind", // db-kind
+                DatabaseOptions.DB_URL.getKey(), "-full"  // db-url-full
+        );
 
-    /**
-     * You can override some {@link OptionBuilder} methods for additional datasources in this map
-     */
-    private static final Map<Option<?>, Consumer<OptionBuilder<?>>> DATASOURCES_OVERRIDES_OPTIONS = Map.of(
-            DatabaseOptions.DB, builder -> builder.defaultValue(Optional.empty()) // no default value for DB kind for datasources
-    );
+        /**
+         * You can override some {@link OptionBuilder} methods for additional datasources in this map
+         */
+        private static final Map<Option<?>, Consumer<OptionBuilder<?>>> DATASOURCES_OVERRIDES_OPTIONS = Map.of(
+                DatabaseOptions.DB, builder -> builder
+                        .defaultValue(Optional.empty()) // no default value for DB kind for datasources
+                        .connectedOptions(
+                                getDatasourceOption(DatabaseOptions.DB_URL).orElseThrow(),
+                                TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE
+                        )
+        );
 
-    private static final Map<String, Option<?>> cachedDatasourceOptions = new HashMap<>();
+        private static final Map<String, Option<?>> cachedDatasourceOptions = new HashMap<>();
 
-
-    /**
-     * Get datasource option containing named datasource mapped to parent DB options.
-     * <p>
-     * We map DB options to named datasource options like:
-     * <ul>
-     *     <li>{@code db-url-host --> db-url-host-<datasource>}</li>
-     *     <li>{@code db-username --> db-username-<datasource>}</li>
-     *     <li>{@code db --> db-kind-<datasource>}</li>
-     * </ul>
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> Optional<Option<T>> getDatasourceOption(Option<T> parentOption) {
-        if (!OPTIONS_DATASOURCES.contains(parentOption)) {
-            return Optional.empty();
-        }
-
-        var key = getKeyForDatasource(parentOption);
-        if (key.isEmpty()) {
-            return Optional.empty();
-        }
-
-        // check if we already created the same option and return it from the cache
-        Option<?> option = cachedDatasourceOptions.get(key.get());
-
-        if (option == null) {
-            var builder = parentOption.toBuilder()
-                    .key(key.get())
-                    .category(OptionCategory.DATABASE_DATASOURCES);
-
-            if (!parentOption.isHidden()) {
-                builder.description("Used for named <datasource>. " + parentOption.getDescription());
+        /**
+         * Get datasource option containing named datasource mapped to parent DB options.
+         * <p>
+         * We map DB options to named datasource options like:
+         * <ul>
+         *     <li>{@code db-url-host --> db-url-host-<datasource>}</li>
+         *     <li>{@code db-username --> db-username-<datasource>}</li>
+         *     <li>{@code db --> db-kind-<datasource>}</li>
+         * </ul>
+         */
+        @SuppressWarnings("unchecked")
+        public static <T> Optional<Option<T>> getDatasourceOption(Option<T> parentOption) {
+            if (!OPTIONS_DATASOURCES.contains(parentOption)) {
+                return Optional.empty();
             }
 
-            // override some settings for options
-            var override = DATASOURCES_OVERRIDES_OPTIONS.get(parentOption);
-            if (override != null) {
-                override.accept(builder);
+            var key = getKeyForDatasource(parentOption);
+            if (key.isEmpty()) {
+                return Optional.empty();
             }
 
-            option = builder.build();
-            cachedDatasourceOptions.put(key.get(), option);
-        }
-        return Optional.of((Option<T>) option);
-    }
+            // check if we already created the same option and return it from the cache
+            Option<?> option = cachedDatasourceOptions.get(key.get());
 
-    /**
-     * Get mapped datasource key based on DB option {@param option}
-     */
-    public static Optional<String> getKeyForDatasource(Option<?> option) {
-        return getKeyForDatasource(option.getKey());
-    }
+            if (option == null) {
+                var builder = parentOption.toBuilder()
+                        .key(key.get())
+                        .category(OptionCategory.DATABASE_DATASOURCES);
+
+                if (!parentOption.isHidden()) {
+                    builder.description("Used for named <datasource>. " + parentOption.getDescription());
+                }
+
+                // override some settings for options
+                var override = DATASOURCES_OVERRIDES_OPTIONS.get(parentOption);
+                if (override != null) {
+                    override.accept(builder);
+                }
+
+                option = builder.build();
+                cachedDatasourceOptions.put(key.get(), option);
+            }
+            return Optional.of((Option<T>) option);
+        }
+
+        /**
+         * Get mapped datasource key based on DB option {@param option}
+         */
+        public static Optional<String> getKeyForDatasource(Option<?> option) {
+            return getKeyForDatasource(option.getKey());
+        }
 
     /**
      * Get mapped datasource key based on DB option {@param option}
@@ -216,17 +221,18 @@ public class DatabaseOptions {
                 .map(key -> key.concat("-<datasource>"));
     }
 
-    /**
-     * Returns datasource option based on DB option {@code option} with actual wildcard value.
-     * It replaces the {@code <datasource>} with actual value in {@code namedProperty}.
-     * <p>
-     * f.e. Consider {@code option}={@link DatabaseOptions#DB_DRIVER}, and {@code namedProperty}=my-store.
-     * <p>
-     * Result: {@code db-driver-my-store}
-     */
-    public static Optional<String> getNamedKey(Option<?> option, String namedProperty) {
-        return getKeyForDatasource(option)
-                .map(key -> key.substring(0, key.indexOf("<")))
-                .map(key -> key.concat(namedProperty));
+        /**
+         * Returns datasource option based on DB option {@code option} with actual wildcard value.
+         * It replaces the {@code <datasource>} with actual value in {@code namedProperty}.
+         * <p>
+         * f.e. Consider {@code option}={@link DatabaseOptions#DB_DRIVER}, and {@code namedProperty}=my-store.
+         * <p>
+         * Result: {@code db-driver-my-store}
+         */
+        public static Optional<String> getNamedKey(Option<?> option, String namedProperty) {
+            return getKeyForDatasource(option)
+                    .map(key -> key.substring(0, key.indexOf("<")))
+                    .map(key -> key.concat(namedProperty));
+        }
     }
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
@@ -4,6 +4,7 @@ import com.google.common.base.CaseFormat;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class Option<T> {
@@ -18,8 +19,11 @@ public class Option<T> {
     private final boolean strictExpectedValues;
     private final boolean caseInsensitiveExpectedValues;
     private final DeprecatedMetadata deprecatedMetadata;
+    private final Set<String> connectedOptions;
 
-    public Option(Class<T> type, String key, OptionCategory category, boolean hidden, boolean buildTime, String description, Optional<T> defaultValue, List<String> expectedValues, boolean strictExpectedValues, boolean caseInsensitiveExpectedValues, DeprecatedMetadata deprecatedMetadata) {
+    public Option(Class<T> type, String key, OptionCategory category, boolean hidden, boolean buildTime, String description,
+                  Optional<T> defaultValue, List<String> expectedValues, boolean strictExpectedValues, boolean caseInsensitiveExpectedValues,
+                  DeprecatedMetadata deprecatedMetadata, Set<String> connectedOptions) {
         this.type = type;
         this.key = key;
         this.category = category;
@@ -31,6 +35,7 @@ public class Option<T> {
         this.strictExpectedValues = strictExpectedValues;
         this.caseInsensitiveExpectedValues = caseInsensitiveExpectedValues;
         this.deprecatedMetadata = deprecatedMetadata;
+        this.connectedOptions = connectedOptions;
     }
 
     public Class<T> getType() {
@@ -85,6 +90,14 @@ public class Option<T> {
 
     public Option<T> withRuntimeSpecificDefault(T defaultValue) {
         return toBuilder().defaultValue(defaultValue).build();
+    }
+
+    /**
+     * Get connected options that have a certain relationship with the current option.
+     * Usually when the current option is set, the connected options should be set as well.
+     */
+    public Set<String> getConnectedOptions() {
+        return connectedOptions;
     }
 
     public OptionBuilder<T> toBuilder() {

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
@@ -2,10 +2,13 @@ package org.keycloak.config;
 
 import io.smallrye.common.constraint.Assert;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -16,6 +19,8 @@ public class OptionBuilder<T> {
 
     private final Class<T> type;
     private final Class<?> auxiliaryType;
+    private final Set<String> connectedOptions = new HashSet<>();
+
     private String key;
     private OptionCategory category;
     private boolean hidden;
@@ -134,6 +139,14 @@ public class OptionBuilder<T> {
         return this;
     }
 
+    /**
+     * For more details, see the {@link Option#getConnectedOptions()}
+     */
+    public OptionBuilder<T> connectedOptions(Option<?>... connectedOptions) {
+        this.connectedOptions.addAll(Arrays.stream(connectedOptions).map(Option::getKey).collect(Collectors.toSet()));
+        return this;
+    }
+
     public Option<T> build() {
         if (deprecatedMetadata == null && category.getSupportLevel() == ConfigSupportLevel.DEPRECATED) {
             deprecated();
@@ -169,7 +182,7 @@ public class OptionBuilder<T> {
             }
         }
 
-        return new Option<T>(type, key, category, hidden, build, description, defaultValue, expectedValues, strictExpectedValues, caseInsensitiveExpectedValues, deprecatedMetadata);
+        return new Option<T>(type, key, category, hidden, build, description, defaultValue, expectedValues, strictExpectedValues, caseInsensitiveExpectedValues, deprecatedMetadata, connectedOptions);
     }
 
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -282,7 +282,7 @@ public final class Database {
 
         private static String getProperty(Option<?> option, String namedProperty, String defaultValue) {
             return "${kc.%s:%s}".formatted(StringUtil.isNullOrEmpty(namedProperty) ? option.getKey() :
-                            DatabaseOptions.getNamedKey(option, namedProperty).orElseThrow(() -> new IllegalArgumentException("Cannot find the named property")),
+                            DatabaseOptions.Datasources.getNamedKey(option, namedProperty).orElseThrow(() -> new IllegalArgumentException("Cannot find the named property")),
                     defaultValue);
         }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -17,9 +17,11 @@
 package org.keycloak.quarkus.runtime.configuration;
 
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
 
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -35,6 +37,7 @@ import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Priorities;
 import jakarta.annotation.Priority;
+import org.keycloak.quarkus.runtime.configuration.mappers.WildcardPropertyMapper;
 
 /**
  * <p>This interceptor is responsible for mapping Keycloak properties to their corresponding properties in Quarkus.
@@ -84,7 +87,7 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
      */
     @Override
     public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {
-        Iterable<String> iterable = () -> context.iterateNames();
+        Iterable<String> iterable = context::iterateNames;
 
         final Set<PropertyMapper<?>> allMappers = PropertyMappers.getMappers();
 
@@ -105,10 +108,20 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
             }
             allMappers.remove(mapper);
 
-            // include additional mappings if we're on the from side of the mapping
-            // as the mapping may not be bi-directional
+            if (mapper.hasWildcard()) {
+                // non-wildcard connected options should be already advertised by the logic in iterateNames()
+                if (mapper.hasConnectedOptions()) {
+                    var wildcardMapper = (WildcardPropertyMapper<?>) mapper;
+                    var wildcardValue = wildcardMapper.extractWildcardValue(name).orElseThrow();
+                    var connectedTo = wildcardMapper.getConnectedOptions(wildcardValue).stream()
+                            .map(option -> Optional.ofNullable(PropertyMappers.getMapper(NS_KEYCLOAK_PREFIX + option)).orElseThrow(() -> new IllegalArgumentException("Cannot find connected options")))
+                            .map(m -> m.hasWildcard() ? ((WildcardPropertyMapper<?>) m).getTo(wildcardValue) : m.getTo());
 
-            if (!mapper.hasWildcard() && name.equals(mapper.getFrom())) {
+                    return Stream.concat(toDistinctStream(name, wildcardMapper.getTo(wildcardValue)), connectedTo);
+                }
+            } else if (name.equals(mapper.getFrom())) {
+                // include additional mappings if we're on the from side of the mapping as the mapping may not be bi-directional
+                // -----------------------------------------
                 // this is not a wildcard value, but may map to wildcards
                 // the current example is something like log-level=wildcardCat1:level,wildcardCat2:level
                 var wildCard = PropertyMappers.getWildcardMappedFrom(mapper.getOption());
@@ -132,7 +145,7 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
         // include anything remaining that has a default value
         var defaultStream = allMappers.stream()
-                .filter(m -> !m.getDefaultValue().isEmpty() && !m.hasWildcard()
+                .filter(m -> m.getDefaultValue().isPresent() && !m.hasWildcard()
                         && m.getCategory() != OptionCategory.CONFIG) // advertising the keystore type causes the keystore to be used early
                 .flatMap(m -> toDistinctStream(m.getTo()));
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -21,10 +21,11 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.keycloak.config.DatabaseOptions.DB;
-import static org.keycloak.config.DatabaseOptions.OPTIONS_DATASOURCES;
-import static org.keycloak.config.DatabaseOptions.getDatasourceOption;
-import static org.keycloak.config.DatabaseOptions.getKeyForDatasource;
+import static org.keycloak.config.DatabaseOptions.Datasources.OPTIONS_DATASOURCES;
+import static org.keycloak.config.DatabaseOptions.Datasources.getDatasourceOption;
+import static org.keycloak.config.DatabaseOptions.Datasources.getKeyForDatasource;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+import static org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers.Datasources.appendDatasourceMappers;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 final class DatabasePropertyMappers {
@@ -180,67 +181,68 @@ final class DatabasePropertyMappers {
         return isDevModeDatabase(database) ? "1" : getParentPoolMinSize.get();
     }
 
-    // Datasources
+    public static final class Datasources {
 
-    /**
-     * Automatically create mappers for datasource options
-     */
-    private static PropertyMapper<?>[] appendDatasourceMappers(PropertyMapper<?>[] mappers, Map<Option<?>, Consumer<PropertyMapper.Builder<?>>> transformDatasourceMappers) {
-        List<PropertyMapper<?>> datasourceMappers = new ArrayList<>(OPTIONS_DATASOURCES.size() + mappers.length);
+        /**
+         * Automatically create mappers for datasource options
+         */
+        static PropertyMapper<?>[] appendDatasourceMappers(PropertyMapper<?>[] mappers, Map<Option<?>, Consumer<PropertyMapper.Builder<?>>> transformDatasourceMappers) {
+            List<PropertyMapper<?>> datasourceMappers = new ArrayList<>(OPTIONS_DATASOURCES.size() + mappers.length);
 
-        for (var parent : mappers) {
-            var parentOption = parent.getOption();
+            for (var parent : mappers) {
+                var parentOption = parent.getOption();
 
-            var datasourceOption = getDatasourceOption(parentOption);
-            if (datasourceOption.isEmpty()) {
-                log.debugf("No datasource option found for '%s'", parentOption.getKey());
-                continue;
+                var datasourceOption = getDatasourceOption(parentOption);
+                if (datasourceOption.isEmpty()) {
+                    log.debugf("No datasource option found for '%s'", parentOption.getKey());
+                    continue;
+                }
+
+                var created = fromOption(datasourceOption.get())
+                        .isMasked(parent.isMask())
+                        .transformer(parent.getMapper());
+
+                if (parent.getMapFrom() != null) {
+                    var wildcardMapFromOption = getKeyForDatasource(parent.getMapFrom())
+                            .orElseThrow(() -> new IllegalArgumentException("Option '%s' in mapFrom() method for mapper '%s' does not have any associated wildcard option".formatted(parent.getMapFrom(), datasourceOption.get().getKey())));
+                    created.wildcardMapFrom(wildcardMapFromOption, parent.getParentMapper() != null ? (name, value, context) -> parent.getParentMapper().map(name, value, context) : null);
+                }
+
+                if (parent.getParamLabel() != null) {
+                    created.paramLabel(parent.getParamLabel());
+                }
+
+                var transformedTo = transformDatasourceTo(parent.getTo());
+                if (transformedTo != null) {
+                    created.to(transformedTo);
+                }
+
+                var customTransformer = transformDatasourceMappers.get(parent.getOption());
+                if (customTransformer != null) {
+                    customTransformer.accept(created);
+                }
+
+                datasourceMappers.add(created.build());
             }
 
-            var created = fromOption(datasourceOption.get())
-                    .isMasked(parent.isMask())
-                    .transformer(parent.getMapper());
+            datasourceMappers.addAll(List.of(mappers));
 
-            if (parent.getMapFrom() != null) {
-                var wildcardMapFromOption = getKeyForDatasource(parent.getMapFrom())
-                        .orElseThrow(() -> new IllegalArgumentException("Option '%s' in mapFrom() method for mapper '%s' does not have any associated wildcard option".formatted(parent.getMapFrom(), datasourceOption.get().getKey())));
-                created.wildcardMapFrom(wildcardMapFromOption, parent.getParentMapper() != null ? (name, value, context) -> parent.getParentMapper().map(name, value, context) : null);
-            }
-
-            if (parent.getParamLabel() != null) {
-                created.paramLabel(parent.getParamLabel());
-            }
-
-            var transformedTo = transformDatasourceTo(parent.getTo());
-            if (transformedTo != null) {
-                created.to(transformedTo);
-            }
-
-            var customTransformer = transformDatasourceMappers.get(parent.getOption());
-            if (customTransformer != null) {
-                customTransformer.accept(created);
-            }
-
-            datasourceMappers.add(created.build());
+            return datasourceMappers.toArray(new PropertyMapper[0]);
         }
 
-        datasourceMappers.addAll(List.of(mappers));
+        private static String transformDatasourceTo(String to) {
+            if (StringUtil.isBlank(to)) {
+                return null;
+            }
 
-        return datasourceMappers.toArray(new PropertyMapper[0]);
-    }
-
-    private static String transformDatasourceTo(String to) {
-        if (StringUtil.isBlank(to)) {
-            return null;
+            if (to.startsWith("quarkus.datasource.")) {
+                return to.replaceFirst("quarkus\\.datasource\\.", "quarkus.datasource.\"<datasource>\".");
+            } else if (to.startsWith("kc.db-")) {
+                return to.concat("-<datasource>");
+            } else {
+                log.warnf("Cannot determine how to map datasource option to '%s'", to);
+            }
+            return to;
         }
-
-        if (to.startsWith("quarkus.datasource.")) {
-            return to.replaceFirst("quarkus\\.datasource\\.", "quarkus.datasource.\"<datasource>\".");
-        } else if (to.startsWith("kc.db-")) {
-            return to.concat("-<datasource>");
-        } else {
-            log.warnf("Cannot determine how to map datasource option to '%s'", to);
-        }
-        return to;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -628,6 +628,10 @@ public class PropertyMapper<T> {
         return this;
     }
 
+    public boolean hasConnectedOptions() {
+        return !option.getConnectedOptions().isEmpty();
+    }
+
     String getMapFrom() {
         return mapFrom;
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -201,7 +201,7 @@ public final class PropertyMappers {
     }
 
     public static WildcardPropertyMapper<?> getWildcardMappedFrom(Option<?> from) {
-        return MAPPERS.wildcardMapFrom.get(from.getKey());
+        return MAPPERS.wildcardConfig.wildcardMapFrom.get(from.getKey());
     }
 
     public static boolean isSupported(PropertyMapper<?> mapper) {
@@ -239,8 +239,7 @@ public final class PropertyMappers {
         private final Map<String, PropertyMapper<?>> disabledBuildTimeMappers = new HashMap<>();
         private final Map<String, PropertyMapper<?>> disabledRuntimeMappers = new HashMap<>();
 
-        private final Set<WildcardPropertyMapper<?>> wildcardMappers = new HashSet<>();
-        private final Map<String, WildcardPropertyMapper<?>> wildcardMapFrom = new HashMap<>();
+        private final WildcardMappersConfig wildcardConfig = new WildcardMappersConfig();
 
         public void addAll(PropertyMapper<?>[] mappers) {
             for (PropertyMapper<?> mapper : mappers) {
@@ -260,10 +259,7 @@ public final class PropertyMappers {
 
         public void addMapper(PropertyMapper<?> mapper) {
             if (mapper.hasWildcard()) {
-                if (mapper.getMapFrom() != null) {
-                    wildcardMapFrom.put(mapper.getMapFrom(), (WildcardPropertyMapper<?>) mapper);
-                }
-                wildcardMappers.add((WildcardPropertyMapper<?>)mapper);
+                wildcardConfig.addMapper((WildcardPropertyMapper<?>) mapper);
             } else {
                 handleMapper(mapper, this::add);
             }
@@ -271,10 +267,7 @@ public final class PropertyMappers {
 
         public void removeMapper(PropertyMapper<?> mapper) {
             if (mapper.hasWildcard()) {
-                wildcardMappers.remove(mapper);
-                if (mapper.getFrom() != null) {
-                    wildcardMapFrom.remove(mapper.getMapFrom());
-                }
+                wildcardConfig.removeMapper((WildcardPropertyMapper<?>) mapper);
             } else {
                 handleMapper(mapper, this::remove);
             }
@@ -301,16 +294,8 @@ public final class PropertyMappers {
             // TODO: we may want to introduce a prefix tree here as we add more wildcardMappers
             // for now we'll just limit ourselves to searching wildcards when we see a quarkus or
             // keycloak key
-            if (strKey.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX) || strKey.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX)) {
-                ret = wildcardMappers.stream()
-                        .filter(m -> m.matchesWildcardOptionName(strKey))
-                        .toList();
-                if (!ret.isEmpty()) {
-                    return ret;
-                }
-            }
-
-            return null;
+            ret = wildcardConfig.get(strKey);
+            return !ret.isEmpty() ? ret : null;
         }
 
         @Override
@@ -319,7 +304,7 @@ public final class PropertyMappers {
         }
 
         public Set<WildcardPropertyMapper<?>> getWildcardMappers() {
-            return Collections.unmodifiableSet(wildcardMappers);
+            return Collections.unmodifiableSet(wildcardConfig.wildcardMappers);
         }
 
         public void sanitizeDisabledMappers(AbstractCommand command) {
@@ -410,4 +395,37 @@ public final class PropertyMappers {
         }
     }
 
+    /**
+     * Helper class for handling Mappers config for wildcards
+     */
+    private static class WildcardMappersConfig {
+        private final Set<WildcardPropertyMapper<?>> wildcardMappers = new HashSet<>();
+        private final Map<String, WildcardPropertyMapper<?>> wildcardMapFrom = new HashMap<>();
+
+        public void addMapper(WildcardPropertyMapper<?> mapper) {
+            if (mapper.getMapFrom() != null) {
+                wildcardMapFrom.put(mapper.getMapFrom(), mapper);
+            }
+            wildcardMappers.add(mapper);
+        }
+
+        public void removeMapper(WildcardPropertyMapper<?> mapper) {
+            wildcardMappers.remove(mapper);
+            if (mapper.getFrom() != null) {
+                wildcardMapFrom.remove(mapper.getMapFrom());
+            }
+        }
+
+        public List<WildcardPropertyMapper<?>> get(String key) {
+            // TODO: we may want to introduce a prefix tree here as we add more wildcardMappers
+            // for now we'll just limit ourselves to searching wildcards when we see a quarkus or
+            // keycloak key
+            if (key.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX) || key.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX)) {
+                return wildcardMappers.stream()
+                        .filter(m -> m.matchesWildcardOptionName(key))
+                        .toList();
+            }
+            return Collections.emptyList();
+        }
+    }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -12,8 +12,10 @@ import org.mariadb.jdbc.MariaDbDataSource;
 import org.postgresql.xa.PGXADataSource;
 
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -470,5 +472,33 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
                 "db-debug-jpql-my-store", "true",
                 "db-log-slow-queries-threshold-my-store","5000"
         ));
+    }
+
+    @Test
+    public void propagatedPropertyNames() {
+        ConfigArgsConfigSource.setCliArgs("--db-kind-user-store=mysql");
+
+        var config = createConfig();
+        Iterable<String> propertyNames = config.getPropertyNames();
+
+        assertThat(propertyNames, hasItems(
+                "kc.db-kind-user-store",
+                "quarkus.datasource.\"user-store\".db-kind",
+                "quarkus.datasource.\"user-store\".jdbc.url",
+                "quarkus.datasource.\"user-store\".jdbc.transactions"
+        ));
+
+        // verify the db-kind is there only once
+        long quarkusDbKindCount = StreamSupport.stream(propertyNames.spliterator(), false)
+                .filter("quarkus.datasource.\"user-store\".jdbc.url"::equals)
+                .count();
+        assertThat(quarkusDbKindCount, is(1L));
+
+        assertThat(propertyNames, not(hasItems(
+                "kc.db-dialect-user-store",
+                "quarkus.datasource.\"user-store\".username",
+                "quarkus.datasource.\"user-store\".password",
+                "quarkus.datasource.\"user-store\".jdbc.driver"
+        )));
     }
 }

--- a/quarkus/tests/integration/src/test-providers/resources/com/acme/provider/legacy/jpa/entity/persistence.xml
+++ b/quarkus/tests/integration/src/test-providers/resources/com/acme/provider/legacy/jpa/entity/persistence.xml
@@ -35,4 +35,7 @@
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
         </properties>
     </persistence-unit>
+
+    <persistence-unit name="pu-without-dialect-store" transaction-type="JTA">
+    </persistence-unit>
 </persistence>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
@@ -34,33 +34,38 @@ import org.keycloak.it.utils.KeycloakDistribution;
 @TestProvider(CustomJpaEntityProvider.class)
 public class CustomJpaEntityProviderDistTest {
 
+    private static final String MULTIPLE_DATASOURCES_MSG = "Multiple datasources are specified: <default>, client-store, new-user-store, pu-without-dialect-store";
+
     @Test
     void dbKindSpecifiedInBuildTime(KeycloakDistribution dist) {
-        var result = dist.run("build", "--db=dev-file", "--db-kind-new-user-store=dev-mem");
-        result.assertMessage("Multiple datasources are specified: <default>, client-store, new-user-store");
+        var result = dist.run("build", "--db=dev-file", "--db-kind-new-user-store=dev-mem", "--db-kind-pu-without-dialect-store=dev-mem");
+        result.assertMessage(MULTIPLE_DATASOURCES_MSG);
         result.assertMessage("You have set DB kind for 'client-store' datasource via a Quarkus property. This approach is deprecated and you should use the Keycloak 'db-kind-client-store' property.");
         result.assertBuild();
 
         result = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
         result.assertNoError("Detected additional named datasources. You need to explicitly set the DB kind for the datasource(s) to properly work as: db-kind-user-store");
 
-        // Remove once https://github.com/keycloak/keycloak/pull/41026 is solved
-        result.assertError("Datasource 'new-user-store' was deactivated automatically because its URL is not set");
+        result.assertMessage("Datasource 'client-store' was deactivated automatically because its URL is not set");
+        result.assertNoMessage("Datasource 'new-user-store' was deactivated automatically because its URL is not set");
+        result.assertNoMessage("Datasource 'pu-without-dialect-store' was deactivated automatically because its URL is not set");
+        result.assertStarted();
     }
 
     @Test
     @Launch({"start-dev", "--db=dev-file"})
     void notSpecifiedDbKind(CLIResult cliResult) {
         // it is printed at build time and the check done at runtime
-        cliResult.assertNoMessage("Multiple datasources are specified: <default>, client-store, user-store");
+        cliResult.assertNoMessage(MULTIPLE_DATASOURCES_MSG);
         cliResult.assertError("Detected additional named datasources without a DB kind set, please specify: db-kind-new-user-store");
     }
 
     @Test
-    @Launch({"start-dev", "--db=dev-file", "--log-level=org.hibernate.jpa.internal.util.LogHelper:debug,org.keycloak.quarkus.deployment.KeycloakProcessor:debug", "--db-kind-new-user-store=dev-mem", "--db-kind-client-store=dev-file"})
+    @Launch({"start-dev", "--db=dev-file", "--log-level=org.hibernate.jpa.internal.util.LogHelper:debug,org.keycloak.quarkus.deployment.KeycloakProcessor:debug", "--db-kind-new-user-store=dev-mem", "--db-kind-client-store=dev-file", "--db-kind-pu-without-dialect-store=dev-mem"})
     void testUserManagedEntityNotAddedToDefaultPU(CLIResult cliResult) {
-        cliResult.assertMessage("Multiple datasources are specified: <default>, client-store, new-user-store");
+        cliResult.assertMessage(MULTIPLE_DATASOURCES_MSG);
         cliResult.assertMessage("Datasource name 'client-store' is obtained from the 'Persistence unit name' configuration property in persistence.xml file. Use 'client-store' name for datasource options like 'db-kind-client-store'.");
+        cliResult.assertMessage("Datasource name 'pu-without-dialect-store' is obtained from the 'Persistence unit name' configuration property in persistence.xml file. Use 'pu-without-dialect-store' name for datasource options like 'db-kind-pu-without-dialect-store'.");
         cliResult.assertMessage("Datasource name 'new-user-store' is obtained from the 'jakarta.persistence.jtaDataSource' configuration property in persistence.xml file. Use 'new-user-store' name for datasource options like 'db-kind-new-user-store'.");
 
         // tests for https://github.com/keycloak/keycloak/issues/41641
@@ -69,7 +74,14 @@ public class CustomJpaEntityProviderDistTest {
 
         cliResult.assertStringCount("name: new-user-store", 1);
         cliResult.assertStringCount("name: client-store", 1);
+        cliResult.assertStringCount("name: pu-without-dialect-store", 1);
         cliResult.assertStringCount("com.acme.provider.legacy.jpa.entity.Realm", 1);
+
+        cliResult.assertMessage("jakarta.persistence.jtaDataSource: client-store");
+        cliResult.assertMessage("jakarta.persistence.jtaDataSource: new-user-store");
+        cliResult.assertMessage("jakarta.persistence.jtaDataSource: pu-without-dialect-store");
+        cliResult.assertStringCount("hibernate.dialect: org.hibernate.dialect.H2Dialect", 4);
+
         cliResult.assertStartedDevMode();
     }
 }


### PR DESCRIPTION
- Closes #40997

----------------------
- Wrapped Datasource logic ([DatabaseOptions.Datasources](https://github.com/keycloak/keycloak/pull/41026/files#diff-922effaaab1831700be05842474f2d2a14f07e5faeecf3ee285a9881e4de52adR115), [DatabasePropertyMappers.Datasources](https://github.com/keycloak/keycloak/pull/41026/files#diff-3b84b4432d8b3bde7601af78ae093ed420569e5d440b830bce84302dea0a831cR184) and [PropertyMappers.WildcardMappersConfig](https://github.com/keycloak/keycloak/pull/41026/files#diff-a1bb1ef613469cf669070d52be8a88079005dcaed860e8d11d4231b5e2f530f7R409))
- [Automatic mapping](https://github.com/keycloak/keycloak/pull/41026/files#diff-6ebe7f8db3e4dea9dbefd50eed883b8aac997e6c01127e283631e92e9d022835R545) of DB dialect and schema to Hibernate properties
- [Advertise all connected options to Quarkus](https://github.com/keycloak/keycloak/pull/41026/files#diff-bd3f5749f7a9d562e7e2efef70bad30ab4f3d77d5a63c566044cdb5810504767R113)
- Solved the issue with the `persistence.xml` files and it is possible to [rewrite quickstarts](https://github.com/mabartos/keycloak-quickstarts/commit/4c4b3043da9fd48772ad3a2c4c89d9cfb1086565) with this
