### PR TITLE
Fix unstable user tests for admin console

### DIFF
--- a/js/apps/admin-ui/test/clients/authorization.spec.ts
+++ b/js/apps/admin-ui/test/clients/authorization.spec.ts
@@ -205,7 +205,10 @@ test.describe
   });
 
   test("Should view authorization tab", async ({ page }) => {
-    await login(page, "test-view-authz-user", "password");
+    await login(page, {
+      username: "test-view-authz-user",
+      password: "password",
+    });
 
     await goToRealm(page, "realm-view-authz");
     await page.reload();

--- a/js/apps/admin-ui/test/events/list.spec.ts
+++ b/js/apps/admin-ui/test/events/list.spec.ts
@@ -85,12 +85,11 @@ test.describe.serial("Events tests", () => {
     });
 
     test.beforeEach(async ({ page }) => {
-      await login(
-        page,
-        eventsTestUser.userRepresentation.username,
-        eventsTestUser.userRepresentation.credentials[0].value,
-        realmName,
-      );
+      await login(page, {
+        realm: realmName,
+        username: eventsTestUser.userRepresentation.username,
+        password: eventsTestUser.userRepresentation.credentials[0].value,
+      });
       await goToEvents(page);
     });
 

--- a/js/apps/admin-ui/test/masthead/main.spec.ts
+++ b/js/apps/admin-ui/test/masthead/main.spec.ts
@@ -87,7 +87,7 @@ test.describe.serial("Masthead tests", () => {
 
     test("Login without privileges to see admin console", async ({ page }) => {
       await logout(page);
-      await login(page, username, "test", realmName);
+      await login(page, { realm: realmName, username, password: "test" });
       await expect(
         page.getByText(
           "You do not have permission to access this resource, sign in with a user that has permission, or contact your administrator.",

--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
+import { DEFAULT_REALM } from "../utils/constants.ts";
 import { assertRequiredFieldError, switchOff } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
 import {
@@ -46,7 +47,7 @@ test.describe.serial("Realm tests", () => {
     await page.getByTestId("create").click();
     await assertRequiredFieldError(page, "realm");
 
-    await fillRealmName(page, "master");
+    await fillRealmName(page, DEFAULT_REALM);
     await clickCreateRealmForm(page);
 
     await assertNotificationMessage(

--- a/js/apps/admin-ui/test/realm-settings/i18n.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/i18n.spec.ts
@@ -53,12 +53,11 @@ async function updateUserLocale(locale: string) {
 
 async function goToPage(page: Page, locale: string) {
   await updateUserLocale(locale);
-  await login(
-    page,
-    testConfig.username,
-    testConfig.password,
-    testConfig.realmName,
-  );
+  await login(page, {
+    realm: testConfig.realmName,
+    username: testConfig.username,
+    password: testConfig.password,
+  });
   await goToUserFederation(page);
 }
 

--- a/js/apps/admin-ui/test/support/testbed.ts
+++ b/js/apps/admin-ui/test/support/testbed.ts
@@ -1,0 +1,12 @@
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation.js";
+import adminClient from "../utils/AdminClient.ts";
+
+export async function createTestBed(
+  overrides?: RealmRepresentation,
+): Promise<string> {
+  const { realmName } = await adminClient.createRealm(
+    crypto.randomUUID(),
+    overrides,
+  );
+  return realmName;
+}

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -43,7 +43,7 @@ class AdminClient {
 
   async createRealm(realm: string, payload?: RealmRepresentation) {
     await this.#login();
-    await this.#client.realms.create({ realm, ...payload });
+    return await this.#client.realms.create({ realm, ...payload });
   }
 
   async updateRealm(realm: string, payload: RealmRepresentation) {
@@ -666,6 +666,22 @@ class AdminClient {
         ...policy,
       },
     );
+  }
+
+  async findUserByUsername(
+    realm: string,
+    username: string,
+  ): Promise<UserRepresentation> {
+    await this.#login();
+
+    const users = await this.#client.users.find({
+      realm,
+      username,
+      exact: true,
+      max: 1,
+    });
+
+    return users[0];
   }
 }
 

--- a/js/apps/admin-ui/test/utils/login.ts
+++ b/js/apps/admin-ui/test/utils/login.ts
@@ -1,28 +1,50 @@
 import type { Page } from "@playwright/test";
+import { generatePath, type Path } from "react-router-dom";
 
 import {
   ADMIN_PASSWORD,
   ADMIN_USER,
   DEFAULT_REALM,
-  SERVER_URL,
   ROOT_PATH,
-} from "./constants";
+  SERVER_URL,
+} from "./constants.ts";
 
-export const login = async (
+export type LoginOptions = {
+  realm?: string;
+  username?: string;
+  password?: string;
+  to?: Partial<Path>;
+};
+
+const DEFAULT_LOGIN_OPTIONS: Required<LoginOptions> = {
+  realm: DEFAULT_REALM,
+  username: ADMIN_USER,
+  password: ADMIN_PASSWORD,
+  to: {},
+};
+
+export async function login(
   page: Page,
-  username = ADMIN_USER,
-  password = ADMIN_PASSWORD,
-  realm = DEFAULT_REALM,
-) => {
-  const rootPath = SERVER_URL + ROOT_PATH.replace(":realm", realm);
+  options: LoginOptions = {},
+): Promise<void> {
+  const { realm, username, password, to } = {
+    ...DEFAULT_LOGIN_OPTIONS,
+    ...options,
+  };
 
-  await page.goto(rootPath);
+  const url = new URL(generatePath(ROOT_PATH, { realm }), SERVER_URL);
+
+  if (to.pathname) {
+    url.hash = to.pathname;
+  }
+
+  await page.goto(url.toString());
   await page.getByLabel("Username").fill(username);
   await page.getByLabel("Password", { exact: true }).fill(password);
   await page.getByRole("button", { name: "Sign In" }).click();
-};
+}
 
-export const logout = async (page: Page, username: string = "admin") => {
+export async function logout(page: Page, username = ADMIN_USER): Promise<void> {
   await page.getByRole("button", { name: username, exact: true }).click();
   await page.getByRole("menuitem", { name: "Sign out" }).click();
-};
+}


### PR DESCRIPTION
Fixes the last failures in the test suite, which now passes 100 runs on CI without retries, nor a single failure :partying_face:. Also introduces all the functionality required to start using proper realm isolation in the test suite, including the first test suite converted to make use of this.

It would be a Herculean effort to convert all the test suites over to use the new realm isolation, but it would allow the tests to run fully in parallel, allowing it to finish several orders of magnitude faster, depending on the available workers. I won't be able to land this, but I am hoping someone is willing to pick up where this is left off.

Closes #42477

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
