### PR TITLE
Disable preview of the json file if the content is more than 100KB

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -870,6 +870,7 @@ votedToStatus=voted to {{status}}
 credentialResetConfirmText=Are you sure you want to email this user?
 clientScopeType.default=Default
 helpFileUpload=Upload a JSON file
+fileUploadPreviewDisabled=Preview disabled because content is too long.
 addProvider_one=Add {{provider}} provider
 clientPoliciesPolicies=Client Policies Policies
 editUSernameHelp=If enabled, the username is editable, otherwise it is read-only.

--- a/js/apps/admin-ui/src/components/form/CodeEditor.tsx
+++ b/js/apps/admin-ui/src/components/form/CodeEditor.tsx
@@ -1,4 +1,5 @@
 import CodeEditorComponent from "@uiw/react-textarea-code-editor";
+import { useMemo } from "react";
 
 type CodeEditorProps = {
   id?: string;
@@ -12,18 +13,33 @@ type CodeEditorProps = {
   height?: number;
 };
 
-const CodeEditor = ({ onChange, height = 128, ...rest }: CodeEditorProps) => (
-  <div style={{ height: `${height}px`, overflow: "auto" }}>
-    <CodeEditorComponent
-      padding={15}
-      minHeight={height}
-      style={{
-        font: "var(--pf-global--FontFamily--monospace)",
-      }}
-      onChange={(event) => onChange?.(event.target.value)}
-      {...rest}
-    />
-  </div>
-);
+const CodeEditor = ({
+  onChange,
+  height = 128,
+  value,
+  language,
+  ...rest
+}: CodeEditorProps) => {
+  const codeEditor = useMemo(
+    () => (
+      <CodeEditorComponent
+        padding={15}
+        minHeight={height}
+        style={{
+          font: "var(--pf-global--FontFamily--monospace)",
+        }}
+        onChange={(event) => onChange?.(event.target.value)}
+        value={value}
+        language={language}
+        {...rest}
+      />
+    ),
+    [value, language],
+  );
+
+  return (
+    <div style={{ height: `${height}px`, overflow: "auto" }}>{codeEditor}</div>
+  );
+};
 
 export default CodeEditor;

--- a/js/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
+++ b/js/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
@@ -38,6 +38,7 @@ export type FileUploadFormProps = Omit<FileUploadProps, "onChange"> & {
   helpText?: string;
   unWrap?: boolean;
   language?: string;
+  previewMaxLength?: number;
 };
 
 export const FileUploadForm = ({
@@ -45,6 +46,7 @@ export const FileUploadForm = ({
   onChange,
   helpText = "helpFileUpload",
   unWrap = false,
+  previewMaxLength = 102400, // 100KB
   language,
   extension,
   ...rest
@@ -150,15 +152,23 @@ export const FileUploadForm = ({
             isLoading={fileUpload.isLoading}
             hideDefaultPreview
           >
-            {!rest.hideDefaultPreview && (
-              <CodeEditor
-                aria-label="File content"
-                value={fileUpload.value}
-                language={language}
-                onChange={(value) => handleTextOrDataChange(value)}
-                readOnly={!rest.allowEditingUploadedText}
-              />
-            )}
+            {!rest.hideDefaultPreview &&
+              (!fileUpload.value ||
+              fileUpload.value.length < previewMaxLength ? (
+                <CodeEditor
+                  aria-label="File content"
+                  value={fileUpload.value}
+                  language={language}
+                  onChange={(value) => handleTextOrDataChange(value)}
+                  readOnly={!rest.allowEditingUploadedText}
+                />
+              ) : (
+                <CodeEditor
+                  aria-label="File content"
+                  value={t("fileUploadPreviewDisabled")}
+                  readOnly
+                />
+              ))}
           </FileUpload>
           <FormHelperText>
             <HelperText>

--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -19,6 +19,8 @@ import {
   clickCreateRealmForm,
   fillRealmName,
   goToRealmSection,
+  getTextArea,
+  assertTextAreaContains,
 } from "./realm.ts";
 
 const testRealmName = `Test-realm-${uuid()}`;
@@ -112,5 +114,26 @@ test.describe.serial("Realm tests", () => {
 
     await goToClients(page);
     await assertRowExists(page, "account-console");
+  });
+
+  test("should disable preview if json very long", async ({ page }) => {
+    await page.getByTestId("create").click();
+    await getTextArea(page).fill("{}");
+    await assertTextAreaContains(page, "{}");
+
+    const s = '"attribute-name": "attribute-value",';
+    await getTextArea(page).fill(`{${s.repeat(3000)}"final":"value"}`);
+    await assertTextAreaContains(
+      page,
+      "Preview disabled because content is too long.",
+    );
+
+    await fillRealmName(page, testRealmName);
+    await clickCreateRealmForm(page);
+
+    await assertNotificationMessage(
+      page,
+      "Could not create realm unable to read contents from stream",
+    );
   });
 });

--- a/js/apps/admin-ui/test/masthead/realm.ts
+++ b/js/apps/admin-ui/test/masthead/realm.ts
@@ -42,3 +42,11 @@ export async function assertCurrentRealm(
     await expect(getCurrentRealmItem(page)).not.toContainText(realmName);
   }
 }
+
+export function getTextArea(page: Page) {
+  return page.getByRole("textbox", { name: "File content" });
+}
+
+export async function assertTextAreaContains(page: Page, content: string) {
+  await expect(getTextArea(page)).toContainText(content);
+}


### PR DESCRIPTION
Closes #40557

The root cause of the problem is the upload is doing a preview of the file that is also highlighted, that is consuming a lot of time when the file is big. This PR does the following:

* `useMemo` is added to cache the content by value and language. This makes to not re-render if the content is the same. This is OK for partial import when selecting the parts to upload.
* Disable preview if the content is bigger than 100KB by default (parameter `previewMaxLength`) because typing is too slow when it's big.
* This means that you can write and modify while the size is less than 100KB. Preview is disabled when the data is bigger than 100KB.

The only other solution is changing the `react-textarea-code-editor` for other project that is more performant. But probably there will be always a limit, so I think that setting the limit is more or less OK. You can always edit the file outside the console.

Draft for the moment.
