### PR TITLE
Do not fail when querying user federation providers and log messages to indicate the problem

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -225,6 +225,16 @@ This implicit fallback mechanism ensures a smooth upgrade process for deployment
 
 For more information about fine-grained admin permissions, see link:{adminguide_finegrained_link}[{adminguide_finegrained_name}].
 
+=== Errors when searching users from LDAP will not fail the request anymore and local users will be returned
+
+Until now, failures when searching for users from an LDAP user federation provider caused the whole request to fail and no users were returned.
+In this release, if an error occurs during the search, local users will still be returned and the error will be logged at the `ERROR` level,
+so that administrators can investigate the root cause of the problem and fix any issue with their LDAP configuration or connectivity
+with the LDAP server.
+
+This change improves the resilience of the system when there are temporary issues with the LDAP server, ensuring that local users can still be accessed even if the LDAP search fails.
+If a local user is linked to a failing LDAP provider, the user will be marked as disabled and read-only until the LDAP server is available again.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -173,9 +173,8 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
             return validated;
         } catch (Exception e) {
             logger.warnf(e, "User storage provider %s failed during federated user validation", model.getName());
+            return new ReadOnlyUserModelDelegate(user, false, ignore -> new ReadOnlyException("The user is read-only. The user storage provider '" + model.getName() + "' is currently unavailable. Check the server logs for more details."));
         }
-
-        return null;
     }
 
     private ReadOnlyUserModelDelegate deleteFederatedUser(RealmModel realm, UserModel user) {

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -163,13 +163,19 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
             return user;
         }
 
-        UserModel validated = validator.validate(realm, user);
+        try {
+            UserModel validated = validator.validate(realm, user);
 
-        if (validated == null) {
-            return deleteFederatedUser(realm, user);
+            if (validated == null) {
+                return deleteFederatedUser(realm, user);
+            }
+
+            return validated;
+        } catch (Exception e) {
+            logger.warnf(e, "User storage provider %s failed during federated user validation", model.getName());
         }
 
-        return validated;
+        return null;
     }
 
     private ReadOnlyUserModelDelegate deleteFederatedUser(RealmModel realm, UserModel user) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ReadOnlyUserModelDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ReadOnlyUserModelDelegate.java
@@ -47,6 +47,11 @@ public class ReadOnlyUserModelDelegate extends UserModelDelegate {
         this.exceptionCreator = exceptionCreator;
     }
 
