### PR TITLE
Use an OS-specific key for writing for maven cache (#41735)

### DIFF
--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -3,7 +3,7 @@ description: Caches Maven artifacts
 
 inputs:
   create-cache-if-it-doesnt-exist:
-    description: > 
+    description: >
       Only those callers which fill the cache with the right contents should set this to true to avoid creating a cache
       which contains too few or too many entries.
     required: false
@@ -24,10 +24,14 @@ runs:
       with:
         # Two asterisks are needed to make the follow-up exclusion work
         # see https://github.com/actions/toolkit/issues/713 for the upstream issue
+        #
+        # Hybrid cache strategy: Use an OS-specific key for writing, but allow fallback to a cross-OS cache for reading.
         path: |
           ~/.m2/repository/*/*
           !~/.m2/repository/org/keycloak
-        key: ${{ steps.weekly-cache-key.outputs.key }}
+        key: mvn-${{ runner.os }}-${{ steps.weekly-cache-key.outputs.key }}
+        restore-keys: |
+          mvn--${{ steps.weekly-cache-key.outputs.key }}
         # Enable cross-os archive use the cache on both Linux and Windows
         enableCrossOsArchive: true
 
@@ -37,10 +41,13 @@ runs:
       if: inputs.create-cache-if-it-doesnt-exist == 'false'
       with:
         # This needs to repeat the same path pattern as above to find the matching cache
+        # Hybrid cache strategy used again
         path: |
           ~/.m2/repository/*/*
           !~/.m2/repository/org/keycloak
-        key: ${{ steps.weekly-cache-key.outputs.key }}
+        key: mvn-${{ runner.os }}-${{ steps.weekly-cache-key.outputs.key }}
+        restore-keys: |
+          mvn--${{ steps.weekly-cache-key.outputs.key }}
         enableCrossOsArchive: true
 
     - shell: bash


### PR DESCRIPTION
Closes: #41664

This PR was successfully tested solved the cache instabilities in the quarkus next branch for the last 3 days ([Aug 10 - Aug 12](https://github.com/keycloak/keycloak/actions/workflows/ci.yml?query=branch%3Aquarkus-next)). This makes me confident that the issues were really caused by some OS specifics hidden in atriffacts (e.g. symlinks). I opted for a hybrid strategy while refactoring this (f the OS-specific cache does not exist , the runner will then try the restore-keys - cross-OS cache).

But as @ahus1 later [pointed out](https://github.com/keycloak/keycloak/issues/41664#issuecomment-3168227479), we can fully get rid of cross-OS cache, even as a fallback, in case  it would cause issues in the future.

cc: @mabartos @vmuzikar 
