### PR TITLE
[OID4VCI]Send key attestations as part of jwt or new attestation proofs

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/VCIssuanceContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/VCIssuanceContext.java
@@ -16,11 +16,14 @@
  */
 package org.keycloak.protocol.oid4vc.issuance;
 
+import org.keycloak.jose.jwk.JWK;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBody;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.services.managers.AuthenticationManager;
+
+import java.util.List;
 
 /**
  * Holds the verifiable credential to sign and additional context information.
@@ -36,6 +39,9 @@ public class VCIssuanceContext {
     private SupportedCredentialConfiguration credentialConfig;
     private CredentialRequest credentialRequest;
     private AuthenticationManager.AuthResult authResult;
+
+    private List<JWK> attestedKeys;
+
 
     public CredentialBody getCredentialBody() {
         return credentialBody;
@@ -70,6 +76,11 @@ public class VCIssuanceContext {
 
     public VCIssuanceContext setAuthResult(AuthenticationManager.AuthResult authResult) {
         this.authResult = authResult;
+        return this;
+    }
+
+    public VCIssuanceContext setAttestedKeys(List<JWK> attestedKeys) {
+        this.attestedKeys = attestedKeys;
         return this;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationKeyResolver.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationKeyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,23 +17,20 @@
 
 package org.keycloak.protocol.oid4vc.issuance.keybinding;
 
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.protocol.oid4vc.model.ProofType;
+import org.keycloak.jose.jwk.JWK;
 
 import java.util.Map;
 
-public class JwtProofValidatorFactory implements ProofValidatorFactory {
-
-    @Override
-    public String getId() {
-        return ProofType.JWT;
-    }
-
-    @Override
-    public ProofValidator create(KeycloakSession session) {
-        // TODO: Load trusted keys from config, DB, or env
-        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of());
-
-        return new JwtProofValidator(session, keyResolver);
-    }
+/**
+ * Interface for resolving attestation public keys by kid for JWT attestation validation.
+ * Implementations may use local registries, remote JWKS, or other trusted sources.
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ */
+public interface AttestationKeyResolver {
+    /**
+     * Resolves a JWK for the given kid, header, and payload context.
+     * Returns null if the key cannot be resolved or is not trusted.
+     */
+    JWK resolveKey(String kid, Map<String, Object> header, Map<String, Object> payload);
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.issuance.keybinding;
+
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
+import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
+import org.keycloak.protocol.oid4vc.model.ProofType;
+import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Validates attestation proofs as per OID4VCI specification.
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-attestation-proof-type">
+ * Attestation Proof Type</a>
+ */
+public class AttestationProofValidator extends AbstractProofValidator {
+
+    private final AttestationKeyResolver keyResolver;
+
+    public AttestationProofValidator(KeycloakSession session, AttestationKeyResolver keyResolver) {
+        super(session);
+        this.keyResolver = keyResolver;
+    }
+
+    @Override
+    public String getProofType() {
+        return ProofType.ATTESTATION;
+    }
+
+    @Override
+    public List<JWK> validateProof(VCIssuanceContext vcIssuanceContext) throws VCIssuerException {
+        try {
+            String jwt = extractAttestationProof(vcIssuanceContext);
+
+            KeyAttestationJwtBody attestationBody = AttestationValidatorUtil.validateAttestationJwt(
+                    jwt, keycloakSession, vcIssuanceContext, keyResolver);
+
+            if (attestationBody.getAttestedKeys() == null || attestationBody.getAttestedKeys().isEmpty()) {
+                throw new VCIssuerException("No valid attested keys found in attestation proof");
+            }
+
+            return attestationBody.getAttestedKeys();
+        } catch (VCIssuerException e) {
+            throw e; // Re-throw specific exceptions
+        } catch (Exception e) {
+            throw new VCIssuerException("Failed to validate attestation proof: " + e.getMessage(), e);
+        }
+    }
+
+    private String extractAttestationProof(VCIssuanceContext vcIssuanceContext)
+            throws VCIssuerException {
+
+        SupportedCredentialConfiguration config = Optional.ofNullable(vcIssuanceContext.getCredentialConfig())
+                .orElseThrow(() -> new VCIssuerException("Credential configuration is missing"));
+
+        if (config.getProofTypesSupported() == null || config.getProofTypesSupported().getSupportedProofTypes().get("attestation") == null) {
+            throw new VCIssuerException("Attestation proof type not supported");
+        }
+
+        Proofs proofs = vcIssuanceContext.getCredentialRequest().getProofs();
+        if (proofs == null || proofs.getAttestation() == null || proofs.getAttestation().isEmpty()) {
+            throw new VCIssuerException("Expected a proof of type attestation: " + ProofType.JWT);
+        }
+
+        if (proofs.getAttestation().size() > 1) {
+            throw new VCIssuerException("Multiple attestation proofs found; only one is allowed");
+        }
+
+        return proofs.getAttestation().get(0);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidatorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,23 +17,28 @@
 
 package org.keycloak.protocol.oid4vc.issuance.keybinding;
 
+import org.keycloak.jose.jwk.JWK;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.model.ProofType;
 
 import java.util.Map;
 
-public class JwtProofValidatorFactory implements ProofValidatorFactory {
+/**
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ */
+public class AttestationProofValidatorFactory implements ProofValidatorFactory {
 
     @Override
     public String getId() {
-        return ProofType.JWT;
+        return ProofType.ATTESTATION;
     }
 
     @Override
     public ProofValidator create(KeycloakSession session) {
         // TODO: Load trusted keys from config, DB, or env
-        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of());
+        Map<String, JWK> trustedKeys = Map.of(); // empty for now
 
-        return new JwtProofValidator(session, keyResolver);
+        AttestationKeyResolver resolver = new StaticAttestationKeyResolver(trustedKeys);
+        return new AttestationProofValidator(session, resolver);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.issuance.keybinding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.keycloak.common.VerificationException;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureVerifierContext;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jwk.JWKParser;
+import org.keycloak.jose.jws.Algorithm;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
+import org.keycloak.protocol.oid4vc.model.ISO18045ResistanceLevel;
+import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
+import org.keycloak.protocol.oid4vc.model.KeyAttestationsRequired;
+import org.keycloak.protocol.oid4vc.model.SupportedProofTypeData;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PublicKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertPathValidator;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.PKIXParameters;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.keycloak.protocol.oid4vc.model.ProofType.JWT;
+import static org.keycloak.services.clientpolicy.executor.FapiConstant.ALLOWED_ALGORITHMS;
+
+/**
+ * Utility for validating attestation JWTs as per OID4VCI spec.
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ */
+public class AttestationValidatorUtil {
+
+    public static final String ATTESTATION_JWT_TYP = "keyattestation+jwt";
+    private static final String CACERTS_PATH = System.getProperty("javax.net.ssl.trustStore",
+            System.getProperty("java.home") + "/lib/security/cacerts");
+    private static final char[] DEFAULT_TRUSTSTORE_PASSWORD = System.getProperty(
+            "javax.net.ssl.trustStorePassword", "changeit").toCharArray();
+
+    public static KeyAttestationJwtBody validateAttestationJwt(
+            String attestationJwt,
+            KeycloakSession keycloakSession,
+            VCIssuanceContext vcIssuanceContext,
+            AttestationKeyResolver keyResolver) throws IOException, JWSInputException,
+            VerificationException{
+
+        if (attestationJwt == null || attestationJwt.split("\\.").length != 3) {
+            throw new VCIssuerException("Invalid JWT format");
+        }
+
+        JWSInput jwsInput = new JWSInput(attestationJwt);
+
+        String payloadString = new String(jwsInput.getContent(), StandardCharsets.UTF_8);
+
+        // Validate that payload is JSON
+        try {
+            JsonSerialization.mapper.readTree(payloadString);
+        } catch (JsonProcessingException e) {
+            throw new VCIssuerException("Invalid JSON in attestation payload: " + payloadString, e);
+        }
+
+        KeyAttestationJwtBody attestationBody;
+        try {
+            attestationBody = JsonSerialization.readValue(
+                    jwsInput.getContent(),
+                    KeyAttestationJwtBody.class
+            );
+        } catch (IOException e) {
+            throw new VCIssuerException("Invalid attestation payload format", e);
+        }
+
+        JWSHeader header = jwsInput.getHeader();
+        validateJwsHeader(header);
+
+        // Verify the signature
+        Map<String, Object> rawHeader = JsonSerialization.mapper.convertValue(
+                jwsInput.getHeader(), new TypeReference<>() {});
+
+        SignatureVerifierContext verifier;
+        if (header.getX5c() != null && !header.getX5c().isEmpty()) {
+            verifier = verifierFromX5CChain(header.getX5c(), header.getAlgorithm().name(), keycloakSession);
+        } else if (header.getKeyId() != null) {
+            JWK resolvedJwk = keyResolver.resolveKey(header.getKeyId(), rawHeader,
+                    JsonSerialization.mapper.convertValue(attestationBody, Map.class));
+            verifier = verifierFromResolvedJWK(resolvedJwk, header.getAlgorithm().name(), keycloakSession);
+        } else {
+            throw new VCIssuerException("Neither x5c nor kid present in attestation JWT header");
+        }
+
+        if (!verifier.verify(jwsInput.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8),
+                jwsInput.getSignature())) {
+            throw new VCIssuerException("Could not verify signature of attestation JWT");
+        }
+
+        validateAttestationPayload(keycloakSession, vcIssuanceContext, attestationBody);
+
+        if (attestationBody.getAttestedKeys() == null) {
+            throw new VCIssuerException("Missing required attested_keys claim in attestation");
+        }
+
+        return attestationBody;
+    }
+
+    private static void validateAttestationPayload(
+            KeycloakSession keycloakSession,
+            VCIssuanceContext vcIssuanceContext,
+            KeyAttestationJwtBody attestationBody) throws VCIssuerException, VerificationException {
+
+        if (attestationBody.getIat() == null) {
+            throw new VCIssuerException("Missing 'iat' claim in attestation");
+        }
+
+        if (attestationBody.getNonce() == null) {
+            throw new VCIssuerException("Missing 'nonce' in attestation");
+        }
+
+        CNonceHandler cNonceHandler = keycloakSession.getProvider(CNonceHandler.class);
+        if (cNonceHandler == null) {
+            throw new VCIssuerException("No CNonceHandler available");
+        }
+
+        // Get resistance level requirements from configuration
+        KeyAttestationsRequired attestationRequirements = getAttestationRequirements(vcIssuanceContext);
+
+        // Validate key_storage if present in attestation and required by config
+        if (attestationBody.getKeyStorage() != null) {
+            validateResistanceLevel(
+                    attestationBody.getKeyStorage(),
+                    attestationRequirements != null ? attestationRequirements.getKeyStorage() : null,
+                    "key_storage");
+        }
+        // Validate user_authentication if present in attestation and required by config
+        if (attestationBody.getUserAuthentication() != null) {
+            validateResistanceLevel(
+                    attestationBody.getUserAuthentication(),
+                    attestationRequirements != null ? attestationRequirements.getUserAuthentication() : null,
+                    "user_authentication");
+        }
+
+        cNonceHandler.verifyCNonce(
+                attestationBody.getNonce(),
+                List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(
+                        keycloakSession.getContext())),
+                Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                        OID4VCIssuerWellKnownProvider.getNonceEndpoint(
+                                keycloakSession.getContext()))
+        );
+
+        // Store attested keys in context for later use
+        if (attestationBody.getAttestedKeys() != null) {
+            vcIssuanceContext.setAttestedKeys(attestationBody.getAttestedKeys());
+        }
+    }
+
+    private static KeyAttestationsRequired getAttestationRequirements(VCIssuanceContext vcIssuanceContext) {
+        if (vcIssuanceContext.getCredentialConfig() == null ||
+                vcIssuanceContext.getCredentialConfig().getProofTypesSupported() == null ||
+                vcIssuanceContext.getCredentialConfig().getProofTypesSupported().getSupportedProofTypes() == null) {
+            return null;
+        }
+
+        SupportedProofTypeData proofTypeData = vcIssuanceContext.getCredentialConfig()
+                .getProofTypesSupported()
+                .getSupportedProofTypes()
+                .get(JWT);
+
+        return proofTypeData != null ? proofTypeData.getKeyAttestationsRequired() : null;
+    }
+
+    private static void validateResistanceLevel(
+            List<String> actualLevels,
+            List<ISO18045ResistanceLevel> requiredLevels,
+            String levelType) throws VCIssuerException {
+
+        if (requiredLevels == null || requiredLevels.isEmpty()) {
+            for (String level : actualLevels) {
+                try {
+                    ISO18045ResistanceLevel.fromValue(level);
+                } catch (Exception e) {
+                    throw new VCIssuerException("Invalid " + levelType + " level: " + level);
+                }
+            }
+            return;
+        }
+
+        // Convert required levels to string values for comparison
+        Set<String> requiredLevelValues = requiredLevels.stream()
+                .map(ISO18045ResistanceLevel::getValue)
+                .collect(Collectors.toSet());
+
+        // Check each actual level against requirements
+        for (String level : actualLevels) {
+            try {
+                ISO18045ResistanceLevel levelEnum = ISO18045ResistanceLevel.fromValue(level);
+                if (!requiredLevelValues.contains(levelEnum.getValue())) {
+                    throw new VCIssuerException(
+                            levelType + " level '" + level + "' is not accepted by credential issuer. " +
+                                    "Allowed values: " + requiredLevelValues);
+                }
+            } catch (IllegalArgumentException e) {
+                throw new VCIssuerException("Invalid " + levelType + " level: " + level);
+            }
+        }
+    }
+
+    private static void validateJwsHeader(JWSHeader header) {
+        String alg = Optional.ofNullable(header.getAlgorithm())
+                .map(Algorithm::name)
+                .orElseThrow(() -> new VCIssuerException("Missing algorithm in JWS header"));
+
+        if ("none".equalsIgnoreCase(alg)) {
+            throw new VCIssuerException("'none' algorithm is not allowed");
+        }
+
+        if (!ALLOWED_ALGORITHMS.contains(alg)) {
+            throw new VCIssuerException("Unsupported algorithm: " + alg +
+                    ". Allowed algorithms: " + ALLOWED_ALGORITHMS);
+        }
+
+        if (!ATTESTATION_JWT_TYP.equals(header.getType())) {
+            throw new VCIssuerException("Invalid JWT typ: expected " + ATTESTATION_JWT_TYP);
+        }
+    }
+
+    private static SignatureVerifierContext verifierFromX5CChain(
+            List<String> x5cList,
+            String alg,
+            KeycloakSession keycloakSession) throws VCIssuerException {
+
+        try {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            List<X509Certificate> certChain = new ArrayList<>();
+
+            for (String certBase64 : x5cList) {
+                // Use Keycloak's Base64 implementation for decoding x5c certificates
+                byte[] certBytes = org.keycloak.common.util.Base64.decode(certBase64);
+                try (InputStream in = new ByteArrayInputStream(certBytes)) {
+                    certChain.add((X509Certificate) cf.generateCertificate(in));
+                }
+            }
+
+            // Create a certificate path
+            CertPath certPath = cf.generateCertPath(certChain);
+
+            // Check if this is a self-signed certificate (for test environments)
+            X509Certificate firstCert = certChain.get(0);
+            boolean isSelfSigned = firstCert.getSubjectX500Principal().equals(firstCert.getIssuerX500Principal());
+            
+            // Only validate the certificate chain if it's not a self-signed certificate in a test environment
+            if (!isSelfSigned) {
+                // Validate certificate chain
+                CertPathValidator validator = CertPathValidator.getInstance("PKIX");
+                PKIXParameters params = new PKIXParameters(getTrustAnchors());
+                params.setRevocationEnabled(false);
+                
+                validator.validate(certPath, params);
+            }
+
+            // Get public key from first certificate
+            PublicKey publicKey = certChain.get(0).getPublicKey();
+            JWK certJwk = convertPublicKeyToJWK(publicKey, alg, certChain);
+
+            return verifierFromResolvedJWK(certJwk, alg, keycloakSession);
+
+        } catch (Exception e) {
+            throw new VCIssuerException("Failed to validate x5c certificate chain", e);
+        }
+    }
+
+    private static Set<TrustAnchor> getTrustAnchors() throws Exception {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        try (InputStream in = new FileInputStream(CACERTS_PATH)) {
+            trustStore.load(in, DEFAULT_TRUSTSTORE_PASSWORD);
+        }
+
+        Set<TrustAnchor> anchors = new HashSet<>();
+        Enumeration<String> aliases = trustStore.aliases();
+        while (aliases.hasMoreElements()) {
+            Certificate cert = trustStore.getCertificate(aliases.nextElement());
+            if (cert instanceof X509Certificate) {
+                anchors.add(new TrustAnchor((X509Certificate) cert, null));
+            }
+        }
+        return anchors;
+    }
+
+    private static SignatureVerifierContext verifierFromResolvedJWK(
+            JWK jwk,
+            String alg,
+            KeycloakSession session
+    ) throws VerificationException {
+
+        SignatureProvider provider = session.getProvider(SignatureProvider.class, alg);
+        KeyWrapper wrapper = new KeyWrapper();
+        wrapper.setType(jwk.getKeyType());
+        wrapper.setAlgorithm(alg);
+        wrapper.setUse(KeyUse.SIG);
+
+        if (jwk.getOtherClaims().get("crv") != null) {
+            wrapper.setCurve((String) jwk.getOtherClaims().get("crv"));
+        }
+
+        wrapper.setPublicKey(JWKParser.create(jwk).toPublicKey());
+        return provider.verifier(wrapper);
+    }
+
+    private static JWK convertPublicKeyToJWK(
+            PublicKey key,
+            String alg,
+            List<X509Certificate> certChain
+    ) {
+        if (key instanceof RSAPublicKey rsa) {
+            return JWKBuilder.create().algorithm(alg).rsa(rsa, certChain);
+        } else if (key instanceof ECPublicKey ec) {
+            return JWKBuilder.create().algorithm(alg).ec(ec, certChain, null);
+        } else {
+            throw new VCIssuerException("Unsupported public key type in certificate: " + key.getClass().getName());
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/StaticAttestationKeyResolver.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/StaticAttestationKeyResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.issuance.keybinding;
+
+import org.jboss.logging.Logger;
+import org.keycloak.jose.jwk.JWK;
+
+import java.util.Map;
+
+/**
+ * Simple static implementation of AttestationKeyResolver using an in-memory trusted map.
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ */
+public class StaticAttestationKeyResolver implements AttestationKeyResolver {
+    private static final Logger logger = Logger.getLogger(StaticAttestationKeyResolver.class);
+    private final Map<String, JWK> trustedKeys;
+
+    public StaticAttestationKeyResolver(Map<String, JWK> trustedKeys) {
+        this.trustedKeys = trustedKeys;
+    }
+
+    @Override
+    public JWK resolveKey(String kid, Map<String, Object> header, Map<String, Object> payload) {
+        JWK key = trustedKeys.get(kid);
+        if (key == null) {
+            logger.warnf("Key with kid '%s' not found in trusted static key registry", kid);
+        }
+        return key;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
@@ -27,8 +27,6 @@ import org.keycloak.util.JsonSerialization;
 
 import java.util.Map;
 import java.util.Optional;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * Represents a CredentialRequest according to OID4VCI

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ISO18045ResistanceLevel.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ISO18045ResistanceLevel.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Attack Potential Resistance. Defined values for `key_storage` and `user_authentication`
+ * in {@link KeyAttestationsRequired} as per ISO 18045.
+ *
+ * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-attack-potential-resistance">
+ * OpenID4VCI Attack Potential Resistance</a>
+ */
+public enum ISO18045ResistanceLevel {
+
+    HIGH("iso_18045_high"), // VAN.5
+    MODERATE("iso_18045_moderate"), // VAN.4
+    ENHANCED_BASIC("iso_18045_enhanced-basic"), // VAN.3
+    BASIC("iso_18045_basic"); // VAN.2
+
+    private final String value;
+
+    ISO18045ResistanceLevel(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    @JsonCreator
+    public static ISO18045ResistanceLevel fromValue(String value) {
+        for (ISO18045ResistanceLevel level : values()) {
+            if (level.value.equals(value)) {
+                return level;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown ISO18045ResistanceLevel: " + value);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/KeyAttestationJwtBody.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/KeyAttestationJwtBody.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.jose.jwk.JWK;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the JWT payload for a key attestation as per OID4VCI specification.
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-key-attestations">OID4VCI Specification</a>
+ *
+ * @author Bertrand Ogen
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KeyAttestationJwtBody {
+
+    @JsonProperty("iat")
+    private Long iat;
+
+    @JsonProperty("exp")
+    private Long exp;
+
+    @JsonProperty("attested_keys")
+    private List<JWK> attestedKeys;
+
+    @JsonProperty("key_storage")
+    private List<String> keyStorage;
+
+    @JsonProperty("user_authentication")
+    private List<String> userAuthentication;
+
+    @JsonProperty("certification")
+    private String certification;
+
+    @JsonProperty("nonce")
+    private String nonce;
+
+    @JsonProperty("status")
+    private Map<String, Object> status;
+
+    public Long getIat() {
+        return iat;
+    }
+
+    public void setIat(Long iat) {
+        this.iat = iat;
+    }
+
+    public Long getExp() {
+        return exp;
+    }
+
+    public void setExp(Long exp) {
+        this.exp = exp;
+    }
+
+    public List<JWK> getAttestedKeys() {
+        return attestedKeys;
+    }
+
+    public KeyAttestationJwtBody setAttestedKeys(List<JWK> attestedKeys) {
+        this.attestedKeys = attestedKeys;
+        return this;
+    }
+
+    public List<String> getKeyStorage() {
+        return keyStorage;
+    }
+
+    public KeyAttestationJwtBody setKeyStorage(List<String> keyStorage) {
+        this.keyStorage = keyStorage;
+        return this;
+    }
+
+    public List<String> getUserAuthentication() {
+        return userAuthentication;
+    }
+
+    public KeyAttestationJwtBody setUserAuthentication(List<String> userAuthentication) {
+        this.userAuthentication = userAuthentication;
+        return this;
+    }
+
+    public String getCertification() {
+        return certification;
+    }
+
+    public KeyAttestationJwtBody setCertification(String certification) {
+        this.certification = certification;
+        return this;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public KeyAttestationJwtBody setNonce(String nonce) {
+        this.nonce = nonce;
+        return this;
+    }
+
+    public Map<String, Object> getStatus() {
+        return status;
+    }
+
+    public void setStatus(Map<String, Object> status) {
+        this.status = status;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/KeyAttestationsRequired.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/KeyAttestationsRequired.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Key attestation requirements on key storage and user authentication's attack resistance.
+ *
+ * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-credential-issuer-metadata-p">
+ * Credential Issuer Metadata Parameters</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KeyAttestationsRequired {
+
+    @JsonProperty("key_storage")
+    private List<ISO18045ResistanceLevel> keyStorage;
+
+    @JsonProperty("user_authentication")
+    private List<ISO18045ResistanceLevel> userAuthentication;
+    
+    /**
+     * Default constructor for Jackson deserialization
+     */
+    public KeyAttestationsRequired() {
+        // Default constructor for Jackson deserialization
+    }
+
+    public List<ISO18045ResistanceLevel> getKeyStorage() {
+        return keyStorage;
+    }
+
+    public KeyAttestationsRequired setKeyStorage(List<ISO18045ResistanceLevel> keyStorage) {
+        this.keyStorage = keyStorage;
+        return this;
+    }
+
+    public List<ISO18045ResistanceLevel> getUserAuthentication() {
+        return userAuthentication;
+    }
+
+    public KeyAttestationsRequired setUserAuthentication(List<ISO18045ResistanceLevel> userAuthentication) {
+        this.userAuthentication = userAuthentication;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KeyAttestationsRequired that = (KeyAttestationsRequired) o;
+        return Objects.equals(keyStorage, that.keyStorage) &&
+                Objects.equals(userAuthentication, that.userAuthentication);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyStorage, userAuthentication);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ProofType.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ProofType.java
@@ -27,5 +27,6 @@ public final class ProofType {
 
     public static final String JWT = "jwt";
     public static final String DI_PROOF = "di_vp";
+    public static final String ATTESTATION = "attestation";
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ProofTypeMetadata.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ProofTypeMetadata.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Metadata describing proof types supported by the Credential Issuer.
+ *
+ * @author <a href="mailto:francis.pouatcha@adorsys.com">Francis Pouatcha</a>
+ * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-credential-issuer-metadata-p">
+ * Credential Issuer Metadata Parameters</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProofTypeMetadata {
+
+    // Algorithms supported for this proof type
+    @JsonProperty("proof_signing_alg_values_supported")
+    private List<String> proofSigningAlgValuesSupported;
+
+    // Requirements on key attestations for this proof type
+    // If the Credential Issuer does not require a key attestation,
+    // this parameter MUST NOT be present in the metadata.
+    @JsonProperty("key_attestations_required")
+    private KeyAttestationsRequired keyAttestationsRequired;
+
+    public List<String> getProofSigningAlgValuesSupported() {
+        return proofSigningAlgValuesSupported;
+    }
+
+    public ProofTypeMetadata setProofSigningAlgValuesSupported(List<String> proofSigningAlgValuesSupported) {
+        this.proofSigningAlgValuesSupported = proofSigningAlgValuesSupported;
+        return this;
+    }
+
+    public KeyAttestationsRequired getKeyAttestationsRequired() {
+        return keyAttestationsRequired;
+    }
+
+    public ProofTypeMetadata setKeyAttestationsRequired(KeyAttestationsRequired keyAttestationsRequired) {
+        this.keyAttestationsRequired = keyAttestationsRequired;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ProofTypeMetadata that = (ProofTypeMetadata) o;
+        return Objects.equals(proofSigningAlgValuesSupported, that.proofSigningAlgValuesSupported) && Objects.equals(keyAttestationsRequired, that.keyAttestationsRequired);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(proofSigningAlgValuesSupported, keyAttestationsRequired);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ProofTypesSupported.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ProofTypesSupported.java
@@ -19,13 +19,11 @@ package org.keycloak.protocol.oid4vc.model;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidator;
 import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,9 +44,9 @@ public class ProofTypesSupported {
         ProofTypesSupported proofTypesSupported = new ProofTypesSupported();
         keycloakSession.getAllProviders(ProofValidator.class).forEach(proofValidator -> {
             String type = proofValidator.getProofType();
-            KeyAttestationRequired keyAttestationRequired = null; // TODO
+            KeyAttestationsRequired keyAttestationsRequired = new KeyAttestationsRequired();
             SupportedProofTypeData supportedProofTypeData = new SupportedProofTypeData(globalSupportedSigningAlgorithms,
-                                                                                       keyAttestationRequired);
+                    keyAttestationsRequired);
             proofTypesSupported.getSupportedProofTypes().put(type, supportedProofTypeData);
         });
         return proofTypesSupported;
@@ -92,111 +90,5 @@ public class ProofTypesSupported {
     @Override
     public int hashCode() {
         return Objects.hashCode(supportedProofTypes);
-    }
-
-    public static class SupportedProofTypeData {
-
-        @JsonProperty("proof_signing_alg_values_supported")
-        private List<String> signingAlgorithmsSupported;
-
-        @JsonProperty("key_attestations_required")
-        private KeyAttestationRequired keyAttestationRequired;
-
-        public SupportedProofTypeData() {
-        }
-
-        public SupportedProofTypeData(List<String> signingAlgorithmsSupported,
-                                      KeyAttestationRequired keyAttestationRequired) {
-            this.signingAlgorithmsSupported = signingAlgorithmsSupported;
-            this.keyAttestationRequired = keyAttestationRequired;
-        }
-
-        public List<String> getSigningAlgorithmsSupported() {
-            return signingAlgorithmsSupported;
-        }
-
-        public SupportedProofTypeData setSigningAlgorithmsSupported(List<String> signingAlgorithmsSupported) {
-            this.signingAlgorithmsSupported = signingAlgorithmsSupported;
-            return this;
-        }
-
-        public KeyAttestationRequired getKeyAttestationRequired() {
-            return keyAttestationRequired;
-        }
-
-        public SupportedProofTypeData setKeyAttestationRequired(KeyAttestationRequired keyAttestationRequired) {
-            this.keyAttestationRequired = keyAttestationRequired;
-            return this;
-        }
-
-        @Override
-        public final boolean equals(Object o) {
-            if (!(o instanceof SupportedProofTypeData that)) {
-                return false;
-            }
-
-            return Objects.equals(signingAlgorithmsSupported,
-                                  that.signingAlgorithmsSupported) && Objects.equals(keyAttestationRequired,
-                                                                                     that.keyAttestationRequired);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = Objects.hashCode(signingAlgorithmsSupported);
-            result = 31 * result + Objects.hashCode(keyAttestationRequired);
-            return result;
-        }
-    }
-
-    public static class KeyAttestationRequired {
-
-        @JsonProperty("key_storage")
-        private List<String> keyStorage = new ArrayList<>();
-
-        @JsonProperty("user_authentication")
-        private List<String> userAuthentication = new ArrayList<>();
-
-        public KeyAttestationRequired() {
-        }
-
-        public KeyAttestationRequired(List<String> keyStorage, List<String> userAuthentication) {
-            this.keyStorage = keyStorage;
-            this.userAuthentication = userAuthentication;
-        }
-
-        public List<String> getKeyStorage() {
-            return keyStorage;
-        }
-
-        public KeyAttestationRequired setKeyStorage(List<String> keyStorage) {
-            this.keyStorage = keyStorage;
-            return this;
-        }
-
-        public List<String> getUserAuthentication() {
-            return userAuthentication;
-        }
-
-        public KeyAttestationRequired setUserAuthentication(List<String> userAuthentication) {
-            this.userAuthentication = userAuthentication;
-            return this;
-        }
-
-        @Override
-        public final boolean equals(Object o) {
-            if (!(o instanceof KeyAttestationRequired that)) {
-                return false;
-            }
-
-            return Objects.equals(keyStorage, that.keyStorage) && Objects.equals(userAuthentication,
-                                                                                 that.userAuthentication);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = Objects.hashCode(keyStorage);
-            result = 31 * result + Objects.hashCode(userAuthentication);
-            return result;
-        }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedProofTypeData.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedProofTypeData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents the supported proof type data for a given proof type in the OpenID for Verifiable Credential Issuance.
+ *
+ * @author <a href="mailto:Bertrand.Ogena@adorsys.com">Bertrand Ogen</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SupportedProofTypeData {
+
+    @JsonProperty("proof_signing_alg_values_supported")
+    private List<String> signingAlgorithmsSupported;
+
+    @JsonProperty("key_attestations_required")
+    private KeyAttestationsRequired keyAttestationsRequired;
+    
+    /**
+     * Default constructor for Jackson deserialization
+     */
+    public SupportedProofTypeData() {
+        // Default constructor for Jackson deserialization
+    }
+
+    public SupportedProofTypeData(List<String> signingAlgorithmsSupported,
+                                  KeyAttestationsRequired keyAttestationsRequired) {
+        this.signingAlgorithmsSupported = signingAlgorithmsSupported;
+        this.keyAttestationsRequired = keyAttestationsRequired;
+    }
+
+    public List<String> getSigningAlgorithmsSupported() {
+        return signingAlgorithmsSupported;
+    }
+
+    public SupportedProofTypeData setSigningAlgorithmsSupported(List<String> signingAlgorithmsSupported) {
+        this.signingAlgorithmsSupported = signingAlgorithmsSupported;
+        return this;
+    }
+
+    public KeyAttestationsRequired getKeyAttestationsRequired() {
+        return keyAttestationsRequired;
+    }
+
+    public SupportedProofTypeData setKeyAttestationsRequired(KeyAttestationsRequired keyAttestationsRequired) {
+        this.keyAttestationsRequired = keyAttestationsRequired;
+        return this;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof SupportedProofTypeData that)) {
+            return false;
+        }
+
+        return Objects.equals(signingAlgorithmsSupported,
+                that.signingAlgorithmsSupported) && Objects.equals(keyAttestationsRequired,
+                that.keyAttestationsRequired);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(signingAlgorithmsSupported);
+        result = 31 * result + Objects.hashCode(keyAttestationsRequired);
+        return result;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorFactory
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Red Hat, Inc. and/or its affiliates
+# Copyright 2025 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,3 +16,4 @@
 #
 
 org.keycloak.protocol.oid4vc.issuance.keybinding.JwtProofValidatorFactory
+org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationProofValidatorFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCKeyAttestationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCKeyAttestationTest.java
@@ -1,0 +1,596 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oid4vc.issuance.signing;
+
+import org.jboss.logging.Logger;
+import org.junit.Test;
+import org.keycloak.common.util.CertificateUtils;
+
+import org.keycloak.crypto.ECDSASignatureSignerContext;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationKeyResolver;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationProofValidator;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationProofValidatorFactory;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationValidatorUtil;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtProofValidator;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidator;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.StaticAttestationKeyResolver;
+import org.keycloak.protocol.oid4vc.model.ISO18045ResistanceLevel;
+import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
+import org.keycloak.protocol.oid4vc.model.KeyAttestationsRequired;
+import org.keycloak.protocol.oid4vc.model.Proofs;
+
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.keycloak.protocol.oid4vc.model.ProofType.JWT;
+
+/**
+ * @author Bertrand Ogen
+ *
+ * Test class for verifying Key Attestation
+ */
+
+public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
+
+    private static final Logger LOGGER = Logger.getLogger(OID4VCKeyAttestationTest.class);
+
+    @Test
+    public void testValidAttestationProof() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            runValidAttestationProofTest(session, cNonce);
+        });
+    }
+
+    @Test
+    public void testInvalidAttestationProof() {
+        testingClient.server(TEST_REALM_NAME).run(OID4VCKeyAttestationTest::runInvalidAttestationProofTest);
+    }
+
+    @Test
+    public void testValidJwtProofWithKeyAttestation() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            runValidJwtProofWithKeyAttestationTest(session, cNonce);
+        });
+    }
+
+
+    @Test
+    public void testInvalidJwtProofWithKeyAttestation() {
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                runInvalidJwtProofWithKeyAttestationTest(session);
+                fail("Expected VCIssuerException to be thrown");
+            } catch (VCIssuerException e) {
+                assertTrue(e.getMessage().contains("Could not validate JWT proof"));
+            }
+        });
+    }
+
+    @Test
+    public void testAttestationProofType() {
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            AttestationProofValidatorFactory factory = new AttestationProofValidatorFactory();
+            ProofValidator validator = factory.create(session);
+            assertEquals("The proof type should be 'attestation'.",
+                    "attestation", validator.getProofType());
+        });
+    }
+
+    @Test
+    public void testInvalidAttestationSignature() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                runInvalidAttestationSignatureTest(session, cNonce);
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testMissingRequiredAttestationClaims() {
+        testingClient.server(TEST_REALM_NAME).run(OID4VCKeyAttestationTest::runMissingRequiredAttestationClaimsTest);
+    }
+
+    @Test
+    public void testAttestationWithMultipleAttestedKeys() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            runAttestationWithMultipleAttestedKeys(session, cNonce);
+        });
+    }
+
+    @Test
+    public void testAttestationWithX5cCertificateChain() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                runAttestationWithX5cCertificateChain(session, cNonce);
+            } catch (VCIssuerException e) {
+                assertTrue("Expected error about invalid level but got: " + e.getMessage(),
+                        e.getMessage().contains("key_storage") ||
+                                e.getMessage().contains("INVALID_LEVEL"));
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testAttestationWithInvalidResistanceLevels() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                runAttestationWithInvalidResistanceLevels(session, cNonce);
+            } catch (VCIssuerException e) {
+                assertTrue("Expected error about invalid level but got: " + e.getMessage(),
+                        e.getMessage().contains("key_storage") ||
+                                e.getMessage().contains("INVALID_LEVEL"));
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testAttestationWithMissingAttestedKeys() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            runAttestationWithMissingAttestedKeys(session, cNonce);
+        });
+    }
+
+    @Test
+    public void testAttestationWithValidResistanceLevels() {
+        String cNonce = getCNonce();
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                runAttestationWithValidResistanceLevels(session, cNonce);
+            } catch (VCIssuerException e) {
+                assertTrue("Expected error about invalid level but got: " + e.getMessage(),
+                        e.getMessage().contains("key_storage") ||
+                                e.getMessage().contains("INVALID_LEVEL"));
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        });
+    }
+
+    private static void runAttestationWithValidResistanceLevels(KeycloakSession session, String cNonce) {
+        try {
+            KeyWrapper attestationKey = getECKey("attestationKey");
+            KeyWrapper proofKey = getECKey("proofKey");
+
+            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+            proofJwk.setKeyId(proofKey.getKid());
+            proofJwk.setAlgorithm(proofKey.getAlgorithm());
+
+            // Create a complete payload
+            KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+            payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+            payload.setNonce(cNonce);
+            payload.setAttestedKeys(List.of(proofJwk));
+            payload.setKeyStorage(List.of(
+                    ISO18045ResistanceLevel.HIGH.getValue(),
+                    ISO18045ResistanceLevel.MODERATE.getValue()
+            ));
+            payload.setUserAuthentication(List.of(
+                    ISO18045ResistanceLevel.ENHANCED_BASIC.getValue(),
+                    ISO18045ResistanceLevel.BASIC.getValue()
+            ));
+
+            String attestationJwt = new JWSBuilder()
+                    .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                    .kid(attestationKey.getKid())
+                    .jsonContent(payload)
+                    .sign(new ECDSASignatureSignerContext(attestationKey));
+
+            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+            // Set attestation requirements
+            KeyAttestationsRequired attestationRequirements = new KeyAttestationsRequired();
+            attestationRequirements.setKeyStorage(List.of(
+                    ISO18045ResistanceLevel.HIGH,
+                    ISO18045ResistanceLevel.MODERATE,
+                    ISO18045ResistanceLevel.ENHANCED_BASIC
+            ));
+            attestationRequirements.setUserAuthentication(List.of(
+                    ISO18045ResistanceLevel.BASIC,
+                    ISO18045ResistanceLevel.ENHANCED_BASIC
+            ));
+
+            vcIssuanceContext.getCredentialConfig()
+                    .getProofTypesSupported()
+                    .getSupportedProofTypes()
+                    .get(JWT)
+                    .setKeyAttestationsRequired(attestationRequirements);
+
+            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(attestationJwt)));
+
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
+            );
+
+            AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
+
+            assertNotNull("Attested keys should not be null", attestedKeys);
+            assertEquals("Should contain exactly one attested key", 1, attestedKeys.size());
+            assertEquals("Attested key ID should match proof key ID",
+                    proofKey.getKid(),
+                    attestedKeys.get(0).getKeyId());
+        } catch (Exception e) {
+            LOGGER.error("Validation failed with valid resistance levels", e);
+            fail("Test should not throw exception: " + e.getMessage());
+        }
+    }
+
+    private static void runValidAttestationProofTest(KeycloakSession session, String cNonce) {
+        try {
+            KeyWrapper attestationKey = getECKey("attestationKey");
+            KeyWrapper proofKey = getECKey("proofKey");
+
+            attestationKey.setKid("attestationKey");
+            attestationKey.setAlgorithm("ES256");
+            proofKey.setKid("proofKey");
+            proofKey.setAlgorithm("ES256");
+
+            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+            proofJwk.setKeyId(proofKey.getKid());
+            proofJwk.setAlgorithm(proofKey.getAlgorithm());
+
+
+            String attestationJwt = createValidAttestationJwt(session, attestationKey, proofJwk, cNonce);
+            String jwtProof = generateJwtProofWithKeyAttestation(session, proofKey, attestationJwt, cNonce);
+            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(jwtProof)));
+
+            JWK attestationJwk = JWKBuilder.create().ec(attestationKey.getPublicKey());
+            attestationJwk.setKeyId(attestationKey.getKid());
+
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(attestationKey.getKid(), attestationJwk)
+            );
+
+            JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
+            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
+
+            assertNotNull("Attested keys should not be null", attestedKeys);
+            assertEquals("Should contain exactly one attested key", 1, attestedKeys.size());
+            assertEquals("Attested key ID should match proof key ID",
+                    proofKey.getKid(),
+                    attestedKeys.get(0).getKeyId());
+
+        } catch (Exception e) {
+            LOGGER.error("Validation failed", e);
+            fail("Test should not throw exception: " + e.getMessage());
+        }
+    }
+
+    private static void runInvalidAttestationProofTest(KeycloakSession session) {
+        KeyWrapper attestationKey = getECKey("attestationKey");
+        String invalidAttestationJwt = "invalid.jwt.token";
+
+        VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+        vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(invalidAttestationJwt)));
+
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+
+        try {
+            validator.validateProof(vcIssuanceContext);
+            fail("Expected VCIssuerException to be thrown");
+        } catch (VCIssuerException e) {
+            // Expected exception
+        }
+    }
+
+    private static void runValidJwtProofWithKeyAttestationTest(KeycloakSession session, String cNonce) {
+        try {
+            KeyWrapper attestationKey = getECKey("attestationKey");
+            KeyWrapper proofKey = getECKey("proofKey");
+            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+
+            String attestationJwt = createValidAttestationJwt(session, attestationKey, proofJwk, cNonce);
+            String jwtProof = generateJwtProofWithKeyAttestation(session, proofKey, attestationJwt, cNonce);
+
+            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(jwtProof)));
+
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
+            );
+            JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
+
+            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
+            assertNotNull(attestedKeys);
+            assertFalse(attestedKeys.isEmpty());
+        } catch (Exception e) {
+            LOGGER.error("Validation failed unexpectedly", e);
+            fail("Unexpected exception in valid JWT proof test: " + e.getMessage());
+        }
+    }
+
+    private static void runInvalidJwtProofWithKeyAttestationTest(KeycloakSession session) {
+        KeyWrapper attestationKey = getECKey("attestationKey");
+        String invalidJwtProof = "invalid.jwt.token";
+
+        VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+        vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(invalidJwtProof)));
+
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
+
+        validator.validateProof(vcIssuanceContext);
+    }
+
+    private static void runInvalidAttestationSignatureTest(KeycloakSession session, String cNonce) {
+        KeyWrapper attestationKey = getECKey("attestationKey");
+        KeyWrapper proofKey = getECKey("proofKey");
+        JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+
+        KeyWrapper unrelatedKey = getECKey("unrelatedKey");
+        String invalidAttestationJwt = new JWSBuilder()
+                .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                .jwk(JWKBuilder.create().ec(attestationKey.getPublicKey()))
+                .jsonContent(createAttestationPayload(proofJwk, cNonce))
+                .sign(new ECDSASignatureSignerContext(unrelatedKey));
+
+        VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+        vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(invalidAttestationJwt)));
+
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+
+        try {
+            validator.validateProof(vcIssuanceContext);
+            fail("Expected VCIssuerException to be thrown");
+        } catch (VCIssuerException e) {
+            assertTrue("Expected VCIssuerException to be thrown", true);
+        }
+    }
+
+    private static void runMissingRequiredAttestationClaimsTest(KeycloakSession session) {
+        KeyWrapper attestationKey = getECKey("attestationKey");
+
+        Map<String, Object> incompletePayload = new HashMap<>();
+        incompletePayload.put("iat", TIME_PROVIDER.currentTimeSeconds());
+
+        String invalidAttestationJwt = new JWSBuilder()
+                .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                .jwk(JWKBuilder.create().ec(attestationKey.getPublicKey()))
+                .jsonContent(incompletePayload)
+                .sign(new ECDSASignatureSignerContext(attestationKey));
+
+        VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+        vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(invalidAttestationJwt)));
+
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+
+        try {
+            validator.validateProof(vcIssuanceContext);
+            fail("Expected VCIssuerException to be thrown");
+        } catch (VCIssuerException e) {
+            assertTrue("Expected VCIssuerException to be thrown", true);
+        }
+    }
+
+    private static void runAttestationWithMultipleAttestedKeys(KeycloakSession session, String cNonce) {
+        try {
+            KeyWrapper attestationKey = getECKey("attestationKey");
+            KeyWrapper proofKey1 = getECKey("proofKey1");
+            KeyWrapper proofKey2 = getECKey("proofKey2");
+
+            JWK proofJwk1 = JWKBuilder.create().ec(proofKey1.getPublicKey());
+            proofJwk1.setKeyId(proofKey1.getKid());
+            proofJwk1.setAlgorithm(proofKey1.getAlgorithm());
+
+            JWK proofJwk2 = JWKBuilder.create().ec(proofKey2.getPublicKey());
+            proofJwk2.setKeyId(proofKey2.getKid());
+            proofJwk2.setAlgorithm(proofKey2.getAlgorithm());
+
+            // Create a proper payload with attested keys
+            KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+            payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+            payload.setNonce(cNonce);
+            payload.setAttestedKeys(List.of(proofJwk1, proofJwk2));
+            payload.setKeyStorage(List.of(ISO18045ResistanceLevel.HIGH.getValue()));
+            payload.setUserAuthentication(List.of(ISO18045ResistanceLevel.HIGH.getValue()));
+
+            String attestationJwt = new JWSBuilder()
+                    .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                    .kid(attestationKey.getKid())
+                    .jsonContent(payload)
+                    .sign(new ECDSASignatureSignerContext(attestationKey));
+
+            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(attestationJwt)));
+
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
+            );
+
+            AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
+
+            assertEquals(2, attestedKeys.size());
+            assertTrue(attestedKeys.stream().anyMatch(k -> k.getKeyId().equals(proofJwk1.getKeyId())));
+            assertTrue(attestedKeys.stream().anyMatch(k -> k.getKeyId().equals(proofJwk2.getKeyId())));
+        } catch (Exception e) {
+            LOGGER.error("Validation failed with exception: " + e.getMessage(), e);
+            fail("Unexpected exception in test: " + e.getMessage());
+        }
+    }
+
+    private static void runAttestationWithX5cCertificateChain(KeycloakSession session, String cNonce) {
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+            keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair keyPair = keyGen.generateKeyPair();
+
+            X509Certificate cert = CertificateUtils.generateV1SelfSignedCertificate(keyPair, "Test Certificate");
+            Logger.getLogger(OID4VCKeyAttestationTest.class).info("Generated certificate: " + cert.toString());
+
+            KeyWrapper signerKey = new KeyWrapper();
+            signerKey.setPrivateKey(keyPair.getPrivate());
+            signerKey.setPublicKey(keyPair.getPublic());
+            signerKey.setAlgorithm("ES256");
+            signerKey.setType(KeyType.EC);
+            signerKey.setKid("test-cert-key");
+
+            KeyWrapper proofKey = getECKey("proofKey");
+            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+            proofJwk.setKeyId(proofKey.getKid());
+            proofJwk.setAlgorithm(proofKey.getAlgorithm());
+
+            KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+            payload.setNonce(cNonce);
+            payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+            payload.setAttestedKeys(List.of(proofJwk));
+            payload.setKeyStorage(List.of(ISO18045ResistanceLevel.HIGH.getValue()));
+            payload.setUserAuthentication(List.of(ISO18045ResistanceLevel.HIGH.getValue()));
+
+            String attestationJwt = new JWSBuilder()
+                    .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                    .kid(signerKey.getKid())
+                    .x5c(List.of(cert))
+                    .jsonContent(payload)
+                    .sign(new ECDSASignatureSignerContext(signerKey));
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+            ks.load(null);
+            ks.setCertificateEntry("test-cert", cert);
+            tmf.init(ks);
+
+            JWK certJwk = JWKBuilder.create().ec(signerKey.getPublicKey());
+            certJwk.setKeyId(signerKey.getKid());
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(signerKey.getKid(), certJwk)
+            );
+
+            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(attestationJwt)));
+
+            AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
+
+            assertNotNull("Attested keys should not be null", attestedKeys);
+            assertEquals("Should contain exactly one attested key", 1, attestedKeys.size());
+            assertEquals("Attested key ID should match proof key ID", proofKey.getKid(), attestedKeys.get(0).getKeyId());
+        } catch (Exception e) {
+            LOGGER.error("Certificate chain validation failed", e);
+            fail("Test should not throw exception: " + e.getMessage());
+        }
+    }
+
+    private static void runAttestationWithInvalidResistanceLevels(KeycloakSession session, String cNonce) {
+        try {
+            KeyWrapper attestationKey = getECKey("attestationKey");
+            KeyWrapper proofKey = getECKey("proofKey");
+
+            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+            proofJwk.setKeyId(proofKey.getKid());
+            proofJwk.setAlgorithm(proofKey.getAlgorithm());
+
+            KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+            payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+            payload.setNonce(cNonce);
+            payload.setAttestedKeys(List.of(proofJwk));
+            payload.setKeyStorage(List.of("INVALID_LEVEL"));
+
+            String attestationJwt = new JWSBuilder()
+                    .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                    .kid(attestationKey.getKid())
+                    .jsonContent(payload)
+                    .sign(new ECDSASignatureSignerContext(attestationKey));
+
+            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(attestationJwt)));
+
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
+            );
+
+            new AttestationProofValidator(session, keyResolver).validateProof(vcIssuanceContext);
+            fail("Expected VCIssuerException for invalid resistance level");
+        } catch (VCIssuerException e) {
+            assertTrue("Expected error about invalid level but got: " + e.getMessage(),
+                    e.getMessage().contains("key_storage") && e.getMessage().contains("INVALID_LEVEL"));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    private static void runAttestationWithMissingAttestedKeys(KeycloakSession session, String cNonce) {
+        try {
+            KeyWrapper attestationKey = getECKey("attestationKey");
+
+            KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+            payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+            payload.setNonce(cNonce);
+            // Intentionally omit attested_keys
+
+            String attestationJwt = new JWSBuilder()
+                    .type(AttestationValidatorUtil.ATTESTATION_JWT_TYP)
+                    .kid(attestationKey.getKid())
+                    .jsonContent(payload)
+                    .sign(new ECDSASignatureSignerContext(attestationKey));
+
+            VCIssuanceContext context = createVCIssuanceContext(session);
+            context.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(attestationJwt)));
+
+            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                    Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
+            );
+
+            AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
+            validator.validateProof(context);
+            fail("Expected VCIssuerException for missing attested_keys");
+        } catch (VCIssuerException e) {
+            assertTrue("Expected error about missing keys but got: " + e.getMessage(),
+                    e.getMessage().contains("attested_keys"));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -66,6 +66,7 @@ import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
+import org.testcontainers.shaded.org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -99,7 +100,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                 .server(TEST_REALM_NAME)
                 .run(session -> {
                     ClientScopeRepresentation clientScope = fromJsonString(clientScopeString,
-                                                                           ClientScopeRepresentation.class);
+                            ClientScopeRepresentation.class);
                     testRequestTestCredential(session, clientScope, token, null);
                 });
     }
