### PR TITLE
Getting error 405 'Method Not Allowed' when calling the 'certs' endpo…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oidc;
 
+import jakarta.ws.rs.HEAD;
 import org.jboss.resteasy.reactive.NoCache;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.OAuthErrorException;
@@ -191,6 +192,16 @@ public class OIDCLoginProtocolService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getVersionPreflight() {
         return Cors.builder().allowedMethods("GET").preflight().auth().add(Response.ok());
+    }
+
+    // The method added just as a workaround to https://github.com/quarkusio/quarkus/issues/49172 . It can be removed once that one is
+    // fixed in quarkus and Keycloak updated to the corresponding version
+    @HEAD
+    @Path("/certs")
+    @Produces({MediaType.APPLICATION_JSON})
+    @NoCache
+    public Response certsHead() {
+        return certs();
     }
 
     @GET

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/broker/util/SimpleHttpDefault.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/broker/util/SimpleHttpDefault.java
@@ -49,4 +49,8 @@ public abstract class SimpleHttpDefault extends SimpleHttp {
         return SimpleHttp.doGet(url, client, HttpClientProvider.DEFAULT_MAX_CONSUMED_RESPONSE_SIZE);
     }
 
+    public static SimpleHttp doHead(String url, HttpClient client) {
+        return SimpleHttp.doHead(url, client, HttpClientProvider.DEFAULT_MAX_CONSUMED_RESPONSE_SIZE);
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.common.Profile;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.jose.jwe.JWEConstants;
@@ -288,6 +289,10 @@ public abstract class AbstractWellKnownProviderTest extends AbstractKeycloakTest
 
         JSONWebKeySet jsonWebKeySet = SimpleHttpDefault.doGet(jwksUri, client).asJson(JSONWebKeySet.class);
         assertEquals(3, jsonWebKeySet.getKeys().length);
+
+        // Test HEAD method works (Issue 41537)
+        SimpleHttp.Response responseHead = SimpleHttpDefault.doHead(jwksUri, client).asResponse();
+        assertEquals(Response.Status.OK.getStatusCode(), responseHead.getStatus());
     }
 
     @Test


### PR DESCRIPTION
…int with HEAD method

closes #41537


(cherry picked from commit 2dab73063dd5cc1fdcd5080f8a9f01222ea32d81) (cherry picked from commit 7a9c0d3290c84f215fcf020e2fe22472d897b898)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
