### PR TITLE
Check for non-ascii local part on emails depending on SMTP configuration

### DIFF
--- a/docs/documentation/server_admin/topics/realms/email.adoc
+++ b/docs/documentation/server_admin/topics/realms/email.adoc
@@ -72,12 +72,7 @@ Auth Token Client Secret::
 Allow UTF-8::
   Enable to UTF-8-encode email address when sending them to the server. This should only be enabled if the mail server supports UTF-8 via the SMTPUTF8 extension. If disabled, domain names containing non-ASCII characters will be encoded using punycode, and addresses containing non-ASCII characters in the local part of the address will return an error.
 +
-If you do not enable this option, take additional measures to prevent non-ASCII characters in users' email addresses:
-+
---
-. Verifying that no email addresses of existing users have non-ASCII characters in the local part of the email address.
-. Updating the validation of email addresses to prevent non-ASCII characters in the local part of the email address, for example, by adding a regex pattern validation in the user profile for the email address field similar to `\p&#123;ASCII&#125;*@.*` with an error message similar to `Local part of the address must contain only ASCII characters`.
---
+If the realm is configured to send emails (this SMTP configuration is setup) and *Allow UTF-8* option is disabled, the built-in <<user-profile, user profile>> email validator checks the local part of the address contains only ASCII characters. This way, {project_name} prevents user emails that cannot be notified.
 
 ifeval::[{project_community}==true]
 

--- a/docs/documentation/server_admin/topics/users/user-profile.adoc
+++ b/docs/documentation/server_admin/topics/users/user-profile.adoc
@@ -269,7 +269,7 @@ The list below provides a list of all the built-in validators:
 *error-message*: the key of the error message in i18n bundle. If not set a generic message is used.
 
 |email
-|Check if the value has a valid e-mail format.
+|Check if the value has a valid e-mail format. If <<_email, the realm is configured to send emails>> and the option *Allow UTF-8* is not enabled to support internationalized emails, this validator also checks that the local part of the address contains only ASCII characters.
 |
 *max-local-length*: an integer to define the maximum length for the local part of the email. It defaults to 64 per specification.
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -133,13 +133,14 @@ The input fields  in the login theme for OTP and recovery codes and have been op
 
 * The input mode is now `numeric`, which will ease the input on mobile devices.
 * The auto-complete is set to `one-time-code` to avoid interference with password managers.
+
 === UTF-8 management in the email sender
 
 Since this release, {project_name} adds a new option `allowutf8` for the realm SMTP configuration (*Allow UTF-8* field inside the *Email* tab in the *Realm settings* section of the Admin Console).
 For more information about email configuration, see the link:{adminguide_link}#_email[Configuring email for a realm] chapter in the {adminguide_name}.
 
 Enabling the option encodes email addresses in UTF-8 when sending them, but it depends on the SMTP server to also supports UTF-8 via the SMTPUTF8 extension.
-If *Allow UTF-8* is disabled, {project_name} will encode the domain part of the email address (second part after `@`) using punycode if non-ASCII characters are used, and will reject email addresses that use non-ASCII characters in the local part.
+If *Allow UTF-8* is disabled, {project_name} will encode the domain part of the email address (second part after `@`) using punycode if non-ASCII characters are used, and will reject email addresses that use non-ASCII characters in the local part. The built-in User Profile email validator also checks that the local part of the address contains only ASCII characters when this option is disabled, avoiding the registration of emails that cannot be used by the SMTP configuration.
 
 If you have an SMTP server configured for your realm, perform the following migration after the upgrade:
 
@@ -147,8 +148,7 @@ If you have an SMTP server configured for your realm, perform the following migr
 . Enable the *Allow UTF-8* option.
 * If your SMTP server does not support SMTPUTF8:
 . Keep the *Allow UTF-8* option disabled.
-. Verify that no email addresses of users have non-ASCII characters in the local part of the email address.
-. Update the validation of email addresses to prevent allow non-ASCII characters in the local part of the email address, for example, by adding a regex pattern validation in the user profile for the email address field similar to `\p&#123;ASCII&#125;*@.*` with an error message similar to `Local part of the address must contain only ASCII characters`.
+. Verify that no email addresses of users have non-ASCII characters in the local part of the email address. If you detect emails with non-ascii characters in the local part you can use the Verify Profile action to force the user to modify the email after the upgrade.
 
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features

