### PR TITLE
Use a plain representation for WhoAmI context

### DIFF
--- a/js/apps/admin-ui/src/Banners.tsx
+++ b/js/apps/admin-ui/src/Banners.tsx
@@ -37,7 +37,7 @@ const WarnBanner = ({ msg, className }: WarnBannerProps) => {
 export const Banners = () => {
   const { whoAmI } = useWhoAmI();
 
-  if (whoAmI.isTemporary()) return <WarnBanner msg="loggedInAsTempAdminUser" />;
+  if (whoAmI.temporary) return <WarnBanner msg="loggedInAsTempAdminUser" />;
 };
 
 export const EventsBanners = ({ type }: { type: EventsBannerType }) => {

--- a/js/apps/admin-ui/src/context/access/Access.tsx
+++ b/js/apps/admin-ui/src/context/access/Access.tsx
@@ -1,11 +1,11 @@
 import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
-import { PropsWithChildren, useEffect, useState } from "react";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { useWhoAmI } from "../../context/whoami/WhoAmI";
 import {
   createNamedContext,
   useRequiredContext,
 } from "@keycloak/keycloak-ui-shared";
+import { PropsWithChildren, useEffect, useState } from "react";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { useWhoAmI } from "../../context/whoami/WhoAmI";
 
 type AccessContextProps = {
   hasAccess: (...types: AccessType[]) => boolean;
@@ -25,8 +25,8 @@ export const AccessContextProvider = ({ children }: PropsWithChildren) => {
   const [access, setAccess] = useState<readonly AccessType[]>([]);
 
   useEffect(() => {
-    if (whoAmI.getRealmAccess()[realm]) {
-      setAccess(whoAmI.getRealmAccess()[realm]);
+    if (whoAmI.realm_access[realm]) {
+      setAccess(whoAmI.realm_access[realm]);
     }
   }, [whoAmI, realm]);
 

--- a/js/apps/admin-ui/src/context/whoami/WhoAmI.tsx
+++ b/js/apps/admin-ui/src/context/whoami/WhoAmI.tsx
@@ -1,12 +1,12 @@
 import type WhoAmIRepresentation from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
-import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 import {
   createNamedContext,
+  KeycloakSpinner,
   useEnvironment,
   useFetch,
   useRequiredContext,
 } from "@keycloak/keycloak-ui-shared";
-import { PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { useAdminClient } from "../../admin-client";
 import { DEFAULT_LOCALE, i18n } from "../../i18n/i18n";
 import { useRealm } from "../realm-context/RealmContext";
@@ -27,67 +27,9 @@ const RTL_LOCALES = [
   "yi",
 ];
 
-export class WhoAmI {
-  #me?: WhoAmIRepresentation;
-
-  constructor(me?: WhoAmIRepresentation) {
-    this.#me = me;
-    if (this.#me?.locale) {
-      void i18n.changeLanguage(this.#me.locale, (error) => {
-        if (error) {
-          console.warn("Error(s) loading locale", this.#me?.locale, error);
-        }
-      });
-      if (RTL_LOCALES.includes(this.#me.locale)) {
-        document.getElementsByTagName("html")[0].setAttribute("dir", "rtl");
-      }
-    }
-  }
-
-  public getDisplayName(): string {
-    if (this.#me === undefined) return "";
-
-    return this.#me.displayName;
-  }
-
-  public getLocale() {
-    return this.#me?.locale ?? DEFAULT_LOCALE;
-  }
-
-  public getRealm() {
-    return this.#me?.realm ?? "";
-  }
-
-  public getUserId(): string {
-    if (this.#me === undefined) return "";
-
-    return this.#me.userId;
-  }
-
-  public canCreateRealm(): boolean {
-    return !!this.#me?.createRealm;
-  }
-
-  public getRealmAccess(): Readonly<{
-    [key: string]: ReadonlyArray<AccessType>;
-  }> {
-    if (this.#me === undefined) return {};
-
-    return this.#me.realm_access;
-  }
-
-  public isTemporary(): boolean {
-    return this.#me?.temporary ?? false;
-  }
-
-  public isEmpty(): boolean {
-    return !this.#me;
-  }
-}
-
 type WhoAmIProps = {
   refresh: () => void;
-  whoAmI: WhoAmI;
+  whoAmI: WhoAmIRepresentation;
 };
 
 export const WhoAmIContext = createNamedContext<WhoAmIProps | undefined>(
@@ -101,7 +43,7 @@ export const WhoAmIContextProvider = ({ children }: PropsWithChildren) => {
   const { adminClient } = useAdminClient();
   const { environment } = useEnvironment();
 
-  const [whoAmI, setWhoAmI] = useState<WhoAmI>(new WhoAmI());
+  const [whoAmI, setWhoAmI] = useState<WhoAmIRepresentation>();
   const { realm } = useRealm();
   const [key, setKey] = useState(0);
 
@@ -110,33 +52,51 @@ export const WhoAmIContextProvider = ({ children }: PropsWithChildren) => {
       try {
         return await adminClient.whoAmI.find({
           realm: environment.realm,
-          currentRealm: realm!,
+          currentRealm: realm,
         });
       } catch (error) {
-        console.warn("Error fetching whoami", error);
-      }
-      return Promise.resolve(undefined);
-    },
-    (me) => {
-      if (me === undefined) {
-        setWhoAmI(
-          new WhoAmI({
-            userId: "",
-            realm: environment.realm,
-            displayName: "",
-            locale: "en",
-            temporary: false,
-            createRealm: false,
-            realm_access: {},
-          }),
+        console.warn(
+          "Unable to fetch whoami, falling back to empty defaults.",
+          error,
         );
-      } else {
-        const whoAmI = new WhoAmI(me);
-        setWhoAmI(whoAmI);
+
+        return {
+          realm: "",
+          userId: "",
+          displayName: "",
+          locale: DEFAULT_LOCALE,
+          createRealm: false,
+          realm_access: {},
+          temporary: false,
+        };
       }
     },
-    [key, realm],
+    setWhoAmI,
+    [key, environment.realm, realm],
   );
+
+  useFetch(
+    async () => {
+      if (whoAmI?.locale) {
+        await i18n.changeLanguage(whoAmI.locale);
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    () => {}, // noop
+    [whoAmI?.locale],
+  );
+
+  useEffect(() => {
+    if (whoAmI?.locale && RTL_LOCALES.includes(whoAmI.locale)) {
+      document.documentElement.setAttribute("dir", "rtl");
+    } else {
+      document.documentElement.removeAttribute("dir");
+    }
+  }, [whoAmI?.locale]);
+
+  if (!whoAmI) {
+    return <KeycloakSpinner />;
+  }
 
   return (
     <WhoAmIContext.Provider value={{ refresh: () => setKey(key + 1), whoAmI }}>

--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -352,10 +352,7 @@ export const RealmSettingsTokensTab = ({
               <HelperText>
                 <HelperTextItem>
                   {t("recommendedSsoTimeout", {
-                    time: toHumanFormat(
-                      ssoSessionIdleTimeout!,
-                      whoAmI.getLocale(),
-                    ),
+                    time: toHumanFormat(ssoSessionIdleTimeout!, whoAmI.locale),
                   })}
                 </HelperTextItem>
               </HelperText>

--- a/js/apps/admin-ui/src/realm-settings/localization/EffectiveMessageBundles.tsx
+++ b/js/apps/admin-ui/src/realm-settings/localization/EffectiveMessageBundles.tsx
@@ -392,10 +392,7 @@ export const EffectiveMessageBundles = ({
                                 field.onChange("");
                               }}
                             >
-                              {localeToDisplayName(
-                                field.value,
-                                whoAmI.getLocale(),
-                              )}
+                              {localeToDisplayName(field.value, whoAmI.locale)}
                             </Chip>
                           ) : null}
                         </ChipGroup>
@@ -412,7 +409,7 @@ export const EffectiveMessageBundles = ({
                       ].concat(
                         combinedLocales.map((option) => (
                           <SelectOption key={option} value={option}>
-                            {localeToDisplayName(option, whoAmI.getLocale())}
+                            {localeToDisplayName(option, whoAmI.locale)}
                           </SelectOption>
                         )),
                       )}
@@ -509,7 +506,7 @@ export const EffectiveMessageBundles = ({
                         {key === "locale"
                           ? localeToDisplayName(
                               value,
-                              whoAmI.getLocale(),
+                              whoAmI.locale,
                             )?.toLowerCase()
                           : value}
                       </Chip>

--- a/js/apps/admin-ui/src/realm-settings/localization/LocalizationTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/localization/LocalizationTab.tsx
@@ -112,7 +112,7 @@ export const LocalizationTab = ({
                   placeholderText={t("selectLocales")}
                   options={allLocales.map((l) => ({
                     key: l,
-                    value: localeToDisplayName(l, whoAmI.getLocale()) || l,
+                    value: localeToDisplayName(l, whoAmI.locale) || l,
                   }))}
                 />
                 <SelectControl
@@ -130,7 +130,7 @@ export const LocalizationTab = ({
                   data-testid="select-default-locale"
                   options={watchSupportedLocales!.map((l) => ({
                     key: l,
-                    value: localeToDisplayName(l, whoAmI.getLocale()) || l,
+                    value: localeToDisplayName(l, whoAmI.locale) || l,
                   }))}
                 />
               </>

--- a/js/apps/admin-ui/src/realm-settings/localization/RealmOverrides.tsx
+++ b/js/apps/admin-ui/src/realm-settings/localization/RealmOverrides.tsx
@@ -119,9 +119,7 @@ export const RealmOverrides = ({
           max,
           realm: realm.realm!,
           selectedLocale:
-            selectMenuLocale ||
-            getValues("defaultLocale") ||
-            whoAmI.getLocale(),
+            selectMenuLocale || getValues("defaultLocale") || whoAmI.locale,
         });
 
         setTranslations(Object.entries(result));
@@ -190,14 +188,14 @@ export const RealmOverrides = ({
   const options = [
     <SelectGroup label={t("defaultLocale")} key="group1">
       <SelectOption key={DEFAULT_LOCALE} value={DEFAULT_LOCALE}>
-        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.getDisplayName())}
+        {localeToDisplayName(DEFAULT_LOCALE, whoAmI.displayName)}
       </SelectOption>
     </SelectGroup>,
     <Divider key="divider" />,
     <SelectGroup label={t("supportedLocales")} key="group2">
       {watchSupportedLocales.map((locale) => (
         <SelectOption key={locale} value={locale}>
-          {localeToDisplayName(locale, whoAmI.getLocale())}
+          {localeToDisplayName(locale, whoAmI.locale)}
         </SelectOption>
       ))}
     </SelectGroup>,
@@ -244,7 +242,7 @@ export const RealmOverrides = ({
       try {
         for (const key of selectedRowKeys) {
           delete (
-            i18n.store.data[whoAmI.getLocale()][currentRealm] as Record<
+            i18n.store.data[whoAmI.locale][currentRealm] as Record<
               string,
               string
             >
@@ -440,9 +438,9 @@ export const RealmOverrides = ({
               }}
               selections={
                 selectMenuValueSelected
-                  ? localeToDisplayName(selectMenuLocale, whoAmI.getLocale())
+                  ? localeToDisplayName(selectMenuLocale, whoAmI.locale)
                   : realm.defaultLocale !== ""
-                    ? localeToDisplayName(DEFAULT_LOCALE, whoAmI.getLocale())
+                    ? localeToDisplayName(DEFAULT_LOCALE, whoAmI.locale)
                     : t("placeholderText")
               }
             >

--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AddTranslationsDialog.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/AddTranslationsDialog.tsx
@@ -79,7 +79,7 @@ export const AddTranslationsDialog = ({
     async () => {
       const selectedLocales = combinedLocales
         .filter((l) =>
-          localeToDisplayName(l, whoAmI.getLocale())
+          localeToDisplayName(l, whoAmI.locale)
             ?.toLocaleLowerCase(realm?.defaultLocale)
             ?.includes(filter.toLocaleLowerCase(realm?.defaultLocale)),
         )
@@ -221,7 +221,7 @@ export const AddTranslationsDialog = ({
                           <Td dataLabel={t("supportedLanguage")}>
                             {localeToDisplayName(
                               translation.locale,
-                              whoAmI.getLocale(),
+                              whoAmI.locale,
                             )}
                             {translation.locale === realm?.defaultLocale && (
                               <Label className="pf-v5-u-ml-xs" color="blue">

--- a/js/apps/admin-ui/src/realm/RealmSection.tsx
+++ b/js/apps/admin-ui/src/realm/RealmSection.tsx
@@ -209,7 +209,7 @@ export default function RealmSection() {
           toolbarItem={
             <>
               <ToolbarItem>
-                {whoAmI.canCreateRealm() && (
+                {whoAmI.createRealm && (
                   <Button
                     onClick={() => setOpenNewRealm(true)}
                     data-testid="add-realm"

--- a/js/apps/admin-ui/src/realm/add/NewRealmForm.tsx
+++ b/js/apps/admin-ui/src/realm/add/NewRealmForm.tsx
@@ -92,7 +92,7 @@ export default function NewRealmForm({ onClose }: NewRealmFormProps) {
           isHorizontal
           onSubmit={handleSubmit(save)}
           role="view-realm"
-          isReadOnly={!whoAmI.canCreateRealm()}
+          isReadOnly={!whoAmI.createRealm}
         >
           <JsonFileUpload
             id="kc-realm-filename"

--- a/js/apps/admin-ui/src/root/AuthWall.tsx
+++ b/js/apps/admin-ui/src/root/AuthWall.tsx
@@ -3,8 +3,6 @@ import { useMatches } from "react-router-dom";
 
 import { ForbiddenSection } from "../ForbiddenSection";
 import { useAccess } from "../context/access/Access";
-import { useWhoAmI } from "../context/whoami/WhoAmI";
-import { KeycloakSpinner } from "@keycloak/keycloak-ui-shared";
 
 function hasProp<K extends PropertyKey>(
   data: object,
@@ -16,7 +14,6 @@ function hasProp<K extends PropertyKey>(
 export const AuthWall = ({ children }: any) => {
   const matches = useMatches();
   const { hasAccess } = useAccess();
-  const { whoAmI } = useWhoAmI();
 
   const permissionNeeded = matches.flatMap(({ handle }) => {
     if (
@@ -33,10 +30,6 @@ export const AuthWall = ({ children }: any) => {
 
     return [handle.access] as AccessType[];
   });
-
-  if (whoAmI.isEmpty()) {
-    return <KeycloakSpinner />;
-  }
 
   if (!hasAccess(...permissionNeeded)) {
     return <ForbiddenSection permissionNeeded={permissionNeeded} />;

--- a/js/apps/admin-ui/src/sessions/SessionsTable.tsx
+++ b/js/apps/admin-ui/src/sessions/SessionsTable.tsx
@@ -184,7 +184,7 @@ export default function SessionsTable({
       isOffline: false,
     });
 
-    if (session.userId === whoAmI.getUserId()) {
+    if (session.userId === whoAmI.userId) {
       await keycloak.logout({ redirectUri: "" });
     } else if (isOnUserPage && isLightweightUser(session.userId)) {
       navigate(toUsers({ realm: realm }));

--- a/js/apps/admin-ui/src/user/UserForm.tsx
+++ b/js/apps/admin-ui/src/user/UserForm.tsx
@@ -79,7 +79,6 @@ export const UserForm = ({
   const isManager = hasAccess("manage-users");
   const canViewFederationLink = hasAccess("view-realm");
   const { whoAmI } = useWhoAmI();
-  const currentLocale = whoAmI.getLocale();
 
   const { handleSubmit, setValue, control, reset, formState } = form;
   const { errors } = formState;
@@ -246,7 +245,7 @@ export const UserForm = ({
               userProfileMetadata={userProfileMetadata}
               hideReadOnly={!user}
               supportedLocales={realm.supportedLocales || []}
-              currentLocale={currentLocale}
+              currentLocale={whoAmI.locale}
               t={
                 ((key: unknown, params) =>
                   t(key as string, params as any)) as TFunction

--- a/js/apps/admin-ui/src/utils/useCurrentUser.ts
+++ b/js/apps/admin-ui/src/utils/useCurrentUser.ts
@@ -9,11 +9,11 @@ export function useCurrentUser() {
   const { whoAmI } = useWhoAmI();
   const [currentUser, setCurrentUser] = useState<UserRepresentation>();
 
-  const userId = whoAmI.getUserId();
+  useFetch(
+    () => adminClient.users.findOne({ id: whoAmI.userId }),
+    setCurrentUser,
+    [whoAmI.userId],
+  );
 
-  useFetch(() => adminClient.users.findOne({ id: userId }), setCurrentUser, [
-    userId,
-  ]);
-
-  return { ...currentUser, realm: whoAmI.getRealm() };
+  return { ...currentUser, realm: whoAmI.realm };
 }

--- a/js/apps/admin-ui/src/utils/useFormatDate.ts
+++ b/js/apps/admin-ui/src/utils/useFormatDate.ts
@@ -7,9 +7,8 @@ export const FORMAT_DATE_AND_TIME: Intl.DateTimeFormatOptions = {
 
 export default function useFormatDate() {
   const { whoAmI } = useWhoAmI();
-  const locale = whoAmI.getLocale();
 
   return function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
-    return date.toLocaleString(locale, options);
+    return date.toLocaleString(whoAmI.locale, options);
   };
 }

--- a/js/apps/admin-ui/src/utils/useLocaleSort.ts
+++ b/js/apps/admin-ui/src/utils/useLocaleSort.ts
@@ -6,8 +6,6 @@ export default function useLocaleSort() {
   const { whoAmI } = useWhoAmI();
 
   return function localeSort<T>(items: T[], mapperFn: ValueMapperFn<T>): T[] {
-    const locale = whoAmI.getLocale();
-
     return [...items].sort((a, b) => {
       const valA = mapperFn(a);
       const valB = mapperFn(b);
@@ -16,7 +14,7 @@ export default function useLocaleSort() {
         return 0;
       }
 
-      return valA.localeCompare(valB, locale);
+      return valA.localeCompare(valB, whoAmI.locale);
     });
   };
 }


### PR DESCRIPTION
Cleans up the WhoAmI context to align it with how other contexts work, using a plain representation. This also moves the loading state to the context itself to prevent rendering partial UI.

Closes #42132

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
