### PR TITLE
ExternalLinks are broken in documentation (26.0)

### DIFF
--- a/docs/documentation/release_notes/topics/16_0_0.adoc
+++ b/docs/documentation/release_notes/topics/16_0_0.adoc
@@ -6,7 +6,7 @@ Keycloak server was upgraded to use Wildfly 25.0.1.Final as the underlying conta
 
 WildFly 25 drops support for the legacy security subsystem, which is being replaced fully by Elytron. This requires significant changes to how Keycloak is configured. Please, refer to the migration guide for more details.
 
-For more information on WildFly 25 refer to the https://www.wildfly.org/news/2021/10/05/WildFly25-Final-Released/[WildFly 25 release notes].
+For more information on WildFly 25 refer to the https://www.wildfly.org/news/2021/10/05/WildFly-25-is-released/[WildFly 25 release notes].
 
 == Upgrade to Quarkus 2.5.3
 

--- a/docs/documentation/release_notes/topics/16_1_0.adoc
+++ b/docs/documentation/release_notes/topics/16_1_0.adoc
@@ -4,4 +4,4 @@
 
 Keycloak server was upgraded to use Wildfly 26.0.0.Final as the underlying container.
 
-For more information on WildFly 26 refer to the https://www.wildfly.org/news/2021/12/16/WildFly26-Final-Released/[WildFly 26 release notes].
+For more information on WildFly 26 refer to the https://www.wildfly.org/news/2021/12/16/WildFly-26-is-released/[WildFly 26 release notes].

--- a/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
+++ b/docs/documentation/server_admin/topics/authentication/recovery-codes.adoc
@@ -1,5 +1,4 @@
 [[_recovery-codes]]
-
 === Recovery Codes (RecoveryCodes)
 
 You can configure Recovery codes for two-factor authentication by adding 'Recovery Authentication Code Form' as a two-factor authenticator to your authentication flow. For an example of configuring this authenticator, see xref:webauthn_{context}[WebAuthn].

--- a/docs/documentation/server_admin/topics/sso-protocols/con-oidc.adoc
+++ b/docs/documentation/server_admin/topics/sso-protocols/con-oidc.adoc
@@ -4,7 +4,7 @@
 [role="_abstract"]
 link:https://openid.net/developers/how-connect-works/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
 
-OAuth 2.0 is a framework for building authorization protocols and is incomplete. OIDC, however, is a full authentication and authorization protocol that uses the link:https://jwt.io[Json Web Token] (JWT) standards.  The JWT standards define an identity token JSON format and methods to digitally sign and encrypt data in a compact and web-friendly way.
+OAuth 2.0 is a framework for building authorization protocols and is incomplete. OIDC, however, is a full authentication and authorization protocol that uses the link:https://www.jwt.io/[Json Web Token] (JWT) standards.  The JWT standards define an identity token JSON format and methods to digitally sign and encrypt data in a compact and web-friendly way.
 
 In general, OIDC implements two use cases. The first case is an application requesting that a  {project_name} server authenticates a user. Upon successful login, the application receives an _identity token_ and an _access token_.
 The _identity token_ contains user information including user name, email, and profile information. The realm digitally signs the _access token_ which contains access information (such as user role mappings) that applications use to determine the resources users can access in the application.

--- a/docs/documentation/server_admin/topics/sso-protocols/oidc.adoc
+++ b/docs/documentation/server_admin/topics/sso-protocols/oidc.adoc
@@ -4,7 +4,7 @@
 
 link:https://openid.net/developers/how-connect-works/[OpenID Connect] (OIDC) is an authentication protocol that is an extension of link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0].
 While OAuth 2.0 is only a framework for building authorization protocols and is mainly incomplete, OIDC is a full-fledged authentication and authorization
-protocol.  OIDC also makes heavy use of the link:https://jwt.io[Json Web Token] (JWT) set of standards.  These standards define an
+protocol.  OIDC also makes heavy use of the link:https://www.jwt.io/[Json Web Token] (JWT) set of standards.  These standards define an
 identity token JSON format and ways to digitally sign and encrypt that data in a compact and web-friendly way.
 
 There are really two types of use cases when using OIDC.  The first is an application that asks the {project_name} server to authenticate

--- a/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
+++ b/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/utils/HttpUtils.java
@@ -81,6 +81,7 @@ public class HttpUtils {
             // add common headers that are needed by some pages
             method.addHeader(HttpHeaders.ACCEPT_LANGUAGE, "en-US,en;q=0.9");
             method.addHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            method.addHeader(HttpHeaders.USER_AGENT, "Java/" + System.getProperty("java.version") + " (https://www.keycloak.org; keycloak-dev@googlegroups.com)");
             client.execute(method, responseHandler);
         } catch (Exception e) {
             response.setError("exception " + e.getMessage());

--- a/docs/documentation/upgrading/topics/changes/changes-16_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-16_0_0.adoc
@@ -12,7 +12,7 @@ We are really sorry for this inconvenience and understand this will make it sign
 
 One thing worth pointing out is the switch to Quarkus distribution, which we plan to make fully supported in Keycloak 17, will make it significantly easier to configure and upgrade Keycloak.
 
-For more information on WildFly 25 refer to the https://www.wildfly.org/news/2021/10/05/WildFly25-Final-Released/[WildFly 25 release notes].
+For more information on WildFly 25 refer to the https://www.wildfly.org/news/2021/10/05/WildFly-25-is-released/[WildFly 25 release notes].
 
 = Proxy environment variables
 


### PR DESCRIPTION
Closes #42164
Closes #41491

I have backported those two commits to 26.0. There were broken links in 26.0 documentation for those two issues in this branch. The two commits were needed.