### PR TITLE
More efficient secure ID generator

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
+++ b/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
@@ -1,7 +1,6 @@
 package org.keycloak.common.util;
 
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.UUID;
 
 public class SecretGenerator {
@@ -18,12 +17,7 @@ public class SecretGenerator {
 
     private static final SecretGenerator instance = new SecretGenerator();
 
-    private ThreadLocal<Random> random = new ThreadLocal<Random>() {
-        @Override
-        protected Random initialValue() {
-            return new SecureRandom();
-        }
-    };
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private SecretGenerator() {
     }
@@ -33,12 +27,7 @@ public class SecretGenerator {
     }
     
     public String generateSecureID() {
-        StringBuilder builder = new StringBuilder(instance.randomBytesHex(16));
-        builder.insert(8, '-');
-        builder.insert(13, '-');
-        builder.insert(18, '-');
-        builder.insert(23, '-');
-        return builder.toString();
+        return generateSecureUUID().toString();
     }
 
     public String randomString() {
@@ -57,11 +46,10 @@ public class SecretGenerator {
             throw new IllegalArgumentException();
         }
 
-        Random r = random.get();
         char[] buf = new char[length];
 
         for (int idx = 0; idx < buf.length; ++idx) {
-            buf[idx] = symbols[r.nextInt(symbols.length)];
+            buf[idx] = symbols[SECURE_RANDOM.nextInt(symbols.length)];
         }
 
         return new String(buf);
@@ -77,7 +65,7 @@ public class SecretGenerator {
         }
 
         byte[] buf = new byte[length];
-        random.get().nextBytes(buf);
+        SECURE_RANDOM.nextBytes(buf);
         return buf;
     }
 
@@ -121,6 +109,18 @@ public class SecretGenerator {
      * @return UUID with all bits random
      */
     public UUID generateSecureUUID() {
-        return new UUID(random.get().nextLong(), random.get().nextLong());
+        byte[] data = randomBytes(16);
+        return new UUID(toLong(data, 0), toLong(data, 8));
+    }
+
+    private static long toLong(byte[] data, int offset) {
+        return  ((data[offset] & 0xFFL) << 56) |
+                ((data[offset + 1] & 0xFFL) << 48) |
+                ((data[offset + 2] & 0xFFL) << 40) |
+                ((data[offset + 3] & 0xFFL) << 32) |
+                ((data[offset + 4] & 0xFFL) << 24) |
+                ((data[offset + 5] & 0xFFL) << 16) |
+                ((data[offset + 6] & 0xFFL) <<  8) |
+                ((data[offset + 7] & 0xFFL)) ;
     }
 }


### PR DESCRIPTION
Closes #42283

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

**`ThreadLocal` Removal**
Removed the `ThreadLocal` mainly for 2 reasons: 
* With `VirtualThread`, the `ThreadLocal` is created and garbage collected immediately as `VirtualThread`s are never cached in a pool.
* The `SecureRandom` is thread-safe.

**Performance**

Micro-benchmark with `VM version: JDK 21.0.7, OpenJDK 64-Bit Server VM, 21.0.7+6-LTS`. The benchmark code can be found here: https://github.com/pruivo/playground/tree/master/uuid-generator

| Method generateSecureID | Time ns/op | Memory byte/op |
|--------|--------|--------|
| Original | 322.014 | 376.000 |
| This PR| 177.973 | 176.000 |

| Method generateSecureUUID | Time ns/op | Memory byte/op |
|--------|--------|--------|
| Original | 280.327 | 256.000 |
| This PR| 158.623 | 128.000 |