### PR TITLE
Disable tests for specific databases and servers in test framework

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/conditions/AbstractDisabledForSupplierCondition.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/conditions/AbstractDisabledForSupplierCondition.java
@@ -1,0 +1,47 @@
+package org.keycloak.testframework.conditions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.keycloak.testframework.injection.Extensions;
+import org.keycloak.testframework.injection.Supplier;
+import org.keycloak.testframework.injection.SupplierHelpers;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+
+abstract class AbstractDisabledForSupplierCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Extensions extensions = Extensions.getInstance();
+
+        Class<?> valueType = valueType();
+        String valueTypeAlias = extensions.getValueTypeAlias().getAlias(valueType);
+
+        Annotation annotation = getAnnotation(context, annotation());
+        String[] excludedSuppliers = SupplierHelpers.getAnnotationField(annotation, "value");
+
+        Supplier<?, ?> supplier = extensions.findSupplierByType(valueType);
+
+        boolean excluded = Arrays.asList(excludedSuppliers).contains(supplier.getAlias());
+
+        if (excluded) {
+            return ConditionEvaluationResult.disabled("Disabled for " + valueTypeAlias + " " + supplier.getAlias());
+        } else {
+            return ConditionEvaluationResult.enabled("Enabled for " + valueTypeAlias + " " + supplier.getAlias());
+        }
+    }
+
+    abstract Class<?> valueType();
+
+    abstract Class<? extends Annotation> annotation();
+
+    private <T extends Annotation> T getAnnotation(ExtensionContext context, Class<T> annotationClass) {
+        T[] annotations = context.getElement().get().getAnnotationsByType(annotationClass);
+        if (annotations.length == 0) {
+            annotations = context.getParent().get().getElement().get().getAnnotationsByType(annotationClass);
+        }
+        return annotations[0];
+    }
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForDatabases.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForDatabases.java
@@ -1,0 +1,19 @@
+package org.keycloak.testframework.conditions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith({DisabledForDatabasesCondition.class})
+public @interface DisabledForDatabases {
+
+    String[] value() default "";
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForDatabasesCondition.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForDatabasesCondition.java
@@ -1,0 +1,18 @@
+package org.keycloak.testframework.conditions;
+
+import org.keycloak.testframework.database.TestDatabase;
+
+import java.lang.annotation.Annotation;
+
+class DisabledForDatabasesCondition extends AbstractDisabledForSupplierCondition {
+
+    @Override
+    Class<?> valueType() {
+        return TestDatabase.class;
+    }
+
+    Class<? extends Annotation> annotation() {
+        return DisabledForDatabases.class;
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForServers.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForServers.java
@@ -1,0 +1,19 @@
+package org.keycloak.testframework.conditions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith({DisabledForDatabasesCondition.class})
+public @interface DisabledForServers {
+
+    String[] value() default "";
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForServersCondition.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/conditions/DisabledForServersCondition.java
@@ -1,0 +1,18 @@
+package org.keycloak.testframework.conditions;
+
+import org.keycloak.testframework.server.KeycloakServer;
+
+import java.lang.annotation.Annotation;
+
+class DisabledForServersCondition extends AbstractDisabledForSupplierCondition {
+
+    @Override
+    Class<?> valueType() {
+        return KeycloakServer.class;
+    }
+
+    Class<? extends Annotation> annotation() {
+        return DisabledForServers.class;
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/Extensions.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/Extensions.java
@@ -20,7 +20,20 @@ public class Extensions {
     private final List<Supplier<?, ?>> suppliers;
     private final List<Class<?>> alwaysEnabledValueTypes;
 
-    public Extensions() {
+    private static Extensions INSTANCE;
+
+    public static Extensions getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new Extensions();
+        }
+        return INSTANCE;
+    }
+
+    public static void reset() {
+        INSTANCE = null;
+    }
+
+    private Extensions() {
         List<TestFrameworkExtension> extensions = loadExtensions();
         valueTypeAlias = loadValueTypeAlias(extensions);
         Config.registerValueTypeAlias(valueTypeAlias);

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/Registry.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/Registry.java
@@ -22,7 +22,7 @@ public class Registry implements ExtensionContext.Store.CloseableResource {
     private final List<RequestedInstance<?, ?>> requestedInstances = new LinkedList<>();
 
     public Registry() {
-        extensions = new Extensions();
+        extensions = Extensions.getInstance();
         logger = new RegistryLogger(extensions.getValueTypeAlias());
     }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/SuiteSupport.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/SuiteSupport.java
@@ -15,6 +15,7 @@ public class SuiteSupport {
     public static void stopSuite() {
         SuiteConfigSource.clear();
         Config.initConfig();
+        Extensions.reset();
         suiteConfig = null;
     }
 

--- a/test-framework/core/src/test/java/org/keycloak/testframework/injection/RegistryTest.java
+++ b/test-framework/core/src/test/java/org/keycloak/testframework/injection/RegistryTest.java
@@ -26,6 +26,7 @@ public class RegistryTest {
         MockInstances.reset();
         MockParentSupplier.reset();
         MockChildSupplier.reset();
+        Extensions.reset();
         registry = new Registry();
     }
 
@@ -173,6 +174,7 @@ public class RegistryTest {
         try {
             Config.initConfig();
 
+            Extensions.reset();
             registry = new Registry();
             List<Supplier<?, ?>> suppliers = registry.getSuppliers();
             Assertions.assertEquals(1, suppliers.stream().filter(s -> s.getValueType().equals(MockParentValue.class)).count());
@@ -261,6 +263,7 @@ public class RegistryTest {
 
         try {
             Config.initConfig();
+            Extensions.reset();
             registry = new Registry();
             parentTest = new ParentTest();
             registry.beforeEach(parentTest);

--- a/tests/base/src/test/java/org/keycloak/tests/db/CaseSensitiveSchemaTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/db/CaseSensitiveSchemaTest.java
@@ -1,12 +1,12 @@
 package org.keycloak.tests.db;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.keycloak.admin.client.resource.RolesResource;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectTestDatabase;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.conditions.DisabledForDatabases;
 import org.keycloak.testframework.config.Config;
 import org.keycloak.testframework.database.DatabaseConfigBuilder;
 import org.keycloak.testframework.database.PostgresTestDatabase;
@@ -17,8 +17,9 @@ import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testsuite.util.RoleBuilder;
 
-@DisabledIfEnvironmentVariable(named = "KC_TEST_DATABASE", matches = "mssql", disabledReason = "MSSQL does not support setting the default schema per session")
 @KeycloakIntegrationTest(config = CaseSensitiveSchemaTest.KeycloakConfig.class)
+// MSSQL does not support setting the default schema per session
+@DisabledForDatabases("mssql")
 public class CaseSensitiveSchemaTest {
     @InjectTestDatabase(lifecycle = LifeCycle.CLASS, config = DatabaseConfigurator.class)
     TestDatabase db;

--- a/tests/base/src/test/java/org/keycloak/tests/db/PreserveSchemaCaseLiquibaseTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/db/PreserveSchemaCaseLiquibaseTest.java
@@ -1,8 +1,8 @@
 package org.keycloak.tests.db;
 
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.keycloak.testframework.annotations.InjectTestDatabase;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.conditions.DisabledForDatabases;
 import org.keycloak.testframework.database.DatabaseConfigBuilder;
 import org.keycloak.testframework.database.PostgresTestDatabase;
 import org.keycloak.testframework.database.TestDatabase;
@@ -10,9 +10,10 @@ import org.keycloak.testframework.injection.LifeCycle;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 
-@DisabledIfEnvironmentVariable(named = "KC_TEST_DATABASE", matches = "mssql", disabledReason = "MSSQL does not support setting the default schema per session")
-@DisabledIfEnvironmentVariable(named = "KC_TEST_DATABASE", matches = "oracle", disabledReason = "Oracle image does not support configuring user/databases with '-'")
 @KeycloakIntegrationTest(config = PreserveSchemaCaseLiquibaseTest.KeycloakConfig.class)
+// MSSQL does not support setting the default schema per session.
+// Oracle image does not support configuring user/databases with '-'
+@DisabledForDatabases({ "mssql", "oracle" })
 public class PreserveSchemaCaseLiquibaseTest extends CaseSensitiveSchemaTest {
 
     @InjectTestDatabase(lifecycle = LifeCycle.CLASS, config = DatabaseConfigurator.class)


### PR DESCRIPTION
`@DisabledIfEnvironmentVariable` approach doesn't always work as it's not a requirement that the database is specified with an environment variable. This PR provides a simpler way for tests and at the same time supports all mechanism for setting the database supplier, not just environment variables.

Not sure we need `@DisabledForServers`, but added it just in case that is useful, and also to make sure we have a sensible Abstract class to allow implementing multiple conditions for different supplier types.

Closes #41357

Signed-off-by: stianst <stianst@gmail.com>
