### PR TITLE
Updated the upstream WildFly version & updated the WildFly subsystem module to avoid using deprecated and removed functionality

### DIFF
--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessor.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessor.java
@@ -28,7 +28,6 @@ import org.jboss.as.web.common.WarMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.metadata.web.spec.LoginConfigMetaData;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 /**
@@ -36,10 +35,10 @@ import org.jboss.modules.ModuleLoader;
  */
 public abstract class KeycloakDependencyProcessor implements DeploymentUnitProcessor {
 
-    private static final ModuleIdentifier KEYCLOAK_JBOSS_CORE_ADAPTER = KeycloakSubsystemDefinition.KEYCLOAK_JBOSS_CORE_ADAPTER;
-    private static final ModuleIdentifier KEYCLOAK_CORE_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-adapter-core");
-    private static final ModuleIdentifier KEYCLOAK_API_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-adapter-api-public");
-    private static final ModuleIdentifier KEYCLOAK_COMMON = ModuleIdentifier.create("org.keycloak.keycloak-common");
+    static final String KEYCLOAK_JBOSS_CORE_ADAPTER = "org.keycloak.keycloak-jboss-adapter-core";
+    static final String KEYCLOAK_CORE_ADAPTER = "org.keycloak.keycloak-saml-adapter-core";
+    static final String KEYCLOAK_API_ADAPTER = "org.keycloak.keycloak-saml-adapter-api-public";
+    static final String KEYCLOAK_COMMON = "org.keycloak.keycloak-common";
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessorWildFly.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakDependencyProcessorWildFly.java
@@ -23,7 +23,6 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.ModuleClassLoader;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 /**
@@ -33,8 +32,7 @@ import org.jboss.modules.ModuleLoader;
  */
 public class KeycloakDependencyProcessorWildFly extends KeycloakDependencyProcessor {
 
-    private static final ModuleIdentifier KEYCLOAK_CORE_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-adapter-core");
-    private static final ModuleIdentifier KEYCLOAK_ELYTRON_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-saml-wildfly-elytron-adapter");
+    private static final String KEYCLOAK_ELYTRON_ADAPTER = "org.keycloak.keycloak-saml-wildfly-elytron-adapter";
 
     @Override
     protected void addCoreModules(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakSubsystemDefinition.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeycloakSubsystemDefinition.java
@@ -21,7 +21,8 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.RuntimePackageDependency;
-import org.jboss.modules.ModuleIdentifier;
+
+import static org.keycloak.subsystem.adapter.saml.extension.KeycloakDependencyProcessor.KEYCLOAK_JBOSS_CORE_ADAPTER;
 
 /**
  * Definition of subsystem=keycloak-saml.
@@ -31,7 +32,6 @@ import org.jboss.modules.ModuleIdentifier;
 public class KeycloakSubsystemDefinition extends SimpleResourceDefinition {
 
     static final KeycloakSubsystemDefinition INSTANCE = new KeycloakSubsystemDefinition();
-    static final ModuleIdentifier KEYCLOAK_JBOSS_CORE_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-jboss-adapter-core");
 
     private KeycloakSubsystemDefinition() {
         super(KeycloakSamlExtension.SUBSYSTEM_PATH,
@@ -51,6 +51,6 @@ public class KeycloakSubsystemDefinition extends SimpleResourceDefinition {
     public void registerAdditionalRuntimePackages(ManagementResourceRegistration resourceRegistration) {
         // This module is required by deployment but not referenced by JBoss modules
         resourceRegistration.registerAdditionalRuntimePackages(
-                RuntimePackageDependency.required(KEYCLOAK_JBOSS_CORE_ADAPTER.getName()));
+                RuntimePackageDependency.required(KEYCLOAK_JBOSS_CORE_ADAPTER));
     }
 }


### PR DESCRIPTION
- Updated the WildFly and wildfly-core versions to 34.0.0.Final & 29.0.0.Final respectively. These are the minimum versions that include the ModuleDependency builder. 
- Replaced instances of the deprecated class ModuleIdentifier with strings.
- Replaced invocations of the deprecated and marked for removal ModuleDependency constructors with the builder.

This does mean the adapter will only support WildFly 34+ but does keep things future proof. If we didn't switch to using the ModuleDependency builders and only removed the ModuleIdentifier usages, we risk the same issue happening with a newer WildFly version as the last remaining ModuleDependency constructor is marked for removal as well. But hasn't yet been removed as of 29.0.0.Final.

I've left the EAP versions and `tests.wildfly.core.version` as they were as I'm not so familiar with EAP so not sure the best way forward so I'm happy to take some feedback onboard for this.

Closes #41669
