### PR TITLE
fix: remove robots meta tags from Freemarker templates (#34206)

### DIFF
--- a/themes/src/main/resources/theme/base/account/index.ftl
+++ b/themes/src/main/resources/theme/base/account/index.ftl
@@ -4,7 +4,6 @@
         <title>${msg("accountManagementTitle")}</title>
 
         <meta charset="utf-8">
-        <meta name="robots" content="noindex, nofollow">
     </head>
 
     <body>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -6,7 +6,6 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="robots" content="noindex, nofollow">
 
     <#if properties.meta?has_content>
         <#list properties.meta?split(' ') as meta>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -29,7 +29,6 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="robots" content="noindex, nofollow">
     <meta name="color-scheme" content="light${darkMode?then(' dark', '')}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light${(properties.darkMode)?boolean?then(' dark', '')}">
     <title>Welcome to ${productName}</title>


### PR DESCRIPTION
Closes: https://github.com/keycloak/keycloak/issues/34206

This is carrying on from: https://github.com/keycloak/keycloak/pull/34116.
Currently there is both robots meta tags in the Freemarker templates, as well as in the realm-specific `X-Robots-Tag` header responses. It is redundant to include both.

From discussion on https://github.com/keycloak/keycloak/pull/34116., the `X-Robots-Tag` is the preferred method, as it is customizable by realm.