### PR TITLE
fix: adding a default for ldap connection timeout

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -99,6 +99,10 @@ When tracing is enabled, now also calls to other nodes of a {project_name} clust
 
 To disable this kind of tracing, set the option `tracing-infinispan-enabled` to `false`.
 
+=== LDAP Connection Timeout Default
+
+If no value is specified either on the LDAP configuration as the connectionTimeout or via the `com.sun.jndi.ldap.connect.timeout` system property, the default timeout
+will be 5 seconds. This will ensure that requests will see errors rather than indefinite waits in obtaining an LDAP connection from the pool or when making a connection to the LDAP server.
 
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -34,6 +34,8 @@ import java.util.Set;
  */
 public class LDAPConfig {
 
+    public static final String DEFAULT_CONNECTION_TIMEOUT = "5000";
+
     private final MultivaluedHashMap<String, String> config;
     private final Set<String> binaryAttributeNames = new HashSet<>();
 
@@ -142,7 +144,8 @@ public class LDAPConfig {
     }
 
     public String getConnectionTimeout() {
-        return config.getFirst(LDAPConstants.CONNECTION_TIMEOUT);
+        return config.getFirstOrDefault(LDAPConstants.CONNECTION_TIMEOUT,
+                System.getProperty("com.sun.jndi.ldap.connect.timeout", DEFAULT_CONNECTION_TIMEOUT));
     }
 
     public String getReadTimeout() {


### PR DESCRIPTION
Alternative to #41726

If not specified on the LDAPConfig, we'll look for the system property, then use the default of 5000. The alternative is to skip looking for the system property at all, but that could be consider a breaking change given that we've document the usage of the property.

A separate follow-up issue will be needed to deprecate directly using the ldap system properties.

closes: #39299

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
