### PR TITLE
fix: undeprecating legacy-observability-interface

### DIFF
--- a/docs/documentation/release_notes/topics/26_4_0.adoc
+++ b/docs/documentation/release_notes/topics/26_4_0.adoc
@@ -31,3 +31,9 @@ In order to support basic TLS termination (edge) deployments via the operator, y
 While access logs are often used for debugging and traffic analysis, they are also important for security auditing and compliance monitoring.
 
 For more information, see the https://www.keycloak.org/server/logging[Logging guide].
+
+= Legacy interface for metrics and health endpoints
+
+The `legacy-observability-interface` option is no longer deprecated. You may use that to make the `/health` and `/metrics` endpoints accessible by the main ports, which default to `8080` for HTTP and `8443` for HTTPS.
+
+Administrators using this option should take care at their proxy to block unintended access to the `/health` and `/metrics` endpoints.

--- a/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-25_0_0.adoc
@@ -345,7 +345,6 @@ The `/health` and `/metrics` endpoints are accessible on the management port `90
 That means these endpoints are no longer exposed to the standard Keycloak ports `8080` and `8443`.
 
 In order to reflect the old behavior, use the property `--legacy-observability-interface=true`, which will not expose these endpoints on the management port.
-However, this property is deprecated and will be removed in future releases, so it is recommended not to use it.
 
 The management interface uses a different HTTP server than the default {project_name} HTTP server, and it is possible to configure them separately.
 Beware, if no values are supplied for the management interface properties, they are inherited from the default {project_name} HTTP server.

--- a/docs/guides/server/management-interface.adoc
+++ b/docs/guides/server/management-interface.adoc
@@ -52,9 +52,7 @@ If you want to disable exposing them on the management interface, set the {proje
 
 [WARNING]
 ====
-Exposing health and metrics endpoints on the default server is not recommended for security reasons, and you should always use the management interface.
-Beware, the `legacy-observability-interface` option is deprecated and will be removed in future releases.
-It only allows you to give more time for the migration.
+Exposing health and metrics endpoints on the default server is not recommended for security reasons. If you enable the `legacy-observability-interface` be sure that your proxy blocks unintended traffic to the /health and /metrics endpoints.
 ====
 
 </@tmpl.guide>


### PR DESCRIPTION
closes: #41303

This is the far simpler option for offering health checks on the main interface.

The guidance here isn't much different than what we have for using a hostname-admin - that is if you don't want users accessing /admin via hostname, then you have to block that at the proxy.

We could also consider renaming this option so that it doesn't use the term legacy.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
