### PR TITLE
[admin-api-v2] APIs as CDI beans - Flexibility to leverage SPIs

### DIFF
--- a/core/src/main/java/org/keycloak/representations/admin/v2/validation/CreateClientDefault.java
+++ b/core/src/main/java/org/keycloak/representations/admin/v2/validation/CreateClientDefault.java
@@ -1,0 +1,9 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import jakarta.validation.GroupSequence;
+import jakarta.validation.groups.Default;
+
+@GroupSequence({CreateClient.class, Default.class})
+// Jakarta Validation Group - validation is done only when creating a client + default group included
+public interface CreateClientDefault {
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminApiFactory.java
@@ -1,6 +1,4 @@
 package org.keycloak.admin.api;
 
-import org.keycloak.provider.ProviderFactory;
-
-public interface AdminApiFactory extends ProviderFactory<AdminApi> {
+public interface AdminApiFactory extends CdiProviderFactory<AdminApi> {
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminApiProducer.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminApiProducer.java
@@ -1,0 +1,57 @@
+package org.keycloak.admin.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.keycloak.admin.api.client.ClientApi;
+import org.keycloak.admin.api.client.ClientsApi;
+import org.keycloak.admin.api.realm.RealmApi;
+import org.keycloak.admin.api.realm.RealmsApi;
+import org.keycloak.provider.Provider;
+import org.keycloak.utils.KeycloakSessionUtil;
+
+/**
+ * Produces CDI-managed references to the API providers selected by the SPI configuration.
+ * <p>
+ * The producer itself is {@code @ApplicationScoped}, but the returned beans are {@code @RequestScoped}.
+ * <p>
+ * This avoids resolving the provider via {@code KeycloakSession} on every injection point.
+ * The selection logic is executed only once per application lifecycle, and the returned
+ * reference will delegate to the actual provider implementation.
+ */
+@ApplicationScoped
+public class AdminApiProducer {
+
+    @Produces
+    @ApplicationScoped
+    AdminApi getAdminApi() {
+        return getBean(AdminApi.class);
+    }
+
+    @Produces
+    @ApplicationScoped
+    RealmsApi getRealmsApi() {
+        return getBean(RealmsApi.class);
+    }
+
+    @Produces
+    @ApplicationScoped
+    RealmApi getRealmApi() {
+        return getBean(RealmApi.class);
+    }
+
+    @Produces
+    @ApplicationScoped
+    ClientsApi getClientsApi() {
+        return getBean(ClientsApi.class);
+    }
+
+    @Produces
+    @ApplicationScoped
+    ClientApi getClientApi() {
+        return getBean(ClientApi.class);
+    }
+
+    private <T extends Provider> T getBean(Class<T> apiClass) {
+        return KeycloakSessionUtil.getKeycloakSession().getProvider(apiClass);
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminRootV2.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/AdminRootV2.java
@@ -1,5 +1,7 @@
 package org.keycloak.admin.api;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
@@ -10,20 +12,24 @@ import org.keycloak.services.resources.admin.AdminCorsPreflightService;
 
 @Provider
 @Path("admin/api")
+@RequestScoped
 public class AdminRootV2 {
 
     @Context
     protected KeycloakSession session;
 
+    @Inject
+    AdminApi adminApi;
+
     @Path("")
     public AdminApi latestAdminApi() {
         // we could return the latest Admin API if no version is specified
-        return session.getProvider(AdminApi.class);
+        return adminApi;
     }
 
     @Path("v2")
     public AdminApi adminApi() {
-        return session.getProvider(AdminApi.class);
+        return adminApi;
     }
 
     @Path("{any:.*}")

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/CdiProviderFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/CdiProviderFactory.java
@@ -1,0 +1,33 @@
+package org.keycloak.admin.api;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.util.AnnotationLiteral;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+
+import java.util.Set;
+
+public interface CdiProviderFactory<T extends Provider> extends ProviderFactory<T> {
+
+    Class<? extends T> getProviderClass();
+
+    @Override
+    default T create(KeycloakSession session) {
+        BeanManager beanManager = CDI.current().getBeanManager();
+
+        Set<Bean<?>> beans = beanManager.getBeans(getProviderClass(), new AnnotationLiteral<ChosenBySpi>() {});
+        // might check ambiguity?
+        Bean<?> matchingBean = beans.stream()
+                .filter(b -> b.getBeanClass().equals(getProviderClass()))
+                .findFirst()
+                .orElseThrow();
+
+        CreationalContext<?> ctx = beanManager.createCreationalContext(matchingBean);
+        //noinspection unchecked
+        return (T) beanManager.getReference(matchingBean, getProviderClass(), ctx);
+    }
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/ChosenBySpi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/ChosenBySpi.java
@@ -1,0 +1,16 @@
+package org.keycloak.admin.api;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, FIELD})
+public @interface ChosenBySpi {
+}

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/DefaultAdminApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/DefaultAdminApi.java
@@ -1,21 +1,21 @@
 package org.keycloak.admin.api;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import org.keycloak.admin.api.realm.DefaultRealmsApi;
 import org.keycloak.admin.api.realm.RealmsApi;
-import org.keycloak.models.KeycloakSession;
 
+@RequestScoped
+@ChosenBySpi
 public class DefaultAdminApi implements AdminApi {
-    private final KeycloakSession session;
 
-    public DefaultAdminApi(KeycloakSession session) {
-        this.session = session;
-    }
+    @Inject
+    RealmsApi realmsApi;
 
     @Path("realms")
     @Override
     public RealmsApi realms() {
-        return new DefaultRealmsApi(session);
+        return realmsApi;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/DefaultAdminApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/DefaultAdminApiFactory.java
@@ -8,13 +8,13 @@ public class DefaultAdminApiFactory implements AdminApiFactory {
     public static final String PROVIDER_ID = "default";
 
     @Override
-    public String getId() {
-        return PROVIDER_ID;
+    public Class<DefaultAdminApi> getProviderClass() {
+        return DefaultAdminApi.class;
     }
 
     @Override
-    public AdminApi create(KeycloakSession session) {
-        return new DefaultAdminApi(session);
+    public String getId() {
+        return PROVIDER_ID;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientApiFactory.java
@@ -1,6 +1,6 @@
 package org.keycloak.admin.api.client;
 
-import org.keycloak.provider.ProviderFactory;
+import org.keycloak.admin.api.CdiProviderFactory;
 
-public interface ClientApiFactory extends ProviderFactory<ClientApi> {
+public interface ClientApiFactory extends CdiProviderFactory<ClientApi> {
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
@@ -19,8 +19,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.keycloak.representations.admin.v2.validation.CreateClient;
 import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.representations.admin.v2.validation.CreateClientDefault;
 
 @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS_V2)
 @Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
@@ -36,7 +36,7 @@ public interface ClientsApi extends Provider {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Create a new client", description = "Creates a new client in the realm")
-    ClientRepresentation createClient(@Valid @ConvertGroup(to = CreateClient.class) ClientRepresentation client,
+    ClientRepresentation createClient(@Valid @ConvertGroup(to = CreateClientDefault.class) ClientRepresentation client,
                                       @QueryParam("fieldValidation") FieldValidation fieldValidation);
 
     @Path("{id}")

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/ClientsApiFactory.java
@@ -1,6 +1,6 @@
 package org.keycloak.admin.api.client;
 
-import org.keycloak.provider.ProviderFactory;
+import org.keycloak.admin.api.CdiProviderFactory;
 
-public interface ClientsApiFactory extends ProviderFactory<ClientsApi> {
+public interface ClientsApiFactory extends CdiProviderFactory<ClientsApi> {
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -1,50 +1,62 @@
 package org.keycloak.admin.api.client;
 
-import java.io.IOException;
-import java.util.Objects;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import io.fabric8.zjsonpatch.JsonPatch;
+import io.fabric8.zjsonpatch.JsonPatchException;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.admin.api.ChosenBySpi;
 import org.keycloak.admin.api.FieldValidation;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.mapper.ClientModelMapper;
+import org.keycloak.models.mapper.ModelMapper;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ServiceException;
 import org.keycloak.services.client.ClientService;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
 
-import io.fabric8.zjsonpatch.JsonPatch;
-import io.fabric8.zjsonpatch.JsonPatchException;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-
+@RequestScoped
+@ChosenBySpi
 public class DefaultClientApi implements ClientApi {
-    private final KeycloakSession session;
-    private final RealmModel realm;
-    private final ClientModel client;
-    private final ClientService clientService;
+
+    private RealmModel realm;
+    private ClientModel client;
+    private ClientService clientService;
+    private ClientModelMapper mapper;
     private HttpResponse response;
 
-    public DefaultClientApi(KeycloakSession session) {
-        this.session = session;
-        this.realm = Objects.requireNonNull(session.getContext().getRealm());
-        this.client = Objects.requireNonNull(session.getContext().getClient());
+    @Context
+    KeycloakSession session;
+
+    @PostConstruct
+    public void init() {
+        this.realm = session.getContext().getRealm();
+        this.client = session.getContext().getClient();
         this.clientService = session.services().clients();
+        this.mapper = session.getProvider(ModelMapper.class).clients();
         this.response = session.getContext().getHttpResponse();
     }
 
     @Override
     public ClientRepresentation getClient() {
-        return clientService.getClient(realm, client.getClientId(), null)
-                .orElseThrow(() -> new NotFoundException("Cannot find the specified client"));
+        if (client == null) {
+            throw new NotFoundException("Cannot find the specified client");
+        }
+        return mapper.fromModel(client);
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientApiFactory.java
@@ -1,7 +1,6 @@
 package org.keycloak.admin.api.client;
 
 import org.keycloak.Config;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
 public class DefaultClientApiFactory implements ClientApiFactory {
@@ -12,9 +11,8 @@ public class DefaultClientApiFactory implements ClientApiFactory {
         return PROVIDER_ID;
     }
 
-    @Override
-    public ClientApi create(KeycloakSession session) {
-        return new DefaultClientApi(session);
+    public Class<? extends ClientApi> getProviderClass() {
+        return DefaultClientApi.class;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -1,51 +1,57 @@
 package org.keycloak.admin.api.client;
 
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
-
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.groups.ConvertGroup;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.admin.api.ChosenBySpi;
 import org.keycloak.admin.api.FieldValidation;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
-import org.keycloak.representations.admin.v2.validation.CreateClient;
+import org.keycloak.representations.admin.v2.validation.CreateClientDefault;
 import org.keycloak.services.ServiceException;
-import org.keycloak.services.client.ClientService;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Response;
+import java.util.Optional;
+import java.util.stream.Stream;
 
+@RequestScoped
+@ChosenBySpi
 public class DefaultClientsApi implements ClientsApi {
-    private final KeycloakSession session;
-    private final RealmModel realm;
-    private final HttpResponse response;
-    private final ClientService clientService;
+    private RealmModel realm;
+    private HttpResponse response;
 
-    public DefaultClientsApi(KeycloakSession session) {
-        this.session = session;
-        this.realm = Objects.requireNonNull(session.getContext().getRealm());
-        this.clientService = session.services().clients();
+    @Context
+    KeycloakSession session;
+
+    @Inject
+    ClientApi clientApi;
+
+    @PostConstruct
+    public void init() {
+        this.realm = session.getContext().getRealm();
         this.response = session.getContext().getHttpResponse();
     }
 
     @Override
-    @GET
     public Stream<ClientRepresentation> getClients() {
-        return clientService.getClients(realm, null, null, null);
+        return session.services().clients().getClients(realm, null, null, null);
     }
 
     @Override
-    public ClientRepresentation createClient(@Valid @ConvertGroup(to = CreateClient.class) ClientRepresentation client,
-                                             FieldValidation fieldValidation) {
+    public ClientRepresentation createClient(@Valid @ConvertGroup(to = CreateClientDefault.class) ClientRepresentation client,
+                                             @QueryParam("fieldValidation") FieldValidation fieldValidation) {
         try {
             response.setStatus(Response.Status.CREATED.getStatusCode());
-            return clientService.createOrUpdate(realm, client, false).representation();
+            return session.services().clients().createOrUpdate(realm, client, false).representation();
         } catch (ServiceException e) {
             throw new WebApplicationException(e.getMessage(), e.getSuggestedResponseStatus().orElse(Response.Status.BAD_REQUEST));
         }
@@ -53,9 +59,10 @@ public class DefaultClientsApi implements ClientsApi {
 
     @Override
     public ClientApi client(@PathParam("id") String clientId) {
-        var client = Optional.ofNullable(session.clients().getClientByClientId(realm, clientId)).orElseThrow(() -> new NotFoundException("Client cannot be found"));
+        var client = Optional.ofNullable(session.clients().getClientByClientId(realm, clientId))
+                .orElseThrow(() -> new NotFoundException("Client cannot be found"));
         session.getContext().setClient(client);
-        return session.getProvider(ClientApi.class);
+        return clientApi;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApi.java
@@ -1,27 +1,25 @@
 package org.keycloak.admin.api.realm;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
+import org.keycloak.admin.api.ChosenBySpi;
 import org.keycloak.admin.api.client.ClientsApi;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
 
-import java.util.Objects;
-
+@RequestScoped
+@ChosenBySpi
 public class DefaultRealmApi implements RealmApi {
-    private final KeycloakSession session;
-    private final RealmModel realm;
 
-    public DefaultRealmApi(KeycloakSession session) {
-        this.session = session;
-        this.realm = Objects.requireNonNull(session.getContext().getRealm());
-    }
+    @Inject
+    ClientsApi clientsApi;
 
     @Path("clients")
     @Override
     public ClientsApi clients() {
-        return session.getProvider(ClientsApi.class);
+        return clientsApi;
     }
 
     @Override
-    public void close() {}
+    public void close() {
+    }
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApiFactory.java
@@ -1,7 +1,6 @@
 package org.keycloak.admin.api.realm;
 
 import org.keycloak.Config;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
 public class DefaultRealmApiFactory implements RealmApiFactory {
@@ -13,8 +12,8 @@ public class DefaultRealmApiFactory implements RealmApiFactory {
     }
 
     @Override
-    public RealmApi create(KeycloakSession session) {
-        return new DefaultRealmApi(session);
+    public Class<? extends RealmApi> getProviderClass() {
+        return DefaultRealmApi.class;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmsApi.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmsApi.java
@@ -1,25 +1,33 @@
 package org.keycloak.admin.api.realm;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Context;
+import org.keycloak.admin.api.ChosenBySpi;
 import org.keycloak.models.KeycloakSession;
 
 import java.util.Optional;
 
+@RequestScoped
+@ChosenBySpi
 public class DefaultRealmsApi implements RealmsApi {
-    private final KeycloakSession session;
 
-    public DefaultRealmsApi(KeycloakSession session) {
-        this.session = session;
-    }
+    @Inject
+    RealmApi realmApi;
+
+    @Context
+    KeycloakSession session;
 
     @Path("{name}")
     @Override
     public RealmApi realm(@PathParam("name") String name) {
-        var realm = Optional.ofNullable(session.realms().getRealmByName(name)).orElseThrow(() -> new NotFoundException("Realm cannot be found"));
+        var realm = Optional.ofNullable(session.realms().getRealmByName(name))
+                .orElseThrow(() -> new NotFoundException("Realm cannot be found"));
         session.getContext().setRealm(realm);
-        return session.getProvider(RealmApi.class);
+        return realmApi;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmsApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/DefaultRealmsApiFactory.java
@@ -1,7 +1,6 @@
 package org.keycloak.admin.api.realm;
 
 import org.keycloak.Config;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
 public class DefaultRealmsApiFactory implements RealmsApiFactory {
@@ -13,8 +12,8 @@ public class DefaultRealmsApiFactory implements RealmsApiFactory {
     }
 
     @Override
-    public RealmsApi create(KeycloakSession session) {
-        return new DefaultRealmsApi(session);
+    public Class<DefaultRealmsApi> getProviderClass() {
+        return DefaultRealmsApi.class;
     }
 
     @Override

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmApiFactory.java
@@ -1,6 +1,6 @@
 package org.keycloak.admin.api.realm;
 
-import org.keycloak.provider.ProviderFactory;
+import org.keycloak.admin.api.CdiProviderFactory;
 
-public interface RealmApiFactory extends ProviderFactory<RealmApi> {
+public interface RealmApiFactory extends CdiProviderFactory<RealmApi> {
 }

--- a/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmsApiFactory.java
+++ b/rest/admin-api/src/main/java/org/keycloak/admin/api/realm/RealmsApiFactory.java
@@ -1,6 +1,6 @@
 package org.keycloak.admin.api.realm;
 
-import org.keycloak.provider.ProviderFactory;
+import org.keycloak.admin.api.CdiProviderFactory;
 
-public interface RealmsApiFactory extends ProviderFactory<RealmsApi> {
+public interface RealmsApiFactory extends CdiProviderFactory<RealmsApi> {
 }

--- a/services/src/main/java/org/keycloak/services/error/ValidationExceptionHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/ValidationExceptionHandler.java
@@ -1,0 +1,29 @@
+package org.keycloak.services.error;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Provider
+public class ValidationExceptionHandler implements ExceptionMapper<ConstraintViolationException> {
+
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        return Response.status(400)
+                .entity(new ViolationExceptionResponse("Provided data is invalid",
+                        exception.getConstraintViolations()
+                                .stream()
+                                .map(f -> "%s: %s".formatted(f.getPropertyPath(), f.getMessage()))
+                                .collect(Collectors.toSet())))
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
+    }
+
+    public record ViolationExceptionResponse(String error, Set<String> violations) {
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AdminV2Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AdminV2Test.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
@@ -29,9 +30,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.keycloak.admin.api.client.ClientApi;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.error.ValidationExceptionHandler;
 import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KeycloakIntegrationTest()
@@ -96,6 +101,51 @@ public class AdminV2Test {
 
             ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
             assertEquals("I'm also a description", client.getDescription());
+        }
+    }
+
+    @Test
+    public void clientRepresentationValidation() throws Exception {
+        HttpPost request = new HttpPost(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "displayName": "something",
+                    "appUrl": "notUrl"
+                }
+                """));
+
+        try (var response = client.execute(request)) {
+            assertThat(response, notNullValue());
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ValidationExceptionHandler.ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            var violations = body.violations();
+            assertThat(violations.size(), is(1));
+            assertThat(violations.iterator().next(), is("createClient.arg0.clientId: must not be blank"));
+        }
+
+        request.setEntity(new StringEntity("""
+                {
+                    "clientId": "some-client",
+                    "displayName": "something",
+                    "appUrl": "notUrl",
+                    "auth": {
+                        "method":"missing-enabled"
+                    }
+                }
+                """));
+
+        try (var response = client.execute(request)) {
+            assertThat(response, notNullValue());
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ValidationExceptionHandler.ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            var violations = body.violations();
+            assertThat(violations.size(), is(1));
+            assertThat(violations.iterator().next(), is("createClient.arg0.appUrl: must be a valid URL"));
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/api/v2/CustomClientsApiTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/api/v2/CustomClientsApiTest.java
@@ -1,0 +1,64 @@
+package org.keycloak.tests.admin.api.v2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.api.client.ClientsApiSpi;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testsuite.admin.client.TestClientsApiFactory;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@KeycloakIntegrationTest(config = CustomClientsApiTest.CustomClientsProvider.class)
+public class CustomClientsApiTest {
+    private static final String HOSTNAME_LOCAL_ADMIN = "http://localhost:8080/admin/api/v2";
+    private static ObjectMapper mapper;
+
+    @InjectHttpClient
+    CloseableHttpClient client;
+
+    @BeforeAll
+    public static void setupMapper() {
+        mapper = new ObjectMapper();
+    }
+
+    @Test
+    public void getClients() throws Exception {
+        HttpGet request = new HttpGet(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/");
+        try (var response = client.execute(request)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            var clients = (List<ClientRepresentation>) mapper
+                    .createParser(response.getEntity().getContent())
+                    .readValueAs(new TypeReference<List<ClientRepresentation>>() {
+                    });
+
+            assertThat(clients, notNullValue());
+            assertThat(clients.size(), is(1));
+            var client = clients.get(0);
+            assertThat(client.getClientId(), is("test"));
+            assertThat(client.getDisplayName(), is("testCdi"));
+        }
+    }
+
+    public static class CustomClientsProvider implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder builder) {
+            builder.option("spi-%s--provider".formatted(ClientsApiSpi.NAME), TestClientsApiFactory.PROVIDER_ID);
+            builder.dependency("org.keycloak.tests", "keycloak-tests-custom-providers");
+            return builder;
+        }
+    }
+}

--- a/tests/custom-providers/pom.xml
+++ b/tests/custom-providers/pom.xml
@@ -56,5 +56,9 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-storage-private</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/tests/custom-providers/src/main/java/org/keycloak/testsuite/admin/client/TestClientsApi.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/testsuite/admin/client/TestClientsApi.java
@@ -1,0 +1,38 @@
+package org.keycloak.testsuite.admin.client;
+
+import jakarta.enterprise.context.RequestScoped;
+import org.keycloak.admin.api.ChosenBySpi;
+import org.keycloak.admin.api.FieldValidation;
+import org.keycloak.admin.api.client.ClientApi;
+import org.keycloak.admin.api.client.ClientsApi;
+import org.keycloak.representations.admin.v2.ClientRepresentation;
+
+import java.util.stream.Stream;
+
+@RequestScoped
+@ChosenBySpi
+public class TestClientsApi implements ClientsApi {
+
+    @Override
+    public Stream<ClientRepresentation> getClients() {
+        var client = new ClientRepresentation();
+        client.setClientId("test");
+        client.setDisplayName("testCdi");
+        return Stream.of(client);
+    }
+
+    @Override
+    public ClientRepresentation createClient(ClientRepresentation client, FieldValidation fieldValidation) {
+        throw new UnsupportedOperationException("Testing instance");
+    }
+
+    @Override
+    public ClientApi client(String id) {
+        throw new UnsupportedOperationException("Testing instance");
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/tests/custom-providers/src/main/java/org/keycloak/testsuite/admin/client/TestClientsApiFactory.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/testsuite/admin/client/TestClientsApiFactory.java
@@ -1,10 +1,12 @@
-package org.keycloak.admin.api.client;
+package org.keycloak.testsuite.admin.client;
 
 import org.keycloak.Config;
+import org.keycloak.admin.api.client.ClientsApi;
+import org.keycloak.admin.api.client.ClientsApiFactory;
 import org.keycloak.models.KeycloakSessionFactory;
 
-public class DefaultClientsApiFactory implements ClientsApiFactory {
-    public static final String PROVIDER_ID = "default";
+public class TestClientsApiFactory implements ClientsApiFactory {
+    public static final String PROVIDER_ID = "test";
 
     @Override
     public String getId() {
@@ -13,7 +15,7 @@ public class DefaultClientsApiFactory implements ClientsApiFactory {
 
     @Override
     public Class<? extends ClientsApi> getProviderClass() {
-        return DefaultClientsApi.class;
+        return TestClientsApi.class;
     }
 
     @Override

--- a/tests/custom-providers/src/main/resources/META-INF/services/org.keycloak.admin.api.client.ClientsApiFactory
+++ b/tests/custom-providers/src/main/resources/META-INF/services/org.keycloak.admin.api.client.ClientsApiFactory
@@ -1,0 +1,1 @@
+org.keycloak.testsuite.admin.client.TestClientsApiFactory


### PR DESCRIPTION
- Follow-up on: https://github.com/keycloak/keycloak/pull/41665

PoC to be able to specify which provider for API will be used and leverage CDI inside simultaneously, that might level-up our API endpoints. 

Providing CDI support helps to:

- use automatic Jakarta/Hibernate validations specified via annotations
- inject context more easily (no AdminEventBuilder, AdminPermissionEvaluator, KeycloakSession context propagation in sub-resources)
- inject CDI-aware objects, helping to fulfill all requirements for these APIs

#### Implementation details

- only the default provider specified via SPI (--spi options) is initialized 
- first request on the APIs initializes finding the proxy class (only once per app lifetime), then the proxy class has application lifespan ( no need to check the property again)
- On every request, beans are created based on the used proxy class via CDI
- Similar concepts might be used even for the services to use CDI
- We might potentially set the default providers in build-time (not yet) 

--------------------------------------

See comments in: https://github.com/keycloak/keycloak/pull/41665#discussion_r2272299543

cc: @vmuzikar @shawkins @Pepo48 