### PR TITLE
fix: adding group import handling similar to users

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
@@ -149,7 +149,7 @@ public class DefaultExportImportManager implements ExportImportManager {
     private final KeycloakSession session;
     private static final Logger logger = Logger.getLogger(DefaultExportImportManager.class);
 
-    public static class UserBatcher implements Consumer<KeycloakSession> {
+    public static class Batcher implements Consumer<KeycloakSession> {
         private int count;
 
         @Override
@@ -463,7 +463,7 @@ public class DefaultExportImportManager implements ExportImportManager {
             // run in a batch to mimic the behavior of directory based import
             // this is using nested entity managers to keep the parent context clean
             EntityManagers.runInBatch(session, () -> {
-                UserBatcher onUserAdded = new UserBatcher();
+                Batcher onUserAdded = new Batcher();
                 if (rep.getUsers() != null) {
                     for (UserRepresentation userRep : rep.getUsers()) {
                         createUser(newRealm, userRep);
@@ -789,10 +789,10 @@ public class DefaultExportImportManager implements ExportImportManager {
         if (rep.isPermanentLockout() != null) realm.setPermanentLockout(rep.isPermanentLockout());
         if (rep.getMaxTemporaryLockouts() != null) realm.setMaxTemporaryLockouts(checkNonNegativeNumber(rep.getMaxTemporaryLockouts(),"Maximum temporary lockouts"));
         if (rep.getBruteForceStrategy() != null) realm.setBruteForceStrategy(rep.getBruteForceStrategy());
-        if (rep.getMaxFailureWaitSeconds() != null) realm.setMaxFailureWaitSeconds(checkNonNegativeNumber(rep.getMaxFailureWaitSeconds(),"Maximum failure wait seconds")); 
+        if (rep.getMaxFailureWaitSeconds() != null) realm.setMaxFailureWaitSeconds(checkNonNegativeNumber(rep.getMaxFailureWaitSeconds(),"Maximum failure wait seconds"));
         if (rep.getMinimumQuickLoginWaitSeconds() != null) realm.setMinimumQuickLoginWaitSeconds(checkNonNegativeNumber(rep.getMinimumQuickLoginWaitSeconds(),"Minimum quick login wait seconds"));
-        if (rep.getWaitIncrementSeconds() != null) realm.setWaitIncrementSeconds(checkNonNegativeNumber(rep.getWaitIncrementSeconds(),"Wait increment seconds")); 
-        if (rep.getQuickLoginCheckMilliSeconds() != null) realm.setQuickLoginCheckMilliSeconds(checkNonNegativeNumber(rep.getQuickLoginCheckMilliSeconds().intValue(), "Quick login check milliseconds")); 
+        if (rep.getWaitIncrementSeconds() != null) realm.setWaitIncrementSeconds(checkNonNegativeNumber(rep.getWaitIncrementSeconds(),"Wait increment seconds"));
+        if (rep.getQuickLoginCheckMilliSeconds() != null) realm.setQuickLoginCheckMilliSeconds(checkNonNegativeNumber(rep.getQuickLoginCheckMilliSeconds().intValue(), "Quick login check milliseconds"));
         if (rep.getMaxDeltaTimeSeconds() != null) realm.setMaxDeltaTimeSeconds(checkNonNegativeNumber(rep.getMaxDeltaTimeSeconds(),"Maximum delta time seconds"));
         if (rep.getFailureFactor() != null) realm.setFailureFactor(checkNonNegativeNumber(rep.getFailureFactor(),"Failure factor"));
         if (rep.isRegistrationAllowed() != null) realm.setRegistrationAllowed(rep.isRegistrationAllowed());
@@ -1251,14 +1251,20 @@ public class DefaultExportImportManager implements ExportImportManager {
         }
     }
 
-    public static void importGroups(RealmModel realm, RealmRepresentation rep) {
+    public void importGroups(RealmModel realm, RealmRepresentation rep) {
         List<GroupRepresentation> groups = rep.getGroups();
         if (groups == null) return;
 
-        GroupModel parent = null;
-        for (GroupRepresentation group : groups) {
-            importGroup(realm, parent, group);
-        }
+
+        EntityManagers.runInBatch(session, () -> {
+            Batcher batcher = new Batcher();
+            GroupModel parent = null;
+            for (GroupRepresentation group : groups) {
+                importGroup(realm, parent, group);
+                batcher.accept(session);
+            }
+        }, true);
+
     }
 
     private static WebAuthnPolicy getWebAuthnPolicyTwoFactor(RealmRepresentation rep) {

--- a/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirImportProvider.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirImportProvider.java
@@ -167,7 +167,7 @@ public class DirImportProvider extends AbstractFileBasedImportProvider {
                     @Override
                     protected void runExportImportTask(KeycloakSession session) throws IOException {
                         session.getContext().setRealm(session.realms().getRealmByName(realmName));
-                        ImportUtils.importUsersFromStream(session, realmName, JsonSerialization.mapper, fis, federated, new DefaultExportImportManager.UserBatcher());
+                        ImportUtils.importUsersFromStream(session, realmName, JsonSerialization.mapper, fis, federated, new DefaultExportImportManager.Batcher());
                         logger.infof("Imported %susers from %s", federated?"federated ":"", userFile.getAbsolutePath());
                     }
                 }.runTask(factory, Mode.BATCHED);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -68,6 +68,7 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.common.util.UriUtils;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.connections.jpa.support.EntityManagers;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.deployment.DeployedConfigurationsManager;
 import org.keycloak.migration.migrators.MigrationUtils;
@@ -130,6 +131,7 @@ import org.keycloak.representations.idm.authorization.ResourceServerRepresentati
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.KeycloakSessionUtil;
 import org.keycloak.utils.StringUtil;
 
 import static java.util.Optional.ofNullable;

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -68,7 +68,6 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.common.util.UriUtils;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.connections.jpa.support.EntityManagers;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.deployment.DeployedConfigurationsManager;
 import org.keycloak.migration.migrators.MigrationUtils;
@@ -131,7 +130,6 @@ import org.keycloak.representations.idm.authorization.ResourceServerRepresentati
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.util.JsonSerialization;
-import org.keycloak.utils.KeycloakSessionUtil;
 import org.keycloak.utils.StringUtil;
 
 import static java.util.Optional.ofNullable;


### PR DESCRIPTION
closes: #41235

Basically anything that pushes the size of the persistence context beyond a couple thousand items will cause performance to drop dramatically. Users were the most obvious case of this, but here it was due to groups.

This seems like the narrowest fix for group import performance. Like the user import performance test, I can include one that imports several thousand groups if that seems like a good idea.

It was mentioned in some of the initial work that got rid of using multiple transactions that we could eventually try to align with the other batching logic - which implicitly is doing a flush and clear of the context. Pursuing that more broadly is still a possible alternative but requires a good deal more care.

The only other alternative is doing something like escape analysis to figure out when entities can be flushed / detached - but that breaks how the logic is encapsulated even more than using the static EntityManagers calls.

@ahus1 @pedroigor 

cc @gryffus

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
