### PR TITLE
FGAP v2: Introduce RESET_PASSWORD scope and evaluation; scope-first with fallback to MANAGE when no policies

### DIFF
--- a/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
@@ -68,6 +68,8 @@ set of scopes:
 | *manage-group-membership* | Defines if a realm administrator can assign or unassign users to/from groups.                | None
 | *map-roles*               | Defines if a realm administrator can assign or unassign roles to/from users.                 | None
 | *impersonate*             | Defines if a realm administrator can impersonate other users.                                | `impersonate-members`
+| *reset-password*          | Defines if a realm administrator can reset user passwords. By default, this scope falls      | None
+                              back to `manage` scope behavior (configurable via `fgap.v2.resetPassword.fallbackToManageUsers`).
 |===
 
 The user resource type has a strong relationship with some of the permissions you can set to groups. Most of the time,

--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -4,7 +4,22 @@
 Breaking changes are identified as requiring changes from existing users to their configurations.
 In minor or patch releases we will only do breaking changes to fix bugs.
 
-=== <TODO>
+=== Fine-grained admin permissions: RESET_PASSWORD scope for Users
+
+A new `reset-password` scope has been added to the Users resource type in Fine-Grained Admin Permissions v2. This scope allows administrators to grant password reset permissions independently from the broader `manage` scope.
+
+By default, the behavior remains compatible with previous versions through the `fallbackToManageUsers` configuration option, which is set to `true` by default. When this fallback is enabled, password reset permissions will use the existing `manage` scope behavior.
+
+To enable the new granular password reset permissions, set the configuration option:
+
+[source]
+----
+fgap.v2.resetPassword.fallbackToManageUsers=false
+----
+
+When the fallback is disabled, only explicit `reset-password` scope permissions will allow password reset operations, providing more fine-grained control over administrative access.
+
+For more information about fine-grained admin permissions, see the link:{adminguide_finegrained_link}[{adminguide_finegrained_name}] chapter in the {adminguide_name}.
 
 // ------------------------ Notable changes ------------------------ //
 == Notable changes

