### PR TITLE
Re-enable test for setting the basic info in the account console

### DIFF
--- a/js/apps/account-ui/test/personal-info/personal-info.spec.ts
+++ b/js/apps/account-ui/test/personal-info/personal-info.spec.ts
@@ -17,10 +17,10 @@ test.describe("Personal info page", () => {
   test.beforeAll(() => createRandomUserWithPassword(user, "pwd", realm));
   test.afterAll(async () => deleteUser(user, realm));
 
-  test.skip("sets basic information", async ({ page }) => {
+  test("sets basic information", async ({ page }) => {
     await login(page, user, "pwd", realm);
 
-    await page.getByTestId("email").fill(`${user}@somewhere.com`); //<-- field disabled
+    await page.getByTestId("email").fill(`${user}@somewhere.com`);
     await page.getByTestId("firstName").fill("Erik");
     await page.getByTestId("lastName").fill("de Wit");
     await page.getByTestId("save").click();


### PR DESCRIPTION
Closes #41289

* The test should be re-enabled to at least cover updating user's basic info when the `Update Email` feature is disabled for a realm. By default, the feature is disabled as per https://github.com/keycloak/keycloak/blob/main/docs/documentation/server_admin/topics/login-settings/update-email-workflow.adoc#update-email-workflow-updateemail.

We need UI tests to cover realms where the feature is enabled, though. I think we can do it as a follow-up.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
