### PR TITLE
fix: disable devservices api server

### DIFF
--- a/operator/src/test/resources/application.properties
+++ b/operator/src/test/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.test.hang-detection-timeout=30m
 
 # we start operator manually during tests
 quarkus.operator-sdk.start-operator=false
-# we take responsibility for startin the apiserver
+# we take responsibility for starting the apiserver
 quarkus.kubernetes-client.devservices.enabled=false
 
 quarkus.log.level=INFO

--- a/operator/src/test/resources/application.properties
+++ b/operator/src/test/resources/application.properties
@@ -2,6 +2,8 @@ quarkus.test.hang-detection-timeout=30m
 
 # we start operator manually during tests
 quarkus.operator-sdk.start-operator=false
+# we take responsibility for startin the apiserver
+quarkus.kubernetes-client.devservices.enabled=false
 
 quarkus.log.level=INFO
 


### PR DESCRIPTION
closes: #41903

because of how we are taking over manually for creating the operator and don't have prior usage of devservices, we can just disable it for now.

At some point we can revisit doing this in a more standard way.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
