### PR TITLE
Temporarily disable UpdateTest.testCacheMaxCount for Local API server

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/UpdateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/UpdateTest.java
@@ -87,6 +87,7 @@ public class UpdateTest extends BaseOperatorTest {
         }
     }
 
+    @DisabledIfApiServerTest // ignore for now as it is very unstable - see https://github.com/keycloak/keycloak/pull/41252 for more details
     @ParameterizedTest(name = "testCacheMaxCount-{0}")
     @EnumSource(UpdateStrategy.class)
     public void testCacheMaxCount(UpdateStrategy updateStrategy) throws InterruptedException {


### PR DESCRIPTION
Relates to: https://github.com/keycloak/keycloak/issues/41204

It should be temporarily disabled for now as it causes a lot of trouble in CI.

For now, the UpdateTest fails only for the `testCacheMaxCount` and not for the one described in the parent issue.

@shawkins Could you check it? 

