### PR TITLE
create helm chart for keycloak-operator

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -196,6 +196,72 @@ jobs:
           echo "$out" | grep -A4 'resources:' | grep -q 'cpu: 1500m'
           echo "$out" | grep -A4 'resources:' | grep -q 'memory: 1Gi'
 
+  test-helm-install:
+    name: Helm chart install on Kubernetes
+    if: needs.conditional.outputs.operator == 'true'
+    runs-on: ubuntu-latest
+    needs: conditional
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Java
+        uses: ./.github/actions/java-setup
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.14.4
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55 # v2.18.0
+        with:
+          minikube version: ${{ env.MINIKUBE_VERSION }}
+          kubernetes version: ${{ env.KUBERNETES_VERSION }}
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+          start args: --memory=${{ env.MINIKUBE_MEMORY }} --cpus=max
+
+      - name: Build the operator image and Helm chart
+        # Build the chart cluster-wide (see test-helm) and the operator image in
+        # one reactor run, inside minikube's docker daemon so the cluster can use
+        # the image without a registry push. image-pull-policy=IfNotPresent makes
+        # the kubelet use the local image instead of pulling.
+        run: |
+          eval $(minikube -p minikube docker-env)
+          ./mvnw -B -Poperator -Pcluster-wide -pl :keycloak-operator -am package -DskipTests \
+            -Dquarkus.container-image.build=true \
+            -Dquarkus.container-image.tag=ci \
+            -Dquarkus.kubernetes.image-pull-policy=IfNotPresent
+
+      - name: helm install
+        # A real API-server install validates what `helm template` cannot: the
+        # ClusterRoleBinding ServiceAccount subjects must carry a namespace or
+        # the API server rejects them. --wait blocks until the Deployment is
+        # Available, so a crash-looping or unschedulable operator fails the job.
+        run: |
+          set -euo pipefail
+          kubectl create namespace keycloak-operator
+          helm install kc-op operator/target/helm/kubernetes/keycloak-operator \
+            --namespace keycloak-operator \
+            --set operator.image=keycloak/keycloak-operator:ci \
+            --wait --timeout 5m
+
+      - name: Verify the operator is running
+        run: |
+          set -euo pipefail
+          kubectl -n keycloak-operator rollout status deployment/keycloak-operator --timeout=300s
+          for crd in keycloaks keycloakrealmimports keycloakoidcclients keycloaksamlclients; do
+            kubectl get crd "${crd}.k8s.keycloak.org"
+          done
+          kubectl -n keycloak-operator get pods
+
+      - name: Dump operator diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n keycloak-operator get all || true
+          kubectl -n keycloak-operator describe deployment/keycloak-operator || true
+          kubectl -n keycloak-operator logs deployment/keycloak-operator --tail=300 || true
+
   test-olm:
     name: Test OLM installation
     runs-on: ubuntu-latest
@@ -426,6 +492,7 @@ jobs:
       - test-local-apiserver
       - test-remote
       - test-helm
+      - test-helm-install
       - test-olm
       - test-kustomize
     runs-on: ubuntu-latest

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -166,7 +166,7 @@ jobs:
           # Default install ships one CRD per CR class (Keycloak, KeycloakRealmImport,
           # KeycloakOIDCClient, KeycloakSAMLClient) plus the operator's Deployment.
           crds=$(echo "$out" | grep -cE '^kind: "?CustomResourceDefinition"?$' || true)
-          if [ "$crds" -lt 2 ]; then echo "expected >=2 CRDs, got $crds"; exit 1; fi
+          if [ "$crds" -ne 4 ]; then echo "expected 4 CRDs, got $crds"; exit 1; fi
           echo "$out" | grep -qE '^kind: Deployment$'
           # Cluster-wide install binds the controllers via ClusterRoleBinding.
           echo "$out" | grep -qE '^kind: ClusterRoleBinding$'

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -135,6 +135,67 @@ jobs:
               -Dtest.operator.custom.image=custom-keycloak:${{ env.version_remote }} \
               --no-transfer-progress -Dtest.operator.deployment=remote ${PARAMS["${{ matrix.suite }}"]}
 
