### PR TITLE
Exclude invalid JavaScript files from CodeQL

### DIFF
--- a/.github/actions/conditional/conditions
+++ b/.github/actions/conditional/conditions
@@ -12,6 +12,8 @@
 .github/workflows/operator-ci.yml           operator
 .github/workflows/js-ci.yml                 js
 .github/workflows/codeql-analysis.yml       codeql-java codeql-javascript codeql-typescript codeql-actions
+.github/codeql/codeql-config-javascript.yml codeql-javascript
+.github/codeql/codeql-config-typescript.yml codeql-typescript
 .github/workflows/guides.yml                guides
 .github/workflows/documentation.yml         documentation
 .github/workflows/*.yml                     codeql-actions

--- a/.github/codeql/codeql-config-javascript.yml
+++ b/.github/codeql/codeql-config-javascript.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  # This file is invalid on purpose for testing. Exclude it to prevent an "Unexpected token" error in CodeQL being reported.
+  - testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/src/main/resources/scripts/test-bad-script-mapper3.js

--- a/.github/codeql/codeql-config-typescript.yml
+++ b/.github/codeql/codeql-config-typescript.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  # This file is invalid on purpose for testing. Exclude it to prevent an "Unexpected token" error in CodeQL being reported.
+  - testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/src/main/resources/scripts/test-bad-script-mapper3.js

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,6 +92,7 @@ jobs:
           CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"finalize":["--no-run-unnecessary-builds"]}}'
         with:
           languages: javascript
+          config-file: ./.github/codeql/codeql-config-javascript.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
@@ -119,6 +120,7 @@ jobs:
           CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"finalize":["--no-run-unnecessary-builds"]}}'
         with:
           languages: typescript
+          config-file: ./.github/codeql/codeql-config-typescript.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3


### PR DESCRIPTION
Closes #42664

This now reports that it scans 67 instead of 68 JavaScript files compared to before, so I assume this is working as expected.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
