### PR TITLE
[OTel] Micrometer to OpenTelemetry bridge support for metrics

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -131,6 +131,7 @@ public class Profile {
 
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),
+        OPENTELEMETRY_METRICS("Micrometer to OpenTelemetry bridge support for metrics", Type.EXPERIMENTAL, OPENTELEMETRY),
 
         DECLARATIVE_UI("declarative ui spi", Type.EXPERIMENTAL),
 

--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -156,6 +156,13 @@ For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guid
 == OpenTelemetry Logs (preview)
 
 {project_name} now supports exporting logs to OpenTelemetry collectors, enabling centralized log management.
-This preview feature allows you to export {project_name} logs to any OpenTelemetry-compatible backend and use the same OpenTelemetry collector for logs and traces.
+This preview feature allows you to export {project_name} logs to any OpenTelemetry-compatible backend and use the same OpenTelemetry collector for logs, metrics and traces.
+
+For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.
+
+== OpenTelemetry Metrics (experimental)
+
+{project_name} now provides the experimental support for exporting metrics to OpenTelemetry collectors by using the https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry[Micrometer-to-OpenTelemetry bridge].
+This experimental feature allows you to export {project_name} metrics to any OpenTelemetry-compatible backend and use the same OpenTelemetry collector for logs, metrics and traces.
 
 For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.

--- a/docs/guides/observability/telemetry.adoc
+++ b/docs/guides/observability/telemetry.adoc
@@ -82,12 +82,13 @@ For example, if you want only to export `WARN` and `ERROR` logs, you can change 
 
 == Metrics
 
-WARNING: This OpenTelemetry Metrics feature is currently in an experimental mode, and it is not recommended for use in production.
+WARNING: The OpenTelemetry Metrics feature is currently experimental, and it is not recommended for use in production.
 
-NOTE: The OpenTelemetry feature (`opentelemetry`) needs to be turned on (by default).
+NOTE: In order for the Metrics feature to function, the OpenTelemetry feature `opentelemetry` cannot be disabled.
 
-For integrating OpenTelemetry Metrics, {project_name} uses the https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry[Micrometer-to-OpenTelemetry bridge] that provides the functionality to export metrics created by Micrometer to OpenTelemetry Collector.
-It means that all metrics created via Micrometer or OpenTelemetry metrics will be exported to the OpenTelemetry.
+For integrating OpenTelemetry Metrics, {project_name} uses the https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry[Micrometer-to-OpenTelemetry bridge],
+which provides the functionality to export metrics created by Micrometer to the OpenTelemetry Collector.
+This means that all metrics created via Micrometer or OpenTelemetry metrics will be exported to the OpenTelemetry.
 
 There are some https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry#metric-differences-between-micrometer-and-opentelemetry[API, and Semantic convention differences] for Micrometer vs OTel Metrics, so you should check if all required metrics are exported.
 

--- a/docs/guides/observability/telemetry.adoc
+++ b/docs/guides/observability/telemetry.adoc
@@ -80,6 +80,26 @@ For example, if you want only to export `WARN` and `ERROR` logs, you can change 
 
 <@kc.start parameters="--telemetry-logs-level=WARN"/>
 
+== Metrics
+
+WARNING: This OpenTelemetry Metrics feature is currently in an experimental mode, and it is not recommended for use in production.
+
+NOTE: The OpenTelemetry feature (`opentelemetry`) needs to be turned on (by default).
+
+For integrating OpenTelemetry Metrics, {project_name} uses the https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry[Micrometer-to-OpenTelemetry bridge] that provides the functionality to export metrics created by Micrometer to OpenTelemetry Collector.
+It means that all metrics created via Micrometer or OpenTelemetry metrics will be exported to the OpenTelemetry.
+
+There are some https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry#metric-differences-between-micrometer-and-opentelemetry[API, and Semantic convention differences] for Micrometer vs OTel Metrics, so you should check if all required metrics are exported.
+
+=== Enable Metrics
+You can enable the OpenTelemetry Metrics via CLI as follows:
+
+<@kc.start parameters="--features=opentelemetry-metrics --telemetry-metrics-enabled=true --metrics-enabled=true"/>
+
+NOTE: Metrics (`metrics-enabled`) needs to be enabled as well
+
+For more information on how to set up metrics, see the configuration options below or visit the https://www.keycloak.org/observability/configuration-metrics[Gaining insights with metrics guide].
+
 <@profile.ifCommunity>
 
 == Development setup
