### PR TITLE
Fix for missing object representation in admin event log when deleting user, group, client

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -250,6 +250,10 @@ public class ClientResource {
 
         AdminPermissionsSchema.SCHEMA.throwExceptionIfAdminPermissionClient(session, client.getId());
 
+        ClientScopeRepresentation clientRepresentation = new ClientScopeRepresentation();
+        clientRepresentation.setId(client.getId());
+        clientRepresentation.setName(client.getName());
+
         try {
             session.clientPolicy().triggerOnEvent(new AdminClientUnregisterContext(client, auth.adminAuth()));
         } catch (ClientPolicyException cpe) {
@@ -257,7 +261,7 @@ public class ClientResource {
         }
 
         if (new ClientManager(new RealmManager(session)).removeClient(realm, client)) {
-            adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
+            adminEvent.operation(OperationType.DELETE).representation(clientRepresentation).resourcePath(session.getContext().getUri()).success();
         }
         else {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Could not delete client",

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -164,9 +164,12 @@ public class GroupResource {
     @Operation()
     public void deleteGroup() {
         this.auth.groups().requireManage(group);
+        GroupRepresentation groupRepresentation = new GroupRepresentation();
+        groupRepresentation.setId(group.getId());
+        groupRepresentation.setId(group.getName());
 
         realm.removeGroup(group);
-        adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
+        adminEvent.operation(OperationType.DELETE).representation(groupRepresentation).resourcePath(session.getContext().getUri()).success();
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -704,9 +704,13 @@ public class UserResource {
     public Response deleteUser() {
         auth.users().requireManage(user);
 
+        UserRepresentation userRepresentation = new UserRepresentation();
+        userRepresentation.setId(user.getId());
+        userRepresentation.setUsername(user.getUsername());
+
         boolean removed = new UserManager(session).removeUser(realm, user);
         if (removed) {
-            adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
+            adminEvent.operation(OperationType.DELETE).representation(userRepresentation).resourcePath(session.getContext().getUri()).success();
             return Response.noContent().build();
         } else {
             throw ErrorResponse.error("User couldn't be deleted", Status.BAD_REQUEST);

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/AdminEventsTest.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/AdminEventsTest.java
@@ -56,11 +56,15 @@ public class AdminEventsTest {
 
         adminClient.realm(realm.getName()).users().delete(userId);
 
+        UserRepresentation extectedRep = new UserRepresentation();
+        extectedRep.setId(userRep.getId());
+        extectedRep.setUsername(userName);
+
         AdminEventAssertion.assertSuccess(adminEvents.poll())
                 .operationType(OperationType.DELETE)
                 .resourceType(ResourceType.USER)
                 .resourcePath("users", userId)
-                .representation(null);
+                .representation(extectedRep);
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/AbstractUserTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/AbstractUserTest.java
@@ -204,7 +204,10 @@ public class AbstractUserTest {
         try (Response response = managedRealm.admin().users().delete(id)) {
             assertEquals(204, response.getStatus());
         }
-        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.DELETE, AdminEventPaths.userResourcePath(id), ResourceType.USER);
+        AdminEventRepresentation event = adminEvents.poll();
+        AdminEventAssertion.assertEvent(event, OperationType.DELETE, AdminEventPaths.userResourcePath(id), ResourceType.USER);
+        Assertions.assertNotNull(event.getRepresentation());
+        Assertions.assertTrue(event.getRepresentation().contains(id));
     }
 
     protected void addFederatedIdentity(String keycloakUserId, String identityProviderAlias1,


### PR DESCRIPTION
Fix for missing object representation in admin event log when deleting user, group, client

Closes #33009