### PR TITLE
[OID4VCI] rename keyattestation+jwt to key-attestation+jwt

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
@@ -76,7 +76,7 @@ import static org.keycloak.services.clientpolicy.executor.FapiConstant.ALLOWED_A
  */
 public class AttestationValidatorUtil {
 
-    public static final String ATTESTATION_JWT_TYP = "keyattestation+jwt";
+    public static final String ATTESTATION_JWT_TYP = "key-attestation+jwt ";
     private static final String CACERTS_PATH = System.getProperty("javax.net.ssl.trustStore",
             System.getProperty("java.home") + "/lib/security/cacerts");
     private static final char[] DEFAULT_TRUSTSTORE_PASSWORD = System.getProperty(


### PR DESCRIPTION
This PR simply aims at verifying that the we correctly constructs key attestation JWTs with required JOSE headers and JWT body parameters.

closes: https://github.com/keycloak/keycloak/issues/41579
