### PR TITLE
align /users/count with /users behavior around service-accounts

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -192,6 +192,15 @@ If you have an SMTP server configured for your realm, perform the following migr
 . Keep the *Allow UTF-8* option disabled.
 . Verify that no email addresses of users have non-ASCII characters in the local part of the email address. If you detect emails with non-ascii characters in the local part you can use the Verify Profile action to force the user to modify the email after the upgrade.
 
+=== Aligning the count of users with the actual number of users returned from searches
+
+When searching for users in the Admin Console or via the User API, the count of users returned from the
+`/admin/realms/{realm}/users/count` endpoint is now aligned with the actual number of users returned when executing
+searches via `/admin/realms/{realm}/users`.
+
+If you are relying on the users count endpoint, make sure to review your client(s) so that they expect the users count
+to be aligned with the actual number of users returned from searches.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 


### PR DESCRIPTION
closes #22730 

it is simpler than #22732 as it doesn't introduce any changes to APIs or breaking changes to the `/users` endpoint.

it simply aligns `/users/count` with `/users` such that a call for a count returns the same number as an equivalent manual count of the results of the list/search endpoint (ignoring pagination).

in a realm with 5 users and 5 service accounts
e.g. calling `/users/count?search=*` should return 5 (equivalent to running `/users?search=*`

equivalently calling `/users/count?username=&exact=false` should return 10 (equivalent to running `/users?username=&exact=false`
