### PR TITLE
fix: adds simple log scraping to error state detection

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -43,6 +43,12 @@ rules:
     verbs:
       - list
   - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
       - batch
     resources:
       - jobs

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
@@ -75,10 +75,10 @@ public final class CRAssert {
     public static void assertKeycloakStatusCondition(Keycloak kc, String condition, Boolean status) {
         assertKeycloakStatusCondition(kc, condition, status, null);
     }
-    public static void assertKeycloakStatusCondition(Keycloak kc, String condition, Boolean status, String containedMessage) {
+    public static ObjectAssert<KeycloakStatusCondition> assertKeycloakStatusCondition(Keycloak kc, String condition, Boolean status, String containedMessage) {
         Log.debugf("Asserting CR: %s, condition: %s, status: %s, message: %s", kc.getMetadata().getName(), condition, status, containedMessage);
         try {
-            assertKeycloakStatusCondition(kc.getStatus(), condition, status, containedMessage, null);
+            return assertKeycloakStatusCondition(kc.getStatus(), condition, status, containedMessage, null);
         } catch (Exception e) {
             Log.infof("Asserting CR: %s with status:\n%s", kc.getMetadata().getName(), Serialization.asYaml(kc.getStatus()));
             throw e;


### PR DESCRIPTION
closes: #21816

Rather than creating a standalone set of validation logic, or running a specialized error-detection job, it seems straight-forward just to show the last snippet of the log. In most cases with configuration errors, even with verbose enabled, we will show them as simple output at the end of the log.

The downsides of this approach:
- are there things in the log that we don't want a Keycloak CR reader to see? Ideally not, but we may need to put further guidence that any anyone who can read a Keycloak CR should be namespace level admin.
- We'll poll on every status update when there is pod in an error state for the end of the log
- Could just add more docs on getting pod logs instead - but that may involve a broader obserability story as well.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
