### PR TITLE
enhance: adding the ability to set truststores via configmaps

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -323,7 +323,7 @@ For more details, see <@links.server id="management-interface" />.
 
 If you need to provide trusted certificates, the Keycloak CR provides a top level feature for configuring the server's truststore as discussed in <@links.server id="keycloak-truststore"/>.
 
-Use the truststores stanza of the Keycloak spec to specify Secrets containing PEM encoded files, or PKCS12 files with extension `.p12`, `.pfx`, or `.pkcs12`, for example:
+Use the truststores stanza of the Keycloak spec to specify Secrets or ConfigMaps containing PEM encoded files, or PKCS12 files with extension `.p12`, `.pfx`, or `.pkcs12`, for example:
 
 [source,yaml]
 ----

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/Truststore.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/Truststore.java
@@ -17,11 +17,10 @@
 
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
-import io.fabric8.generator.annotation.Required;
-import io.sundr.builder.annotations.Buildable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.sundr.builder.annotations.Buildable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
@@ -29,8 +28,11 @@ public class Truststore {
 
     @JsonPropertyDescription("Not used. To be removed in later versions.")
     private String name;
-    @Required
+
+    @JsonPropertyDescription("The Secret containing the trust material - only set one of the other secret or configMap")
     private TruststoreSource secret;
+    @JsonPropertyDescription("The ConfigMap containing the trust material - only set one of the other secret or configMap")
+    private TruststoreSource configMap;
 
     public String getName() {
         return name;
@@ -46,6 +48,14 @@ public class Truststore {
 
     public void setSecret(TruststoreSource secret) {
         this.secret = secret;
+    }
+
+    public TruststoreSource getConfigMap() {
+        return configMap;
+    }
+
+    public void setConfigMap(TruststoreSource configMap) {
+        this.configMap = configMap;
     }
 
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakTruststoresTests.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakTruststoresTests.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.operator.testsuite.integration;
 
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -40,6 +41,7 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
         var kc = getTestKeycloakDeployment(true);
         var deploymentName = kc.getMetadata().getName();
         kc.getSpec().getTruststores().put("xyz", new TruststoreBuilder().withNewSecret().withName("xyz").endSecret().build());
+        kc.getSpec().getTruststores().put("abc", new TruststoreBuilder().withNewConfigMap().withName("abc").endConfigMap().build());
 
         deployKeycloak(k8sclient, kc, false);
         Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);
@@ -49,6 +51,10 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
                     statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_SECRETS_ANNOTATION));
             assertTrue(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_WATCHING_ANNOTATION)
                     .contains("xyz"));
+            assertEquals("true",
+                    statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION));
+            assertTrue(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_WATCHING_CONFIGMAPS_ANNOTATION)
+                    .contains("abc"));
         });
     }
 
@@ -59,6 +65,9 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
 
         K8sUtils.set(k8sclient, getResourceFromFile("example-truststore-secret.yaml", Secret.class));
         kc.getSpec().getTruststores().put("example", new TruststoreBuilder().withNewSecret().withName("example-truststore-secret").endSecret().build());
+        kc.getSpec().getTruststores().put("abc", new TruststoreBuilder().withNewConfigMap().withName("abc").endConfigMap().build());
+
+        k8sclient.configMaps().resource(new ConfigMapBuilder().withNewMetadata().withName("abc").endMetadata().build()).create();
 
         deployKeycloak(k8sclient, kc, true);
         Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);
@@ -68,6 +77,11 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
         assertTrue(statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getVolumeMounts().stream()
                 .anyMatch(v -> v.getMountPath()
                         .equals("/opt/keycloak/conf/truststores/secret-example-truststore-secret")));
+        assertEquals("false",
+                statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION));
+        assertTrue(statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getVolumeMounts().stream()
+                .anyMatch(v -> v.getMountPath()
+                        .equals("/opt/keycloak/conf/truststores/configmap-abc")));
     }
 
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -19,6 +19,7 @@ package org.keycloak.operator.testsuite.unit;
 
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.IntOrString;
@@ -26,6 +27,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
@@ -576,6 +578,8 @@ public class PodTemplateTest {
                 .filter(v -> v.getName().equals(KeycloakDeploymentDependentResource.CACHE_CONFIG_FILE_MOUNT_NAME))
                 .findFirst().orElseThrow();
         assertThat(volume.getConfigMap().getName()).isEqualTo("cm");
+
+        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(List.of("cm")), Mockito.eq(ConfigMap.class), Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -779,7 +783,7 @@ public class PodTemplateTest {
         envVar = env.get("SECRET");
         assertEquals("key", envVar.getValueFrom().getSecretKeyRef().getKey());
 
-        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(List.of("example-tls-secret", "instance-initial-admin", "my-secret")), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(List.of("example-tls-secret", "instance-initial-admin", "my-secret")), Mockito.eq(Secret.class), Mockito.any(), Mockito.any());
     }
 
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/WatchedResourcesTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/WatchedResourcesTest.java
@@ -39,7 +39,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class WatchedResourcesTest {
 
     public static final String KEYCLOAK_WATCHING_ANNOTATION = "operator.keycloak.org/watching-secrets";
+    public static final String KEYCLOAK_WATCHING_CONFIGMAPS_ANNOTATION = "operator.keycloak.org/watching-configmaps";
     public static final String KEYCLOAK_MISSING_SECRETS_ANNOTATION = "operator.keycloak.org/missing-secrets";
+    public static final String KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION = "operator.keycloak.org/missing-configmaps";
+
 
     @Inject
     WatchedResources watchedResources;


### PR DESCRIPTION
closes: #34114

This removes the Required annotation from the secret field, but does not add validation that only one secret or configMap should be set - it is mentioned in the documentation for the the fields. Later we should be able to add a oneOf restriction to the CRD via the josdk / fabric8.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
