### PR TITLE
Allow to sort users by attribute

### DIFF
--- a/federation/ipatuura/src/main/java/org/keycloak/ipatuura_user_spi/IpatuuraUserStorageProvider.java
+++ b/federation/ipatuura/src/main/java/org/keycloak/ipatuura_user_spi/IpatuuraUserStorageProvider.java
@@ -287,7 +287,7 @@ public class IpatuuraUserStorageProvider implements UserStorageProvider, UserLoo
 
     @Override
     public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult,
-            Integer maxResults) {
+            Integer maxResults, String sortBy) {
         String search = params.get(UserModel.SEARCH);
         /* only supports searching by username */
         if (search == null)

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -82,6 +82,7 @@ import org.keycloak.storage.adapter.UpdateOnlyChangeUserModelDelegate;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.Condition;
+import org.keycloak.storage.ldap.idm.query.Sort;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQueryConditionsBuilder;
 import org.keycloak.storage.ldap.idm.store.ldap.LDAPIdentityStore;
@@ -385,11 +386,11 @@ public class LDAPStorageProvider implements UserStorageProvider,
      * <em>getUserAttributes</em>).
      */
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults, String sortBy) {
         String search = params.get(UserModel.SEARCH);
         Stream<LDAPObject> result = search != null ?
-                searchLDAP(realm, search, firstResult, maxResults) :
-                searchLDAPByAttributes(realm, params, firstResult, maxResults);
+                searchLDAP(realm, search, firstResult, maxResults, sortBy) :
+                searchLDAPByAttributes(realm, params, firstResult, maxResults, sortBy);
 
         if (model.isImportEnabled()) {
             result = result.filter(filterLocalUsers(realm));
@@ -527,7 +528,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
      * mappers then empty stream is returned (the attribute is not mapped
      * into ldap, therefore no ldap user can have the specified value).
      */
-    private Stream<LDAPObject> searchLDAPByAttributes(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults) {
+    private Stream<LDAPObject> searchLDAPByAttributes(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults, String sortBy) {
         // get the attributes that are managed by the configured ldap mappers
         Set<String> managedAttrs = realm.getComponentsStream(model.getId(), LDAPStorageMapper.class.getName())
                 .map(mapperManager::getMapper)
@@ -539,6 +540,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
         try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm)) {
 
             LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
+            if (sortBy != null) {
+                ldapQuery.sortBy(new Sort(sortBy, true));
+            }
 
             for (Map.Entry<String, String> entry : attributes.entrySet()) {
                 String attrName = entry.getKey();
@@ -594,10 +598,14 @@ public class LDAPStorageProvider implements UserStorageProvider,
      *
      * This method serves for {@code search} param of {@link org.keycloak.services.resources.admin.UsersResource#getUsers}
      */
-    private Stream<LDAPObject> searchLDAP(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
+    private Stream<LDAPObject> searchLDAP(RealmModel realm, String search, Integer firstResult, Integer maxResults, String sortBy) {
 
         try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm)) {
             LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
+
+            if (sortBy != null) {
+                ldapQuery.sortBy(new Sort(sortBy, true));
+            }
 
             for (String s : search.split("\\s+")) {
                 boolean equals = false;

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -669,7 +669,7 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults, String sortBy) {
         return getDelegate().searchForUserStream(realm, attributes, firstResult, maxResults).map(u -> returnFromCacheIfPresent(realm, u));
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -796,7 +796,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
 
     @Override
     @SuppressWarnings("unchecked")
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults, String sortBy) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
         CriteriaQuery<UserEntity> queryBuilder = builder.createQuery(UserEntity.class);
         Root<UserEntity> root = queryBuilder.from(UserEntity.class);
@@ -808,7 +808,11 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
 
         predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.USERS, this, realm, builder, queryBuilder, root));
 
-        queryBuilder.distinct(true).where(predicates.toArray(Predicate[]::new)).orderBy(builder.asc(root.get(UserModel.USERNAME)));
+        if (sortBy == null) {
+            sortBy = UserModel.USERNAME;
+        }
+
+        queryBuilder.distinct(true).where(predicates.toArray(Predicate[]::new)).orderBy(builder.asc(root.get(sortBy)));
 
         TypedQuery<UserEntity> query = em.createQuery(queryBuilder);
 

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -592,7 +592,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults, String sortBy) {
         Stream<UserModel> results = query((provider, firstResultInQuery, maxResultsInQuery) -> {
             if (provider instanceof UserQueryMethodsProvider) {
                 return ((UserQueryMethodsProvider)provider).searchForUserStream(realm, attributes, firstResultInQuery, maxResultsInQuery);

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryMethodsProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryMethodsProvider.java
@@ -138,7 +138,42 @@ public interface UserQueryMethodsProvider {
      * @param maxResults  maximum number of results to return. Ignored if negative or {@code null}.
      * @return a non-null {@link Stream} of users that match the search criteria.
      */
-    Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults);
+    default Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
+        return searchForUserStream(realm, params, firstResult, maxResults, null);
+    }
+
+    /**
+     * Searches for user by parameter. If possible, implementations should treat the parameter values as partial match patterns
+     * (i.e. in RDMBS terms use LIKE).
+     * <p/>
+     * Valid parameters are:
+     * <ul>
+     *     <li>{@link UserModel#SEARCH} - search for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace, when {@code SEARCH} is set all other params are ignored</li>
+     *     <li>{@link UserModel#FIRST_NAME} - first name (case insensitive string)</li>
+     *     <li>{@link UserModel#LAST_NAME} - last name (case insensitive string)</li>
+     *     <li>{@link UserModel#EMAIL} - email (case insensitive string)</li>
+     *     <li>{@link UserModel#USERNAME} - username (case insensitive string)</li>
+     *     <li>{@link UserModel#EXACT} - whether search with FIRST_NAME, LAST_NAME, USERNAME or EMAIL should be exact match</li>
+     *     <li>{@link UserModel#EMAIL_VERIFIED} - search only for users with verified/non-verified email (true/false)</li>
+     *     <li>{@link UserModel#ENABLED} - search only for enabled/disabled users (true/false)</li>
+     *     <li>{@link UserModel#IDP_ALIAS} - search only for users that have a federated identity
+     *     from idp with the given alias configured (case sensitive string)</li>
+     *     <li>{@link UserModel#IDP_USER_ID} - search for users with federated identity with
+     *     the given userId (case sensitive string)</li>
+     * </ul>
+     * <p>
+     * Any other parameters will be treated as custom user attributes.
+     * <p>
+     * This method is used by the REST API when querying users.
+     *
+     * @param realm       a reference to the realm.
+     * @param params      a map containing the search parameters.
+     * @param firstResult first result to return. Ignored if negative, zero, or {@code null}.
+     * @param maxResults  maximum number of results to return. Ignored if negative or {@code null}.
+     * @param sortBy      specifies which attribute to sort by
+     * @return a non-null {@link Stream} of users that match the search criteria.
+     */
+    Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults, String sortBy);
 
     /**
      * Obtains users that belong to a specific group.

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -261,6 +261,7 @@ public class UsersResource {
      * @param briefRepresentation Boolean which defines whether brief representations are returned (default: false)
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param sortBy A string which specifies which attribute to sort by
      * @return a non-null {@code Stream} of users
      */
     @GET
@@ -286,7 +287,8 @@ public class UsersResource {
             @Parameter(description = "Boolean representing if user is enabled or not") @QueryParam("enabled") Boolean enabled,
             @Parameter(description = "Boolean which defines whether brief representations are returned (default: false)") @QueryParam("briefRepresentation") Boolean briefRepresentation,
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
-            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery) {
+            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
+            @Parameter(description = "A string which specifies which attribute to sort by") String sortBy) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
 
         userPermissionEvaluator.requireQuery();
@@ -317,7 +319,7 @@ public class UsersResource {
                 }
 
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                        maxResults, false);
+                        maxResults, false, sortBy);
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
                 || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()) {
@@ -353,10 +355,10 @@ public class UsersResource {
                     attributes.putAll(searchAttributes);
 
                     return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                            maxResults, true);
+                            maxResults, true, sortBy);
                 } else {
                     return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
-                            firstResult, maxResults, false);
+                            firstResult, maxResults, false, sortBy);
                 }
 
         return toRepresentation(realm, userPermissionEvaluator, briefRepresentation, userModels);
