### PR TITLE
[Admin API v2] PoC for a field projection mechanism

### DIFF
--- a/core/src/main/java/org/keycloak/representations/admin/v2/BaseRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/BaseRepresentation.java
@@ -5,9 +5,11 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonFilter("projection")
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 public class BaseRepresentation {
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/ProjectionsPreFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/ProjectionsPreFilter.java
@@ -1,0 +1,20 @@
+package org.keycloak.quarkus.runtime.integration.jaxrs;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.ext.Provider;
+import org.keycloak.services.util.Projections;
+
+@Provider
+@PreMatching
+public class ProjectionsPreFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String projectionsParam = requestContext.getUriInfo().getQueryParameters().getFirst(Projections.PARAM);
+        if (projectionsParam != null) {
+            Projections.setCurrent(requestContext, projectionsParam);
+        }
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
@@ -3,7 +3,6 @@ package org.keycloak.admin.api.client;
 import java.util.stream.Stream;
 
 import jakarta.validation.Valid;
-import jakarta.validation.groups.ConvertGroup;
 import jakarta.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
@@ -19,8 +18,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.keycloak.representations.admin.v2.validation.CreateClient;
 import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.util.Projections;
 
 @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS_V2)
 @Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
@@ -40,6 +39,6 @@ public interface ClientsApi extends Provider {
                                       @QueryParam("fieldValidation") FieldValidation fieldValidation);
 
     @Path("{id}")
-    ClientApi client(@PathParam("id") String id);
+    ClientApi client(@PathParam("id") String id, @QueryParam(Projections.PARAM) Projections projections);
 }
 

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.keycloak.validation.jakarta.JakartaValidatorProvider;
+import org.keycloak.services.util.Projections;
 
 public class DefaultClientsApi implements ClientsApi {
     private final KeycloakSession session;
@@ -53,7 +54,7 @@ public class DefaultClientsApi implements ClientsApi {
     }
 
     @Override
-    public ClientApi client(@PathParam("id") String clientId) {
+    public ClientApi client(@PathParam("id") String clientId, @QueryParam("fields") Projections projections) {
         var client = Optional.ofNullable(session.clients().getClientByClientId(realm, clientId)).orElseThrow(() -> new NotFoundException("Client cannot be found"));
         session.getContext().setClient(client);
         return session.getProvider(ClientApi.class);

--- a/services/src/main/java/org/keycloak/services/util/Projections.java
+++ b/services/src/main/java/org/keycloak/services/util/Projections.java
@@ -1,0 +1,56 @@
+package org.keycloak.services.util;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class Projections {
+
+    public static final String PARAM = "fields";
+
+    private static final String REQUEST_PROPERTY = "projections";
+
+    private static final Pattern COMMA = Pattern.compile(",");
+
+    private static final Set<String> INCLUDE_ALL = Collections.unmodifiableSet(new HashSet<>());
+
+    private final Set<String> fields;
+
+    public Projections(String raw) {
+        this.fields = raw == null ? INCLUDE_ALL : Set.of(COMMA.split(raw));
+    }
+
+    public Set<String> getFields() {
+        return fields;
+    }
+
+    @Override
+    public String toString() {
+        return fields.toString();
+    }
+
+    public boolean contains(String attr) {
+        if (fields == INCLUDE_ALL) {
+            return true;
+        }
+        return fields.contains(attr);
+    }
+
+    public static Projections getCurrent() {
+        ResteasyReactiveRequestContext context = CurrentRequestManager.get();
+        if (context == null) {
+            return null;
+        }
+        return (Projections) context.getProperty(Projections.REQUEST_PROPERTY);
+    }
+
+    public static void setCurrent(ContainerRequestContext requestContext, String projectionsParam) {
+        // TODO avoid duplicate parsing here and on resource method
+        requestContext.setProperty(Projections.REQUEST_PROPERTY, new Projections(projectionsParam));
+    }
+}


### PR DESCRIPTION
PoC for a field selection / projection mechanism 

The projection works on the Jackson ObjectMapper level and uses a SimpleBeanPropertyFilter (FieldProjectionFilter) to control the properties during JSON marshalling. Consumers can select the desired result fields with a `fields` query parameter. Note that the selection only works with top-level object properties. There is currently no support for nested property selection.

Currently, all representations inheriting from BaseRepresentation support this filtering via the JsonFilter annotation.

JAX-RS resource methods which declare a 
`@QueryParam(Projections.PARAM) Projections projections` become eligible for projections.

The explicit parameter declaration ensures that the projection parameter can be inferred for the OpenAPI metadata.

A request without the fields parameter will return the full resource:

```
curl -v -H "Authorization: Bearer $KC_ACCESS_TOKEN" \
http://localhost:8081/auth/admin/api/v2/realms/adminapiv2/clients/custom-client1 | jq -C
```

A request with the included filter:
```
curl -v -H "Authorization: Bearer $KC_ACCESS_TOKEN" \
http://localhost:8081/auth/admin/api/v2/realms/adminapiv2/clients/custom-client1?fields=clientId,displayName
```
will only return the selected fields.

```
curl -s -H "Authorization: Bearer $KC_ACCESS_TOKEN" \
http://localhost:8081/auth/admin/api/v2/realms/adminapiv2/clients?fields=clientId
```

Yields:
```json
[
  {
    "clientId": "account"
  },
  {
    "clientId": "account-console"
  },
  {
    "clientId": "admin-api"
  },
  {
    "clientId": "admin-cli"
  },
  {
    "clientId": "broker"
  },
  {
    "clientId": "custom-client1"
  },
  {
    "clientId": "realm-management"
  },
  {
    "clientId": "security-admin-console"
  }
]
```