### PR TITLE
Client Authenticator configurable per client

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
@@ -28,6 +28,7 @@ public class ComponentTypeRepresentation {
     protected String id;
     protected String helpText;
     protected List<ConfigPropertyRepresentation> properties;
+    protected List<ConfigPropertyRepresentation> clientProperties;
 
     protected Map<String, Object> metadata = new HashMap<>();
 
@@ -54,6 +55,14 @@ public class ComponentTypeRepresentation {
 
     public void setProperties(List<ConfigPropertyRepresentation> properties) {
         this.properties = properties;
+    }
+
+    public List<ConfigPropertyRepresentation> getClientProperties() {
+        return clientProperties;
+    }
+
+    public void setClientProperties(List<ConfigPropertyRepresentation> clientProperties) {
+        this.clientProperties = clientProperties;
     }
 
     /**

--- a/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
+++ b/js/apps/admin-ui/src/clients/credentials/Credentials.tsx
@@ -34,6 +34,7 @@ import { FormFields } from "../ClientDetails";
 import { ClientSecret } from "./ClientSecret";
 import { SignedJWT } from "./SignedJWT";
 import { X509 } from "./X509";
+import { convertAttributeNameToForm } from "../../util";
 
 type AccessToken = {
   registrationAccessToken: string;
@@ -80,7 +81,7 @@ export const Credentials = ({ client, save, refresh }: CredentialsProps) => {
     () =>
       componentTypes?.["org.keycloak.authentication.ClientAuthenticator"]?.find(
         (p) => p.id === clientAuthenticatorType,
-      )?.properties,
+      )?.clientProperties,
     [clientAuthenticatorType, componentTypes],
   );
 
@@ -186,7 +187,9 @@ export const Credentials = ({ client, save, refresh }: CredentialsProps) => {
               <Form>
                 <DynamicComponents
                   properties={providerProperties}
-                  convertToName={(name) => `attributes.${name}`}
+                  convertToName={(name) =>
+                    convertAttributeNameToForm(`attributes.${name}`)
+                  }
                 />
               </Form>
             )}

--- a/js/libs/keycloak-admin-client/src/defs/componentTypeRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/componentTypeRepresentation.ts
@@ -7,5 +7,6 @@ export default interface ComponentTypeRepresentation {
   id: string;
   helpText: string;
   properties: ConfigPropertyRepresentation[];
+  clientProperties: ConfigPropertyRepresentation[];
   metadata: { [index: string]: any };
 }

--- a/server-spi-private/src/main/java/org/keycloak/authentication/ClientAuthenticatorFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/ClientAuthenticatorFactory.java
@@ -18,10 +18,9 @@
 package org.keycloak.authentication;
 
 import org.keycloak.models.ClientModel;
-import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ConfiguredPerClientProvider;
 import org.keycloak.provider.ProviderFactory;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +33,7 @@ import java.util.Set;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public interface ClientAuthenticatorFactory extends ProviderFactory<ClientAuthenticator>, ConfigurableAuthenticatorFactory {
+public interface ClientAuthenticatorFactory extends ProviderFactory<ClientAuthenticator>, ConfigurableAuthenticatorFactory, ConfiguredPerClientProvider {
     ClientAuthenticator create();
 
     /**
@@ -44,14 +43,6 @@ public interface ClientAuthenticatorFactory extends ProviderFactory<ClientAuthen
      */
     @Override
     boolean isConfigurable();
-
-    /**
-     * List of config properties for this client implementation. Those will be shown in admin console in clients credentials tab and can be configured per client.
-     * Applicable only if "isConfigurablePerClient" is true
-     *
-     * @return
-     */
-    List<ProviderConfigProperty> getConfigPropertiesPerClient();
 
     /**
      * Get configuration, which needs to be used for adapter ( keycloak.json ) of particular client. Some implementations

--- a/server-spi/src/main/java/org/keycloak/provider/ConfiguredPerClientProvider.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ConfiguredPerClientProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.provider;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:ggrazian@redhat.com">Giuseppe Graziano</a>
+ */
+public interface ConfiguredPerClientProvider extends ConfiguredProvider {
+
+    /**
+     * List of config properties for this client implementation. Those will be shown in admin console in clients credentials tab and can be configured per client.
+     *
+     * @return
+     */
+    List<ProviderConfigProperty> getConfigPropertiesPerClient();
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.resteasy.reactive.NoCache;
+import org.keycloak.provider.ConfiguredPerClientProvider;
 import org.keycloak.broker.provider.IdentityProvider;
 import org.keycloak.broker.provider.IdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProvider;
@@ -183,6 +184,10 @@ public class ServerInfoAdminResource {
                     rep.setProperties(ModelToRepresentation.toRepresentation(configProperties));
                     if (pi instanceof ComponentFactory) {
                         rep.setMetadata(((ComponentFactory)pi).getTypeMetadata());
+                    }
+                    if (pi instanceof ConfiguredPerClientProvider) {
+                        List<ProviderConfigProperty> configClientProperties = ((ConfiguredPerClientProvider) pi).getConfigPropertiesPerClient();
+                        rep.setClientProperties(ModelToRepresentation.toRepresentation(configClientProperties));
                     }
                     List<ComponentTypeRepresentation> reps = info.getComponentTypes().get(spi.getProviderClass().getName());
                     if (reps == null) {


### PR DESCRIPTION
Closes #42044

Before this PR:

- Client authenticators in Keycloak such as "Client Id and Secret" or "X509 Certificate" use a custom UI component to load their configuration, so they were not resolved dynamically either from `getConfigProperties()` or from `getConfigPropertiesPerClient()`.

- If no custom UI component was present, a dynamic component was used and the configuration properties were loaded from the result of `getConfigProperties()`.

- However, when the dynamic component was used, saving the configuration caused a parsing error on the server because the configuration was stored as JSON in the client attributes, so it never actually worked.

With this PR:

- Client authenticators like "Client Id and Secret" still use their custom UI components, which are needed for features like the "regenerate secret" button.

- Added the method `isConfigurablePerClient()` to `ClientAuthenticatorFactory`, which returns `false` by default, since this method was mentioned in the comment of `getConfigPropertiesPerClient()` but did not exist at all.

- Added to the server info the boolean `configurablePerClient` and the `clientProperties` for providers implementing `ClientAuthenticatorFactory`, so that configuration properties can be used in the Credentials tab of the client to load the configuration from the result of `getConfigPropertiesPerClient()` if `isConfigurablePerClient()` returns true.

- There should be no backward compatibility issues, since it was previously not possible to save the configuration of client authenticators that did not use custom UI components. 
- The "Signed JWT - Federated" client authenticator can be used for testing.
