### PR TITLE
Allow claim extraction of email_verified to handle non-native boolean types

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -1031,6 +1031,12 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             return null;
         }
 
-        return (Boolean) token.getOtherClaims().get(IDToken.EMAIL_VERIFIED);
+        Object emailVerified = token.getOtherClaims().get(IDToken.EMAIL_VERIFIED);
+
+        if (emailVerified == null) {
+            return null;
+        }
+
+        return Boolean.valueOf(emailVerified.toString());
     }
 }


### PR DESCRIPTION
### Context
After the change in [keycloak/keycloak#40006](https://github.com/keycloak/keycloak/pull/40006), Keycloak starts supporting the standard `email_verified` claim.

However, Azure AD does not provide this standard claim by default, which causes the verification process to trigger every time the user re-authenticates.

To work around this in Azure AD, we can configure `email_verified` as a custom claim provided from Azure. The limitation is that **Azure AD always sends it as a string ("true" / "false")**, and there is no way to enforce a native boolean type on their side.

### Proposed Change
Update getEmailVerifiedClaim to accept non-native boolean types by:

Converting the claim value to a string and parsing it to a Boolean.

Supporting both native Boolean and string-based "true"/"false" values.

This allows Keycloak to correctly interpret the email_verified claim from Azure AD without triggering unnecessary re-verification.
