### PR TITLE
Do not remove the recaptcha form data because it is useless

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/AbstractRegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/AbstractRegistrationRecaptcha.java
@@ -128,7 +128,6 @@ public abstract class AbstractRegistrationRecaptcha implements FormAction, FormA
 
         List<FormMessage> errors = new ArrayList<>();
         errors.add(new FormMessage(null, Messages.RECAPTCHA_FAILED));
-        formData.remove(G_RECAPTCHA_RESPONSE);
         context.error(Errors.INVALID_REGISTRATION);
         context.validationError(formData, errors);
         context.excludeOtherErrors();


### PR DESCRIPTION
Closes #41148

Just deleting the line that removes the captcha form data from the map. The form data is retrieved from quarkus using the the method [getDecodedFormParameters](https://github.com/keycloak/keycloak/blob/26.2.7/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusHttpRequest.java#L66), and the map is always rebuilt. So removing the parameter is useless as it will be returned in the same way when calling the method again. As commented in the issue, I think the only way of returning an immutable map is when it is empty (EMPTY_FORM_PARAM). If you think that we should always return an immutable (or mutable) map just let me know.

I was waiting for @derlin but it seems that he is busy. I tested manually with google captcha v3 and it works as before removing the line.
