### PR TITLE
fix: making the /opt/keycloak read-only

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -26,9 +26,10 @@ ENV LANG en_US.UTF-8
 ENV KC_RUN_IN_CONTAINER true
 
 COPY --from=ubi-micro-build /tmp/null/rootfs/ /
-COPY --from=ubi-micro-build --chown=1000:0 /opt/keycloak /opt/keycloak
+COPY --from=ubi-micro-build --chown=0:0 /opt/keycloak /opt/keycloak
 
-RUN echo "keycloak:x:0:root" >> /etc/group && \
+RUN chown 1000:0 /opt/keycloak/lib/quarkus /opt/keycloak/data && \
+    echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 
 USER 1000


### PR DESCRIPTION
closes: #25761

Looking to close out low-hanging issues. This change leaves /opt/keycloak as read-only with writability only for lib/quarkus and /data.

To prevent backwards compatibility issues, we may need to mark the provider and theme directories as writable - for example does it seem possible that someone's custom image uses the keycloak user to copy content from somewhere else to one of these directories. 

@ahus1 @mabartos @ASzc - WDYT, or should we just close #25761 without changes to our Dockerfile?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
