### PR TITLE
fix: expands our warnings/notes around placeholder usage (#42151)

### DIFF
--- a/docs/guides/operator/basic-deployment.adoc
+++ b/docs/guides/operator/basic-deployment.adoc
@@ -300,10 +300,10 @@ You can use those credentials to access the Admin Console or the Admin REST API.
 
 [WARNING]
 ====
-Anyone with the ability to create or edit a Keycloak CR should be a namespace level admin.  
+Anyone with the ability to create or edit Keycloak or KeycloakRealmImport CRs should be a namespace level admin.
 ====
 
-Setting the  Keycloak CR image requires a high degree of trust as whatever image is running will have access to any Secrets used for environement variables.
+Setting the Keycloak CR image requires a high degree of trust as whatever image is running will at least have access to any Secrets used for environment variables.
 
 Similarly the unsupported podTemplate gives the ability to deploy alternative workloads which may be granted the same permissions as the operator itself - which includes the ability to access Secrets in the namespace.
 

--- a/docs/guides/operator/realm-import.adoc
+++ b/docs/guides/operator/realm-import.adoc
@@ -119,4 +119,13 @@ spec:
 In the above example placeholder replacement will be enabled and an environment variable with key `ENV_KEY` will be created from the Secret `SECRET_NAME`'s value for key `SECRET_KEY`.
 Currently only Secrets are supported and they must be in the same namespace as the Keycloak CR.
 
+=== Security Considerations
+
+[WARNING]
+====
+Anyone with the ability to create or edit KeycloakRealmImport CRs should be a namespace level admin.
+====
+
+Placeholder replacement gives access to all environment variables even sensitive ones.
+
 </@tmpl.guide>

--- a/docs/guides/server/importExport.adoc
+++ b/docs/guides/server/importExport.adoc
@@ -120,6 +120,8 @@ You are able to use placeholders to resolve values from environment variables fo
 
 In the example above, the value set to the `MY_REALM_NAME` environment variable is going to be used to set the `realm` property.
 
+NOTE: there are currently no restrictions on what environment variables may be referenced. When environment variables are used to convey sensitive information, take care to ensure placeholders references do not inappropriately expose sensitive environment variable values.
+
 == Importing a Realm during Startup
 
 You are also able to import realms when the server is starting by using the `--import-realm` option.


### PR DESCRIPTION
addresses CVE-2025-9162

closes: #42046

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit e89133616732ba441185813aac7e0279fde6e9d4)