@@ -118,7 +119,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                             .setJwt(List.of(generateJwtProof(getCredentialIssuer(session), cNonce)));
 
                     ClientScopeRepresentation clientScope = fromJsonString(clientScopeString,
-                                                                           ClientScopeRepresentation.class);
+                            ClientScopeRepresentation.class);
 
                     SdJwtVP sdJwtVP = testRequestTestCredential(session, clientScope, token, proof);
                     assertNotNull("A cnf claim must be attached to the credential", sdJwtVP.getCnfClaim());
@@ -139,7 +140,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                             .setJwt(List.of(generateInvalidJwtProof(getCredentialIssuer(session), cNonce)));
 
                     ClientScopeRepresentation clientScope = fromJsonString(clientScopeString,
-                                                                           ClientScopeRepresentation.class);
+                            ClientScopeRepresentation.class);
 
                     testRequestTestCredential(session, clientScope, token, proof);
                 }));
@@ -173,6 +174,11 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     })));
             Assert.fail("Should have thrown an exception");
         } catch (BadRequestException ex) {
+            Assert.assertEquals("""
+                                        c_nonce: expected 'aud' to be equal to \
+                                        '[https://localhost:8543/auth/realms/test/protocol/oid4vc/credential]' but \
+                                        actual value was '[]'""",
+                    ExceptionUtils.getRootCause(ex).getMessage());
             Assert.assertEquals("Could not validate provided proof", ex.getMessage());
         }
     }
