### PR TITLE
fix: adding raw environment variables

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -100,7 +100,31 @@ spec:
 ----
 NOTE:  The name format of options defined in this way is identical to the key format of options specified in the configuration file.
        For details on various configuration formats, see <@links.server id="configuration"/>.
+       
+==== Custom environment variables
 
+You may find a need to set custom environment variables - such as for theme properties or `kc.[sh|bat]` script variables.
+The `spec.env` field of the Keycloak CR allows you to directly set any environment variable.
+Logic in the operator based upon looking for value of a particular setting does not consult `spec.env`,
+therefore do not use `spec.env` for anything that has a first-class configuration in the CR or may be specified as an `additionalOption`.
+
+Here's an example setting JAVA_OPTS_APPEND:  
+     
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  ...
+  env:
+    - name: JAVA_OPTS_APPEND
+      value: -Djava.net.preferIPv6Addresses=true
+----
+
+Similar to `additionalOptions` you may specify either a value or reference a Secret.
+       
 === Secret References
 
 Secret References are used by some dedicated options in the Keycloak CR, such as a `tlsSecret`, or as a value in `additionalOptions`.

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -67,6 +67,10 @@ public class KeycloakSpec {
             "expressed as a keys (reference: https://www.keycloak.org/server/all-config) and values that can be either direct values or references to secrets.")
     private List<ValueOrSecret> additionalOptions = new ArrayList<ValueOrSecret>(); // can't use Set due to a bug in Sundrio https://github.com/sundrio/sundrio/issues/316
 
+    @JsonPropertyDescription("Environment variables for the Keycloak server.\n" +
+            "Values can be either direct values or references to secrets. Use additionalOptions for first-class options rather than KC_ values here.")
+    private List<ValueOrSecret> env = new ArrayList<ValueOrSecret>();
+
     @JsonProperty("http")
     @JsonPropertyDescription("In this section you can configure Keycloak features related to HTTP and HTTPS")
     private HttpSpec httpSpec;
@@ -139,7 +143,6 @@ public class KeycloakSpec {
     @JsonProperty("readinessProbe")
     @JsonPropertyDescription("Configuration for readiness probe, by default it is 10 for periodSeconds and 3 for failureThreshold")
     private ProbeSpec readinessProbeSpec;
-
 
     @JsonProperty("livenessProbe")
     @JsonPropertyDescription("Configuration for liveness probe, by default it is 10 for periodSeconds and 3 for failureThreshold")
@@ -243,6 +246,14 @@ public class KeycloakSpec {
             this.additionalOptions = new ArrayList<>();
         }
         return additionalOptions;
+    }
+
+    public List<ValueOrSecret> getEnv() {
+        return env;
+    }
+
+    public void setEnv(List<ValueOrSecret> env) {
+        this.env = env;
     }
 
     public void setAdditionalOptions(List<ValueOrSecret> additionalOptions) {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -109,7 +109,7 @@ public class CRSerializationTest {
         assertEquals(1,keycloak.getSpec().getLivenessProbeSpec().getProbeFailureThreshold());
         assertEquals(40,keycloak.getSpec().getStartupProbeSpec().getProbePeriodSeconds());
         assertEquals(2,keycloak.getSpec().getStartupProbeSpec().getProbeFailureThreshold());
-
+        assertEquals("MY_ENV_VAR", keycloak.getSpec().getEnv().get(0).getName());
     }
 
     @Test

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -135,6 +135,9 @@ spec:
   update:
     strategy: Auto
     revision: 1
+  env:
+    - name : MY_ENV_VAR
+      value: my-value
   unsupported:
     podTemplate:
       metadata:


### PR DESCRIPTION
closes: #41766

It seems fine to align the name, env, with what is already in kubernetes rather than something more verbose like environment-variables

Also seems like this would be considered an advanced deployment feature - or do we even want to promote it in that context, and instead document it as a rarely used escape hatch?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