@@ -510,7 +512,7 @@ public class UsersResource {
         return new UserProfileResource(session, auth, adminEvent);
     }
 
-    private Stream<UserRepresentation> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {
+    private Stream<UserRepresentation> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts, String sortBy) {
         attributes.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.toString());
 
         if (Profile.isFeatureEnabled(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ)) {
@@ -520,7 +522,7 @@ public class UsersResource {
             }
         }
 
-        return toRepresentation(realm, usersEvaluator, briefRepresentation, session.users().searchForUserStream(realm, attributes, firstResult, maxResults));
+        return toRepresentation(realm, usersEvaluator, briefRepresentation, session.users().searchForUserStream(realm, attributes, firstResult, maxResults, sortBy));
     }
 
     private Stream<UserRepresentation> toRepresentation(RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Stream<UserModel> userModels) {

--- a/tests/custom-providers/src/main/java/org/keycloak/testsuite/federation/UserMapStorage.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/testsuite/federation/UserMapStorage.java
@@ -303,7 +303,7 @@ public class UserMapStorage implements UserLookupProvider, UserStorageProvider, 
     }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults, String sortBy) {
         Stream<String> userStream = userPasswords.keySet().stream()
           .sorted();
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
@@ -392,7 +392,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults, String sortBy) {
         return searchForUserStream(realm, params.get(UserModel.SEARCH), firstResult, maxResults);
     }
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
@@ -246,7 +246,7 @@ public class FailableHardcodedStorageProvider implements UserStorageProvider, Us
     }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults, String sortBy) {
         checkForceFail();
         if (!username.equals(params.get("username")))return Stream.empty();
         UserModel model = getUserByUsername(realm, username);

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserMapStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserMapStorage.java
@@ -313,7 +313,7 @@ public class UserMapStorage implements UserLookupProvider, UserStorageProvider, 
     }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults, String sortBy) {
         Stream<String> userStream = userPasswords.keySet().stream()
           .sorted();
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserPropertyFileStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserPropertyFileStorage.java
@@ -112,7 +112,7 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
         addCall(COUNT_SEARCH_METHOD);
 
         String search = params.get(UserModel.SEARCH);
-        return (int) searchForUser(realm, search, null, null, username -> search == null || username.contains(search)).count();
+        return (int) searchForUser(realm, search, null, null, username -> search == null || username.contains(search), null).count();
     }
 
     @Override