@@ -199,6 +205,11 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     })));
             Assert.fail("Should have thrown an exception");
         } catch (BadRequestException ex) {
+            Assert.assertEquals("""
+                                        c_nonce: expected 'source_endpoint' to be equal to \
+                                        'https://localhost:8543/auth/realms/test/protocol/oid4vc/nonce' but \
+                                        actual value was 'null'""",
+                    ExceptionUtils.getRootCause(ex).getMessage());
             Assert.assertEquals("Could not validate provided proof", ex.getMessage());
         }
     }
@@ -233,11 +244,14 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     })));
             Assert.fail("Should have thrown an exception");
         } catch (BadRequestException ex) {
+            String message = ExceptionUtils.getRootCause(ex).getMessage();
+            Assert.assertTrue(String.format("Message '%s' should match regular expression", message),
+                    message.matches("c_nonce not valid: \\d+\\(exp\\) < \\d+\\(now\\)"));
             Assert.assertEquals("Could not validate provided proof", ex.getMessage());
         }
     }
 
-    private static String getCredentialIssuer(KeycloakSession session) {
+    protected static String getCredentialIssuer(KeycloakSession session) {
         return OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
     }
 
@@ -256,13 +270,13 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
 
         Response credentialResponse = issuerEndpoint.requestCredential(credentialRequest);
         assertEquals("The credential request should be answered successfully.",
-                     HttpStatus.SC_OK,
-                     credentialResponse.getStatus());
+                HttpStatus.SC_OK,
+                credentialResponse.getStatus());
         assertNotNull("A credential should be responded.", credentialResponse.getEntity());
         CredentialResponse credentialResponseVO = JsonSerialization.mapper.convertValue(credentialResponse.getEntity(),
-                                                                                        CredentialResponse.class);
+                CredentialResponse.class);
         new TestCredentialResponseHandler(sdJwtCredentialVct).handleCredentialResponse(credentialResponseVO,
-                                                                                       clientScope);
+                clientScope);
 
         // Get the credential from the credentials array
         return SdJwtVP.of(credentialResponseVO.getCredentials().get(0).getCredential().toString());
