### PR TITLE
Add additional Keycloak lifecycle events

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/PostMigrationEvent.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/PostMigrationEvent.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.utils;
 
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.AbstractLifecycleEvent;
 import org.keycloak.provider.ProviderEvent;
 
 /**
@@ -25,15 +26,9 @@ import org.keycloak.provider.ProviderEvent;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class PostMigrationEvent implements ProviderEvent {
-
-    private final KeycloakSessionFactory factory;
+public class PostMigrationEvent extends AbstractLifecycleEvent {
 
     public PostMigrationEvent(KeycloakSessionFactory factory) {
-        this.factory = factory;
-    }
-
-    public KeycloakSessionFactory getFactory() {
-        return this.factory;
+        super(factory);
     }
 }

--- a/server-spi/src/main/java/org/keycloak/provider/AbstractLifecycleEvent.java
+++ b/server-spi/src/main/java/org/keycloak/provider/AbstractLifecycleEvent.java
@@ -1,0 +1,16 @@
+package org.keycloak.provider;
+
+import org.keycloak.models.KeycloakSessionFactory;
+
+public abstract class AbstractLifecycleEvent implements ProviderEvent {
+
+    protected final KeycloakSessionFactory sessionFactory;
+
+    public AbstractLifecycleEvent(KeycloakSessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    public KeycloakSessionFactory getFactory() {
+        return sessionFactory;
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/provider/KeycloakInitializedEvent.java
+++ b/server-spi/src/main/java/org/keycloak/provider/KeycloakInitializedEvent.java
@@ -1,0 +1,13 @@
+package org.keycloak.provider;
+
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Signals that the infrastructure initialization has completed.
+ */
+public class KeycloakInitializedEvent extends AbstractLifecycleEvent {
+
+    public KeycloakInitializedEvent(KeycloakSessionFactory factory) {
+        super(factory);
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/provider/KeycloakShutdownEvent.java
+++ b/server-spi/src/main/java/org/keycloak/provider/KeycloakShutdownEvent.java
@@ -1,0 +1,13 @@
+package org.keycloak.provider;
+
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Signals that Keycloak is about to be shutdown.
+ */
+public class KeycloakShutdownEvent extends AbstractLifecycleEvent {
+
+    public KeycloakShutdownEvent(KeycloakSessionFactory factory) {
+        super(factory);
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/provider/KeycloakShutdownEvent.java
+++ b/server-spi/src/main/java/org/keycloak/provider/KeycloakShutdownEvent.java
@@ -3,7 +3,7 @@ package org.keycloak.provider;
 import org.keycloak.models.KeycloakSessionFactory;
 
 /**
- * Signals that Keycloak is about to be shutdown.
+ * Signals that Keycloak is about to shutdown.
  */
 public class KeycloakShutdownEvent extends AbstractLifecycleEvent {
 

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -38,6 +38,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.PostMigrationEvent;
 import org.keycloak.platform.Platform;
 import org.keycloak.platform.PlatformProvider;
+import org.keycloak.provider.KeycloakInitializedEvent;
+import org.keycloak.provider.KeycloakShutdownEvent;
 import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.transaction.JtaTransactionManagerLookup;
 
@@ -97,10 +99,12 @@ public abstract class KeycloakApplication extends Application {
         }
 
         sessionFactory.publish(new PostMigrationEvent(sessionFactory));
+        sessionFactory.publish(new KeycloakInitializedEvent(sessionFactory));
     }
 
     protected void shutdown() {
         if (sessionFactory != null) {
+            sessionFactory.publish(new KeycloakShutdownEvent(sessionFactory));
             sessionFactory.close();
         }
     }


### PR DESCRIPTION
This adds a KeycloakInitializedEvent and KeycloakShutdownEvent.

Those events can be used by extensions to register custom logic that should execute after Keycloak server initialization or when the server is about to get stopped.

Fixes #42670

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
