### PR TITLE
Log applied cache configurations as part of debug logs

### DIFF
--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -125,6 +125,8 @@ This cache is needed for the Brute Force Protection feature to work in a multi-n
 Action tokens are used for scenarios when a user needs to confirm an action asynchronously, for example in the emails sent by the forgot password flow.
 The `actionTokens` distributed cache is used to track metadata about action tokens.
 
+TIP: You can see the applied Infinispan configuration in the logs by configuring `--log-level=info,org.keycloak.connections.infinispan:debug`.
+
 === Volatile user sessions
 
 By default, regular user sessions are stored in the database and loaded on-demand to the cache.

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -129,6 +129,13 @@ public class ClusterConfigDistTest {
     }
 
     @Test
+    @Launch({ "start", "--cache=ispn", "--log-level=info,org.keycloak.connections.infinispan:debug", "--http-enabled=true", "--hostname-strict=false"})
+    void testPrintCacheConfigurationsDebug(CLIResult result) {
+        result.assertStarted();
+        result.assertMessage("Infinispan configuration");
+    }
+
+    @Test
     @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start", "--db=dev-file", "--log-level=info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true", "--hostname-strict=false" })
     void testStartDefaultsToClustering(CLIResult result) {


### PR DESCRIPTION
Closes #41950

I have also included the `GlobalConfiguration` as I think this could also be helpful for debugging. If this isn't desired, I can limit the output to only cache-configurations by passing `null` instead.

Example log for the default configuration:

```
2025-08-18 16:52:26,485 DEBUG [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Infinispan configuration: <?xml version="1.0"?>
<infinispan xmlns="urn:infinispan:config:15.0">
    <jgroups transport="org.infinispan.remoting.transport.jgroups.JGroupsTransport">
        <stacks>
            <stack name="jdbc-ping">
                <org.keycloak.jgroups.protocol.KEYCLOAK-JDBC-PING2 select-all-pingdata-sql="SELECT address, name, ip, coord FROM JGROUPS_PING WHERE cluster_name=?" insert-single-sql="INSERT INTO JGROUPS_PING values (?, ?, ?, ?, ?)" initialize-sql="" clear-sql="DELETE from JGROUPS_PING WHERE cluster_name=?" delete-single-sql="DELETE from JGROUPS_PING WHERE address=?" write-data-on-find="true" register-shutdown-hook="false" remove-all-data-on-view-change="true"/>
                <TCP bundler-type="per-destination"/>
            </stack>
        </stacks>
    </jgroups>
    <cache-container name="keycloak" shutdown-hook="DONT_REGISTER" statistics="false">
        <transport stack="jdbc-ping" lock-timeout="60000"/>
        <serialization>
            <context-initializers>
                <context-initializer class="org.infinispan.protostream.types.java.CommonTypesSchema"/>
                <context-initializer class="org.keycloak.marshalling.KeycloakModelSchemaImpl"/>
                <context-initializer class="org.infinispan.protostream.types.protobuf.TimestampSchemaImpl"/>
                <context-initializer class="org.infinispan.protostream.types.protobuf.EmptySchemaImpl"/>
                <context-initializer class="org.infinispan.protostream.types.protobuf.DurationSchemaImpl"/>
                <context-initializer class="org.infinispan.protostream.types.protobuf.AnySchemaImpl"/>
                <context-initializer class="org.infinispan.protostream.types.protobuf.WrappersSchemaImpl"/>
                <context-initializer class="org.infinispan.protostream.types.java.CommonContainerTypesSchema"/>
            </context-initializers>
        </serialization>
        <caches>
            <local-cache name="realms" simple-cache="true">
                <memory max-count="10000" when-full="REMOVE"/>
            </local-cache>
            <distributed-cache name="authenticationSessions" mode="SYNC">
                <encoding media-type="application/x-java-object"/>
            </distributed-cache>
            <distributed-cache name="sessions" owners="1" mode="SYNC">
                <memory max-count="10000"/>
            </distributed-cache>
            <local-cache name="authorizationRevisions" simple-cache="false">
                <encoding media-type="application/x-java-object"/>
                <transaction mode="BATCH" locking="PESSIMISTIC" transaction-manager-lookup="org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup"/>
                <memory max-count="20000" when-full="REMOVE"/>
            </local-cache>
            <local-cache name="keys" simple-cache="true">
                <expiration max-idle="3600000"/>
                <memory max-count="1000" when-full="REMOVE"/>
            </local-cache>
            <distributed-cache name="clientSessions" owners="1" mode="SYNC">
                <memory max-count="10000"/>
            </distributed-cache>
            <replicated-cache name="work" mode="SYNC"/>
            <local-cache name="users" simple-cache="true">
                <memory max-count="10000" when-full="REMOVE"/>
            </local-cache>
            <distributed-cache name="loginFailures" mode="SYNC">
                <encoding media-type="application/x-java-object"/>
            </distributed-cache>
            <local-cache name="realmRevisions" simple-cache="false">
                <encoding media-type="application/x-java-object"/>
                <transaction mode="BATCH" locking="PESSIMISTIC" transaction-manager-lookup="org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup"/>
                <memory max-count="20000" when-full="REMOVE"/>
            </local-cache>
            <local-cache name="authorization" simple-cache="true">
                <memory max-count="10000" when-full="REMOVE"/>
            </local-cache>
            <distributed-cache name="offlineClientSessions" owners="1" mode="SYNC">
                <memory max-count="10000"/>
            </distributed-cache>
            <local-cache name="crl" simple-cache="true">
                <memory max-count="1000" when-full="REMOVE"/>
            </local-cache>
            <distributed-cache name="offlineSessions" owners="1" mode="SYNC">
                <memory max-count="10000"/>
            </distributed-cache>
            <distributed-cache name="actionTokens" mode="SYNC">
                <encoding media-type="application/x-java-object"/>
            </distributed-cache>
            <local-cache name="userRevisions" simple-cache="false">
                <encoding media-type="application/x-java-object"/>
                <transaction mode="BATCH" locking="PESSIMISTIC" transaction-manager-lookup="org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup"/>
                <memory max-count="20000" when-full="REMOVE"/>
            </local-cache>
        </caches>
    </cache-container>
</infinispan>
```