### PR TITLE
Fixed how multi-value attributes are modified in jpa model adapters

### DIFF
--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -123,6 +123,32 @@
             <version>${jdbc.mvn.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- libraries needed for unit tests using an in-memory database -->
+		    <dependency>
+		        <groupId>com.h2database</groupId>
+		        <artifactId>h2</artifactId>
+		        <scope>test</scope>
+		    </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-core</artifactId>
+		        <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-default</artifactId>
+		        <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+            <scope>test</scope>
+        </dependency>
+			  <dependency>
+					  <groupId>io.smallrye</groupId> 
+					  <artifactId>jandex</artifactId> 
+            <scope>test</scope>
+			  </dependency>
     </dependencies>
 
     <build>

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -123,32 +123,6 @@
             <version>${jdbc.mvn.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- libraries needed for unit tests using an in-memory database -->
-		    <dependency>
-		        <groupId>com.h2database</groupId>
-		        <artifactId>h2</artifactId>
-		        <scope>test</scope>
-		    </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-saml-core</artifactId>
-		        <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-crypto-default</artifactId>
-		        <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer</artifactId>
-            <scope>test</scope>
-        </dependency>
-			  <dependency>
-					  <groupId>io.smallrye</groupId> 
-					  <artifactId>jandex</artifactId> 
-            <scope>test</scope>
-			  </dependency>
     </dependencies>
 
     <build>

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -45,14 +45,12 @@ import org.keycloak.models.jpa.entities.GroupAttributeEntity;
 import org.keycloak.models.jpa.entities.GroupEntity;
 import org.keycloak.models.jpa.entities.GroupRoleMappingEntity;
 import org.keycloak.models.jpa.entities.OrganizationEntity;
+import org.keycloak.models.jpa.util.ModelAdapterUtil;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.storage.UserStoragePrivateUtil;
 
-import static java.util.Optional.ofNullable;
-
-import static org.keycloak.common.util.CollectionUtil.collectionEquals;
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
 
@@ -74,6 +72,7 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
         this.realm = realm;
     }
 
+    @Override
     public GroupEntity getEntity() {
         return group;
     }
@@ -271,19 +270,8 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
 
     @Override
     public void setAttribute(String name, List<String> values) {
-        List<String> current = getAttributes().getOrDefault(name, List.of());
-
-        if (collectionEquals(current, ofNullable(values).orElse(List.of()))) {
-            return;
-        }
-
-        // Remove all existing
-        removeAttribute(name);
-
-        // Put all new
-        for (String value : values) {
-            persistAttributeValue(name, value);
-        }
+        ModelAdapterUtil.setMultiValueAttribute(name, values, this::getAttributes, this::removeAttribute,
+                this::persistAttributeValue);
     }
 
     private void persistAttributeValue(String name, String value) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
@@ -36,6 +36,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.jpa.entities.CompositeRoleEntity;
 import org.keycloak.models.jpa.entities.RoleAttributeEntity;
 import org.keycloak.models.jpa.entities.RoleEntity;
+import org.keycloak.models.jpa.util.ModelAdapterUtil;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.utils.StreamsUtil;
 
@@ -155,11 +156,8 @@ public class RoleAdapter implements RoleModel, JpaModel<RoleEntity> {
 
     @Override
     public void setAttribute(String name, List<String> values) {
-        removeAttribute(name);
-
-        for (String value : values) {
-            persistAttributeValue(name, value);
-        }
+        ModelAdapterUtil.setMultiValueAttribute(name, values, this::getAttributes, this::removeAttribute,
+                this::persistAttributeValue);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.jpa;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +58,7 @@ import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.jpa.entities.UserGroupMembershipEntity;
 import org.keycloak.models.jpa.entities.UserRequiredActionEntity;
 import org.keycloak.models.jpa.entities.UserRoleMappingEntity;
+import org.keycloak.models.jpa.util.ModelAdapterUtil;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.organization.OrganizationProvider;
@@ -205,24 +205,8 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
             return;
         }
 
-        Set<String> oldEntries = getAttributeStream(name).collect(Collectors.toSet());
-        Set<String> newEntries;
-        if (values == null) {
-            newEntries = new HashSet<>();
-        } else {
-            newEntries = new HashSet<>(values);
-        }
-        if (CollectionUtil.collectionEquals(oldEntries, newEntries)) {
-            return;
-        }
-
-        // Remove all existing
-        removeAttribute(name);
-        if (values != null) {
-            for (Iterator<String> it = values.stream().filter(Objects::nonNull).iterator(); it.hasNext();) {
-                persistAttributeValue(name, it.next());
-            }
-        }
+        ModelAdapterUtil.setMultiValueAttribute(name, values, this::getAttributes, this::removeAttribute,
+                this::persistAttributeValue);
     }
 
     private void persistAttributeValue(String name, String value) {
@@ -295,8 +279,8 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         } else if (UserModel.USERNAME.equals(name)) {
             return Stream.of(user.getUsername());
         }
-        return user.getAttributes().stream().filter(attribute -> Objects.equals(attribute.getName(), name)).
-                map(attribute -> attribute.getValue());
+        return user.getAttributes().stream().filter(attribute -> Objects.equals(attribute.getName(), name))
+                .map(attribute -> attribute.getValue());
     }
 
     @Override
