### PR TITLE
Upgrade Prep doc polishing

### DIFF
--- a/docs/documentation/upgrading/topics/prep_migration.adoc
+++ b/docs/documentation/upgrading/topics/prep_migration.adoc
@@ -1,27 +1,29 @@
 [[_prep_migration]]
 
-== Preparing for upgrading
+== Preparing for an upgrade
 
 Perform the following steps before you upgrade the server.
 
 .Procedure
-. Shutdown {project_name}.
+. Shut down {project_name}.
 . Back up the old installation, such as configuration, themes, and so on.
-. If XA transaction is enabled, handle any open transactions and delete the `data/transaction-logs/` transaction directory.
-. Back up the database using instructions in the documentation for your relational
-  database.
-+
-The database will no longer be compatible with the old server after you upgrade the server. If you need to revert the upgrade, first restore the old installation, and then restore the database from the backup copy.
+. If XA transactions are enabled, handle any open transactions and delete the `data/transaction-logs/` transaction directory.
+. Back up the database using the instructions in the documentation for your relational database.
+
+[WARNING]
+====
+The database schema will no longer be compatible with the old server after the upgrade. Because {project_name} does not support rolling back the database changes, if you need to roll back to the previous version, first restore the old installation, and then restore the database from the backup copy.
+====
 
 [NOTE]
 ====
-In case the feature `persistent-user-sessions` is disabled in your current setup and the server is upgraded, all user sessions will be lost except for offline user sessions.
-Users owning these sessions will have to log in again.
-Note the feature `persistent-user-sessions` is disabled by default in the {project_name} server releases prior to 26.0.0.
+If the `persistent-user-sessions` feature is disabled in your current setup and the server is upgraded, all user sessions will be lost except for offline user sessions.
+Users with these sessions will have to log in again.
+Note that the `persistent-user-sessions` feature is disabled by default in {project_name} server releases prior to 26.0.0.
 ====
 
 [WARNING]
 ====
-Information about failed logins for the brute force detection and currently ongoing authentication flows is only stored in the internal caches that are cleared when {project_name} is shut down.
-Users currently authenticating, changing their passwords or resetting their password will need to restart the authentication flow once {project_name} is up and running again.
+Information about failed logins for brute force detection and currently ongoing authentication flows is only stored in the internal caches that are cleared when {project_name} is shut down.
+Users currently authenticating, changing their passwords, or resetting their passwords will need to restart the authentication flow once {project_name} is up and running again.
 ====


### PR DESCRIPTION
This Pull Request highlights the fact that Keycloak doesn't perform automatic database downgrades, which has been assumed by some of the engineers running it in our org.

Apart from this, the change also polishes the language in this page (but I'm also fine dropping these changes if requested). 

Fixes https://github.com/keycloak/keycloak/issues/41898