### PR TITLE
Upgrade to Quarkus 3.26.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.26.1</quarkus.version>
-        <quarkus.build.version>3.26.1</quarkus.build.version>
+        <quarkus.version>3.26.2</quarkus.version>
+        <quarkus.build.version>3.26.2</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>


### PR DESCRIPTION
- Closes #42342

Executed script: `./set-quarkus-version.sh 3.26.2
`