### PR TITLE
[26.3] MariaDB connector dependency is not properly overriden

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,14 @@
                 <version>${nashorn.version}</version>
             </dependency>
 
+            <!-- BEGIN Remove once org.mariadb.jdbc:mariadb-java-client:3.5.3 is part of Quarkus distribution. See https://github.com/keycloak/keycloak/issues/41371 -->
+            <dependency>
+                <groupId>org.mariadb.jdbc</groupId>
+                <artifactId>mariadb-java-client</artifactId>
+                <version>${mariadb-jdbc.version}</version>
+            </dependency>
+            <!-- END -->
+
             <!-- Twitter -->
             <dependency>
                 <groupId>org.twitter4j</groupId>


### PR DESCRIPTION
- Closes #41370

This is probably the least invasive, straightforward fix for the issue. 

Follow-up task once we have it in Quarkus by default: 
- https://github.com/keycloak/keycloak/issues/41373

Distribution JARs:
<img width="1509" height="100" alt="Screenshot From 2025-07-23 16-48-25" src="https://github.com/user-attachments/assets/4e96cb02-0e98-4fad-867f-40d6463f8f1d" />

<details>
<summary>Dependency report:</summary>

```
===================================================================================================
Dependency tree for org.mariadb.jdbc:mariadb-java-client
---------------------------------------------------------------------------------------------------
org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT
\- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
   \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak:keycloak-quarkus-server-deployment:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
      \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak:keycloak-quarkus-server-app:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
      \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak:keycloak-quarkus-dist:pom:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server-app:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
         \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
      \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
         \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-junit5-config:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-db-mariadb:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-db-mssql:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-db-mysql:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-db-oracle:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-db-postgres:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-email-server:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-ui:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-oauth:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-remote:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testframework:keycloak-test-framework-example-tests:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:test
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:test
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:test
org.keycloak.testframework:keycloak-test-framework-clustering:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.tests:keycloak-tests-utils:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
         \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.tests:keycloak-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:test
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:test
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:test
org.keycloak.tests:keycloak-tests-clustering:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:test
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:test
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:test
org.keycloak:keycloak-quarkus-integration-tests:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:test
         \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:test
org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT
\- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testsuite:integration-arquillian-servers-auth-server-undertow:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT:compile
   \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testsuite:integration-arquillian-servers-auth-server-quarkus:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-dist:zip:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server-app:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testsuite:integration-arquillian-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.testsuite:integration-arquillian-servers-auth-server-undertow:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT:compile
      \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak.testsuite:keycloak-model-test:jar:999.0.0-SNAPSHOT
\- org.keycloak.testsuite:integration-arquillian-tests-base:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testsuite:integration-arquillian-servers-auth-server-undertow:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT:compile
         \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak:keycloak-guides-maven-plugin:maven-plugin:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server-deployment:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
         \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
org.keycloak:keycloak-guides:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-guides-maven-plugin:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server-deployment:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-mariadb:jar:3.20.2:compile
            \- org.mariadb.jdbc:mariadb-java-client:jar:3.5.3:compile
==================================================================================================
```
</details