### PR TITLE
Fix formatting issue for Operator Realm Import docs

### DIFF
--- a/docs/guides/operator/realm-import.adoc
+++ b/docs/guides/operator/realm-import.adoc
@@ -116,7 +116,7 @@ spec:
     ...
 ----
 
-In the above example placeholder replacement will be enabled and an environment variable with key `ENV_KEY` will be created from the Secret `SECRET_NAME`'s value for key `SECRET_KEY`.
+In the above example placeholder replacement will be enabled and an environment variable with key `ENV_KEY` will be created from the Secret ``SECRET_NAME``'s value for key `SECRET_KEY`.
 Currently only Secrets are supported and they must be in the same namespace as the Keycloak CR.
 
 </@tmpl.guide>


### PR DESCRIPTION
https://www.keycloak.org/operator/realm-import

Before:
<img width="721" height="145" alt="image" src="https://github.com/user-attachments/assets/e519f929-26db-4e5d-b70f-f51d40c0da4c" />

After (generated docs, not website): 
<img width="868" height="130" alt="image" src="https://github.com/user-attachments/assets/a3be0e3e-d834-42d9-8ff5-f950bbded944" />

@shawkins Could you please check this small improvement? Thanks!
