### PR TITLE
Add User_agent header for documentation links checker

### DIFF
--- a/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
+++ b/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
@@ -81,6 +81,7 @@ public class HttpUtils {
             // add common headers that are needed by some pages
             method.addHeader(HttpHeaders.ACCEPT_LANGUAGE, "en-US,en;q=0.9");
             method.addHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            method.addHeader(HttpHeaders.USER_AGENT, "Java/" + System.getProperty("java.version") + " (https://www.keycloak.org; keycloak-dev@googlegroups.com)");
             client.execute(method, responseHandler);
         } catch (Exception e) {
             response.setError("exception " + e.getMessage());

--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -39,9 +39,5 @@ https://stackapps.com/apps/oauth/register
 # Failing because of broken certificate, can likely be restored later.
 https://docs.kantarainitiative.org*
 https://saml.xml.org*
-# To be removed once KC 26.2 has been released
-https://www.keycloak.org/server/caching#_securing_transport_stacks
-https://www.keycloak.org/observability/grafana-dashboards
-https://www.keycloak.org/securing-apps/token-exchange*
-https://www.keycloak.org/operator/rolling-updates
-https://www.keycloak.org/server/update-compatibility#rolling-updates-for-patch-releases
+# To be removed once KC 26.4 has been released
+https://www.keycloak.org/securing-apps/specifications


### PR DESCRIPTION
Closes #42164

The wikipedia seems to require now the user-agent header and the apache http-client does not add any by default. Just adding a generic one using the java version and links to our project and the keycloak-dev mailing list. If you prefer something else just let me know. There is one error remaining to link https://www.keycloak.org/securing-apps/specifications but that one will be fixed when the new guides are published.
