### PR TITLE
Allow target attribute for anchor tags in html-sanitizer

### DIFF
--- a/services/src/main/java/org/keycloak/theme/KeycloakSanitizerPolicy.java
+++ b/services/src/main/java/org/keycloak/theme/KeycloakSanitizerPolicy.java
@@ -62,6 +62,8 @@ public class KeycloakSanitizerPolicy {
 
   private static final Pattern NAME = Pattern.compile("[a-zA-Z0-9\\-_\\$]+");
 
+  private static final Pattern TARGET = Pattern.compile("_blank");
+
   private static final Pattern ALIGN = Pattern.compile(
       "(?i)center|left|right|justify|char");
 
@@ -102,6 +104,7 @@ public class KeycloakSanitizerPolicy {
           .allowStandardUrlProtocols()
           .allowAttributes("nohref").onElements("a")
           .allowAttributes("name").matching(NAME).onElements("a")
+          .allowAttributes("target").matching(TARGET).onElements("a")
           .allowAttributes(
               "onfocus", "onblur", "onclick", "onmousedown", "onmouseup")
               .matching(HISTORY_BACK).onElements("a")

--- a/services/src/test/java/org/keycloak/theme/KeycloakSanitizerTest.java
+++ b/services/src/test/java/org/keycloak/theme/KeycloakSanitizerTest.java
@@ -64,8 +64,8 @@ public class KeycloakSanitizerTest {
     public void testLinks() throws Exception {
         List<String> html = new ArrayList<>();
 
-        html.set(0, "<a href=\"https://www.example.org/sub-page\">Link text</a>");
-        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        html.add("<a href=\"https://www.example.org/sub-page\">Link text</a>");
+        String expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow\">Link text</a>";
         assertResult(expectedResult, html);
 
         html.set(0, "<a href=\"https://www.example.org/terms-of-service\" target=\"_blank\">Link text</a>");
@@ -73,11 +73,11 @@ public class KeycloakSanitizerTest {
         assertResult(expectedResult, html);
 
         html.set(0, "<a href=\"https://www.example.org/sub-page\" target=\"_top\">Link text</a>");
-        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow\">Link text</a>";
         assertResult(expectedResult, html);
 
         html.set(0, "<a href=\"https://www.example.org/sub-page\" target=\"someframe\">Link text</a>");
-        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow\">Link text</a>";
         assertResult(expectedResult, html);
     }
 

--- a/services/src/test/java/org/keycloak/theme/KeycloakSanitizerTest.java
+++ b/services/src/test/java/org/keycloak/theme/KeycloakSanitizerTest.java
@@ -61,6 +61,27 @@ public class KeycloakSanitizerTest {
     }
 
     @Test
+    public void testLinks() throws Exception {
+        List<String> html = new ArrayList<>();
+
+        html.set(0, "<a href=\"https://www.example.org/sub-page\">Link text</a>");
+        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        assertResult(expectedResult, html);
+
+        html.set(0, "<a href=\"https://www.example.org/terms-of-service\" target=\"_blank\">Link text</a>");
+        expectedResult = "<a href=\"https://www.example.org/terms-of-service\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        assertResult(expectedResult, html);
+
+        html.set(0, "<a href=\"https://www.example.org/sub-page\" target=\"_top\">Link text</a>");
+        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        assertResult(expectedResult, html);
+
+        html.set(0, "<a href=\"https://www.example.org/sub-page\" target=\"someframe\">Link text</a>");
+        expectedResult = "<a href=\"https://www.example.org/sub-page\" rel=\"nofollow noopener noreferrer\">Link text</a>";
+        assertResult(expectedResult, html);
+    }
+
+    @Test
     public void testUrls() throws Exception {
         List<String> html = new ArrayList<>();
 


### PR DESCRIPTION
`kcSanitize` allows for a `target` attribute in anchor tags.

Especially on the registration or accept terms of service page the links to terms of service must open in a new window. If the link opens in the same window, the user is thrown out of the registration or login process.

Therefore the html-sanitizer must not remove the `target` attribute from anchor tags like:
`<a href="…" target="_blank">…</a>`

This fixes https://github.com/keycloak/keycloak/issues/28846