### PR TITLE
testsuite: use KC_TEST_SERVER_STARTUP_TIMEOUT env var for distribution startup timeout

### DIFF
--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -398,7 +398,21 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
     }
 
     private long getStartTimeout() {
-        return TimeUnit.SECONDS.toMillis(Long.getLong("keycloak.distribution.start.timeout", 120L));
+        
+        String env = System.getenv("KC_TEST_SERVER_STARTUP_TIMEOUT");
+        if (env != null && !env.isBlank()) {
+            try {
+                long seconds = Long.parseLong(env.trim());
+                return TimeUnit.SECONDS.toMillis(seconds);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                "Invalid value for KC_TEST_SERVER_STARTUP_TIMEOUT: " + env, e
+            );
+            }
+        }
+    
+        long secFromProp = Long.getLong("keycloak.distribution.start.timeout", 120L);
+        return TimeUnit.SECONDS.toMillis(secFromProp);
     }
 
     private HostnameVerifier createInsecureHostnameVerifier() {


### PR DESCRIPTION
Closes #39142

This changes RawKeycloakDistribution to read KC_TEST_SERVER_STARTUP_TIMEOUT environment variable
(first), and fall back to the previous system property keycloak.distribution.start.timeout if not set.
Default remains 120 seconds. This avoids using ad-hoc system properties directly, and aligns the
testsuite configuration with KC_ environment variables.

Files changed:
 - quarkus/tests/junit5/.../RawKeycloakDistribution.java
 
 Note: I’m new to Keycloak contributions and was unable to run the full testsuite locally.
