### PR TITLE
Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/keycloak/keycloak?style=flat)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/keycloak/keycloak)
 [![Translation status](https://hosted.weblate.org/widget/keycloak/svg-badge.svg)](docs/translation.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/keycloak/keycloak)
 
 # Open Source Identity and Access Management
 


### PR DESCRIPTION
From DeepWiki:

```
What is DeepWiki?

DeepWiki provides up-to-date documentation you can talk to, for every repo in the world. Add this badge to your repository to help users find documentation.
```

Keycloak repository is very well organized, but still quite complex to learn. This helps a lot