### PR TITLE
fix: allows for schedulings to be defined for operator jobs

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -82,7 +82,7 @@ NOTE: If a `http-relative-path` is configured, configure a reverse proxy to map 
 
 === Operator default affinity configuration changed
 
-The default affinity strategy has been updated so that a `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity rule
+The default scheduling strategy has been updated so that a topology spread constraint
 is created for both zones and nodes in order to increase availability in the presence of failures. Previously the default
 preferred that all nodes were deployed to the same availability zone. See the link:{highavailabilityguide_link}[{highavailabilityguide_name}]
 for more details.

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -290,7 +290,7 @@ spec:
 
 Please see https://kubernetes.io/docs/concepts/scheduling-eviction[the kubernetes docs] for more on scheduling concepts.
 
-If you do not specify a custom topology spread constraint, your Pods will have a spread constraint across zones and nodes to improve availability.
+If you do not specify a custom topology spread constraint, your Pods will have a spread constraint across zones and nodes to improve availability. These defaults do not affect import and update Jobs, only server Pods.
 
 ==== Job Scheduling
 

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -290,7 +290,26 @@ spec:
 
 Please see https://kubernetes.io/docs/concepts/scheduling-eviction[the kubernetes docs] for more on scheduling concepts.
 
-If you do not specify a custom affinity, your Pods will have an anti-affinity for the same zone and node to improve availability.
+If you do not specify a custom topology spread constraint, your Pods will have a spread constraint across zones and nodes to improve availability.
+
+==== Job Scheduling
+
+Realm import and update Jobs inherit the scheduling of the server Pods if it is specified in the Keycloak CR `spec.scheduling` field. If your server Pod scheduling is highly restrictive this may result in the 
+Job Pods being unschedulable. In this situation you may override the Job scheduling using the Keycloak CR `spec.update.scheduling` and `spec.import.scheduling` fields.
+ 
+For example the following will remove the use of any server Pod scheduling for the update Job: 
+ 
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  update:
+    scheduling: {}
+  ...
+----
 
 === Management Interface
 

--- a/operator/src/main/java/org/keycloak/operator/ContextUtils.java
+++ b/operator/src/main/java/org/keycloak/operator/ContextUtils.java
@@ -21,6 +21,8 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.keycloak.operator.controllers.KeycloakDistConfigurator;
 import org.keycloak.operator.controllers.WatchedResources;
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.update.UpdateType;
 
 import java.util.Optional;
@@ -28,6 +30,7 @@ import java.util.Optional;
 public final class ContextUtils {
 
     // context keys
+    public static final String KEYCLOAK = "keycloak";
     public static final String OLD_DEPLOYMENT_KEY = "current_stateful_set";
     public static final String NEW_DEPLOYMENT_KEY = "desired_new_stateful_set";
     public static final String UPDATE_TYPE_KEY = "update_type";
@@ -90,5 +93,13 @@ public final class ContextUtils {
 
     public static KeycloakDistConfigurator getDistConfigurator(Context<?> context) {
         return context.managedWorkflowAndDependentResourceContext().getMandatory(DIST_CONFIGURATOR_KEY, KeycloakDistConfigurator.class);
+    }
+
+    public static void storeKeycloak(Context<KeycloakRealmImport> context, Keycloak existingKeycloak) {
+        context.managedWorkflowAndDependentResourceContext().put(KEYCLOAK, existingKeycloak);
+    }
+
+    public static Keycloak getKeycloak(Context<?> context) {
+        return context.managedWorkflowAndDependentResourceContext().getMandatory(KEYCLOAK, Keycloak.class);
     }
 }

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportController.java
@@ -30,6 +30,7 @@ import io.quarkus.logging.Log;
 import jakarta.inject.Inject;
 import org.keycloak.operator.Config;
 import org.keycloak.operator.ContextUtils;
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatus;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusBuilder;
@@ -61,9 +62,13 @@ public class KeycloakRealmImportController implements Reconciler<KeycloakRealmIm
         StatefulSet existingDeployment = context.getClient().resources(StatefulSet.class).inNamespace(realm.getMetadata().getNamespace())
                 .withName(realm.getSpec().getKeycloakCRName()).get();
 
+        Keycloak existingKeycloak = context.getClient().resources(Keycloak.class).inNamespace(realm.getMetadata().getNamespace())
+                .withName(realm.getSpec().getKeycloakCRName()).require();
+
         if (existingDeployment != null) {
             ContextUtils.storeOperatorConfig(context, config);
             ContextUtils.storeCurrentStatefulSet(context, existingDeployment);
+            ContextUtils.storeKeycloak(context, existingKeycloak);
             if (getReadyReplicas(existingDeployment) > 0) {
                 context.managedWorkflowAndDependentResourceContext().reconcileManagedWorkflow();
             }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -27,6 +27,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpManagementSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.ImportSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.NetworkPolicySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.ProbeSpec;
@@ -123,6 +124,10 @@ public class KeycloakSpec {
     @JsonProperty("scheduling")
     @JsonPropertyDescription("In this section you can configure Keycloak's scheduling")
     private SchedulingSpec schedulingSpec;
+
+    @JsonProperty("import")
+    @JsonPropertyDescription("In this section you can configure import Jobs")
+    private ImportSpec importSpec;
 
     @JsonProperty("bootstrapAdmin")
     @JsonPropertyDescription("In this section you can configure Keycloak's bootstrap admin - will be used only for initial cluster creation.")
@@ -360,4 +365,13 @@ public class KeycloakSpec {
     public void setStartupProbeSpec(ProbeSpec startupProbeSpec) {
         this.startupProbeSpec = startupProbeSpec;
     }
+
+    public ImportSpec getImportSpec() {
+        return importSpec;
+    }
+
+    public void setImportSpec(ImportSpec importSpec) {
+        this.importSpec = importSpec;
+    }
+
 }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/ImportSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/ImportSpec.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.crds.v2alpha1.deployment.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.sundr.builder.annotations.Buildable;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class ImportSpec {
+
+    @JsonProperty("scheduling")
+    @JsonPropertyDescription("In this section you can configure import jobs scheduling")
+    private SchedulingSpec schedulingSpec;
+
+    public SchedulingSpec getSchedulingSpec() {
+        return schedulingSpec;
+    }
+
+    public void setSchedulingSpec(SchedulingSpec schedulingSpec) {
+        this.schedulingSpec = schedulingSpec;
+    }
+
+}

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/UpdateSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/UpdateSpec.java
@@ -20,6 +20,7 @@ package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.fabric8.generator.annotation.Default;
 import io.fabric8.generator.annotation.ValidationRule;
@@ -40,6 +41,10 @@ public class UpdateSpec {
     // those are the default, keep them in sync.
     private static final UpdateStrategy DEFAULT = UpdateStrategy.RECREATE_ON_IMAGE_CHANGE;
     private static final String DEFAULT_JSON = "RecreateOnImageChange";
+
+    @JsonProperty("scheduling")
+    @JsonPropertyDescription("In this section you can configure the update job's scheduling")
+    private SchedulingSpec schedulingSpec;
 
     @JsonPropertyDescription("Sets the update strategy to use.")
     @Default(DEFAULT_JSON)
@@ -62,6 +67,14 @@ public class UpdateSpec {
 
     public void setRevision(String revision) {
         this.revision = revision;
+    }
+
+    public SchedulingSpec getSchedulingSpec() {
+        return schedulingSpec;
+    }
+
+    public void setSchedulingSpec(SchedulingSpec schedulingSpec) {
+        this.schedulingSpec = schedulingSpec;
     }
 
     public static UpdateStrategy getUpdateStrategy(Keycloak keycloak) {

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/realmimport/KeycloakRealmImportSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/realmimport/KeycloakRealmImportSpec.java
@@ -76,4 +76,5 @@ public class KeycloakRealmImportSpec {
     public void setPlaceholders(Map<String, Placeholder> placeholders) {
         this.placeholders = placeholders;
     }
+
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -110,6 +110,8 @@ public class CRSerializationTest {
         assertEquals(40,keycloak.getSpec().getStartupProbeSpec().getProbePeriodSeconds());
         assertEquals(2,keycloak.getSpec().getStartupProbeSpec().getProbeFailureThreshold());
         assertEquals("MY_ENV_VAR", keycloak.getSpec().getEnv().get(0).getName());
+        assertEquals("--- {}\n", Serialization.asYaml(keycloak.getSpec().getUpdateSpec().getSchedulingSpec()));
+        assertEquals("x", keycloak.getSpec().getSchedulingSpec().getPriorityClassName());
     }
 
     @Test

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -135,6 +135,9 @@ spec:
   update:
     strategy: Auto
     revision: 1
+    scheduling: {}
+  scheduling:
+    priorityClassName: x
   env:
     - name : MY_ENV_VAR
       value: my-value


### PR DESCRIPTION
closes: #42057

It's probably worth discussing, but we actually have several options here:

- this pr - keep the current behavior that defaults the job scheduling to that of the server, and allow that to be overriden by specific scheduling fields. 

- An alternative to putting the import scheduling on the import cr is to instead put that on the keycloak cr - it's highly likely that users would want the same scheduling for all imports.

- Add a declarative field on or beside the scheduling spec to state whether the scheduling should be inherited - it would default to true as to not be a breaking change, but we could later default it false.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
