### PR TITLE
add configuration option to automatically add recovery codes action

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
+++ b/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
@@ -6,6 +6,8 @@ The Recovery Codes are a number of sequential one-time passwords (currently 12) 
 
 Due to its nature, the Recovery Codes work normally as a backup for another 2FA methods. They can complement the `OTP Form` or the `WebAuthn Authenticator` to give a backing way to log inside {project_name}, for example, if the software or hardware device used for the previous 2FA methods is broken or unavailable.
 
+You can configure the `Configure OTP` required action to ask for recovery codes automatically by enabling *Add recovery codes*.
+
 ==== Check Recovery Codes required action is enabled
 
 Check the Recovery Codes action is enabled in {project_name}:
@@ -19,8 +21,8 @@ Toggle the *Default Action* switch to *On* if you want all the new users to regi
 ==== Configure the Recovery Codes required action
 
 From the *Required Actions* tab of the admin console, you have the option to configure the *Recovery Authentication Codes* required action. So far, there is a configuration option
-*Warning Threshold* available. When user has smaller amount of remaining recovery codes on his account than the value configured here, account console will show warning to the user, which will
-recommend him to setup new set of recovery codes. The warning displayed to the user may look similar to this:
+*Warning Threshold* available. When a user has a smaller amount of remaining recovery codes on his account than the value configured here, account console will show warning to the user, which will
+recommend them to set up a new set of recovery codes. The warning displayed to the user may look similar to this:
 
 .Recovery Codes Account console warning
 image:images/recovery-codes-account-console-warn.png[Recovery Codes Account console warning]

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
@@ -17,7 +17,10 @@
 
 package org.keycloak.authentication.requiredactions;
 
+import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
 import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.InitiatedActionSupport;
@@ -30,16 +33,20 @@ import org.keycloak.credential.OTPCredentialProvider;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.OTPPolicy;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
 import org.keycloak.models.utils.CredentialValidation;
 import org.keycloak.models.utils.FormMessage;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.services.messages.Messages;
@@ -52,7 +59,10 @@ import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
+
+import static org.keycloak.models.AuthenticationExecutionModel.Requirement.DISABLED;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -60,6 +70,7 @@ import java.util.stream.Stream;
  */
 public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory, CredentialRegistrator {
 
+    private static final Logger log = Logger.getLogger(KeycloakModelUtils.class);
     public static final String ADD_RECOVERY_CODES = "add-recovery-codes";
 
     List<ProviderConfigProperty> ADD_RECOVERY_CODES_CONFIG_PROPERTIES = addRecoveryCodesConfig();
@@ -69,7 +80,10 @@ public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory
                 .property()
                 .name(ADD_RECOVERY_CODES)
                 .label("Add Recovery Codes")
-                .helpText("If this option is enabled, the user will be required to configure recovery codes following to the OTP configuration. If the user already has recovery codes configured, he won't be asked.")
+                .helpText("""
+                        If this option is enabled, the user will be required to configure recovery codes following the OTP configuration.
+                        If the user already has recovery codes configured, Keycloak will not ask for setting them up.
+                        As a prerequisite, enable the recovery codes required action and enable recovery codes in your authentication flow.""")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .defaultValue(false)
                 .add()
@@ -162,9 +176,16 @@ public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory
             return;
         }
 
