### PR TITLE
Make sure inner transactions are using their own session

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/AbstractLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/AbstractLDAPStorageMapper.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.keycloak.models.RoleModel;
+import org.keycloak.utils.KeycloakSessionUtil;
 
 /**
  * Stateful per-request object
@@ -39,14 +40,12 @@ import org.keycloak.models.RoleModel;
  */
 public abstract class AbstractLDAPStorageMapper implements LDAPStorageMapper {
 
-    protected final KeycloakSession session;
     protected final ComponentModel mapperModel;
     protected final LDAPStorageProvider ldapProvider;
 
     public AbstractLDAPStorageMapper(ComponentModel mapperModel, LDAPStorageProvider ldapProvider) {
         this.mapperModel = mapperModel;
         this.ldapProvider = ldapProvider;
-        this.session = ldapProvider.getSession();
     }
 
     @Override
@@ -99,4 +98,7 @@ public abstract class AbstractLDAPStorageMapper implements LDAPStorageMapper {
 
     }
 
+    protected KeycloakSession getSession() {
+        return KeycloakSessionUtil.getKeycloakSession();
+    }
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/HardcodedLDAPGroupStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/HardcodedLDAPGroupStorageMapper.java
@@ -97,7 +97,7 @@ public class HardcodedLDAPGroupStorageMapper extends AbstractLDAPStorageMapper {
 
     private GroupModel getGroup(RealmModel realm) {
         String groupName = mapperModel.getConfig().getFirst(HardcodedLDAPGroupStorageMapper.GROUP);
-        GroupModel group = KeycloakModelUtils.findGroupByPath(session, realm, groupName);
+        GroupModel group = KeycloakModelUtils.findGroupByPath(getSession(), realm, groupName);
         if (group == null) {
             logger.warnf("Hardcoded group '%s' configured in mapper '%s' is not available anymore");
         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
@@ -374,7 +374,7 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
                     .filter(group -> Objects.equals(group.getName(), groupName)).findFirst().orElse(null);
         } else {
             // Without preserved inheritance, it's always at groups path
-            return session.groups().getGroupByName(realm, parent, groupName);
+            return getSession().groups().getGroupByName(realm, parent, groupName);
         }
     }
 
@@ -807,7 +807,7 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
      * Provides KC group defined as groups path or null (top-level group) if corresponding group is not available.
      */
     protected GroupModel getKcGroupsPathGroup(RealmModel realm) {
-        return config.isTopLevelGroupsPath() ? null : KeycloakModelUtils.findGroupByPath(session, realm, config.getGroupsPath());
+        return config.isTopLevelGroupsPath() ? null : KeycloakModelUtils.findGroupByPath(getSession(), realm, config.getGroupsPath());
     }
 
     protected boolean isGroupInGroupPath(RealmModel realm, GroupModel group) {
@@ -817,7 +817,7 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
         if (config.isTopLevelGroupsPath()) {
             return true; // any group is in the path of the top level path.
         }
-        GroupModel groupPathGroup = KeycloakModelUtils.findGroupByPath(session, realm, config.getGroupsPath());
+        GroupModel groupPathGroup = KeycloakModelUtils.findGroupByPath(getSession(), realm, config.getGroupsPath());
         if (groupPathGroup != null) {
             while(!groupPathGroup.getId().equals(group.getId())) {
                 group = group.getParent();
@@ -851,7 +851,7 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
         if (parentGroup == null) {
             parentGroup = getKcGroupsPathGroup(realm);
         }
-        return parentGroup == null ? session.groups().getTopLevelGroupsStream(realm) :
+        return parentGroup == null ? getSession().groups().getTopLevelGroupsStream(realm) :
             parentGroup.getSubGroupsStream();
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/msad/MSADUserAccountControlStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/msad/MSADUserAccountControlStorageMapper.java
@@ -163,7 +163,7 @@ public class MSADUserAccountControlStorageMapper extends AbstractLDAPStorageMapp
                 // User needs to change his MSAD password. Allow him to login, but add UPDATE_PASSWORD required action to authenticationSession
                 if (user.getRequiredActionsStream().noneMatch(action -> Objects.equals(action, UserModel.RequiredAction.UPDATE_PASSWORD.name()))) {
                     // This usually happens when 532 was returned, which means that "pwdLastSet" is set to some positive value, which is older than MSAD password expiration policy.
-                    AuthenticationSessionModel authSession = session.getContext().getAuthenticationSession();
+                    AuthenticationSessionModel authSession = getSession().getContext().getAuthenticationSession();
                     if (authSession != null) {
                         if (authSession.getRequiredActions().stream().noneMatch(action -> Objects.equals(action, UserModel.RequiredAction.UPDATE_PASSWORD.name()))) {
                             logger.debugf("Adding requiredAction UPDATE_PASSWORD to the authenticationSession of user %s", user.getUsername());
@@ -226,7 +226,7 @@ public class MSADUserAccountControlStorageMapper extends AbstractLDAPStorageMapp
             return control;
         }
 
-        RealmModel realm = session.getContext().getRealm();
+        RealmModel realm = getSession().getContext().getRealm();
 
         if (realm == null) {
             return control;
@@ -250,7 +250,7 @@ public class MSADUserAccountControlStorageMapper extends AbstractLDAPStorageMapp
     }
 
     private String getRealmName() {
-        RealmModel realm = session.getContext().getRealm();
+        RealmModel realm = getSession().getContext().getRealm();
         return (realm != null) ? realm.getName() : "null";
     }
 


### PR DESCRIPTION
Closes #41942

* The problem was that methods like `getKcSubGroups` are being invoked in different transactions and using the top-level session instead of the session bound to the inner transaction from where they are invoked

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
