### PR TITLE
fix: moving multi-option validation to propertymappergrouping interface

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -20,7 +20,7 @@ package org.keycloak.quarkus.runtime;
 import static org.keycloak.quarkus.runtime.Environment.getKeycloakModeFromProfile;
 import static org.keycloak.quarkus.runtime.Environment.isNonServerMode;
 import static org.keycloak.quarkus.runtime.Environment.isTestLaunchMode;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 import org.keycloak.quarkus.runtime.cli.command.Build;
 import picocli.CommandLine;
 
@@ -49,7 +49,7 @@ public final class Messages {
     }
 
     public static String optimizedUsedForFirstStartup() {
-        return String.format("The '%s' flag was used for first ever server start. Please don't use this flag for the first startup or use '%s %s' to build the server first.", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, Environment.getCommand(), Build.NAME);
+        return String.format("The '%s' flag was used for first ever server start. Please don't use this flag for the first startup or use '%s %s' to build the server first.", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, Environment.getCommand(), Build.NAME);
     }
 
     public static String invalidLogLevel(String logLevel) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -22,7 +22,7 @@ import static org.keycloak.quarkus.runtime.Environment.getProviderFiles;
 import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import static org.keycloak.quarkus.runtime.Environment.isRebuildCheck;
 import static org.keycloak.quarkus.runtime.cli.OptionRenderer.decorateDuplicitOptionName;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isUserModifiable;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
 import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_COMMAND_LIST;
@@ -54,7 +54,7 @@ import org.keycloak.quarkus.runtime.KeycloakMain;
 import org.keycloak.quarkus.runtime.Messages;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
 import org.keycloak.quarkus.runtime.cli.command.AbstractNonServerCommand;
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 import org.keycloak.quarkus.runtime.cli.command.Main;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
@@ -921,7 +921,7 @@ public class Picocli {
         }
         this.parsedCommand = Optional.ofNullable(command);
 
