### PR TITLE
Upgrade to Quarkus 3.24.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.24.2</quarkus.version>
+        <quarkus.version>3.24.3</quarkus.version>
         <quarkus.build.version>3.24.2</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 


### PR DESCRIPTION
Closes #41172

Executed script `./set-quarkus-version.sh 3.24.3`