-        if (context.getConfig() != null && Boolean.parseBoolean(context.getConfig().getConfigValue(ADD_RECOVERY_CODES, "false"))) {
-            if (!context.getUser().credentialManager().isConfiguredFor(RecoveryAuthnCodesCredentialModel.TYPE)) {
-                context.getUser().addRequiredAction(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES);
+        if (context.getConfig() != null &&
+                Boolean.parseBoolean(context.getConfig().getConfigValue(ADD_RECOVERY_CODES, "false"))) {
+            if (!isRecoveryCodesEnabledInAuthenticationFlow(context.getRealm(), context.getSession())) {
+                log.info("OTP configured to set up recovery codes, but recovery codes are not enabled in the authentication flows. Skipping the setup of recovery codes.");
+            } else if (!context.getRealm().getRequiredActionProviderByAlias(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name()).isEnabled()) {
+                log.info("OTP configured to set up recovery codes, but recovery codes required action is not enabled. Skipping the setup of recovery codes.");
+            } else if (context.getUser().getRequiredActionsStream().noneMatch(s -> s.equals(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name()))) {
+                if (!context.getUser().credentialManager().isConfiguredFor(RecoveryAuthnCodesCredentialModel.TYPE)) {
+                    context.getUser().addRequiredAction(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES);
+                }
             }
         }
 
@@ -173,6 +194,39 @@ public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory
         deprecatedEvent.success();
     }
 
+    /**
+     * Check if recovery codes are enabled in the authentication flow.
+     * This is the same logic that is applied in the account console to show if recovery codes can be set up.
+     */
+    private boolean isRecoveryCodesEnabledInAuthenticationFlow(RealmModel realm, KeycloakSession session) {
+        return realm.getAuthenticationFlowsStream()
+                .filter(s -> !isFlowEffectivelyDisabled(realm, s))
+                .flatMap(flow ->
+                        realm.getAuthenticationExecutionsStream(flow.getId())
+                                .filter(exe -> Objects.nonNull(exe.getAuthenticator()) && exe.getRequirement() != DISABLED)
+                                .map(exe -> (AuthenticatorFactory) session.getKeycloakSessionFactory()
+                                        .getProviderFactory(Authenticator.class, exe.getAuthenticator()))
+                                .filter(Objects::nonNull)
+                                .flatMap(authFact -> Stream.concat(Stream.of(authFact.getReferenceCategory()), authFact.getOptionalReferenceCategories(session).stream()))
+                                .filter(Objects::nonNull)
+                ).anyMatch(s -> s.equals(RecoveryAuthnCodesCredentialModel.TYPE));
+    }
+
+    // Returns true if flow is effectively disabled - either it's execution or some parent execution is disabled
+    private boolean isFlowEffectivelyDisabled(RealmModel realm, AuthenticationFlowModel flow) {
+        while (!flow.isTopLevel()) {
+            AuthenticationExecutionModel flowExecution = realm.getAuthenticationExecutionByFlowId(flow.getId());
+            if (flowExecution == null) return false; // Can happen under some corner cases
+            if (DISABLED == flowExecution.getRequirement()) return true;
+            if (flowExecution.getParentFlow() == null) return false;
+
+            // Check parent flow
+            flow = realm.getAuthenticationFlowById(flowExecution.getParentFlow());
+            if (flow == null) return false;
+        }
+
+        return false;
+    }
 
     // Use separate method, so it's possible to override in the custom provider
     protected boolean validateOTPCredential(RequiredActionContext context, String token, OTPCredentialModel credentialModel, OTPPolicy policy) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionTotpSetupTest.java
@@ -16,14 +16,12 @@
  */
 package org.keycloak.testsuite.actions;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authentication.requiredactions.UpdateTotp;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -33,17 +31,23 @@ import org.keycloak.models.utils.HmacOTP;
 import org.keycloak.models.utils.TimeBasedOTP;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.LoginConfigTotpPage;
 import org.keycloak.testsuite.pages.LoginTotpPage;
 import org.keycloak.testsuite.pages.RegisterPage;
+import org.keycloak.testsuite.pages.SetupRecoveryAuthnCodesPage;
 import org.keycloak.testsuite.util.AccountHelper;
-import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.openqa.selenium.By;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -85,6 +89,9 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
 
     @Page
     protected RegisterPage registerPage;
+
+    @Page
+    protected SetupRecoveryAuthnCodesPage setupRecoveryAuthnCodesPage;
 
     protected TimeBasedOTP totp = new TimeBasedOTP();
 
@@ -613,6 +620,55 @@ public class AppInitiatedActionTotpSetupTest extends AbstractAppInitiatedActionT
                 .otpInitialCounter(0);
         adminClient.realm("test").update(realmRep);
 
+    }
+
+    @Test(expected = AssertionError.class)
+    public void setupTotpRegisterVerifyRecoveryCodesSetupDisabled() {
+        setupTotpRegisterVerifyRecoveryCodesSetup(false);
+    }
+
+    @Test
+    public void setupTotpRegisterVerifyRecoveryCodesSetupEnabled() {
+        setupTotpRegisterVerifyRecoveryCodesSetup(true);
+    }
+
+    private void setupTotpRegisterVerifyRecoveryCodesSetup(boolean enforceRecoveryCodesSetup) {
+        configureTotpActionToEnforceRecoveryCodes(enforceRecoveryCodesSetup);
+
+        // Login
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+
+        // Configure OTP as AIA
+        doAIA();
+        totpPage.assertCurrent();
+        totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));
+
+        // The next page should be the setup page for recovery codes
+        setupRecoveryAuthnCodesPage.assertCurrent();
+        setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();
+
+        // call the action the second time, now no recovery code setup should be shown
+        doAIA();
+        totpPage.assertCurrent();
+        totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));
+        try {
+            // This should now fail
+            setupRecoveryAuthnCodesPage.assertCurrent();
+            Assert.fail("Expected AssertionError was not thrown");
+        } catch (AssertionError e) {
+            Assert.assertTrue(e.getMessage().startsWith("Expected SetupRecoveryAuthnCodesPage"));
+        }
+
+        // finally, reset totp action config
+        configureTotpActionToEnforceRecoveryCodes(false);
+    }
+
+    private void configureTotpActionToEnforceRecoveryCodes(boolean enforceRecoveryCodes) {
+        List<RequiredActionProviderRepresentation> requiredActions = testRealm().flows().getRequiredActions();
+        RequiredActionProviderRepresentation totpAction = requiredActions.stream().filter(ra -> ra.getProviderId().equals(UserModel.RequiredAction.CONFIGURE_TOTP.name())).findFirst().orElseThrow();
+        totpAction.setConfig(Map.of(UpdateTotp.ADD_RECOVERY_CODES, Boolean.toString(enforceRecoveryCodes)));
+        testRealm().flows().updateRequiredAction(UserModel.RequiredAction.CONFIGURE_TOTP.name(), totpAction);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
@@ -28,6 +28,7 @@ import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticatorFactory;
+import org.keycloak.authentication.requiredactions.UpdateTotp;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -41,8 +42,8 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
-import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.AppPage.RequestType;
@@ -51,13 +52,14 @@ import org.keycloak.testsuite.pages.LoginConfigTotpPage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.LoginTotpPage;
 import org.keycloak.testsuite.pages.RegisterPage;
+import org.keycloak.testsuite.pages.SetupRecoveryAuthnCodesPage;
 import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.AccountHelper;
-import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
-import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.SecondBrowser;
 import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
@@ -65,6 +67,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -85,8 +88,15 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
         requiredAction.setEnabled(true);
         requiredAction.setDefaultAction(true);
 
+        RequiredActionProviderRepresentation recoveryCodesAction = new RequiredActionProviderRepresentation();
+        recoveryCodesAction.setAlias(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
+        recoveryCodesAction.setProviderId(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name());
+        recoveryCodesAction.setName("Recovery codes");
+        recoveryCodesAction.setEnabled(true);
+
         List<RequiredActionProviderRepresentation> requiredActions = new LinkedList<>();
         requiredActions.add(requiredAction);
+        requiredActions.add(recoveryCodesAction);
         testRealm.setRequiredActions(requiredActions);
         testRealm.setResetPasswordAllowed(Boolean.TRUE);
     }
@@ -144,6 +154,9 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
 
     @Page
     protected RegisterPage registerPage;
+
+    @Page
+    protected SetupRecoveryAuthnCodesPage setupRecoveryAuthnCodesPage;
 
     @Drone
     @SecondBrowser
@@ -755,5 +768,40 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
             MatcherAssert.assertThat(sessions.stream().map(UserSessionRepresentation::getId).collect(Collectors.toList()),
                     Matchers.containsInAnyOrder(event1.getSessionId(), event2.getSessionId()));
         }
