### PR TITLE
add logout_hint to broker browser logout url

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3172,6 +3172,8 @@ defaultValueHelp=Default value when attribute value is not specified.
 to the attribute. For that, make sure to use any of the built-in validators to properly validate the size and the values.
 sendIdTokenOnLogout=Send 'id_token_hint' in logout requests
 sendIdTokenOnLogoutHelp=If the 'id_token_hint' parameter should be sent in logout requests.
+sendLogoutHintOnLogout=Send 'logout_hint' in logout requests
+sendLogoutHintOnLogoutHelp=If enabled, the 'logout_hint' parameter in the logout request will be added with the value of the 'login_hint' parameter from the id_token.
 sendClientIdOnLogout=Send 'client_id' in logout requests
 sendClientIdOnLogoutHelp=If the 'client_id' parameter should be sent in logout requests.
 addAttributeTranslationBtn=Add translation button

--- a/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
@@ -99,6 +99,11 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           stringify
         />
         <DefaultSwitchControl
+          name="config.sendLogoutHintOnLogout"
+          label={t("sendLogoutHintOnLogout")}
+          stringify
+        />
+        <DefaultSwitchControl
           name="config.sendClientIdOnLogout"
           label={t("sendClientIdOnLogout")}
           isDisabled={readOnly}

--- a/js/apps/admin-ui/src/identity-providers/add/ExtendedNonDiscoverySettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/ExtendedNonDiscoverySettings.tsx
@@ -52,6 +52,10 @@ export const ExtendedNonDiscoverySettings = () => {
           defaultValue={"true"}
         />
         <SwitchField
+          field="config.sendLogoutHintOnLogout"
+          label="sendLogoutHintOnLogout"
+        />
+        <SwitchField
           field="config.sendClientIdOnLogout"
           label="sendClientIdOnLogout"
         />

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProviderConfig.java
@@ -16,11 +16,11 @@
  */
 package org.keycloak.broker.oidc;
 
-import static org.keycloak.common.util.UriUtils.checkUrl;
-
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.RealmModel;
+
+import static org.keycloak.common.util.UriUtils.checkUrl;
 
 /**
  * @author Pedro Igor
@@ -78,6 +78,14 @@ public class OIDCIdentityProviderConfig extends OAuth2IdentityProviderConfig {
 
     public void setSendIdTokenOnLogout(boolean value) {
         getConfig().put("sendIdTokenOnLogout", Boolean.valueOf(value).toString());
+    }
+
+    public boolean isSendLogoutHintOnLogout() {
+        return Boolean.parseBoolean(getConfig().getOrDefault("sendLogoutHintOnLogout", Boolean.TRUE.toString()));
+    }
+
+    public void setSendLogoutHintOnLogout(boolean value) {
+        getConfig().put("sendLogoutHintOnLogout", Boolean.valueOf(value).toString());
     }
 
     public String getPublicKeySignatureVerifier() {


### PR DESCRIPTION
closes #33008

Adds the `logout_hint` parameter to the broker browser logout url with the value the external IdP sent as claim `login_hint` in the ID token.
If there's no `login_hint` claim in the ID token, or if there's any other problem resolving it, it is ignored to not invoke an error/exception.