### PR TITLE
Fix broken HA guide links

### DIFF
--- a/docs/guides/getting-started/templates/hw-requirements.adoc
+++ b/docs/guides/getting-started/templates/hw-requirements.adoc
@@ -1,4 +1,4 @@
 <#import "/templates/links.adoc" as links>
 
-Make sure your machine or container platform can provide sufficient memory and CPU for your desired usage of {project_name}. 
-See <@links.ha id="concepts-memory-and-cpu-sizing" /> for more on how to get started with production sizing.
+Make sure your machine or container platform can provide sufficient memory and CPU for your desired usage of {project_name}.
+See <@links.ha id="single-cluster-concepts-memory-and-cpu-sizing" /> for more on how to get started with production sizing.

--- a/docs/guides/observability/metrics-for-troubleshooting-database.adoc
+++ b/docs/guides/observability/metrics-for-troubleshooting-database.adoc
@@ -12,7 +12,7 @@ tileVisible="false"
 == Database connection pool metrics
 
 Configure {project_name} to use a fixed size database connection pool.
-See the <@links.ha id="concepts-database-connections"/> {section} for more information.
+See the <@links.ha id="single-cluster-concepts-database-connections"/> {section} for more information.
 
 [TIP]
 ====


### PR DESCRIPTION
Closes #42426

@ahus1 I have just fixed the links for now. Currently the generic tuning guide is part of "getting-started", which doesn't seem right to me, so I think we need a discussion about where non-ha related tuning/configuration should be located. My initial thoughts are that it might be worth creating a dedicated scaling or tuning guide, where we move the following content:

- `getting-started/getting-started-scaling-and-tuning.adoc`
- `high-availability/*-cluster/concepts-database-connections.adoc`
- `high-availability/*-cluster/concepts-threads.adoc`
- `high-availability/*-cluster/concepts-memory-and-cpu-sizing.adoc`

There's some multi-site specific content in `high-availability/multi-cluster/concepts-memory-and-cpu-sizing.adoc`, so I would retain this guide.