### PR TITLE
Using a different attrib name fixes flakiness

### DIFF
--- a/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
@@ -69,10 +69,12 @@ test.describe("User profile tabs", () => {
     test("Completes new attribute form and performs cancel", async ({
       page,
     }) => {
+      const uniqueName = "UniqueName";
       await clickCreateAttribute(page);
-      await fillAttributeForm(page, { name, displayName });
+      await fillAttributeForm(page, { name: uniqueName, displayName });
       await clickCancelAttribute(page);
-      await assertRowExists(page, name, false);
+      await assertRowExists(page, uniqueName, false);
+      await assertRowExists(page, "firstName", true);
     });
 
     test("Completes new attribute form and performs submit", async ({


### PR DESCRIPTION
Fixes #41648

Flaky test failing: test/realm-settings/userprofile.spec.ts:69:5 › User profile tabs › Attributes sub tab tests › Completes new attribute form and performs cancel 

`assertRowExists()` would sometimes get a false positive because of another attribute that was created in `beforeAll()`.  Both were using the word `Test`.

Just changing to use a different attribute name for this simple test makes the test pass every time.  

Also added an extra line to make sure we returned to the attribute list after cancel.
