### PR TITLE
Upgrade to Quarkus 3.15.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.15.6.1</quarkus.version>
-        <quarkus.build.version>3.15.6.1</quarkus.build.version>
+        <quarkus.version>3.15.6.2</quarkus.version>
+        <quarkus.build.version>3.15.6.2</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 


### PR DESCRIPTION
Closes #42246

Keeping the Angus Mail version as it was as Quarkus is using older one.
