### PR TITLE
Upgrade angus mail to 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
         <!--JAKARTA-->
         <jakarta.mail.version>2.1.1</jakarta.mail.version>
-        <angus.mail.version>2.0.3</angus.mail.version>
+        <angus.mail.version>2.0.4</angus.mail.version>
         <jakarta.xml.ws.version>4.0.0</jakarta.xml.ws.version>
         <jakarta.xml.soap.version>3.0.0</jakarta.xml.soap.version>
 


### PR DESCRIPTION
Closes #41808

Upgrading angus mail to 2.0.4. The new release is very short on changes and mainly to fix the low severity CVE. @pskopek did the approval from product team.
