### PR TITLE
Do not regenerate the secret key when the size is not explicitly passed

### DIFF
--- a/services/src/main/java/org/keycloak/keys/AbstractGeneratedSecretKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/AbstractGeneratedSecretKeyProviderFactory.java
@@ -37,16 +37,18 @@ public abstract class AbstractGeneratedSecretKeyProviderFactory<T extends KeyPro
         ConfigurationValidationHelper validation = SecretKeyProviderUtils.validateConfiguration(model);
         validation.checkList(Attributes.SECRET_SIZE_PROPERTY, false);
 
-        int size = model.get(Attributes.SECRET_SIZE_KEY, getDefaultKeySize());
-
         if (!(model.contains(Attributes.SECRET_KEY))) {
+            int size = model.get(Attributes.SECRET_SIZE_KEY, getDefaultKeySize());
             generateSecret(model, size);
             logger().debugv("Generated secret for {0}", realm.getName());
         } else {
             int currentSize = Base64Url.decode(model.get(Attributes.SECRET_KEY)).length;
+            int size = model.get(Attributes.SECRET_SIZE_KEY, currentSize);
             if (currentSize != size) {
                 generateSecret(model, size);
                 logger().debugv("Secret size changed, generating new secret for {0}", realm.getName());
+            } else if (model.get(Attributes.SECRET_SIZE_KEY) == null && currentSize != getDefaultKeySize()) {
+                model.put(Attributes.SECRET_SIZE_KEY, currentSize);
             }
         }
     }


### PR DESCRIPTION
Closes #42405

The PR just checks if the `secretSize` config option is explicitly passed to regenerate the key, if not the key is maintained. It also adds the model config when missing and no the default size. Tests added.

The other option is just adding a migration task to add the config option to the keys that does not have the default size (previous default) and the label is not there. But I decided to do it this way as the upgrade task is more difficult to migrate. But if you prefer this way I can change it.
