### PR TITLE
fix: simplifying places where the configuration is initted

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -233,7 +233,10 @@ class KeycloakProcessor {
     @BuildStep
     @Produce(ConfigBuildItem.class)
     void initConfig(KeycloakRecorder recorder) {
+        // other buildsteps directly use the Config
+        // so directly init it
         Config.init(new MicroProfileConfigProvider());
+        // also init in byte code for the actual server start
         recorder.initConfig();
     }
 
@@ -628,6 +631,7 @@ class KeycloakProcessor {
      */
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
+    @Consume(ConfigBuildItem.class)
     @Consume(CryptoProviderInitBuildItem.class)
     @Produce(KeycloakSessionFactoryPreInitBuildItem.class)
     void configureKeycloakSessionFactory(KeycloakRecorder recorder, List<PersistenceXmlDescriptorBuildItem> descriptors) {
@@ -882,7 +886,6 @@ class KeycloakProcessor {
 
     private Map<Spi, Map<Class<? extends Provider>, Map<String, ProviderFactory>>> loadFactories(
             Map<String, ProviderFactory> preConfiguredProviders) {
-        Config.init(new MicroProfileConfigProvider());
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         ProviderManager pm = getProviderManager(classLoader);
         Map<Spi, Map<Class<? extends Provider>, Map<String, ProviderFactory>>> factories = new HashMap<>();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractUpdatesCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractUpdatesCommand.java
@@ -91,7 +91,8 @@ public abstract class AbstractUpdatesCommand extends AbstractStartCommand {
     }
 
     private static void loadConfiguration() {
-        // Initialize config
+        // Initialize config without directly referencing MicroProfileConfigProvider
+        // as that currently causing classloading issue during command creation
         var configProvider = ServiceLoader.load(ConfigProviderFactory.class)
                 .stream()
                 .findFirst()


### PR DESCRIPTION
closes: #25668

@mabartos I believe we need all 4 of these locations for calling Config.init:
- KeycloakProcessor.initConfig - this covers logic that runs in the build steps
- KeycloakRecorder.initConfig - this covers the recorded byte code for the regular keycloak launch
- AbstractUpdatesCommand.callCommand - the command is running before quarkus, so it's taking responsiblity for the init.
- In the updates command logic - it is taking responsiblity for creating providers

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
