### PR TITLE
fix: further refining when profile info is logged

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -251,10 +251,6 @@ class KeycloakProcessor {
     void configureProfile(KeycloakRecorder recorder) {
         Profile profile = getCurrentOrCreateFeatureProfile();
 
-        if (!Environment.isRebuildCheck()) {
-            profile.logUnsupportedFeatures();
-        }
-
         // record the features so that they are not calculated again at runtime
         recorder.configureProfile(profile.getName(), profile.getFeatures());
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
@@ -135,13 +135,6 @@ public abstract class AbstractAutoBuildCommand extends AbstractCommand {
         }
     }
 
-    /**
-     * Controls whether the command actually starts the server
-     */
-    protected boolean shouldStart() {
-        return true;
-    }
-
     protected void doBeforeRun() {
 
     }
@@ -154,6 +147,11 @@ public abstract class AbstractAutoBuildCommand extends AbstractCommand {
 
     protected EnumSet<OptionCategory> excludedCategories() {
         return EnumSet.of(OptionCategory.IMPORT, OptionCategory.EXPORT);
+    }
+
+    @Override
+    public boolean shouldStart() {
+        return true;
     }
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -144,4 +144,11 @@ public abstract class AbstractCommand implements Callable<Integer> {
         return false;
     }
 
+    /**
+     * Controls whether the command actually starts the server
+     */
+    public boolean shouldStart() {
+        return false;
+    }
+
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractUpdatesCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractUpdatesCommand.java
@@ -36,7 +36,7 @@ public abstract class AbstractUpdatesCommand extends AbstractAutoBuildCommand {
     OptimizedMixin optimizedMixin = new OptimizedMixin();
 
     @Override
-    protected boolean shouldStart() {
+    public boolean shouldStart() {
         return false;
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -5,6 +5,7 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Expressions;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import org.jboss.logging.Logger;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.config.ConfigSupportLevel;
 import org.keycloak.config.Option;
@@ -313,6 +314,10 @@ public final class PropertyMappers {
                     PersistedConfigSource.getInstance().runWithDisabled(Environment::getCurrentOrCreateFeatureProfile);
                 } else {
                     Environment.getCurrentOrCreateFeatureProfile();
+                    if (!command.shouldStart()) {
+                        // this will use the deferred logger, which means it may not be seen in some circumstances
+                        Profile.getInstance().logUnsupportedFeatures();
+                    }
                 }
 
                 sanitizeMappers(buildTimeMappers, disabledBuildTimeMappers);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -34,7 +34,9 @@ public class FeaturesDistTest {
             .filter(feature -> feature.getType() == Profile.Feature.Type.PREVIEW)
             .filter(feature -> {
                 Set<Profile.Feature> versions = Profile.getFeatureVersions(feature.getUnversionedKey());
-                if (versions.size() == 1) return true;
+                if (versions.size() == 1) {
+                    return true;
+                }
                 return versions.iterator().next().getVersion() == feature.getVersion();
             })
             .map(Profile.Feature::getVersionedKey)
@@ -58,12 +60,12 @@ public class FeaturesDistTest {
         assertPreviewFeaturesEnabled(cliResult);
     }
 
-    // Should enable "fips" together with all other "preview" features
+    // Should enable "docker" together with all other "preview" features
     @Test
-    @Launch({StartDev.NAME, "--features=preview,fips"})
-    public void testEnablePreviewFeaturesAndFips(CLIResult cliResult) {
+    @Launch({StartDev.NAME, "--features=preview,docker"})
+    public void testEnablePreviewFeaturesAndDocker(CLIResult cliResult) {
+        cliResult.assertStartedDevMode();
         assertPreviewFeaturesEnabled(cliResult);
-        cliResult.assertError("Failed to configure FIPS.");
     }
 
     @Test

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -59,7 +59,6 @@ public abstract class KeycloakApplication extends Application {
         try {
 
             logger.debugv("PlatformProvider: {0}", platform.getClass().getName());
-            Profile.getInstance().logUnsupportedFeatures();
             loadConfig();
 
             platform.onStartup(this::startup);
@@ -71,6 +70,7 @@ public abstract class KeycloakApplication extends Application {
     }
 
     protected void startup() {
+        Profile.getInstance().logUnsupportedFeatures();
         CryptoIntegration.init(KeycloakApplication.class.getClassLoader());
         KeycloakApplication.sessionFactory = createSessionFactory();
 


### PR DESCRIPTION
closes: #42334

@mabartos I'd propose this as an alternative to #42334

The intention behind having the logging in KeycloakApplication is for it to be shown even for our non-quarkus usage. The problem with having the log in the constructor is that resteasy annotation scanning is also causing the the constructor to be used.

On the quarkus / picocli side we then should only log any time we aren't going to start quarkus - which we can elevate the shouldStart method to check. This is a more complete check than was being done before, so we'll see the warnings even with the update-compatibility commands.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
