### PR TITLE
Validate actions that support aggregating actions

### DIFF
--- a/services/src/main/java/org/keycloak/models/workflow/AggregatedStepProvider.java
+++ b/services/src/main/java/org/keycloak/models/workflow/AggregatedStepProvider.java
@@ -23,11 +23,7 @@ public class AggregatedStepProvider implements WorkflowStepProvider {
 
     @Override
     public void run(List<String> userIds) {
-        WorkflowsManager manager = new WorkflowsManager(session);
-        List<WorkflowStepProvider> steps = manager.getStepById(session, model.getId())
-                .getSteps().stream()
-                .map(manager::getStepProvider)
-                .toList();
+        List<WorkflowStepProvider> steps = getSteps();
 
         for (String userId : userIds) {
             for (WorkflowStepProvider step : steps) {
@@ -38,5 +34,14 @@ public class AggregatedStepProvider implements WorkflowStepProvider {
                 }
             }
         }
+    }
+
+    private List<WorkflowStepProvider> getSteps() {
+        WorkflowsManager manager = new WorkflowsManager(session);
+
+        return manager.getStepById(model.getId())
+                .getSteps().stream()
+                .map(manager::getStepProvider)
+                .toList();
     }
 }

--- a/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowResource.java
+++ b/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowResource.java
@@ -12,10 +12,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.workflow.ResourceType;
 import org.keycloak.models.workflow.Workflow;
 import org.keycloak.models.workflow.WorkflowsManager;
 import org.keycloak.representations.workflows.WorkflowRepresentation;
+import org.keycloak.services.ErrorResponse;
 
 public class WorkflowResource {
 
@@ -29,12 +32,20 @@ public class WorkflowResource {
 
     @DELETE
     public void delete() {
-        manager.removeWorkflow(workflow.getId());
+        try {
+            manager.removeWorkflow(workflow.getId());
+        } catch (ModelException me) {
+            throw ErrorResponse.error(me.getMessage(), Response.Status.BAD_REQUEST);
+        }
     }
 
     @PUT
     public void update(WorkflowRepresentation rep) {
-        manager.updateWorkflow(workflow, rep.getConfig());
+        try {
+            manager.updateWorkflow(workflow, rep.getConfig());
+        } catch (ModelException me) {
+            throw ErrorResponse.error(me.getMessage(), Response.Status.BAD_REQUEST);
+        }
     }
 
     @GET


### PR DESCRIPTION
Closes #42381

* We can do better and provide hooks in the SPI to check if an action provider supports aggregated actions. However, introduce that now is anticipating use cases we don't have yet, but just a single action that supports aggregating actions.
* It should be trivial to add support for other types of aggregated actions, as we now have a single place where actions are validated.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
