### PR TITLE
fix: removing test os restriction

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
@@ -37,7 +37,7 @@ public final class ImportRealmMixin {
             description = "Import realms during startup by reading any realm configuration file from the 'data/import' directory.",
             paramLabel = NO_PARAM_LABEL,
             arity = "0")
-    public void setImportRealm(String realmFiles) {
+    public void setImportRealm(boolean importRealm) {
         File importDir = Environment.getHomePath().resolve("data").resolve("import").toFile();
 
         if (importDir.exists()) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -466,6 +466,20 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void invalidImportRealmArgument() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--import-realm", "some-file");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertTrue(nonRunningPicocli.getErrString(), nonRunningPicocli.getErrString().contains("Unknown option: 'some-file'"));
+    }
+
+    @Test
+    public void invalidImportRealmEqualsArgument() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--import-realm=some-file");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertTrue(nonRunningPicocli.getErrString(), nonRunningPicocli.getErrString().contains("option '--import-realm' should be specified without 'some-file' parameter"));
+    }
+
+    @Test
     public void wrongLevelForCategory() {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-level-org.keycloak=wrong");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
@@ -24,8 +24,6 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.BeforeStartDistribution;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -78,14 +76,6 @@ public class ImportAtStartupDistTest {
     @Launch({"start-dev", "--import-realm", "--log-level=org.keycloak.exportimport.ExportImportManager:debug"})
     void testIgnoreFileWithUnsupportedExtension(CLIResult cliResult) {
         cliResult.assertMessage("Ignoring import file because it is not a valid file");
-    }
-
-    @Test
-    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
-    @BeforeStartDistribution(CreateRealmConfigurationFile.class)
-    @Launch({"start-dev", "--import-realm=some-file"})
-    void failSetValueToImportRealmOption(CLIResult cliResult) {
-        cliResult.assertError("option '--import-realm' should be specified without 'some-file' parameter");
     }
 
     @Test


### PR DESCRIPTION
closes: #13501

@Pepo48 there was a logic error in our import-realm option. It needs to specifically take a boolean argument, not string. The converted the test(s) to PicoCli tests to prevent any need for quoting an = on windows.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
