### PR TITLE
Support for RSA Key Size of 3072

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -9,7 +9,7 @@ if [ $? -ne 0 ]; then
 fi
 STRICT_OPTIONS=""
 if [ "$1" = "strict" ]; then
-  STRICT_OPTIONS="-Dauth.server.fips.mode=strict -Dauth.server.supported.keystore.types=BCFKS -Dauth.server.keystore.type=bcfks -Dauth.server.supported.rsa.key.sizes=2048,4096"
+  STRICT_OPTIONS="-Dauth.server.fips.mode=strict -Dauth.server.supported.keystore.types=BCFKS -Dauth.server.keystore.type=bcfks -Dauth.server.supported.rsa.key.sizes=2048,3072,4096"
 fi
 echo "STRICT_OPTIONS: $STRICT_OPTIONS"
 TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh fips`

--- a/common/src/main/java/org/keycloak/common/crypto/CryptoProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/CryptoProvider.java
@@ -135,6 +135,6 @@ public interface CryptoProvider {
      * @return Allowed key sizes of RSA key modulus, which this cryptoProvider supports
      */
     default String[] getSupportedRsaKeySizes() {
-        return new String[] {"1024", "2048", "4096"};
+        return new String[] {"1024", "2048", "3072", "4096"};
     }
 }

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/Fips1402StrictCryptoProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/Fips1402StrictCryptoProvider.java
@@ -18,6 +18,6 @@ public class Fips1402StrictCryptoProvider extends FIPS1402Provider {
     @Override
     public String[] getSupportedRsaKeySizes() {
         // RSA key of 1024 bits not supported in BCFIPS approved mode
-        return new String[] {"2048", "4096"};
+        return new String[] {"2048", "3072", "4096"};
     }
 }

--- a/services/src/main/java/org/keycloak/keys/GeneratedRsaEncKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedRsaEncKeyProviderFactory.java
@@ -51,8 +51,7 @@ public class GeneratedRsaEncKeyProviderFactory extends AbstractGeneratedRsaKeyPr
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return AbstractGeneratedRsaKeyProviderFactory.rsaKeyConfigurationBuilder()
-                .property(Attributes.KEY_SIZE_PROPERTY.get())
+        return generatedRsaKeyConfigurationBuilder()
                 .property(Attributes.RS_ENC_ALGORITHM_PROPERTY)
                 .build();
     }

--- a/services/src/main/java/org/keycloak/keys/GeneratedRsaKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedRsaKeyProviderFactory.java
@@ -53,8 +53,7 @@ public class GeneratedRsaKeyProviderFactory extends AbstractGeneratedRsaKeyProvi
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return AbstractGeneratedRsaKeyProviderFactory.rsaKeyConfigurationBuilder()
-                .property(Attributes.KEY_SIZE_PROPERTY.get())
+        return generatedRsaKeyConfigurationBuilder()
                 .property(Attributes.RS_ALGORITHM_PROPERTY)
                 .build();
     }

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -656,7 +656,7 @@ For running testsuite with server using BCFIPS approved mode, those additional p
 -Dauth.server.fips.mode=strict \
 -Dauth.server.supported.keystore.types=BCFKS \
 -Dauth.server.keystore.type=bcfks \
--Dauth.server.supported.rsa.key.sizes=2048,4096
+-Dauth.server.supported.rsa.key.sizes=2048,3072,4096
 ```
 The log should contain `KeycloakFipsSecurityProvider` mentioning "Approved mode". Something like:
 ```

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -259,7 +259,7 @@
         <auth.server.quarkus.cluster.config>local</auth.server.quarkus.cluster.config>
         <auth.server.fips.mode>disabled</auth.server.fips.mode>
         <auth.server.supported.keystore.types>JKS,PKCS12,BCFKS</auth.server.supported.keystore.types>
-        <auth.server.supported.rsa.key.sizes>1024,2048,4096</auth.server.supported.rsa.key.sizes>
+        <auth.server.supported.rsa.key.sizes>1024,2048,3072,4096</auth.server.supported.rsa.key.sizes>
         <auth.server.kerberos.supported>true</auth.server.kerberos.supported>
     </properties>
 


### PR DESCRIPTION
I added 3072 as a supported key size in the first commit (see [#41551](https://github.com/keycloak/keycloak/issues/41551)).
The second commit makes the default key size configurable via a spi config. I left the default to 2048. If you don't like that idea, feel free to revert that second change.