+  test-helm:
+    name: Helm chart lint and smoke render
+    if: needs.conditional.outputs.operator == 'true'
+    runs-on: ubuntu-latest
+    needs: conditional
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Java
+        uses: ./.github/actions/java-setup
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.14.4
+
+      - name: Generate the Helm chart
+        # The Helm chart installs the Operator cluster-wide (see docs). Build it with
+        # the cluster-wide profile so the generated RBAC watches all namespaces.
+        run: ./mvnw -B -Poperator -Pcluster-wide -pl :keycloak-operator -am package -DskipTests -Dmaven.test.skip=true
+
+      - name: helm lint
+        run: helm lint operator/target/helm/kubernetes/keycloak-operator
+
+      - name: helm template — default
+        run: |
+          set -euo pipefail
+          out=$(helm template kc-op operator/target/helm/kubernetes/keycloak-operator)
+          # Default install ships one CRD per CR class (Keycloak, KeycloakRealmImport,
+          # KeycloakOIDCClient, KeycloakSAMLClient) plus the operator's Deployment.
+          crds=$(echo "$out" | grep -cE '^kind: "?CustomResourceDefinition"?$' || true)
+          if [ "$crds" -lt 2 ]; then echo "expected >=2 CRDs, got $crds"; exit 1; fi
+          echo "$out" | grep -qE '^kind: Deployment$'
+          # Cluster-wide install binds the controllers via ClusterRoleBinding.
+          echo "$out" | grep -qE '^kind: ClusterRoleBinding$'
+          # No resource should be rendered twice (kind+name+namespace must be unique).
+          dupes=$(echo "$out" | awk '
+            /^kind:/{k=$2} /^  name:/{n=$2} /^  namespace:/{ns=$2}
+            /^---/{if(k&&n)print k"/"ns"/"n; k=n=ns=""}
+            END{if(k&&n)print k"/"ns"/"n}' | sort | uniq -d)
+          if [ -n "$dupes" ]; then echo "duplicate resources rendered:"; echo "$dupes"; exit 1; fi
+
+      - name: helm template — crds.enabled=false
+        run: |
+          set -euo pipefail
+          out=$(helm template kc-op operator/target/helm/kubernetes/keycloak-operator --set crds.enabled=false)
+          # CRDs are excluded; everything else still renders.
+          if echo "$out" | grep -qE '^kind: "?CustomResourceDefinition"?$'; then
+            echo "expected no CRDs with crds.enabled=false"; exit 1
+          fi
+          echo "$out" | grep -cE '^kind: Deployment$' | grep -q '^1$'
+
+      - name: helm template — resource overrides
+        run: |
+          set -euo pipefail
+          out=$(helm template kc-op operator/target/helm/kubernetes/keycloak-operator \
+            --set-string operator.resources.limits.cpu=1500m \
+            --set-string operator.resources.limits.memory=1Gi)
+          echo "$out" | grep -A4 'resources:' | grep -q 'cpu: 1500m'
+          echo "$out" | grep -A4 'resources:' | grep -q 'memory: 1Gi'
+
   test-olm:
     name: Test OLM installation
     runs-on: ubuntu-latest
@@ -364,6 +425,7 @@ jobs:
       - build
       - test-local-apiserver
       - test-remote
+      - test-helm
       - test-olm
       - test-kustomize
     runs-on: ubuntu-latest

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -141,20 +141,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: conditional
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.14.4
 
       - name: Generate the Helm chart
         # The Helm chart installs the Operator cluster-wide (see docs). Build it with
         # the cluster-wide profile so the generated RBAC watches all namespaces.
-        run: ./mvnw -B -Poperator -Pcluster-wide -pl :keycloak-operator -am package -DskipTests -Dmaven.test.skip=true
+        run: ./mvnw -B -Poperator -Pcluster-wide -pl :keycloak-operator -am package -DskipTests
 
       - name: helm lint
         run: helm lint operator/target/helm/kubernetes/keycloak-operator

--- a/docs/guides/operator/installation.adoc
+++ b/docs/guides/operator/installation.adoc
@@ -258,6 +258,56 @@ kubectl apply -k ./
 ----
 
 You can now create `Keycloak` custom resources in any namespace. The Operator reconciles resources cluster-wide.
+
+=== Installing by using Helm
+
+The Operator Helm chart is published as an OCI artifact to Quay alongside each Operator release. It installs the Operator cluster-wide, deploying the same resources as the `kubectl` install path above, with values that let you tune image, resources, and CRD management.
+
+Install the Operator into the `keycloak` namespace:
+
+[source,bash,subs="attributes+"]
+----
+helm install keycloak-operator oci://quay.io/keycloak/keycloak-operator-helm \
+  --namespace keycloak --create-namespace
+----
+
+By default, the chart installs the Operator CRDs (for example `Keycloak`, `KeycloakRealmImport`, `KeycloakOIDCClient`, `KeycloakSAMLClient`) as part of the release. If your CRDs are managed out-of-band (for example, applied separately as part of a cluster bootstrap), disable CRD installation with `--set crds.enabled=false`.
+
+==== Tuning the install
+
+Common values you may want to override:
+
+[cols="1,2",options="header"]
+|===
+| Value | Description
+| `operator.image` | Operator image reference. Defaults to the image published for this release.
+| `operator.resources.limits.cpu` / `operator.resources.limits.memory` | Container CPU/memory limits.
+| `operator.resources.requests.cpu` / `operator.resources.requests.memory` | Container CPU/memory requests.
+| `crds.enabled` | Whether to install the CRDs as part of this release. Defaults to `true`.
+|===
+
+Run `helm show values oci://quay.io/keycloak/keycloak-operator-helm` for the full list.
+
+==== Migrating from the kubectl install path
+
+The Helm chart deploys the same Kubernetes resources as the kustomize install above (same `ServiceAccount`, `ClusterRole`, `ClusterRoleBinding`, `Service`, `Deployment` names). Migration steps:
+
+. Delete the existing operator install, **keeping** the CRDs (do not delete the `keycloaks.k8s.keycloak.org` or `keycloakrealmimports.k8s.keycloak.org` CRDs — that would garbage-collect every `Keycloak` and `KeycloakRealmImport` resource in the cluster).
++
+[source,bash,subs="attributes+"]
+----
+kubectl delete -k 'github.com/keycloak/keycloak-k8s-resources/cluster-wide?ref={version}'
+----
+
+. Install via Helm with `crds.enabled=false` so Helm does not try to re-create the CRDs Helm did not originally install:
++
+[source,bash,subs="attributes+"]
+----
+helm install keycloak-operator oci://quay.io/keycloak/keycloak-operator-helm \
+  --namespace keycloak --set crds.enabled=false
+----
+
+After the chart is installed and the operator is healthy, you can leave CRD management as-is (out-of-band) or transfer ownership to the chart on the next upgrade by setting the `helm.sh/resource-policy: keep` annotation on the existing CRDs and re-installing with `crds.enabled=true`.
 </@profile.ifCommunity>
 
 === Installing Multiple Operators

--- a/docs/guides/operator/installation.adoc
+++ b/docs/guides/operator/installation.adoc
@@ -296,7 +296,7 @@ The Helm chart deploys the same Kubernetes resources as the kustomize install ab
 +
 [source,bash,subs="attributes+"]
 ----
-kubectl delete -k 'github.com/keycloak/keycloak-k8s-resources/cluster-wide?ref={version}'
+kubectl delete -k 'github.com/keycloak/keycloak-k8s-resources/kubernetes/cluster-wide?ref={version}'
 ----
 
 . Install via Helm with `crds.enabled=false` so Helm does not try to re-create the CRDs Helm did not originally install:

--- a/docs/guides/operator/installation.adoc
+++ b/docs/guides/operator/installation.adoc
@@ -292,11 +292,13 @@ Run `helm show values oci://quay.io/keycloak/keycloak-operator-helm` for the ful
 
 The Helm chart deploys the same Kubernetes resources as the kustomize install above (same `ServiceAccount`, `ClusterRole`, `ClusterRoleBinding`, `Service`, `Deployment` names). Migration steps:
 
-. Delete the existing operator install, **keeping** the CRDs (do not delete the `keycloaks.k8s.keycloak.org` or `keycloakrealmimports.k8s.keycloak.org` CRDs — that would garbage-collect every `Keycloak` and `KeycloakRealmImport` resource in the cluster).
+. Delete only the existing operator workload and RBAC resources, **keeping** the CRDs. Do not run `kubectl delete -k` against the kustomization, because it also deletes the CRDs (`keycloaks.k8s.keycloak.org`, `keycloakrealmimports.k8s.keycloak.org`, and the client CRDs) — that would garbage-collect every `Keycloak`, `KeycloakRealmImport`, and client custom resource in the cluster. Delete the resources by name instead (replace `keycloak` with the namespace you installed the Operator into):
 +
 [source,bash,subs="attributes+"]
 ----
-kubectl delete -k 'github.com/keycloak/keycloak-k8s-resources/kubernetes/cluster-wide?ref={version}'
+kubectl delete deployment,service,serviceaccount keycloak-operator -n keycloak
+kubectl delete clusterrole keycloak-operator-clusterrole
+kubectl delete clusterrolebinding keycloak-operator-clusterrole-binding
 ----
 
 . Install via Helm with `crds.enabled=false` so Helm does not try to re-create the CRDs Helm did not originally install:

--- a/operator/README.md
+++ b/operator/README.md
@@ -32,7 +32,7 @@ A Helm chart is generated alongside the regular build, under `operator/target/he
 To regenerate locally (from the repo root):
 
 ```bash
-./mvnw -Poperator -pl :keycloak-operator -am package -DskipTests -Dmaven.test.skip=true
+./mvnw -Poperator -Pcluster-wide -pl :keycloak-operator -am package -DskipTests
 ```
 
 Then `helm install` / `helm template` against `operator/target/helm/kubernetes/keycloak-operator/`. See the [Operator Installation guide](../docs/guides/operator/installation.adoc) for end-user instructions.

--- a/operator/README.md
+++ b/operator/README.md
@@ -25,6 +25,20 @@ This will build a container image from `Dockerfile`, using `docker` by default. 
 - Set the `DOCKER_HOST` environment variable to point at this user socket. For example: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`.
 - You may also have to set `QUARKUS_DOCKER_EXECUTABLE_NAME=podman`
 
+## Helm chart
+
+A Helm chart is generated alongside the regular build, under `operator/target/helm/kubernetes/keycloak-operator/`. The chart is produced by the `quarkus-helm` + `quarkus-operator-sdk-helm` extensions from the same source manifests as the `kubectl` install path — it is not a hand-written copy.
+
+To regenerate locally (from the repo root):
+
+```bash
+./mvnw -Poperator -pl :keycloak-operator -am package -DskipTests -Dmaven.test.skip=true
+```
+
+Then `helm install` / `helm template` against `operator/target/helm/kubernetes/keycloak-operator/`. See the [Operator Installation guide](../docs/guides/operator/installation.adoc) for end-user instructions.
+
+Helm chart configuration lives in `operator/src/main/resources/application.properties` under the `quarkus.helm.*` keys. CRDs are post-processed by `operator/scripts/post-process-helm-chart.sh` (wrapping them in a `{{ if .Values.crds.enabled }}` guard) — the rest is purely declarative.
+
 ## Configuration
 
 The Keycloak image can be configured, when starting the operator, using the Java property:

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -68,6 +68,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Helm chart generation -->
+        <dependency>
+            <groupId>io.quarkiverse.helm</groupId>
+            <artifactId>quarkus-helm</artifactId>
+            <version>1.2.7</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.operatorsdk</groupId>
+            <artifactId>quarkus-operator-sdk-helm</artifactId>
+            <version>7.4.0</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Quarkus -->
         <dependency>
             <groupId>io.quarkiverse.operatorsdk</groupId>
@@ -339,6 +353,28 @@
                     </systemPropertyVariables>
                     <groups>${kc.quarkus.tests.groups}</groups>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <!-- Post-process the chart emitted by quarkus-helm: wrap the
+                         generated CRDs in a {{ if .Values.crds.enabled }} guard. -->
+                    <execution>
+                        <id>post-process-helm-chart</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${basedir}/scripts/post-process-helm-chart.sh</executable>
+                            <arguments>
+                                <argument>${project.build.directory}/helm/kubernetes/keycloak-operator</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/operator/scripts/post-process-helm-chart.sh
+++ b/operator/scripts/post-process-helm-chart.sh
@@ -6,12 +6,26 @@
 # verbatim, which Helm installs unconditionally. Move them into templates/
 # wrapped in a {{ if .Values.crds.enabled }} guard so users can manage CRDs
 # out-of-band.
+#
+# RBAC subject namespaces: the (Cluster)RoleBinding subjects reference the
+# operator ServiceAccount without a namespace (the non-Helm install relies on
+# kustomize to fill these in). A ClusterRoleBinding ServiceAccount subject with
+# no namespace is rejected by the API server, and the base binding hardcodes
+# "keycloak"; both are wrong for a Helm release installed into an arbitrary
+# namespace. Rewrite every ServiceAccount subject to the release namespace.
+#
+# NOTE: quarkus-helm is pinned to 1.2.7 because quarkus-operator-sdk-helm is
+# pinned to 7.4.0 (the last version before 7.5.0's template-injection breaks the
+# chart). quarkus-helm 1.3.0+ populates empty subject namespaces on its own. Once
+# a newer quarkus-operator-sdk-helm is released, upgrade it ASAP and bump
+# quarkus-helm past 1.3.0, then delete the subject-namespace rewriting below.
 set -euo pipefail
 
 CHART_DIR="${1:?usage: post-process-helm-chart.sh <chart-dir>}"
 CRDS_DIR="${CHART_DIR}/crds"
 TEMPLATES_CRDS_DIR="${CHART_DIR}/templates/crds"
 VALUES_FILE="${CHART_DIR}/values.yaml"
+TEMPLATES_DIR="${CHART_DIR}/templates"
 
 if [[ -d "${CRDS_DIR}" ]]; then
   mkdir -p "${TEMPLATES_CRDS_DIR}"
@@ -32,3 +46,33 @@ fi
 if ! grep -q '^crds:' "${VALUES_FILE}" 2>/dev/null; then
   printf '\ncrds:\n  enabled: true\n' >> "${VALUES_FILE}"
 fi
+
+# Set every ServiceAccount subject's namespace to the release namespace. For
+# each subject, replace an existing namespace line or inject one right after the
+# "name:" line, preserving indentation.
+for binding in "${TEMPLATES_DIR}/clusterrolebinding.yaml" "${TEMPLATES_DIR}/rolebinding.yaml"; do
+  [[ -f "${binding}" ]] || continue
+  tmp="${binding}.tmp"
+  awk '
+    function flush_pending() {
+      if (pending) { print name_line; print indent "namespace: {{ .Release.Namespace }}"; pending=0 }
+    }
+    {
+      if (pending) {
+        if ($0 ~ /^[[:space:]]*namespace:[[:space:]]/) {
+          match($0, /^[[:space:]]*/); ind = substr($0, 1, RLENGTH)
+          print name_line; print ind "namespace: {{ .Release.Namespace }}"; pending=0; next
+        } else { flush_pending() }
+      }
+      if ($0 ~ /kind:[[:space:]]*ServiceAccount[[:space:]]*$/) { sa=1; print; next }
+      if (sa && $0 ~ /^[[:space:]]*name:[[:space:]]/) {
+        match($0, /^[[:space:]]*/); indent = substr($0, 1, RLENGTH)
+        name_line = $0; pending=1; sa=0; next
+      }
+      print
+    }
+    END { flush_pending() }
+  ' "${binding}" > "${tmp}"
+  mv "${tmp}" "${binding}"
+  echo "post-process-helm-chart: set ServiceAccount subject namespaces in $(basename "${binding}")"
+done

--- a/operator/scripts/post-process-helm-chart.sh
+++ b/operator/scripts/post-process-helm-chart.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Post-processes the chart emitted by quarkus-helm so it covers things the
+# extension cannot express today.
+#
+# CRDs: quarkus-operator-sdk-helm writes them into the chart's crds/ directory
+# verbatim, which Helm installs unconditionally. Move them into templates/
+# wrapped in a {{ if .Values.crds.enabled }} guard so users can manage CRDs
+# out-of-band.
+set -euo pipefail
+
+CHART_DIR="${1:?usage: post-process-helm-chart.sh <chart-dir>}"
+CRDS_DIR="${CHART_DIR}/crds"
+TEMPLATES_CRDS_DIR="${CHART_DIR}/templates/crds"
+VALUES_FILE="${CHART_DIR}/values.yaml"
+
+if [[ -d "${CRDS_DIR}" ]]; then
+  mkdir -p "${TEMPLATES_CRDS_DIR}"
+  shopt -s nullglob
+  for crd in "${CRDS_DIR}"/*.yml "${CRDS_DIR}"/*.yaml; do
+    dest="${TEMPLATES_CRDS_DIR}/$(basename "${crd}")"
+    {
+      echo '{{- if .Values.crds.enabled }}'
+      cat "${crd}"
+      echo '{{- end }}'
+    } > "${dest}"
+    rm "${crd}"
+  done
+  rmdir "${CRDS_DIR}" 2>/dev/null || true
+  echo "post-process-helm-chart: wrapped CRDs into ${TEMPLATES_CRDS_DIR}"
+fi
+
+if ! grep -q '^crds:' "${VALUES_FILE}" 2>/dev/null; then
+  printf '\ncrds:\n  enabled: true\n' >> "${VALUES_FILE}"
+fi

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -37,7 +37,6 @@ quarkus.operator-sdk.crd.post-processor=org.keycloak.operator.MultiVersionCRDPos
 # CRDs are auto-included by quarkus-operator-sdk-helm (crds/ directory).
 quarkus.helm.name=keycloak-operator
 quarkus.helm.description=A Helm chart to install the Keycloak Operator
-quarkus.helm.create-tar-file=true
 quarkus.helm.values-root-alias=operator
 
 quarkus.helm.type=application

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -31,3 +31,40 @@ quarkus.operator-sdk.bundle.channels=fast
 quarkus.docker.additional-args=--ulimit,nofile=1024000
 
 quarkus.operator-sdk.crd.post-processor=org.keycloak.operator.MultiVersionCRDPostProcessor
+
+# Helm chart generation (output: target/helm/kubernetes/keycloak-operator/)
+# Most templating is auto-derived from quarkus.kubernetes.* properties.
+# CRDs are auto-included by quarkus-operator-sdk-helm (crds/ directory).
+quarkus.helm.name=keycloak-operator
+quarkus.helm.description=A Helm chart to install the Keycloak Operator
+quarkus.helm.create-tar-file=true
+quarkus.helm.values-root-alias=operator
+
+quarkus.helm.type=application
+quarkus.helm.home=https://www.keycloak.org/operator/installation
+quarkus.helm.icon=https://www.keycloak.org/resources/images/logo.svg
+quarkus.helm.sources[0]=https://github.com/keycloak/keycloak
+quarkus.helm.keywords[0]=keycloak
+quarkus.helm.keywords[1]=operator
+quarkus.helm.keywords[2]=iam
+quarkus.helm.keywords[3]=sso
+quarkus.helm.maintainers."keycloak".name=Keycloak Team
+quarkus.helm.maintainers."keycloak".url=https://www.keycloak.org/community
+
+# Map container resources into values.yaml so they can be overridden at install time.
+quarkus.helm.values."resources.requests.cpu".paths=(kind == Deployment).spec.template.spec.containers.resources.requests.cpu
+quarkus.helm.values."resources.requests.cpu".description=CPU request for the operator container.
+quarkus.helm.values."resources.requests.memory".paths=(kind == Deployment).spec.template.spec.containers.resources.requests.memory
+quarkus.helm.values."resources.requests.memory".description=Memory request for the operator container.
+quarkus.helm.values."resources.limits.cpu".paths=(kind == Deployment).spec.template.spec.containers.resources.limits.cpu
+quarkus.helm.values."resources.limits.cpu".description=CPU limit for the operator container.
+quarkus.helm.values."resources.limits.memory".paths=(kind == Deployment).spec.template.spec.containers.resources.limits.memory
+quarkus.helm.values."resources.limits.memory".description=Memory limit for the operator container.
+
+# Declare crds.enabled at the top level so it lands in values.yaml and values.schema.json
+# with a description. The actual {{ if .Values.crds.enabled }} wrapping of the CRD files
+# is done by scripts/post-process-helm-chart.sh
+quarkus.helm.values."crds.enabled".property=@.crds.enabled
+quarkus.helm.values."crds.enabled".value-as-bool=true
+quarkus.helm.values."crds.enabled".description=Install the Keycloak Operator CRDs as part of this Helm release. Disable to manage CRDs out-of-band.
+# Chart files are generated under target/ (target/helm/...) as part of the build.


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This PR creates a Helm Chart that deploys the Keycloak operator and allows to also install the CRD via a flag
part of #37636

Im not that knowledgeable about GitHub Actions, but i think that doing something similar to the [prometheus-community helm chart ](https://github.com/prometheus-community/helm-charts/blob/main/.github/workflows/ci.yaml)
or the [grafana helm chart](https://github.com/grafana/helm-charts/blob/main/.github/workflows/ci.yml) is a good starting point, for release i haven't found the github action for this [this repo](https://github.com/keycloak/keycloak-k8s-resources/tree/26.3.3), but maybe we can do the same mechanism and update the CRD in this folder?

