### PR TITLE
Only view svc acct users on exact search

### DIFF
--- a/js/apps/admin-ui/src/components/users/UserDataTable.tsx
+++ b/js/apps/admin-ui/src/components/users/UserDataTable.tsx
@@ -126,7 +126,7 @@ export function UserDataTable() {
   const [searchType, setSearchType] = useState<SearchType>("default");
   const [searchDropdownOpen, setSearchDropdownOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<UserFilter>({
-    exact: true,
+    exact: false,
     userAttribute: [],
   });
   const [profile, setProfile] = useState<UserProfileConfig>({});
@@ -170,7 +170,7 @@ export function UserDataTable() {
       params.search = searchParam;
     }
 
-    params.exact = activeFilters.exact;
+    if (activeFilters.exact) params.exact = true;
 
     if (!listUsers && !(params.search || params.q)) {
       return [];
@@ -238,7 +238,7 @@ export function UserDataTable() {
   const listUsers = !uiRealmInfo.userProfileProvidersEnabled;
 
   const clearAllFilters = () => {
-    setActiveFilters({ exact: true, userAttribute: [] });
+    setActiveFilters({ exact: false, userAttribute: [] });
     setSearchUser("");
     setQuery("");
     refresh();


### PR DESCRIPTION
Fixes #41103 

Search for service account users was accidentally triggered when we added the `exact` search feature.  But including that parameter (true or false) in the search would trigger a search that includes service account users.

Now you only see service account users if you are really doing an exact search for it.
