### PR TITLE
Fix #42114 - Prevent caching closed EntityManager in KeycloakSession attributes

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -89,10 +89,10 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
         logger.trace("Create JpaConnectionProvider");
         lazyInit(session);
 
-        return new DefaultJpaConnectionProvider(createEntityManager(session));
+        return new DefaultJpaConnectionProvider(createEntityManager(session, true));
     }
 
-    private EntityManager createEntityManager(KeycloakSession session) {
+    private EntityManager createEntityManager(KeycloakSession session, boolean nestedEntityManagers) {
         EntityManager em;
         if (!jtaEnabled) {
             logger.trace("enlisting EntityManager in JpaKeycloakTransaction");
@@ -101,7 +101,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
 
             em = emf.createEntityManager(SynchronizationType.SYNCHRONIZED);
         }
-        em = EntityManagerProxy.create(session, em);
+        em = EntityManagerProxy.create(session, em, nestedEntityManagers);
         if (!jtaEnabled) {
             session.getTransactionManager().enlist(new JpaKeycloakTransaction(em));
         }
@@ -111,7 +111,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
     private void addSpecificNamedQueries(KeycloakSession session, Connection connection) {
         EntityManager em = null;
         try {
-            em = createEntityManager(session);
+            em = createEntityManager(session, false);
             String dbKind = getDatabaseType(connection.getMetaData().getDatabaseProductName());
             for (Map.Entry<Object, Object> query : loadSpecificNamedQueries(dbKind.toLowerCase()).entrySet()) {
                 String queryName = query.getKey().toString();


### PR DESCRIPTION
Fixes (#42114) "Session/EntityManager is closed" when trying to perform users import during application bootstrapping.

While performing `DefaultJpaConnectionProviderFactory::addSpecificNamedQueries` during lazy initialization the entity manager should not be cached for users import batch processing (aka "nested entity managers"). The EntityManager instance is transient and the given method closes it and the JPA connection along with it during the method's "finally" block.

The issue got introduced with commit https://github.com/keycloak/keycloak/commit/24910d9e1c76a1e953936c558ab02a27eb91820e which was first introduced to Keycloak v26.3.0.

Closes #42114