### PR TITLE
fix: ensuring the ordering of the providers

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -521,9 +521,9 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         testRealm.getComponents().add("org.keycloak.keys.KeyProvider", getKeyProvider());
 
         testRealm.getComponents().add("org.keycloak.keys.KeyProvider",
-                getRsaEncKeyProvider(RSA_OAEP_256, "enc-key-oaep256"));
+                getRsaEncKeyProvider(RSA_OAEP_256, "enc-key-oaep256", 100));
         testRealm.getComponents().add("org.keycloak.keys.KeyProvider",
-                getRsaEncKeyProvider(RSA_OAEP, "enc-key-oaep"));
+                getRsaEncKeyProvider(RSA_OAEP, "enc-key-oaep", 101));
 
         // Find existing client representation
         ClientRepresentation existingClient = testRealm.getClients().stream()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
@@ -93,9 +93,9 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerEndpointTest 
         }
 
         testRealm.getComponents().add("org.keycloak.keys.KeyProvider",
-                getRsaEncKeyProvider(RSA_OAEP_256, "enc-key-oaep256"));
+                getRsaEncKeyProvider(RSA_OAEP_256, "enc-key-oaep256", 100));
         testRealm.getComponents().add("org.keycloak.keys.KeyProvider",
-                getRsaEncKeyProvider(RSA_OAEP, "enc-key-oaep"));
+                getRsaEncKeyProvider(RSA_OAEP, "enc-key-oaep", 101));
 
         super.configureTestRealm(testRealm);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
@@ -222,7 +222,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
         return componentExportRepresentation;
     }
 
-    public static ComponentExportRepresentation getRsaEncKeyProvider(String algorithm, String keyName) {
+    public static ComponentExportRepresentation getRsaEncKeyProvider(String algorithm, String keyName, int priority) {
         KeyWrapper keyWrapper = getRsaKey(KeyUse.ENC, algorithm, keyName);
         ComponentExportRepresentation componentExportRepresentation = new ComponentExportRepresentation();
         componentExportRepresentation.setName(keyName);
@@ -237,7 +237,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
                         "privateKey", List.of(PemUtils.encodeKey(keyWrapper.getPrivateKey())),
                         "certificate", List.of(PemUtils.encodeCertificate(certificate)),
                         "active", List.of("true"),
-                        "priority", List.of("100"),
+                        "priority", List.of(String.valueOf(priority)),
                         "enabled", List.of("true"),
                         "algorithm", List.of(algorithm),
                         "keyUse", List.of(KeyUse.ENC.name())


### PR DESCRIPTION
With using the same prioirty for both providers, they were being sorted by a uuid so the order was not stable.

closes: #41653

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
