### PR TITLE
Fix broken anchor for caching docs

### DIFF
--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -260,7 +260,7 @@ Please refer to {infinispan_embedding_docs}#cluster-transport[Setting up Infinis
 
 == Securing transport stacks
 
-Encryption using TLS is enabled by default for TCP-based transport stacks, which is also the default configuration
+Encryption using TLS is enabled by default for TCP-based transport stacks, which is also the default configuration.
 No additional CLI options or modifications of the cache XML are required as long as you are using a TCP-based transport stack.
 
 [NOTE]
@@ -315,6 +315,7 @@ Although not recommended for standard setups, if it is essential in a specific s
 The truststore contains the valid certificates to accept connection from, and it can be configured with `cache-embedded-mtls-trust-store-file` (path to the truststore), and `cache-embedded-mtls-trust-store-password` (password to decrypt it).
 To restrict unauthorized access, always use a self-signed certificate for each {project_name} deployment.
 
+[#network-ports]
 == Network Ports
 
 To ensure a healthy {project_name} clustering, some network ports need to be open.

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -50,17 +50,12 @@ Any request that exceeds this limit would return with an immediate `503 Server n
 == Production grade database
 The database used by {project_name} is crucial for the overall performance, availability, reliability and integrity of {project_name}. For details on how to configure a supported database, see <@links.server id="db"/>.
 
-== Support for {project_name} in a cluster
+== Running {project_name} in a cluster
 To ensure that users can continue to log in when a {project_name} instance goes down, a typical production environment contains two or more {project_name} instances.
 
-{project_name} runs on top of JGroups and Infinispan, which provide a reliable, high-availability stack for a clustered scenario. When deployed to a cluster, the embedded Infinispan server communication should be secured. You secure this communication either by enabling authentication and encryption or by isolating the network used for cluster communication.
+{project_name} runs on top of JGroups and Infinispan, which provide a reliable, high-availability stack for a clustered scenario. In the default setup, communication between the nodes is encrypted using TLS.
 
 To find out more about using multiple nodes, the different caches and an appropriate stack for your environment, see <@links.server id="caching"/>.
-
-=== Secure network communication
-
-JGroups supports Java SSL sockets for TCP communication.
-Check <@links.server id="caching" anchor="securing-cache-communication"/> for more information on how to configure TLS and the alternatives available for UDP communication.
 
 === Configure Firewall ports
 


### PR DESCRIPTION
Also shorten the docs as KC is now encrypting by default.

Closes #41421

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
