### PR TITLE
Include group-derived users in role member lookup

### DIFF
--- a/docs/documentation/api_documentation/topics/role-members-include-groups.adoc
+++ b/docs/documentation/api_documentation/topics/role-members-include-groups.adoc
@@ -1,0 +1,8 @@
+= Role members including groups
+
+The Admin REST API endpoints `GET /{realm}/roles/{role-name}/users` and `GET /{realm}/clients/{client-id}/roles/{role-name}/users`
+now support the query parameter `includeGroups`.
+
+When `includeGroups=true`, the response contains not only users directly assigned the role
+but also users that inherit the role from a group or any of its sub-groups. Pagination is applied
+after combining direct and group-derived users to avoid duplicate entries.

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -151,6 +151,24 @@ public interface RoleResource {
             @QueryParam("max") Integer maxResults);
 
     /**
+     * Get role members.
+     * <p>Returns users that have the given role, optionally including users that inherit the role from a group.</p>
+     *
+     * @param briefRepresentation If the user should be returned in brief or full representation. Parameter available since Keycloak server 26. Will be ignored on older Keycloak versions with the default value false.
+     * @param firstResult Pagination offset
+     * @param maxResults Pagination size
+     * @param includeGroups If true, users that inherit the role from a group are also returned
+     * @return a list of users with the given role
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getUserMembers(@QueryParam("briefRepresentation") Boolean briefRepresentation,
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults,
+            @QueryParam("includeGroups") Boolean includeGroups);
+
+    /**
      * Get role groups.
      * <p>Returns groups that have the given role.</p>
      *


### PR DESCRIPTION
Addresses #37209, #19391 and #16949

Add `effective-role` optional query parameter to endpoints `GET /{realm}/roles/{role-name}/users` and `GET /admin/realms/{realm}/roles/{role-name}/users`, allowing us to query on effective role instead of direct role only.
