### PR TITLE
changed minimal required node.js version in admin ui readme

### DIFF
--- a/js/apps/admin-ui/CONTRIBUTING.md
+++ b/js/apps/admin-ui/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This project is the next generation of the Keycloak Administration UI. It is wri
 
 ### Prerequisites
 
-Make sure that you have Node.js version 18 (or later) installed on your system. If you do not have Node.js installed we recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install it.
+Make sure that you have Node.js version 20.19+ or 22.12+ (or later) installed on your system. If you do not have Node.js installed we recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install it.
 
 You can find out which version of Node.js you are using by running the following command:
 


### PR DESCRIPTION
Changed the minimal required Node.js version for the admin ui development server from 18 to 20.19+/22.12+ in admin ui readme. Due to the vite version bump from v6 to v7, Node.js 18 is no longer supported. For more details and links see the linked issue.

Closes #41710

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
