### PR TITLE
[26.0] Upgrade to Quarkus 3.15.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.15.5</quarkus.version>
-        <quarkus.build.version>3.15.5</quarkus.build.version>
+        <quarkus.version>3.15.6.1</quarkus.version>
+        <quarkus.build.version>3.15.6.1</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 
@@ -160,7 +160,7 @@
         <postgresql.version>16</postgresql.version>
         <aurora-postgresql.version>16.1</aurora-postgresql.version>
         <aws-jdbc-wrapper.version>2.3.1</aws-jdbc-wrapper.version>
-        <postgresql-jdbc.version>42.7.4</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
         <mariadb.version>10.11</mariadb.version>
         <mariadb-jdbc.version>3.4.1</mariadb-jdbc.version>
         <mssql.version>2022-latest</mssql.version>


### PR DESCRIPTION
- Closes #41366

Executed script: `./set-quarkus-version.sh 3.15.6.1`

We need to wait for RHBQ -> putting `hold` label