-        if (!Environment.isRebuilt() && command instanceof AbstractStartCommand
+        if (!Environment.isRebuilt() && command instanceof AbstractAutoBuildCommand
                 && !cliArgs.contains(OPTIMIZED_BUILD_OPTION_LONG)) {
             Environment.setRebuildCheck();
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -256,7 +256,6 @@ public class Picocli {
 
         final boolean disabledMappersInterceptorEnabled = DisabledMappersInterceptor.isEnabled(); // return to the state before the disable
         try {
-            PropertyMappingInterceptor.disable(); // we don't want the mapped / transformed properties, we want what the user effectively supplied
             DisabledMappersInterceptor.disable(); // we want all properties, even disabled ones
 
             final List<String> ignoredRunTime = new ArrayList<>();
@@ -295,7 +294,7 @@ public class Picocli {
                 }
                 String from = mapper.forKey(name).getFrom();
                 if (!name.equals(from)) {
-                    ConfigValue value = Configuration.getConfigValue(name);
+                    ConfigValue value = getUnmappedValue(name);
                     if (value.getValue() != null && isUserModifiable(value)) {
                         secondClassOptions.put(name, from);
                     }
@@ -313,14 +312,24 @@ public class Picocli {
             });
 
             // second pass validate any property mapper not seen in the first pass
-            // - this will catch required values, anything missing from the property names, or disabled
-            List<PropertyMapper<?>> mappers = new ArrayList<>(disabledMappers);
+            // - this will catch required values, anything missing from the property names
+            List<PropertyMapper<?>> mappers = new ArrayList<>();
             for (OptionCategory category : categories) {
                 Optional.ofNullable(PropertyMappers.getRuntimeMappers().get(category)).ifPresent(mappers::addAll);
                 Optional.ofNullable(PropertyMappers.getBuildTimeMappers().get(category)).ifPresent(mappers::addAll);
             }
 
             for (PropertyMapper<?> mapper : mappers) {
+                if (!mapper.hasWildcard()) {
+                    validateProperty(abstractCommand, options, ignoredRunTime, disabledBuildTime, disabledRunTime,
+                            deprecatedInUse, missingOption, disabledMappers, mapper, mapper.getFrom());
+                }
+            }
+
+            PropertyMappers.getPropertyMapperGroupings().forEach(g -> g.validateConfig(this));
+
+            // third pass check for disabled mappers
+            for (PropertyMapper<?> mapper : disabledMappers) {
                 if (!mapper.hasWildcard()) {
                     validateProperty(abstractCommand, options, ignoredRunTime, disabledBuildTime, disabledRunTime,
                             deprecatedInUse, missingOption, disabledMappers, mapper, mapper.getFrom());
@@ -355,7 +364,6 @@ public class Picocli {
             });
         } finally {
             DisabledMappersInterceptor.enable(disabledMappersInterceptorEnabled);
-            PropertyMappingInterceptor.enable();
         }
     }
 
@@ -366,11 +374,20 @@ public class Picocli {
         return ((longNewValue / 1000) * 1000) != longNewValue || ((longOldValue / 1000) * 1000) != longNewValue;
     }
 
+    private ConfigValue getUnmappedValue(String key) {
+        PropertyMappingInterceptor.disable();
+        try {
+            return Configuration.getConfigValue(key);
+        } finally {
+            PropertyMappingInterceptor.enable();
+        }
+    }
+
     private void validateProperty(AbstractCommand abstractCommand, IncludeOptions options,
             final List<String> ignoredRunTime, final Set<String> disabledBuildTime, final Set<String> disabledRunTime,
             final Set<String> deprecatedInUse, final Set<String> missingOption,
             final Set<PropertyMapper<?>> disabledMappers, PropertyMapper<?> mapper, String from) {
-        ConfigValue configValue = Configuration.getConfigValue(from);
+        ConfigValue configValue = getUnmappedValue(from);
         String configValueStr = configValue.getValue();
 
         // don't consider missing or anything below standard env properties
@@ -408,12 +425,7 @@ public class Picocli {
             return;
         }
 
-        PropertyMappingInterceptor.enable();
-        try {
-            mapper.validate(configValue);
-        } finally {
-            PropertyMappingInterceptor.disable();
-        }
+        mapper.validate(configValue);
 
         mapper.getDeprecatedMetadata().ifPresent(metadata -> handleDeprecated(deprecatedInUse, mapper, configValueStr, metadata));
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
@@ -1,7 +1,7 @@
 package org.keycloak.quarkus.runtime.cli;
 
 import static java.lang.String.format;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import java.io.PrintWriter;
 import java.util.Optional;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
@@ -41,7 +41,7 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 import picocli.CommandLine;
 import picocli.CommandLine.Help.Ansi;
 
-public abstract class AbstractStartCommand extends AbstractCommand {
+public abstract class AbstractAutoBuildCommand extends AbstractCommand {
 
     public static final String OPTIMIZED_BUILD_OPTION_LONG = "--optimized";
 
@@ -154,11 +154,6 @@ public abstract class AbstractStartCommand extends AbstractCommand {
 
     protected EnumSet<OptionCategory> excludedCategories() {
         return EnumSet.of(OptionCategory.IMPORT, OptionCategory.EXPORT);
-    }
-
-    @Override
-    public boolean isServing() {
-        return shouldStart();
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -137,4 +137,11 @@ public abstract class AbstractCommand implements Callable<Integer> {
         return Environment.PROD_PROFILE_VALUE;
     }
 
+    /**
+     * @return true if the command results in a server
+     */
+    public boolean isServing() {
+        return false;
+    }
+
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -138,7 +138,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
     }
 
     /**
-     * @return true if the command results in a server
+     * @return true if the command starts an http server
      */
     public boolean isServing() {
         return false;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractNonServerCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractNonServerCommand.java
@@ -26,7 +26,7 @@ import picocli.CommandLine;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class AbstractNonServerCommand extends AbstractStartCommand {
+public abstract class AbstractNonServerCommand extends AbstractAutoBuildCommand {
 
     @CommandLine.Mixin
     OptimizedMixin optimizedMixin = new OptimizedMixin();
@@ -57,8 +57,4 @@ public abstract class AbstractNonServerCommand extends AbstractStartCommand {
     public void onStart(QuarkusKeycloakApplication application) {
     }
 
-    @Override
-    public boolean isServing() {
-        return false;
-    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractNonServerCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractNonServerCommand.java
@@ -56,4 +56,9 @@ public abstract class AbstractNonServerCommand extends AbstractStartCommand {
 
     public void onStart(QuarkusKeycloakApplication application) {
     }
+
+    @Override
+    public boolean isServing() {
+        return false;
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -35,8 +35,6 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.mappers.HostnameV2PropertyMappers;
-import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
@@ -149,15 +147,6 @@ public abstract class AbstractStartCommand extends AbstractCommand {
     }
 
     @Override
-    protected void validateConfig() {
-        super.validateConfig(); // we want to run the generic validation here first to check for unknown options
-        if (shouldStart()) { // if not starting, we aren't accepting http requests so no validation needed
-            HttpPropertyMappers.validateConfig();
-            HostnameV2PropertyMappers.validateConfig(picocli);
-        }
-    }
-
-    @Override
     public List<OptionCategory> getOptionCategories() {
         EnumSet<OptionCategory> excludedCategories = excludedCategories();
         return super.getOptionCategories().stream().filter(optionCategory -> !excludedCategories.contains(optionCategory)).collect(Collectors.toList());
@@ -165,6 +154,11 @@ public abstract class AbstractStartCommand extends AbstractCommand {
 
     protected EnumSet<OptionCategory> excludedCategories() {
         return EnumSet.of(OptionCategory.IMPORT, OptionCategory.EXPORT);
+    }
+
+    @Override
+    public boolean isServing() {
+        return shouldStart();
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractUpdatesCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractUpdatesCommand.java
@@ -30,7 +30,7 @@ import org.keycloak.config.ConfigProviderFactory;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import picocli.CommandLine;
 
-public abstract class AbstractUpdatesCommand extends AbstractStartCommand {
+public abstract class AbstractUpdatesCommand extends AbstractAutoBuildCommand {
 
     @CommandLine.Mixin
     OptimizedMixin optimizedMixin = new OptimizedMixin();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
@@ -47,9 +47,4 @@ public final class Export extends AbstractNonServerCommand {
         return EnumSet.of(OptionCategory.IMPORT);
     }
 
-    @Override
-    public boolean isServing() {
-        return false;
-    }
-
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
@@ -21,7 +21,6 @@ import static org.keycloak.exportimport.ExportImportConfig.ACTION_EXPORT;
 
 import org.keycloak.config.OptionCategory;
 import org.keycloak.exportimport.ExportImportConfig;
-import org.keycloak.quarkus.runtime.configuration.mappers.ExportPropertyMappers;
 import picocli.CommandLine.Command;
 
 import java.util.EnumSet;
@@ -39,12 +38,6 @@ public final class Export extends AbstractNonServerCommand {
     }
 
     @Override
-    public void validateConfig() {
-        ExportPropertyMappers.validateConfig();
-        super.validateConfig();
-    }
-
-    @Override
     public String getName() {
         return NAME;
     }
@@ -52,6 +45,11 @@ public final class Export extends AbstractNonServerCommand {
     @Override
     protected EnumSet<OptionCategory> excludedCategories() {
         return EnumSet.of(OptionCategory.IMPORT);
+    }
+
+    @Override
+    public boolean isServing() {
+        return false;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
@@ -50,9 +50,4 @@ public final class Import extends AbstractNonServerCommand {
         return EnumSet.of(OptionCategory.EXPORT);
     }
 
-    @Override
-    public boolean isServing() {
-        return false;
-    }
-
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
@@ -21,7 +21,6 @@ import static org.keycloak.exportimport.ExportImportConfig.ACTION_IMPORT;
 
 import org.keycloak.config.OptionCategory;
 import org.keycloak.exportimport.ExportImportConfig;
-import org.keycloak.quarkus.runtime.configuration.mappers.ImportPropertyMappers;
 import picocli.CommandLine.Command;
 
 import java.util.EnumSet;
@@ -42,12 +41,6 @@ public final class Import extends AbstractNonServerCommand {
     }
 
     @Override
-    public void validateConfig() {
-        ImportPropertyMappers.validateConfig();
-        super.validateConfig();
-    }
-
-    @Override
     public String getName() {
         return NAME;
     }
@@ -55,6 +48,11 @@ public final class Import extends AbstractNonServerCommand {
     @Override
     protected EnumSet<OptionCategory> excludedCategories() {
         return EnumSet.of(OptionCategory.EXPORT);
+    }
+
+    @Override
+    public boolean isServing() {
+        return false;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/OptimizedMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/OptimizedMixin.java
@@ -20,7 +20,7 @@ package org.keycloak.quarkus.runtime.cli.command;
 import picocli.CommandLine;
 
 import static org.keycloak.quarkus.runtime.cli.Picocli.NO_PARAM_LABEL;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 public final class OptimizedMixin {
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.quarkus.runtime.cli.command;
 
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ import picocli.CommandLine.Command;
         footer = "%nBy default, this command tries to update the server configuration by running a '" + Build.NAME + "' before starting the server. You can disable this behavior by using the '" + OPTIMIZED_BUILD_OPTION_LONG + "' option:%n%n"
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} '" + OPTIMIZED_BUILD_OPTION_LONG + "'%n%n"
                 + "By doing that, the server should start faster based on any previous configuration you have set when manually running the '" + Build.NAME + "' command.")
-public final class Start extends AbstractStartCommand {
+public final class Start extends AbstractAutoBuildCommand {
 
     public static final String NAME = "start";
 
@@ -76,5 +76,10 @@ public final class Start extends AbstractStartCommand {
         } catch (PropertyException | ProfileException e) {
             picocli.usageException(e.getMessage(), e.getCause());
         }
+    }
+
+    @Override
+    public boolean isServing() {
+        return true;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/StartDev.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/StartDev.java
@@ -29,7 +29,7 @@ import picocli.CommandLine.Command;
         },
         footer = "%nDo NOT start the server using this command when deploying to production.%n%n"
                 + "Use '${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --help-all' to list all available options, including build options.")
-public final class StartDev extends AbstractStartCommand {
+public final class StartDev extends AbstractAutoBuildCommand {
 
     public static final String NAME = "start-dev";
 
@@ -54,5 +54,10 @@ public final class StartDev extends AbstractStartCommand {
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public boolean isServing() {
+        return true;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
@@ -18,20 +18,19 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import org.keycloak.config.BootstrapAdminOptions;
+import org.keycloak.config.OptionCategory;
 
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public final class BootstrapAdminPropertyMappers {
+public final class BootstrapAdminPropertyMappers implements PropertyMapperGrouping {
 
     private static final String PASSWORD_SET = "bootstrap admin password is set";
     private static final String CLIENT_SECRET_SET = "bootstrap admin client secret is set";
 
-    private BootstrapAdminPropertyMappers() {
-    }
-
     // We prefer validators here to isEnabled so that the options show up in help
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[]{
                 fromOption(BootstrapAdminOptions.USERNAME)
                         .paramLabel("username")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/BootstrapAdminPropertyMappers.java
@@ -18,10 +18,11 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import org.keycloak.config.BootstrapAdminOptions;
-import org.keycloak.config.OptionCategory;
 
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
+
+import java.util.List;
 
 public final class BootstrapAdminPropertyMappers implements PropertyMapperGrouping {
 
@@ -30,8 +31,8 @@ public final class BootstrapAdminPropertyMappers implements PropertyMapperGroupi
 
     // We prefer validators here to isEnabled so that the options show up in help
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(BootstrapAdminOptions.USERNAME)
                         .paramLabel("username")
                         .addValidateEnabled(BootstrapAdminPropertyMappers::isPasswordSet, PASSWORD_SET)
@@ -51,8 +52,8 @@ public final class BootstrapAdminPropertyMappers implements PropertyMapperGroupi
                 fromOption(BootstrapAdminOptions.CLIENT_SECRET)
                         .paramLabel("client secret")
                         .isMasked(true)
-                        .build(),
-        };
+                        .build()
+        );
     }
 
     private static boolean isPasswordSet() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/CachingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/CachingPropertyMappers.java
@@ -33,7 +33,7 @@ final class CachingPropertyMappers implements PropertyMapperGrouping {
     private static final String CACHE_STACK_SET_TO_ISPN = "'cache' type is set to '" + CachingOptions.Mechanism.ispn.name() + "'";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
+    public List<PropertyMapper<?>> getPropertyMappers() {
         List<PropertyMapper<?>> staticMappers = List.of(
                 fromOption(CachingOptions.CACHE)
                         .paramLabel("type")
@@ -167,7 +167,7 @@ final class CachingPropertyMappers implements PropertyMapperGrouping {
             mappers.add(maxCountOpt(cache, InfinispanUtils::isEmbeddedInfinispan, "embedded Infinispan clusters configured"));
         }
 
-        return mappers.toArray(new PropertyMapper[0]);
+        return mappers;
     }
 
     private static boolean getDefaultMtlsEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/CachingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/CachingPropertyMappers.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-import org.hibernate.boot.model.source.spi.Caching;
 import org.keycloak.common.Profile;
 import org.keycloak.config.CachingOptions;
 import org.keycloak.config.Option;
@@ -25,7 +24,7 @@ import com.google.common.base.CaseFormat;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
 
-final class CachingPropertyMappers {
+final class CachingPropertyMappers implements PropertyMapperGrouping {
 
     private static final String REMOTE_HOST_SET = "remote host is set";
     private static final String MULTI_SITE_OR_EMBEDDED_REMOTE_FEATURE_SET = "feature '%s' or '%s' is set".formatted(Profile.Feature.MULTI_SITE.getKey(), Profile.Feature.CLUSTERLESS.getKey());
@@ -33,10 +32,8 @@ final class CachingPropertyMappers {
 
     private static final String CACHE_STACK_SET_TO_ISPN = "'cache' type is set to '" + CachingOptions.Mechanism.ispn.name() + "'";
 
-    private CachingPropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getClusteringPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         List<PropertyMapper<?>> staticMappers = List.of(
                 fromOption(CachingOptions.CACHE)
                         .paramLabel("type")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
@@ -8,16 +8,18 @@ import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
 import static org.keycloak.config.ClassLoaderOptions.QUARKUS_REMOVED_ARTIFACTS_PROPERTY;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 final class ClassLoaderPropertyMappers implements PropertyMapperGrouping {
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(ClassLoaderOptions.IGNORE_ARTIFACTS)
                         .to(QUARKUS_REMOVED_ARTIFACTS_PROPERTY)
                         .transformer(ClassLoaderPropertyMappers::resolveIgnoredArtifacts)
                         .build()
-        };
+        );
     }
 
     private static String resolveIgnoredArtifacts(String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
@@ -8,11 +8,10 @@ import org.keycloak.quarkus.runtime.configuration.IgnoredArtifacts;
 import static org.keycloak.config.ClassLoaderOptions.QUARKUS_REMOVED_ARTIFACTS_PROPERTY;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-final class ClassLoaderPropertyMappers {
+final class ClassLoaderPropertyMappers implements PropertyMapperGrouping {
 
-    private ClassLoaderPropertyMappers(){}
-
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(ClassLoaderOptions.IGNORE_ARTIFACTS)
                         .to(QUARKUS_REMOVED_ARTIFACTS_PROPERTY)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
@@ -9,15 +9,13 @@ import java.nio.file.Path;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public final class ConfigKeystorePropertyMappers {
+public final class ConfigKeystorePropertyMappers implements PropertyMapperGrouping {
     private static final String SMALLRYE_KEYSTORE_PATH = "smallrye.config.source.keystore.kc-default.path";
     private static final String SMALLRYE_KEYSTORE_PASSWORD = "smallrye.config.source.keystore.kc-default.password";
 
 
-    private ConfigKeystorePropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getConfigKeystorePropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(ConfigKeystoreOptions.CONFIG_KEYSTORE)
                         .to(SMALLRYE_KEYSTORE_PATH)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigKeystorePropertyMappers.java
@@ -6,6 +6,7 @@ import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
@@ -15,8 +16,8 @@ public final class ConfigKeystorePropertyMappers implements PropertyMapperGroupi
 
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(ConfigKeystoreOptions.CONFIG_KEYSTORE)
                         .to(SMALLRYE_KEYSTORE_PATH)
                         .transformer(ConfigKeystorePropertyMappers::validatePath)
@@ -32,7 +33,7 @@ public final class ConfigKeystorePropertyMappers implements PropertyMapperGroupi
                         .to("smallrye.config.source.keystore.kc-default.type")
                         .paramLabel("config-keystore-type")
                         .build()
-        };
+        );
     }
 
     private static String validatePath(String option, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -28,13 +28,11 @@ import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvi
 import static org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers.Datasources.appendDatasourceMappers;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-final class DatabasePropertyMappers {
+final class DatabasePropertyMappers implements PropertyMapperGrouping {
     private static final Logger log = Logger.getLogger(DatabasePropertyMappers.class);
 
-    private DatabasePropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getDatabasePropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         var mappers = new PropertyMapper<?>[]{
                 fromOption(DatabaseOptions.DB_DIALECT)
                         .mapFrom(DatabaseOptions.DB, DatabasePropertyMappers::transformDialect)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -32,8 +32,8 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
     private static final Logger log = Logger.getLogger(DatabasePropertyMappers.class);
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        var mappers = new PropertyMapper<?>[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        List<PropertyMapper<?>> mappers = List.of(
                 fromOption(DatabaseOptions.DB_DIALECT)
                         .mapFrom(DatabaseOptions.DB, DatabasePropertyMappers::transformDialect)
                         .build(),
@@ -104,7 +104,7 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
                         .build(),
                 fromOption(DB_URL_PATH)
                         .build()
-        };
+        );
 
         return appendDatasourceMappers(mappers, Map.of(
                 // Inherit options from the DB mappers
@@ -184,8 +184,8 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
         /**
          * Automatically create mappers for datasource options
          */
-        static PropertyMapper<?>[] appendDatasourceMappers(PropertyMapper<?>[] mappers, Map<Option<?>, Consumer<PropertyMapper.Builder<?>>> transformDatasourceMappers) {
-            List<PropertyMapper<?>> datasourceMappers = new ArrayList<>(OPTIONS_DATASOURCES.size() + mappers.length);
+        static List<PropertyMapper<?>> appendDatasourceMappers(List<PropertyMapper<?>> mappers, Map<Option<?>, Consumer<PropertyMapper.Builder<?>>> transformDatasourceMappers) {
+            List<PropertyMapper<?>> datasourceMappers = new ArrayList<>(OPTIONS_DATASOURCES.size() + mappers.size());
 
             for (var parent : mappers) {
                 var parentOption = parent.getOption();
@@ -223,9 +223,9 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 datasourceMappers.add(created.build());
             }
 
-            datasourceMappers.addAll(List.of(mappers));
+            datasourceMappers.addAll(mappers);
 
-            return datasourceMappers.toArray(new PropertyMapper[0]);
+            return datasourceMappers;
         }
 
         private static String transformDatasourceTo(String to) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/EventPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/EventPropertyMappers.java
@@ -11,11 +11,10 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.MetricsProperty
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 
-final class EventPropertyMappers {
+final class EventPropertyMappers implements PropertyMapperGrouping {
 
-    private EventPropertyMappers(){}
-
-    public static PropertyMapper<?>[] getMetricsPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(USER_EVENT_METRICS_ENABLED)
                         .to("kc.spi-events-listener--micrometer-user-event-metrics--enabled")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/EventPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/EventPropertyMappers.java
@@ -10,12 +10,14 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.MetricsProperty
 import static org.keycloak.quarkus.runtime.configuration.mappers.MetricsPropertyMappers.metricsEnabled;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 
 final class EventPropertyMappers implements PropertyMapperGrouping {
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(USER_EVENT_METRICS_ENABLED)
                         .to("kc.spi-events-listener--micrometer-user-event-metrics--enabled")
                         .isEnabled(EventPropertyMappers::userEventsMetricsEnabled, METRICS_ENABLED_MSG + " and feature " + Profile.Feature.USER_EVENT_METRICS.getKey() + " is enabled")
@@ -29,8 +31,8 @@ final class EventPropertyMappers implements PropertyMapperGrouping {
                         .to("kc.spi-events-listener--micrometer-user-event-metrics--events")
                         .paramLabel("events")
                         .isEnabled(EventPropertyMappers::userEventsMetricsTags, "user event metrics are enabled")
-                        .build(),
-        };
+                        .build()
+        );
     }
 
     private static boolean userEventsMetricsEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
@@ -24,7 +24,9 @@ import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.exportimport.UsersExportStrategy;
+import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
+import org.keycloak.quarkus.runtime.cli.command.Export;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.exportimport.ExportImportConfig.PROVIDER;
@@ -32,15 +34,13 @@ import static org.keycloak.quarkus.runtime.configuration.Configuration.getOption
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isBlank;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public final class ExportPropertyMappers {
+public final class ExportPropertyMappers implements PropertyMapperGrouping {
     private static final String EXPORTER_PROPERTY = "kc.spi-export--exporter";
     private static final String SINGLE_FILE = "singleFile";
     private static final String DIR = "dir";
 
-    private ExportPropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[]{
                 fromOption(EXPORTER_PLACEHOLDER)
                         .to(EXPORTER_PROPERTY)
@@ -88,8 +88,9 @@ public final class ExportPropertyMappers {
         }
     }
 
-    public static void validateConfig() {
-        if (getOptionalValue(EXPORTER_PROPERTY).isEmpty() && System.getProperty(PROVIDER) == null) {
+    @Override
+    public void validateConfig(Picocli picocli) {
+        if (picocli.getParsedCommand().orElse(null) instanceof Export && getOptionalValue(EXPORTER_PROPERTY).isEmpty() && System.getProperty(PROVIDER) == null) {
             throw new PropertyException("Must specify either --dir or --file options.");
         }
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
@@ -34,14 +34,16 @@ import static org.keycloak.quarkus.runtime.configuration.Configuration.getOption
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isBlank;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 public final class ExportPropertyMappers implements PropertyMapperGrouping {
     private static final String EXPORTER_PROPERTY = "kc.spi-export--exporter";
     private static final String SINGLE_FILE = "singleFile";
     private static final String DIR = "dir";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(EXPORTER_PLACEHOLDER)
                         .to(EXPORTER_PROPERTY)
                         .transformer(ExportPropertyMappers::transformExporter)
@@ -75,7 +77,7 @@ public final class ExportPropertyMappers implements PropertyMapperGrouping {
                         .isEnabled(ExportPropertyMappers::isDirProvider)
                         .paramLabel("number")
                         .build()
-        };
+        );
     }
 
     private static void validateUsersUsage(PropertyMapper<?> mapper, ConfigValue value) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/FeaturePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/FeaturePropertyMappers.java
@@ -12,14 +12,13 @@ import java.util.stream.Collectors;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public final class FeaturePropertyMappers {
+public final class FeaturePropertyMappers implements PropertyMapperGrouping {
 
     private static final Pattern VERSIONED_PATTERN = Pattern.compile("([^:]+):v(\\d+)");
 
-    private FeaturePropertyMappers() {
-    }
 
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(FeatureOptions.FEATURES)
                         .paramLabel("feature")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/FeaturePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/FeaturePropertyMappers.java
@@ -5,6 +5,7 @@ import org.keycloak.common.Profile.Feature;
 import org.keycloak.config.FeatureOptions;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,8 +19,8 @@ public final class FeaturePropertyMappers implements PropertyMapperGrouping {
 
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(FeatureOptions.FEATURES)
                         .paramLabel("feature")
                         .validator(FeaturePropertyMappers::validateEnabledFeature)
@@ -27,7 +28,7 @@ public final class FeaturePropertyMappers implements PropertyMapperGrouping {
                 fromOption(FeatureOptions.FEATURES_DISABLED)
                         .paramLabel("feature")
                         .build()
-        };
+        );
     }
 
     public static void validateEnabledFeature(String feature) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HealthPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HealthPropertyMappers.java
@@ -4,18 +4,20 @@ import org.keycloak.config.HealthOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 
 final class HealthPropertyMappers implements PropertyMapperGrouping {
 
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(HealthOptions.HEALTH_ENABLED)
                         // no need to map to a quarkus option, this option exists to
                         // to control artifact / extension inclusion. Quarkus will default to enabled
                         .build()
-        };
+        );
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HealthPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HealthPropertyMappers.java
@@ -5,11 +5,11 @@ import org.keycloak.config.HealthOptions;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 
-final class HealthPropertyMappers {
+final class HealthPropertyMappers implements PropertyMapperGrouping {
 
-    private HealthPropertyMappers(){}
 
-    public static PropertyMapper<?>[] getHealthPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(HealthOptions.HEALTH_ENABLED)
                         // no need to map to a quarkus option, this option exists to

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
@@ -24,7 +24,7 @@ public final class HostnameV2PropertyMappers implements PropertyMapperGrouping {
     private static final List<String> REMOVED_OPTIONS = Arrays.asList("hostname-admin-url", "hostname-path", "hostname-port", "hostname-strict-backchannel", "hostname-url", "proxy", "hostname-strict-https");
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
+    public List<? extends PropertyMapper<?>> getPropertyMappers() {
         return Stream.of(
                 fromOption(HostnameV2Options.HOSTNAME)
                         .to("kc.spi-hostname--v2--hostname")
@@ -39,7 +39,7 @@ public final class HostnameV2PropertyMappers implements PropertyMapperGrouping {
                 fromOption(HostnameV2Options.HOSTNAME_DEBUG)
         )
         .map(b -> b.isEnabled(() -> Profile.isFeatureEnabled(Profile.Feature.HOSTNAME_V2), "hostname:v2 feature is enabled").build())
-        .toArray(s -> new PropertyMapper<?>[s]);
+        .toList();
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HostnameV2PropertyMappers.java
@@ -13,18 +13,18 @@ import org.keycloak.common.Profile;
 import org.keycloak.config.HostnameV2Options;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
+import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
 import org.keycloak.config.ProxyOptions;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.utils.SecureContextResolver;
 
-public final class HostnameV2PropertyMappers {
+public final class HostnameV2PropertyMappers implements PropertyMapperGrouping {
 
     private static final String CONTEXT_WARNING = "the server is running in an insecure context. Secure contexts are required for full functionality, including cross-origin cookies.";
     private static final List<String> REMOVED_OPTIONS = Arrays.asList("hostname-admin-url", "hostname-path", "hostname-port", "hostname-strict-backchannel", "hostname-url", "proxy", "hostname-strict-https");
 
-    private HostnameV2PropertyMappers(){}
-
-    public static PropertyMapper<?>[] getHostnamePropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return Stream.of(
                 fromOption(HostnameV2Options.HOSTNAME)
                         .to("kc.spi-hostname--v2--hostname")
@@ -42,8 +42,11 @@ public final class HostnameV2PropertyMappers {
         .toArray(s -> new PropertyMapper<?>[s]);
     }
 
-    public static void validateConfig(Picocli picocli) {
-        validateConfig(picocli::warn);
+    @Override
+    public void validateConfig(Picocli picocli) {
+        if (picocli.getParsedCommand().filter(AbstractCommand::isServing).isPresent()) {
+            validateConfig(picocli::warn);
+        }
     }
 
     public static void validateConfig(Consumer<String> warn) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
@@ -5,12 +5,14 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
     public static final String ACCESS_LOG_ENABLED_MSG = "HTTP Access log is enabled";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_ENABLED)
                         .to("quarkus.http.access-log.enabled")
                         .build(),
@@ -21,8 +23,8 @@ public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
                 fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_EXCLUDE)
                         .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogEnabled, ACCESS_LOG_ENABLED_MSG)
                         .to("quarkus.http.access-log.exclude-pattern")
-                        .build(),
-        };
+                        .build()
+        );
     }
 
     static boolean isHttpAccessLogEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
@@ -5,10 +5,11 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public class HttpAccessLogPropertyMappers {
+public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
     public static final String ACCESS_LOG_ENABLED_MSG = "HTTP Access log is enabled";
 
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[]{
                 fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_ENABLED)
                         .to("quarkus.http.access-log.enabled")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
@@ -54,9 +55,9 @@ public final class HttpPropertyMappers implements PropertyMapperGrouping {
     }
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
+    public List<PropertyMapper<?>> getPropertyMappers() {
         setCustomExceptionTransformer();
-        return new PropertyMapper[] {
+        return List.of(
                 fromOption(HttpOptions.HTTP_ENABLED)
                         .to("quarkus.http.insecure-requests")
                         .transformer(HttpPropertyMappers::getHttpEnabledTransformer)
@@ -154,7 +155,7 @@ public final class HttpPropertyMappers implements PropertyMapperGrouping {
                         .isEnabled(MetricsPropertyMappers::metricsEnabled, MetricsPropertyMappers.METRICS_ENABLED_MSG)
                         .paramLabel("list of buckets")
                         .build()
-        };
+        );
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ImportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ImportPropertyMappers.java
@@ -32,14 +32,16 @@ import static org.keycloak.exportimport.ExportImportConfig.PROVIDER;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 public final class ImportPropertyMappers implements PropertyMapperGrouping {
     private static final String IMPORTER_PROPERTY = "kc.spi-import--importer";
     private static final String SINGLE_FILE = "singleFile";
     private static final String DIR = "dir";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(IMPORTER_PLACEHOLDER)
                         .to(IMPORTER_PROPERTY)
                         .transformer(ImportPropertyMappers::transformImporter)
@@ -62,8 +64,8 @@ public final class ImportPropertyMappers implements PropertyMapperGrouping {
                         .to("kc.spi-import--dir--strategy")
                         .transformer(ImportPropertyMappers::transformOverride)
                         .isEnabled(ImportPropertyMappers::isDirProvider)
-                        .build(),
-        };
+                        .build()
+        );
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ImportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ImportPropertyMappers.java
@@ -24,21 +24,21 @@ import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.exportimport.Strategy;
+import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
+import org.keycloak.quarkus.runtime.cli.command.Import;
 
 import static org.keycloak.exportimport.ExportImportConfig.PROVIDER;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public final class ImportPropertyMappers {
+public final class ImportPropertyMappers implements PropertyMapperGrouping {
     private static final String IMPORTER_PROPERTY = "kc.spi-import--importer";
     private static final String SINGLE_FILE = "singleFile";
     private static final String DIR = "dir";
 
-    private ImportPropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[]{
                 fromOption(IMPORTER_PLACEHOLDER)
                         .to(IMPORTER_PROPERTY)
@@ -66,8 +66,9 @@ public final class ImportPropertyMappers {
         };
     }
 
-    public static void validateConfig() {
-        if (getOptionalValue(IMPORTER_PROPERTY).isEmpty() && System.getProperty(PROVIDER) == null) {
+    @Override
+    public void validateConfig(Picocli picocli) {
+        if (picocli.getParsedCommand().orElse(null) instanceof Import && getOptionalValue(IMPORTER_PROPERTY).isEmpty() && System.getProperty(PROVIDER) == null) {
             throw new PropertyException("Must specify either --dir or --file options.");
         }
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -32,7 +32,7 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
 
-public final class LoggingPropertyMappers {
+public final class LoggingPropertyMappers implements PropertyMapperGrouping {
 
     private static final String CONSOLE_ENABLED_MSG = "Console log handler is activated";
     private static final String FILE_ENABLED_MSG = "File log handler is activated";
@@ -41,10 +41,9 @@ public final class LoggingPropertyMappers {
 
     private final static Map<String, Map<String, String>> rootLogLevels = new HashMap<String, Map<String,String>>();
 
-    private LoggingPropertyMappers() {
-    }
 
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         rootLogLevels.clear(); // reset the cached root log level and categories
         PropertyMapper<?>[] defaultMappers = new PropertyMapper[]{
                 fromOption(LoggingOptions.LOG)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -43,9 +44,9 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
 
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
+    public List<PropertyMapper<?>> getPropertyMappers() {
         rootLogLevels.clear(); // reset the cached root log level and categories
-        PropertyMapper<?>[] defaultMappers = new PropertyMapper[]{
+        return List.of(
                 fromOption(LoggingOptions.LOG)
                         .paramLabel("<handler>")
                         .build(),
@@ -257,11 +258,9 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .isEnabled(LoggingPropertyMappers::isMdcActive, "MDC logging is enabled")
                         .to("kc.spi-mapped-diagnostic-context--default--mdc-keys")
                         .paramLabel("keys")
-                        .build(),
+                        .build()
 
-        };
-
-        return defaultMappers;
+        );
     }
 
     public static boolean isConsoleEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
@@ -27,13 +27,15 @@ import static org.keycloak.config.ManagementOptions.LEGACY_OBSERVABILITY_INTERFA
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 public class ManagementPropertyMappers implements PropertyMapperGrouping {
 
     private static final String HTTP_MANAGEMENT_SCHEME_IS_INHERITED = "http-management-scheme is inherited";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(ManagementOptions.HTTP_MANAGEMENT_ENABLED)
                         .to("quarkus.management.enabled")
                         .transformer((val, ctx) -> managementEnabledTransformer())
@@ -116,8 +118,8 @@ public class ManagementPropertyMappers implements PropertyMapperGrouping {
                         .mapFrom(HttpOptions.HTTPS_KEY_STORE_TYPE)
                         .to("quarkus.management.ssl.certificate.key-store-file-type")
                         .paramLabel("type")
-                        .build(),
-        };
+                        .build()
+        );
     }
 
     public static boolean isManagementEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ManagementPropertyMappers.java
@@ -27,14 +27,12 @@ import static org.keycloak.config.ManagementOptions.LEGACY_OBSERVABILITY_INTERFA
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public class ManagementPropertyMappers {
+public class ManagementPropertyMappers implements PropertyMapperGrouping {
 
     private static final String HTTP_MANAGEMENT_SCHEME_IS_INHERITED = "http-management-scheme is inherited";
 
-    private ManagementPropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getManagementPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[]{
                 fromOption(ManagementOptions.HTTP_MANAGEMENT_ENABLED)
                         .to("quarkus.management.enabled")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/MetricsPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/MetricsPropertyMappers.java
@@ -6,13 +6,12 @@ import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 
-final class MetricsPropertyMappers {
+final class MetricsPropertyMappers implements PropertyMapperGrouping {
 
     public static final String METRICS_ENABLED_MSG = "metrics are enabled";
 
-    private MetricsPropertyMappers(){}
-
-    public static PropertyMapper<?>[] getMetricsPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(MetricsOptions.METRICS_ENABLED)
                         .to("quarkus.micrometer.enabled")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/MetricsPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/MetricsPropertyMappers.java
@@ -5,18 +5,20 @@ import org.keycloak.config.MetricsOptions;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 
 final class MetricsPropertyMappers implements PropertyMapperGrouping {
 
     public static final String METRICS_ENABLED_MSG = "metrics are enabled";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(MetricsOptions.METRICS_ENABLED)
                         .to("quarkus.micrometer.enabled")
                         .build()
-        };
+        );
     }
 
     public static boolean metricsEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapperGrouping.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapperGrouping.java
@@ -1,0 +1,13 @@
+package org.keycloak.quarkus.runtime.configuration.mappers;
+
+import org.keycloak.quarkus.runtime.cli.Picocli;
+
+public interface PropertyMapperGrouping {
+
+    PropertyMapper<?>[] getPropertyMappers();
+
+    default void validateConfig(Picocli picocli) {
+
+    }
+
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapperGrouping.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapperGrouping.java
@@ -1,10 +1,12 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
+import java.util.List;
+
 import org.keycloak.quarkus.runtime.cli.Picocli;
 
 public interface PropertyMapperGrouping {
 
-    PropertyMapper<?>[] getPropertyMappers();
+    List<? extends PropertyMapper<?>> getPropertyMappers();
 
     default void validateConfig(Picocli picocli) {
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -44,6 +44,21 @@ public final class PropertyMappers {
     public static String VALUE_MASK = "*******";
     private static MappersConfig MAPPERS;
     private static final Logger log = Logger.getLogger(PropertyMappers.class);
+    private final static List<PropertyMapperGrouping> GROUPINGS;
+    static {
+        GROUPINGS = List.of(new CachingPropertyMappers(), new DatabasePropertyMappers(),
+                new ConfigKeystorePropertyMappers(), new EventPropertyMappers(), new ClassLoaderPropertyMappers(),
+                new ExportPropertyMappers(), new BootstrapAdminPropertyMappers(), new HostnameV2PropertyMappers(),
+                new HttpPropertyMappers(), new HttpAccessLogPropertyMappers(), new HealthPropertyMappers(),
+                new FeaturePropertyMappers(), new ImportPropertyMappers(), new ManagementPropertyMappers(),
+                new MetricsPropertyMappers(), new LoggingPropertyMappers(), new ProxyPropertyMappers(),
+                new VaultPropertyMappers(), new TracingPropertyMappers(), new TransactionPropertyMappers(),
+                new SecurityPropertyMappers(), new TruststorePropertyMappers());
+    }
+
+    public static List<PropertyMapperGrouping> getPropertyMapperGroupings() {
+        return GROUPINGS;
+    }
 
     private PropertyMappers(){}
 
@@ -53,28 +68,7 @@ public final class PropertyMappers {
 
     public static void reset() {
         MAPPERS = new MappersConfig();
-        MAPPERS.addAll(CachingPropertyMappers.getClusteringPropertyMappers());
-        MAPPERS.addAll(DatabasePropertyMappers.getDatabasePropertyMappers());
-        MAPPERS.addAll(HostnameV2PropertyMappers.getHostnamePropertyMappers());
-        MAPPERS.addAll(HttpPropertyMappers.getHttpPropertyMappers());
-        MAPPERS.addAll(HttpAccessLogPropertyMappers.getMappers());
-        MAPPERS.addAll(HealthPropertyMappers.getHealthPropertyMappers());
-        MAPPERS.addAll(ConfigKeystorePropertyMappers.getConfigKeystorePropertyMappers());
-        MAPPERS.addAll(ManagementPropertyMappers.getManagementPropertyMappers());
-        MAPPERS.addAll(MetricsPropertyMappers.getMetricsPropertyMappers());
-        MAPPERS.addAll(EventPropertyMappers.getMetricsPropertyMappers());
-        MAPPERS.addAll(ProxyPropertyMappers.getProxyPropertyMappers());
-        MAPPERS.addAll(VaultPropertyMappers.getVaultPropertyMappers());
-        MAPPERS.addAll(FeaturePropertyMappers.getMappers());
-        MAPPERS.addAll(LoggingPropertyMappers.getMappers());
-        MAPPERS.addAll(TracingPropertyMappers.getMappers());
-        MAPPERS.addAll(TransactionPropertyMappers.getTransactionPropertyMappers());
-        MAPPERS.addAll(ClassLoaderPropertyMappers.getMappers());
-        MAPPERS.addAll(SecurityPropertyMappers.getMappers());
-        MAPPERS.addAll(ExportPropertyMappers.getMappers());
-        MAPPERS.addAll(ImportPropertyMappers.getMappers());
-        MAPPERS.addAll(TruststorePropertyMappers.getMappers());
-        MAPPERS.addAll(BootstrapAdminPropertyMappers.getMappers());
+        GROUPINGS.forEach(g -> MAPPERS.addAll(g.getPropertyMappers()));
     }
 
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -239,7 +239,7 @@ public final class PropertyMappers {
 
         private final WildcardMappersConfig wildcardConfig = new WildcardMappersConfig();
 
-        public void addAll(PropertyMapper<?>[] mappers) {
+        public void addAll(List<? extends PropertyMapper<?>> mappers) {
             for (PropertyMapper<?> mapper : mappers) {
                 addMapper(mapper);
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
@@ -8,11 +8,13 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 final class ProxyPropertyMappers implements PropertyMapperGrouping{
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(ProxyOptions.PROXY_HEADERS)
                         .to("quarkus.http.proxy.proxy-address-forwarding")
                         .transformer((v, c) -> proxyEnabled(null, v, c))
@@ -48,7 +50,7 @@ final class ProxyPropertyMappers implements PropertyMapperGrouping{
                         .addValidateEnabled(() -> !Configuration.isBlank(ProxyOptions.PROXY_HEADERS), "proxy-headers is set")
                         .paramLabel("trusted proxies")
                         .build()
-        };
+        );
     }
 
     private static void validateAddress(String address) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
@@ -8,11 +8,10 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-final class ProxyPropertyMappers {
+final class ProxyPropertyMappers implements PropertyMapperGrouping{
 
-    private ProxyPropertyMappers(){}
-
-    public static PropertyMapper<?>[] getProxyPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(ProxyOptions.PROXY_HEADERS)
                         .to("quarkus.http.proxy.proxy-address-forwarding")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
@@ -9,12 +9,11 @@ import org.keycloak.config.SecurityOptions;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
 
-final class SecurityPropertyMappers {
+final class SecurityPropertyMappers implements PropertyMapperGrouping {
 
-    private SecurityPropertyMappers() {
-    }
 
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(SecurityOptions.FIPS_MODE).transformer(SecurityPropertyMappers::resolveFipsMode)
                         .paramLabel("mode")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
@@ -2,6 +2,8 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.crypto.FipsMode;
@@ -13,12 +15,12 @@ final class SecurityPropertyMappers implements PropertyMapperGrouping {
 
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(SecurityOptions.FIPS_MODE).transformer(SecurityPropertyMappers::resolveFipsMode)
                         .paramLabel("mode")
-                        .build(),
-        };
+                        .build()
+        );
     }
 
     private static String resolveFipsMode(String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
@@ -26,6 +26,7 @@ import org.keycloak.utils.StringUtil;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 
 import static org.keycloak.config.TracingOptions.TRACING_COMPRESSION;
 import static org.keycloak.config.TracingOptions.TRACING_ENABLED;
@@ -44,8 +45,8 @@ public class TracingPropertyMappers implements PropertyMapperGrouping {
     private static final String TRACING_ENABLED_MSG = "Tracing is enabled";
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[]{
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(TRACING_ENABLED)
                         .isEnabled(TracingPropertyMappers::isFeatureEnabled, OTEL_FEATURE_ENABLED_MSG)
                         .to("quarkus.otel.enabled") // enable/disable whole OTel, tracing is enabled by default
@@ -97,7 +98,7 @@ public class TracingPropertyMappers implements PropertyMapperGrouping {
                         .to("kc.spi-cache-embedded--default--tracing-enabled")
                         .isEnabled(TracingPropertyMappers::isTracingAndEmbeddedInfinispanEnabled, "tracing and embedded Infinispan is enabled")
                         .build()
-        };
+        );
     }
 
     private static void validateEndpoint(String value) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TracingPropertyMappers.java
@@ -39,14 +39,12 @@ import static org.keycloak.config.TracingOptions.TRACING_SAMPLER_TYPE;
 import static org.keycloak.config.TracingOptions.TRACING_SERVICE_NAME;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public class TracingPropertyMappers {
+public class TracingPropertyMappers implements PropertyMapperGrouping {
     private static final String OTEL_FEATURE_ENABLED_MSG = "'opentelemetry' feature is enabled";
     private static final String TRACING_ENABLED_MSG = "Tracing is enabled";
 
-    private TracingPropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[]{
                 fromOption(TRACING_ENABLED)
                         .isEnabled(TracingPropertyMappers::isFeatureEnabled, OTEL_FEATURE_ENABLED_MSG)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -6,11 +6,13 @@ import org.keycloak.config.TransactionOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 public class TransactionPropertyMappers implements PropertyMapperGrouping {
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(TransactionOptions.TRANSACTION_XA_ENABLED)
                         .to("quarkus.datasource.jdbc.transactions")
                         .transformer(TransactionPropertyMappers::getQuarkusTransactionsValue)
@@ -19,7 +21,7 @@ public class TransactionPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.datasource.\"<datasource>\".jdbc.transactions")
                         .transformer(TransactionPropertyMappers::getQuarkusTransactionsValue)
                         .build()
-        };
+        );
     }
 
     private static String getQuarkusTransactionsValue(String txValue, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -6,11 +6,10 @@ import org.keycloak.config.TransactionOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public class TransactionPropertyMappers {
+public class TransactionPropertyMappers implements PropertyMapperGrouping {
 
-    private TransactionPropertyMappers(){}
-
-    public static PropertyMapper<?>[] getTransactionPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(TransactionOptions.TRANSACTION_XA_ENABLED)
                         .to("quarkus.datasource.jdbc.transactions")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TruststorePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TruststorePropertyMappers.java
@@ -4,19 +4,21 @@ import org.keycloak.config.TruststoreOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 public class TruststorePropertyMappers implements PropertyMapperGrouping {
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(TruststoreOptions.TRUSTSTORE_PATHS)
                         .paramLabel(TruststoreOptions.TRUSTSTORE_PATHS.getKey())
                         .build(),
                 fromOption(TruststoreOptions.HOSTNAME_VERIFICATION_POLICY)
                         .paramLabel(TruststoreOptions.HOSTNAME_VERIFICATION_POLICY.getKey())
                         .to("kc.spi-truststore--file--hostname-verification-policy")
-                        .build(),
-        };
+                        .build()
+        );
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TruststorePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TruststorePropertyMappers.java
@@ -4,9 +4,10 @@ import org.keycloak.config.TruststoreOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-public class TruststorePropertyMappers {
+public class TruststorePropertyMappers implements PropertyMapperGrouping {
 
-    public static PropertyMapper<?>[] getMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(TruststoreOptions.TRUSTSTORE_PATHS)
                         .paramLabel(TruststoreOptions.TRUSTSTORE_PATHS.getKey())

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
@@ -4,11 +4,13 @@ import org.keycloak.config.VaultOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
+import java.util.List;
+
 final class VaultPropertyMappers implements PropertyMapperGrouping {
 
     @Override
-    public PropertyMapper<?>[] getPropertyMappers() {
-        return new PropertyMapper[] {
+    public List<PropertyMapper<?>> getPropertyMappers() {
+        return List.of(
                 fromOption(VaultOptions.VAULT)
                         .paramLabel("provider")
                         .build(),
@@ -28,7 +30,7 @@ final class VaultPropertyMappers implements PropertyMapperGrouping {
                         .to("kc.spi-vault--keystore--type")
                         .paramLabel("type")
                         .build()
-        };
+        );
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
@@ -4,12 +4,10 @@ import org.keycloak.config.VaultOptions;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-final class VaultPropertyMappers {
+final class VaultPropertyMappers implements PropertyMapperGrouping {
 
-    private VaultPropertyMappers() {
-    }
-
-    public static PropertyMapper<?>[] getVaultPropertyMappers() {
+    @Override
+    public PropertyMapper<?>[] getPropertyMappers() {
         return new PropertyMapper[] {
                 fromOption(VaultOptions.VAULT)
                         .paramLabel("provider")

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -46,7 +46,7 @@ import org.keycloak.config.LoggingOptions;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.KeycloakMain;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 import org.keycloak.quarkus.runtime.configuration.AbstractConfigurationTest;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
@@ -358,7 +358,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("build", "--db=dev-file");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--hostname=name", "--http-enabled=true");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertTrue(nonRunningPicocli.reaug);
         assertEquals("dev", nonRunningPicocli.buildProps.getProperty(org.keycloak.common.util.Environment.PROFILE));
     }
@@ -378,7 +378,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         int code = CommandLine.ExitCode.OK;
         if (Stream.of(args).anyMatch("start-dev"::equals)) {
             Environment.setRebuildCheck();
-            code = AbstractStartCommand.REBUILT_EXIT_CODE;
+            code = AbstractAutoBuildCommand.REBUILT_EXIT_CODE;
         }
         NonRunningPicocli nonRunningPicocli = pseudoLaunch(args);
         assertTrue(nonRunningPicocli.getErrString(), nonRunningPicocli.reaug);
@@ -394,7 +394,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("build", "--db=dev-file");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("--profile=dev", "export", "--file=file");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertTrue(nonRunningPicocli.reaug);
     }
 
@@ -403,7 +403,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("build", "--db=dev-file");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("export", "--db=dev-file", "--file=file");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertFalse(nonRunningPicocli.reaug);
     }
 
@@ -421,7 +421,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("start-dev");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--db=dev-file", "--hostname=name", "--http-enabled=true");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertTrue(nonRunningPicocli.reaug);
     }
 
@@ -430,7 +430,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("start-dev");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("--profile=dev", "export", "--file=file");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertFalse(nonRunningPicocli.reaug);
     }
 
@@ -439,7 +439,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("start-dev", "-v");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("export", "--db=dev-file", "--file=file");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertTrue(nonRunningPicocli.reaug);
         assertEquals("prod", nonRunningPicocli.buildProps.getProperty(org.keycloak.common.util.Environment.PROFILE));
     }
@@ -449,7 +449,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("build", "--db=dev-file");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--db=dev-file", "--features=docker", "--hostname=name", "--http-enabled=true");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getOutString(), containsString("features=<unset> > features=docker"));
         assertTrue(nonRunningPicocli.reaug);
     }
@@ -899,7 +899,7 @@ public class PicocliTest extends AbstractConfigurationTest {
 
         putEnvVar("KC_SPI_EVENTS_LISTENER_PROVIDER", "new-jboss-logging");
         nonRunningPicocli = pseudoLaunch("start", "--http-enabled=true", "--hostname-strict=false");
-        assertEquals(AbstractStartCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
         assertTrue(nonRunningPicocli.reaug);
         assertThat(nonRunningPicocli.getOutString(), containsString("The following SPI options"));
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -32,7 +32,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 @WithEnvVars({"KC_CACHE", "local"}) // avoid flakey port conflicts
 @DistributionTest

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -19,7 +19,7 @@ package org.keycloak.it.cli.dist;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_LONG_NAME;
 
 import org.junit.jupiter.api.Test;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HelpCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HelpCommandDistTest.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.it.cli.dist;
 
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -32,7 +32,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import com.acme.provider.legacy.jpa.user.CustomUserProvider;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_LONG_NAME;
 
 import org.junit.jupiter.api.MethodOrderer;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.utils.RawDistRootPath;
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,13 +44,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public abstract class BasicDatabaseTest {
 
     @Test
-    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
     protected void testSuccessful(CLIResult cliResult) {
         cliResult.assertStarted();
     }
 
     @Test
-    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false", "--db-username=wrong" })
+    @Launch({ "start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false", "--db-username=wrong" })
     protected void testWrongUsername(CLIResult cliResult) {
         cliResult.assertMessage("ERROR: Failed to obtain JDBC connection");
         assertWrongUsername(cliResult);
@@ -59,7 +59,7 @@ public abstract class BasicDatabaseTest {
     protected abstract void assertWrongUsername(CLIResult cliResult);
 
     @Test
-    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false", "--db-password=wrong" })
+    @Launch({ "start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false", "--db-password=wrong" })
     protected void testWrongPassword(CLIResult cliResult) {
         cliResult.assertMessage("ERROR: Failed to obtain JDBC connection");
         assertWrongPassword(cliResult);
@@ -69,7 +69,7 @@ public abstract class BasicDatabaseTest {
 
     @Order(1)
     @Test
-    @Launch({ "export", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--dir=./target/export"})
+    @Launch({ "export", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--dir=./target/export"})
     public void testExportSucceeds(CLIResult cliResult) {
         cliResult.assertMessage("Full model export requested");
         cliResult.assertMessage("Export finished successfully");
@@ -77,7 +77,7 @@ public abstract class BasicDatabaseTest {
 
     @Order(2)
     @Test
-    @Launch({ "import", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--dir=./target/export" })
+    @Launch({ "import", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--dir=./target/export" })
     void testImportSucceeds(CLIResult cliResult) {
         cliResult.assertMessage("target/export");
         cliResult.assertMessage("Realm 'master' imported");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MariaDBDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MariaDBDistTest.java
@@ -24,7 +24,7 @@ import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.WithDatabase;
 import org.keycloak.it.storage.database.MariaDBTest;
 import org.keycloak.it.utils.RawDistRootPath;
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 
 import io.quarkus.test.junit.main.Launch;
 
@@ -35,14 +35,14 @@ public class MariaDBDistTest extends MariaDBTest {
     @Override
     @Tag(DistributionTest.STORAGE)
     @Test
-    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
     protected void testSuccessful(CLIResult result) {
         super.testSuccessful(result);
     }
 
     @Tag(DistributionTest.STORAGE)
     @Test
-    @Launch({"start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--spi-connections-jpa-quarkus-migration-strategy=manual", "--spi-connections-jpa-quarkus-initialize-empty=false", "--http-enabled=true", "--hostname-strict=false",})
+    @Launch({"start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--spi-connections-jpa-quarkus-migration-strategy=manual", "--spi-connections-jpa-quarkus-initialize-empty=false", "--http-enabled=true", "--hostname-strict=false",})
     public void testKeycloakDbUpdateScript(CLIResult cliResult, RawDistRootPath rawDistRootPath) {
         assertManualDbInitialization(cliResult, rawDistRootPath);
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MySQLDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MySQLDistTest.java
@@ -7,7 +7,7 @@ import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.WithDatabase;
 import org.keycloak.it.storage.database.MySQLTest;
 import org.keycloak.it.utils.RawDistRootPath;
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 
 import io.quarkus.test.junit.main.Launch;
 
@@ -18,14 +18,14 @@ public class MySQLDistTest extends MySQLTest {
     @Override
     @Tag(DistributionTest.STORAGE)
     @Test
-    @Launch({ "start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--http-enabled=true", "--hostname-strict=false" })
     protected void testSuccessful(CLIResult result) {
         super.testSuccessful(result);
     }
 
     @Tag(DistributionTest.STORAGE)
     @Test
-    @Launch({"start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--spi-connections-jpa-quarkus-migration-strategy=manual", "--spi-connections-jpa-quarkus-initialize-empty=false", "--http-enabled=true", "--hostname-strict=false",})
+    @Launch({"start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--spi-connections-jpa-quarkus-migration-strategy=manual", "--spi-connections-jpa-quarkus-initialize-empty=false", "--http-enabled=true", "--hostname-strict=false",})
     public void testKeycloakDbUpdateScript(CLIResult cliResult, RawDistRootPath rawDistRootPath) {
         assertManualDbInitialization(cliResult, rawDistRootPath);
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/PostgreSQLDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/PostgreSQLDistTest.java
@@ -29,7 +29,7 @@ import org.keycloak.it.storage.database.PostgreSQLTest;
 
 import io.quarkus.test.junit.main.Launch;
 import org.keycloak.it.utils.RawDistRootPath;
-import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
+import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 
 @DistributionTest(removeBuildOptionsAfterBuild = true)
 @WithDatabase(alias = "postgres")
@@ -44,7 +44,7 @@ public class PostgreSQLDistTest extends PostgreSQLTest {
 
     @Tag(DistributionTest.STORAGE)
     @Test
-    @Launch({"start", AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG, "--spi-connections-jpa-quarkus-migration-strategy=manual", "--spi-connections-jpa-quarkus-initialize-empty=false", "--http-enabled=true", "--hostname-strict=false",})
+    @Launch({"start", AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG, "--spi-connections-jpa-quarkus-migration-strategy=manual", "--spi-connections-jpa-quarkus-initialize-empty=false", "--http-enabled=true", "--hostname-strict=false",})
     public void testKeycloakDbUpdateScript(CLIResult cliResult, RawDistRootPath rawDistRootPath) {
         assertManualDbInitialization(cliResult, rawDistRootPath);
     }

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/ServerOptions.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/ServerOptions.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.it.junit5.extension;
 
-import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
closes: #27025

Since most of the grouping don't do validation, we could instead have a method that returns validation functions rather than directly calling a validateConfig method.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
