### PR TITLE
Remove /etc/system-fips file before executing fips-mode-setup

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+rm -f /etc/system-fips
 dnf install -y java-21-openjdk-devel
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --is-enabled

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -f /etc/system-fips
 dnf install -y java-21-openjdk-devel crypto-policies-scripts
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --is-enabled


### PR DESCRIPTION
Closes #41038

FIPS jobs started to fail today. I checked that this `/etc/system-fips` file is created with a link to a non-existent folder (probably because we are using a hack in ubuntu to simulate the fips configuration and it thinks it is partially configured). This file is a mark that the `fips-mode-setup` creates when it is initialized. The scripts now remove the file before executing the `fips-mode-setup` and the file is created OK in the initialization.
