### PR TITLE
Test flaky due to dual certificates

### DIFF
--- a/js/apps/admin-ui/test/clients/saml.spec.ts
+++ b/js/apps/admin-ui/test/clients/saml.spec.ts
@@ -34,6 +34,7 @@ import {
   selectEncryptionDigestMethodInput,
   selectEncryptionMaskGenerationFunctionInput,
   setTermsOfServiceUrl,
+  assertDualCertificates,
 } from "./saml.ts";
 
 test.describe("Fine Grain SAML Endpoint Configuration", () => {
@@ -143,7 +144,7 @@ test.describe("Clients SAML tests", () => {
       "New key pair and certificate generated successfully",
     );
     await confirmModal(page);
-    await assertCertificate(page, false);
+    await assertDualCertificates(page);
 
     // assert encryption algorithms can be modified
     await goToClientSettingsTab(page);

--- a/js/apps/admin-ui/test/clients/saml.spec.ts
+++ b/js/apps/admin-ui/test/clients/saml.spec.ts
@@ -9,7 +9,7 @@ import { goToClients } from "../utils/sidebar.ts";
 import { clickTableRowItem } from "../utils/table.ts";
 import { goToAdvancedTab, revertFineGrain, saveFineGrain } from "./advanced.ts";
 import {
-  assertCertificate,
+  assertCertificates,
   assertEncryptionAlgorithm,
   assertEncryptionKeyAlgorithm,
   assertEncryptionDigestMethod,
@@ -34,7 +34,6 @@ import {
   selectEncryptionDigestMethodInput,
   selectEncryptionMaskGenerationFunctionInput,
   setTermsOfServiceUrl,
-  assertDualCertificates,
 } from "./saml.ts";
 
 test.describe("Fine Grain SAML Endpoint Configuration", () => {
@@ -122,7 +121,7 @@ test.describe("Clients SAML tests", () => {
     await clickClientSignature(page);
     await assertModalTitle(page, 'Disable "Client signature required"');
     await cancelModal(page);
-    await assertCertificate(page, false);
+    await assertCertificates(page);
   });
 
   test("should disable client signature", async ({ page }) => {
@@ -131,7 +130,7 @@ test.describe("Clients SAML tests", () => {
     await assertModalTitle(page, 'Disable "Client signature required"');
     await confirmModal(page);
     await assertNotificationMessage(page, "Client successfully updated");
-    await assertCertificate(page);
+    await assertCertificates(page);
   });
 
   test("should enable Encryption keys config", async ({ page }) => {
@@ -144,7 +143,7 @@ test.describe("Clients SAML tests", () => {
       "New key pair and certificate generated successfully",
     );
     await confirmModal(page);
-    await assertDualCertificates(page);
+    await assertCertificates(page);
 
     // assert encryption algorithms can be modified
     await goToClientSettingsTab(page);

--- a/js/apps/admin-ui/test/clients/saml.ts
+++ b/js/apps/admin-ui/test/clients/saml.ts
@@ -66,12 +66,14 @@ export async function clickClientSignature(page: Page) {
   await switchOff(page, "#clientSignature");
 }
 
-export async function assertCertificate(page: Page, exists = true) {
-  await expect(page.getByTestId("certificate")).toHaveCount(exists ? 0 : 1);
-}
+// Assert that the number of certificates enabled matches the number of certificates displayed
+export async function assertCertificates(page: Page) {
+  const certsEnabled = [
+    await page.getByTestId("encryptAssertions").isChecked(),
+    await page.getByTestId("clientSignature").isChecked(),
+  ].filter(Boolean).length;
 
-export async function assertDualCertificates(page: Page) {
-  await expect(page.getByTestId("certificate")).toHaveCount(2);
+  await expect(page.getByTestId("certificate")).toHaveCount(certsEnabled);
 }
 
 export async function clickEncryptionAssertions(page: Page) {

--- a/js/apps/admin-ui/test/clients/saml.ts
+++ b/js/apps/admin-ui/test/clients/saml.ts
@@ -87,7 +87,7 @@ export async function clickOffEncryptionAssertions(page: Page) {
 export async function clickGenerate(page: Page) {
   const responsePromise = page.waitForResponse(
     (res) => res.url().includes("/generate") && res.status() === 200,
-    { timeout: 10000 },
+    { timeout: 60000 },
   );
   await page.getByTestId("generate").click();
   await responsePromise;

--- a/js/apps/admin-ui/test/clients/saml.ts
+++ b/js/apps/admin-ui/test/clients/saml.ts
@@ -70,6 +70,10 @@ export async function assertCertificate(page: Page, exists = true) {
   await expect(page.getByTestId("certificate")).toHaveCount(exists ? 0 : 1);
 }
 
+export async function assertDualCertificates(page: Page) {
+  await expect(page.getByTestId("certificate")).toHaveCount(2);
+}
+
 export async function clickEncryptionAssertions(page: Page) {
   await switchOn(page, "#encryptAssertions");
 }


### PR DESCRIPTION
Fixes #41823

The problem was that the test should be expecting two certificates on the page. The way it was written, the test waits for one certificate. Sometimes the second certificate has not been rendered yet and the test would erroneously pass.  Instead it should be waiting for the second certificate to be rendered so it is checking the correct assertion.