### PR TITLE
Support Aurora PostgreSQL 17.5 in Keycloak's nightly run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
         <postgresql.version>17</postgresql.version>
         <postgresql.container>mirror.gcr.io/postgres:${postgresql.version}</postgresql.container>
-        <aurora-postgresql.version>16.8</aurora-postgresql.version>
+        <aurora-postgresql.version>17.5</aurora-postgresql.version>
         <aws-jdbc-wrapper.version>2.5.6</aws-jdbc-wrapper.version>
         <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>


### PR DESCRIPTION
Closes #42308

Successful run with Aurora on my fork: https://github.com/ryanemerson/keycloak/actions/runs/17433070440

All Keycloak-benchmark integration tests are also passing with 17.5.