### PR TITLE
Allow resource policies to be deactivated for a resource based on events

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/policy/AbstractUserResourcePolicyProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/policy/AbstractUserResourcePolicyProvider.java
@@ -130,9 +130,9 @@ public abstract class AbstractUserResourcePolicyProvider implements ResourcePoli
     }
 
     @Override
-    public boolean scheduleOnEvent(ResourcePolicyEvent event) {
+    public boolean activateOnEvent(ResourcePolicyEvent event) {
         return this.supports(event.getResourceType())
-                && this.getSupportedOperationsForScheduling().contains(event.getOperation())
+                && this.getSupportedOperationsForActivation().contains(event.getOperation())
                 && this.isResourceInScope(event.getResourceId());
     }
 
@@ -143,17 +143,31 @@ public abstract class AbstractUserResourcePolicyProvider implements ResourcePoli
                 && this.isResourceInScope(event.getResourceId());
     }
 
+    public boolean deactivateOnEvent(ResourcePolicyEvent event) {
+        return this.supports(event.getResourceType())
+                && this.getSupportedOperationsForDeactivation().contains(event.getOperation())
+                && !this.isResourceInScope(event.getResourceId());
+    }
+
     @Override
     public void close() {
         // no-op
     }
 
-    protected List<ResourceOperationType> getSupportedOperationsForScheduling() {
-        return List.of();
+    protected List<ResourceOperationType> getSupportedOperationsForActivation() {
+        return this.getBrokerAliases().isEmpty()
+                    ? Collections.emptyList()
+                    : List.of(ResourceOperationType.ADD_FEDERATED_IDENTITY);
     }
 
     protected List<ResourceOperationType> getSupportedOperationsForResetting() {
-        return List.of();
+        return Collections.emptyList();
+    }
+
+    protected List<ResourceOperationType> getSupportedOperationsForDeactivation() {
+        return this.getBrokerAliases().isEmpty()
+                    ? Collections.emptyList()
+                    : List.of(ResourceOperationType.REMOVE_FEDERATED_IDENTITY);
     }
 
     protected EntityManager getEntityManager() {

--- a/model/jpa/src/main/java/org/keycloak/models/policy/UserCreationTimeResourcePolicyProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/policy/UserCreationTimeResourcePolicyProvider.java
@@ -31,7 +31,9 @@ public class UserCreationTimeResourcePolicyProvider extends AbstractUserResource
     }
 
     @Override
-    protected List<ResourceOperationType> getSupportedOperationsForScheduling() {
-        return List.of(CREATE);
+    protected List<ResourceOperationType> getSupportedOperationsForActivation() {
+        return new java.util.ArrayList<>(super.getSupportedOperationsForActivation()) {{
+            add(CREATE);
+        }};
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/policy/UserSessionRefreshTimeResourcePolicyProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/policy/UserSessionRefreshTimeResourcePolicyProvider.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.policy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.keycloak.component.ComponentModel;
@@ -32,8 +33,11 @@ public class UserSessionRefreshTimeResourcePolicyProvider extends AbstractUserRe
     }
 
     @Override
-    protected List<ResourceOperationType> getSupportedOperationsForScheduling() {
-        return List.of(CREATE, LOGIN);
+    protected List<ResourceOperationType> getSupportedOperationsForActivation() {
+        return new ArrayList<>(super.getSupportedOperationsForActivation()) {{
+            add(CREATE);
+            add(LOGIN);
+        }};
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/policy/ResourceOperationType.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/policy/ResourceOperationType.java
@@ -3,6 +3,8 @@ package org.keycloak.models.policy;
 public enum ResourceOperationType {
 
     CREATE,
+    LOGIN,
+    ADD_FEDERATED_IDENTITY,
+    REMOVE_FEDERATED_IDENTITY
 
-    LOGIN
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/policy/ResourcePolicyEvent.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/policy/ResourcePolicyEvent.java
@@ -1,15 +1,26 @@
 package org.keycloak.models.policy;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ResourcePolicyEvent {
 
     private final ResourceType type;
     private final ResourceOperationType operation;
     private final String resourceId;
+    private final Map<String, String> details = new HashMap<>();
 
     public ResourcePolicyEvent(ResourceType type, ResourceOperationType operation, String resourceId) {
+        this(type, operation, resourceId, null);
+    }
+
+    public ResourcePolicyEvent(ResourceType type, ResourceOperationType operation, String resourceId, Map<String, String> details) {
         this.type = type;
         this.operation = operation;
         this.resourceId = resourceId;
+        if (details != null) {
+            this.details.putAll(details);
+        }
     }
 
     public ResourceType getResourceType() {
@@ -22,5 +33,9 @@ public class ResourcePolicyEvent {
 
     public String getResourceId() {
         return resourceId;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/policy/ResourcePolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/policy/ResourcePolicyProvider.java
@@ -38,18 +38,18 @@ public interface ResourcePolicyProvider extends Provider {
     boolean supports(ResourceType type);
 
     /**
-     * Indicates whether the policy supports being assigned to a resource based on the event or not. If {@code true}, the
-     * policy's first action will be scheduled for the resource.
+     * Indicates whether the policy supports being activated for a resource based on the event or not. If {@code true}, the
+     * policy will be activated for the resource. For scheduled policies, this means the first action will be scheduled. For
+     * immediate policies, this means all actions will be executed right away.
      *
      * At the very least, implementations should validate the event's resource type and operation to ensure the policy will
-     * only be assigned on expected operations being performed on the expected type.
+     * only be activated on expected operations being performed on the expected type.
      *
      * @param event a {@link ResourcePolicyEvent} containing details of the event that was triggered such as operation
      *              (CREATE, LOGIN, etc.), the resource type, and the resource id.
-     * @return {@code true} if the policy allows for the setup of the first action based on the received event; {@code false}
-     *              otherwise.
+     * @return {@code true} if the policy can be activated based on the received event; {@code false} otherwise.
      */
-    boolean scheduleOnEvent(ResourcePolicyEvent event);
+    boolean activateOnEvent(ResourcePolicyEvent event);
 
     /**
      * Indicates whether the policy supports being reset (i.e. go back to the first action) based on the event received or not.
@@ -65,4 +65,18 @@ public interface ResourcePolicyProvider extends Provider {
      * @return {@code true} if the policy supports resetting the flow based on the received event; {@code false} otherwise.
      */
     boolean resetOnEvent(ResourcePolicyEvent event);
+
+    /**
+     * Indicates whether the policy supports being deactivated for a resource based on the event or not. If {@code true}, the
+     * policy will be deactivated for the resource, meaning any existing scheduled actions will be removed and no further
+     * actions will be executed.
+     *
+     * At the very least, implementations should validate the event's resource type and operation to ensure the policy will
+     * only be deactivated on expected operations being performed on the expected type.
+     *
+     * @param event a {@link ResourcePolicyEvent} containing details of the event that was triggered such as operation
+     *              (CREATE, LOGIN, etc.), the resource type, and the resource id.
+     * @return {@code true} if the policy can be deactivated based on the received event; {@code false} otherwise.
+     */
+    boolean deactivateOnEvent(ResourcePolicyEvent event);
 }

--- a/services/src/main/java/org/keycloak/models/policy/ResourcePolicyManager.java
+++ b/services/src/main/java/org/keycloak/models/policy/ResourcePolicyManager.java
@@ -239,15 +239,17 @@ public class ResourcePolicyManager {
                 .forEach(policy -> {
                     ResourcePolicyProvider provider = getPolicyProvider(policy);
                     if (!currentlyAssignedPolicies.contains(policy.getId())) {
-                        // if policy is not assigned, check if the provider allows assigning based on the event
-                        if (provider.scheduleOnEvent(event)) {
+                        // if policy is not active for the resource, check if the provider allows activating based on the event
+                        if (provider.activateOnEvent(event)) {
+                            // TODO run actions for immediate policies right away and do not schedule them
                             policyStateProvider.scheduleAction(policy, getFirstAction(policy), event.getResourceId());
                         }
                     } else {
                         if (provider.resetOnEvent(event)) {
                             policyStateProvider.scheduleAction(policy, getFirstAction(policy), event.getResourceId());
+                        } else if (provider.deactivateOnEvent(event)) {
+                            policyStateProvider.remove(policy.getId(), event.getResourceId());
                         }
-                        // TODO add a removeOnEvent to allow policies to detach from resources on specific events (e.g. unlinking an identity)
                     }
                 });
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/policy/ResourcePolicyManagementTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/policy/ResourcePolicyManagementTest.java
@@ -216,7 +216,7 @@ public class ResourcePolicyManagementTest {
             assertEquals(2, manager.getActions(policy).size());
             ResourceAction notifyAction = manager.getActions(policy).get(0);
 
-            ResourcePolicyStateProvider stateProvider = session.getKeycloakSessionFactory().getProviderFactory(ResourcePolicyStateProvider.class).create(session);
+            ResourcePolicyStateProvider stateProvider = session.getProvider(ResourcePolicyStateProvider.class);
             ResourcePolicyStateProvider.ScheduledAction scheduledAction = stateProvider.getScheduledAction(policy.getId(), user.getId());
             assertNotNull(scheduledAction, "An action should have been scheduled for the user " + user.getUsername());
             assertEquals(notifyAction.getId(), scheduledAction.actionId());


### PR DESCRIPTION
- Listen for federated identity add/remove events to activate and deactivate policies based on IDP association

Closes #42107
Closes #42108

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
