### PR TITLE
Move flaky test to top so it will run first.

### DIFF
--- a/js/apps/admin-ui/test/user-federation/kerberos.spec.ts
+++ b/js/apps/admin-ui/test/user-federation/kerberos.spec.ts
@@ -90,6 +90,21 @@ test.describe("User Fed Kerberos tests", () => {
       await goToUserFederation(page);
     });
 
+    test("Should edit existing Kerberos provider and cancel", async ({
+      page,
+    }) => {
+      await clickUserFederationCard(page, firstKerberosName);
+      await selectItem(page, "#kc-cache-policy", weeklyPolicy);
+      await selectItem(page, "#kc-eviction-day", newKerberosDay);
+      await selectItem(page, "#kc-eviction-hour", newKerberosHour);
+      await selectItem(page, "#kc-eviction-minute", newKerberosMinute);
+      await page.getByTestId(`${provider}-cancel`).click();
+
+      await clickUserFederationCard(page, firstKerberosName);
+
+      await expect(page.locator("#kc-cache-policy")).toHaveText(defaultPolicy);
+    });
+
     test("Should edit existing Kerberos provider", async ({ page }) => {
       await goToUserFederation(page);
       await clickUserFederationCard(page, firstKerberosName);
@@ -175,21 +190,6 @@ test.describe("User Fed Kerberos tests", () => {
 
       await expect(page.getByText(noCachePolicy)).toBeVisible();
       await expect(page.getByText(defaultPolicy)).toBeHidden();
-    });
-
-    test("Should edit existing Kerberos provider and cancel", async ({
-      page,
-    }) => {
-      await clickUserFederationCard(page, firstKerberosName);
-      await selectItem(page, "#kc-cache-policy", weeklyPolicy);
-      await selectItem(page, "#kc-eviction-day", newKerberosDay);
-      await selectItem(page, "#kc-eviction-hour", newKerberosHour);
-      await selectItem(page, "#kc-eviction-minute", newKerberosMinute);
-      await page.getByTestId(`${provider}-cancel`).click();
-
-      await clickUserFederationCard(page, firstKerberosName);
-
-      await expect(page.locator("#kc-cache-policy")).toHaveText(defaultPolicy);
     });
 
     test("Should disable an existing Kerberos provider", async ({ page }) => {


### PR DESCRIPTION
Fixes #41598

The flaky test would sometimes fail because the cache policy had been changed by another test.

Simplest fix is to just move it to the top of the file so it runs first.  This test just cancels so it has no side effects.  Since it is first in the file it will always run first and won't be flaky any more.
