### PR TITLE
QuarkusTest fetches JARs again when executed

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -298,6 +298,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <!-- We want to avoid any other artifacts fetches done via surefire and @QuarkusTest - see https://github.com/keycloak/keycloak/issues/41466 -->
+                        <maven.settings>void</maven.settings>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- Closes #41466
- Closes #41468

There are still some dependencies fetched inside the surefire, but the count has drastically reduced and fixed the issue with Windows: #41468. We use `@QuarkusTest` even on the Operator side, but there are no artifact fetches, so I left it unchanged. We had some problems on Windows with the additional fetching which was probably the root cause of compatibility issues with JUnit Jupiter engine.

There might be possibly a better approach on how to set maven for the Surefire plugin, but I think it's not worth the effort to analyze surefire codebase to find some hack for maven dependencies. 

@shawkins @Pepo48 Are you ok with this approach?

### Test run 1 :ok: 
https://github.com/keycloak/keycloak/actions/runs/16574061153/job/46874414243?pr=41467
https://github.com/keycloak/keycloak/actions/runs/16574061153/job/46874414267?pr=41467

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/platform/quarkus-bom-quarkus-platform-properties/999-SNAPSHOT/maven-metadata.xml
Progress (1): maven-metadata.xml (812 B)
                                        
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/platform/quarkus-bom-quarkus-platform-properties/999-SNAPSHOT/maven-metadata.xml (812 B at 1.0 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/platform/quarkus-bom-quarkus-platform-properties/999-SNAPSHOT/quarkus-bom-quarkus-platform-properties-999-20250728.052405-62.properties
Progress (1): quarkus-bom-quarkus-platform-properties-999-20250728.052405-62.properties (883 B)
                                                                                               
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/platform/quarkus-bom-quarkus-platform-properties/999-SNAPSHOT/quarkus-bom-quarkus-platform-properties-999-20250728.052405-62.properties (883 B at 3.3 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-rest-kotlin/999-SNAPSHOT/maven-metadata.xml
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-hibernate-orm-derby/999-SNAPSHOT/maven-metadata.xml
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-postgresql/999-SNAPSHOT/maven-metadata.xml
Progress (1): maven-metadata.xml (1.2 kB)
Progress (2): maven-metadata.xml (1.2 kB) | maven-metadata.xml (997 B)
                                                                      
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-rest-kotlin/999-SNAPSHOT/maven-metadata.xml (1.2 kB at 3.4 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-rest-kotlin/999-SNAPSHOT/quarkus-rest-kotlin-999-20250728.002633-62.jar
Progress (2): maven-metadata.xml (997 B) | maven-metadata.xml (995 B)
                                                                     
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-hibernate-orm-derby/999-SNAPSHOT/maven-metadata.xml (997 B at 2.1 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-hibernate-orm-derby/999-SNAPSHOT/quarkus-hibernate-orm-derby-999-20250728.002633-46.jar
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-postgresql/999-SNAPSHOT/maven-metadata.xml (995 B at 2.1 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-postgresql/999-SNAPSHOT/quarkus-flyway-postgresql-999-20250728.002633-62.jar
Progress (1): quarkus-rest-kotlin-999-20250728.002633-62.jar (7.7/32 kB)
Progress (1): quarkus-rest-kotlin-999-20250728.002633-62.jar (16/32 kB) 
Progress (1): quarkus-rest-kotlin-999-20250728.002633-62.jar (32 kB)   
Progress (2): quarkus-rest-kotlin-999-20250728.002633-62.jar (32 kB) | quarkus-hibernate-orm-derby-999-20250728.002633-46.jar (3.0 kB)
Progress (3): quarkus-rest-kotlin-999-20250728.002633-62.jar (32 kB) | quarkus-hibernate-orm-derby-999-20250728.002633-46.jar (3.0 kB) | quarkus-flyway-postgresql-999-20250728.002633-62.jar (3.0 kB)
                                                                                                                                                                                                      
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-rest-kotlin/999-SNAPSHOT/quarkus-rest-kotlin-999-20250728.002633-62.jar (32 kB at 81 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mysql/999-SNAPSHOT/maven-metadata.xml
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-hibernate-orm-derby/999-SNAPSHOT/quarkus-hibernate-orm-derby-999-20250728.002633-46.jar (3.0 kB at 9.7 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mssql/999-SNAPSHOT/maven-metadata.xml
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-postgresql/999-SNAPSHOT/quarkus-flyway-postgresql-999-20250728.002633-62.jar (3.0 kB at 10 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-oracle/999-SNAPSHOT/maven-metadata.xml
Progress (1): maven-metadata.xml (990 B)
Progress (2): maven-metadata.xml (990 B) | maven-metadata.xml (991 B)
Progress (3): maven-metadata.xml (990 B) | maven-metadata.xml (991 B) | maven-metadata.xml (990 B)
                                                                                                  
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mssql/999-SNAPSHOT/maven-metadata.xml (990 B at 2.9 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mssql/999-SNAPSHOT/quarkus-flyway-mssql-999-20250728.002633-62.jar
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mysql/999-SNAPSHOT/maven-metadata.xml (990 B at 2.4 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mysql/999-SNAPSHOT/quarkus-flyway-mysql-999-20250728.002633-62.jar
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-oracle/999-SNAPSHOT/maven-metadata.xml (991 B at 3.3 kB/s)
Downloading from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-oracle/999-SNAPSHOT/quarkus-flyway-oracle-999-20250728.002633-62.jar
Progress (1): quarkus-flyway-oracle-999-20250728.002633-62.jar (3.0 kB)
Progress (2): quarkus-flyway-oracle-999-20250728.002633-62.jar (3.0 kB) | quarkus-flyway-mssql-999-20250728.002633-62.jar (3.0 kB)
Progress (3): quarkus-flyway-oracle-999-20250728.002633-62.jar (3.0 kB) | quarkus-flyway-mssql-999-20250728.002633-62.jar (3.0 kB) | quarkus-flyway-mysql-999-20250728.002633-62.jar (2.9 kB)
                                                                                                                                                                                             
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-oracle/999-SNAPSHOT/quarkus-flyway-oracle-999-20250728.002633-62.jar (3.0 kB at 13 kB/s)
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mysql/999-SNAPSHOT/quarkus-flyway-mysql-999-20250728.002633-62.jar (2.9 kB at 11 kB/s)
Downloaded from sonatype-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/quarkus/quarkus-flyway-mssql/999-SNAPSHOT/quarkus-flyway-mssql-999-20250728.002633-62.jar (3.0 kB at 10 kB/s)
2025-07-28 16:16:14,779 WARN  [io.quarkus.deployment.index.IndexWrapper] (build-47) Failed to index oracle.jdbc.xa.OracleXADataSource: Class does not exist in ClassLoader QuarkusClassLoader:Deployment Class Loader: TEST for JUnitQuarkusTest-test.org.keycloak.quarkus.services.health.MetricsEnabledProfile (QuarkusTest)@5a0f5567
2025-07-28 16:16:14,779 WARN  [io.quarkus.deployment.index.IndexWrapper] (build-47) Failed to index oracle.jdbc.datasource.impl.OracleDataSource: Class does not exist in ClassLoader QuarkusClassLoader:Deployment Class Loader: TEST for JUnitQuarkusTest-test.org.keycloak.quarkus.services.health.MetricsEnabledProfile (QuarkusTest)@5a0f5567
2025-07-28 16:16:23,924 WARN  [io.quarkus.deployment.index.IndexWrapper] (build-45) Failed to index oracle.jdbc.xa.OracleXADataSource: Class does not exist in ClassLoader QuarkusClassLoader:Deployment Class Loader: TEST for JUnitQuarkusTest-test.org.keycloak.quarkus.services.health.MetricsEnabledProfileWithPath (QuarkusTest)@4b96b0bd
2025-07-28 16:16:23,924 WARN  [io.quarkus.deployment.index.IndexWrapper] (build-45) Failed to index oracle.jdbc.datasource.impl.OracleDataSource: Class does not exist in ClassLoader QuarkusClassLoader:Deployment Class Loader: TEST for JUnitQuarkusTest-test.org.keycloak.quarkus.services.health.MetricsEnabledProfileWithPath (QuarkusTest)@4b96b0bd
[INFO] Running test.org.keycloak.quarkus.services.health.KeycloakMetricsConfigurationTest
2025-07-28 16:16:28,871 INFO  [org.hibernate.jpa.internal.util.LogHelper] (main) HHH000204: Processing PersistenceUnitInfo [name: keycloak-default]
2025-07-28 16:16:29,027 INFO  [org.hibernate.Version] (main) HHH000412: Hibernate ORM core version 7.0.7.Final
2025-07-28 16:16:29,278 WARN  [org.hibernate.orm.deprecation] (main) HHH90000025: H2Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
2025-07-28 16:16:29,278 INFO  [org.hibernate.orm.connections.pooling] (main) HHH10001005: Database info:
	Database JDBC URL [undefined/unknown]
	Database driver: undefined/unknown
	Database version: 2.3.230
	Autocommit mode: undefined/unknown
	Isolation level: <unknown>
	Pool: undefined/unknown
	Minimum pool size: undefined/unknown
	Maximum pool size: undefined/unknown
2025-07-28 16:16:33,532 INFO  [org.keycloak.quarkus.runtime.storage.database.liquibase.QuarkusJpaUpdaterProvider] (main) Initializing database schema. Using changelog META-INF/jpa-changelog-master.xml
2025-07-28 16:16:37,907 INFO  [org.keycloak.spi.infinispan.impl.embedded.JGroupsConfigurator] (main) JGroups JDBC_PING discovery enabled.
2025-07-28 16:16:38,408 INFO  [org.keycloak.spi.infinispan.impl.embedded.JGroupsConfigurator] (main) JGroups Encryption enabled (mTLS).
2025-07-28 16:16:38,580 INFO  [org.keycloak.jgroups.certificates.CertificateReloadManager] (main) Starting JGroups certificate reload manager
2025-07-28 16:16:38,720 INFO  [org.infinispan.CONTAINER] (main) ISPN000556: Starting user marshaller 'org.infinispan.commons.marshall.ImmutableProtoStreamMarshaller'
2025-07-28 16:16:39,377 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Node name: node_668231, Site name: null
2025-07-28 16:16:39,706 INFO  [org.keycloak.services] (main) KC-SERVICES0050: Initializing master realm
2025-07-28 16:16:41,443 WARN  [io.micrometer.core.instrument.MeterRegistry] (vert.x-acceptor-thread-0) This Gauge has been already registered (MeterId{name='http.server.active.connections', tags=[]}), the registration will be ignored. Note that subsequent logs will be logged at debug level.
2025-07-28 16:16:41,443 INFO  [io.quarkus] (main) Keycloak 999.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 29.817s. Listening on: http://0.0.0.0:8081./ Management interface listening on http://0.0.0.0:9001./
2025-07-28 16:16:41,490 INFO  [io.quarkus] (main) Profile test activated. 
2025-07-28 16:16:41,490 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, jdbc-h2, jdbc-mariadb, jdbc-mssql, jdbc-mysql, jdbc-oracle, jdbc-postgresql, keycloak, micrometer, narayana-jta, opentelemetry, reactive-routes, rest, rest-jackson, smallrye-context-propagation, smallrye-health, vertx]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.019 s - in test.org.keycloak.quarkus.services.health.KeycloakMetricsConfigurationTest
[INFO] Running test.org.keycloak.quarkus.services.health.KeycloakNegativeHealthCheckTest
``` 

### Test run 2 :ok: 

PR with CI: https://github.com/keycloak/keycloak/pull/41482

https://github.com/keycloak/keycloak/actions/runs/16590794992/job/46926146170?pr=41482
https://github.com/keycloak/keycloak/actions/runs/16590794992/job/46926146163?pr=41482

