### PR TITLE
Getting error 405 'Method Not Allowed' when calling the 'certs' endpo…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oidc;
 
+import jakarta.ws.rs.HEAD;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.OAuthErrorException;
@@ -193,6 +194,16 @@ public class OIDCLoginProtocolService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getVersionPreflight() {
         return Cors.builder().allowedMethods("GET").preflight().auth().add(Response.ok());
+    }
+
+    // The method added just as a workaround to https://github.com/quarkusio/quarkus/issues/49172 . It can be removed once that one is
+    // fixed in quarkus and Keycloak updated to the corresponding version
+    @HEAD
+    @Path("/certs")
+    @Produces({MediaType.APPLICATION_JSON, org.keycloak.utils.MediaType.APPLICATION_JWKS})
+    @NoCache
+    public Response certsHead() {
+        return certs();
     }
 
     @GET

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/broker/util/SimpleHttpDefault.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/broker/util/SimpleHttpDefault.java
@@ -49,4 +49,8 @@ public abstract class SimpleHttpDefault extends SimpleHttp {
         return SimpleHttp.doGet(url, client, HttpClientProvider.DEFAULT_MAX_CONSUMED_RESPONSE_SIZE);
     }
 
+    public static SimpleHttp doHead(String url, HttpClient client) {
+        return SimpleHttp.doHead(url, client, HttpClientProvider.DEFAULT_MAX_CONSUMED_RESPONSE_SIZE);
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
@@ -308,6 +308,11 @@ public abstract class AbstractWellKnownProviderTest extends AbstractKeycloakTest
 
         SimpleHttp.Response response = SimpleHttpDefault.doGet(jwksUri, client).header(ACCEPT, APPLICATION_JWKS).asResponse();
         assertEquals(APPLICATION_JWKS, response.getFirstHeader(CONTENT_TYPE));
+
+        // Test HEAD method works (Issue 41537)
+        SimpleHttp.Response responseHead = SimpleHttpDefault.doHead(jwksUri, client).header(ACCEPT, APPLICATION_JWKS).asResponse();
+        assertEquals(Response.Status.OK.getStatusCode(), responseHead.getStatus());
+        assertEquals(APPLICATION_JWKS, responseHead.getFirstHeader(CONTENT_TYPE));
     }
 
     @Test


### PR DESCRIPTION
…int with HEAD method

closes #41537

This PR adds a workaround to the quarkus issue https://github.com/quarkusio/quarkus/issues/49172 . Once that one is fixed in quarkus, we can remove the workaround possibly.