+    }
+
+    @Test(expected = AssertionError.class)
+    public void setupTotpRegisterVerifyRecoveryCodesSetupDisabled() {
+        setupTotpRegisterVerifyRecoveryCodesSetup(false);
+    }
+
+    @Test
+    public void setupTotpRegisterVerifyRecoveryCodesSetupEnabled() {
+        setupTotpRegisterVerifyRecoveryCodesSetup(true);
+    }
+
+    private void setupTotpRegisterVerifyRecoveryCodesSetup(boolean enforceRecoveryCodesSetup) {
+        configureTotpActionToEnforceRecoveryCodes(enforceRecoveryCodesSetup);
+
+        // Login
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+
+        // Configure OTP
+        totpPage.assertCurrent();
+        totpPage.configure(this.totp.generateTOTP(totpPage.getTotpSecret()));
+
+        // The next page should be the setup page for recovery codes
+        setupRecoveryAuthnCodesPage.assertCurrent();
+
+        // finally, reset totp action config
+        configureTotpActionToEnforceRecoveryCodes(false);
+    }
+
+    private void configureTotpActionToEnforceRecoveryCodes(boolean enforceRecoveryCodes) {
+        List<RequiredActionProviderRepresentation> requiredActions = testRealm().flows().getRequiredActions();
+        RequiredActionProviderRepresentation totpAction = requiredActions.stream().filter(ra -> ra.getProviderId().equals(UserModel.RequiredAction.CONFIGURE_TOTP.name())).findFirst().orElseThrow();
+        totpAction.setConfig(Map.of(UpdateTotp.ADD_RECOVERY_CODES, Boolean.toString(enforceRecoveryCodes)));
+        testRealm().flows().updateRequiredAction(UserModel.RequiredAction.CONFIGURE_TOTP.name(), totpAction);
     }
 }


### PR DESCRIPTION
after otp configuration

closes #41836

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
