### PR TITLE
Check null for new keySize and validity parameters when generating certificates (26.3)

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -109,6 +109,9 @@ public final class KeycloakModelUtils {
 
     public static final int MAX_CLIENT_LOOKUPS_DURING_ROLE_RESOLVE = 25;
 
+    public static final int DEFAULT_RSA_KEY_SIZE = 4096;
+    public static final int DEFAULT_CERTIFICATE_VALIDITY_YEARS = 3;
+
     private KeycloakModelUtils() {
     }
 
@@ -221,8 +224,8 @@ public final class KeycloakModelUtils {
 
     public static CertificateRepresentation generateKeyPairCertificate(String subject) {
         Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.YEAR, 3);
-        return generateKeyPairCertificate(subject, 4096, calendar);
+        calendar.add(Calendar.YEAR, DEFAULT_CERTIFICATE_VALIDITY_YEARS);
+        return generateKeyPairCertificate(subject, DEFAULT_RSA_KEY_SIZE, calendar);
     }
 
     public static CertificateRepresentation generateKeyPairCertificate(String subject, int keysize, Calendar endDate) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
@@ -18,7 +18,6 @@
 package org.keycloak.services.resources.admin;
 
 import com.google.common.base.Strings;
-import jakarta.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -342,15 +341,15 @@ public class ClientAttributeCertificateResource {
             throw new ErrorResponseException("password-missing", "Need to specify a store password for jks generation and download", Response.Status.BAD_REQUEST);
         }
 
-        CertificateRepresentation info;
-        if (config.getKeySize() <= 0 || config.getValidity() <= 0) {
-            info = KeycloakModelUtils.generateKeyPairCertificate(client.getClientId());
-        }
-        else {
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.YEAR, config.getValidity());
-            info = KeycloakModelUtils.generateKeyPairCertificate(client.getClientId(), config.getKeySize(), calendar);
-        }
+        int keySize = config.getKeySize() != null && config.getKeySize() > 0
+                ? config.getKeySize()
+                : KeycloakModelUtils.DEFAULT_RSA_KEY_SIZE;
+        int validity = config.getValidity() != null && config.getValidity() > 0
+                ? config.getValidity()
+                : KeycloakModelUtils.DEFAULT_CERTIFICATE_VALIDITY_YEARS;
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, validity);
+        CertificateRepresentation info = KeycloakModelUtils.generateKeyPairCertificate(client.getClientId(), keySize, calendar);
         byte[] rtn = getKeystore(config, info.getPrivateKey(), info.getCertificate());
 
         info.setPrivateKey(null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
@@ -337,19 +337,19 @@ public class ClientAuthSignedJWTTest extends AbstractClientAuthSignedJWTTest {
     @Test
     public void testClientWithGeneratedKeysJKS() throws Exception {
         KeystoreUtils.assumeKeystoreTypeSupported(KeystoreFormat.JKS);
-        testClientWithGeneratedKeys("JKS");
+        testClientWithGeneratedKeys("JKS", null, null);
     }
 
     @Test
     public void testClientWithGeneratedKeysPKCS12() throws Exception {
         KeystoreUtils.assumeKeystoreTypeSupported(KeystoreFormat.PKCS12);
-        testClientWithGeneratedKeys("PKCS12");
+        testClientWithGeneratedKeys("PKCS12", 2048, null);
     }
 
     @Test
     public void testClientWithGeneratedKeysBCFKS() throws Exception {
         KeystoreUtils.assumeKeystoreTypeSupported(KeystoreFormat.BCFKS);
-        testClientWithGeneratedKeys(KeystoreFormat.BCFKS.toString());
+        testClientWithGeneratedKeys(KeystoreFormat.BCFKS.toString(), 3072, 5);
     }
 
     @Test


### PR DESCRIPTION
Closes #41906

PR:             https://github.com/keycloak/keycloak/pull/41966
Commit:         https://github.com/keycloak/keycloak/commit/0ff7d551dd2aab42da9cfdb03a5267a73d4e470e
PR branch:      backport-41966-26.3
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.3