+    public ReadOnlyUserModelDelegate(UserModel delegate, boolean enabled, Function<String, RuntimeException> exceptionCreator) {
+        this(delegate, exceptionCreator);
+        this.enabled = enabled;
+    }
+
     @Override
     public void setUsername(String username) {
         throw readOnlyException("username");

--- a/server-spi/src/main/java/org/keycloak/models/ModelException.java
+++ b/server-spi/src/main/java/org/keycloak/models/ModelException.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.models;
 
+import java.util.List;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -46,5 +48,24 @@ public class ModelException extends RuntimeException {
 
     public void setParameters(Object[] parameters) {
         this.parameters = parameters;
+    }
+
+    @SafeVarargs
+    public final boolean isCausedBy(Class<? extends Exception>... type) {
+        int limit = 3;
+        List<Class<? extends Exception>> types = List.of(type);
+        Throwable cause = getCause();
+
+        while (cause != null) {
+            if (limit-- == 0) {
+                break;
+            }
+            if (types.contains(cause.getClass())) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+
+        return false;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
@@ -37,7 +37,7 @@ import org.keycloak.federation.kerberos.KerberosFederationProvider;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.ComponentRepresentation;
-import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.representations.idm.ErrorRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPAttribute;
@@ -50,11 +50,13 @@ import org.keycloak.testsuite.util.LDAPRule;
 import org.keycloak.testsuite.util.LDAPTestUtils;
 import org.keycloak.testsuite.util.UserBuilder;
 
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.userprofile.UserProfileUtil.setUserProfileConfiguration;
 import static org.keycloak.util.JsonSerialization.writeValueAsString;
@@ -235,29 +237,47 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
         String newUserId1 = createUserExpectSuccess(user1);
         getCleanup().addUserId(newUserId1);
 
-        List<ComponentRepresentation> storageProviders = testRealm().components().query(testRealm().toRepresentation().getId(), UserStorageProvider.class.getName());
+        String realmId = testRealm().toRepresentation().getId();
+        List<ComponentRepresentation> storageProviders = testRealm().components().query(realmId, UserStorageProvider.class.getName());
         ComponentRepresentation ldapProvider = storageProviders.get(0);
         List<String> originalUrl = ldapProvider.getConfig().get(LDAPConstants.CONNECTION_URL);
 
-        getCleanup().addCleanup(new AutoCloseable() {
-            @Override
-            public void close() {
-                ldapProvider.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
-                testRealm().components().component(ldapProvider.getId()).update(ldapProvider);
-            }
+        getCleanup().addCleanup(() -> {
+            ldapProvider.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
+            testRealm().components().component(ldapProvider.getId()).update(ldapProvider);
         });
 
         ldapProvider.getConfig().put(LDAPConstants.CONNECTION_URL, List.of("ldap://invalid"));
         testRealm().components().component(ldapProvider.getId()).update(ldapProvider);
 
+        List<UserRepresentation> search = testRealm().users().search("*", -1, -1, true);
+        assertThat(search.isEmpty(), is(false));
+        user1 = search.stream().filter(u -> u.getUsername().equals("admintestuser1")).findFirst().orElseThrow();
+        assertThat(user1.getAttributes().containsKey(LDAPConstants.LDAP_ID), is(true));
+        assertThat(user1.isEnabled(), is(false));
+
+        UserResource userResource = testRealm().users().get(newUserId1);
+
         try {
-            List<UserRepresentation> search = testRealm().users().search("*", -1, -1, true);
-            Assert.fail("Should fail because LDAP is in failing state");
+            userResource.update(user1);
+            Assert.fail("Not expected to successfully update user");
         } catch (WebApplicationException expected) {
             Response response = expected.getResponse();
-            OAuth2ErrorRepresentation error = response.readEntity(OAuth2ErrorRepresentation.class);
-            assertEquals("unknown_error", error.getError());
+            ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
+            assertTrue(error.getErrorMessage().contains("The user is read-only. The user storage provider 'test-ldap' is currently unavailable. Check the server logs for more details."));
         }
+
+        // fix the LDAP connection configuration and try again to update the user
+        storageProviders = testRealm().components().query(realmId, UserStorageProvider.class.getName());
+        ComponentRepresentation ldapProviderValid = storageProviders.get(0);
+        ldapProviderValid.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
+        testRealm().components().component(ldapProviderValid.getId()).update(ldapProviderValid);
+        user1 = userResource.toRepresentation();
+        user1.setLastName("changed");
+        userResource.update(user1);
+        user1 = userResource.toRepresentation();
+        assertTrue(user1.isEnabled());
+        assertEquals("changed", user1.getLastName());
     }
 
     @Test


### PR DESCRIPTION
Closes #42276

* Makes it possible to at least query local users when there are errors querying user federation providers such as LDAP.
* Mark users from an unstable/unavailable user provider as disabled, read-only, and add an error message like `Could not create user: The user is read-only. The user storage provider '<provider name>' is currently unavailable. Check the server logs for more details.`

It is a follow-up of https://github.com/keycloak/keycloak/pull/42478.

Basically, admins will be able to list local users and federated users. But federated users imported to the local database will be marked as disabled and read-only, so that you won't be able to perform any updates. Doing updates on such users will result in an error with the message above.

Ideally, we could also propagate some error message in the response. But I'm not sure we can do that given that errors are only thrown when processing the stream when writing to the HTTP response. It might happen that bytes were already written and sent to the client.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
