### PR TITLE
Add upstream architectures for the Operator

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakSharedCsvMetadata.java
@@ -141,7 +141,11 @@ import io.quarkiverse.operatorsdk.annotations.SharedCSVMetadata;
     icon = @CSVMetadata.Icon(
         fileName = "KeycloakController.icon.png",
         mediatype = "image/png"
-    )
+    ),
+    labels = {
+        @CSVMetadata.Label(name = "operatorframework.io/arch.amd64", value = "supported"),
+        @CSVMetadata.Label(name = "operatorframework.io/arch.arm64", value = "supported")
+    }
 )
 public class KeycloakSharedCsvMetadata implements SharedCSVMetadata {
 }


### PR DESCRIPTION
Closes #38928

This generates the labels as expected: 

```
  labels:
    operatorframework.io/arch.amd64: supported
    operatorframework.io/arch.arm64: supported
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