@@ -230,7 +230,7 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
 //    }
 
     @Override
-    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults, String sortBy) {
         addCall(SEARCH_METHOD, firstResult, maxResults);
         String search = Optional.ofNullable(attributes.get(UserModel.USERNAME))
                 .orElseGet(()-> attributes.get(UserModel.SEARCH));
@@ -242,7 +242,7 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
                     ? username -> username.equals(search)
                     : username -> username.contains(search);
         }
-        return searchForUser(realm, search, firstResult, maxResults, p);
+        return searchForUser(realm, search, firstResult, maxResults, p, sortBy);
     }
 
     @Override
@@ -265,11 +265,19 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
 
     }
 
-    private Stream<UserModel> searchForUser(RealmModel realm, String search, Integer firstResult, Integer maxResults, Predicate<String> matcher) {
+    private Stream<UserModel> searchForUser(RealmModel realm, String search, Integer firstResult, Integer maxResults, Predicate<String> matcher, String sortBy) {
         if (maxResults != null && maxResults == 0) return Stream.empty();
         return paginatedStream(userPasswords.keySet().stream(), firstResult, maxResults)
                 .map(String.class::cast)
                 .filter(matcher)
-                .map(username -> createUser(realm, username));
+                .map(username -> createUser(realm, username))
+                .sorted((u1, u2) -> {
+                    if (sortBy == null) {
+                        return 0;
+                    }
+                    String p1 = u1.getFirstAttribute(sortBy);
+                    String p2 = u2.getFirstAttribute(sortBy);
+                    return p1.compareTo(p2);
+                });
     }
 }


### PR DESCRIPTION
This extends the API to sort by the specified attribute. Currently the sorting is done by the username and cannot be changed. This draft pull request serves to gather feedback on the API design.

TODO:
- [ ] How should the API look like for ascending and descending sorting
- [ ] How to handle errors when a non existing field was specified
- [ ] How to handle custom user attributes
- [ ] Extend tests

Related #14189