### PR TITLE
Handle unique constraint when creating user-session during IDP brokering

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
@@ -69,7 +69,8 @@ public class InfinispanAuthenticationSessionProvider implements AuthenticationSe
         this.sessionTx = new InfinispanChangelogBasedTransaction<>(session, cache, SessionTimeouts::getAuthSessionLifespanMS, SessionTimeouts::getAuthSessionMaxIdleMS, serializer);
         this.clusterEventsSenderTx = new SessionEventsSenderTransaction(session);
 
-        session.getTransactionManager().enlistAfterCompletion(sessionTx);
+        // TODO: If we bind ourselves to the transaction manager of Quarkus and use the embedded caches, we should perform all tasks in the prepare phase (to be verified)
+        session.getTransactionManager().enlistPrepare(sessionTx);
         session.getTransactionManager().enlistAfterCompletion(clusterEventsSenderTx);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -402,8 +402,12 @@ public final class CacheConfigurator {
                 builder.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(1);
                 builder.memory().maxCount(SESSIONS_CACHE_DEFAULT_MAX);
                 return builder;
-            case ACTION_TOKEN_CACHE:
             case AUTHENTICATION_SESSIONS_CACHE_NAME:
+                // Adding a pessimistic transactional cache to allow for locking of entries to prevent concurrent operations on authentication sessions
+                // TODO: Check if pessimistic or optimistic should be used here, and if
+                builder.transaction().lockingMode(LockingMode.PESSIMISTIC);
+                builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+            case ACTION_TOKEN_CACHE:
             case LOGIN_FAILURE_CACHE_NAME:
                 builder.clustering().cacheMode(CacheMode.DIST_SYNC);
                 builder.encoding().mediaType(MediaType.APPLICATION_OBJECT_TYPE);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -48,6 +48,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.KeycloakSessionTask;
 import org.keycloak.models.KeycloakSessionTaskWithResult;
+import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.ScopeContainerModel;
@@ -399,6 +400,11 @@ public final class KeycloakModelUtils {
                     targetSession.getContext().setClient(clientModel);
                 }
             }
+        }
+
+        // Setup clientConnection if necessary
+        if (origContext.getConnection() != null) {
+            targetSession.getContext().setConnection(origContext.getConnection());
         }
 
         // setup auth session model if necessary.
@@ -1241,5 +1247,20 @@ public final class KeycloakModelUtils {
             acceptedClientProtocols = List.of(client.getProtocol());
         }
         return acceptedClientProtocols;