--- a/server-spi-private/src/main/java/org/keycloak/authorization/Decision.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/Decision.java
@@ -42,4 +42,14 @@ public interface Decision<D extends Evaluation> {
 
     default void onComplete(ResourcePermission permission) {
     }
+
+    /**
+     * Checks if the given {@code scope} is associated with any policy processed in this decision.
+     *
+     * @param scope the scope name
+     * @return {@code true} if the scope is associated with a policy. Otherwise, {@code false}.
+     */
+    default boolean isEvaluated(String scope) {
+        return false;
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/AdminPermissionsSchema.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/AdminPermissionsSchema.java
@@ -95,13 +95,14 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
 
     // user specific scopes
     public static final String IMPERSONATE = "impersonate";
+    public static final String RESET_PASSWORD = "reset-password";
 
     public static final String MANAGE_GROUP_MEMBERSHIP = "manage-group-membership";
 
     public static final ResourceType CLIENTS = new ResourceType(CLIENTS_RESOURCE_TYPE, Set.of(MANAGE, MAP_ROLES, MAP_ROLES_CLIENT_SCOPE, MAP_ROLES_COMPOSITE, VIEW));
     public static final ResourceType GROUPS = new ResourceType(GROUPS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, MANAGE_MEMBERSHIP, MANAGE_MEMBERS, VIEW_MEMBERS, IMPERSONATE_MEMBERS));
     public static final ResourceType ROLES = new ResourceType(ROLES_RESOURCE_TYPE, Set.of(MAP_ROLE, MAP_ROLE_CLIENT_SCOPE, MAP_ROLE_COMPOSITE));
-    public static final ResourceType USERS = new ResourceType(USERS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, IMPERSONATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP), Map.of(VIEW, Set.of(VIEW_MEMBERS), MANAGE, Set.of(MANAGE_MEMBERS), IMPERSONATE, Set.of(IMPERSONATE_MEMBERS)), GROUPS.getType());
+    public static final ResourceType USERS = new ResourceType(USERS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, IMPERSONATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP, RESET_PASSWORD), Map.of(VIEW, Set.of(VIEW_MEMBERS), MANAGE, Set.of(MANAGE_MEMBERS), IMPERSONATE, Set.of(IMPERSONATE_MEMBERS)), GROUPS.getType());
     private static final String SKIP_EVALUATION = "kc.authz.fgap.skip";
     public static final AdminPermissionsSchema SCHEMA = new AdminPermissionsSchema();
 

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/FGAPDecision.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/FGAPDecision.java
@@ -55,4 +55,9 @@ class FGAPDecision implements Decision<Evaluation> {
     public void onComplete(ResourcePermission permission) {
         decision.onComplete(permission);
     }
+
+    @Override
+    public boolean isEvaluated(String scope) {
+        return decision.isEvaluated(scope);
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/evaluator/IterablePermissionEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/evaluator/IterablePermissionEvaluator.java
@@ -88,10 +88,16 @@ class IterablePermissionEvaluator implements PermissionEvaluator {
 
     @Override
     public Collection<Permission> evaluate(ResourceServer resourceServer, AuthorizationRequest request) {
+        DecisionPermissionCollector decision = getDecision(resourceServer, request, DecisionPermissionCollector.class);
+        return decision.results();
+    }
+
+    @Override
+    public <D extends Decision<?>> D getDecision(ResourceServer resourceServer, AuthorizationRequest request, Class<D> decisionType) {
         DecisionPermissionCollector decision = new DecisionPermissionCollector(authorizationProvider, resourceServer, request);
 
         evaluate(decision);
 
-        return decision.results();
+        return decisionType.cast(decision);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/evaluator/PermissionEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/evaluator/PermissionEvaluator.java
@@ -34,4 +34,5 @@ public interface PermissionEvaluator {
 
     <D extends Decision> D evaluate(D decision);
     Collection<Permission> evaluate(ResourceServer resourceServer, AuthorizationRequest request);
+    <D extends Decision<?>> D getDecision(ResourceServer resourceServer, AuthorizationRequest request, Class<D> decisionType);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/evaluator/UnboundedPermissionEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/evaluator/UnboundedPermissionEvaluator.java
@@ -60,10 +60,16 @@ public class UnboundedPermissionEvaluator implements PermissionEvaluator {
 
     @Override
     public Collection<Permission> evaluate(ResourceServer resourceServer, AuthorizationRequest request) {
+        DecisionPermissionCollector decision = getDecision(resourceServer, request, DecisionPermissionCollector.class);
+        return decision.results();
+    }
+
+    @Override
+    public <D extends Decision<?>> D getDecision(ResourceServer resourceServer, AuthorizationRequest request, Class<D> decisionType) {
         DecisionPermissionCollector decision = new DecisionPermissionCollector(authorizationProvider, resourceServer, request);
 
         evaluate(decision);
 
-        return decision.results();
+        return decisionType.cast(decision);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/AbstractDecisionCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/AbstractDecisionCollector.java
@@ -20,6 +20,7 @@ package org.keycloak.authorization.policy.evaluation;
 import org.keycloak.authorization.Decision;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.permission.ResourcePermission;
+import org.keycloak.authorization.policy.evaluation.Result.PolicyResult;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
 
 import java.util.Collection;
@@ -128,5 +129,20 @@ public abstract class AbstractDecisionCollector implements Decision<Evaluation> 
                 }
                 return true;
         }
+    }
+
+    @Override
+    public boolean isEvaluated(String scope) {
+        for (Result result : results.values()) {
+            for (PolicyResult policyResult : result.getResults()) {
+                Policy policy = policyResult.getPolicy();
+
+                if (policy.getScopes().stream().anyMatch(s -> s.getName().equals(scope))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -757,7 +757,7 @@ public class UserResource {
         @APIResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class)))
     })
     public void resetPassword(@Parameter(description = "The representation must contain a rawPassword with the plain-text password") CredentialRepresentation cred) {
-        auth.users().requireManage(user);
+        auth.users().requireResetPassword(user);
         if (cred == null || cred.getValue() == null) {
             throw new BadRequestException("No password provided");
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionEvaluator.java
@@ -58,6 +58,23 @@ public interface UserPermissionEvaluator {
     boolean canManage(UserModel user);
 
     /**
+     * Throws ForbiddenException if {@link #canResetPassword(UserModel)} returns {@code false}.
+     */
+    default void requireResetPassword(UserModel user) {
+        if (!canResetPassword(user)) {
+            throw new jakarta.ws.rs.ForbiddenException();
+        }
+    }
+
+    /**
+     * Returns {@code true} if the caller has permission to {@link org.keycloak.authorization.fgap.AdminPermissionsSchema#RESET_PASSWORD}
+     * for the given user. Default implementation falls back to {@link #canManage(UserModel)} for backward compatibility.
+     */
+    default boolean canResetPassword(UserModel user) {
+        return canManage(user);
+    }
+
+    /**
      * Throws ForbiddenException if {@link #canQuery()} returns {@code false}.
      */
     void requireQuery();

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissions.java
@@ -434,6 +434,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         map.put("mapRoles", canMapRoles(user));
         map.put("manageGroupMembership", canManageGroupMembership(user));
         map.put("impersonate", canImpersonate(user));
+        map.put("resetPassword", ((UserPermissionEvaluator)this).canResetPassword(user));
         return map;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
@@ -147,6 +147,24 @@ class UserPermissionsV2 extends UserPermissions {
         return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.MANAGE_GROUP_MEMBERSHIP);
     }
 
+    @Override
+    public boolean canResetPassword(UserModel user) {
+        // admin roles has the precedence over permissions
+        if (root.hasOneAdminRole(AdminRoles.MANAGE_USERS)) {
+            return true;
+        }
+
+        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.RESET_PASSWORD,
+                () -> eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.MANAGE));
+    }
+
+    @Override
+    public void requireResetPassword(UserModel user) {
+        if (!canResetPassword(user)) {
+            throw new ForbiddenException();
+        }
+    }
+
     // todo this method should be removed and replaced by canImpersonate(user, client); once V1 is removed
     @Override
     public boolean canClientImpersonate(ClientModel client, UserModel user) {


### PR DESCRIPTION
Closes #41901  
Supersedes #42298  
Restores and replaces the context from #41904

### Summary
Introduce a dedicated `RESET_PASSWORD` scope for the FGAP v2 USERS resource and evaluate password-reset access via explicit policies first.  
If **no** `reset-password` policies exist for the target, evaluation **falls back** to `MANAGE` (backward-compatible path).  
Self-service password change (caller == target user) remains allowed without FGAP checks.

### Motivation
Currently, password resets can be implicitly allowed via `MANAGE_USERS`, which weakens governance/auditing.  
With FGAP v2, password resets should be controlled by explicit policies with deny-overrides semantics.

### Behavior (FGAP v2)
- If there is at least one policy referencing `reset-password`:
  - Decisions come **only** from these policies (deny-overrides, secure-by-default).
- If there are **no** `reset-password` policies:
  - We **fallback** to `MANAGE` evaluation to keep compatibility.
- Self-service flows are unaffected.

> **Note:** If the team prefers a configuration switch instead of unconditional fallback, this PR can be trivially adjusted to use `fgap.v2.resetPassword.fallbackToManageUsers` (default `true`/`false`) and documented accordingly.

### Implementation
- Add `RESET_PASSWORD` to `AdminPermissionsSchema.USERS`.
- Require `RESET_PASSWORD` in `UserResource.resetPassword()` rather than `MANAGE_USERS`.
- Expose `canResetPassword()` / `requireResetPassword()` in the user permissions API.
- Implement scope-first evaluation in `UserPermissionsV2`, with fallback to `MANAGE` only when no `reset-password` policies exist.
- Deny-overrides decision model; secure-by-default once policies are present.
- Include `getAccess(user).resetPassword` for Admin Console (hide the **Reset Password** button when `false`).
- Preserve self-service behavior.
- Auditing/logging shows whether access was granted by policy or by fallback.

### Tests
- Added coverage for:
  - Policies present: ALLOW/DENY paths, deny-overrides.
  - No policies: fallback to `MANAGE` (ALLOW/DENY).
  - Self-service unaffected.
  - Access flag propagation to `getAccess(user).resetPassword`.

### Documentation
- Server Admin Guide: Admin Permissions section updated with the new `RESET_PASSWORD` scope and evaluation flow.
- Upgrading Guide: note on behavior and fallback path; guidance on migrating to explicit `reset-password` policies.

### UI
- Admin Console hides **Reset Password** when `getAccess(user).resetPassword == false`.

### Backward compatibility & Security
- Backward-compat maintained via fallback when no policies exist.
- Once policies exist, model becomes secure-by-default with deny-overrides.

### Performance
- Scope-first check plus optional fallback adds a minor evaluation step; negligible in practice.

### Follow-ups
- Group-based `RESET_PASSWORD` permissions (separate PR).

