### PR TITLE
[OID4VCI]: Remove format parameter from CredentialRequest

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
@@ -53,8 +53,6 @@ public class CredentialRequest {
     @JsonProperty("credential_response_encryption")
     private CredentialResponseEncryption credentialResponseEncryption;
 
-    private String format;
-
     public String getCredentialIdentifier() {
         return credentialIdentifier;
     }
@@ -97,15 +95,6 @@ public class CredentialRequest {
 
     public CredentialRequest setCredentialResponseEncryption(CredentialResponseEncryption credentialResponseEncryption) {
         this.credentialResponseEncryption = credentialResponseEncryption;
-        return this;
-    }
-
-    public String getFormat() {
-        return format;
-    }
-
-    public CredentialRequest setFormat(String format) {
-        this.format = format;
         return this;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointEncryptionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointEncryptionTest.java
@@ -91,7 +91,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
                     PrivateKey privateKey = (PrivateKey) jwkPair.get("privateKey");
 
                     CredentialRequest credentialRequest = new CredentialRequest()
-                            .setFormat(Format.JWT_VC)
                             .setCredentialIdentifier(scopeName)
                             .setCredentialResponseEncryption(
                                     new CredentialResponseEncryption()
@@ -146,7 +145,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
                 OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setFormat(Format.JWT_VC)
                         .setCredentialIdentifier("test-credential");
 
                 String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
@@ -194,7 +192,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
                 PrivateKey responsePrivateKey = (PrivateKey) jwkPair.get("privateKey");
 
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setFormat(Format.JWT_VC)
                         .setCredentialIdentifier(scopeName)
                         .setCredentialResponseEncryption(
                                 new CredentialResponseEncryption()
@@ -263,7 +260,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
 
                 // Create credential request with response encryption parameters
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setFormat(Format.JWT_VC)
                         .setCredentialIdentifier(scopeName)
                         .setCredentialResponseEncryption(
                                 new CredentialResponseEncryption()
@@ -317,7 +313,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
             // Missing enc parameter
             JWK jwk = JWKParser.create().parse("{\"kty\":\"RSA\",\"n\":\"test-n\",\"e\":\"AQAB\"}").getJwk();
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setFormat(Format.JWT_VC)
                     .setCredentialIdentifier("test-credential")
                     .setCredentialResponseEncryption(
                             new CredentialResponseEncryption()
@@ -420,7 +415,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
             }
 
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setFormat(Format.JWT_VC)
                     .setCredentialIdentifier("test-credential")
                     .setCredentialResponseEncryption(
                             new CredentialResponseEncryption()
@@ -456,7 +450,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
             }
 
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setFormat(Format.JWT_VC)
                     .setCredentialIdentifier("test-credential")
                     .setCredentialResponseEncryption(
                             new CredentialResponseEncryption()
@@ -488,7 +481,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
             // Invalid JWK (missing modulus but WITH alg parameter)
             JWK jwk = JWKParser.create().parse("{\"kty\":\"RSA\",\"alg\":\"RSA-OAEP-256\",\"e\":\"AQAB\"}").getJwk();
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setFormat(Format.JWT_VC)
                     .setCredentialIdentifier(scopeName)
                     .setCredentialResponseEncryption(
                             new CredentialResponseEncryption()
@@ -523,7 +515,6 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
                 OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setFormat(Format.JWT_VC)
                         .setCredentialIdentifier(scopeName);
 
                 String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -639,7 +639,6 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
 
                 CredentialRequest request = new CredentialRequest()
-                        .setFormat(Format.JWT_VC)
                         .setCredentialIdentifier(scopeName)
                         .setProofs(proofs);
 


### PR DESCRIPTION
The "format" parameter is no longer supported in the OID4VCI specification 

(see: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-16.html#name-credential-request).

This PR removes the `format` field from `CredentialRequest` and its getter/setter, 
and updates tests to stop setting the format explicitly.

Closes #42677