### PR TITLE
Use single worker to run tests on CI

### DIFF
--- a/js/apps/admin-ui/playwright.config.ts
+++ b/js/apps/admin-ui/playwright.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   testDir: "./test",
   forbidOnly: !!process.env.CI,
   retries: retryCount,
+  workers: process.env.CI ? 1 : undefined,
   timeout: 60_000,
   reporter: process.env.CI ? [["github"], ["html"]] : "list",
 


### PR DESCRIPTION
Use only a single worker on CI to reduce failures.

Closes #41543