--- a/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/messages/messages_en.properties
+++ b/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/messages/messages_en.properties
@@ -188,6 +188,7 @@ webauthn-passwordless-display-name=Passkey
 webauthn-passwordless-help-text=Use your Passkey for passwordless sign in.
 passwordless=Passwordless
 error-invalid-multivalued-size=Attribute {{0}} must have at least {{1}} and at most {{2}} value(s).
+error-non-ascii-local-part-email=Local part of the address must contain only ASCII characters.
 recovery-authn-code=My recovery authentication codes
 recovery-authn-codes-display-name=Recovery authentication codes
 recovery-authn-codes-help-text=These codes can be used to regain your access in case your other 2FA means are not available.

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3034,6 +3034,7 @@ error-person-name-invalid-character='{{0}}' contains invalid character.
 error-user-attribute-required=Please specify '{{0}}'.
 error-username-invalid-character='{{0}}' contains invalid character.
 error-user-attribute-read-only=The field {{0}} is read only.
+error-non-ascii-local-part-email=Local part of the address must contain only ASCII characters.
 missingUsernameMessage='{{0}}': Please specify username.
 missingFirstNameMessage='{{0}}': Please specify first name.
 invalidEmailMessage='{{0}}': Invalid email address.

--- a/server-spi-private/src/main/java/org/keycloak/email/EmailSenderProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/email/EmailSenderProvider.java
@@ -27,6 +27,8 @@ import java.util.Map;
  */
 public interface EmailSenderProvider extends Provider {
 
+    String CONFIG_ALLOW_UTF8 = "allowutf8";
+
     default void send(Map<String, String> config, UserModel user, String subject, String textBody, String htmlBody) throws EmailException {
         send(config, user.getEmail(), subject, textBody, htmlBody);
     }

--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -233,7 +233,7 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
     }
 
     private static boolean isAllowUTF8(Map<String, String> config) {
-        return "true".equals(config.get("allowutf8"));
+        return "true".equals(config.get(CONFIG_ALLOW_UTF8));
     }
 
     private static boolean isDebugEnabled(Map<String, String> config) {

--- a/services/src/main/java/org/keycloak/utils/SMTPUtil.java
+++ b/services/src/main/java/org/keycloak/utils/SMTPUtil.java
@@ -58,7 +58,7 @@ public class SMTPUtil {
      * @return The converted email or null (if IDN.toASCII throws an exception)
      */
     public static String convertIDNEmailAddress(String email) {
-        final int idx = email == null ? -1 : email.indexOf('@');
+        final int idx = email == null ? -1 : email.lastIndexOf('@');
         if (idx < 0) {
             return email;
         }

--- a/themes/src/main/resources/theme/base/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/account/messages/messages_en.properties
@@ -386,3 +386,4 @@ error-invalid-date=Invalid date.
 error-user-attribute-read-only=The field {0} is read only.
 error-username-invalid-character=Username contains invalid character.
 error-person-name-invalid-character=Name contains invalid character.
+error-non-ascii-local-part-email=Local part of the address must contain only ASCII characters.

--- a/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
@@ -67,6 +67,7 @@ error-user-attribute-read-only=Attribute {0} is read only.
 error-username-invalid-character={0} contains invalid character.
 error-person-name-invalid-character={0} contains invalid character.
 error-invalid-multivalued-size=Attribute {0} must have at least {1} and at most {2} {2,choice,0#values|1#value|1<values}.
+error-non-ascii-local-part-email=Local part of the address must contain only ASCII characters.
 
 client_account=Account
 client_account-console=Account Console

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -274,6 +274,7 @@ error-user-attribute-read-only=This field is read only.
 error-username-invalid-character=Value contains invalid character.
 error-person-name-invalid-character=Value contains invalid character.
 error-reset-otp-missing-id=Please choose an OTP configuration.
+error-non-ascii-local-part-email=Local part of the address must contain only ASCII characters.
 
 invalidPasswordExistingMessage=Invalid existing password.
 invalidPasswordBlacklistedMessage=Invalid password: password is blacklisted.


### PR DESCRIPTION
Closes #41994

Adding the checking for non-ascii in the email local part if the realm is configured to send emails to an SMTP without `allowutf8`. Finally it was talked to use the direct option with no option in the validator. 

@ahus1 @pedroigor @mposolda @stianst For your information.
