### PR TITLE
Align and optimize Playwright configurations

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -147,6 +147,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WORKSPACE: "@keycloak/keycloak-account-ui"
+    strategy:
+      matrix:
+        browser: [chromium, firefox]
+        exclude:
+          # Only test with Firefox on scheduled runs
+          - browser: ${{ github.event_name != 'workflow_dispatch' && 'firefox' || '' }}
+      fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -173,14 +180,14 @@ jobs:
         working-directory: js
 
       - name: Run Playwright tests
-        run: pnpm --fail-if-no-match --filter ${{ env.WORKSPACE }} test
+        run: pnpm --fail-if-no-match --filter ${{ env.WORKSPACE }} test -- --project=${{ matrix.browser }}
         working-directory: js
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: account-ui-playwright-report
+          name: account-ui-playwright-report-${{ matrix.browser }}
           path: js/apps/account-ui/playwright-report
           retention-days: 30
 
@@ -188,35 +195,18 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: account-ui-server-log
+          name: account-ui-server-log-${{ matrix.browser }}
           path: ~/server.log
-
-
-  generate-test-seed:
-    name: Generate Test Seed
-    needs:
-      - conditional
-    if: needs.conditional.outputs.js-ci == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      seed: ${{ steps.generate-random-number.outputs.value }}
-    steps:
-      - name: Generate random number
-        id: generate-random-number
-        shell: bash
-        run: |
-          echo "value=$(shuf -i 1-100 -n 1)" >> $GITHUB_OUTPUT
 
   admin-ui-e2e:
     name: Admin UI E2E
     needs:
       - conditional
       - build-keycloak
-      - generate-test-seed
     if: needs.conditional.outputs.js-ci == 'true'
     runs-on: ubuntu-latest
     env:
-      WORKSPACE: keycloak-admin-ui
+      WORKSPACE: "@keycloak/keycloak-admin-ui"
     strategy:
       matrix:
         browser: [chromium, firefox]
@@ -228,10 +218,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/pnpm-setup
-
-      - name: Compile Admin Client
-        run: pnpm --fail-if-no-match --filter @keycloak/keycloak-admin-client build
-        working-directory: js
 
       - name: Download Keycloak server
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -256,7 +242,7 @@ jobs:
         working-directory: js
 
       - name: Run Playwright tests
-        run: pnpm --fail-if-no-match --filter ${{ env.WORKSPACE }} test:integration --project=${{ matrix.browser }}
+        run: pnpm --fail-if-no-match --filter ${{ env.WORKSPACE }} test:integration -- --project=${{ matrix.browser }}
         working-directory: js
 
       - name: Upload Playwright report

--- a/js/apps/account-ui/playwright.config.ts
+++ b/js/apps/account-ui/playwright.config.ts
@@ -1,26 +1,22 @@
-import { defineConfig, devices } from "@playwright/test";
+import { type ViewportSize, defineConfig, devices } from "@playwright/test";
 
 import { getAccountUrl } from "./test/utils";
 
 const retryCount = parseInt(process.env.RETRY_COUNT || "0");
+const viewport: ViewportSize = { width: 1920, height: 1080 };
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
   testDir: "./test",
-  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: retryCount,
-  workers: 1,
   reporter: process.env.CI ? [["github"], ["html"]] : "list",
-  expect: {
-    timeout: 20 * 1000,
-  },
 
   use: {
     baseURL: getAccountUrl(),
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
 
   /* Configure projects for major browsers */
@@ -38,7 +34,15 @@ export default defineConfig({
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        viewport: { width: 1920, height: 1200 },
+        viewport,
+      },
+      dependencies: ["import realms"],
+    },
+    {
+      name: "firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+        viewport,
       },
       dependencies: ["import realms"],
     },

--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -23,7 +23,7 @@
     "preview": "wireit",
     "lint": "wireit",
     "test": "wireit",
-    "test:integration": "playwright test"
+    "test:integration": "wireit"
   },
   "wireit": {
     "dev": {
@@ -74,6 +74,12 @@
       "command": "vitest",
       "dependencies": [
         "../../libs/ui-shared:build",
+        "../../libs/keycloak-admin-client:build"
+      ]
+    },
+    "test:integration": {
+      "command": "playwright test",
+      "dependencies": [
         "../../libs/keycloak-admin-client:build"
       ]
     }

--- a/js/apps/admin-ui/playwright.config.ts
+++ b/js/apps/admin-ui/playwright.config.ts
@@ -1,22 +1,21 @@
-import { defineConfig, devices } from "@playwright/test";
+import { type ViewportSize, defineConfig, devices } from "@playwright/test";
 
 const retryCount = parseInt(process.env.RETRY_COUNT || "0");
+const viewport: ViewportSize = { width: 1920, height: 1080 };
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
   testDir: "./test",
-  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: retryCount,
-  workers: 1,
-  timeout: 60 * 1000,
+  timeout: 60_000,
   reporter: process.env.CI ? [["github"], ["html"]] : "list",
 
   use: {
     baseURL: "http://localhost:8080",
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
 
   /* Configure projects for major browsers */
@@ -25,14 +24,14 @@ export default defineConfig({
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        viewport: { width: 1920, height: 1200 },
+        viewport,
       },
     },
     {
       name: "firefox",
       use: {
         ...devices["Desktop Firefox"],
-        viewport: { width: 1920, height: 1200 },
+        viewport,
       },
     },
   ],


### PR DESCRIPTION
Aligns the Playwrights configurations between the admin and account consoles as much as possible. This also changes the following:

- Tests for the account console now also run on Firefox during the nightly.
- Tests will now execute over as many workers are GitHub advertises, speeding up test runs.
- Full parallelization of tests (`fullyParallel`) has been disabled (this was implicitly already the case, as only a single worker was configured, essentially disabling parallelization), as there are tests that depend on serial execution.
- Test traces are now retained on first failure, instead of on retries, this will make it easier to trace failures on CI.
- The admin client is now built by WireIt before running the admin console tests (same as the account console).
- Some jobs to generate a test seed have been removed, as these were used only for the Cypress tests, which no longer exists.