### PR TITLE
Upgrade to Quarkus 3.20.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.20.2.1</quarkus.version>
-        <quarkus.build.version>3.20.2.1</quarkus.build.version>
+        <quarkus.version>3.20.2.2</quarkus.version>
+        <quarkus.build.version>3.20.2.2</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>


### PR DESCRIPTION
Closes #42245

Keeping the Angus Mail and Maria DB versions as they were as Quarkus is using older ones.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
