### PR TITLE
Update MariaDB connector to 3.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.2</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/39634

With this PR, we can verify all tests pass when we update the MariaDB connector on our side. Already in contact with Quarkus team to verify it on their end.

EDIT: After discussion with Quarkus team, we should be safe to update it on our end for now, and it will be part of the next 3.20.x patch release. For more info, see https://github.com/quarkusio/quarkus/pull/47053#issuecomment-3107402006