### PR TITLE
DPoP verification support for admin/account REST API endpoints. Java …

### DIFF
--- a/core/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/core/src/main/java/org/keycloak/OAuth2Constants.java
@@ -17,6 +17,10 @@
 
 package org.keycloak;
 
+import org.keycloak.jose.jws.Algorithm;
+
+import static org.keycloak.jose.jws.Algorithm.PS256;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -155,6 +159,12 @@ public interface OAuth2Constants {
     String AUTHENTICATOR_METHOD_REFERENCE = "amr";
 
     String CNF = "cnf";
+
+    // DPoP - https://datatracker.ietf.org/doc/html/rfc9449
+    String DPOP_HTTP_HEADER = "DPoP";
+    Algorithm DPOP_DEFAULT_ALGORITHM = PS256;
+    String DPOP_JWT_HEADER_TYPE = "dpop+jwt";
+
 }
 
 

--- a/core/src/main/java/org/keycloak/util/DPoPGenerator.java
+++ b/core/src/main/java/org/keycloak/util/DPoPGenerator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.util;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.common.util.Time;
+import org.keycloak.crypto.AsymmetricSignatureSignerContext;
+import org.keycloak.crypto.ECDSASignatureSignerContext;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureException;
+import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.RSAPublicJWK;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.crypto.HashUtils;
+import org.keycloak.representations.dpop.DPoP;
+
+import static org.keycloak.OAuth2Constants.DPOP_DEFAULT_ALGORITHM;
+import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
+import static org.keycloak.jose.jwk.JWKUtil.toIntegerBytes;
+
+/**
+ * Utility for generating signed DPoP proofs
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc9449">OAuth 2.0 Demonstrating Proof of Possession (DPoP) specification</a>
+ *
+ */
+public class DPoPGenerator {
+
+    // TODO: Similar for EC and EdDSA
+    public static String generateRsaSignedDPoPProof(KeyPair rsaKeyPair, String httpMethod, String endpointURL, String accessToken) {
+        JWK jwkRsa = createRsaJwk(rsaKeyPair.getPublic());
+        JWSHeader jwsRsaHeader = new JWSHeader(DPOP_DEFAULT_ALGORITHM, DPOP_JWT_HEADER_TYPE, jwkRsa.getKeyId(), jwkRsa);
+        return generateSignedDPoPProof(SecretGenerator.getInstance().generateSecureID(), httpMethod, endpointURL, (long) Time.currentTime(),
+                jwsRsaHeader, rsaKeyPair.getPrivate(), accessToken);
+    }
+
+
+    public static JWK createRsaJwk(Key publicKey) {
+        RSAPublicKey rsaKey = (RSAPublicKey) publicKey;
+
+        RSAPublicJWK k = new RSAPublicJWK();
+        k.setKeyType(KeyType.RSA);
+        k.setModulus(Base64Url.encode(toIntegerBytes(rsaKey.getModulus())));
+        k.setPublicExponent(Base64Url.encode(toIntegerBytes(rsaKey.getPublicExponent())));
+
+        return k;
+    }
+
+
+    public static String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken) {
+        try {
+            DPoP dpop = new DPoP();
+            dpop.id(jti);
+            dpop.setHttpMethod(htm);
+            dpop.setHttpUri(htu);
+            dpop.iat(iat);
+            if (accessToken != null) {
+                dpop.setAccessTokenHash(HashUtils.accessTokenHash(OAuth2Constants.DPOP_DEFAULT_ALGORITHM.toString(), accessToken, true));
+            }
+
+            KeyWrapper keyWrapper = new KeyWrapper();
+            keyWrapper.setKid(jwsHeader.getKeyId());
+            keyWrapper.setAlgorithm(jwsHeader.getAlgorithm().toString());
+            keyWrapper.setPrivateKey(privateKey);
+            keyWrapper.setType(privateKey.getAlgorithm());
+            keyWrapper.setUse(KeyUse.SIG);
+            SignatureSignerContext sigCtx = createSignatureSignerContext(keyWrapper);
+
+            return new JWSBuilder()
+                    .header(jwsHeader)
+                    .jsonContent(dpop)
+                    .sign(sigCtx);
+        } catch (SignatureException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static SignatureSignerContext createSignatureSignerContext(KeyWrapper keyWrapper) {
+        switch (keyWrapper.getType()) {
+            case KeyType.RSA:
+                return new AsymmetricSignatureSignerContext(keyWrapper);
+            case KeyType.EC:
+                return new ECDSASignatureSignerContext(keyWrapper);
+             // TODO: EdDSA?
+            default:
+                throw new IllegalArgumentException("No signer provider for key algorithm type " + keyWrapper.getType());
+        }
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Config.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Config.java
@@ -33,6 +33,7 @@ public class Config {
     private String clientSecret;
     private String grantType;
     private String scope;
+    private boolean useDPoP = false;
 
     public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret) {
         this(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, null);
@@ -124,5 +125,13 @@ public class Config {
             throw new IllegalArgumentException("Unsupported grantType: " + grantType +
                     " (only " + PASSWORD + " and " + CLIENT_CREDENTIALS + " are supported)");
         }
+    }
+
+    public boolean isUseDPoP() {
+        return useDPoP;
+    }
+
+    public void setUseDPoP(boolean useDPoP) {
+        this.useDPoP = useDPoP;
     }
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.admin.client;
 
-import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
 import static org.keycloak.OAuth2Constants.PASSWORD;
 
 import jakarta.ws.rs.client.Client;
@@ -66,6 +65,7 @@ public class KeycloakBuilder {
     private Client resteasyClient;
     private String authorization;
     private String scope;
+    private boolean useDPoP = false;
 
     public KeycloakBuilder serverUrl(String serverUrl) {
         this.serverUrl = serverUrl;
@@ -125,6 +125,16 @@ public class KeycloakBuilder {
     }
 
     /**
+     * @param useDPoP If true, then admin-client will add DPoP proofs to the token-requests and to the admin REST API requests. DPoP feature must be
+     *                enabled on Keycloak server side to work properly. It is false by default.
+     * @return admin client builder
+     */
+    public KeycloakBuilder useDPoP(boolean useDPoP) {
+        this.useDPoP = useDPoP;
+        return this;
+    }
+
+    /**
      * Builds a new Keycloak client from this builder.
      */
     public Keycloak build() {
@@ -154,7 +164,7 @@ public class KeycloakBuilder {
             throw new IllegalStateException("clientId required");
         }
 
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, grantType, resteasyClient, authorization, scope);
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, grantType, resteasyClient, authorization, scope, useDPoP);
     }
 
     private KeycloakBuilder() {

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/BearerAuthFilter.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/BearerAuthFilter.java
@@ -34,7 +34,7 @@ public class BearerAuthFilter implements ClientRequestFilter, ClientResponseFilt
 
     public static final String AUTH_HEADER_PREFIX = "Bearer ";
     private final String tokenString;
-    private final TokenManager tokenManager;
+    protected final TokenManager tokenManager;
 
     public BearerAuthFilter(String tokenString) {
         this.tokenString = tokenString;
@@ -66,12 +66,17 @@ public class BearerAuthFilter implements ClientRequestFilter, ClientResponseFilt
             for (Object authHeader : authHeaders) {
                 if (authHeader instanceof String) {
                     String headerValue = (String) authHeader;
-                    if (headerValue.startsWith(AUTH_HEADER_PREFIX)) {
-                        String token = headerValue.substring( AUTH_HEADER_PREFIX.length() );
+                    String authHeaderPrefix = getAuthHeaderPrefix();
+                    if (headerValue.startsWith(authHeaderPrefix)) {
+                        String token = headerValue.substring( authHeaderPrefix.length() );
                         tokenManager.invalidate( token );
                     }
                 }
             }
         }
+    }
+
+    protected String getAuthHeaderPrefix() {
+        return AUTH_HEADER_PREFIX;
     }
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/DPoPAuthFilter.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/DPoPAuthFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.keycloak.admin.client.token.TokenManager;
+import org.keycloak.util.DPoPGenerator;
+
+import static org.keycloak.OAuth2Constants.DPOP_HTTP_HEADER;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class DPoPAuthFilter extends BearerAuthFilter {
+
+    private final boolean tokenRequest;
+
+    public DPoPAuthFilter(TokenManager tokenManager, boolean tokenRequest) {
+        super(tokenManager);
+        this.tokenRequest = tokenRequest;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        String requestUri = requestContext.getUri().toString();
+        if (tokenRequest) {
+            if (requestUri.endsWith("/token")) {
+                // Request for obtain new accessToken or refresh-token request
+                String dpop = DPoPGenerator.generateRsaSignedDPoPProof(tokenManager.getDpopKeyPair(), requestContext.getMethod(), requestUri, null);
+                requestContext.getHeaders().add(DPOP_HTTP_HEADER, dpop);
+            }
+        } else {
+            // Regular request to admin REST API
+            String accessToken = tokenManager.getAccessTokenString();
+            String dpop = DPoPGenerator.generateRsaSignedDPoPProof(tokenManager.getDpopKeyPair(), requestContext.getMethod(), requestUri, accessToken);
+            requestContext.getHeaders().add(DPOP_HTTP_HEADER, dpop);
+
+            String authHeader = DPOP_HTTP_HEADER + " " + accessToken;
+            requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, authHeader);
+        }
+    }
+
+
+    @Override
+    protected String getAuthHeaderPrefix() {
+        return DPOP_HTTP_HEADER;
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -17,12 +17,14 @@
 
 package org.keycloak.admin.client.token;
 
+import java.security.KeyPair;
+
 import jakarta.ws.rs.client.WebTarget;
-import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.keycloak.admin.client.Config;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.BasicAuthFilter;
+import org.keycloak.admin.client.resource.DPoPAuthFilter;
+import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.Time;
 import org.keycloak.representations.AccessTokenResponse;
 
@@ -30,7 +32,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Form;
 
-import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
 import static org.keycloak.OAuth2Constants.CLIENT_ID;
 import static org.keycloak.OAuth2Constants.GRANT_TYPE;
 import static org.keycloak.OAuth2Constants.PASSWORD;
@@ -51,6 +52,7 @@ public class TokenManager {
     private final Config config;
     private final TokenService tokenService;
     private final String accessTokenGrantType;
+    private final KeyPair dpopKeyPair;
 
     public TokenManager(Config config, Client client) {
         this.config = config;
@@ -58,6 +60,14 @@ public class TokenManager {
         if (!config.isPublicClient()) {
             target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
         }
+
+        if (this.config.isUseDPoP()) {
+            this.dpopKeyPair = KeyUtils.generateRsaKeyPair(2048);
+            target.register(new DPoPAuthFilter(this, true));
+        } else {
+            this.dpopKeyPair = null;
+        }
+
         this.tokenService = Keycloak.getClientProvider().targetProxy(target, TokenService.class);
         this.accessTokenGrantType = config.getGrantType();
     }
@@ -160,5 +170,12 @@ public class TokenManager {
             // When used next, this cause a refresh attempt, that in turn will cause a grant attempt if refreshing fails.
             expirationTime = -1;
         }
+    }
+
+    /**
+     * @return dpopKeyPair if it was generated or null if DPoP is not being requested by the configuration
+     */
+    public KeyPair getDpopKeyPair() {
+        return dpopKeyPair;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -122,7 +122,8 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
 
         event.detail(Details.REQUESTED_TOKEN_TYPE, context.getParams().getRequestedTokenType());
 
-        AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, null, false, subjectToken, context.getHeaders());
+        AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, null,
+                false, subjectToken, context.getHeaders(), verifier -> {});
         if (authResult == null) {
             event.detail(Details.REASON, "subject_token validation failure");
             event.error(Errors.INVALID_TOKEN);

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
@@ -115,7 +115,8 @@ public class V1TokenExchangeProvider extends AbstractTokenExchangeProvider {
 
             }
 
-            AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, null, false, subjectToken, context.getHeaders());
+            AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, null,
+                    false, subjectToken, context.getHeaders(), verifier -> {});
             if (authResult == null) {
                 event.detail(Details.REASON, "subject_token validation failure");
                 event.error(Errors.INVALID_TOKEN);

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/DPoPBindEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/DPoPBindEnforcerExecutor.java
@@ -26,18 +26,14 @@ import org.keycloak.common.Profile.Feature;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
-import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.representations.AccessToken;
-import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
-import org.keycloak.services.clientpolicy.context.TokenRefreshContext;
 import org.keycloak.services.clientpolicy.context.TokenRevokeContext;
-import org.keycloak.services.clientpolicy.context.UserInfoRequestContext;
 import org.keycloak.services.util.DPoPUtil;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -105,7 +101,7 @@ public class DPoPBindEnforcerExecutor implements ClientPolicyExecutorProvider<DP
             case BACKCHANNEL_TOKEN_REQUEST:
                 // Codes for processing these requests verifies DPoP.
                 // If this verification is done twice, DPoPReplayCheck fails. Therefore, the executor only checks existence of DPoP Proof
-                if (request.getHttpHeaders().getHeaderString(DPoPUtil.DPOP_HTTP_HEADER) == null) {
+                if (request.getHttpHeaders().getHeaderString(OAuth2Constants.DPOP_HTTP_HEADER) == null) {
                     throw new ClientPolicyException(OAuthErrorException.INVALID_DPOP_PROOF, "DPoP proof is missing");
                 }
                 break;

--- a/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
@@ -24,10 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.BooleanSupplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -84,6 +80,8 @@ import org.keycloak.services.cors.Cors;
 import org.keycloak.util.JWKSUtils;
 import org.keycloak.util.TokenUtil;
 
+import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
+import static org.keycloak.OAuth2Constants.DPOP_HTTP_HEADER;
 import static org.keycloak.utils.StringUtil.isNotBlank;
 
 /**
@@ -102,10 +100,6 @@ public class DPoPUtil {
         OPTIONAL,
         DISABLED
     }
-
-    public static final String DPOP_HTTP_HEADER = "DPoP";
-    private static final String DPOP_JWT_HEADER_TYPE = "dpop+jwt";
-    public static final String DPOP_ATH_ALG = "RS256";
 
     private static URI normalize(URI uri) {
         return UriBuilder.fromUri(uri).replaceQuery("").build();
@@ -151,7 +145,7 @@ public class DPoPUtil {
 
         HttpRequest request = keycloakSession.getContext().getHttpRequest();
         final boolean isClientRequiresDpop = clientConfig != null && clientConfig.isUseDPoP();
-        final boolean isDpopHeaderPresent = request.getHttpHeaders().getHeaderString(DPoPUtil.DPOP_HTTP_HEADER) != null;
+        final boolean isDpopHeaderPresent = request.getHttpHeaders().getHeaderString(DPOP_HTTP_HEADER) != null;
 
         if (!isClientRequiresDpop && !isDpopHeaderPresent) {
             return;
@@ -445,7 +439,7 @@ public class DPoPUtil {
         private final String hash;
 
         public DPoPAccessTokenHashCheck(String tokenString) {
-            hash = HashUtils.accessTokenHash(DPOP_ATH_ALG, tokenString, true);
+            hash = HashUtils.accessTokenHash(OAuth2Constants.DPOP_DEFAULT_ALGORITHM.toString(), tokenString, true);
         }
 
         @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/AdminClientUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/AdminClientUtil.java
@@ -59,18 +59,18 @@ public class AdminClientUtil {
 
     public static Keycloak createAdminClient(boolean ignoreUnknownProperties, String authServerContextRoot) throws Exception {
         return createAdminClient(ignoreUnknownProperties, authServerContextRoot, MASTER, ADMIN, ADMIN,
-            Constants.ADMIN_CLI_CLIENT_ID, null, null);
+            Constants.ADMIN_CLI_CLIENT_ID, null, null, false);
 
     }
 
     public static Keycloak createAdminClient(boolean ignoreUnknownProperties, String realmName, String username,
         String password, String clientId, String clientSecret) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, KeyManagementException {
         return createAdminClient(ignoreUnknownProperties, getAuthServerContextRoot(), realmName, username, password,
-            clientId, clientSecret, null);
+            clientId, clientSecret, null, false);
     }
 
     public static Keycloak createAdminClient(boolean ignoreUnknownProperties, String authServerContextRoot, String realmName,
-        String username, String password, String clientId, String clientSecret, String scope)
+        String username, String password, String clientId, String clientSecret, String scope, boolean useDPoP)
         throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, KeyManagementException {
 
         ResteasyClient resteasyClient = createResteasyClient(ignoreUnknownProperties, null);
@@ -83,7 +83,9 @@ public class AdminClientUtil {
                 .clientId(clientId)
                 .clientSecret(clientSecret)
                 .resteasyClient(resteasyClient)
-                .scope(scope).build();
+                .scope(scope)
+                .useDPoP(useDPoP)
+                .build();
     }
 
     public static Keycloak createAdminClientWithClientCredentials(String realmName, String clientId, String clientSecret, String scope)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminClientTest.java
@@ -220,7 +220,7 @@ public class AdminClientTest extends AbstractKeycloakTest {
     @Test
     public void adminAuthUserDisabled() throws Exception {
         try (Keycloak adminClient = AdminClientUtil.createAdminClient(false, realmName, "test-user@localhost", "password", Constants.ADMIN_CLI_CLIENT_ID, null);
-             Keycloak adminClientOffline = AdminClientUtil.createAdminClient(false, ServerURLs.getAuthServerContextRoot(), realmName, "test-user@localhost", "password", Constants.ADMIN_CLI_CLIENT_ID, null, OAuth2Constants.OFFLINE_ACCESS);
+             Keycloak adminClientOffline = AdminClientUtil.createAdminClient(false, ServerURLs.getAuthServerContextRoot(), realmName, "test-user@localhost", "password", Constants.ADMIN_CLI_CLIENT_ID, null, OAuth2Constants.OFFLINE_ACCESS, false);
         ) {
             // Check possible to load the realm
             RealmRepresentation realm = adminClient.realm(realmName).toRepresentation();


### PR DESCRIPTION
…admin-client DPoP support

closes #33942

- PR adds support for the DPoP verification for the admin REST API and account REST API endpoints. The only real change on the server-side is in fact introducing DPoP validation support in the `AppAuthManager.authenticate()` , which is done by re-using same validator already used for user-info endpoint . The `AppAuthManager` is used by both admin REST API and account REST API, so this adds support to both of them (it adds support to few other server endpoints, which supported authentication by `Authorization: Bearer` header and which are using `AppAuthManager` like for example https://www.keycloak.org/docs/latest/server_admin/index.html#retrieving-external-idp-tokens endpoint)

- Support for DPoP in the java admin-client . This is implemented by adding `DPoPAuthFilter` in the java admin-client stack instead of `BearerAuthFilter` . Some minor refactoring done to re-use some snippets already used in the testsuite (Especially introducing `DPoPGenerator`, which is now used by both admin-client and testsuite. This contains just some methods, which were moved to it from `ClientPoliciesUtil` ).
