### PR TITLE
Update email feature only enabled if the required action is enabled at the realm

### DIFF
--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
@@ -18,6 +18,8 @@
 package org.keycloak.federation.kerberos;
 
 import org.jboss.logging.Logger;
+import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.constants.KerberosConstants;
 import org.keycloak.credential.CredentialAuthentication;
 import org.keycloak.credential.CredentialInput;
@@ -30,10 +32,12 @@ import org.keycloak.models.CredentialValidationOutput;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserManager;
+import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.storage.ReadOnlyException;
 import org.keycloak.storage.UserStoragePrivateUtil;
@@ -288,11 +292,23 @@ public class KerberosFederationProvider implements UserStorageProvider,
         user.setSingleAttribute(KERBEROS_PRINCIPAL, kerberosPrincipal.toString());
 
         if (kerberosConfig.isUpdateProfileFirstLogin()) {
-            user.addRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL);
+            if (isUpdateEmailEnabled(realm)) {
+                user.addRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL);
+            }
             user.addRequiredAction(UserModel.RequiredAction.UPDATE_PROFILE);
         }
 
         return validate(realm, user);
+    }
+
+    private static boolean isUpdateEmailEnabled(RealmModel realm) {
+        if (!Profile.isFeatureEnabled(Profile.Feature.UPDATE_EMAIL)) {
+            return false;
+        }
+
+        RequiredActionProviderModel model = realm.getRequiredActionProviderByAlias(RequiredAction.UPDATE_EMAIL.name());
+
+        return model != null && model.isEnabled();
     }
 
     @Override

