### PR TITLE
Specify link to where containers are published in start-keycloak-container.adoc

### DIFF
--- a/docs/guides/getting-started/getting-started-docker.adoc
+++ b/docs/guides/getting-started/getting-started-docker.adoc
@@ -16,7 +16,7 @@ include::templates/hw-requirements.adoc[]
 
 Make sure you have Docker installed.
 
-include::templates/start-keycloak-container.adoc[]
+<#include "templates/start-keycloak-container.adoc" />
 
 include::templates/realm-config.adoc[]
 

--- a/docs/guides/getting-started/getting-started-podman.adoc
+++ b/docs/guides/getting-started/getting-started-podman.adoc
@@ -16,7 +16,7 @@ include::templates/hw-requirements.adoc[]
 
 Make sure you have Podman installed.
 
-include::templates/start-keycloak-container.adoc[]
+<#include "templates/start-keycloak-container.adoc" />
 
 include::templates/realm-config.adoc[]
 

--- a/docs/guides/getting-started/templates/start-keycloak-container.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-container.adoc
@@ -1,3 +1,5 @@
+<#import "/templates/profile.adoc" as profile>
+
 == Start {project_name}
 
 From a terminal, enter the following command to start {project_name}:

--- a/docs/guides/getting-started/templates/start-keycloak-container.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-container.adoc
@@ -9,3 +9,5 @@ From a terminal, enter the following command to start {project_name}:
 
 This command starts {project_name} exposed on the local port 8080 and creates an initial admin user with the username `admin`
 and password `admin`.
+
+Container images are published at https://quay.io/organization/keycloak .

--- a/docs/guides/getting-started/templates/start-keycloak-container.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-container.adoc
@@ -10,4 +10,6 @@ From a terminal, enter the following command to start {project_name}:
 This command starts {project_name} exposed on the local port 8080 and creates an initial admin user with the username `admin`
 and password `admin`.
 
-Container images are published at https://quay.io/organization/keycloak .
+<@profile.ifCommunity>
+Container images are published at https://quay.io/repository/keycloak/keycloak?tab=tags[Keycloak's Quay.io organization].
+</@profile.ifCommunity>


### PR DESCRIPTION
Specify link to where containers are published.

It's useful to check other versions and other images. 
ESP if you don't use quay.io that much / at all .

Closes #42392

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