@@ -388,7 +372,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
     }
 
     private TypedQuery<String> createGetGroupsQuery() {
-        // we query ids only as the group  might be cached and following the @ManyToOne will result in a load
+        // we query ids only as the group might be cached and following the @ManyToOne will result in a load
         // even if we're getting just the id.
         CriteriaBuilder builder = em.getCriteriaBuilder();
         CriteriaQuery<String> queryBuilder = builder.createQuery(String.class);
@@ -404,7 +388,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
     }
 
     private TypedQuery<Long> createCountGroupsQuery() {
-        // we query ids only as the group  might be cached and following the @ManyToOne will result in a load
+        // we query ids only as the group might be cached and following the @ManyToOne will result in a load
         // even if we're getting just the id.
         CriteriaBuilder builder = em.getCriteriaBuilder();
         CriteriaQuery<Long> queryBuilder = builder.createQuery(Long.class);
@@ -443,7 +427,8 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public long getGroupsCountByNameContaining(String search) {
-        if (search == null) return getGroupsCount();
+        if (search == null)
+            return getGroupsCount();
         return session.groups().getGroupsCount(realm, closing(createGetGroupsQuery().getResultStream()), search);
     }
 
@@ -489,12 +474,14 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public void leaveGroup(GroupModel group) {
-        if (user == null || group == null) return;
+        if (user == null || group == null)
+            return;
 
         TypedQuery<UserGroupMembershipEntity> query = getUserGroupMappingQuery(group);
         query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
         List<UserGroupMembershipEntity> results = query.getResultList();
-        if (results.isEmpty()) return;
+        if (results.isEmpty())
+            return;
         for (UserGroupMembershipEntity entity : results) {
             em.remove(entity);
         }
@@ -514,11 +501,9 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         return query;
     }
 
-
     @Override
     public boolean hasRole(RoleModel role) {
-        return RoleUtils.hasRole(getRoleMappingsStream(), role)
-                || RoleUtils.hasRoleFromGroup(getGroupsStream(), role, true);
+        return RoleUtils.hasRole(getRoleMappingsStream(), role) || RoleUtils.hasRoleFromGroup(getGroupsStream(), role, true);
     }
 
     protected TypedQuery<UserRoleMappingEntity> getUserRoleMappingEntityTypedQuery(RoleModel role) {
@@ -530,7 +515,8 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public void grantRole(RoleModel role) {
-        if (hasDirectRole(role)) return;
+        if (hasDirectRole(role))
+            return;
         grantRoleImpl(role);
         RoleGrantedEvent.fire(role, this, session);
     }
@@ -564,7 +550,6 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         return getRoleMappingsStream().filter(RoleUtils::isRealmRole);
     }
 
-
     @Override
     public Stream<RoleModel> getRoleMappingsStream() {
         // we query ids only as the role might be cached and following the @ManyToOne will result in a load
@@ -576,12 +561,14 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public void deleteRoleMapping(RoleModel role) {
-        if (user == null || role == null) return;
+        if (user == null || role == null)
+            return;
 
         TypedQuery<UserRoleMappingEntity> query = getUserRoleMappingEntityTypedQuery(role);
         query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
         List<UserRoleMappingEntity> results = query.getResultList();
-        if (results.isEmpty()) return;
+        if (results.isEmpty())
+            return;
         for (UserRoleMappingEntity entity : results) {
             em.remove(entity);
         }
@@ -621,8 +608,10 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || !(o instanceof UserModel)) return false;
+        if (this == o)
+            return true;
+        if (o == null || !(o instanceof UserModel))
+            return false;
 
         UserModel that = (UserModel) o;
         return that.getId().equals(getId());

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/util/ModelAdapterUtil.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/util/ModelAdapterUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.jpa.util;
+
+import static java.util.Optional.*;
+import static org.keycloak.common.util.CollectionUtil.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Static stateless methods for reuse in model adapter classes.
+ */
+public class ModelAdapterUtil {
+
+    /**
+     * Common logic for updating an attribute with potentially multiple values.
+     * Actually, the same value might occur multiple times.
+     * 
+     * @param attrName The case-sensitive name of the attribute (must not be null).
+     * @param newValues The new list of values to be set. If this is null or empty, the attribute will be removed.
+     * @param currentAttributesProvider The provider of the current (i.e. persistent) attribute values (must not be null).
+     * @param attrRemover The Supplier that is used to remove the attribute with all its values from persistence (must not be null).
+     * @param attrSingleValuePersister A function that persists a single pair of attribute name and value (must not be null).
+     */
+    public static void setMultiValueAttribute(String attrName, List<String> newValues,
+            Supplier<Map<String, List<String>>> currentAttributesProvider, Consumer<String> attrRemover,
+            BiConsumer<String, String> attrSingleValuePersister) {
+
+        List<String> currentValues = currentAttributesProvider.get().getOrDefault(attrName, List.of());
+
+        if (collectionEquals(currentValues, ofNullable(newValues).orElse(List.of()))) {
+            return;
+        }
+
+        // Remove all existing
+        attrRemover.accept(attrName);
+
+        if (newValues != null) {
+            // Put all new
+            for (String value : newValues) {
+                attrSingleValuePersister.accept(attrName, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Aligned handling of setAttribute() in UserAdapter, RoleAdapter and GroupAdapter.
Duplicate values in the same attribute are now handled correctly. Duplicate values can be added and removed.

Closes #38526
