### PR TITLE
Fix: allow changing username in reset credentials flow when using separate username and password forms

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
@@ -115,16 +115,15 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
 
         // we don't want people guessing usernames, so if there is a problem, just continue, but don't set the user
         // a null user will notify further executions, that this was a failure.
+        context.clearUser();
         if (user == null) {
             event.clone()
                     .detail(Details.USERNAME, username)
                     .error(Errors.USER_NOT_FOUND);
-            context.clearUser();
         } else if (!user.isEnabled()) {
             event.clone()
                     .detail(Details.USERNAME, username)
                     .user(user).error(Errors.USER_DISABLED);
-            context.clearUser();
         } else {
             context.setUser(user);
         }


### PR DESCRIPTION
Closes #40643

This change clears the user before setting it. Open to feedback if this approach could introduce security concerns.
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
