### PR TITLE
[26.2] Update MariaDB connector to 3.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <postgresql-jdbc.version>42.7.5</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.2</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->
@@ -605,6 +605,14 @@
                 <artifactId>nashorn-core</artifactId>
                 <version>${nashorn.version}</version>
             </dependency>
+
+            <!-- BEGIN Remove once org.mariadb.jdbc:mariadb-java-client:3.5.3 is part of Quarkus distribution. See https://github.com/keycloak/keycloak/issues/41371 -->
+            <dependency>
+                <groupId>org.mariadb.jdbc</groupId>
+                <artifactId>mariadb-java-client</artifactId>
+                <version>${mariadb-jdbc.version}</version>
+            </dependency>
+            <!-- END -->
 
             <!-- Twitter -->
             <dependency>


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/39634
- Wait for: https://github.com/keycloak/keycloak/pull/41360

For more details, see https://github.com/keycloak/keycloak/pull/41361