### PR TITLE
fix: adding better management of closed entitymanagers

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -89,10 +89,10 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
         logger.trace("Create JpaConnectionProvider");
         lazyInit(session);
 
-        return new DefaultJpaConnectionProvider(createEntityManager(session));
+        return new DefaultJpaConnectionProvider(createEntityManager(session, true));
     }
 
-    private EntityManager createEntityManager(KeycloakSession session) {
+    private EntityManager createEntityManager(KeycloakSession session, boolean sessionManaged) {
         EntityManager em;
         if (!jtaEnabled) {
             logger.trace("enlisting EntityManager in JpaKeycloakTransaction");
@@ -101,7 +101,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
 
             em = emf.createEntityManager(SynchronizationType.SYNCHRONIZED);
         }
-        em = EntityManagerProxy.create(session, em);
+        em = EntityManagerProxy.create(session, em, sessionManaged);
         if (!jtaEnabled) {
             session.getTransactionManager().enlist(new JpaKeycloakTransaction(em));
         }
@@ -111,7 +111,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
     private void addSpecificNamedQueries(KeycloakSession session, Connection connection) {
         EntityManager em = null;
         try {
-            em = createEntityManager(session);
+            em = createEntityManager(session, false);
             String dbKind = getDatabaseType(connection.getMetaData().getDatabaseProductName());
             for (Map.Entry<Object, Object> query : loadSpecificNamedQueries(dbKind.toLowerCase()).entrySet()) {
                 String queryName = query.getKey().toString();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
@@ -29,6 +29,8 @@ import jakarta.persistence.SynchronizationType;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.keycloak.Config;
 import org.keycloak.config.DatabaseOptions;
+import org.keycloak.connections.jpa.DefaultJpaConnectionProvider;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
 import org.keycloak.connections.jpa.support.EntityManagerProxy;
 import org.keycloak.models.KeycloakSession;
@@ -46,6 +48,11 @@ public abstract class AbstractJpaConnectionProviderFactory implements JpaConnect
 
     protected Config.Scope config;
     protected EntityManagerFactory entityManagerFactory;
+
+    @Override
+    public JpaConnectionProvider create(KeycloakSession session) {
+        return new DefaultJpaConnectionProvider(createEntityManager(entityManagerFactory, session, true));
+    }
 
     @Override
     public Connection getConnection() {
@@ -108,8 +115,8 @@ public abstract class AbstractJpaConnectionProviderFactory implements JpaConnect
         return Optional.empty();
     }
 
-    protected EntityManager createEntityManager(EntityManagerFactory emf, KeycloakSession session) {
-        EntityManager entityManager = EntityManagerProxy.create(session, emf.createEntityManager(SynchronizationType.SYNCHRONIZED));
+    protected EntityManager createEntityManager(EntityManagerFactory emf, KeycloakSession session, boolean sessionManaged) {
+        EntityManager entityManager = EntityManagerProxy.create(session, emf.createEntityManager(SynchronizationType.SYNCHRONIZED), sessionManaged);
 
         entityManager.setFlushMode(FlushModeType.AUTO);
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/NamedJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/NamedJpaConnectionProviderFactory.java
@@ -28,11 +28,6 @@ public final class NamedJpaConnectionProviderFactory extends AbstractJpaConnecti
     private String unitName;
 
     @Override
-    public JpaConnectionProvider create(KeycloakSession session) {
-        return new DefaultJpaConnectionProvider(createEntityManager(entityManagerFactory, session));
-    }
-
-    @Override
     protected EntityManagerFactory getEntityManagerFactory() {
         return getEntityManagerFactory(unitName).orElseThrow(new Supplier<IllegalStateException>() {
             @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -40,8 +40,6 @@ import io.quarkus.arc.Arc;
 import org.jboss.logging.Logger;
 import org.keycloak.ServerStartupError;
 import org.keycloak.common.Version;
-import org.keycloak.connections.jpa.DefaultJpaConnectionProvider;
-import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.updater.JpaUpdaterProvider;
 import org.keycloak.connections.jpa.util.JpaUtils;
 import org.keycloak.migration.MigrationModelManager;
@@ -72,18 +70,12 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
     private Map<String, String> operationalInfo;
 
     @Override
-    public JpaConnectionProvider create(KeycloakSession session) {
-        logger.trace("Create QuarkusJpaConnectionProvider");
-        return new DefaultJpaConnectionProvider(createEntityManager(entityManagerFactory, session));
-    }
-
-    @Override
     public String getId() {
         return "quarkus";
     }
 
     private void addSpecificNamedQueries(KeycloakSession session) {
-        EntityManager em = createEntityManager(entityManagerFactory, session);
+        EntityManager em = createEntityManager(entityManagerFactory, session, false);
 
         try {
             Map<String, Object> unitProperties = entityManagerFactory.getProperties();

--- a/server-spi-private/src/main/java/org/keycloak/connections/jpa/support/EntityManagerProxy.java
+++ b/server-spi-private/src/main/java/org/keycloak/connections/jpa/support/EntityManagerProxy.java
@@ -47,28 +47,42 @@ public class EntityManagerProxy {
 
     private static final Pattern WRITE_METHOD_NAMES = Pattern.compile("persist|merge");
 
+    private Set<EntityManagerProxy> entityManagerProxies;
     private EntityManager em;
     private final boolean batchEnabled;
     private final int batchSize;
     private int changeCount = 0;
 
-    public static EntityManager create(KeycloakSession session, EntityManager em) {
-        // the alternative to this tracking is to have a method on the session for
-        // getting the in use providers - not something that will create all providers
-        EntityManagerProxy converter = new EntityManagerProxy(session, em);
-        Set<EntityManagerProxy> entityManagerProxies = session.getAttribute(EntityManagers.ENTITY_MANAGER_PROXIES, Set.class);
-        if (entityManagerProxies == null) {
-            entityManagerProxies = new HashSet<>();
-            session.setAttribute(EntityManagers.ENTITY_MANAGER_PROXIES, entityManagerProxies);
+    public static EntityManager create(KeycloakSession session, EntityManager em, boolean sessionManaged) {
+        Set<EntityManagerProxy> entityManagerProxies = null;
+        if (sessionManaged) {
+            // the alternative to this tracking is to have a method on the session for
+            // getting the in use providers - not something that will create all providers
+            entityManagerProxies = session.getAttribute(EntityManagers.ENTITY_MANAGER_PROXIES, Set.class);
+            if (entityManagerProxies == null) {
+                entityManagerProxies = new HashSet<>();
+                session.setAttribute(EntityManagers.ENTITY_MANAGER_PROXIES, entityManagerProxies);
+            }
         }
-        entityManagerProxies.add(converter);
+        boolean batchEnabled = session.getAttributeOrDefault(Constants.STORAGE_BATCH_ENABLED, false);
+        int batchSize = session.getAttributeOrDefault(Constants.STORAGE_BATCH_SIZE, 100);
+        return create(em, entityManagerProxies, batchEnabled, batchSize);
+    }
+
+    static EntityManager create(EntityManager em, Set<EntityManagerProxy> entityManagerProxies,
+            boolean batchEnabled, int batchSize) {
+        EntityManagerProxy converter = new EntityManagerProxy(em, entityManagerProxies, batchEnabled, batchSize);
+        if (entityManagerProxies != null) {
+            entityManagerProxies.add(converter);
+        }
         return (EntityManager) Proxy.newProxyInstance(EntityManager.class.getClassLoader(), new Class[]{EntityManager.class}, converter::invoke);
     }
 
-    private EntityManagerProxy(KeycloakSession session, EntityManager em) {
-        batchEnabled = session.getAttributeOrDefault(Constants.STORAGE_BATCH_ENABLED, false);
-        batchSize = session.getAttributeOrDefault(Constants.STORAGE_BATCH_SIZE, 100);
+    private EntityManagerProxy(EntityManager em, Set<EntityManagerProxy> entityManagerProxies, boolean batchEnabled, int batchSize) {
+        this.batchEnabled = batchEnabled;
+        this.batchSize = batchSize;
         this.em = em;
+        this.entityManagerProxies = entityManagerProxies;
     }
 
     void setEntityManager(EntityManager manager) {
@@ -89,6 +103,9 @@ public class EntityManagerProxy {
                 // if this or disabling persist/detach where correct for a given batch
                 // and types were correct
                 query.setFlushMode(FlushModeType.COMMIT);
+            }
+            if (entityManagerProxies != null && args == null && method.getName().equals("close")) {
+                entityManagerProxies.remove(this);
             }
             return result;
         } catch (InvocationTargetException e) {

--- a/server-spi-private/src/main/java/org/keycloak/connections/jpa/support/EntityManagers.java
+++ b/server-spi-private/src/main/java/org/keycloak/connections/jpa/support/EntityManagers.java
@@ -102,6 +102,9 @@ public class EntityManagers {
         // create a localized entitymanager with a shared transaction coordinator, so nothing is left behind
         if (nestedEntityManagers) {
             getEntityManagerProxies(session).forEach(p -> {
+                if (!p.getEntityManager().isOpen()) {
+                    return;
+                }
                 Session em = p.getEntityManager().unwrap(Session.class);
                 Session derived = em.sessionWithOptions().connection().openSession();
                 previous.put(p, em);

--- a/server-spi-private/src/test/java/org/keycloak/connections/jpa/support/EntityManagerProxyTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/connections/jpa/support/EntityManagerProxyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.jpa.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import jakarta.persistence.EntityManager;
+
+public class EntityManagerProxyTest {
+
+    @Test
+    public void testClosure() {
+        HashSet<EntityManagerProxy> proxies = new HashSet<EntityManagerProxy>();
+        EntityManager em = (EntityManager)Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{EntityManager.class}, (proxy, method, args) -> null);
+        EntityManager proxy = EntityManagerProxy.create(em, proxies, false, 1);
+        assertEquals(1, proxies.size());
+        proxy.close();
+        // once closed, the entity manager should not be tracked
+        assertTrue(proxies.isEmpty());
+    }
+
+}


### PR DESCRIPTION
closes: #42114

@vellotis I'd like to propose a change so that callers don't have to differentiate what type of EntityManager they need.

Then perhaps a simple unit test will suffice based upon your comments in the other pr.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