@@ -100,13 +120,16 @@ Then, you can navigate to Grafana UI by accessing `+localhost:3000+` and then yo
 
 </@profile.ifCommunity>
 
-<@opts.printRelevantOptions includedOptions="telemetry-*" excludedOptions="telemetry-logs-*">
+<@opts.printRelevantOptions includedOptions="telemetry-*" excludedOptions="telemetry-logs-* telemetry-metrics-*">
 
 === Traces
 <@opts.includeOptions includedOptions="tracing-enabled tracing-endpoint tracing-protocol tracing-service-name tracing-resource-attributes"/>
 
 === Logs
 <@opts.includeOptions includedOptions="telemetry-logs-*"/>
+
+=== Metrics
+<@opts.includeOptions includedOptions="metrics-enabled telemetry-metrics-*"/>
 
 </@opts.printRelevantOptions>
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
@@ -37,19 +37,19 @@ public class TelemetryOptions {
     // Telemetry Logs
     public static final Option<Boolean> TELEMETRY_LOGS_ENABLED = new OptionBuilder<>("telemetry-logs-enabled", Boolean.class)
             .category(OptionCategory.TELEMETRY)
-            .description("Enables exporting logs to a destination handling telemetry data (OpenTelemetry Logs).")
+            .description("Enables exporting logs to a destination handling OpenTelemetry logs.")
             .defaultValue(Boolean.FALSE)
             .buildTime(true)
             .build();
 
     public static final Option<String> TELEMETRY_LOGS_ENDPOINT = new OptionBuilder<>("telemetry-logs-endpoint", String.class)
             .category(OptionCategory.TELEMETRY)
-            .description("Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value is inherited from the '%s' option.".formatted(TELEMETRY_ENDPOINT.getKey()))
+            .description("OpenTelemetry endpoint to export logs to. If not given, the value is inherited from the '%s' option.".formatted(TELEMETRY_ENDPOINT.getKey()))
             .build();
 
     public static final Option<String> TELEMETRY_LOGS_PROTOCOL = new OptionBuilder<>("telemetry-logs-protocol", String.class)
             .category(OptionCategory.TELEMETRY)
-            .description("Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the value is inherited from the '%s' option.".formatted(TELEMETRY_PROTOCOL.getKey()))
+            .description("OpenTelemetry protocol used for exporting logs. If not given, the value is inherited from the '%s' option.".formatted(TELEMETRY_PROTOCOL.getKey()))
             .expectedValues("grpc", "http/protobuf")
             .build();
 
@@ -63,25 +63,25 @@ public class TelemetryOptions {
     // Telemetry Metrics
     public static final Option<Boolean> TELEMETRY_METRICS_ENABLED = new OptionBuilder<>("telemetry-metrics-enabled", Boolean.class)
             .category(OptionCategory.TELEMETRY)
-            .description("Enables exporting metrics to a destination handling telemetry data (OpenTelemetry Metrics).")
+            .description("Enables exporting metrics to a destination handling OpenTelemetry metrics.")
             .defaultValue(Boolean.FALSE)
             .buildTime(true)
             .build();
 
     public static final Option<String> TELEMETRY_METRICS_ENDPOINT = new OptionBuilder<>("telemetry-metrics-endpoint", String.class)
             .category(OptionCategory.TELEMETRY)
-            .description("Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given, the value is inherited from the '%s' option.".formatted(TelemetryOptions.TELEMETRY_ENDPOINT.getKey()))
+            .description("OpenTelemetry endpoint to connect to for Metrics. If not given, the value is inherited from the '%s' option.".formatted(TelemetryOptions.TELEMETRY_ENDPOINT.getKey()))
             .build();
 
     public static final Option<String> TELEMETRY_METRICS_PROTOCOL = new OptionBuilder<>("telemetry-metrics-protocol", String.class)
             .category(OptionCategory.TELEMETRY)
-            .description("Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not given, the value is inherited from the '%s' option.".formatted(TelemetryOptions.TELEMETRY_PROTOCOL.getKey()))
+            .description("OpenTelemetry protocol used for the metrics telemetry data. If not given, the value is inherited from the '%s' option.".formatted(TelemetryOptions.TELEMETRY_PROTOCOL.getKey()))
             .expectedValues("grpc", "http/protobuf")
             .build();
 
     public static final Option<String> TELEMETRY_METRICS_INTERVAL = new OptionBuilder<>("telemetry-metrics-interval", String.class)
             .category(OptionCategory.TELEMETRY)
-            .description("The interval between the start of two metric export attempts to the destination handling telemetry data (OpenTelemetry Metrics). It accepts simplified format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If the value is only a number, it represents time in seconds.")
+            .description("The interval between the start of two metric export attempts to the destination handling OpenTelemetry metrics data. It accepts simplified format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If the value is only a number, it represents time in seconds.")
             .defaultValue("60s")
             .build();
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
@@ -59,4 +59,29 @@ public class TelemetryOptions {
             .defaultValue(LoggingOptions.Level.ALL)
             .caseInsensitiveExpectedValues(true)
             .build();
+
+    // Telemetry Metrics
+    public static final Option<Boolean> TELEMETRY_METRICS_ENABLED = new OptionBuilder<>("telemetry-metrics-enabled", Boolean.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("Enables exporting metrics to a destination handling telemetry data (OpenTelemetry Metrics).")
+            .defaultValue(Boolean.FALSE)
+            .buildTime(true)
+            .build();
+
+    public static final Option<String> TELEMETRY_METRICS_ENDPOINT = new OptionBuilder<>("telemetry-metrics-endpoint", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given, the value is inherited from the '%s' option.".formatted(TelemetryOptions.TELEMETRY_ENDPOINT.getKey()))
+            .build();
+
+    public static final Option<String> TELEMETRY_METRICS_PROTOCOL = new OptionBuilder<>("telemetry-metrics-protocol", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not given, the value is inherited from the '%s' option.".formatted(TelemetryOptions.TELEMETRY_PROTOCOL.getKey()))
+            .expectedValues("grpc", "http/protobuf")
+            .build();
+
+    public static final Option<String> TELEMETRY_METRICS_INTERVAL = new OptionBuilder<>("telemetry-metrics-interval", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("The interval between the start of two metric export attempts to the destination handling telemetry data (OpenTelemetry Metrics). It accepts simplified format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If the value is only a number, it represents time in seconds.")
+            .defaultValue("60s")
+            .build();
 }

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -270,6 +270,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -125,6 +125,10 @@
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-apache-httpclient-4.3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.apicatalog</groupId>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.keycloak.common.Profile;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.MetricsOptions;
+import org.keycloak.config.TelemetryOptions;
 import org.keycloak.config.database.Database;
 
 import static java.util.Collections.emptySet;
@@ -41,7 +42,8 @@ public class IgnoredArtifacts {
                         fips(),
                         jdbcDrivers(),
                         health(),
-                        metrics()
+                        metrics(),
+                        otelMetrics()
                 )
                 .flatMap(Collection::stream)
                 .collect(Collectors.toUnmodifiableSet());
@@ -170,5 +172,17 @@ public class IgnoredArtifacts {
     private static Set<String> metrics() {
         boolean isMetricsEnabled = Configuration.isTrue(MetricsOptions.METRICS_ENABLED);
         return !isMetricsEnabled ? METRICS : emptySet();
+    }
+
+    // OpenTelemetry Metrics (Micrometer to OTel bridge)
+    public static Set<String> OTEL_METRICS = Set.of(
+            "io.quarkus:quarkus-micrometer-opentelemetry",
+            "io.quarkus:quarkus-micrometer-opentelemetry-deployment",
+            "io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5"
+    );
+
+    private static Set<String> otelMetrics() {
+        boolean isOtelMetricsEnabled = Configuration.isTrue(TelemetryOptions.TELEMETRY_METRICS_ENABLED);
+        return !isOtelMetricsEnabled ? OTEL_METRICS : emptySet();
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifactsTest.java
@@ -31,6 +31,7 @@ import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.MetricsOptions;
 import org.keycloak.config.Option;
+import org.keycloak.config.TelemetryOptions;
 
 import org.junit.Test;
 
@@ -153,6 +154,11 @@ public class IgnoredArtifactsTest extends AbstractConfigurationTest {
     @Test
     public void metrics() {
         assertIgnoredArtifacts(IgnoredArtifacts.METRICS, MetricsOptions.METRICS_ENABLED);
+    }
+
+    @Test
+    public void otelMetrics(){
+        assertIgnoredArtifacts(IgnoredArtifacts.OTEL_METRICS, TelemetryOptions.TELEMETRY_METRICS_ENABLED);
     }
 
     private void assertIgnoredArtifacts(Set<String> artifactsSet, Option<Boolean> enabledOption) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TelemetryConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TelemetryConfigurationTest.java
@@ -124,4 +124,58 @@ public class TelemetryConfigurationTest extends AbstractConfigurationTest {
                 "quarkus.otel.exporter.otlp.logs.protocol", "http/protobuf"
         ));
     }
+
+    @Test
+    public void metricsDefaults() {
+        initConfig();
+
+        assertConfig(Map.of(
+                "telemetry-metrics-enabled", "false",
+                "telemetry-metrics-endpoint", "http://localhost:4317",
+                "telemetry-metrics-protocol", "grpc",
+                "telemetry-metrics-interval", "60s"
+        ));
+
+        assertExternalConfig(Map.of(
+                "quarkus.otel.metrics.enabled", "false",
+                "quarkus.otel.enabled", "false",
+                "quarkus.otel.exporter.otlp.metrics.endpoint", "http://localhost:4317",
+                "quarkus.otel.exporter.otlp.metrics.protocol", "grpc",
+                "quarkus.otel.metric.export.interval", "60s"
+        ));
+    }
+
+    @Test
+    public void metricsPriorities() {
+        ConfigArgsConfigSource.setCliArgs("--features=opentelemetry-metrics", "--metrics-enabled=true", "--telemetry-metrics-enabled=true", "--telemetry-metrics-endpoint=localhost:2000", "--telemetry-metrics-protocol=http/protobuf");
+        initConfig();
+        assertConfig(Map.of(
+                "telemetry-metrics-enabled", "true",
+                "telemetry-metrics-endpoint", "localhost:2000",
+                "telemetry-metrics-protocol", "http/protobuf"
+        ));
+        assertExternalConfig(Map.of(
+                "quarkus.otel.metrics.enabled", "true",
+                "quarkus.otel.enabled", "true",
+                "quarkus.otel.exporter.otlp.metrics.endpoint", "localhost:2000",
+                "quarkus.otel.exporter.otlp.metrics.protocol", "http/protobuf"
+        ));
+        onAfter();
+
+        ConfigArgsConfigSource.setCliArgs("--features=opentelemetry-metrics", "--metrics-enabled=true", "--telemetry-endpoint=http://keycloak.org:1234", "--telemetry-protocol=grpc", "--telemetry-metrics-enabled=true", "--telemetry-metrics-endpoint=my-domain:2001", "--telemetry-metrics-protocol=http/protobuf");
+        initConfig();
+        assertConfig(Map.of(
+                "telemetry-metrics-enabled", "true",
+                "telemetry-metrics-endpoint", "my-domain:2001",
+                "telemetry-metrics-protocol", "http/protobuf",
+                "telemetry-endpoint", "http://keycloak.org:1234",
+                "telemetry-protocol", "grpc"
+        ));
+        assertExternalConfig(Map.of(
+                "quarkus.otel.metrics.enabled", "true",
+                "quarkus.otel.enabled", "true",
+                "quarkus.otel.exporter.otlp.metrics.endpoint", "my-domain:2001",
+                "quarkus.otel.exporter.otlp.metrics.protocol", "http/protobuf"
+        ));
+    }
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -316,13 +316,12 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
-                     Enables exporting logs to a destination handling telemetry data (OpenTelemetry
-                       Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
-                       is enabled.
+                     Enables exporting logs to a destination handling OpenTelemetry logs. Default:
+                       false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -330,32 +329,32 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-enabled <true|false>
-                     Enables exporting metrics to a destination handling telemetry data
-                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
-                       feature 'opentelemetry-metrics:v1' are enabled.
+                     Enables exporting metrics to a destination handling OpenTelemetry metrics.
+                       Default: false. Available only when metrics and feature
+                       'opentelemetry-metrics:v1' are enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -313,8 +313,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling telemetry data (OpenTelemetry
                        Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
@@ -334,20 +334,42 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-enabled <true|false>
+                     Enables exporting metrics to a destination handling telemetry data
+                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
+                       feature 'opentelemetry-metrics:v1' are enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -316,13 +316,12 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
-                     Enables exporting logs to a destination handling telemetry data (OpenTelemetry
-                       Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
-                       is enabled.
+                     Enables exporting logs to a destination handling OpenTelemetry logs. Default:
+                       false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -330,32 +329,32 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-enabled <true|false>
-                     Enables exporting metrics to a destination handling telemetry data
-                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
-                       feature 'opentelemetry-metrics:v1' are enabled.
+                     Enables exporting metrics to a destination handling OpenTelemetry metrics.
+                       Default: false. Available only when metrics and feature
+                       'opentelemetry-metrics:v1' are enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -313,8 +313,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling telemetry data (OpenTelemetry
                        Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
@@ -334,20 +334,42 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-enabled <true|false>
+                     Enables exporting metrics to a destination handling telemetry data
+                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
+                       feature 'opentelemetry-metrics:v1' are enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -640,8 +640,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling telemetry data (OpenTelemetry
                        Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
@@ -661,20 +661,42 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-enabled <true|false>
+                     Enables exporting metrics to a destination handling telemetry data
+                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
+                       feature 'opentelemetry-metrics:v1' are enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -643,13 +643,12 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
-                     Enables exporting logs to a destination handling telemetry data (OpenTelemetry
-                       Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
-                       is enabled.
+                     Enables exporting logs to a destination handling OpenTelemetry logs. Default:
+                       false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -657,32 +656,32 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-enabled <true|false>
-                     Enables exporting metrics to a destination handling telemetry data
-                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
-                       feature 'opentelemetry-metrics:v1' are enabled.
+                     Enables exporting metrics to a destination handling OpenTelemetry metrics.
+                       Default: false. Available only when metrics and feature
+                       'opentelemetry-metrics:v1' are enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -641,8 +641,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling telemetry data (OpenTelemetry
                        Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
@@ -662,20 +662,42 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-enabled <true|false>
+                     Enables exporting metrics to a destination handling telemetry data
+                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
+                       feature 'opentelemetry-metrics:v1' are enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -644,13 +644,12 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
-                     Enables exporting logs to a destination handling telemetry data (OpenTelemetry
-                       Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
-                       is enabled.
+                     Enables exporting logs to a destination handling OpenTelemetry logs. Default:
+                       false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -658,32 +657,32 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-enabled <true|false>
-                     Enables exporting metrics to a destination handling telemetry data
-                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
-                       feature 'opentelemetry-metrics:v1' are enabled.
+                     Enables exporting metrics to a destination handling OpenTelemetry metrics.
+                       Default: false. Available only when metrics and feature
+                       'opentelemetry-metrics:v1' are enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -567,8 +567,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-endpoint <url>
                      Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
                        is inherited from the 'telemetry-endpoint' option. Available only when
@@ -584,20 +584,38 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -570,9 +570,9 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -580,28 +580,28 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -640,8 +640,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling telemetry data (OpenTelemetry
                        Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
@@ -661,20 +661,42 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-enabled <true|false>
+                     Enables exporting metrics to a destination handling telemetry data
+                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
+                       feature 'opentelemetry-metrics:v1' are enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -643,13 +643,12 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
-                     Enables exporting logs to a destination handling telemetry data (OpenTelemetry
-                       Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
-                       is enabled.
+                     Enables exporting logs to a destination handling OpenTelemetry logs. Default:
+                       false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -657,32 +656,32 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-enabled <true|false>
-                     Enables exporting metrics to a destination handling telemetry data
-                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
-                       feature 'opentelemetry-metrics:v1' are enabled.
+                     Enables exporting metrics to a destination handling OpenTelemetry metrics.
+                       Default: false. Available only when metrics and feature
+                       'opentelemetry-metrics:v1' are enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -638,8 +638,8 @@ Telemetry (OpenTelemetry):
 
 --telemetry-endpoint <url>
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
-                       Available only when any of available OpenTelemetry components (Logs, Traces)
-                       is turned on.
+                       Available only when any of available OpenTelemetry components (Logs,
+                       Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling telemetry data (OpenTelemetry
                        Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
@@ -659,20 +659,42 @@ Telemetry (OpenTelemetry):
                        value is inherited from the 'telemetry-protocol' option. Possible values
                        are: grpc, http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
+--telemetry-metrics-enabled <true|false>
+                     Enables exporting metrics to a destination handling telemetry data
+                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
+                       feature 'opentelemetry-metrics:v1' are enabled.
+--telemetry-metrics-endpoint <url>
+                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
+                       the value is inherited from the 'telemetry-endpoint' option. Available only
+                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-interval <duration>
+                     The interval between the start of two metric export attempts to the
+                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
+                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
+                       5m, 1h). If the value is only a number, it represents time in seconds.
+                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
+                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-protocol <protocol>
+                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
+                       given, the value is inherited from the 'telemetry-protocol' option. Possible
+                       values are: grpc, http/protobuf. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:
                        grpc. Available only when any of available OpenTelemetry components (Logs,
-                       Traces) is turned on.
+                       Metrics, Traces) is turned on.
 --telemetry-resource-attributes <attributes>
                      OpenTelemetry resource attributes characterize the telemetry producer. Values
                        in format 'key1=val1,key2=val2'. Available only when any of available
-                       OpenTelemetry components (Logs, Traces) is turned on.
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-service-name <name>
                      OpenTelemetry service name. Takes precedence over 'service.name' defined in
                        the 'telemetry-resource-attributes' property. Default: keycloak. Available
-                       only when any of available OpenTelemetry components (Logs, Traces) is turned
-                       on.
+                       only when any of available OpenTelemetry components (Logs, Metrics, Traces)
+                       is turned on.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -641,13 +641,12 @@ Telemetry (OpenTelemetry):
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
-                     Enables exporting logs to a destination handling telemetry data (OpenTelemetry
-                       Logs). Default: false. Available only when feature 'opentelemetry-logs:v1'
-                       is enabled.
+                     Enables exporting logs to a destination handling OpenTelemetry logs. Default:
+                       false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to export logs to. If not given, the value
-                       is inherited from the 'telemetry-endpoint' option. Available only when
-                       Telemetry Logs functionality ('telemetry-logs-enabled') is enabled.
+                     OpenTelemetry endpoint to export logs to. If not given, the value is inherited
+                       from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
                        information, check the Telemetry guide. Possible values are (case
@@ -655,32 +654,32 @@ Telemetry (OpenTelemetry):
                        all. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for exporting logs. If not given, the
-                       value is inherited from the 'telemetry-protocol' option. Possible values
-                       are: grpc, http/protobuf. Available only when Telemetry Logs functionality
+                     OpenTelemetry protocol used for exporting logs. If not given, the value is
+                       inherited from the 'telemetry-protocol' option. Possible values are: grpc,
+                       http/protobuf. Available only when Telemetry Logs functionality
                        ('telemetry-logs-enabled') is enabled.
 --telemetry-metrics-enabled <true|false>
-                     Enables exporting metrics to a destination handling telemetry data
-                       (OpenTelemetry Metrics). Default: false. Available only when metrics and
-                       feature 'opentelemetry-metrics:v1' are enabled.
+                     Enables exporting metrics to a destination handling OpenTelemetry metrics.
+                       Default: false. Available only when metrics and feature
+                       'opentelemetry-metrics:v1' are enabled.
 --telemetry-metrics-endpoint <url>
-                     Telemetry (OpenTelemetry) endpoint to connect to for Metrics. If not given,
-                       the value is inherited from the 'telemetry-endpoint' option. Available only
-                       when metrics ('metrics-enabled') and Telemetry Metrics functionality
+                     OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
+                       inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>
                      The interval between the start of two metric export attempts to the
-                       destination handling telemetry data (OpenTelemetry Metrics). It accepts
-                       simplified format for time units as java.time.Duration (like 5000ms, 30s,
-                       5m, 1h). If the value is only a number, it represents time in seconds.
-                       Default: 60s. Available only when metrics ('metrics-enabled') and Telemetry
-                       Metrics functionality ('telemetry-metrics-enabled') are enabled.
+                       destination handling OpenTelemetry metrics data. It accepts simplified
+                       format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If
+                       the value is only a number, it represents time in seconds. Default: 60s.
+                       Available only when metrics ('metrics-enabled') and Telemetry Metrics
+                       functionality ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-protocol <protocol>
-                     Telemetry (OpenTelemetry) protocol used for the metrics telemetry data. If not
-                       given, the value is inherited from the 'telemetry-protocol' option. Possible
-                       values are: grpc, http/protobuf. Available only when metrics
-                       ('metrics-enabled') and Telemetry Metrics functionality
-                       ('telemetry-metrics-enabled') are enabled.
+                     OpenTelemetry protocol used for the metrics telemetry data. If not given, the
+                       value is inherited from the 'telemetry-protocol' option. Possible values
+                       are: grpc, http/protobuf. Available only when metrics ('metrics-enabled')
+                       and Telemetry Metrics functionality ('telemetry-metrics-enabled') are
+                       enabled.
 --telemetry-protocol <protocol>
                      OpenTelemetry protocol used for the communication between server and
                        OpenTelemetry collector. Possible values are: grpc, http/protobuf. Default:


### PR DESCRIPTION
- Closes #41006 
- Metrics are exported to the OTel Collector
- However, as we don't have any better OTel testing, we cannot verify that all metrics are sent properly
<img width="1551" height="456" alt="image" src="https://github.com/user-attachments/assets/40513421-9762-4f3a-b21e-cc5fb43881a2" />

## Try it out
1. Start the LGTM service:
```
docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -ti grafana/otel-lgtm
```
2. Start the KC server:
```
 ./kc.sh start-dev --metrics-enabled=true --feature-opentelemetry-metrics=enabled --telemetry-metrics-enabled=true
```

3. Access the `localhost:3000` to see Grafana --> Drilldown --> Metrics
