### PR TITLE
Fix add/del bundle test

### DIFF
--- a/js/apps/admin-ui/test/realm-settings/localization.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/localization.spec.ts
@@ -49,7 +49,7 @@ test.describe("Go to localization tab", () => {
     });
 
     test("Realm Overrides - Add and delete bundle", async ({ page }) => {
-      await addBundle(page, "key", "123");
+      await addBundle(page, "bar", "123");
       await clickCreateButton(page);
       await addBundle(page, "foo", "abc");
       await clickCreateButton(page);
@@ -59,8 +59,8 @@ test.describe("Go to localization tab", () => {
         "Success! The translation has been added.",
       );
 
-      await assertRowExists(page, "key");
-      await clickRowKebabItem(page, "key", "Delete");
+      await assertRowExists(page, "bar");
+      await clickRowKebabItem(page, "bar", "Delete");
       await confirmModal(page);
       await assertNotificationMessage(
         page,


### PR DESCRIPTION
Fixes #41339

Test was finding two elements named "key", which lead to a strict violation.
