### PR TITLE
Fix Jandex version collision to allow running tests using auth-server-quarkus-embedded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-simple</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -56,7 +56,6 @@
         <undertow-embedded.version>1.0.0.Final</undertow-embedded.version>
         <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <jakarta.persistence-legacy.version>2.2.3</jakarta.persistence-legacy.version>
-        <smallrye.jandex.version>3.0.5</smallrye.jandex.version>
         <commons.validator.version>1.8.0</commons.validator.version>
         <byte-buddy.version>1.14.13</byte-buddy.version>
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -145,11 +145,6 @@
             <artifactId>maven-resolver-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>jandex</artifactId>
-            <version>${smallrye.jandex.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>${systemrules.version}</version>


### PR DESCRIPTION
Closes #41821

* Also removing what it seems to be an unnecessary declaration of the jandex dependency in the old testsuite.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
