### PR TITLE
fix: allows for the dev-file database to be accessible

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -147,7 +147,7 @@ final class DatabasePropertyMappers {
     }
 
     private static String getDatabaseUrl(String name, String value, ConfigSourceInterceptorContext c) {
-        return Database.getDefaultUrl(name, value).orElse(null);
+        return Database.getDefaultUrl(name, value, CachingPropertyMappers.cacheSetToInfinispan()).orElse(null);
     }
 
     private static String getXaOrNonXaDriver(String name, String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -250,7 +250,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db=dev-mem");
         config = createConfig();
         assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
-        assertEquals("jdbc:h2:mem:keycloakdb;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+        assertEquals("jdbc:h2:mem:keycloakdb;NON_KEYWORDS=VALUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("h2", config.getConfigValue("quarkus.datasource.db-kind").getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=dev-mem", "--db-username=other");

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -100,10 +100,15 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:file:" + Environment.getHomeDir() + "/data/h2/keycloakdb-store;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
         onAfter();
 
+        ConfigArgsConfigSource.setCliArgs("--db=dev-file", "--cache=local");
+        initConfig();
+        assertExternalConfig("quarkus.datasource.jdbc.url", "jdbc:h2:file:" + Environment.getHomeDir() + "/data/h2/keycloakdb;NON_KEYWORDS=VALUE;AUTO_SERVER=true");
+        onAfter();
+
         ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-mem");
         initConfig();
         assertConfig("db-dialect-store", H2Dialect.class.getName());
-        assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:mem:keycloakdb-store;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
+        assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:mem:keycloakdb-store;NON_KEYWORDS=VALUE");
         assertExternalConfig("quarkus.datasource.\"store\".db-kind", "h2");
         onAfter();
 


### PR DESCRIPTION
Draft of automatically adding support for AUTO_SERVER.

This restricts the auto close changes for jdbc ping to only the case when infinispan is the cache (a check for non-custom or non-jdbc ping stack seems too involved).

There is a security implication here because h2 chooses to bind to a non-localhost ip if available. For example from my lock.db file: server=192.168.1.55\:33123 - so we may not want to automatically enable this mode.

closes: #33800

cc @ryanemerson @thomasdarimont @Dissem @mabartos @vmuzikar 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
