### PR TITLE
Wrap deprecated passkeys authenticator behind the feature

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -125,6 +125,7 @@ public class Profile {
         ORGANIZATION("Organization support within realms", Type.DEFAULT),
 
         PASSKEYS("Passkeys", Type.PREVIEW, Feature.WEB_AUTHN),
+        PASSKEYS_CONDITIONAL_UI_AUTHENTICATOR("Passkeys conditional UI authenticator", Type.DEPRECATED, FeatureUpdatePolicy.ROLLING_NO_UPGRADE, Feature.PASSKEYS),
 
         USER_EVENT_METRICS("Collect metrics based on user events", Type.DEFAULT),
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -110,6 +110,14 @@ The options `+--spi-user-sessions--infinispan--offline-session-cache-entry-lifes
 
 Instead use the options `cache-embedded-offline-sessions-max-count` and `cache-embedded-offline-client-sessions-max-count` to limit the memory usage if the default of 10000 cache offline user and client sessions does not work in your scenario.
 
+=== Deprecated Passkeys Conditional UI Authenticator requires a feature
+
+The authenticator *Passkeys Conditional UI Authenticator*, which was deprecated in the previous version 26.3.0, is still available for now, but it requires the feature
+`passkeys_conditional_ui_authenticator` to be explicitly enabled during server startup. The feature itself is deprecated and disabled by default.
+This allows administrator to start the server and re-configure authentication flows for passkeys authentication in a recommended way as described
+in the link:{adminguide_link}#passkeys_server_administration_guide[Passkeys] chapter in the {adminguide_name}. In the future major version, we plan to remove the feature
+as well as the *Passkeys Conditional UI Authenticator* as already announced.
+
 // ------------------------ Removed features ------------------------ //
 == Removed features
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasskeysConditionalUIAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasskeysConditionalUIAuthenticatorFactory.java
@@ -56,7 +56,7 @@ public class PasskeysConditionalUIAuthenticatorFactory extends WebAuthnPasswordl
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return Profile.isFeatureEnabled(Profile.Feature.PASSKEYS);
+        return Profile.isFeatureEnabled(Profile.Feature.PASSKEYS_CONDITIONAL_UI_AUTHENTICATOR);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysConditionalUITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysConditionalUITest.java
@@ -45,6 +45,7 @@ import org.openqa.selenium.firefox.FirefoxDriver;
  * @author rmartinc
  */
 @EnableFeature(value = Profile.Feature.PASSKEYS, skipRestart = true)
+@EnableFeature(value = Profile.Feature.PASSKEYS_CONDITIONAL_UI_AUTHENTICATOR, skipRestart = true)
 @IgnoreBrowserDriver(FirefoxDriver.class) // See https://github.com/keycloak/keycloak/issues/10368
 public class PasskeysConditionalUITest extends AbstractWebAuthnVirtualTest {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -167,6 +167,12 @@
         }
     },
 
+    "datastore": {
+        "legacy": {
+            "allowMigrateExistingDatabaseToSnapshot": "${keycloak.datastore.allowMigrateExistingDatabaseToSnapshot:false}"
+        }
+    },
+
     "realmCache": {
         "default" : {
             "enabled": "${keycloak.realmCache.enabled:true}"

--- a/testsuite/utils/src/main/resources/META-INF/keycloak-server.json
+++ b/testsuite/utils/src/main/resources/META-INF/keycloak-server.json
@@ -96,6 +96,12 @@
         }
     },
 
+    "datastore": {
+        "legacy": {
+            "allowMigrateExistingDatabaseToSnapshot": "${keycloak.datastore.allowMigrateExistingDatabaseToSnapshot:false}"
+        }
+    },
+
     "realmCache": {
         "default" : {
             "enabled": "${keycloak.realmCache.enabled:true}"


### PR DESCRIPTION
closes #40696

We have the issue for removing the **Passkeys Conditional UI Authenticator**, which is deprecated since 26.3.0. In theory, it should be fine to remove the existing stuff as long as it was wrapped behind the *preview* feature flag, which was the case of passkeys. However:

- When the authenticator is currently configured in the authentication flow in the KEycloak 26.3 or older, then after removing the authenticator implementation, users will not be able to authenticate to the realm. Also administrator cannot display authentication flow with unavailable authenticator in the admin console.

- Customers migrating from RHBK 26.2 to RHBK 26.4 do not have the "deprecation" period for the authenticator as the authenticator is not yet deprecated in the RHBK 26.2. So if we remove it in RHBK 26.4, it is "straight removal" without any deprecation period (which could be still fine in theory due the preview feature, but possibly not so great...).

Hence gave it another though to rather wrap this authenticator behind the "deprecated feature", which should be explicitly enabled if people want this deprecated authenticator to be used. This give administrator a chance to start the server with the deprecated feature and re-configure their flows to the supported way and properly migrate. Then finally remove this in Keycloak 27, which should be fine.

NOTE: Draft PR for now as I am curious for the feedback.
