### PR TITLE
Disable webauthn buttons after click

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.util;
 import org.jboss.arquillian.graphene.wait.ElementBuilder;
 import org.keycloak.executors.ExecutorsProvider;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
+import org.keycloak.testsuite.pages.AbstractPage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
@@ -89,6 +90,12 @@ public final class WaitUtils {
         new WebDriverWait(getCurrentDriver(), Duration.ofSeconds(1)).until(
                 ExpectedConditions.attributeContains(element, "class", value)
         );
+    }
+
+    public static void waitUntilPageIsCurrent(AbstractPage page) {
+        WebDriver driver = getCurrentDriver();
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofMillis(PAGELOAD_TIMEOUT_MILLIS));
+        wait.until((WebDriver driver1) -> page.isCurrent());
     }
 
     public static void pause(long millis) {

--- a/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
@@ -114,7 +114,7 @@
             };
             authButton.addEventListener("click", () => {
                 authenticateByWebAuthn(input);
-            });
+            }, { once: true });
 
             const args = {
                 isUserIdentified : ${isUserIdentified},

--- a/themes/src/main/resources/theme/base/login/passkeys.ftl
+++ b/themes/src/main/resources/theme/base/login/passkeys.ftl
@@ -33,7 +33,7 @@
                authButton.addEventListener("click", (event) => {
                    event.preventDefault();
                    authenticateByWebAuthn({errmsg : "${msg("webauthn-unsupported-browser-text")?no_esc}", ...args});
-               });
+               }, { once: true });
            }
         </script>
         <a id="authenticateWebAuthnButton" href="#" class="${properties.kcButtonSecondaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcMarginTopClass!}">

--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -89,7 +89,7 @@
                 errmsg : "${msg("webauthn-unsupported-browser-text")?no_esc}"
             };
             authenticateByWebAuthn(input);
-        });
+        }, { once: true });
     </script>
 
     <#elseif section = "info">

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -43,7 +43,7 @@
                     errmsg : "${msg("webauthn-unsupported-browser-text")?no_esc}"
                 };
                 registerByWebAuthn(input);
-            });
+            }, { once: true });
         </script>
 
         <input type="submit"

--- a/themes/src/main/resources/theme/keycloak.v2/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/webauthn-authenticate.ftl
@@ -116,7 +116,7 @@
                 errmsg : "${msg("webauthn-unsupported-browser-text")?no_esc}"
             };
             authenticateByWebAuthn(input);
-        });
+        }, { once: true });
     </script>
 
     <#elseif section = "info">

--- a/themes/src/main/resources/theme/keycloak.v2/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/webauthn-register.ftl
@@ -44,7 +44,7 @@
                     errmsg : "${msg("webauthn-unsupported-browser-text")?no_esc}"
                 };
                 registerByWebAuthn(input);
-            });
+            },  { once: true });
         </script>
 
             <@buttons.actionGroup horizontal=true>


### PR DESCRIPTION
Closes #41037

In windows there are issues if the webauthn buttons or links (registration and authentication) are double clicked fast. The idea is the button is just for one one-click. When it's clicked the webauthn form is always submitted with the success or the error to the server and the page is refreshed. I'm changing from the initial `disabled=true` idea presented by the reporter to use `{ once : true }`. The `disabled` solution does not work for links (`<a>` elements), which are used for the authentication part in passkeys (we have a mix of buttons and links).

The modified test is because it doesn't work OK now or before. Previously it returned the `a request is already pending` message because the first registration hung, and clicking the button again returned the error we are avoiding now with this PR. Now the button does nothing when clicked, and I just added a timeout to make it fail. The correct usage for that test is that the selenium webauthn authenticator should return an error saying that it is not possible to create a key with those settings (but it seems that selenium has a bug or similar).
