### PR TITLE
Fix broken localization tests on Firefox

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -12,3 +12,8 @@ dist
 
 # NPM
 node_modules
+
+# Playwright
+test-results
+playwright-report
+playwright/.cache

--- a/js/apps/account-ui/.gitignore
+++ b/js/apps/account-ui/.gitignore
@@ -1,5 +1,2 @@
-/test-results/
-/playwright-report/
-/playwright/.cache/
 .auth/
 lib/

--- a/js/apps/admin-ui/test/realm-settings/localization.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/localization.spec.ts
@@ -51,7 +51,7 @@ test.describe("Go to localization tab", () => {
     test("Realm Overrides - Add and delete bundle", async ({ page }) => {
       await addBundle(page, "key", "123");
       await clickCreateButton(page);
-      await addBundle(page, "value", "abc");
+      await addBundle(page, "foo", "abc");
       await clickCreateButton(page);
 
       await assertNotificationMessage(
@@ -87,7 +87,7 @@ test.describe("Go to localization tab", () => {
       const key = "edit";
       await addBundle(page, key, "123");
       await clickCreateButton(page);
-      await addBundle(page, "value", "abc");
+      await addBundle(page, "foo", "abc");
       await clickCreateButton(page);
 
       await assertNotificationMessage(


### PR DESCRIPTION
The tests fail because the `value` key being set overrides a key that is actually used by the table for a column header, making the assertion fail because multiple rows are returned instead of one. Additionally, this PR cleans up the `.gitignore` so temporary test files are not kept around.

Closes #41323

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
