### PR TITLE
[26.3] Upgrade to Quarkus 3.20.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.20.2</quarkus.version>
-        <quarkus.build.version>3.20.2</quarkus.build.version>
+        <quarkus.version>3.20.2.1</quarkus.version>
+        <quarkus.build.version>3.20.2.1</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/41963

The `./set-quarkus-version 3.20.2.1` made these changes:

```diff
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.20.2</quarkus.version>
-        <quarkus.build.version>3.20.2</quarkus.build.version>
+        <quarkus.version>3.20.2.1</quarkus.version>
+        <quarkus.build.version>3.20.2.1</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>
@@ -96,7 +96,7 @@
 
         <!--JAKARTA-->
         <jakarta.mail.version>2.1.1</jakarta.mail.version>
-        <angus.mail.version>2.0.4</angus.mail.version>
+        <angus.mail.version>2.0.3</angus.mail.version>
         <jakarta.xml.ws.version>4.0.0</jakarta.xml.ws.version>
         <jakarta.xml.soap.version>3.0.0</jakarta.xml.soap.version>
 
@@ -161,7 +161,7 @@
         <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.2</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->

```

However, we had to update these downgraded dependencies to fix other issues:
- Angus Mail: https://github.com/keycloak/keycloak/issues/41808
- MariaDB: https://github.com/keycloak/keycloak/issues/39634

@keycloak/cloud-native Could you please check it? Thanks!