### PR TITLE
fix: allowing resolution of log color at build time

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -87,7 +87,9 @@ public final class PropertyMappers {
         // If however expressions are not enabled that means quarkus is specifically looking for runtime defaults, and we should not provide a value
         // See https://github.com/quarkusio/quarkus/pull/42157
         if (isRebuild() && isKeycloakRuntime(name, mapper)
-                && (!NestedPropertyMappingInterceptor.getResolvingRoot().orElse(name).startsWith("quarkus.log.") || !Expressions.isEnabled())) {
+                && (NestedPropertyMappingInterceptor.getResolvingRoot().or(() -> Optional.of(name))
+                        .filter(n -> n.startsWith("quarkus.log.") || n.startsWith("quarkus.console.")).isEmpty()
+                        || !Expressions.isEnabled())) {
             return ConfigValue.builder().withName(name).build();
         }
 


### PR DESCRIPTION
I suppose it's safer to check specifically for log and console options, rather than expanding to all quarkus options.

The only other consideration is that picocli warn/error messages do not honor the color setting. Do we want to change that also? @mabartos @vmuzikar @stianst 

closes: #42335

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