+    }
+
+    /**
+     * @param e exception
+     * @return true if if underlying exception is {@link ModelDuplicateException} or has {@link ModelDuplicateException} as it's cause
+     */
+    public static boolean isModelDuplicateException(Throwable e) {
+        if (e instanceof ModelDuplicateException) return true;
+        if (e.getCause() != null && e.getCause() instanceof ModelDuplicateException) return true;
+        if (e.getSuppressed() != null) {
+            for (Throwable t : e.getSuppressed()) {
+                if (t instanceof ModelDuplicateException) return true;
+            }
+        }
+        return false;
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -37,12 +37,14 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.models.utils.AuthenticationFlowResolver;
 import org.keycloak.models.utils.FormMessage;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.ClientData;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocol.Error;
@@ -1119,7 +1121,7 @@ public class AuthenticationProcessor {
 
     // May create userSession too
     public ClientSessionContext attachSession() {
-        ClientSessionContext clientSessionCtx = attachSession(authenticationSession, userSession, session, realm, connection, event);
+        ClientSessionContext clientSessionCtx = attachSession(authenticationSession, userSession, session, realm, connection, event, false);
 
         if (userSession == null) {
             userSession = clientSessionCtx.getClientSession().getUserSession();
@@ -1129,10 +1131,10 @@ public class AuthenticationProcessor {
     }
 
     // May create new userSession too (if userSession argument is null)
-    public static ClientSessionContext attachSession(AuthenticationSessionModel authSession, UserSessionModel userSession, KeycloakSession session, RealmModel realm, ClientConnection connection, EventBuilder event) {
-        String username = authSession.getAuthenticatedUser().getUsername();
+    public static ClientSessionContext attachSession(AuthenticationSessionModel authSession, UserSessionModel userSession, KeycloakSession session, RealmModel realm,
+                                                     ClientConnection connection, EventBuilder event, boolean createUserSessionInDedicatedTransaction) {
         String attemptedUsername = authSession.getAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME);
-        if (attemptedUsername != null) username = attemptedUsername;
+        String username = (attemptedUsername != null) ? attemptedUsername : authSession.getAuthenticatedUser().getUsername();
         String rememberMe = authSession.getAuthNote(Details.REMEMBER_ME);
         boolean remember = rememberMe != null && rememberMe.equalsIgnoreCase("true");
         String brokerSessionId = authSession.getAuthNote(BROKER_SESSION_ID);
@@ -1142,14 +1144,21 @@ public class AuthenticationProcessor {
 
             userSession = session.sessions().getUserSession(realm, authSession.getParentSession().getId());
             if (userSession == null) {
-                UserSessionModel.SessionPersistenceState persistenceState = UserSessionModel.SessionPersistenceState.fromString(authSession.getClientNote(AuthenticationManager.USER_SESSION_PERSISTENT_STATE));
-
-                userSession = new UserSessionManager(session).createUserSession(authSession.getParentSession().getId(), realm, authSession.getAuthenticatedUser(), username, connection.getRemoteHost(), authSession.getProtocol()
-                        , remember, brokerSessionId, brokerUserId, persistenceState);
-
-                if (isLightweightUser(userSession.getUser())) {
-                    LightweightUserAdapter lua = (LightweightUserAdapter) userSession.getUser();
-                    lua.setOwningUserSessionId(userSession.getId());
+                if (createUserSessionInDedicatedTransaction) {
+                    try {
+                        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session.getContext(), (newKcSession) -> {
+                            createUserSession(newKcSession, realm, authSession, username, connection, remember, brokerSessionId, brokerUserId);
+                        });
+                    } catch (Exception e) {
+                        if (KeycloakModelUtils.isModelDuplicateException(e)) {
+                            logger.debugf("Other transaction created userSession '%s' in the realm '%s'. Will just lookup existing user session", authSession.getParentSession().getId(), realm.getName());
+                        } else {
+                            throw e;
+                        }
+                    }
+                    userSession = session.sessions().getUserSession(realm, authSession.getParentSession().getId());
+                } else {
+                    userSession = createUserSession(session, realm, authSession, username, connection, remember, brokerSessionId, brokerUserId);
                 }
             } else if (userSession.getUser() == null || !AuthenticationManager.isSessionValid(realm, userSession)) {
                 userSession.restartSession(realm, authSession.getAuthenticatedUser(), username, connection.getRemoteHost(), authSession.getProtocol()
@@ -1195,6 +1204,20 @@ public class AuthenticationProcessor {
         return clientSessionCtx;
     }
 
+    private static UserSessionModel createUserSession(KeycloakSession kcSession, RealmModel realm, AuthenticationSessionModel authSession, String username,
+                                                      ClientConnection connection, boolean remember, String brokerSessionId, String brokerUserId) {
+        UserSessionModel.SessionPersistenceState persistenceState = UserSessionModel.SessionPersistenceState.fromString(authSession.getClientNote(AuthenticationManager.USER_SESSION_PERSISTENT_STATE));
+
+        UserSessionModel userSession = new UserSessionManager(kcSession).createUserSession(authSession.getParentSession().getId(), realm, authSession.getAuthenticatedUser(), username, connection.getRemoteHost(), authSession.getProtocol()
+                , remember, brokerSessionId, brokerUserId, persistenceState);
+
+        if (isLightweightUser(userSession.getUser())) {
+            LightweightUserAdapter lua = (LightweightUserAdapter) userSession.getUser();
+            lua.setOwningUserSessionId(userSession.getId());
+        }
+        return userSession;
+    }
+
     public void evaluateRequiredActionTriggers() {
         AuthenticationManager.evaluateRequiredActionTriggers(session, authenticationSession, request, event, realm, authenticationSession.getAuthenticatedUser());
     }
@@ -1227,7 +1250,7 @@ public class AuthenticationProcessor {
             return AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
         } else {
             event.detail(Details.CODE_ID, authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
-            return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+            return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event, false);
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
@@ -249,7 +249,7 @@ public class CibaGrantType extends OAuth2GrantTypeBase {
         AuthenticationManager.setClientScopesInSession(session, authSession);
 
         ClientSessionContext context = AuthenticationProcessor
-                .attachSession(authSession, null, session, realm, session.getContext().getConnection(), event);
+                .attachSession(authSession, null, session, realm, session.getContext().getConnection(), event, false);
         UserSessionModel userSession = context.getClientSession().getUserSession();
 
         if (userSession == null) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -999,7 +999,7 @@ public class AuthenticationManager {
                                                   Set<String> ignoredActions) {
         Response requiredAction = actionRequired(session, authSession, request, event, ignoredActions);
         if (requiredAction != null) return requiredAction;
-        return finishedRequiredActions(session, authSession, null, clientConnection, request, uriInfo, event);
+        return finishedRequiredActions(session, authSession, null, clientConnection, request, uriInfo, event, false);
 
     }
 
@@ -1034,7 +1034,7 @@ public class AuthenticationManager {
 
 
     public static Response finishedRequiredActions(KeycloakSession session, AuthenticationSessionModel authSession, UserSessionModel userSession,
-                                                   ClientConnection clientConnection, HttpRequest request, UriInfo uriInfo, EventBuilder event) {
+                                                   ClientConnection clientConnection, HttpRequest request, UriInfo uriInfo, EventBuilder event, boolean createUserSessionInDedicatedTransaction) {
         String actionTokenKeyToInvalidate = authSession.getAuthNote(INVALIDATE_ACTION_TOKEN);
         if (actionTokenKeyToInvalidate != null) {
             SingleUseObjectKeyModel actionTokenKey = DefaultActionTokenKey.from(actionTokenKeyToInvalidate);
@@ -1065,7 +1065,7 @@ public class AuthenticationManager {
         }
         RealmModel realm = authSession.getRealm();
 
-        ClientSessionContext clientSessionCtx = AuthenticationProcessor.attachSession(authSession, userSession, session, realm, clientConnection, event);
+        ClientSessionContext clientSessionCtx = AuthenticationProcessor.attachSession(authSession, userSession, session, realm, clientConnection, event, createUserSessionInDedicatedTransaction);
         userSession = clientSessionCtx.getClientSession().getUserSession();
 
         event.event(EventType.LOGIN);

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -125,6 +125,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.keycloak.broker.provider.AbstractIdentityProvider.BROKER_REGISTERED_NEW_USER;
+import static org.keycloak.models.light.LightweightUserAdapter.isLightweightUser;
 
 /**
  * <p></p>
@@ -924,7 +925,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             return AuthenticationManager.redirectToRequiredActions(session, realmModel, authSession, session.getContext().getUri(), nextRequiredAction);
         } else {
             event.detail(Details.CODE_ID, authSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
-            return AuthenticationManager.finishedRequiredActions(session, authSession, null, clientConnection, request, session.getContext().getUri(), event);
+            return AuthenticationManager.finishedRequiredActions(session, authSession, null, clientConnection, request, session.getContext().getUri(), event, !isLightweightUser(federatedUser));
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -1058,7 +1058,7 @@ public class LoginActionsService {
         event.detail(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
         event.success();
 
-        ClientSessionContext clientSessionCtx = AuthenticationProcessor.attachSession(authSession, null, session, realm, clientConnection, event);
+        ClientSessionContext clientSessionCtx = AuthenticationProcessor.attachSession(authSession, null, session, realm, clientConnection, event, false);
         return AuthenticationManager.redirectAfterSuccessfulFlow(session, realm, clientSessionCtx.getClientSession().getUserSession(), clientSessionCtx, request, session.getContext().getUri(), clientConnection, event, authSession);
     }
 


### PR DESCRIPTION
closes #40374

The prototype to fix the corner-case, which is hard to simulate, but it can happen in the production environments for people. This prototype implements approach 4 mentioned from this comment https://github.com/keycloak/keycloak/issues/40374#issuecomment-3188494058 .

It introduces `UserSessionExceptionHandler`, which is able to retry the HTTP request in case that other concurrent HTTP request already created same userSession with same ID. It also introduces `SendResponseException`, so the `KeycloakErrorHandler` is able to forward the provided `Response` as is without transforming it to the error page.

TBH I am not 100% happy with this approach, but could not come up with anything better, which would work and at the same time would not be too complicated like some other approaches outlined in the comment https://github.com/keycloak/keycloak/issues/40374#issuecomment-3188494058 .

NOTE: I did not added automated test as I did not manage to write an automated test to simulate the bug. I've simulated the bug just with the use of the debugger as mentioned in the comment above. I've wrote some automated test here https://github.com/mposolda/keycloak/commit/8a82589b83ce4bea1d6a0c14de99d6f2a18fdab2 , but did not manage to simulate the issue with that test (without debugger).
