### PR TITLE
Quarkus config for additional datasources not picked up after 26.3.0

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -198,7 +198,8 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
 
                 var created = fromOption(datasourceOption.get())
                         .isMasked(parent.isMask())
-                        .transformer(parent.getMapper());
+                        .transformer(parent.getMapper())
+                        .allowQuarkusPropertiesFallback(true); // we allow to use properties in quarkus.properties due to backwards compatibility for datasources
 
                 if (parent.getMapFrom() != null) {
                     var wildcardMapFromOption = getKeyForDatasource(parent.getMapFrom())

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -32,6 +32,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import io.smallrye.config.DefaultValuesConfigSource;
 import org.keycloak.config.DeprecatedMetadata;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionCategory;
@@ -67,19 +68,19 @@ public class PropertyMapper<T> {
     private final BooleanSupplier required;
     private final String requiredWhen;
     private final String from;
+    private final boolean allowQuarkusPropertiesFallback;
 
     private final String namedProperty;
 
     PropertyMapper(PropertyMapper<T> mapper, String from, String to, String mapFrom, String namedProperty, ValueMapper parentMapper) {
         this(mapper.option, to, mapper.enabled, mapper.enabledWhen, mapper.mapper, mapFrom, parentMapper,
-                mapper.paramLabel, mapper.mask, mapper.validator, mapper.description, mapper.required,
-                mapper.requiredWhen, from, namedProperty);
+                mapper.paramLabel, mapper.mask, mapper.validator, mapper.description, mapper.required, mapper.requiredWhen, from, namedProperty, mapper.allowQuarkusPropertiesFallback);
     }
 
     PropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen,
                    ValueMapper mapper, String mapFrom, ValueMapper parentMapper,
-                   String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator,
-                   String description, BooleanSupplier required, String requiredWhen, String from, String namedProperty) {
+                   String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator, String description,
+                   BooleanSupplier required, String requiredWhen, String from, String namedProperty, boolean allowQuarkusPropertiesFallback) {
         this.option = option;
         this.from = from == null ? NS_KEYCLOAK_PREFIX + this.option.getKey() : from;
         this.to = to == null ? getFrom() : to;
@@ -97,6 +98,7 @@ public class PropertyMapper<T> {
         this.description = description;
         this.parentMapper = parentMapper;
         this.namedProperty = namedProperty;
+        this.allowQuarkusPropertiesFallback = allowQuarkusPropertiesFallback;
     }
 
     /**
@@ -129,6 +131,11 @@ public class PropertyMapper<T> {
         // this ensures that mapFrom transformers, and regular transformers are applied exclusively - not chained
         ConfigValue config = convertValue(NestedPropertyMappingInterceptor.proceed(context, from));
 
+        // due to backward compatibility, we allow for some options to use Quarkus properties
+        if (allowQuarkusPropertiesFallback) {
+            config = getConfigValueFromQuarkusProperties(config, context);
+        }
+
         boolean parentValue = false;
         if (mapFrom != null && (config == null || config.getValue() == null)) {
             // if the property we want to map depends on another one, we use the value from the other property to call the mapper
@@ -153,6 +160,17 @@ public class PropertyMapper<T> {
 
         // now try any defaults from quarkus
         return context.proceed(name);
+    }
+
+    // due to backward compatibility, we allow for some options to use Quarkus properties
+    private ConfigValue getConfigValueFromQuarkusProperties(ConfigValue currentConfig, ConfigSourceInterceptorContext context) {
+        if ((currentConfig == null || currentConfig.getValue() == null) && !getFrom().equals(getTo())) {
+            var value = context.proceed(getTo());
+            if (isModifiedQuarkusProperty(value)) {
+                return value;
+            }
+        }
+        return currentConfig;
     }
 
     public Option<T> getOption() {
@@ -365,6 +383,7 @@ public class PropertyMapper<T> {
         private String requiredWhen = "";
         private BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer;
         private ValueMapper wildcardMapFrom;
+        private boolean allowQuarkusPropertiesFallback;
 
         public Builder(Option<T> option) {
             this.option = option;
@@ -523,17 +542,22 @@ public class PropertyMapper<T> {
             return this;
         }
 
+        public Builder<T> allowQuarkusPropertiesFallback(boolean allow) {
+            this.allowQuarkusPropertiesFallback = allow;
+            return this;
+        }
+
         public PropertyMapper<T> build() {
             if (paramLabel == null && Boolean.class.equals(option.getType())) {
                 paramLabel = Boolean.TRUE + "|" + Boolean.FALSE;
             }
             if (option.getKey().contains(WildcardPropertyMapper.WILDCARD_FROM_START)) {
-                return new WildcardPropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, wildcardKeysTransformer, wildcardMapFrom);
+                return new WildcardPropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, wildcardKeysTransformer, wildcardMapFrom, allowQuarkusPropertiesFallback);
             }
             if (wildcardKeysTransformer != null || wildcardMapFrom != null) {
                 throw new AssertionError("Wildcard operations not expected with non-wildcard mapper");
             }
-            return new PropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, null, null);
+            return new PropertyMapper<>(option, to, isEnabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, null, null, allowQuarkusPropertiesFallback);
         }
     }
 
@@ -591,6 +615,15 @@ public class PropertyMapper<T> {
 
     public static boolean isEnvOption(ConfigValue configValue) {
         return Optional.ofNullable(configValue.getConfigSourceName()).filter(name -> name.contains(KcEnvConfigSource.NAME)).isPresent();
+    }
+
+    // return true if the configValue is valid quarkus property modified by user -> no defaults from Quarkus
+    private static boolean isModifiedQuarkusProperty(ConfigValue configValue) {
+        return Optional.ofNullable(configValue)
+                .filter(value -> value.getValue() != null)
+                .map(ConfigValue::getConfigSourceName)
+                .filter(name -> !name.equals(DefaultValuesConfigSource.NAME))
+                .isPresent();
     }
 
     void validateExpectedValues(ConfigValue configValue, String v) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -19,7 +19,8 @@ public class TransactionPropertyMappers implements PropertyMapperGrouping {
                         .build(),
                 fromOption(TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE)
                         .to("quarkus.datasource.\"<datasource>\".jdbc.transactions")
-                        .transformer(TransactionPropertyMappers::getQuarkusTransactionsValue)
+                        .transformer(TransactionPropertyMappers::getQuarkusTransactionsValueDatasource)
+                        .allowQuarkusPropertiesFallback(true) // we allow to use properties in quarkus.properties due to backwards compatibility for datasources
                         .build()
         );
     }
@@ -32,5 +33,14 @@ public class TransactionPropertyMappers implements PropertyMapperGrouping {
         }
 
         return "enabled";
+    }
+
+    // temporarily allow to get direct values from the Quarkus property for the datasource
+    private static String getQuarkusTransactionsValueDatasource(String name, String txValue, ConfigSourceInterceptorContext context) {
+        return switch (txValue) {
+            case "true", "xa" -> "xa";
+            case "disabled" -> "disabled";
+            default -> "enabled";
+        };
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/WildcardPropertyMapper.java
@@ -34,8 +34,8 @@ public class WildcardPropertyMapper<T> extends PropertyMapper<T> {
 
     public WildcardPropertyMapper(Option<T> option, String to, BooleanSupplier enabled, String enabledWhen, ValueMapper mapper, String mapFrom, ValueMapper parentMapper,
             String paramLabel, boolean mask, BiConsumer<PropertyMapper<T>, ConfigValue> validator,
-            String description, BooleanSupplier required, String requiredWhen, BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer, ValueMapper wildcardMapFrom) {
-        super(option, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, mask, validator, description, required, requiredWhen, null, null);
+            String description, BooleanSupplier required, String requiredWhen, BiFunction<String, Set<String>, Set<String>> wildcardKeysTransformer, ValueMapper wildcardMapFrom, boolean allowQuarkusPropertiesFallback) {
+        super(option, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, mask, validator, description, required, requiredWhen, null, null, allowQuarkusPropertiesFallback);
         this.wildcardMapFrom = wildcardMapFrom;
 
         this.fromPrefix = getFrom().substring(0, getFrom().indexOf(WILDCARD_FROM_START));

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -501,4 +501,32 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
                 "quarkus.datasource.\"user-store\".jdbc.driver"
         )));
     }
+
+    @Test
+    public void quarkusProperties() {
+        // values obtained from the /src/test/resources/conf/quarkus.properties
+        initConfig();
+
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.userstore.db-kind", "mariadb",
+                "quarkus.datasource.userstore.username", "user-unquoted",
+                "quarkus.datasource.userstore.jdbc.url", "jdbc:mariadb://my-url.com:3333/userstore",
+                "quarkus.datasource.userstore.jdbc.transactions", "xa"
+        ));
+
+        // quoted
+        assertExternalConfig(Map.of(
+                "quarkus.datasource.\"userstore\".db-kind", "postgresql",
+                "quarkus.datasource.\"userstore\".username", "user-quoted",
+                "quarkus.datasource.\"userstore\".jdbc.url", "jdbc:postgresql://localhost:5433/db",
+                "quarkus.datasource.\"userstore\".jdbc.transactions", "disabled"
+        ));
+
+        assertConfig(Map.of(
+                "db-kind-userstore", "postgresql",
+                "db-username-userstore","user-quoted",
+                "db-url-full-userstore","jdbc:postgresql://localhost:5433/db",
+                "transaction-xa-enabled-userstore", "disabled" // should we transform it?
+        ));
+    }
 }

--- a/quarkus/runtime/src/test/resources/conf/quarkus.properties
+++ b/quarkus/runtime/src/test/resources/conf/quarkus.properties
@@ -14,4 +14,14 @@ quarkus.datasource.bar = foo-${kc.prop3:${kc.prop4:${kc.prop5:def}-suffix}}
 quarkus.datasource.dog-store.db-kind=mariadb
 quarkus.datasource.cat-store.db-kind=postgresql
 
+quarkus.datasource."userstore".db-kind=postgresql
+quarkus.datasource."userstore".username=user-quoted
+quarkus.datasource."userstore".jdbc.url=jdbc:postgresql://localhost:5433/db
+quarkus.datasource."userstore".jdbc.transactions=disabled
+
+quarkus.datasource.userstore.db-kind=mariadb
+quarkus.datasource.userstore.username=user-unquoted
+quarkus.datasource.userstore.jdbc.url=jdbc:mariadb://my-url.com:3333/userstore
+quarkus.datasource.userstore.jdbc.transactions=xa
+
 not.quarkus=value


### PR DESCRIPTION
- Closes #42263

After merging https://github.com/keycloak/keycloak/pull/37640, users are not able to use the quotes (") in the named additional datasource as it's mapped to a certain PropertyMapper. We should be backward compatible and still allow users to use the `quarkus.datasource."user-store".xxx` properties in the `quarkus.properties` file.

Once we promote the additional datasource options to _supported_, we would be able to get rid of the `quarkus.datasource.*` options for good. 

@shawkins @vmuzikar Could you please check it? Thanks!