### PR TITLE
Fix flaky org test.

### DIFF
--- a/js/apps/admin-ui/test/organization/main.spec.ts
+++ b/js/apps/admin-ui/test/organization/main.spec.ts
@@ -77,6 +77,10 @@ test.describe("Organization CRUD", () => {
 
     test("should modify existing organization", async ({ page }) => {
       await clickTableRowItem(page, orgName);
+
+      // This waits for the field to be filled before we clear and fill it with a new value
+      await expect(getNameField(page)).toHaveValue(orgName);
+
       const newValue = "newName";
       await fillNameField(page, newValue);
       await expect(getNameField(page)).toHaveValue(newValue);


### PR DESCRIPTION
Fixes #41752

Sometimes, the test would try to clear and fill the name field with a new value before the form had loaded the old value.  So the `Save` button would remain disabled.

This change makes it verify that the old value is present first.
