### PR TITLE
fix: providing a single property to declare management interface as http

### DIFF
--- a/docs/guides/server/management-interface.adoc
+++ b/docs/guides/server/management-interface.adoc
@@ -36,8 +36,10 @@ if you set the CLI option `--http-relative-path=/auth`, these endpoints are acce
 
 === TLS support
 
-When the TLS is set for the default {project_name} server, the management interface will be accessible through HTTPS as well.
+When the TLS is set for the default {project_name} server, by default the management interface will be accessible through HTTPS as well.
 The management interface can run only either on HTTP or HTTPS, not both as for the main server.
+
+NOTE: If you do not want the management interface to use HTTPS, you may set the `http-management-scheme` option to `http`.
 
 Specific {project_name} management interface options with the prefix `https-management-*` were provided for setting different TLS parameters for the management HTTP server. Their function is similar to their counterparts for the main HTTP server, for details see <@links.server id="enabletls" />.
 When these options are not explicitly set, the TLS parameters are inherited from the default HTTP server.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/ManagementOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/ManagementOptions.java
@@ -61,7 +61,18 @@ public class ManagementOptions {
             .defaultValue("0.0.0.0")
             .build();
 
+    public enum Scheme {
+        http,
+        inherited
+    }
+
     //HTTPS
+    public static final Option<Scheme> HTTP_MANAGEMENT_SCHEME = new OptionBuilder<>("http-management-scheme", Scheme.class)
+            .category(OptionCategory.MANAGEMENT)
+            .description("Configures the management interface scheme. If 'inherited', the management interface will inherit the HTTPS settings of the main interface. If 'http', the management interface will be accessible via HTTP - it will not inherit HTTPS settings and cannot be configured for HTTPS.")
+            .defaultValue(Scheme.inherited)
+            .build();
+
     public static final Option<HttpOptions.ClientAuth> HTTPS_MANAGEMENT_CLIENT_AUTH = new OptionBuilder<>("https-management-client-auth", HttpOptions.ClientAuth.class)
             .category(OptionCategory.MANAGEMENT)
             .description("Configures the management interface to require/request client authentication. If not given, the value is inherited from HTTP options. " + RELEVANT_MSG)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
@@ -19,6 +19,7 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.HttpOptions;
 import org.keycloak.config.ManagementOptions;
+import org.keycloak.config.ManagementOptions.Scheme;
 import org.keycloak.config.MetricsOptions;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
@@ -27,6 +28,8 @@ import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 public class ManagementPropertyMappers {
+
+    private static final String HTTP_MANAGEMENT_SCHEME_IS_INHERITED = "http-management-scheme is inherited";
 
     private ManagementPropertyMappers() {
     }
@@ -54,49 +57,60 @@ public class ManagementPropertyMappers {
                         .paramLabel("host")
                         .build(),
                 // HTTPS
+                fromOption(ManagementOptions.HTTP_MANAGEMENT_SCHEME)
+                        .paramLabel("scheme")
+                        .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CLIENT_AUTH)
-                        .mapFrom(HttpOptions.HTTPS_CLIENT_AUTH)
+                        .mapFrom(HttpOptions.HTTPS_CLIENT_AUTH) // we can't check inherited because this is a build time option
                         .to("quarkus.management.ssl.client-auth")
                         .paramLabel("auth")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CIPHER_SUITES)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_CIPHER_SUITES)
                         .to("quarkus.management.ssl.cipher-suites")
                         .paramLabel("ciphers")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_PROTOCOLS)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_PROTOCOLS)
                         .to("quarkus.management.ssl.protocols")
                         .paramLabel("protocols")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATES_RELOAD_PERIOD)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_CERTIFICATES_RELOAD_PERIOD)
                         .to("quarkus.management.ssl.certificate.reload-period")
                         .transformer(HttpPropertyMappers::transformNegativeReloadPeriod)
                         .paramLabel("reload period")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_FILE)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_CERTIFICATE_FILE)
                         .to("quarkus.management.ssl.certificate.files")
                         .paramLabel("file")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_KEY_FILE)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_CERTIFICATE_KEY_FILE)
                         .to("quarkus.management.ssl.certificate.key-files")
                         .paramLabel("file")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_FILE)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_KEY_STORE_FILE)
                         .to("quarkus.management.ssl.certificate.key-store-file")
                         .paramLabel("file")
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_PASSWORD)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_KEY_STORE_PASSWORD)
                         .to("quarkus.management.ssl.certificate.key-store-password")
                         .paramLabel("password")
                         .isMasked(true)
                         .build(),
                 fromOption(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_TYPE)