--- a/js/apps/account-ui/test/personal-info/personal-info.spec.ts
+++ b/js/apps/account-ui/test/personal-info/personal-info.spec.ts
@@ -20,6 +20,7 @@ test.describe("Personal info page", () => {
   test("sets basic information", async ({ page }) => {
     await login(page, user, "pwd", realm);
 
+    await page.getByTestId("email").fill(`${user}@somewhere.com`);
     await page.getByTestId("firstName").fill("Erik");
     await page.getByTestId("lastName").fill("de Wit");
     await page.getByTestId("save").click();

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultRequiredActions.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultRequiredActions.java
@@ -261,7 +261,7 @@ public class DefaultRequiredActions {
 
         if (!isRequiredActionActive) {
             RequiredActionProviderModel updateEmail = new RequiredActionProviderModel();
-            updateEmail.setEnabled(true);
+            updateEmail.setEnabled(false);
             updateEmail.setAlias(PROVIDER_ID);
             updateEmail.setName("Update Email");
             updateEmail.setProviderId(PROVIDER_ID);

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/util/UserUpdateProfileContext.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/util/UserUpdateProfileContext.java
@@ -20,7 +20,8 @@ package org.keycloak.authentication.requiredactions.util;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.keycloak.common.Profile;
+
+import org.keycloak.authentication.requiredactions.UpdateEmail;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.userprofile.UserProfileContext;
@@ -60,7 +61,7 @@ public class UserUpdateProfileContext implements UpdateProfileContext {
 
     @Override
     public boolean isEditEmailAllowed() {
-        return !Profile.isFeatureEnabled(Profile.Feature.UPDATE_EMAIL);
+        return !UpdateEmail.isEnabled(realm);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.requiredactions.DeleteAccount;
+import org.keycloak.authentication.requiredactions.UpdateEmail;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Environment;
@@ -25,7 +26,6 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.RequiredActionProviderModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
@@ -203,8 +203,7 @@ public class AccountConsole implements AccountResourceProvider {
         map.put("isOid4VciEnabled", realm.isVerifiableCredentialsEnabled());
 
         map.put("updateEmailFeatureEnabled", Profile.isFeatureEnabled(Profile.Feature.UPDATE_EMAIL));
-        RequiredActionProviderModel updateEmailActionProvider = realm.getRequiredActionProviderByAlias(UserModel.RequiredAction.UPDATE_EMAIL.name());
-        map.put("updateEmailActionEnabled", updateEmailActionProvider != null && updateEmailActionProvider.isEnabled());
+        map.put("updateEmailActionEnabled", UpdateEmail.isEnabled(realm));
 
         final var devServerUrl = Environment.isDevMode() ? System.getenv(ViteManifest.ACCOUNT_VITE_URL) : null;
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/RequiredActionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/RequiredActionsTest.java
@@ -66,7 +66,7 @@ public class RequiredActionsTest extends AbstractAuthenticationTest {
         addRequiredAction(expected, "CONFIGURE_RECOVERY_AUTHN_CODES", "Recovery Authentication Codes", true, false, null);
         addRequiredAction(expected, "CONFIGURE_TOTP", "Configure OTP", true, false, null);
         addRequiredAction(expected, "TERMS_AND_CONDITIONS", "Terms and Conditions", false, false, null);
-        addRequiredAction(expected, "UPDATE_EMAIL", "Update Email", true, false, null);
+        addRequiredAction(expected, "UPDATE_EMAIL", "Update Email", false, false, null);
         addRequiredAction(expected, "UPDATE_PASSWORD", "Update Password", true, false, null);
         addRequiredAction(expected, "UPDATE_PROFILE", "Update Profile", true, false, null);
         addRequiredAction(expected, "VERIFY_EMAIL", "Verify Email", true, false, null);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
@@ -17,6 +17,7 @@
 package org.keycloak.testsuite.admin;
 
 import org.jboss.logging.Logger;
+import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientScopeResource;
@@ -25,6 +26,7 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
@@ -336,4 +338,12 @@ public class ApiUtil {
         log.infof("updated required actions order for realm '%s': %s", realmName, updatedRequiredActionsOrdered);
     }
 
+    public static void enableRequiredAction(RealmResource realm, RequiredAction action, boolean enable) {
+        AuthenticationManagementResource authMgt = realm.flows();
+        RequiredActionProviderRepresentation requiredAction = authMgt.getRequiredActions().stream()
+                .filter(a -> action.name().equals(a.getAlias()))
+                .findAny().orElseThrow(() -> new IllegalStateException("Required action not found: " + action.name()));
+        requiredAction.setEnabled(enable);
+        authMgt.updateRequiredAction(requiredAction.getAlias(), requiredAction);
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractAppInitiatedActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractAppInitiatedActionUpdateEmailTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
@@ -55,6 +56,7 @@ public abstract class AbstractAppInitiatedActionUpdateEmailTest extends Abstract
 				.lastName("Doh").build();
 		prepareUser(user);
 		ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+        ApiUtil.enableRequiredAction(testRealm(), RequiredAction.UPDATE_EMAIL, true);
 	}
 
 	private void setRegistrationEmailAsUsername(RealmResource realmResource, boolean enabled) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AbstractRequiredActionUpdateEmailTest.java
@@ -28,12 +28,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.common.Profile;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.auth.page.login.UpdateEmailPage;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
@@ -41,6 +44,7 @@ import org.keycloak.testsuite.util.SecondBrowser;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.openqa.selenium.WebDriver;
 
+@EnableFeature(Profile.Feature.UPDATE_EMAIL)
 public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTestRealmKeycloakTest {
 
 	@Rule
@@ -61,6 +65,7 @@ public abstract class AbstractRequiredActionUpdateEmailTest extends AbstractTest
 
 	@Before
 	public void beforeTest() {
+        ApiUtil.enableRequiredAction(testRealm(), RequiredAction.UPDATE_EMAIL, true);
 		ApiUtil.removeUserByUsername(testRealm(), "test-user@localhost");
 		UserRepresentation user = UserBuilder.create().enabled(true)
 				.username("test-user@localhost")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -42,7 +42,6 @@ import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.AuthServerTestEnricher;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.cluster.AuthenticationSessionFailoverClusterTest;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.AppPage.RequestType;
@@ -1112,7 +1111,6 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
     }
 
     @Test
-    @EnableFeature(value = Profile.Feature.UPDATE_EMAIL, skipRestart = true) // The feature is enabled by default but skipRestart = true is important for the test
     public void actionTokenWithInvalidRequiredActions() throws IOException {
         // Send email with required action
         testRealm().users().get(testUserId).executeActionsEmail(List.of(RequiredAction.UPDATE_EMAIL.name()));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionMultipleActionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionMultipleActionsTest.java
@@ -105,11 +105,14 @@ public class RequiredActionMultipleActionsTest extends AbstractTestRealmKeycloak
     }
 
     public String updateProfile(String codeId) {
-        updateProfilePage.prepareUpdate().username("test-user@localhost").firstName("New first").lastName("New last").submit();
+        updateProfilePage.prepareUpdate().username("test-user@localhost").firstName("New first").lastName("New last")
+                .email("new@email.com").submit();
 
         AssertEvents.ExpectedEvent expectedEvent = events.expectRequiredAction(EventType.UPDATE_PROFILE)
                 .detail(Details.UPDATED_FIRST_NAME, "New first")
-                .detail(Details.UPDATED_LAST_NAME, "New last");
+                .detail(Details.UPDATED_LAST_NAME, "New last")
+                .detail(Details.PREVIOUS_EMAIL, "test-user@localhost")
+                .detail(Details.UPDATED_EMAIL, "new@email.com");
 
         if (codeId != null) {
             expectedEvent.detail(Details.CODE_ID, codeId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionPriorityTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionPriorityTest.java
@@ -62,6 +62,7 @@ public class RequiredActionPriorityTest extends AbstractTestRealmKeycloakTest {
     private static final String EMAIL = "test-user@localhost";
     private static final String USERNAME = EMAIL;
     private static final String PASSWORD = "password";
+    private static final String NEW_EMAIL = "new@email.com";
     private static final String NEW_FIRST_NAME = "New first";
     private static final String NEW_LAST_NAME = "New last";
     private static final String NEW_PASSWORD = "new-password";
@@ -145,9 +146,12 @@ public class RequiredActionPriorityTest extends AbstractTestRealmKeycloakTest {
 
         // Finally, update profile
         updateProfilePage.assertCurrent();
-        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME).submit();
+        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME)
+                .email(NEW_EMAIL).submit();
         events.expectRequiredAction(EventType.UPDATE_PROFILE).detail(Details.UPDATED_FIRST_NAME, NEW_FIRST_NAME)
                 .detail(Details.UPDATED_LAST_NAME, NEW_LAST_NAME)
+                .detail(Details.PREVIOUS_EMAIL, EMAIL)
+                .detail(Details.UPDATED_EMAIL, NEW_EMAIL)
                 .assertEvent();
 
         // Logged in
@@ -186,9 +190,12 @@ public class RequiredActionPriorityTest extends AbstractTestRealmKeycloakTest {
 
         // Second, update profile
         updateProfilePage.assertCurrent();
-        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME).submit();
+        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME)
+                .email(NEW_EMAIL).submit();
         events.expectRequiredAction(EventType.UPDATE_PROFILE).detail(Details.UPDATED_FIRST_NAME, NEW_FIRST_NAME)
                 .detail(Details.UPDATED_LAST_NAME, NEW_LAST_NAME)
+                .detail(Details.PREVIOUS_EMAIL, EMAIL)
+                .detail(Details.UPDATED_EMAIL, NEW_EMAIL)
                 .assertEvent();
 
         // Finally, accept terms
@@ -240,9 +247,12 @@ public class RequiredActionPriorityTest extends AbstractTestRealmKeycloakTest {
 
         // Finally, update profile. Action specified by "kc_action" should be always triggered last
         updateProfilePage.assertCurrent();
-        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME).submit();
+        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME)
+                .email(NEW_EMAIL).submit();
         events.expectRequiredAction(EventType.UPDATE_PROFILE).detail(Details.UPDATED_FIRST_NAME, NEW_FIRST_NAME)
                 .detail(Details.UPDATED_LAST_NAME, NEW_LAST_NAME)
+                .detail(Details.PREVIOUS_EMAIL, EMAIL)
+                .detail(Details.UPDATED_EMAIL, NEW_EMAIL)
                 .assertEvent();
 
         // Logged in
@@ -296,9 +306,12 @@ public class RequiredActionPriorityTest extends AbstractTestRealmKeycloakTest {
 
         // Second, update profile
         updateProfilePage.assertCurrent();
-        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME).submit();
+        updateProfilePage.prepareUpdate().firstName(NEW_FIRST_NAME).lastName(NEW_LAST_NAME)
+                .email(NEW_EMAIL).submit();
         events.expectRequiredAction(EventType.UPDATE_PROFILE).detail(Details.UPDATED_FIRST_NAME, NEW_FIRST_NAME)
                 .detail(Details.UPDATED_LAST_NAME, NEW_LAST_NAME)
+                .detail(Details.PREVIOUS_EMAIL, EMAIL)
+                .detail(Details.UPDATED_EMAIL, NEW_EMAIL)
                 .assertEvent();
 
         // Finally, accept terms

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileWithUserProfileTest.java
@@ -212,7 +212,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         //assert fields location in form
         //assert fields and groups location in form, attributes without a group appear first
         List<WebElement> element = driver.findElements(By.cssSelector("form#kc-update-profile-form input"));
-        String[] labelOrder = new String[]{"lastName", "department", "username", "firstName"};
+        String[] labelOrder = new String[]{"lastName", "department", "username", "firstName", "email"};
         for (int i = 0; i < labelOrder.length; i++) {
             WebElement webElement = element.get(i);
             String id = webElement.getAttribute("id");
@@ -274,10 +274,11 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
         assertFalse(updateProfilePage.isCancelDisplayed());
 
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("New first").lastName("").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("New first").lastName("").email("new@email.com").submit();
 
         events.expectRequiredAction(EventType.UPDATE_PROFILE).detail(Details.PREVIOUS_FIRST_NAME, "Tom").detail(Details.UPDATED_FIRST_NAME, "New first")
                 .detail(Details.PREVIOUS_LAST_NAME, "Brady")
+                .detail(Details.PREVIOUS_EMAIL, USERNAME1).detail(Details.UPDATED_EMAIL, "new@email.com")
                 .assertEvent();
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
@@ -287,6 +288,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, USERNAME1);
         Assert.assertEquals("New first", user.getFirstName());
         assertThat(StringUtils.isEmpty(user.getLastName()), is(true));
+        Assert.assertEquals("new@email.com", user.getEmail());
         Assert.assertEquals(USERNAME1, user.getUsername());
         assertNull(user.getLastName());
     }
@@ -308,11 +310,11 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
 
         updateProfilePage.assertCurrent();
         //submit with error
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("L").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("L").email(USERNAME1).submit();
 
         updateProfilePage.assertCurrent();
         //submit OK
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").email(USERNAME1).submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -341,7 +343,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         Assert.assertFalse(updateProfilePage.isDepartmentEnabled());
 
         //update of the other attributes must be successful in this case
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").email(USERNAME1).submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -368,7 +370,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         Assert.assertFalse(updateProfilePage.isDepartmentEnabled());
 
         //update of the other attributes must be successful in this case
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").email(USERNAME1).submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -395,7 +397,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         Assert.assertFalse("'department' field is visible", updateProfilePage.isDepartmentPresent());
 
         //update of the other attributes must be successful in this case
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("First").lastName("Last").email(USERNAME1).submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());
@@ -420,12 +422,12 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
 
         //submit with error
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("").submit();
         updateProfilePage.assertCurrent();
 
         //submit OK
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("DepartmentCC").submit();
 
         // we also test additional attribute configured to be audited in the event
@@ -461,12 +463,12 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
 
         //submit with error
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("").submit();
         updateProfilePage.assertCurrent();
 
         //submit OK
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("DepartmentCC").submit();
 
         events.expectRequiredAction(EventType.UPDATE_PROFILE).client(client_scope_optional.getClientId())
@@ -501,12 +503,12 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
 
         //submit with error
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("").submit();
         updateProfilePage.assertCurrent();
 
         //submit OK
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("DepartmentCC").submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -535,12 +537,12 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
 
         //submit with error
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("").submit();
         updateProfilePage.assertCurrent();
 
         //submit OK
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("DepartmentCC").submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -569,7 +571,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
 
         Assert.assertTrue(updateProfilePage.isDepartmentPresent());
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC")
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1)
                 .department("DepartmentCC").submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
@@ -598,7 +600,7 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends AbstractTest
         updateProfilePage.assertCurrent();
 
         Assert.assertFalse(updateProfilePage.isDepartmentPresent());
-        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").submit();
+        updateProfilePage.prepareUpdate().username(USERNAME1).firstName("FirstCC").lastName("LastCC").email(USERNAME1).submit();
 
         Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.parseLoginResponse().getCode());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
@@ -107,7 +107,7 @@ public class AuthenticationSessionFailoverClusterTest extends AbstractFailoverCl
         updateProfilePage.assertCurrent();
 
         // Successfully update profile and assert user logged
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").email("john@doe3.com").submit();
         appPage.assertCurrent();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.testsuite.federation.kerberos;
 
-import static org.junit.Assert.assertThat;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 
@@ -48,7 +47,6 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.hamcrest.Matchers;
 import org.ietf.jgss.GSSCredential;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
@@ -313,8 +311,8 @@ public abstract class AbstractKerberosTest extends AbstractAuthTest {
             }
 
             if (updateProfileActionExpected) {
-                assertThat(user.getRequiredActions(),
-                        Matchers.containsInAnyOrder(UserModel.RequiredAction.UPDATE_PROFILE.toString(), UserModel.RequiredAction.UPDATE_EMAIL.toString()));
+                Assert.assertEquals(UserModel.RequiredAction.UPDATE_PROFILE.toString(),
+                        user.getRequiredActions().iterator().next());
             } else {
                 Assert.assertTrue(user.getRequiredActions().isEmpty());
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneTest.java
@@ -125,6 +125,7 @@ public class KerberosStandaloneTest extends AbstractKerberosSingleRealmTest {
         Assert.assertEquals(200, spnegoResponse.getStatus());
         String responseText = spnegoResponse.readEntity(String.class);
         Assert.assertTrue(responseText.contains("You need to update your user profile to activate your account."));
+        Assert.assertTrue(responseText.contains("hnelson@" + kerberosRule.getConfig().get(KerberosConstants.KERBEROS_REALM).toLowerCase()));
         spnegoResponse.close();
 
         // Assert user was imported and has required action on him

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAccountRestApiTest.java
@@ -266,18 +266,18 @@ public class LDAPAccountRestApiTest extends AbstractLDAPTest {
             appRealm.setEditUsernameAllowed(false);
         });
         UserRepresentation user = SimpleHttpDefault.doGet(getAccountUrl(null), httpClient).auth(tokenUtil.getToken()).asJson(UserRepresentation.class);
-        user.setLastName("Brady");
+        user.setEmail("john-alias@email.org");
         SimpleHttpDefault.doPost(getAccountUrl(null), httpClient).json(user).auth(tokenUtil.getToken()).asStatus();
 
         UserRepresentation usernew = SimpleHttpDefault.doGet(getAccountUrl(null), httpClient).auth(tokenUtil.getToken()).asJson(UserRepresentation.class);
         assertEquals("johnkeycloak", usernew.getUsername());
         assertEquals("John", usernew.getFirstName());
-        assertEquals("Brady", usernew.getLastName());
-        assertEquals("john@email.org", usernew.getEmail());
+        assertEquals("Doe", usernew.getLastName());
+        assertEquals("john-alias@email.org", usernew.getEmail());
         assertFalse(usernew.isEmailVerified());
 
         //clean up
-        user.setLastName("Doe");
+        usernew.setEmail("john@email.org");
         SimpleHttpDefault.doPost(getAccountUrl(null), httpClient).json(usernew).auth(tokenUtil.getToken()).asStatus();
 
     }
@@ -290,21 +290,21 @@ public class LDAPAccountRestApiTest extends AbstractLDAPTest {
             appRealm.setEditUsernameAllowed(false);
         });
         UserRepresentation user = SimpleHttpDefault.doGet(getAccountUrl(null), httpClient).auth(tokenUtil.getToken()).asJson(UserRepresentation.class);
-        user.setFirstName("Tom");
+        user.setEmail("john-alias@email.org");
         SimpleHttpDefault.doPost(getAccountUrl(null), httpClient).json(user).auth(tokenUtil.getToken()).asStatus();
 
         UserRepresentation usernew = SimpleHttpDefault.doGet(getAccountUrl(null), httpClient).auth(tokenUtil.getToken()).asJson(UserRepresentation.class);
         assertEquals("johnkeycloak", usernew.getUsername());
-        assertEquals("Tom", usernew.getFirstName());
+        assertEquals("John", usernew.getFirstName());
         assertEquals("Doe", usernew.getLastName());
-        assertEquals("john@email.org", usernew.getEmail());
+        assertEquals("john-alias@email.org", usernew.getEmail());
         assertFalse(usernew.isEmailVerified());
 
         // No metadata attributes like LDAP_ID or LDAP_ENTRY_DN present in account REST API
         Assert.assertNull(usernew.getAttributes());
 
         //clean up
-        usernew.setFirstName("John");
+        usernew.setEmail("john@email.org");
         final int i = SimpleHttpDefault.doPost(getAccountUrl(null), httpClient).json(usernew).auth(tokenUtil.getToken()).asStatus();
 
         org.keycloak.representations.idm.UserRepresentation userRep = testRealm().users()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
@@ -159,7 +159,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
 
 
         // Successfully update profile and assert user logged
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").email("john@doe3.com").submit();
         appPage.assertCurrent();
     }
 
@@ -204,7 +204,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         updateProfilePage.assertCurrent();
 
         // Successfully update profile and assert user logged
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").email("john@doe3.com").submit();
         appPage.assertCurrent();
     }
 
@@ -218,7 +218,7 @@ public class BrowserButtonsTest extends AbstractChangeImportedUserPasswordsTest 
         loginPage.open();
         loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").email("john@doe3.com").submit();
 
         // Assert on consent screen
         grantPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
@@ -270,7 +270,8 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
     private void loginSuccessAndDoRequiredActions() {
         loginPage.login("login-test", getPassword("login-test"));
         updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3")
+                .email("john@doe3.com").submit();
         appPage.assertCurrent();
     }
 
@@ -516,7 +517,8 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
         updatePasswordPage.assertCurrent();
 
         updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3")
+                .email("john@doe3.com").submit();
         appPage.assertCurrent();
     }
 
@@ -554,7 +556,8 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
         updatePasswordPage.assertCurrent();
 
         updatePasswordPage.changePassword(getPassword("login-test"), getPassword("login-test"));
-        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3").submit();
+        updateProfilePage.prepareUpdate().firstName("John").lastName("Doe3")
+                .email("john@doe3.com").submit();
         appPage.assertCurrent();
     }
 


### PR DESCRIPTION
Closes #41045

* In order not to break existing deployments and allow users to opt in for the new behavior introduced by the feature, this PR is now enabling the new behavior only if the `Update Email` required action is enabled.
* By default, the required action is disabled
* The PR https://github.com/keycloak/keycloak/pull/40273 introduced the `UPDATE_EMAIL` feature as enabled by default and changed the current behavior. As a consequence, a lot of tests had to change.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
