### PR TITLE
Stabilize personal info tests in account console

### DIFF
--- a/js/apps/account-ui/test/account-security/linked-accounts.spec.ts
+++ b/js/apps/account-ui/test/account-security/linked-accounts.spec.ts
@@ -1,7 +1,7 @@
 import { type Page, expect, test } from "@playwright/test";
 import groupsIdPClient from "../realms/groups-idp.json" with { type: "json" };
 import userProfileRealm from "../realms/user-profile-realm.json" with { type: "json" };
-import { login } from "../support/actions.ts";
+import { assertLastAlert, login } from "../support/actions.ts";
 import { adminClient } from "../support/admin-client.ts";
 import { DEFAULT_USER, getAccountUrl, SERVER_URL } from "../support/common.ts";
 import { createTestBed } from "../support/testbed.ts";
@@ -92,8 +92,9 @@ test.describe("Linked accounts", () => {
       .click();
 
     // Expect an error shown that the account cannot be unlinked
-    await expect(page.getByTestId("last-alert")).toContainText(
-      "You can not remove last federated identity as you do not have a password.",
+    await assertLastAlert(
+      page,
+      "Could not unlink due to: You can not remove last federated identity as you do not have a password.",
     );
   });
 });

--- a/js/apps/account-ui/test/personal-info/personal-info.spec.ts
+++ b/js/apps/account-ui/test/personal-info/personal-info.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { login } from "../support/actions.ts";
+import { assertLastAlert, login } from "../support/actions.ts";
 import { createTestBed } from "../support/testbed.ts";
 import userProfile from "./user-profile.json" with { type: "json" };
 import { adminClient } from "../support/admin-client.ts";
@@ -16,8 +16,7 @@ test.describe("Personal info", () => {
     await page.getByTestId("lastName").fill("de Wit");
     await page.getByTestId("save").click();
 
-    const alerts = page.getByTestId("last-alert");
-    await expect(alerts).toHaveText("Your account has been updated.");
+    await assertLastAlert(page, "Your account has been updated.");
   });
 });
 
@@ -80,7 +79,8 @@ test.describe("Personal info (user profile enabled)", () => {
     await page.getByRole("option", { name: "two" }).click();
     await page.getByTestId("email2").fill("non-valid");
     await page.getByTestId("save").click();
-    await expect(page.getByTestId("last-alert")).toHaveText(
+    await assertLastAlert(
+      page,
       "Could not update account due to validation errors",
     );
 
@@ -91,6 +91,7 @@ test.describe("Personal info (user profile enabled)", () => {
     await page.getByTestId("email2").clear();
     await page.getByTestId("email2").fill("valid@email.com");
     await page.getByTestId("save").click();
+    await assertLastAlert(page, "Your account has been updated.");
 
     await page.reload();
     await page.locator("delete-account").isVisible();
@@ -110,6 +111,8 @@ test.describe("Realm localization", () => {
     page.getByRole("option").filter({ hasText: "Deutsch" });
     await page.getByRole("option", { name: "English" }).click();
     await page.getByTestId("save").click();
+    await assertLastAlert(page, "Your account has been updated.");
+
     await page.reload();
 
     expect(

--- a/js/apps/account-ui/test/support/actions.ts
+++ b/js/apps/account-ui/test/support/actions.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { DEFAULT_PASSWORD, DEFAULT_USERNAME, getAccountUrl } from "./common.ts";
 
 export async function login(
@@ -24,4 +24,15 @@ export async function login(
     .getByRole("textbox", { name: "Password", exact: true })
     .fill(password);
   await page.getByRole("button", { name: "Sign In", exact: true }).click();
+}
+
+export async function assertLastAlert(
+  page: Page,
+  message: string,
+): Promise<void> {
+  await expect(page.getByTestId("last-alert")).toHaveText(message);
+  await page
+    .getByTestId("last-alert")
+    .getByRole("button", { name: "Close alert", exact: false })
+    .click();
 }


### PR DESCRIPTION
Stabilizes the personal information tests for the account console by ensuring the resources are fully saved before performing assertions on them. This also introduces a helper function to make assertions about the alerts, which dismisses them in the process to prevent conflicts later on.

Closes #42006

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
