### PR TITLE
Disable test retries for admin console

### DIFF
--- a/js/apps/admin-ui/playwright.config.ts
+++ b/js/apps/admin-ui/playwright.config.ts
@@ -1,10 +1,5 @@
 import { type ViewportSize, defineConfig, devices } from "@playwright/test";
 
-const retryCount = parseInt(process.env.RETRY_COUNT || "0");
-console.log("----------------------------");
-console.log("Playwright retries = " + retryCount);
-console.log("----------------------------");
-
 const viewport: ViewportSize = { width: 1920, height: 1080 };
 
 /**
@@ -12,18 +7,17 @@ const viewport: ViewportSize = { width: 1920, height: 1080 };
  */
 export default defineConfig({
   testDir: "./test",
+  fullyParallel: true,
+  // The admin console tests are not optimized for parallel execution, long-term
+  // this should be addressed and 'workers' should be returned to the default value.
+  workers: 1,
   forbidOnly: !!process.env.CI,
-  retries: retryCount,
-  workers: process.env.CI ? 1 : undefined,
-  timeout: 60_000,
   reporter: process.env.CI ? [["github"], ["html"]] : "list",
 
   use: {
-    baseURL: "http://localhost:8080",
     trace: "retain-on-failure",
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: "chromium",

--- a/js/apps/admin-ui/test/autentication/flows.spec.ts
+++ b/js/apps/admin-ui/test/autentication/flows.spec.ts
@@ -39,7 +39,7 @@ import {
   goToWebAuthnTab,
 } from "./flow.ts";
 
-test.describe("Authentication test", () => {
+test.describe.serial("Authentication test", () => {
   const realmName = `authentication-flow-${uuidv4()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -84,7 +84,7 @@ test.describe("Authentication test", () => {
     );
   });
 
-  test.describe("Flow details", () => {
+  test.describe.serial("Flow details", () => {
     const flowName = "Copy of browser test";
 
     test.beforeEach(async ({ page }) => {
@@ -188,7 +188,7 @@ test.describe("Authentication test", () => {
   });
 });
 
-test.describe("Required actions", () => {
+test.describe.serial("Required actions", () => {
   const realmName = `test-${uuidv4()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -240,7 +240,7 @@ test.describe("Required actions", () => {
   });
 });
 
-test.describe("Password policies tab", () => {
+test.describe.serial("Password policies tab", () => {
   const realmName = `policies-password-${uuidv4()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -264,7 +264,7 @@ test.describe("Password policies tab", () => {
   });
 });
 
-test.describe("Accessibility tests for authentication", () => {
+test.describe.serial("Accessibility tests for authentication", () => {
   const realmName = "a11y-realm";
   const flowName = `Flow-${uuidv4()}`;
 

--- a/js/apps/admin-ui/test/autentication/policies-ciba.spec.ts
+++ b/js/apps/admin-ui/test/autentication/policies-ciba.spec.ts
@@ -24,7 +24,7 @@ import {
   setIntervalInput,
 } from "./policies-ciba.ts";
 
-test.describe("Authentication - Policies - CIBA", () => {
+test.describe.serial("Authentication - Policies - CIBA", () => {
   const realmName = `authentication-policies-${uuidv4()}`;
 
   test.beforeAll(async () => {

--- a/js/apps/admin-ui/test/autentication/policies.spec.ts
+++ b/js/apps/admin-ui/test/autentication/policies.spec.ts
@@ -16,7 +16,7 @@ import {
   setWebAuthnPolicyCreateTimeout,
 } from "./policies.ts";
 
-test.describe("OTP policies tab", () => {
+test.describe.serial("OTP policies tab", () => {
   const realmName = `policies-otp-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -52,7 +52,7 @@ test.describe("OTP policies tab", () => {
   });
 });
 
-test.describe("Webauthn policies tabs", () => {
+test.describe.serial("Webauthn policies tabs", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await goToAuthentication(page);

--- a/js/apps/admin-ui/test/client-scope/main.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/main.spec.ts
@@ -42,7 +42,7 @@ const FilterProtocol = {
   OpenID: "OpenID Connect",
 };
 
-test.describe("Client Scopes test", () => {
+test.describe.serial("Client Scopes test", () => {
   const clientScopeName = "client-scope-test";
   const itemId = `client-scope-test-${uuidv4()}`;
   const clientScope = {
@@ -74,7 +74,7 @@ test.describe("Client Scopes test", () => {
     }
   });
 
-  test.describe("Client Scope filter list items", () => {
+  test.describe.serial("Client Scope filter list items", () => {
     test.beforeEach(async ({ page }) => {
       await login(page);
       await goToClientScopes(page);
@@ -155,7 +155,7 @@ test.describe("Client Scopes test", () => {
     });
   });
 
-  test.describe("Client Scope modify list items", () => {
+  test.describe.serial("Client Scope modify list items", () => {
     test.beforeEach(async ({ page }) => {
       await login(page);
       await goToClientScopes(page);
@@ -173,7 +173,7 @@ test.describe("Client Scopes test", () => {
     });
   });
 
-  test.describe("Client Scope creation", () => {
+  test.describe.serial("Client Scope creation", () => {
     test.beforeEach(async ({ page }) => {
       await login(page);
       await goToClientScopes(page);

--- a/js/apps/admin-ui/test/client-scope/mappers.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/mappers.spec.ts
@@ -20,7 +20,7 @@ import {
 } from "./mappers.ts";
 import adminClient from "../utils/AdminClient.ts";
 
-test.describe("Mappers tab test", () => {
+test.describe.serial("Mappers tab test", () => {
   const placeHolderClientScope = "Search for client scope";
   const placeHolder = "Search for mapper";
 

--- a/js/apps/admin-ui/test/client-scope/scope.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/scope.spec.ts
@@ -22,7 +22,7 @@ import {
 } from "../utils/table.ts";
 import { goToScopeTab } from "./scope.ts";
 
-test.describe("Scope tab test", () => {
+test.describe.serial("Scope tab test", () => {
   const scopeName = `client-scope-mapper-${uuidv4()}`;
   const tableName = "Role list";
 

--- a/js/apps/admin-ui/test/clients/advanced.spec.ts
+++ b/js/apps/admin-ui/test/clients/advanced.spec.ts
@@ -36,7 +36,7 @@ import {
   switchOid4vciEnabled,
 } from "./advanced.ts";
 
-test.describe("Advanced tab test", () => {
+test.describe.serial("Advanced tab test", () => {
   const clientId = `advanced-tab-${uuidv4()}`;
 
   test.beforeAll(() =>
@@ -109,7 +109,7 @@ test.describe("Advanced tab test", () => {
   });
 });
 
-test.describe("Client Offline Session Max", () => {
+test.describe.serial("Client Offline Session Max", () => {
   const realmName = `client-offline-session-${uuidv4()}`;
   const clientId = `clientId-${uuidv4()}`;
 
@@ -134,7 +134,7 @@ test.describe("Client Offline Session Max", () => {
   });
 });
 
-test.describe("OpenID for Verifiable Credentials", () => {
+test.describe.serial("OpenID for Verifiable Credentials", () => {
   const realmName = `oid4vci-test-${uuidv4()}`;
   const clientIdOpenIdConnect = `client-oidc-${uuidv4()}`;
   test.beforeAll(async () => {
@@ -148,7 +148,7 @@ test.describe("OpenID for Verifiable Credentials", () => {
 
   test.afterAll(() => adminClient.deleteRealm(realmName));
 
-  test.describe("with protocol openid-connect", () => {
+  test.describe.serial("with protocol openid-connect", () => {
     test.beforeEach(async ({ page }) => {
       await login(page);
       await goToRealm(page, realmName);

--- a/js/apps/admin-ui/test/clients/authorization.spec.ts
+++ b/js/apps/admin-ui/test/clients/authorization.spec.ts
@@ -35,7 +35,7 @@ import {
   setPolicy,
 } from "./authorization.ts";
 
-test.describe("Client authentication subtab", () => {
+test.describe.serial("Client authentication subtab", () => {
   const clientId = `client-authentication-${crypto.randomUUID()}`;
 
   test.beforeAll(async () => {
@@ -172,7 +172,8 @@ test.describe("Client authentication subtab", () => {
   });
 });
 
-test.describe("Client authorization tab access for view-realm-authorization", () => {
+test.describe
+  .serial("Client authorization tab access for view-realm-authorization", () => {
   const clientId = `realm-view-authz-client-${crypto.randomUUID()}`;
 
   test.beforeAll(async () => {
@@ -224,7 +225,7 @@ test.describe("Client authorization tab access for view-realm-authorization", ()
   });
 });
 
-test.describe("Accessibility tests for client authorization", () => {
+test.describe.serial("Accessibility tests for client authorization", () => {
   const clientId = `realm-view-authz-client-${crypto.randomUUID()}`;
   test.beforeAll(() =>
     adminClient.createClient({

--- a/js/apps/admin-ui/test/clients/details.spec.ts
+++ b/js/apps/admin-ui/test/clients/details.spec.ts
@@ -12,7 +12,7 @@ import {
   selectKeyForCodeExchangeInput,
 } from "./details.ts";
 
-test.describe("Clients details test", () => {
+test.describe.serial("Clients details test", () => {
   const realmName = `clients-details-realm-${uuid()}`;
   const clientId = `client-details-${uuid()}`;
 

--- a/js/apps/admin-ui/test/clients/initial-access.spec.ts
+++ b/js/apps/admin-ui/test/clients/initial-access.spec.ts
@@ -26,7 +26,7 @@ import {
   goToInitialAccessTokenTab,
 } from "./initial-access.ts";
 
-test.describe("Client initial access tokens", () => {
+test.describe.serial("Client initial access tokens", () => {
   const tableName = "Initial access token";
   const placeHolder = "Search token";
   const countCellNumber = 3;

--- a/js/apps/admin-ui/test/clients/main.spec.ts
+++ b/js/apps/admin-ui/test/clients/main.spec.ts
@@ -21,7 +21,7 @@ import {
   save,
 } from "./utils.ts";
 
-test.describe("Clients test", () => {
+test.describe.serial("Clients test", () => {
   const realmName = `clients-realm-${uuid()}`;
   const clientId = `clientId`;
   const placeHolder = "Search for client";
@@ -119,7 +119,7 @@ test.describe("Clients test", () => {
     await expect(getRowByCellText(page, "account")).toBeVisible();
   });
 
-  test.describe("Clients import", () => {
+  test.describe.serial("Clients import", () => {
     test.beforeAll(() =>
       adminClient.createClient({
         clientId: "identical",

--- a/js/apps/admin-ui/test/clients/registration-policies.spec.ts
+++ b/js/apps/admin-ui/test/clients/registration-policies.spec.ts
@@ -24,7 +24,7 @@ import {
   goToClientRegistrationTab,
 } from "./registration-policies.ts";
 
-test.describe("Client registration policies tab", () => {
+test.describe.serial("Client registration policies tab", () => {
   const tabName = "Client registration";
   const realmName = `clients-details-realm-${uuid()}`;
 
@@ -38,7 +38,7 @@ test.describe("Client registration policies tab", () => {
     await goToClientRegistrationTab(page);
   });
 
-  test.describe("Anonymous client policies subtab", () => {
+  test.describe.serial("Anonymous client policies subtab", () => {
     const policyName = "newAnonymPolicy1";
     const policyNameUpdated = "policy2";
 
@@ -86,7 +86,7 @@ test.describe("Client registration policies tab", () => {
     });
   });
 
-  test.describe("Authenticated client policies subtab", () => {
+  test.describe.serial("Authenticated client policies subtab", () => {
     const policyName = "newAuthPolicy1";
     const policyNameUpdated = "policy3";
 
@@ -140,7 +140,8 @@ test.describe("Client registration policies tab", () => {
   });
 });
 
-test.describe("Accessibility tests for client registration policies", () => {
+test.describe
+  .serial("Accessibility tests for client registration policies", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await goToClients(page);

--- a/js/apps/admin-ui/test/clients/role.spec.ts
+++ b/js/apps/admin-ui/test/clients/role.spec.ts
@@ -36,7 +36,7 @@ import {
   goToRolesTab,
 } from "./role.ts";
 
-test.describe("Roles tab test", () => {
+test.describe.serial("Roles tab test", () => {
   const realmName = `clients-realm-${uuid()}`;
   const itemId = `client-crud-${uuid()}`;
   const updatableItem = `role-name-${uuid()}`;

--- a/js/apps/admin-ui/test/clients/saml.spec.ts
+++ b/js/apps/admin-ui/test/clients/saml.spec.ts
@@ -36,7 +36,7 @@ import {
   setTermsOfServiceUrl,
 } from "./saml.ts";
 
-test.describe("Fine Grain SAML Endpoint Configuration", () => {
+test.describe.serial("Fine Grain SAML Endpoint Configuration", () => {
   const clientName = `saml-advanced-tab-${uuid()}`;
 
   test.beforeAll(() =>
@@ -84,7 +84,7 @@ test.describe("Fine Grain SAML Endpoint Configuration", () => {
   });
 });
 
-test.describe("Clients SAML tests", () => {
+test.describe.serial("Clients SAML tests", () => {
   const clientId = "saml";
 
   const clientName = `saml-settings-${uuid()}`;

--- a/js/apps/admin-ui/test/clients/scope.spec.ts
+++ b/js/apps/admin-ui/test/clients/scope.spec.ts
@@ -46,7 +46,7 @@ type ClientScope = {
   };
 };
 
-test.describe("Client details - Client scopes subtab", () => {
+test.describe.serial("Client details - Client scopes subtab", () => {
   const clientId = "client-scopes-subtab-test";
   const clientScopeName = "client-scope-test";
   const clientScopeNameDefaultType = "client-scope-test-default-type";
@@ -185,7 +185,7 @@ test.describe("Client details - Client scopes subtab", () => {
   });
 });
 
-test.describe("Client scopes evaluate subtab", () => {
+test.describe.serial("Client scopes evaluate subtab", () => {
   const clientName = "testClient";
   const userName = "admin-a";
   const realmName = `clients-realm-${uuid()}`;

--- a/js/apps/admin-ui/test/events/list.spec.ts
+++ b/js/apps/admin-ui/test/events/list.spec.ts
@@ -20,7 +20,7 @@ import {
   goToEventsConfig,
 } from "./list.ts";
 
-test.describe("Events tests", () => {
+test.describe.serial("Events tests", () => {
   const tableName = "Events";
   const realmName = `events-realm-${uuid()}`;
 
@@ -53,7 +53,7 @@ test.describe("Events tests", () => {
 
   test.afterAll(() => adminClient.deleteRealm(realmName));
 
-  test.describe("User events list empty", () => {
+  test.describe.serial("User events list empty", () => {
     test.beforeEach(async ({ page }) => {
       await login(page);
       await goToRealm(page, realmName);
@@ -67,7 +67,7 @@ test.describe("Events tests", () => {
     });
   });
 
-  test.describe("User events with events", () => {
+  test.describe.serial("User events with events", () => {
     let page: Page;
     test.beforeAll(async ({ browser }) => {
       page = await browser.newPage();

--- a/js/apps/admin-ui/test/groups/attributes.spec.ts
+++ b/js/apps/admin-ui/test/groups/attributes.spec.ts
@@ -13,7 +13,7 @@ import { assertNotificationMessage } from "../utils/masthead.ts";
 import { goToGroups } from "../utils/sidebar.ts";
 import { goToGroupDetails } from "./util.ts";
 
-test.describe("Attributes", () => {
+test.describe.serial("Attributes", () => {
   const groupName = `group-${uuid()}`;
 
   test.beforeAll(() => adminClient.createGroup(groupName));

--- a/js/apps/admin-ui/test/groups/list.spec.ts
+++ b/js/apps/admin-ui/test/groups/list.spec.ts
@@ -21,7 +21,7 @@ import {
 import { createGroup, editGroup, searchGroup } from "./list.ts";
 import { goToGroupDetails } from "./util.ts";
 
-test.describe("Group test", () => {
+test.describe.serial("Group test", () => {
   const groupName = `group-${uuid()}`;
   const users: { id: string; username: string }[] = [];
   const username = "test-user";
@@ -86,7 +86,7 @@ test.describe("Group test", () => {
   });
 });
 
-test.describe("Search group under current group", () => {
+test.describe.serial("Search group under current group", () => {
   const predefinedGroups = ["level", "level1", "level2", "level3"];
 
   const placeholder = "Filter groups";

--- a/js/apps/admin-ui/test/groups/members.spec.ts
+++ b/js/apps/admin-ui/test/groups/members.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "./members.ts";
 import { goToChildGroupsTab } from "./util.ts";
 
-test.describe("Members", () => {
+test.describe.serial("Members", () => {
   const predefinedGroups = ["level", "level1", "level2", "level3"];
   const emptyGroup = "empty-group";
   const users: { id: string; username: string }[] = [];

--- a/js/apps/admin-ui/test/groups/role.spec.ts
+++ b/js/apps/admin-ui/test/groups/role.spec.ts
@@ -19,7 +19,7 @@ import {
 } from "../utils/table.ts";
 import { goToRoleMappingTab } from "./role.ts";
 
-test.describe("Role mappings", () => {
+test.describe.serial("Role mappings", () => {
   const predefinedGroup = "group1";
   const predefinedGroup1 = "group2";
 

--- a/js/apps/admin-ui/test/identity-providers/oidc.spec.ts
+++ b/js/apps/admin-ui/test/identity-providers/oidc.spec.ts
@@ -22,7 +22,7 @@ import {
   setUrl,
 } from "./main.ts";
 
-test.describe("OIDC identity provider test", () => {
+test.describe.serial("OIDC identity provider test", () => {
   const oidcProviderName = "oidc";
   const secret = "123";
 
@@ -71,7 +71,7 @@ test.describe("OIDC identity provider test", () => {
   });
 });
 
-test.describe("Edit OIDC Provider", () => {
+test.describe.serial("Edit OIDC Provider", () => {
   const oidcProviderName = "OpenID Connect v1.0";
   const alias = `edit-oidc-${uuid()}`;
 

--- a/js/apps/admin-ui/test/identity-providers/saml.spec.ts
+++ b/js/apps/admin-ui/test/identity-providers/saml.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "./main.ts";
 import { editSAMLSettings } from "./saml.ts";
 
-test.describe("SAML identity provider test", () => {
+test.describe.serial("SAML identity provider test", () => {
   const samlProviderName = "saml";
   const samlDisplayName = "saml";
 
@@ -37,7 +37,7 @@ test.describe("SAML identity provider test", () => {
   });
 });
 
-test.describe("SAML identity provider test", () => {
+test.describe.serial("SAML identity provider test", () => {
   const samlProviderName = "SAML v2.0";
   const classRefName = "acClassRef-1";
   const declRefName = "acDeclRef-1";

--- a/js/apps/admin-ui/test/masthead/main.spec.ts
+++ b/js/apps/admin-ui/test/masthead/main.spec.ts
@@ -15,12 +15,12 @@ import {
   toggleUsernameDropdown,
 } from "./main.ts";
 
-test.describe("Masthead tests", () => {
+test.describe.serial("Masthead tests", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
   });
 
-  test.describe("Desktop view", () => {
+  test.describe.serial("Desktop view", () => {
     test("Go to account console and back to admin console", async ({
       page,
     }) => {
@@ -65,7 +65,7 @@ test.describe("Masthead tests", () => {
     });
   });
 
-  test.describe("Login works for unprivileged users", () => {
+  test.describe.serial("Login works for unprivileged users", () => {
     const realmName = `test-realm-${uuid()}`;
     const username = `test-user-${uuid()}`;
 
@@ -98,7 +98,7 @@ test.describe("Masthead tests", () => {
     });
   });
 
-  test.describe("Mobile view", () => {
+  test.describe.serial("Mobile view", () => {
     test.beforeEach(async ({ page }) => {
       await page.setViewportSize({ width: 360, height: 640 });
     });

--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -26,7 +26,7 @@ const editedRealmName = `Edited-Test-realm-${uuid()}`;
 const testDisabledName = `Test-Disabled-${uuid()}`;
 const specialCharsName = `%22-${uuid()}`;
 
-test.describe("Realm tests", () => {
+test.describe.serial("Realm tests", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await clickCreateRealm(page);

--- a/js/apps/admin-ui/test/organization/idp.spec.ts
+++ b/js/apps/admin-ui/test/organization/idp.spec.ts
@@ -16,7 +16,7 @@ import {
   goToIdentityProviders,
 } from "./idp.ts";
 
-test.describe("Identity providers", () => {
+test.describe.serial("Identity providers", () => {
   const realmName = `organization-idp-${uuid()}`;
 
   test.beforeAll(async () => {

--- a/js/apps/admin-ui/test/organization/main.spec.ts
+++ b/js/apps/admin-ui/test/organization/main.spec.ts
@@ -21,7 +21,7 @@ import {
   goToCreate,
 } from "./main.ts";
 
-test.describe("Organization CRUD", () => {
+test.describe.serial("Organization CRUD", () => {
   const realmName = `organization-${uuid()}`;
 
   test.beforeAll(() =>
@@ -48,7 +48,7 @@ test.describe("Organization CRUD", () => {
     await assertNotificationMessage(page, "Organization successfully saved.");
   });
 
-  test.describe("Existing organization", () => {
+  test.describe.serial("Existing organization", () => {
     const orgName = `org-edit-${uuid()}`;
     const delOrgName = `org-del-${uuid()}`;
     const delOrgName2 = `org-del-${uuid()}`;

--- a/js/apps/admin-ui/test/organization/members.spec.ts
+++ b/js/apps/admin-ui/test/organization/members.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils/table.ts";
 import { clickAddRealmUser, goToMembersTab } from "./members.ts";
 
-test.describe("Members", () => {
+test.describe.serial("Members", () => {
   const realmName = `organization-members-${uuid()}`;
 
   test.beforeAll(async () => {

--- a/js/apps/admin-ui/test/permissions/main.spec.ts
+++ b/js/apps/admin-ui/test/permissions/main.spec.ts
@@ -22,7 +22,7 @@ import {
 } from "./main.ts";
 import { fillPolicyForm, goToPolicies } from "./policy.ts";
 
-test.describe("Permissions section tests", () => {
+test.describe.serial("Permissions section tests", () => {
   const realmName = `permissions-${uuid()}`;
 
   test.beforeAll(async () => {
@@ -116,7 +116,7 @@ test.describe("Permissions section tests", () => {
     );
   });
 
-  test.describe("evaluate permissions", () => {
+  test.describe.serial("evaluate permissions", () => {
     test.beforeAll(async () => {
       await adminClient.createUser({
         realm: realmName,
@@ -173,7 +173,7 @@ test.describe("Permissions section tests", () => {
     });
   });
 
-  test.describe("permission search", () => {
+  test.describe.serial("permission search", () => {
     test.beforeAll(async () => {
       for (let i = 0; i < 5; i++) {
         await adminClient.createPermission({

--- a/js/apps/admin-ui/test/permissions/policy.spec.ts
+++ b/js/apps/admin-ui/test/permissions/policy.spec.ts
@@ -12,7 +12,7 @@ import {
   goToPolicies,
 } from "./policy.ts";
 
-test.describe("Policy section tests", () => {
+test.describe.serial("Policy section tests", () => {
   const realmName = `permissions-policy-${uuid()}`;
 
   test.beforeAll(() =>

--- a/js/apps/admin-ui/test/realm-roles/axe.spec.ts
+++ b/js/apps/admin-ui/test/realm-roles/axe.spec.ts
@@ -6,7 +6,7 @@ import { assertAxeViolations } from "../utils/masthead.ts";
 import { goToRealm, goToRealmRoles } from "../utils/sidebar.ts";
 import { clickTableRowItem } from "../utils/table.ts";
 
-test.describe("Accessibility tests for realm roles", () => {
+test.describe.serial("Accessibility tests for realm roles", () => {
   const realmName = "role-a11y-" + uuid();
   const defaultRolesMaster = "default-roles-" + realmName;
 

--- a/js/apps/admin-ui/test/realm-roles/main.spec.ts
+++ b/js/apps/admin-ui/test/realm-roles/main.spec.ts
@@ -39,7 +39,7 @@ import {
   goToAssociatedRolesTab,
 } from "./main.ts";
 
-test.describe("Realm roles test", () => {
+test.describe.serial("Realm roles test", () => {
   const realmName = `realm-roles-${uuid()}`;
   const prefix = "realm_role_crud";
   const searchPlaceHolder = "Search role by name";
@@ -244,7 +244,7 @@ test.describe("Realm roles test", () => {
     await assertNotificationMessage(page, "Role mapping updated");
   });
 
-  test.describe("edit role details", () => {
+  test.describe.serial("edit role details", () => {
     const editRoleName = "going to edit";
     const description = "some description";
     const updateDescription = "updated description";

--- a/js/apps/admin-ui/test/realm-settings/accessibility.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/accessibility.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "./localization.ts";
 import { goToLoginTab } from "./login.ts";
 
-test.describe("Accessibility tests for realm settings", () => {
+test.describe.serial("Accessibility tests for realm settings", () => {
   const realmName = `realm-settings-accessibility-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/client-policies.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/client-policies.spec.ts
@@ -43,7 +43,7 @@ import {
   shouldReloadJSONPolicies,
 } from "./client-policies.ts";
 
-test.describe("Realm settings client policies tab tests", () => {
+test.describe.serial("Realm settings client policies tab tests", () => {
   const realmName = `realm-settings-client-policies_${uuid()}`;
   const placeHolder = "Search client policy";
 
@@ -74,7 +74,7 @@ test.describe("Realm settings client policies tab tests", () => {
     await assertNotificationMessage(page, "New policy created");
   });
 
-  test.describe("Editing client policy", () => {
+  test.describe.serial("Editing client policy", () => {
     test.beforeAll(() =>
       adminClient.createClientPolicy("Test", "Test Description", realmName),
     );
@@ -175,7 +175,7 @@ test.describe("Realm settings client policies tab tests", () => {
     await shouldReloadJSONPolicies(page);
   });
 
-  test.describe("Delete client policy", () => {
+  test.describe.serial("Delete client policy", () => {
     const testPolicy = "DeletablePolicy";
     test.beforeEach(() =>
       adminClient.createClientPolicy(testPolicy, "Test Description", realmName),

--- a/js/apps/admin-ui/test/realm-settings/client-profiles.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/client-profiles.spec.ts
@@ -26,7 +26,7 @@ import {
 import { clickTableRowItem } from "../utils/table.ts";
 import { confirmModal } from "../utils/modal.ts";
 
-test.describe("Realm settings client profiles tab tests", () => {
+test.describe.serial("Realm settings client profiles tab tests", () => {
   const profileName = "Test";
   const realmName = `client-profiles-${uuid()}`;
 
@@ -63,7 +63,7 @@ test.describe("Realm settings client profiles tab tests", () => {
     await searchNonExistingClientProfile(page, "nonExistentProfile");
   });
 
-  test.describe("Edit client profile", () => {
+  test.describe.serial("Edit client profile", () => {
     const editedProfileName = "Edit";
     test.beforeAll(() =>
       adminClient.createClientProfile(

--- a/js/apps/admin-ui/test/realm-settings/email.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/email.spec.ts
@@ -15,7 +15,7 @@ import {
   assertEmailPageWithTokenAuth,
 } from "./email.ts";
 
-test.describe("Email", () => {
+test.describe.serial("Email", () => {
   const realmName = `email-realm-settings-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/events.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/events.spec.ts
@@ -17,7 +17,7 @@ import {
   goToRealmEventsTab,
 } from "./events.ts";
 
-test.describe("Realm settings events tab tests", () => {
+test.describe.serial("Realm settings events tab tests", () => {
   const realmName = `events-realm-settings-${crypto.randomUUID()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/export.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/export.spec.ts
@@ -12,7 +12,7 @@ import {
   toggleIncludeGroupsAndRoles,
 } from "./export.ts";
 
-test.describe("Partial realm export", () => {
+test.describe.serial("Partial realm export", () => {
   const REALM_NAME = `partial-export-test-${uuid()}`;
 
   test.beforeAll(async () => {

--- a/js/apps/admin-ui/test/realm-settings/general.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/general.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "./general.ts";
 import { SERVER_URL } from "../utils/constants.ts";
 
-test.describe("Realm settings general tab tests", () => {
+test.describe.serial("Realm settings general tab tests", () => {
   const realmName = `general-realm-settings-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/i18n.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/i18n.spec.ts
@@ -71,7 +71,7 @@ async function addLocalization(locale: string, key: string, value: string) {
   );
 }
 
-test.describe("i18n tests", () => {
+test.describe.serial("i18n tests", () => {
   // Constants for test assertions
   const texts = {
     realmLocalizationEn: "realmSettings en",

--- a/js/apps/admin-ui/test/realm-settings/import.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/import.spec.ts
@@ -25,7 +25,7 @@ import {
   toggleUsers,
 } from "./import.ts";
 
-test.describe("Partial import test", () => {
+test.describe.serial("Partial import test", () => {
   const testRealm = `Partial-import-${uuid()}`;
   const testRealm2 = `Partial-import-2-${uuid()}`;
 

--- a/js/apps/admin-ui/test/realm-settings/keys.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/keys.spec.ts
@@ -19,7 +19,7 @@ import {
   switchToFilter,
 } from "./keys.ts";
 
-test.describe("Realm Settings - Keys", () => {
+test.describe.serial("Realm Settings - Keys", () => {
   const realmName = `events-realm-settings-${uuid()}`;
   const searchPlaceholder = "Search key";
 

--- a/js/apps/admin-ui/test/realm-settings/localization.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/localization.spec.ts
@@ -22,7 +22,7 @@ import {
   switchInternationalization,
 } from "./localization.ts";
 
-test.describe("Go to localization tab", () => {
+test.describe.serial("Go to localization tab", () => {
   const realmName = `localization-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -43,7 +43,7 @@ test.describe("Go to localization tab", () => {
     await assertNotificationMessage(page, "Realm successfully updated");
   });
 
-  test.describe("Locales tab - CRUD bundle", () => {
+  test.describe.serial("Locales tab - CRUD bundle", () => {
     test.beforeAll(() =>
       adminClient.updateRealm(realmName, { internationalizationEnabled: true }),
     );

--- a/js/apps/admin-ui/test/realm-settings/login.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/login.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils/sidebar.ts";
 import { goToLoginTab } from "./login.ts";
 
-test.describe("Realm settings tabs tests", () => {
+test.describe.serial("Realm settings tabs tests", () => {
   const realmName = `realm-settings_${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/security-defenses.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/security-defenses.spec.ts
@@ -15,7 +15,7 @@ import {
   goToSecurityDefensesTab,
 } from "./security-defenses.ts";
 
-test.describe("Security defenses", () => {
+test.describe.serial("Security defenses", () => {
   const realmName = `security-defenses-realm-settings-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/session.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/session.spec.ts
@@ -14,7 +14,7 @@ import {
   populateSessionsPage,
 } from "./sessions.ts";
 
-test.describe("Sessions", () => {
+test.describe.serial("Sessions", () => {
   const realmName = `sessions-realm-settings-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/tokens.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/tokens.spec.ts
@@ -13,7 +13,7 @@ import {
   populateTokensPage,
 } from "./tokens.ts";
 
-test.describe("Realm Settings - Tokens", () => {
+test.describe.serial("Realm Settings - Tokens", () => {
   const realmName = `tokens-realm-settings-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));

--- a/js/apps/admin-ui/test/realm-settings/user-registration.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/user-registration.spec.ts
@@ -18,7 +18,7 @@ import {
 
 const groupName = "The default group";
 
-test.describe("Realm settings - User registration tab", () => {
+test.describe.serial("Realm settings - User registration tab", () => {
   const realmName = `realm-settings-user-registration-${uuid()}`;
   const roleName = "theRole";
 

--- a/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
@@ -25,7 +25,7 @@ import {
   switchOffIfOn,
 } from "./userprofile.ts";
 
-test.describe("User profile tabs", () => {
+test.describe.serial("User profile tabs", () => {
   const name = "Test";
   const displayName = "Test display name";
   const modifyName = "ModifyTest";
@@ -65,7 +65,7 @@ test.describe("User profile tabs", () => {
     await adminClient.deleteUser("testuser11", realmName, true);
   });
 
-  test.describe("Attributes sub tab tests", () => {
+  test.describe.serial("Attributes sub tab tests", () => {
     test("Completes new attribute form and performs cancel", async ({
       page,
     }) => {

--- a/js/apps/admin-ui/test/sessions/main.spec.ts
+++ b/js/apps/admin-ui/test/sessions/main.spec.ts
@@ -29,13 +29,13 @@ const client = "security-admin-console";
 const tableName = "Sessions";
 const placeHolder = "Search session";
 
-test.describe("Sessions test", () => {
+test.describe.serial("Sessions test", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await goToSessions(page);
   });
 
-  test.describe("Sessions list view", () => {
+  test.describe.serial("Sessions list view", () => {
     test("check item values", async ({ page }) => {
       await searchItem(page, placeHolder, client);
       const rows = await getTableData(page, tableName);
@@ -52,7 +52,7 @@ test.describe("Sessions test", () => {
   });
 });
 
-test.describe("Offline sessions", () => {
+test.describe.serial("Offline sessions", () => {
   const clientId = `offline-client-${uuid()}`;
   const username = `user-${uuid()}`;
 
@@ -106,7 +106,7 @@ test.describe("Offline sessions", () => {
   });
 });
 
-test.describe("Search", () => {
+test.describe.serial("Search", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await goToSessions(page);
@@ -118,7 +118,7 @@ test.describe("Search", () => {
   });
 });
 
-test.describe("revocation", () => {
+test.describe.serial("revocation", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await goToSessions(page);
@@ -157,7 +157,7 @@ test.describe("revocation", () => {
   });
 });
 
-test.describe("Accessibility tests for sessions", () => {
+test.describe.serial("Accessibility tests for sessions", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await goToSessions(page);

--- a/js/apps/admin-ui/test/user-federation/kerberos.spec.ts
+++ b/js/apps/admin-ui/test/user-federation/kerberos.spec.ts
@@ -46,7 +46,7 @@ const addProviderMenu = "Add new provider";
 const createdSuccessMessage = "User federation provider successfully created";
 const savedSuccessMessage = "User federation provider successfully saved";
 
-test.describe("User Fed Kerberos tests", () => {
+test.describe.serial("User Fed Kerberos tests", () => {
   const realmName = `user-federation-kerberos_${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -73,7 +73,7 @@ test.describe("User Fed Kerberos tests", () => {
     await assertNotificationMessage(page, createdSuccessMessage);
   });
 
-  test.describe("Edit Kerberos provider", () => {
+  test.describe.serial("Edit Kerberos provider", () => {
     test.beforeAll(() =>
       adminClient.createUserFederation(realmName, {
         providerId: provider,

--- a/js/apps/admin-ui/test/user-federation/ldap-mapper.spec.ts
+++ b/js/apps/admin-ui/test/user-federation/ldap-mapper.spec.ts
@@ -36,7 +36,7 @@ const hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
 const roleLdapMapper = "role-ldap-mapper";
 const hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
 
-test.describe("User Fed LDAP mapper tests", () => {
+test.describe.serial("User Fed LDAP mapper tests", () => {
   const realmName = `user-federation-kerberos_${uuid()}`;
 
   test.beforeAll(async () => {

--- a/js/apps/admin-ui/test/user-federation/ldap.spec.ts
+++ b/js/apps/admin-ui/test/user-federation/ldap.spec.ts
@@ -60,7 +60,7 @@ const savedSuccessMessage = "User federation provider successfully saved";
 const validatePasswordPolicyFailMessage =
   "User federation provider could not be saved: Validate Password Policy is applicable only with WRITABLE edit mode";
 
-test.describe("User Federation LDAP tests", () => {
+test.describe.serial("User Federation LDAP tests", () => {
   const realmName = `user-federation-ldap-${uuid()}`;
 
   test.beforeAll(() => adminClient.createRealm(realmName));
@@ -101,7 +101,7 @@ test.describe("User Federation LDAP tests", () => {
     await goToUserFederation(page);
   });
 
-  test.describe("Edit provider", () => {
+  test.describe.serial("Edit provider", () => {
     test.beforeAll(() =>
       adminClient.createUserFederation(realmName, {
         providerId: provider,

--- a/js/apps/admin-ui/test/users/main.spec.ts
+++ b/js/apps/admin-ui/test/users/main.spec.ts
@@ -30,7 +30,7 @@ import {
 let groupName = "group";
 let groupsList: string[] = [];
 
-test.describe("User creation", () => {
+test.describe.serial("User creation", () => {
   const realmName = `users-${uuid()}`;
 
   const userId = `user_crud-${uuid()}`;
@@ -117,7 +117,7 @@ test.describe("User creation", () => {
     await confirmModal(page);
   });
 
-  test.describe("Existing users", () => {
+  test.describe.serial("Existing users", () => {
     const placeHolder = "Search user";
     const existingUserId = `existing_user-${uuid()}`;
     const existingUserId2 = `existing_user2-${uuid()}`;


### PR DESCRIPTION
Disables test retries for the admin console, now that the tests are passing often enough for it not be disruptive. This also aligns the Playwright configuration with the account console, marking any tests that cannot be run in parallel explicitly (pretty much all tests right now).

Closes #42288

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
