### PR TITLE
feat(email): Add cooldown period to prevent rapid resend of verificat…

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -80,6 +80,12 @@ In order to maintain backwards compatibility, {project_name}'s upgrade will modi
 
 For more information about client configuration, please see link:{adminguide_link}#_client-saml-configuration[Creating a SAML client] chapter in the {adminguide_name}.
 
+=== Validate email action
+
+When validating an email address as a required action or an application initiated action, a user can resend the verification email by default only every 30 seconds, while in earlier versions there was no limitation in re-sending the email.
+
+Administrators can configure the interval per realm in the Verify Email required action in the Authentication section of the realmm.
+
 === Tracing extended for embedded Infinispan caches
 
 When tracing is enabled, now also calls to other nodes of a {project_name} cluster will create spans in the traces.

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -103,6 +103,9 @@ public final class Constants {
     public static final String KC_ACTION_ENFORCED = "kc_action_enforced";
     public static final int KC_ACTION_MAX_AGE = 300;
     public static final String MAX_AUTH_AGE_KEY = "max_auth_age";
+    public static final String EMAIL_RESEND_COOLDOWN_SECONDS = "email_resend_cooldown";
+    public static final int EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS = 30;
+    public static final String EMAIL_RESEND_COOLDOWN_KEY_PREFIX = "verify-email-cooldown-";
 
 
     public static final String IS_AIA_REQUEST = "IS_AIA_REQUEST";

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -103,9 +103,6 @@ public final class Constants {
     public static final String KC_ACTION_ENFORCED = "kc_action_enforced";
     public static final int KC_ACTION_MAX_AGE = 300;
     public static final String MAX_AUTH_AGE_KEY = "max_auth_age";
-    public static final String EMAIL_RESEND_COOLDOWN_SECONDS = "email_resend_cooldown";
-    public static final int EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS = 30;
-    public static final String EMAIL_RESEND_COOLDOWN_KEY_PREFIX = "verify-email-cooldown-";
 
 
     public static final String IS_AIA_REQUEST = "IS_AIA_REQUEST";

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
@@ -150,6 +150,9 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
     private Long retrieveCooldownEntry(RequiredActionContext context) {
         SingleUseObjectProvider singleUseCache = context.getSession().singleUseObjects();
         Map<String, String> cooldownDetails = singleUseCache.get(getCacheKey(context));
+        if (cooldownDetails == null) {
+            return null;
+        }
         long remaining = (Long.parseLong(cooldownDetails.get(KEY_EXPIRE)) - Time.currentTime());
         // Avoid the awkward situation where due to rounding the value is zero
         return remaining > 0 ? remaining : null;

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
@@ -41,16 +41,30 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserModel;
+import org.keycloak.policy.MaxAuthAgePasswordPolicyProviderFactory;
 import org.keycloak.protocol.AuthorizationEndpointBase;
+import org.keycloak.provider.ConfiguredProvider;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.services.Urls;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.validation.Validation;
 
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static org.keycloak.models.Constants.EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS;
+import static org.keycloak.models.Constants.EMAIL_RESEND_COOLDOWN_KEY_PREFIX;
+import static org.keycloak.models.Constants.EMAIL_RESEND_COOLDOWN_SECONDS;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -58,6 +72,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class VerifyEmail implements RequiredActionProvider, RequiredActionFactory {
     private static final Logger logger = Logger.getLogger(VerifyEmail.class);
+
+
     @Override
     public void evaluateTriggers(RequiredActionContext context) {
         if (context.getRealm().isVerifyEmail() && !context.getUser().isEmailVerified()) {
@@ -97,12 +113,18 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
         authSession.setClientNote(AuthorizationEndpointBase.APP_INITIATED_FLOW, null);
 
         // Do not allow resending e-mail by simple page refresh, i.e. when e-mail sent, it should be resent properly via email-verification endpoint
-        if (!Objects.equals(authSession.getAuthNote(Constants.VERIFY_EMAIL_KEY), email) && !(isCurrentActionTriggeredFromAIA(context) && isChallenge)) {
-            authSession.setAuthNote(Constants.VERIFY_EMAIL_KEY, email);
+        SingleUseObjectProvider cache = context.getSession().singleUseObjects();
+        String cacheKey = EMAIL_RESEND_COOLDOWN_KEY_PREFIX + context.getUser().getId();
+        long cooldownSeconds = getCooldownInSeconds(context);
+
+        if (cache.putIfAbsent(cacheKey, cooldownSeconds)) {
             EventBuilder event = context.getEvent().clone().event(EventType.SEND_VERIFY_EMAIL).detail(Details.EMAIL, email);
             challenge = sendVerifyEmail(context, event);
         } else {
-            challenge = loginFormsProvider.createResponse(UserModel.RequiredAction.VERIFY_EMAIL);
+            long remaining = cooldownSeconds;
+            challenge = loginFormsProvider
+                    .setError("You must wait " + remaining + " seconds before requesting another verification email.")
+                    .createErrorPage(Response.Status.BAD_REQUEST);
         }
 
         context.challenge(challenge);
@@ -116,10 +138,28 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
     public void processAction(RequiredActionContext context) {
         logger.debugf("Re-sending email requested for user: %s", context.getUser().getUsername());
 
-        // This will allow user to re-send email again
-        context.getAuthenticationSession().removeAuthNote(Constants.VERIFY_EMAIL_KEY);
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        String email = context.getUser().getEmail();
+        if (Validation.isBlank(email)) {
+            context.ignore();
+            return;
+        }
 
-        process(context, false);
+        String cooldownKey = EMAIL_RESEND_COOLDOWN_KEY_PREFIX + context.getUser().getId();
+        long cooldown = getCooldownInSeconds(context);
+        SingleUseObjectProvider singleUseCache = context.getSession().singleUseObjects();
+
+        if (singleUseCache.putIfAbsent(cooldownKey, cooldown)) {
+            EventBuilder event = context.getEvent().clone().event(EventType.SEND_VERIFY_EMAIL).detail(Details.EMAIL, email);
+            sendVerifyEmail(context, event);
+            context.challenge(context.form().createResponse(UserModel.RequiredAction.VERIFY_EMAIL));
+        } else {
+            Response retryPage = context.form()
+                    .setError("You must wait " + cooldown + " seconds before resending the verification email.")
+                    .createResponse(UserModel.RequiredAction.VERIFY_EMAIL); // re-render same verify email page
+
+            context.challenge(retryPage);
+        }
     }
 
 
@@ -153,6 +193,28 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
     public String getId() {
         return UserModel.RequiredAction.VERIFY_EMAIL.name();
     }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+
+        ProviderConfigProperty maxAge = new ProviderConfigProperty();
+        maxAge.setName(Constants.MAX_AUTH_AGE_KEY);
+        maxAge.setLabel("Maximum Age of Authentication");
+        maxAge.setHelpText("Configures the duration in seconds this action can be used after the last authentication before the user is required to re-authenticate. " +
+                "This parameter is used just in the context of AIA when the kc_action parameter is available in the request, which is for instance when user " +
+                "himself updates his password in the account console.");
+        maxAge.setType(ProviderConfigProperty.STRING_TYPE);
+        maxAge.setDefaultValue(MaxAuthAgePasswordPolicyProviderFactory.DEFAULT_MAX_AUTH_AGE);
+
+        ProviderConfigProperty cooldown = new ProviderConfigProperty();
+        cooldown.setName(EMAIL_RESEND_COOLDOWN_SECONDS);
+        cooldown.setLabel("Cooldown Between Email Resend (seconds)");
+        cooldown.setHelpText("Minimum delay in seconds before another email verification email can be sent.");
+        cooldown.setType(ProviderConfigProperty.STRING_TYPE);
+        cooldown.setDefaultValue(String.valueOf(EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS));
+        return List.of(maxAge,cooldown);
+    }
+
 
     private Response sendVerifyEmail(RequiredActionContext context, EventBuilder event) throws UriBuilderException, IllegalArgumentException {
         RealmModel realm = context.getRealm();
@@ -190,6 +252,21 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
             return context.form()
                     .setError(Messages.EMAIL_SENT_ERROR)
                     .createErrorPage(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+    private long getCooldownInSeconds(RequiredActionContext context) {
+        try {
+            RequiredActionProviderModel model = context.getRealm().getRequiredActionProviderByAlias(getId());
+            if (model == null || model.getConfig() == null) {
+                logger.warn("No RequiredActionProviderModel found for alias: " + getId());
+                return EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS;
+            }
+
+            String value = model.getConfig().getOrDefault(EMAIL_RESEND_COOLDOWN_SECONDS, String.valueOf(EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS));
+            return Long.parseLong(value);
+        } catch (Exception e) {
+            logger.error("Failed to fetch cooldown from config: ", e);
+            return EMAIL_RESEND_COOLDOWN_DEFAULT_SECONDS;
         }
     }
 }

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -119,6 +119,8 @@ public class Messages {
 
     public static final String VERIFY_EMAIL = "verifyEmailMessage";
 
+    public static final String COOLDOWN_VERIFICATION_EMAIL = "emailVerifySendCooldown";
+
     public static final String UPDATE_EMAIL = "updateEmailMessage";
 
     public static final String LINK_IDP = "linkIdpMessage";

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyEmailPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyEmailPage.java
@@ -36,6 +36,9 @@ public class VerifyEmailPage extends AbstractPage {
     @FindBy(name = "cancel-aia")
     private WebElement cancelAIAButton;
 
+    @FindBy(className = "kc-feedback-text")
+    private WebElement feedbackText;
+
     public boolean isCurrent() {
         return PageUtils.getPageTitle(driver).equals("Email verification");
     }
@@ -46,6 +49,10 @@ public class VerifyEmailPage extends AbstractPage {
 
     public String getResendEmailLink() {
         return resendEmailLink.getAttribute("href");
+    }
+
+    public String getFeedbackText() {
+        return feedbackText.getText();
     }
 
     public void cancel() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -37,6 +37,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
@@ -86,6 +87,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.keycloak.models.Constants.EMAIL_RESEND_COOLDOWN_KEY_PREFIX;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -147,6 +149,15 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
                 .emailVerified(false)
                 .email("test-user@localhost").build();
         testUserId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+
+        clearCooldownForUser();
+    }
+
+    private void clearCooldownForUser() {
+        String cooldownKey = EMAIL_RESEND_COOLDOWN_KEY_PREFIX + testUserId;
+        testingClient.server().run(session -> {
+            session.singleUseObjects().remove(cooldownKey);
+        });
     }
 
     protected boolean removeVerifyProfileAtImport() {
@@ -329,6 +340,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
           .assertEvent();
         String mailCodeId = sendEvent.getDetails().get(Details.CODE_ID);
 
+        clearCooldownForUser();
         verifyEmailPage.clickResendEmail();
         verifyEmailPage.assertCurrent();
 
@@ -358,6 +370,28 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
     }
 
     @Test
+    public void verifyEmailResendTooFast() {
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+
+        verifyEmailPage.assertCurrent();
+        Assert.assertEquals(1, greenMail.getReceivedMessages().length);
+
+        verifyEmailPage.clickResendEmail();
+        assertThat(verifyEmailPage.getFeedbackText(), Matchers.containsString("You must wait"));
+        Assert.assertEquals(1, greenMail.getReceivedMessages().length);
+
+        try {
+            setTimeOffset(40);
+            verifyEmailPage.clickResendEmail();
+            Assert.assertEquals(2, greenMail.getReceivedMessages().length);
+        } finally {
+            setTimeOffset(0);
+        }
+
+    }
+
+    @Test
     public void verifyEmailResendWithRefreshes() throws IOException, MessagingException {
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
@@ -372,6 +406,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
           .assertEvent();
         String mailCodeId = sendEvent.getDetails().get(Details.CODE_ID);
 
+        clearCooldownForUser();
         verifyEmailPage.clickResendEmail();
         verifyEmailPage.assertCurrent();
         driver.navigate().refresh();
@@ -407,6 +442,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
 
+        clearCooldownForUser();
         verifyEmailPage.clickResendEmail();
         verifyEmailPage.assertCurrent();
 
@@ -441,6 +477,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
 
+        clearCooldownForUser();
         verifyEmailPage.clickResendEmail();
         verifyEmailPage.assertCurrent();
 
@@ -468,6 +505,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         // Email verification can be performed any number of times
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
+        clearCooldownForUser();
         verifyEmailPage.clickResendEmail();
         verifyEmailPage.assertCurrent();
         Assert.assertEquals(2, greenMail.getReceivedMessages().length);
@@ -985,7 +1023,8 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         String realmId = testRealm().toRepresentation().getId();
         testingClient.server().run(session -> {
             RealmModel realm = session.realms().getRealm(realmId);
-            RootAuthenticationSessionModel ras = session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId);
+            RootAuthenticationSessionModel ras = session.authenticationSessions()
+                    .getRootAuthenticationSession(realm, new AuthenticationSessionManager(session).decodeBase64AndValidateSignature(authSessionId, false));
             assertThat("Expecting single auth session", ras.getAuthenticationSessions().keySet(), Matchers.hasSize(1));
             ras.getAuthenticationSessions().forEach((id, as) -> as.addRequiredAction(RequiredAction.VERIFY_EMAIL));
         });

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -87,7 +87,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.keycloak.models.Constants.EMAIL_RESEND_COOLDOWN_KEY_PREFIX;
+import static org.keycloak.authentication.requiredactions.VerifyEmail.EMAIL_RESEND_COOLDOWN_KEY_PREFIX;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -539,6 +539,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
                   .user(userId)
                   .assertEvent();
 
+                setTimeOffset(40);
                 verifyEmailPage.clickResendEmail();
                 verifyEmailPage.assertCurrent();
 
@@ -567,6 +568,8 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
             // test that timestamp is current with 10s tollerance
             // test user info is set from form
+        } finally {
+            setTimeOffset(0);
         }
     }
 

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -174,6 +174,7 @@ emailVerifyInstruction3=to re-send the email.
 emailVerifyInstruction4=To verify your email address, we are about to send you email with instructions to the address {0}.
 emailVerifyResend=Re-send verification email
 emailVerifySend=Send verification email
+emailVerifySendCooldown=You must wait {0} seconds before resending the verification email.
 
 emailLinkIdpTitle=Link {0}
 emailLinkIdp1=An email with instructions to link {0} account {1} with your {2} account has been sent to you.


### PR DESCRIPTION
### Summary

This PR introduces a realm-configurable cooldown period between verification email resends to prevent users from triggering excessive emails by repeatedly clicking the "Resend Email" link.

Fixes [#41331](https://github.com/keycloak/keycloak/issues/41331)

### Details

- Introduces support for a realm-level attribute: `emailResendCooldownSeconds`
- If not defined, falls back to a default cooldown of 30 seconds
- Stores `emailLastSent` timestamp in the user's authentication session
- Respects the cooldown on each resend attempt

### Configuration

To set the cooldown:

```bash
curl -X PUT http://localhost:8080/admin/realms/<realm> \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{
    "attributes": {
      "emailResendCooldownSeconds": "60"
    }
  }'

