### PR TITLE
Fix client scope assigned type test

### DIFF
--- a/js/apps/admin-ui/src/clients/scopes/ClientScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/ClientScopes.tsx
@@ -253,7 +253,7 @@ export const ClientScopes = ({
       <KeycloakDataTable
         key={key}
         loader={loader}
-        ariaLabelKey={`clientScopeList-${key}`}
+        ariaLabelKey="clientScopeList"
         searchPlaceholderKey={
           searchType === "name" ? "searchByName" : undefined
         }

--- a/js/apps/admin-ui/test/client-scope/main.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/main.spec.ts
@@ -8,6 +8,7 @@ import { confirmModal } from "../utils/modal";
 import { goToClientScopes } from "../utils/sidebar";
 import {
   assertRowExists,
+  assertTableRowsLength,
   clickNextPageButton,
   clickRowKebabItem,
   clickSelectRow,
@@ -83,8 +84,7 @@ test.describe("Client Scopes test", () => {
       const itemName = clientScopeName + "0";
       await searchItem(page, placeHolder, itemName);
       await assertRowExists(page, itemName);
-      const rows = await getTableData(page, tableName);
-      expect(rows.length).toBe(1);
+      await assertTableRowsLength(page, tableName, 1);
     });
 
     test("should filter items by Assigned type Default", async ({ page }) => {

--- a/js/apps/admin-ui/test/clients/scope.spec.ts
+++ b/js/apps/admin-ui/test/clients/scope.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
-import adminClient from "../utils/AdminClient";
 import { selectChangeType } from "../client-scope/main";
+import adminClient from "../utils/AdminClient";
 import { login } from "../utils/login";
 import { assertNotificationMessage } from "../utils/masthead";
 import { assertModalTitle, confirmModal } from "../utils/modal";
@@ -9,6 +9,7 @@ import { goToClients, goToRealm } from "../utils/sidebar";
 import {
   assertEmptyTable,
   assertRowExists,
+  assertTableRowsLength,
   clickNextPageButton,
   clickRowKebabItem,
   clickSelectRow,
@@ -53,7 +54,7 @@ test.describe("Client details - Client scopes subtab", () => {
   const msgScopeMappingRemoved = "Scope mapping successfully removed";
   const realmName = `clients-realm-${uuid()}`;
   const placeHolder = "Search by name";
-  const tableName = "clientScopeList-0";
+  const tableName = "Client scopes";
 
   const clientScope: ClientScope = {
     name: clientScopeName,
@@ -110,8 +111,7 @@ test.describe("Client details - Client scopes subtab", () => {
   test("Should search existing client scope by name", async ({ page }) => {
     await searchItem(page, placeHolder, clientScopeName + "0");
     await assertRowExists(page, clientScopeName + "0");
-    const rows = await getTableData(page, tableName);
-    expect(rows.length).toBe(1);
+    await assertTableRowsLength(page, tableName, 1);
   });
 
   test("Should search non-existent client scope by name", async ({ page }) => {
@@ -141,10 +141,11 @@ test.describe("Client details - Client scopes subtab", () => {
     page,
   }) => {
     await searchItem(page, placeHolder, itemName);
-    await clickSelectRow(page, "clientScopeList-0", itemName);
+    await clickSelectRow(page, tableName, itemName);
     await selectChangeType(page, "Default");
     await assertNotificationMessage(page, "Scope mapping updated");
     await searchItem(page, placeHolder, itemName);
+    await assertTableRowsLength(page, tableName, 1);
     await assertTableCellDropdownValue(page, "Default");
     await assertRowExists(page, itemName);
   });

--- a/js/apps/admin-ui/test/utils/table.ts
+++ b/js/apps/admin-ui/test/utils/table.ts
@@ -67,12 +67,8 @@ export async function clickTableToolbarItem(
 }
 
 export async function getTableData(page: Page, name: string) {
-  const table = page
-    .getByRole("grid")
-    .and(page.getByLabel(name, { exact: true }));
-  await table.locator("tbody").waitFor();
-  const rows = await table.locator("tbody tr").elementHandles();
-
+  const rowsLocator = await getTableRows(page, name);
+  const rows = await rowsLocator.elementHandles();
   const tableData = await Promise.all(
     rows.map(async (row) => {
       const cells = await row.$$("td");
@@ -80,6 +76,23 @@ export async function getTableData(page: Page, name: string) {
     }),
   );
   return tableData;
+}
+
+export async function assertTableRowsLength(
+  page: Page,
+  name: string,
+  length: number,
+): Promise<void> {
+  const rows = await getTableRows(page, name);
+  await expect(rows).toHaveCount(length);
+}
+
+async function getTableRows(page: Page, name: string): Promise<Locator> {
+  const table = page
+    .getByRole("grid")
+    .and(page.getByLabel(name, { exact: true }));
+  await table.locator("tbody").waitFor();
+  return table.locator("tbody tr");
 }
 
 export async function clickNextPageButton(page: Page) {


### PR DESCRIPTION
Fixes a test that reliably fails locally, and introduces a new utility function to reliably assert the length of a table, including auto-awaiting. This incidentally fixes a bug where the label for the client scope table was not applied properly, as it was somehow tied to the 'refresh key', which made no sense.

Closes #41195

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
