### PR TITLE
enhance: add KC_ env variables for verbose and .sh options

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -140,16 +140,30 @@ if not "x%JAVA_OPTS_APPEND%" == "x" (
     set JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_APPEND%
 )
 
-if NOT "x%DEBUG%" == "x" (
-    set DEBUG_MODE=%DEBUG%
+if NOT "x%KC_DEBUG%" == "x" (
+    set DEBUG_MODE=%KC_DEBUG%
+) else (
+    if NOT "x%DEBUG%" == "x" (
+        set DEBUG_MODE=%DEBUG%
+    )
 )
 
-if NOT "x%DEBUG_PORT%" == "x" (
-    set DEBUG_PORT_VAR=%DEBUG_PORT%
+if NOT "x%KC_DEBUG_PORT%" == "x" (
+    set DEBUG_PORT_VAR=%KC_DEBUG_PORT%
+    set DEBUG_ADDRESS=0.0.0.0:!DEBUG_PORT_VAR!
+) else (
+    if NOT "x%DEBUG_PORT%" == "x" (
+        set DEBUG_PORT_VAR=%DEBUG_PORT%
+        set DEBUG_ADDRESS=0.0.0.0:!DEBUG_PORT_VAR!
+    )
 )
 
-if NOT "x%DEBUG_SUSPEND%" == "x" (
-    set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
+if NOT "x%KC_DEBUG_SUSPEND%" == "x" (
+    set DEBUG_SUSPEND_VAR=%KC_DEBUG_SUSPEND%
+) else (
+    if NOT "x%DEBUG_SUSPEND%" == "x" (
+        set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
+    )
 )
 
 rem Set debug settings if not already set

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -41,9 +41,9 @@ SERVER_OPTS="$SERVER_OPTS -Dpicocli.disable.closures=true"
 SERVER_OPTS="$SERVER_OPTS -Dquarkus-log-max-startup-records=10000"
 CLASSPATH_OPTS="'$(abs_path "../lib/quarkus-run.jar")'"
 
-DEBUG_MODE="${DEBUG:-false}"
-DEBUG_PORT="${DEBUG_PORT:-8787}"
-DEBUG_SUSPEND="${DEBUG_SUSPEND:-n}"
+DEBUG_MODE="${KC_DEBUG:-${DEBUG:-false}}"
+DEBUG_PORT="${KC_DEBUG_PORT:-${DEBUG_PORT:-8787}}"
+DEBUG_SUSPEND="${KC_DEBUG_SUSPEND:-${DEBUG_SUSPEND:-n}}"
 DEBUG_ADDRESS="0.0.0.0:$DEBUG_PORT"
 
 esceval() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -88,7 +88,8 @@ public final class Main {
     @Option(names = { "-v", "--verbose" },
             description = "Print out error details when running this command.",
             paramLabel = NO_PARAM_LABEL,
-            scope = ScopeType.INHERIT)
+            scope = ScopeType.INHERIT,
+            defaultValue = "${env:KC_VERBOSE}")
     public void setVerbose(boolean verbose) {
         ExecutionExceptionHandler exceptionHandler = (ExecutionExceptionHandler) spec.commandLine().getExecutionExceptionHandler();
         exceptionHandler.setVerbose(verbose);


### PR DESCRIPTION
closes: #19213

Our .bat script never accepted environment variables for DEBUG, etc. Do we want this supported there, and/or documented in any way?

Also is there any concern about potential collisions with other kc options, or are we reasonably sure the KC_DEBUG and KC_VERBOSE prefixes can be reserved for this usage?

cc @pedroigor @Pepo48 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
