### PR TITLE
Store Corepack tools in GitHub cache

### DIFF
--- a/.github/actions/corepack-setup/action.yml
+++ b/.github/actions/corepack-setup/action.yml
@@ -1,0 +1,36 @@
+name: Setup Corepack
+description: Sets up and caches the Corepack tools to speed up the build.
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - id: cache-key
+      name: Generate key for tools cache
+      shell: bash
+      working-directory: js
+      run: echo "key=corepack-tools-$(jq -r '.packageManager' package.json)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      id: cache
+      name: Cache Corepack tools
+      with:
+        # See: https://github.com/nodejs/corepack?tab=readme-ov-file#offline-workflow
+        path: ./js/corepack.tgz
+        key: ${{ runner.os }}-${{ steps.cache-key.outputs.key }}
+
+    - name: Install Corepack tools from cache
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      working-directory: js
+      run: corepack install -g --cache-only ./corepack.tgz
+
+    - name: Package Corepack tools
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: js
+      run: corepack pack
+

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -16,9 +16,8 @@ runs:
         node-version: ${{ inputs.node-version }}
         check-latest: true
 
-    - name: Enable Corepack
-      shell: bash
-      run: corepack enable
+    - name: Setup Corepack
+      uses: ./.github/actions/corepack-setup
 
     - name: PNPM store cache
       uses: ./.github/actions/pnpm-store-cache


### PR DESCRIPTION
Adds a step that installs Corepack tools (PNPM) from a GitHub cache in offline mode, this allows us to install the tools without reaching out to the registry which might be down, or block requests.

Closes #42165

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
