### PR TITLE
Fix language switch on custom forms

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -389,6 +389,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         this.event.event(EventType.LOGIN);
         authenticationSession.setAuthNote(Details.AUTH_TYPE, CODE_AUTH_TYPE);
 
+        // evaluate the locale param, in order to support locale switch for all login pages (including custom pages)
+        LocaleUtil.processLocaleParam(session, realm, authenticationSession);
+
         return handleBrowserAuthenticationRequest(authenticationSession, new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event), TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE), false);
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -328,6 +328,16 @@ public class LoginActionsService {
 
         event.event(EventType.LOGIN);
 
+        /*
+         * evaluate the locale param, in order to support locale switch for all login pages
+         * (including custom pages and "expired page", which may be shown by SessionCodeChecks done below)
+         */
+        final var requestedClient = realm.getClientByClientId(clientId);
+        final var currentAuthSession =
+                new AuthenticationSessionManager(session).getCurrentAuthenticationSession(realm, requestedClient,
+                        tabId);
+        processLocaleParam(currentAuthSession);
+
         SessionCodeChecks checks = checksForCode(authSessionId, code, execution, clientId, tabId, clientData, AUTHENTICATE_PATH);
         if (!checks.verifyActiveAndValidAction(AuthenticationSessionModel.Action.AUTHENTICATE.name(), ClientSessionCode.ActionType.LOGIN)) {
             return checks.getResponse();
@@ -335,8 +345,6 @@ public class LoginActionsService {
 
         AuthenticationSessionModel authSession = checks.getAuthenticationSession();
         boolean actionRequest = checks.isActionRequest();
-
-        processLocaleParam(authSession);
 
         return processAuthentication(actionRequest, execution, authSession, null);
     }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/forms/ClickThroughAuthenticator.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/forms/ClickThroughAuthenticator.java
@@ -61,7 +61,8 @@ public class ClickThroughAuthenticator implements Authenticator, AuthenticatorFa
 
     @Override
     public void action(AuthenticationFlowContext context) {
-        if (context.getHttpRequest().getDecodedFormParameters().containsKey("cancel")) {
+        final var accepted = context.getHttpRequest().getDecodedFormParameters().containsKey("accept");
+        if (!accepted) {
             authenticate(context);
             return;
         }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AbstractPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AbstractPage.java
@@ -22,6 +22,10 @@ import org.junit.Assert;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.openqa.selenium.WebDriver;
 
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -42,7 +46,15 @@ public abstract class AbstractPage {
     abstract public boolean isCurrent();
 
     public boolean isCurrent(String expectedTitle) {
-        return PageUtils.getPageTitle(driver).equals(expectedTitle);
+        return Objects.equals(getPageTitle(), expectedTitle);
+    }
+
+    public void assertPageTitle(final String expectedTitle) {
+        assertEquals(expectedTitle, getPageTitle());
+    }
+
+    private String getPageTitle() {
+        return PageUtils.getPageTitle(driver);
     }
 
     public void setDriver(WebDriver driver) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/TermsAndConditionsPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/TermsAndConditionsPage.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.support.FindBy;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class TermsAndConditionsPage extends AbstractPage {
+public class TermsAndConditionsPage extends LanguageComboboxAwarePage {
 
     @FindBy(id = "kc-accept")
     private WebElement submitButton;


### PR DESCRIPTION
- FreeMarkerLoginFormsProvider
  - extract helper methods to build the locale bean (see #createLocaleBean), in order to reduce cyclomatic complexity
  - introduce new logic for custom forms in new method #createCustomFormLocaleUrlBuilder (with separate logic for "../login-actions" urls and other URLs such as authorization endpoint URL)
- AuthorizationEndpoint#buildAuthorizationCodeAuthorizationResponse: add call to processLocaleParam, to make sure that locale switch is also evaluated for custom forms
- LoginActionsService#authenticate: move up the call to processLocaleParam, to support localization of "expired page"
- add test CustomFlowTest#customAuthenticatorLocalization
- Adjust test class ClickThroughAuthenticator to succeed only when "accept" has been clicked (before the check was that "decline" has NOT been clicked) - otherwise locale switch does not work as expected

Closes #16063

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
