### PR TITLE
Add User_agent header for documentation links checker (26.2)

### DIFF
--- a/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
+++ b/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
@@ -81,6 +81,7 @@ public class HttpUtils {
             // add common headers that are needed by some pages
             method.addHeader(HttpHeaders.ACCEPT_LANGUAGE, "en-US,en;q=0.9");
             method.addHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            method.addHeader(HttpHeaders.USER_AGENT, "Java/" + System.getProperty("java.version") + " (https://www.keycloak.org; keycloak-dev@googlegroups.com)");
             client.execute(method, responseHandler);
         } catch (Exception e) {
             response.setError("exception " + e.getMessage());

--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -39,9 +39,3 @@ https://stackapps.com/apps/oauth/register
 # Failing because of broken certificate, can likely be restored later.
 https://docs.kantarainitiative.org*
 https://saml.xml.org*
-# To be removed once KC 26.2 has been released
-https://www.keycloak.org/server/caching#_securing_transport_stacks
-https://www.keycloak.org/observability/grafana-dashboards
-https://www.keycloak.org/securing-apps/token-exchange*
-https://www.keycloak.org/operator/rolling-updates
-https://www.keycloak.org/server/update-compatibility


### PR DESCRIPTION
Closes #42164

PR:             https://github.com/keycloak/keycloak/pull/42465
Commit:         https://github.com/keycloak/keycloak/commit/93791f67fba08c15be229d1acf7f573d305ccc35
PR branch:      backport-42465-26.2
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.2
