### PR TITLE
Avoid removing client sessions before the user session times out

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -246,50 +247,34 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     public void removeExpired(RealmModel realm) {
         int expiredOffline = calculateOldestSessionTime(realm, true) - SessionTimeoutHelper.PERIODIC_CLEANER_IDLE_TIMEOUT_WINDOW_SECONDS;
 
-        // prefer client session timeout if set
-        int expiredClientOffline = expiredOffline;
-        if (realm.isOfflineSessionMaxLifespanEnabled() && realm.getClientOfflineSessionIdleTimeout() > 0) {
-            expiredClientOffline = Time.currentTime() - realm.getClientOfflineSessionIdleTimeout() - SessionTimeoutHelper.PERIODIC_CLEANER_IDLE_TIMEOUT_WINDOW_SECONDS;
-        }
-
-        expire(realm, expiredClientOffline, expiredOffline, true);
+        expire(realm, expiredOffline, true);
 
         if (MultiSiteUtils.isPersistentSessionsEnabled()) {
 
             int expired = calculateOldestSessionTime(realm, false) - SessionTimeoutHelper.PERIODIC_CLEANER_IDLE_TIMEOUT_WINDOW_SECONDS;
 
-            // prefer client session timeout if set
-            int expiredClient = expired;
-            if (realm.getClientSessionIdleTimeout() > 0) {
-                expiredClient = Time.currentTime() - realm.getClientSessionIdleTimeout() - SessionTimeoutHelper.PERIODIC_CLEANER_IDLE_TIMEOUT_WINDOW_SECONDS;
-            }
-
-            expire(realm, expiredClient, expired, false);
+            expire(realm, expired, false);
         }
     }
 
     private int calculateOldestSessionTime(RealmModel realm, boolean offline) {
-        if (offline) {
-            return Time.currentTime() - SessionExpirationUtils.getOfflineSessionIdleTimeout(realm);
-        } else {
-            return Time.currentTime() - Math.max(SessionExpirationUtils.getSsoSessionIdleTimeout(realm), realm.getSsoSessionIdleTimeoutRememberMe());
-        }
+        return Time.currentTime() - (int) TimeUnit.MILLISECONDS.toSeconds(SessionExpirationUtils.calculateUserSessionIdleTimestamp(offline, realm.isRememberMe(), 0, realm));
     }
 
-    private void expire(RealmModel realm, int expiredClientOffline, int expiredOffline, boolean offline) {
+    private void expire(RealmModel realm, int expired, boolean offline) {
         String offlineStr = offlineToString(offline);
 
         logger.tracef("Trigger removing expired user sessions for realm '%s'", realm.getName());
 
         int cs = em.createNamedQuery("deleteExpiredClientSessions")
                 .setParameter("realmId", realm.getId())
-                .setParameter("lastSessionRefresh", expiredClientOffline)
+                .setParameter("lastSessionRefresh", expired)
                 .setParameter("offline", offlineStr)
                 .executeUpdate();
 
         int us = em.createNamedQuery("deleteExpiredUserSessions")
                 .setParameter("realmId", realm.getId())
-                .setParameter("lastSessionRefresh", expiredOffline)
+                .setParameter("lastSessionRefresh", expired)
                 .setParameter("offline", offlineStr)
                 .executeUpdate();
 


### PR DESCRIPTION
As the client session timeout can be overwritten on a per client level, the realm level timeout can not be used to remove client sessions early.

Closes #35825

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
