### PR TITLE
Better names for workflow events

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/workflow/UserCreationTimeWorkflowProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/UserCreationTimeWorkflowProvider.java
@@ -20,7 +20,7 @@ package org.keycloak.models.workflow;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 
-import static org.keycloak.models.workflow.ResourceOperationType.CREATE;
+import static org.keycloak.models.workflow.ResourceOperationType.USER_ADD;
 
 public class UserCreationTimeWorkflowProvider extends AbstractUserWorkflowProvider {
 
@@ -30,6 +30,6 @@ public class UserCreationTimeWorkflowProvider extends AbstractUserWorkflowProvid
 
     @Override
     protected boolean isActivationEvent(WorkflowEvent event) {
-        return super.isActivationEvent(event) || CREATE.equals(event.getOperation());
+        return super.isActivationEvent(event) || USER_ADD.equals(event.getOperation());
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/UserSessionRefreshTimeWorkflowProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/UserSessionRefreshTimeWorkflowProvider.java
@@ -17,8 +17,8 @@
 
 package org.keycloak.models.workflow;
 
-import static org.keycloak.models.workflow.ResourceOperationType.CREATE;
-import static org.keycloak.models.workflow.ResourceOperationType.LOGIN;
+import static org.keycloak.models.workflow.ResourceOperationType.USER_ADD;
+import static org.keycloak.models.workflow.ResourceOperationType.USER_LOGIN;
 
 import java.util.List;
 
@@ -33,11 +33,11 @@ public class UserSessionRefreshTimeWorkflowProvider extends AbstractUserWorkflow
 
     @Override
     protected boolean isActivationEvent(WorkflowEvent event) {
-        return super.isActivationEvent(event) || List.of(CREATE, LOGIN).contains(event.getOperation());
+        return super.isActivationEvent(event) || List.of(USER_ADD, USER_LOGIN).contains(event.getOperation());
     }
 
     @Override
     protected boolean isResetEvent(WorkflowEvent event) {
-        return LOGIN.equals(event.getOperation());
+        return USER_LOGIN.equals(event.getOperation());
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/workflow/ResourceOperationType.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/workflow/ResourceOperationType.java
@@ -15,12 +15,12 @@ import org.keycloak.provider.ProviderEvent;
 
 public enum ResourceOperationType {
 
-    CREATE(OperationType.CREATE, EventType.REGISTER),
-    LOGIN(EventType.LOGIN),
-    ADD_FEDERATED_IDENTITY(new Class[] {FederatedIdentityCreatedEvent.class}, new Class[] {FederatedIdentityRemovedEvent.class}),
-    REMOVE_FEDERATED_IDENTITY(FederatedIdentityRemovedEvent.class),
-    GROUP_MEMBERSHIP_JOIN(GroupMemberJoinEvent.class),
-    ROLE_GRANTED(new Class[] {RoleGrantedEvent.class}, new Class[] {RoleRevokedEvent.class}),
+    USER_ADD(OperationType.CREATE, EventType.REGISTER),
+    USER_LOGIN(EventType.LOGIN),
+    USER_FEDERATED_IDENTITY_ADD(new Class[] {FederatedIdentityCreatedEvent.class}, new Class[] {FederatedIdentityRemovedEvent.class}),
+    USER_FEDERATED_IDENTITY_REMOVE(FederatedIdentityRemovedEvent.class),
+    USER_GROUP_MEMBERSHIP_ADD(GroupMemberJoinEvent.class),
+    USER_ROLE_ADD(new Class[] {RoleGrantedEvent.class}, new Class[] {RoleRevokedEvent.class}),
     AD_HOC(new Class[] {});
 
     private final List<Object> types;

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/BrokeredUserSessionRefreshTimeWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/BrokeredUserSessionRefreshTimeWorkflowTest.java
@@ -127,7 +127,7 @@ public class BrokeredUserSessionRefreshTimeWorkflowTest {
     public void testInvalidateWorkflowOnIdentityProviderRemoval() {
         consumerRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(IdentityProviderWorkflowConditionFactory.ID)
                         .withConfig(IdentityProviderWorkflowConditionFactory.EXPECTED_ALIASES, IDP_OIDC_ALIAS)
@@ -163,7 +163,7 @@ public class BrokeredUserSessionRefreshTimeWorkflowTest {
     public void tesRunStepOnFederatedUser() {
         consumerRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(IdentityProviderWorkflowConditionFactory.ID)
                         .withConfig(IdentityProviderWorkflowConditionFactory.EXPECTED_ALIASES, IDP_OIDC_ALIAS)
@@ -234,7 +234,7 @@ public class BrokeredUserSessionRefreshTimeWorkflowTest {
     public void testAddRemoveFedIdentityAffectsWorkflowAssociation() {
         consumerRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.ADD_FEDERATED_IDENTITY.toString())
+                .onEvent(ResourceOperationType.USER_FEDERATED_IDENTITY_ADD.toString())
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(IdentityProviderWorkflowConditionFactory.ID)
                         .withConfig(IdentityProviderWorkflowConditionFactory.EXPECTED_ALIASES, IDP_OIDC_ALIAS)

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/GroupMembershipJoinWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/GroupMembershipJoinWorkflowTest.java
@@ -68,7 +68,7 @@ public class GroupMembershipJoinWorkflowTest {
 
         List<WorkflowRepresentation> expectedWorkflows = WorkflowRepresentation.create()
                 .of(EventBasedWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.GROUP_MEMBERSHIP_JOIN.name())
+                .onEvent(ResourceOperationType.USER_GROUP_MEMBERSHIP_ADD.name())
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(GroupMembershipWorkflowConditionFactory.ID)
                         .withConfig(GroupMembershipWorkflowConditionFactory.EXPECTED_GROUPS, groupId)
@@ -126,7 +126,7 @@ public class GroupMembershipJoinWorkflowTest {
 
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(GroupMembershipWorkflowConditionFactory.ID)
                         .withConfig(GroupMembershipWorkflowConditionFactory.EXPECTED_GROUPS, groupId)

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/RoleWorkflowConditionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/RoleWorkflowConditionTest.java
@@ -138,7 +138,7 @@ public class RoleWorkflowConditionTest {
 
         List<WorkflowRepresentation> expectedWorkflows = WorkflowRepresentation.create()
                 .of(EventBasedWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.ROLE_GRANTED.name())
+                .onEvent(ResourceOperationType.USER_ROLE_ADD.name())
                 .recurring()
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(RoleWorkflowConditionFactory.ID)

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/UserAttributeWorkflowConditionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/UserAttributeWorkflowConditionTest.java
@@ -133,7 +133,7 @@ public class UserAttributeWorkflowConditionTest {
     private void createWorkflow(Map<String, List<String>> attributes) {
         List<WorkflowRepresentation> expectedWorkflows = WorkflowRepresentation.create()
                 .of(EventBasedWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.CREATE.name())
+                .onEvent(ResourceOperationType.USER_ADD.name())
                 .recurring()
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(UserAttributeWorkflowConditionFactory.ID)

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/UserSessionRefreshTimeWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/UserSessionRefreshTimeWorkflowTest.java
@@ -102,7 +102,7 @@ public class UserSessionRefreshTimeWorkflowTest {
     public void testDisabledUserAfterInactivityPeriod() {
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
                                 .after(Duration.ofDays(5))
@@ -184,7 +184,7 @@ public class UserSessionRefreshTimeWorkflowTest {
     public void testMultipleWorkflows() {
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
                                 .after(Duration.ofDays(5))
@@ -192,7 +192,7 @@ public class UserSessionRefreshTimeWorkflowTest {
                                 .withConfig("custom_message", "notifier1_message")
                                 .build()
                 ).of(UserSessionRefreshTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
                                 .after(Duration.ofDays(10))

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/WorkflowManagementTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/WorkflowManagementTest.java
@@ -142,14 +142,14 @@ public class WorkflowManagementTest {
 
         workflows.create(WorkflowRepresentation.create()
                 .of(UserCreationTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.CREATE.toString())
+                .onEvent(ResourceOperationType.USER_ADD.toString())
                 .recurring()
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
                                 .after(Duration.ofDays(5))
                                 .build()
                 ).of(EventBasedWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.LOGIN.toString())
+                .onEvent(ResourceOperationType.USER_LOGIN.toString())
                 .recurring()
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
@@ -218,7 +218,7 @@ public class WorkflowManagementTest {
     public void testWorkflowDoesNotFallThroughStepsInSingleRun() {
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserCreationTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.CREATE.toString())
+                .onEvent(ResourceOperationType.USER_ADD.toString())
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
                                 .after(Duration.ofDays(5))
@@ -293,7 +293,7 @@ public class WorkflowManagementTest {
 
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserCreationTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.ADD_FEDERATED_IDENTITY.name())
+                .onEvent(ResourceOperationType.USER_FEDERATED_IDENTITY_ADD.name())
                 .onConditions(WorkflowConditionRepresentation.create()
                         .of(IdentityProviderWorkflowConditionFactory.ID)
                         .withConfig(IdentityProviderWorkflowConditionFactory.EXPECTED_ALIASES, "someidp")
@@ -392,7 +392,7 @@ public class WorkflowManagementTest {
         // create a test workflow
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserCreationTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.CREATE.toString())
+                .onEvent(ResourceOperationType.USER_ADD.toString())
                 .name("test-workflow")
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)
@@ -508,7 +508,7 @@ public class WorkflowManagementTest {
     public void testRecurringWorkflow() {
         managedRealm.admin().workflows().create(WorkflowRepresentation.create()
                 .of(UserCreationTimeWorkflowProviderFactory.ID)
-                .onEvent(ResourceOperationType.CREATE.toString())
+                .onEvent(ResourceOperationType.USER_ADD.toString())
                 .recurring()
                 .withSteps(
                         WorkflowStepRepresentation.create().of(NotifyUserStepProviderFactory.ID)


### PR DESCRIPTION
Closes #42389

The proposal is about:

* Events prefixed with the resource type, such as `USER`. For instance, `USER_LOGIN`.
* Events that map to operations on realm resources, such as users, would have a meaningful description about what is being updated and the operation. For instance, `USER_GROUP_MEMBERSHIP_ADD` maps to the `USER` resource type, where the group membership as per `GROUP_MEMBERSHIP` is being added as per the suffix `_ADD`. The same goes for `USER_FEDERATED_IDENTITY_REMOVE` or `USER_ROLE_ADD`.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
