### PR TITLE
fix: showing only the canonical oauth2 property name

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -20,6 +20,7 @@ package org.keycloak.representations.idm;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.MultivaluedHashMap;
@@ -517,6 +518,7 @@ public class RealmRepresentation {
         this.oauth2DeviceCodeLifespan = oauth2DeviceCodeLifespan;
     }
 
+    @Schema(name = "oauth2DeviceCodeLifespan")
     public Integer getOAuth2DeviceCodeLifespan() {
         return oauth2DeviceCodeLifespan;
     }
@@ -525,6 +527,7 @@ public class RealmRepresentation {
         this.oauth2DevicePollingInterval = oauth2DevicePollingInterval;
     }
 
+    @Schema(name = "oauth2DevicePollingInterval")
     public Integer getOAuth2DevicePollingInterval() {
         return oauth2DevicePollingInterval;
     }


### PR DESCRIPTION
Tested deserialization and lower-case oauth is expected.

closes: #41624

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
