### PR TITLE
Stabilize flow duplication modal to avoid test failures

### DIFF
--- a/js/apps/admin-ui/src/authentication/AuthenticationSection.tsx
+++ b/js/apps/admin-ui/src/authentication/AuthenticationSection.tsx
@@ -133,10 +133,10 @@ export default function AuthenticationSection() {
   return (
     <>
       <DeleteConfirm />
-      {open && (
+      {open && selectedFlow && (
         <DuplicateFlowModal
-          name={selectedFlow ? selectedFlow.alias! : ""}
-          description={selectedFlow?.description!}
+          name={selectedFlow.alias!}
+          description={selectedFlow.description!}
           toggleDialog={toggleOpen}
           onComplete={() => {
             refresh();

--- a/js/apps/admin-ui/src/authentication/DuplicateFlowModal.tsx
+++ b/js/apps/admin-ui/src/authentication/DuplicateFlowModal.tsx
@@ -7,7 +7,6 @@ import {
   Modal,
   ModalVariant,
 } from "@patternfly/react-core";
-import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -33,16 +32,17 @@ export const DuplicateFlowModal = ({
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
-  const form = useForm<AuthenticationFlowRepresentation>({ mode: "onChange" });
-  const { setValue, getValues, handleSubmit } = form;
+  const form = useForm<AuthenticationFlowRepresentation>({
+    mode: "onChange",
+    defaultValues: {
+      alias: t("copyOf", { name }),
+      description: description,
+    },
+  });
+  const { getValues, handleSubmit } = form;
   const { addAlert, addError } = useAlerts();
   const navigate = useNavigate();
   const { realm } = useRealm();
-
-  useEffect(() => {
-    setValue("alias", t("copyOf", { name }));
-    setValue("description", description);
-  }, [name, description]);
 
   const onSubmit = async () => {
     const form = getValues();

--- a/js/apps/admin-ui/src/authentication/FlowDetails.tsx
+++ b/js/apps/admin-ui/src/authentication/FlowDetails.tsx
@@ -329,10 +329,10 @@ export default function FlowDetails() {
           }}
         />
       )}
-      {open && (
+      {open && flow && (
         <DuplicateFlowModal
-          name={flow?.alias!}
-          description={flow?.description!}
+          name={flow.alias!}
+          description={flow.description!}
           toggleDialog={toggleOpen}
           onComplete={() => {
             refresh();


### PR DESCRIPTION
Refactors the flow duplication modal so that the tests that verify its behavior pass consistently. Before a `useEffect()` was used to initialize the form state, however, this could cause the form value to change, even after the tests (or user) had started interacting with it. This has been changed to use the `defaultValue` of the form instead, which is only set on the initial mount.

Additionally, to prevent possibly nullish values from being passed to the duplication modal, the modal is now only mounted when the flow it is duplicating is retrieved.

Closes #41216

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
