### PR TITLE
Change naming for disabling additional datasource

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -101,10 +101,10 @@ public class DatabaseOptions {
             .defaultValue(10000)
             .build();
 
-    public static final Option<Boolean> DB_ACTIVE_DATASOURCE = new OptionBuilder<>("db-active-<datasource>", Boolean.class)
+    public static final Option<Boolean> DB_ENABLED_DATASOURCE = new OptionBuilder<>("db-enabled-<datasource>", Boolean.class)
             .category(OptionCategory.DATABASE_DATASOURCES)
             .defaultValue(true)
-            .description("Deactivate specific named datasource <datasource>.")
+            .description("If the named datasource <datasource> should be enabled at runtime.")
             .build();
 
     public static final Option<String> DB_POSTGRESQL_TARGET_SERVER_TYPE = new OptionBuilder<>("db-postgres-target-server-type", String.class)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -101,7 +101,7 @@ final class DatabasePropertyMappers {
                 fromOption(DatabaseOptions.DB_SQL_LOG_SLOW_QUERIES)
                         .paramLabel("milliseconds")
                         .build(),
-                fromOption(DatabaseOptions.DB_ACTIVE_DATASOURCE)
+                fromOption(DatabaseOptions.DB_ENABLED_DATASOURCE)
                         .to("quarkus.datasource.\"<datasource>\".active")
                         .build(),
                 fromOption(DB_URL_PATH)

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -141,13 +141,13 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
     public void datasourceEnabled() {
         ConfigArgsConfigSource.setCliArgs("");
         initConfig();
-        assertConfig("db-active-store", "true");
+        assertConfig("db-enabled-store", "true");
         assertExternalConfig("quarkus.datasource.\"store\".active", "true");
         onAfter();
 
-        ConfigArgsConfigSource.setCliArgs("--db-active-store=false");
+        ConfigArgsConfigSource.setCliArgs("--db-enabled-store=false");
         initConfig();
-        assertConfig("db-active-store", "false");
+        assertConfig("db-enabled-store", "false");
         assertExternalConfig("quarkus.datasource.\"store\".active", "false");
     }
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -72,8 +72,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -81,6 +79,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -74,8 +74,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -83,6 +81,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -67,8 +67,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -76,6 +74,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -67,8 +67,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -76,6 +74,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -67,8 +67,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -76,6 +74,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -67,8 +67,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -76,6 +74,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -109,8 +109,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -118,6 +116,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -176,8 +176,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -185,6 +183,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -157,8 +157,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -166,6 +164,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -177,8 +177,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -186,6 +184,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -151,11 +151,12 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-log-slow-queries-threshold-<datasource> <milliseconds>
                      Preview: Used for named <datasource>. Log SQL statements slower than the
                        configured threshold with logger org.hibernate.SQL_SLOW and log-level info.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -171,11 +171,12 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-log-slow-queries-threshold-<datasource> <milliseconds>
                      Preview: Used for named <datasource>. Log SQL statements slower than the
                        configured threshold with logger org.hibernate.SQL_SLOW and log-level info.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -156,8 +156,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -165,6 +163,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -176,8 +176,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -185,6 +183,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -154,8 +154,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -163,6 +161,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -174,8 +174,6 @@ Database:
 
 Database - additional datasources (Preview):
 
---db-active-<datasource> <true|false>
-                     Preview: Deactivate specific named datasource <datasource>. Default: true.
 --db-debug-jpql-<datasource> <true|false>
                      Preview: Used for named <datasource>. Add JPQL information as comments to SQL
                        statements to debug JPA SQL statement generation. Default: false.
@@ -183,6 +181,9 @@ Database - additional datasources (Preview):
                      Preview: Used for named <datasource>. The fully qualified class name of the
                        JDBC driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-enabled-<datasource> <true|false>
+                     Preview: If the named datasource <datasource> should be enabled at runtime.
+                       Default: true.
 --db-kind-<datasource> <vendor>
                      Preview: Used for named <datasource>. The database vendor. In production mode
                        the default value of 'dev-file' is deprecated, you should explicitly specify


### PR DESCRIPTION
- Closes #40761

Reference to: https://github.com/keycloak/keycloak/pull/40762

> @mabartos wrote: _Closing this PR as the options for additional datasources might need some more refinements and possibly the best approach for that would be to enable the datasource at build time, but having the possibility to deactivate in runtime. I'll provide some more details later._

We have a different mechanism for enabling datasources.

@vmuzikar I believe we can proceed with this PR.