### PR TITLE
fix: auto-defaulting log console color

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -10,7 +10,7 @@ Notable changes may include internal behavior changes that prevent common miscon
 
 The `log-console-color` previously defaulted to `false`, but it will now instead check if the terminal supports color.
 
-You may still explicitly disable color support by setting the option to false.
+You may still explicitly disable color support by setting the option to `false`.
 
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features

--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -1,0 +1,26 @@
+// ------------------------ Breaking changes ------------------------  //
+== Breaking changes
+
+// ------------------------ Notable changes ------------------------ //
+== Notable changes
+
+Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
+
+=== `log-console-color` will automatically enable if supported by the terminal
+
+The `log-console-color` previously defaulted to `false`, but it will now instead check if the terminal supports color.
+
+You may still explicitly disable color support by setting the option to false.
+
+// ------------------------ Deprecated features ------------------------ //
+== Deprecated features
+
+The following sections provide details on deprecated features.
+
+// ------------------------ Removed features ------------------------ //
+== Removed features
+
+The following features have been removed from this release.
+
+=== <TODO>
+

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -1,6 +1,10 @@
 [[migration-changes]]
 == Migration Changes
 
+=== Migrating to 26.5.0
+
+include::changes-26_5_0.adoc[leveloffset=2]
+
 === Migrating to 26.4.0
 
 include::changes-26_4_0.adoc[leveloffset=2]

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static java.lang.String.format;
@@ -133,8 +134,8 @@ public class LoggingOptions {
 
     public static final Option<Boolean> LOG_CONSOLE_COLOR = new OptionBuilder<>("log-console-color", Boolean.class)
             .category(OptionCategory.LOGGING)
-            .description("Enable or disable colors when logging to console.")
-            .defaultValue(Boolean.FALSE) // :-(
+            .description("Enable or disable colors when logging to console. If this is not present then an attempt will be made to guess if the terminal supports color.")
+            .defaultValue(Optional.empty())
             .build();
 
     public static final Option<Boolean> LOG_CONSOLE_ENABLED = new OptionBuilder<>("log-console-enabled", Boolean.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionBuilder.java
@@ -54,7 +54,6 @@ public class OptionBuilder<T> {
         hidden = false;
         build = false;
         description = null;
-        defaultValue = Optional.empty();
         strictExpectedValues = true;
     }
 
@@ -178,8 +177,12 @@ public class OptionBuilder<T> {
             }
         }
 
-        if (defaultValue.isEmpty() && Boolean.class.equals(expected)) {
-            defaultValue = Optional.of((T) Boolean.FALSE);
+        if (defaultValue == null) {
+            if (Boolean.class.equals(expected)) {
+                defaultValue = Optional.of((T) Boolean.FALSE);
+            } else {
+                defaultValue = Optional.empty();
+            }
         }
 
         if (transformEnumValues) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -267,7 +267,7 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
     }
 
     private String transformConsoleColor(String value, ConfigSourceInterceptorContext context) {
-        return Optional.ofNullable(value).orElse(Boolean.toString(QuarkusConsole.hasColorSupport()));
+        return Optional.ofNullable(value).orElseGet(() -> Boolean.toString(QuarkusConsole.hasColorSupport()));
     }
 
     public static boolean isConsoleEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
@@ -32,6 +33,7 @@ import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
+import picocli.CommandLine.Help.Ansi;
 
 public final class LoggingPropertyMappers implements PropertyMapperGrouping {
 
@@ -87,6 +89,7 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                 fromOption(LoggingOptions.LOG_CONSOLE_COLOR)
                         .isEnabled(LoggingPropertyMappers::isConsoleEnabled, CONSOLE_ENABLED_MSG)
                         .to("quarkus.console.color")
+                        .transformer(this::transformConsoleColor)
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_ENABLED)
                         .mapFrom(LoggingOptions.LOG, LoggingPropertyMappers.resolveLogHandler(LoggingOptions.DEFAULT_LOG_HANDLER.name()))
@@ -261,6 +264,10 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .build()
 
         );
+    }
+
+    private String transformConsoleColor(String value, ConfigSourceInterceptorContext context) {
+        return Optional.ofNullable(value).orElse(Boolean.toString(Ansi.AUTO.enabled()));
     }
 
     public static boolean isConsoleEnabled() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -23,7 +23,6 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.quarkus.runtime.configuration.MemorySizeConverter;
 import org.jboss.logmanager.LogContext;
 import org.keycloak.common.Profile;
 import org.keycloak.config.LoggingOptions;
@@ -32,8 +31,9 @@ import org.keycloak.quarkus.runtime.Messages;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
+import io.quarkus.dev.console.QuarkusConsole;
+import io.quarkus.runtime.configuration.MemorySizeConverter;
 import io.smallrye.config.ConfigSourceInterceptorContext;
-import picocli.CommandLine.Help.Ansi;
 
 public final class LoggingPropertyMappers implements PropertyMapperGrouping {
 
@@ -267,7 +267,7 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
     }
 
     private String transformConsoleColor(String value, ConfigSourceInterceptorContext context) {
-        return Optional.ofNullable(value).orElse(Boolean.toString(Ansi.AUTO.enabled()));
+        return Optional.ofNullable(value).orElse(Boolean.toString(QuarkusConsole.hasColorSupport()));
     }
 
     public static boolean isConsoleEnabled() {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
@@ -20,6 +20,7 @@ package org.keycloak.quarkus.runtime.configuration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.config.LoggingOptions.DEFAULT_LOG_FORMAT;
@@ -39,6 +40,13 @@ import org.keycloak.quarkus.runtime.cli.PropertyException;
 import io.smallrye.config.SmallRyeConfig;
 
 public class LoggingConfigurationTest extends AbstractConfigurationTest {
+
+    @Test
+    public void testDefaultLogColor() {
+        SmallRyeConfig config = createConfig();
+        assertNull(config.getConfigValue("kc.log-console-color").getValue());
+        assertNotNull(config.getConfigValue("quarkus.console.color").getValue());
+    }
 
     @Test
     public void logHandlerConfig() {

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -226,7 +226,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -228,7 +228,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -221,7 +221,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -239,7 +239,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -221,7 +221,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -239,7 +239,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -382,7 +382,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -479,7 +479,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -430,7 +430,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -480,7 +480,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -368,7 +368,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -414,7 +414,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -429,7 +429,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -479,7 +479,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -427,7 +427,8 @@ Logging:
                        parent property 'log-async' is used. Default: false. Available only when
                        Console log handler is activated.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -477,7 +477,8 @@ Logging:
                        Default: 512. Available only when Console log handler is activated and
                        asynchronous logging is enabled.
 --log-console-color <true|false>
-                     Enable or disable colors when logging to console. Default: false. Available
+                     Enable or disable colors when logging to console. If this is not present then
+                       an attempt will be made to guess if the terminal supports color. Available
                        only when Console log handler is activated.
 --log-console-format <format>
                      The format of unstructured console log entries. If the format has spaces in


### PR DESCRIPTION
closes: #42445

~Reviewed the auto color logic in both quarkus and picocli - they are similar, but picocli seems a little more extensive so I decided to default to that.~

Switched to the quarkus console logic instead as picocli is enabling coloring for the windows tests. I believe this is due to having the OSTYPE environment variable set. This relates to #42446 as it means we're currently adding coloring to picocli messages when we shouldn't be.

We do need to change our boolean handling so that they are allowed to have no default.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
