### PR TITLE
[OID4VCI] Adjust Credential Issuer Metadata endpoint, return issuer metadata at /.well-known/openid-credential-issuer/realms/{realm}

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance;
 
+import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import org.apache.http.HttpHeaders;
 import org.keycloak.common.util.Time;
@@ -26,6 +27,7 @@ import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.http.HttpResponse;
 import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
@@ -38,13 +40,15 @@ import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import java.net.URI;
 
-import org.keycloak.protocol.oid4vc.model.CredentialRequestEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryptionMetadata;
+import org.keycloak.protocol.oid4vc.model.CredentialRequestEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.protocol.oidc.utils.JWKSServerUtils;
 import org.keycloak.services.Urls;
+import org.keycloak.services.resources.ServerMetadataResource;
 import org.keycloak.urls.UrlType;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.MediaType;
@@ -129,6 +133,9 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
             }
         }
 
+        // Add deprecation headers/logs if the old realm-scoped route was used
+        addDeprecationHeadersIfOldRoute(keycloakSession);
+
         return new CredentialIssuer()
                 .setCredentialIssuer(getIssuer(context))
                 .setCredentialEndpoint(getCredentialsEndpoint(context))
@@ -155,6 +162,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                 LOGGER.debugf("Falling back to JSON response due to signed metadata failure for realm: %s", realm.getName());
             }
         }
+
         return issuer;
     }
 
@@ -514,6 +522,38 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      */
     public static List<String> getSupportedAsymmetricSignatureAlgorithms(KeycloakSession session) {
         return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
+    }
+
+    /**
+     * Attach OID4VCI-specific deprecation headers (and a server WARN) when the old
+     * realm-scoped route is used.
+     * old: /realms/{realm}/.well-known/openid-credential-issuer
+     * new: /.well-known/openid-credential-issuer/realms/{realm}
+     */
+    private void addDeprecationHeadersIfOldRoute(KeycloakSession session) {
+        String requestPath = session.getContext().getUri().getRequestUri().getPath();
+        if (requestPath == null) {
+            return;
+        }
+
+        int idxRealms = requestPath.indexOf("/realms/");
+        int idxWellKnown = requestPath.indexOf("/.well-known/");
+        boolean isOldRoute = idxRealms >= 0 && idxWellKnown > idxRealms;
+        if (!isOldRoute) {
+            return;
+        }
+
+        UriBuilder base = session.getContext().getUri().getBaseUriBuilder();
+        String logKey = session.getContext().getRealm().getName();
+        URI successor = ServerMetadataResource.wellKnownOAuthProviderUrl(base)
+                .build(Oid4VciConstants.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER, logKey);
+
+        HttpResponse httpResponse = session.getContext().getHttpResponse();
+        httpResponse.setHeader("Warning", "299 - \"Deprecated endpoint; use " + successor + "\"");
+        httpResponse.setHeader("Deprecation", "true");
+        httpResponse.setHeader("Link", "<" + successor + ">; rel=\"successor-version\"");
+
+        LOGGER.warnf("Deprecated realm-scoped well-known endpoint accessed for OID4VCI in realm '%s'. Use %s instead.", logKey, successor);
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -29,8 +29,10 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProviderFactory;
 import org.keycloak.protocol.oauth2.OAuth2WellKnownProviderFactory;
 import org.keycloak.services.cors.Cors;
+import static org.keycloak.utils.MediaType.APPLICATION_JWT;
 
 import java.util.List;
 
@@ -54,7 +56,7 @@ public class ServerMetadataResource {
 
     @GET
     @Path("{provider}/realms/{realm}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, APPLICATION_JWT})
     public Response getOAuth2AuthorizationServerWellKnown(final @PathParam("provider") String providerName,
                                                           final @PathParam("realm") String name) {
         if (!isValidProvider(providerName)) throw new NotFoundException();
@@ -68,6 +70,7 @@ public class ServerMetadataResource {
     private boolean isValidProvider(String providerName) {
         // you can add codes here considering the current status of the implementation (preview, experimental).
         if (OAuth2WellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
+        if (OID4VCIssuerWellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
         return false;
     }
 }


### PR DESCRIPTION
This PR adds support for the spec-defined metadata endpoint while keeping the legacy route operational.

New endpoint:
- Path: /.well-known/openid-credential-issuer/realms/{realm}
- Returns metadata

Legacy endpoint:
- Path: /realms/{realm}/.well-known/openid-credential-issuer
- Still supported for compatibility
- Returns Warning/Deprecation/Link headers
- Logs warning on access

Note:
- Integration tests continue to use the legacy path due to Undertow test-container context-root (/auth) behavior. Runtime is unaffected.

Backwards compatibility:
- Maintained. Legacy clients continue to function, but are clearly warned to migrate.

Closes #41589 