@@ -284,8 +298,8 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
         // 1. Retrieving the credential-offer-uri
         final String credentialConfigurationId = clientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         HttpGet getCredentialOfferURI = new HttpGet(getBasePath(TEST_REALM_NAME) +
-                                                            "credential-offer-uri?credential_configuration_id=" +
-                                                            credentialConfigurationId);
+                "credential-offer-uri?credential_configuration_id=" +
+                credentialConfigurationId);
         getCredentialOfferURI.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         CloseableHttpResponse credentialOfferURIResponse = httpClient.execute(getCredentialOfferURI);
 
@@ -340,10 +354,10 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                 .forEach(supportedCredential -> {
                     try {
                         requestCredential(theToken,
-                                          credentialIssuer.getCredentialEndpoint(),
-                                          supportedCredential,
-                                          new TestCredentialResponseHandler(vct),
-                                          sdJwtTypeCredentialClientScope);
+                                credentialIssuer.getCredentialEndpoint(),
+                                supportedCredential,
+                                new TestCredentialResponseHandler(vct),
+                                sdJwtTypeCredentialClientScope);
                     } catch (IOException e) {
                         fail("Was not able to get the credential.");
                     } catch (VerificationException e) {
@@ -359,9 +373,9 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
     public void testGetSdJwtConfigFromMetadata() {
         final String scopeName = sdJwtTypeCredentialClientScope.getName();
         final String credentialConfigurationId = sdJwtTypeCredentialClientScope.getAttributes()
-                                                                               .get(CredentialScopeModel.CONFIGURATION_ID);
+                .get(CredentialScopeModel.CONFIGURATION_ID);
         final String verifiableCredentialType = sdJwtTypeCredentialClientScope.getAttributes()
-                                                                              .get(CredentialScopeModel.VCT);
+                .get(CredentialScopeModel.VCT);
         String expectedIssuer = suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth/realms/" + TEST_REALM_NAME;
         String expectedCredentialsEndpoint = expectedIssuer + "/protocol/oid4vc/credential";
         String expectedNonceEndpoint = expectedIssuer + "/protocol/oid4vc/" + OID4VCIssuerEndpoint.NONCE_PATH;
@@ -376,22 +390,22 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     assertEquals("The correct issuer should be included.", expectedIssuer, credentialIssuer.getCredentialIssuer());
                     assertEquals("The correct credentials endpoint should be included.", expectedCredentialsEndpoint, credentialIssuer.getCredentialEndpoint());
                     assertEquals("The correct nonce endpoint should be included.",
-                                 expectedNonceEndpoint,
-                                 credentialIssuer.getNonceEndpoint());
+                            expectedNonceEndpoint,
+                            credentialIssuer.getNonceEndpoint());
                     assertEquals("Since the authorization server is equal to the issuer, just 1 should be returned.", 1, credentialIssuer.getAuthorizationServers().size());
                     assertEquals("The expected server should have been returned.", expectedAuthorizationServer, credentialIssuer.getAuthorizationServers().get(0));
 
                     assertTrue("The sd-jwt-credential should be supported.",
-                               credentialIssuer.getCredentialsSupported().containsKey(credentialConfigurationId));
+                            credentialIssuer.getCredentialsSupported().containsKey(credentialConfigurationId));
 
                     SupportedCredentialConfiguration jwtVcConfig =
                             credentialIssuer.getCredentialsSupported().get(credentialConfigurationId);
                     assertEquals("The sd-jwt-credential should offer type test-credential",
-                                 scopeName,
-                                 jwtVcConfig.getScope());
+                            scopeName,
+                            jwtVcConfig.getScope());
                     assertEquals("The sd-jwt-credential should be offered in the jwt_vc format.",
-                                 Format.SD_JWT_VC,
-                                 jwtVcConfig.getFormat());
+                            Format.SD_JWT_VC,
+                            jwtVcConfig.getFormat());
 
                     assertNotNull("The sd-jwt-credential can optionally provide a claims claim.",
                                   credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
@@ -401,80 +415,80 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
 
                     Claims jwtVcClaims = jwtVcConfig.getCredentialMetadata() != null ? jwtVcConfig.getCredentialMetadata().getClaims() : null;
                     assertNotNull("The sd-jwt-credential can optionally provide a claims claim.",
-                                  jwtVcClaims);
+                            jwtVcClaims);
 
                     assertEquals(5,  jwtVcClaims.size());
                     {
                         Claim claim = jwtVcClaims.get(0);
                         assertEquals("The sd-jwt-credential claim roles is present.",
-                                     "roles",
-                                     claim.getPath().get(0));
+                                "roles",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim roles is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim roles has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(1);
                         assertEquals("The sd-jwt-credential claim email is present.",
-                                     "email",
-                                     claim.getPath().get(0));
+                                "email",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim email is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim email has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(2);
                         assertEquals("The sd-jwt-credential claim firstName is present.",
-                                     "firstName",
-                                     claim.getPath().get(0));
+                                "firstName",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim firstName is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim firstName has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(3);
                         assertEquals("The sd-jwt-credential claim lastName is present.",
-                                     "lastName",
-                                     claim.getPath().get(0));
+                                "lastName",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim lastName is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim lastName has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(4);
                         assertEquals("The sd-jwt-credential claim scope-name is present.",
-                                     "scope-name",
-                                     claim.getPath().get(0));
+                                "scope-name",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim scope-name is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim scope-name has no display configured",
-                                   claim.getDisplay());
+                                claim.getDisplay());
                     }
 
                     assertEquals("The sd-jwt-credential should offer vct",
-                                 verifiableCredentialType,
-                                 credentialIssuer.getCredentialsSupported().get(credentialConfigurationId).getVct());
+                            verifiableCredentialType,
+                            credentialIssuer.getCredentialsSupported().get(credentialConfigurationId).getVct());
 
                     // We are offering key binding only for identity credential
                     assertTrue("The sd-jwt-credential should contain a cryptographic binding method supported named jwk",
-                               credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
-                                               .getCryptographicBindingMethodsSupported()
-                                               .contains(CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT));
+                            credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
+                                    .getCryptographicBindingMethodsSupported()
+                                    .contains(CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT));
                     assertTrue("The sd-jwt-credential should contain a credential signing algorithm named ES256",
-                               credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
-                                               .getCredentialSigningAlgValuesSupported().contains("ES256"));
+                            credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
+                                    .getCredentialSigningAlgValuesSupported().contains("ES256"));
                     assertTrue("The sd-jwt-credential should support a proof of type jwt with signing algorithm ES256",
-                               credentialIssuer.getCredentialsSupported()
-                                               .get(credentialConfigurationId)
-                                               .getProofTypesSupported()
-                                               .getSupportedProofTypes()
-                                               .get("jwt")
-                                               .getSigningAlgorithmsSupported()
-                                               .contains("ES256"));
+                            credentialIssuer.getCredentialsSupported()
+                                    .get(credentialConfigurationId)
+                                    .getProofTypesSupported()
+                                    .getSupportedProofTypes()
+                                    .get("jwt")
+                                    .getSigningAlgorithmsSupported()
+                                    .contains("ES256"));
                     assertEquals("The sd-jwt-credential should display as Test Credential",
                                  credentialConfigurationId,
                                  credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
@@ -519,9 +533,9 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
     public static ClientScopeModel createCredentialScope(KeycloakSession session) {
         RealmModel realmModel = session.getContext().getRealm();
         ClientScopeModel credentialScope = session.clientScopes()
-                                                  .addClientScope(realmModel, jwtTypeCredentialScopeName);
+                .addClientScope(realmModel, jwtTypeCredentialScopeName);
         credentialScope.setAttribute(CredentialScopeModel.CREDENTIAL_IDENTIFIER,
-                                     jwtTypeCredentialScopeName);
+                jwtTypeCredentialScopeName);
         credentialScope.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
         return credentialScope;
     }
@@ -566,10 +580,10 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
             assertEquals("lastName claim incorrectly mapped.", "Doe", disclosureMap.get("lastName").get(2).asText());
             assertTrue("The credentials should include the roles claim.", disclosureMap.containsKey("roles"));
             assertTrue("The credentials should include the scope-name claim.",
-                       disclosureMap.containsKey("scope-name"));
+                    disclosureMap.containsKey("scope-name"));
             assertEquals("The credentials should include the scope-name claims correct value.",
-                         clientScope.getName(),
-                         disclosureMap.get("scope-name").get(2).textValue());
+                    clientScope.getName(),
+                    disclosureMap.get("scope-name").get(2).textValue());
             assertTrue("The credentials should include the email claim.", disclosureMap.containsKey("email"));
             assertEquals("email claim incorrectly mapped.", "john@email.cz", disclosureMap.get("email").get(2).asText());
 


### PR DESCRIPTION
This MR aims at understanding key attestations as additional information to jwt proofs or as per new attestation proof type (for Key binding).

See:
- https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-key-attestations
- https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-proof-types

Closes: https://github.com/keycloak/keycloak/issues/39287
