### PR TITLE
Do not query organizations if manage-realm is not granted

### DIFF
--- a/js/apps/admin-ui/src/utils/useIsFeatureEnabled.ts
+++ b/js/apps/admin-ui/src/utils/useIsFeatureEnabled.ts
@@ -1,4 +1,5 @@
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { useAccess } from "../context/access/Access";
 
 export enum Feature {
   AdminFineGrainedAuthz = "ADMIN_FINE_GRAINED_AUTHZ",
@@ -20,13 +21,23 @@ export enum Feature {
 
 export default function useIsFeatureEnabled() {
   const { features } = useServerInfo();
+  const { hasAccess } = useAccess();
+
+  const hasFeatureAccess = (feature: Feature) => {
+    switch (feature) {
+      case Feature.Organizations:
+        return hasAccess("manage-realm");
+      default:
+        return true;
+    }
+  };
 
   return function isFeatureEnabled(feature: Feature) {
     if (!features) {
       return false;
     }
     return features
-      .filter((f) => f.enabled)
+      .filter((f) => f.enabled && hasFeatureAccess(f.name as Feature))
       .map((f) => f.name)
       .includes(feature);
   };


### PR DESCRIPTION
Closes #41418

* Currently, the Organization API relies on the `manage-realm` role to enforce admin access.
* The `useIsFeatureEnabled` hook is updated to also check permissions when checking if a feature is enabled. That should make the UI also a bit better because the `Organizations` settings in the `Realm Settings` tab is not even shown if the admin user does not have the required role.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