+                        .isEnabled(ManagementPropertyMappers::isInheritedScheme, HTTP_MANAGEMENT_SCHEME_IS_INHERITED)
                         .mapFrom(HttpOptions.HTTPS_KEY_STORE_TYPE)
                         .to("quarkus.management.ssl.certificate.key-store-file-type")
                         .paramLabel("type")
@@ -116,15 +130,23 @@ public class ManagementPropertyMappers {
         return Boolean.toString(isManagementEnabled());
     }
 
-    public static boolean isManagementTlsEnabled() {
-        var key = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_KEY_FILE.getKey());
-        var cert = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_FILE.getKey());
-        if (key.isPresent() && cert.isPresent()) {
-            return true;
-        }
+    public static boolean isInheritedScheme() {
+        return !Scheme.http.name()
+                .equals(Configuration.getKcConfigValue(ManagementOptions.HTTP_MANAGEMENT_SCHEME.getKey()).getValue());
+    }
 
-        var keystore = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_FILE.getKey());
-        return keystore.isPresent();
+    public static boolean isManagementTlsEnabled() {
+        if (isInheritedScheme()) {
+            var key = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_KEY_FILE.getKey());
+            var cert = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_CERTIFICATE_FILE.getKey());
+            if (key.isPresent() && cert.isPresent()) {
+                return true;
+            }
+
+            var keystore = Configuration.getOptionalKcValue(ManagementOptions.HTTPS_MANAGEMENT_KEY_STORE_FILE.getKey());
+            return keystore.isPresent();
+        }
+        return false;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -258,7 +258,7 @@ public class PropertyMapper<T> {
         String mappedValue = value;
 
         boolean mapped = false;
-        // use parent mapper/transformer when no mapper is explicitly specified in .mapFrom()
+        // fall back to the transformer when no mapper is explicitly specified in .mapFrom()
         var theMapper = parentValue && parentMapper != null ? this.parentMapper : this.mapper;
         if (theMapper != null && (!name.equals(getFrom()) || parentValue)) {
             mappedValue = theMapper.map(getNamedProperty().orElse(null), value, context);

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ManagementConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ManagementConfigurationTest.java
@@ -17,7 +17,9 @@
 package org.keycloak.quarkus.runtime.configuration;
 
 import org.junit.Test;
+import org.keycloak.quarkus.runtime.cli.command.Build;
 import org.keycloak.quarkus.runtime.configuration.mappers.ManagementPropertyMappers;
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 import java.util.Map;
 
@@ -186,6 +188,27 @@ public class ManagementConfigurationTest extends AbstractConfigurationTest {
         ));
         assertManagementEnabled(true);
         assertManagementHttpsEnabled(true);
+    }
+
+    @Test
+    public void managementSchemeHttp() {
+        makeInterfaceOccupied();
+        putEnvVars(Map.of(
+                "KC_HTTPS_CERTIFICATE_FILE", "/some/path/srv.crt.pem",
+                "KC_HTTPS_CERTIFICATE_KEY_FILE", "/some/path/srv.key.pem",
+                "KC_HTTP_MANAGEMENT_SCHEME", "http"
+        ));
+
+        initConfig();
+        PropertyMappers.sanitizeDisabledMappers(new Build());
+
+        assertConfig(Map.of(
+                "https-certificate-file", "/some/path/srv.crt.pem",
+                "https-certificate-key-file", "/some/path/srv.key.pem"
+        ));
+        assertConfigNull("https-management-certificate-file");
+        assertManagementEnabled(true);
+        assertManagementHttpsEnabled(false);
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementHttpsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementHttpsDistTest.java
@@ -62,4 +62,25 @@ public class ManagementHttpsDistTest {
         when().get(url + "/metrics").then()
                 .statusCode(200);
     }
+
+    @Test
+    @Launch({"start-dev", "--http-management-scheme=http"})
+    public void simpleHttpStartDev(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        var url = "http://localhost:9000";
+        cliResult.assertMessage("Management interface listening on http://0.0.0.0:9000");
+
+        when().get(url).then()
+                .statusCode(200)
+                .and()
+                .body(is("Keycloak Management Interface"));
+        when().get(url + "/health").then()
+                .statusCode(200);
+        when().get(url + "/health/live").then()
+                .statusCode(200);
+        when().get(url + "/health/ready").then()
+                .statusCode(200);
+        when().get(url + "/metrics").then()
+                .statusCode(200);
+    }
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -142,15 +142,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -158,7 +166,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -168,12 +177,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -144,15 +144,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -160,7 +168,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -170,12 +179,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -137,15 +137,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -153,7 +161,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -163,12 +172,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -137,15 +137,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -153,7 +161,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -163,12 +172,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -137,15 +137,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -153,7 +161,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -163,12 +172,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -137,15 +137,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -153,7 +161,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -163,12 +172,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -268,15 +268,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -284,7 +292,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -294,12 +303,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -344,15 +344,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -360,7 +368,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -370,12 +379,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -316,15 +316,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -332,7 +340,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -342,12 +351,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -345,15 +345,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -361,7 +369,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -371,12 +380,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -270,15 +270,23 @@ Management:
 --http-management-port <port>
                      Port of the management interface. Relevant only when something is exposed on
                        the management interface - see the guide for details. Default: 9000.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -286,17 +294,19 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-key-store-file <file>
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 
 Proxy:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -299,15 +299,23 @@ Management:
 --http-management-port <port>
                      Port of the management interface. Relevant only when something is exposed on
                        the management interface - see the guide for details. Default: 9000.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -315,17 +323,19 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-key-store-file <file>
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 
 Proxy:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -315,15 +315,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -331,7 +339,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -341,12 +350,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -344,15 +344,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -360,7 +368,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -370,12 +379,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -313,15 +313,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -329,7 +337,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -339,12 +348,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -342,15 +342,23 @@ Management:
                        The path must start with a '/'. If not given, the value is inherited from
                        HTTP options. Relevant only when something is exposed on the management
                        interface - see the guide for details. Default: /.
+--http-management-scheme <scheme>
+                     Configures the management interface scheme. If 'inherited', the management
+                       interface will inherit the HTTPS settings of the main interface. If 'http',
+                       the management interface will be accessible via HTTP - it will not inherit
+                       HTTPS settings and cannot be configured for HTTPS. Possible values are:
+                       http, inherited. Default: inherited.
 --https-management-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format for
                        the management server. If not given, the value is inherited from HTTP
                        options. Relevant only when something is exposed on the management interface
-                       - see the guide for details.
+                       - see the guide for details. Available only when http-management-scheme is
+                       inherited.
 --https-management-certificate-key-file <file>
                      The file path to a private key in PEM format for the management server. If not
                        given, the value is inherited from HTTP options. Relevant only when
-                       something is exposed on the management interface - see the guide for details.
+                       something is exposed on the management interface - see the guide for
+                       details. Available only when http-management-scheme is inherited.
 --https-management-certificates-reload-period <reload period>
                      Interval on which to reload key store, trust store, and certificate files
                        referenced by https-management-* options for the management server. May be a
@@ -358,7 +366,8 @@ Management:
                        followed by one of [ms, h, m, s, d]. Must be greater than 30 seconds. Use -1
                        to disable. If not given, the value is inherited from HTTP options. Relevant
                        only when something is exposed on the management interface - see the guide
-                       for details. Default: 1h.
+                       for details. Default: 1h. Available only when http-management-scheme is
+                       inherited.
 --https-management-client-auth <auth>
                      Configures the management interface to require/request client authentication.
                        If not given, the value is inherited from HTTP options. Relevant only when
@@ -368,12 +377,13 @@ Management:
                      The key store which holds the certificate information instead of specifying
                        separate files for the management server. If not given, the value is
                        inherited from HTTP options. Relevant only when something is exposed on the
-                       management interface - see the guide for details.
+                       management interface - see the guide for details. Available only when
+                       http-management-scheme is inherited.
 --https-management-key-store-password <password>
                      The password of the key store file for the management server. If not given,
                        the value is inherited from HTTP options. Relevant only when something is
                        exposed on the management interface - see the guide for details. Default:
-                       password.
+                       password. Available only when http-management-scheme is inherited.
 --legacy-observability-interface <true|false>
                      DEPRECATED. If metrics/health endpoints should be exposed on the main HTTP
                        server (not recommended). If set to true, the management interface is


### PR DESCRIPTION
closes: #40945

Introduces http-management-scheme=http to force the management interface to http.

Without this you must do what was shown on #40945 and try to set the keystore / truststore to empty values - this is not a convention that we'd want to document as we generally don't have checks for treating blank the same as unset.

An alternative to having http/inherited is to ahve separate/inherited - with separate meaning that the management configuration is not dependent upon the http configuration at all. This however is difficult for us to implement with our current mapping logic, and we also have a build-time relationship with https-management-client-auth.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
