### PR TITLE
Wildcard mappers might ignore quoting for external .to() properties

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -54,7 +54,7 @@ public final class Configuration {
     public static boolean isUserModifiable(ConfigValue configValue) {
         // This could check as low as SysPropConfigSource DEFAULT_ORDINAL, which is 400
         // for now we won't validate these as it's not expected for the user to specify options via system properties
-        return configValue.getConfigSourceOrdinal() >= KeycloakPropertiesConfigSource.PROPERTIES_FILE_ORDINAL;
+        return configValue.getConfigSourceOrdinal() >= QuarkusPropertiesConfigSource.PROPERTIES_FILE_ORDINAL;
     }
 
     public static boolean isSet(Option<?> option) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
@@ -43,6 +43,7 @@ public final class QuarkusPropertiesConfigSource extends AbstractLocationConfigS
 
     private static final String FILE_NAME = "quarkus.properties";
     public static final String NAME = "KcQuarkusPropertiesConfigSource";
+    public static final int PROPERTIES_FILE_ORDINAL = KeycloakPropertiesConfigSource.PROPERTIES_FILE_ORDINAL-1;
 
     public static Path getConfigurationFile() {
         String homeDir = Environment.getHomeDir();
@@ -77,7 +78,7 @@ public final class QuarkusPropertiesConfigSource extends AbstractLocationConfigS
         Path configFile = getConfigurationFile();
 
         if (configFile != null) {
-            configSources.addAll(loadConfigSources(configFile.toUri().toString(), KeycloakPropertiesConfigSource.PROPERTIES_FILE_ORDINAL, classLoader));
+            configSources.addAll(loadConfigSources(configFile.toUri().toString(), PROPERTIES_FILE_ORDINAL, classLoader));
         }
 
         return configSources;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
@@ -101,8 +101,15 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
         if (key.startsWith(fromPrefix)) {
             result = key.substring(fromPrefix.length());
         } else if (key.startsWith(toPrefix) && key.endsWith(toSuffix)) {
-            // TODO: this presumes that the quarkus value is quoted
+            // this presumes that the quarkus value is quoted
             result = key.substring(toPrefix.length(), key.length() - toSuffix.length());
+        } else if (toPrefix.endsWith("\"") && toSuffix.startsWith("\"")) {
+            // this checks unquoted properties
+            String unquotedToPrefix = toPrefix.replaceAll("\"", "");
+            String unquotedToSuffix = toSuffix.replaceAll("\"", "");
+            if (key.startsWith(unquotedToPrefix) && key.endsWith(unquotedToSuffix)) {
+                result = key.substring(unquotedToPrefix.length(), key.length() - unquotedToSuffix.length());
+            }
         }
         // TODO: it would be nice to warn the user for property file or env entries that look
         // like they should be wildcards, but aren't allowed

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts.JDBC_H2;
 
 public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
 
@@ -30,6 +31,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         assertConfig("db-kind-default", "mariadb");
         assertConfig("db", "postgres");
         assertExternalConfig("quarkus.datasource.\"default\".db-kind", "mariadb");
+        assertExternalConfig("quarkus.datasource.default.db-kind", "mariadb");
         assertExternalConfig("quarkus.datasource.db-kind", "postgresql");
 
         onAfter();
@@ -40,6 +42,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         // KC value is present as CLI is available data source
         assertConfig("db-kind-some<other>datasource", "mssql");
         assertExternalConfigNull("quarkus.datasource.\"some<other>datasource\".db-kind");
+        assertExternalConfigNull("quarkus.datasource.some<other>datasource.db-kind");
     }
 
     @Test
@@ -50,6 +53,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
 
         assertConfig("db-dialect-user-store", MariaDBDialect.class.getName());
         assertExternalConfig("quarkus.datasource.\"user-store\".jdbc.url", "jdbc:mariadb://localhost/keycloak");
+        assertExternalConfig("quarkus.datasource.user-store.jdbc.url", "jdbc:mariadb://localhost/keycloak");
     }
 
     @Test
@@ -64,9 +68,13 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         assertConfig("db-kind-user-store", "mssql");
         assertExternalConfig(Map.of(
                 "quarkus.datasource.\"user-store\".jdbc.url", "jdbc:sqlserver://localhost/keycloak",
+                "quarkus.datasource.user-store.jdbc.url", "jdbc:sqlserver://localhost/keycloak",
                 "quarkus.datasource.\"user-store\".db-kind", "mssql",
+                "quarkus.datasource.user-store.db-kind", "mssql",
                 "quarkus.datasource.\"user-store\".jdbc.driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-                "quarkus.datasource.\"user-store\".jdbc.transactions", "enabled")
+                "quarkus.datasource.user-store.jdbc.driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+                "quarkus.datasource.\"user-store\".jdbc.transactions", "enabled",
+                "quarkus.datasource.user-store.jdbc.transactions", "enabled")
         );
     }
 
@@ -433,7 +441,9 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
 
         assertExternalConfig(Map.of(
                 "quarkus.datasource.\"user_store$something\".db-kind", "mariadb",
-                "quarkus.datasource.\"client.store_123\".password", "password"
+                "quarkus.datasource.user_store$something.db-kind", "mariadb",
+                "quarkus.datasource.\"client.store_123\".password", "password",
+                "quarkus.datasource.client.store_123.password", "password"
         ));
     }
 
@@ -456,6 +466,21 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
                 "db-kind-my-store", "dev-mem",
                 "db-debug-jpql-my-store", "true",
                 "db-log-slow-queries-threshold-my-store","5000"
+        ));
+    }
+
+    @Test
+    public void quarkusPropertiesHandling() {
+        initConfig();
+
+        assertConfig("db-kind-dog-store", "dev-file");
+        assertConfig("db-kind-cat-store", "dev-file");
+
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.dog-store.db-kind", "mariadb",
+                "quarkus.datasource.\"dog-store\".db-kind", "mariadb",
+                "quarkus.datasource.cat-store.db-kind", "postgresql",
+                "quarkus.datasource.\"cat-store\".db-kind", "postgresql"
         ));
     }
 }

--- a/quarkus/runtime/src/test/resources/conf/quarkus.properties
+++ b/quarkus/runtime/src/test/resources/conf/quarkus.properties
@@ -11,7 +11,7 @@ quarkus.datasource.foo = jdbc:h2:file:${kc.home.dir:${kc.db.url.path:~}}/data/ke
 quarkus.datasource.bar = foo-${kc.prop3:${kc.prop4:${kc.prop5:def}-suffix}}
 
 # test multiple datasources db-kind
-quarkus.datasource.dog-store.db-kind=mariadb
+quarkus.datasource."dog-store".db-kind=mariadb
 quarkus.datasource.cat-store.db-kind=postgresql
 
 not.quarkus=value


### PR DESCRIPTION
- Closes #41397
- Blocks https://github.com/keycloak/keycloak/pull/41087

If a property mapper has a default value, we never try to get Quarkus properties from the `quarkus.properties` file. 
We should take into account the value of Quarkus property (defined as .to() in our mapper) that the user has overridden in the `quarkus.properties` file.

Right now, if user has `quarkus.properties` file with property like `quarkus.datasource."my-store".db-kind=mariadb`, and we ask for the value, we get the default value -> H2.

@shawkins Could you please check it? Thanks!