### PR TITLE
fix: ensuring streams are closed

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/KeystoreUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/KeystoreUtil.java
@@ -86,9 +86,7 @@ public class KeystoreUtil {
     }
 
     public static KeyPair loadKeyPairFromKeystore(String keystoreFile, String storePassword, String keyPassword, String keyAlias, KeystoreFormat format) {
-        InputStream stream = FindFile.findFile(keystoreFile);
-
-        try {
+        try (InputStream stream = FindFile.findFile(keystoreFile)) {
             KeyStore keyStore = CryptoIntegration.getProvider().getKeyStore(format);
 
             keyStore.load(stream, storePassword.toCharArray());
@@ -105,7 +103,7 @@ public class KeystoreUtil {
             throw new RuntimeException("Failed to load private key: " + e.getMessage(), e);
         }
     }
-    
+
     public static Optional<KeystoreFormat> getKeystoreFormat(String path) {
         int lastDotIndex = path.lastIndexOf('.');
         if (lastDotIndex > -1) {
@@ -128,7 +126,9 @@ public class KeystoreUtil {
      */
     public static String getKeystoreType(String preferredType, String path, String defaultType) {
         // Configured type has precedence
-        if (preferredType != null) return preferredType;
+        if (preferredType != null) {
+            return preferredType;
+        }
 
         // Fallback to path
         Optional<KeystoreFormat> format = getKeystoreFormat(path);

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/AuthUtil.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/AuthUtil.java
@@ -91,22 +91,22 @@ public class AuthUtil {
                     authorization = BasicAuthHelper.createHeader(realmConfig.getClientId(), realmConfig.getSecret());
                 }
 
-                InputStream result = doPost(realmConfig.serverUrl() + "/realms/" + realmConfig.realm() + "/protocol/openid-connect/token",
-                        APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), authorization);
+                try (InputStream result = doPost(realmConfig.serverUrl() + "/realms/" + realmConfig.realm() + "/protocol/openid-connect/token",
+                        APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), authorization)) {
 
-                AccessTokenResponse token = JsonSerialization.readValue(result, AccessTokenResponse.class);
+                    AccessTokenResponse token = JsonSerialization.readValue(result, AccessTokenResponse.class);
 
-                saveMergeConfig(cfg -> {
-                    RealmConfigData realmData = cfg.sessionRealmConfigData();
-                    realmData.setToken(token.getToken());
-                    realmData.setRefreshToken(token.getRefreshToken());
-                    realmData.setExpiresAt(currentTimeMillis() + token.getExpiresIn() * 1000);
-                    if (token.getRefreshToken() != null) {
-                        realmData.setRefreshExpiresAt(currentTimeMillis() + token.getRefreshExpiresIn() * 1000);
-                    }
-                });
-                return token.getToken();
-
+                    saveMergeConfig(cfg -> {
+                        RealmConfigData realmData = cfg.sessionRealmConfigData();
+                        realmData.setToken(token.getToken());
+                        realmData.setRefreshToken(token.getRefreshToken());
+                        realmData.setExpiresAt(currentTimeMillis() + token.getExpiresIn() * 1000);
+                        if (token.getRefreshToken() != null) {
+                            realmData.setRefreshExpiresAt(currentTimeMillis() + token.getRefreshExpiresIn() * 1000);
+                        }
+                    });
+                    return token.getToken();
+                }
             } catch (Exception e) {
                 throw new RuntimeException("Failed to refresh access token - " + e.getMessage(), e);
             }
@@ -123,10 +123,10 @@ public class AuthUtil {
                     .append("&password=").append(urlencode(password))
                     .append("&client_id=").append(urlencode(clientId));
 
-            InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
-                    APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), null);
-            return JsonSerialization.readValue(result, AccessTokenResponse.class);
-
+            try (InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
+                    APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), null)) {
+                return JsonSerialization.readValue(result, AccessTokenResponse.class);
+            }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Unexpected error: ", e);
         } catch (IOException e) {
@@ -152,10 +152,10 @@ public class AuthUtil {
                 body.append("&grant_type=client_credentials");
             }
 
-            InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
-                    APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), null);
-            return JsonSerialization.readValue(result, AccessTokenResponse.class);
-
+            try (InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
+                    APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), null)) {
+                return JsonSerialization.readValue(result, AccessTokenResponse.class);
+            }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Unexpected error: ", e);
         } catch (IOException e) {
@@ -180,10 +180,10 @@ public class AuthUtil {
                 body.append("grant_type=client_credentials");
             }
 
-            InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
-                    APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), BasicAuthHelper.createHeader(clientId, secret));
-            return JsonSerialization.readValue(result, AccessTokenResponse.class);
-
+            try (InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
+                    APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), BasicAuthHelper.createHeader(clientId, secret))) {
+                return JsonSerialization.readValue(result, AccessTokenResponse.class);
+            }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Unexpected error: ", e);
         } catch (IOException e) {


### PR DESCRIPTION
closes: #40660

mentioned in https://github.com/keycloak/keycloak/issues/40660#issuecomment-2996543294 that closing the AuthUtil streams wasn't required, but it does seem clearer to take responsiblity in AuthUtil - then there's no chance that a change to the mapper configuration will affect stream closure.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
