### PR TITLE
Disable testDisabledUserAfterInactivityPeriod in UserSessionRefreshTimePolicyTest

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/policy/UserSessionRefreshTimePolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/policy/UserSessionRefreshTimePolicyTest.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
@@ -83,6 +84,7 @@ public class UserSessionRefreshTimePolicyTest {
     }
 
     @Test
+    @Disabled
     public void testDisabledUserAfterInactivityPeriod() {
         runOnServer.run((RunOnServer) session -> {
             RealmModel realm = configureSessionContext(session);


### PR DESCRIPTION
 - prevents CI failures while the feature is still being developed

#Closes #41913

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
