### PR TITLE
Lazy load client sessions

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/ClientSessionLoader.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/ClientSessionLoader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.jpa.session;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.session.PersistentAuthenticatedClientSessionAdapter;
+
+class ClientSessionLoader implements Consumer<Map<String, AuthenticatedClientSessionModel>> {
+
+    private boolean loaded = false;
+    private final Supplier<Stream<PersistentAuthenticatedClientSessionAdapter>> supplier;
+
+    ClientSessionLoader(Supplier<Stream<PersistentAuthenticatedClientSessionAdapter>> supplier) {
+        assert supplier != null;
+        this.supplier = supplier;
+    }
+
+
+    @Override
+    public void accept(Map<String, AuthenticatedClientSessionModel> clientSessions) {
+        if (loaded) {
+            return;
+        }
+        supplier.get().forEach(m -> clientSessions.put(m.getClient().getId(), m));
+        loaded = true;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -141,10 +141,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
                 .setParameter("offline", offlineStr)
                 .executeUpdate();
 
-        PersistentUserSessionEntity sessionEntity = em.find(PersistentUserSessionEntity.class, new PersistentUserSessionEntity.Key(userSessionId, offlineStr), LockModeType.PESSIMISTIC_WRITE);
-        if (sessionEntity != null) {
-            em.remove(sessionEntity);
-        }
+        removeUserSessionFromDatabase(userSessionId, offlineStr);
     }
 
     @Override
@@ -167,28 +164,27 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
             if (offline) {
                 // Remove userSession if it was last clientSession
-                List<PersistentClientSessionEntity> clientSessions = getClientSessionsByUserSession(sessionEntity.getUserSessionId(), offline);
-                if (clientSessions.isEmpty()) {
-                    offlineStr = offlineToString(offline);
-                    PersistentUserSessionEntity userSessionEntity = em.find(PersistentUserSessionEntity.class, new PersistentUserSessionEntity.Key(sessionEntity.getUserSessionId(), offlineStr), LockModeType.PESSIMISTIC_WRITE);
-                    if (userSessionEntity != null) {
-                        em.remove(userSessionEntity);
-                    }
+                if (hasNoClientSessions(userSessionId, offlineStr)) {
+                    removeUserSessionFromDatabase(userSessionId, offlineStr);
                 }
             }
         }
     }
 
-    private List<PersistentClientSessionEntity> getClientSessionsByUserSession(String userSessionId, boolean offline) {
-        String offlineStr = offlineToString(offline);
-
-        TypedQuery<PersistentClientSessionEntity> query = em.createNamedQuery("findClientSessionsByUserSession", PersistentClientSessionEntity.class);
-        query.setParameter("userSessionId", userSessionId);
-        query.setParameter("offline", offlineStr);
-        return query.getResultList();
+    private void removeUserSessionFromDatabase(String userSessionId, String offlineStr) {
+        PersistentUserSessionEntity userSessionEntity = em.find(PersistentUserSessionEntity.class, new PersistentUserSessionEntity.Key(userSessionId, offlineStr), LockModeType.PESSIMISTIC_WRITE);
+        if (userSessionEntity != null) {
+            em.remove(userSessionEntity);
+        }
     }
 
-
+    private boolean hasNoClientSessions(String userSessionId, String offline) {
+        TypedQuery<PersistentClientSessionEntity> query = em.createNamedQuery("findClientSessionsByUserSession", PersistentClientSessionEntity.class);
+        query.setParameter("userSessionId", userSessionId);
+        query.setParameter("offline", offline);
+        query.setMaxResults(1);
+        return query.getSingleResultOrNull() == null;
+    }
 
     @Override
     public void onRealmRemoved(RealmModel realm) {
@@ -215,14 +211,10 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
     @Override
     public void onUserRemoved(RealmModel realm, UserModel user) {
-        onUserRemoved(realm, user.getId());
-    }
-
-    private void onUserRemoved(RealmModel realm, String userId) {
+        var userId = user.getId();
         em.createNamedQuery("deleteClientSessionsByUser").setParameter("userId", userId).executeUpdate();
         em.createNamedQuery("deleteUserSessionsByUser").setParameter("userId", userId).executeUpdate();
     }
-
 
     @Override
     public void updateLastSessionRefreshes(RealmModel realm, int lastSessionRefresh, Collection<String> userSessionIds, boolean offline) {
@@ -252,7 +244,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         }
     }
 
-    private int calculateOldestSessionTime(RealmModel realm, boolean offline) {
+    private static int calculateOldestSessionTime(RealmModel realm, boolean offline) {
         return Time.currentTime() - (int) TimeUnit.MILLISECONDS.toSeconds(SessionExpirationUtils.calculateUserSessionIdleTimestamp(offline, realm.isRememberMe(), 0, realm));
     }
 
@@ -311,66 +303,41 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         userSessionQuery.setParameter("lastSessionRefresh", calculateOldestSessionTime(realm, offline));
         userSessionQuery.setMaxResults(1);
 
-        PersistentUserSessionEntity entity = userSessionQuery.getSingleResultOrNull();
+        return handleSingleQuery(userSessionQuery, offlineStr);
+    }
+
+    @Override
+    public UserSessionModel loadUserSessionsStreamByBrokerSessionId(RealmModel realm, String brokerSessionId, boolean offline) {
+        var offlineStr = offlineToString(offline);
+        TypedQuery<PersistentUserSessionEntity> userSessionQuery = em.createNamedQuery("findUserSessionsByBrokerSessionId", PersistentUserSessionEntity.class);
+        userSessionQuery.setParameter("realmId", realm.getId());
+        userSessionQuery.setParameter("brokerSessionId", brokerSessionId);
+        userSessionQuery.setParameter("offline", offlineStr);
+        userSessionQuery.setParameter("lastSessionRefresh", calculateOldestSessionTime(realm, offline));
+        userSessionQuery.setMaxResults(1);
+
+        return handleSingleQuery(userSessionQuery, offlineStr);
+    }
+
+    private UserSessionModel handleSingleQuery(TypedQuery<PersistentUserSessionEntity> query, String offlineStr) {
+        var entity = query.getSingleResultOrNull();
         if (entity == null) {
             return null;
         }
 
-        OfflineUserSessionModel userSession = toAdapter(entity);
+        var userSession = toAdapter(entity);
         if (userSession == null) {
             return null;
         }
 
-        TypedQuery<PersistentClientSessionEntity> clientSessionQuery = em.createNamedQuery("findClientSessionsByUserSession", PersistentClientSessionEntity.class);
-        clientSessionQuery.setParameter("userSessionId", userSessionId);
-        clientSessionQuery.setParameter("offline", offlineStr);
-
-        closing(clientSessionQuery.getResultStream()).forEach(clientSession ->
-                addClientSessionToAuthenticatedClientSessionsIfPresent(userSession, clientSession)
-        );
+        var initializer = new ClientSessionLoader(() -> fetchClientSessions(userSession, offlineStr));
+        userSession.setClientSessionsLoader(initializer);
 
         return userSession;
     }
 
     @Override
-    public UserSessionModel loadUserSessionsStreamByBrokerSessionId(RealmModel realm, String brokerSessionId, boolean offline) {
-
-        TypedQuery<PersistentUserSessionEntity> userSessionQuery = em.createNamedQuery("findUserSessionsByBrokerSessionId", PersistentUserSessionEntity.class);
-        userSessionQuery.setParameter("realmId", realm.getId());
-        userSessionQuery.setParameter("brokerSessionId", brokerSessionId);
-        userSessionQuery.setParameter("offline", offlineToString(offline));
-        userSessionQuery.setParameter("lastSessionRefresh", calculateOldestSessionTime(realm, offline));
-        userSessionQuery.setMaxResults(1);
-
-        Stream<OfflineUserSessionModel> persistentUserSessions = closing(userSessionQuery.getResultStream().map(this::toAdapter));
-
-        return persistentUserSessions.findAny().map(userSession -> {
-
-            TypedQuery<PersistentClientSessionEntity> clientSessionQuery = em.createNamedQuery("findClientSessionsByUserSession", PersistentClientSessionEntity.class);
-            clientSessionQuery.setParameter("userSessionId", userSession.getId());
-            clientSessionQuery.setParameter("offline", offlineToString(userSession.isOffline()));
-
-            Set<String> removedClientUUIDs = new HashSet<>();
-
-            closing(clientSessionQuery.getResultStream()).forEach(clientSession -> {
-                        boolean added = addClientSessionToAuthenticatedClientSessionsIfPresent(userSession, clientSession);
-                        if (!added) {
-                            // client was removed in the meantime
-                            removedClientUUIDs.add(clientSession.getClientId());
-                        }
-                    }
-            );
-
-            removedClientUUIDs.forEach(this::onClientRemoved);
-
-            return userSession;
-        }).orElse(null);
-    }
-
-
-    @Override
     public Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, ClientModel client, boolean offline, Integer firstResult, Integer maxResults) {
-
         String offlineStr = offlineToString(offline);
         TypedQuery<PersistentUserSessionEntity> query;
         StorageId clientStorageId = new StorageId(client.getId());
@@ -392,7 +359,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         query.setParameter("offline", offlineStr);
         query.setParameter("realmId", realm.getId());
 
-        return loadUserSessionsWithClientSessions(query, offlineStr, true);
+        return loadExactUserSessionsWithClientSessions(query, offlineStr);
     }
 
     @Override
@@ -409,7 +376,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         query.setParameter("userId", user.getId());
         query.setParameter("lastSessionRefresh", calculateOldestSessionTime(realm, offline));
 
-        return loadUserSessionsWithClientSessions(query, offlineStr, true);
+        return loadExactUserSessionsWithClientSessions(query, offlineStr);
     }
 
     public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
@@ -420,7 +387,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             .setParameter("offline", offlineStr)
             .setParameter("lastSessionId", lastUserSessionId), firstResult, maxResults);
 
-        return loadUserSessionsWithClientSessions(query, offlineStr, false);
+        return loadUserSessionsWithClientSessions(query, offlineStr);
     }
 
     @Override
@@ -448,78 +415,70 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     }
 
     /**
-     *
-     * @param query
-     * @param offlineStr
-     * @param useExact If {@code true}, then only client sessions from the user sessions
-     *          obtained from the {@code query} are loaded. If {@code false}, then IDs of user sessions
-     *          returned by the query is taken as limits, and all client sessions are loaded that belong
-     *          to user sessions whose ID is in between the minimum and maximum ID from this result.
-     * @return
+     * Only client sessions from the user sessions obtained from the {@code query} are loaded.
      */
-    private Stream<UserSessionModel> loadUserSessionsWithClientSessions(TypedQuery<PersistentUserSessionEntity> query, String offlineStr, boolean useExact) {
+    private Stream<UserSessionModel> loadExactUserSessionsWithClientSessions(TypedQuery<PersistentUserSessionEntity> query, String offlineStr) {
+        // Take the results returned by the database in chunks and enrich them.
+        // The chunking avoids loading all the entries, as the caller usually adds pagination for the frontend.
+        return closing(StreamsUtil.chunkedStream(closing(query.getResultStream()).map(this::toAdapter).filter(Objects::nonNull), 100)
+                .flatMap(batchedUserSessions -> {
+                    Set<String> removedClientUUIDs = new HashSet<>();
 
-        if (useExact) {
+                    Map<String, OfflineUserSessionModel> sessionsById = batchedUserSessions.stream()
+                            .collect(Collectors.toMap(UserSessionModel::getId, Function.identity()));
 
-            // Take the results returned by the database in chunks and enrich them.
-            // The chunking avoids loading all the entries, as the caller usually adds pagination for the frontend.
-            return closing(StreamsUtil.chunkedStream(closing(query.getResultStream()).map(this::toAdapter).filter(Objects::nonNull), 100)
-                    .flatMap(batchedUserSessions -> {
-                        Set<String> removedClientUUIDs = new HashSet<>();
+                    Set<String> userSessionIds = sessionsById.keySet();
 
-                        Map<String, OfflineUserSessionModel> sessionsById = batchedUserSessions.stream()
-                                .collect(Collectors.toMap(UserSessionModel::getId, Function.identity()));
+                    TypedQuery<PersistentClientSessionEntity> queryClientSessions;
+                    queryClientSessions = em.createNamedQuery("findClientSessionsOrderedByIdExact", PersistentClientSessionEntity.class);
+                    queryClientSessions.setParameter("offline", offlineStr);
+                    queryClientSessions.setParameter("userSessionIds", userSessionIds);
 
-                        Set<String> userSessionIds = sessionsById.keySet();
+                    processClientSessions(sessionsById, removedClientUUIDs, queryClientSessions);
 
-                        TypedQuery<PersistentClientSessionEntity> queryClientSessions;
-                        queryClientSessions = em.createNamedQuery("findClientSessionsOrderedByIdExact", PersistentClientSessionEntity.class);
-                        queryClientSessions.setParameter("offline", offlineStr);
-                        queryClientSessions.setParameter("userSessionIds", userSessionIds);
+                    removedClientUUIDs.forEach(this::onClientRemoved);
 
-                        processClientSessions(sessionsById, removedClientUUIDs, queryClientSessions);
+                    logger.tracef("Loaded %d batch of user sessions (offline=%s, sessionIds=%s)", batchedUserSessions.size(), offlineStr, sessionsById.keySet());
 
-                        for (String clientUUID : removedClientUUIDs) {
-                            onClientRemoved(clientUUID);
-                        }
+                    return batchedUserSessions.stream();
+                }).map(UserSessionModel.class::cast));
+    }
 
-                        logger.tracef("Loaded %d batch of user sessions (offline=%s, sessionIds=%s)", batchedUserSessions.size(), offlineStr, sessionsById.keySet());
+    /**
+     * The IDs of user sessions returned by the query is taken as limits, and all client sessions are loaded that belong
+     * to user sessions whose ID is in between the minimum and maximum ID from this result.
+     */
+    private Stream<UserSessionModel> loadUserSessionsWithClientSessions(TypedQuery<PersistentUserSessionEntity> query, String offlineStr) {
+        List<PersistentUserSessionAdapter> userSessionAdapters = closing(query.getResultStream()
+                .map(this::toAdapter)
+                .filter(Objects::nonNull))
+                .toList();
 
-                        return batchedUserSessions.stream();
-                    }).map(UserSessionModel.class::cast));
-        } else {
-            List<OfflineUserSessionModel> userSessionAdapters = closing(query.getResultStream()
-                    .map(this::toAdapter)
-                    .filter(Objects::nonNull))
-                    .toList();
-
-            Map<String, OfflineUserSessionModel> sessionsById = userSessionAdapters.stream()
-                    .collect(Collectors.toMap(UserSessionModel::getId, Function.identity()));
-
-            Set<String> removedClientUUIDs = new HashSet<>();
-
-            if (!sessionsById.isEmpty()) {
-                TypedQuery<PersistentClientSessionEntity> queryClientSessions;
-                String fromUserSessionId = userSessionAdapters.get(0).getId();
-                String toUserSessionId = userSessionAdapters.get(userSessionAdapters.size() - 1).getId();
-
-                queryClientSessions = em.createNamedQuery("findClientSessionsOrderedByIdInterval", PersistentClientSessionEntity.class);
-                queryClientSessions.setParameter("offline", offlineStr);
-                queryClientSessions.setParameter("fromSessionId", fromUserSessionId);
-                queryClientSessions.setParameter("toSessionId", toUserSessionId);
-
-                processClientSessions(sessionsById, removedClientUUIDs, queryClientSessions);
-            }
-
-            for (String clientUUID : removedClientUUIDs) {
-                onClientRemoved(clientUUID);
-            }
-
-            logger.tracef("Loaded %d user sessions (offline=%s, sessionIds=%s)", userSessionAdapters.size(), offlineStr, sessionsById.keySet());
-
-            return userSessionAdapters.stream().map(UserSessionModel.class::cast);
-
+        if (userSessionAdapters.isEmpty()) {
+            return Stream.of();
         }
+
+        Map<String, OfflineUserSessionModel> sessionsById = userSessionAdapters.stream()
+                .collect(Collectors.toMap(UserSessionModel::getId, Function.identity()));
+
+        Set<String> removedClientUUIDs = new HashSet<>();
+
+        TypedQuery<PersistentClientSessionEntity> queryClientSessions;
+        String fromUserSessionId = userSessionAdapters.get(0).getId();
+        String toUserSessionId = userSessionAdapters.get(userSessionAdapters.size() - 1).getId();
+
+        queryClientSessions = em.createNamedQuery("findClientSessionsOrderedByIdInterval", PersistentClientSessionEntity.class);
+        queryClientSessions.setParameter("offline", offlineStr);
+        queryClientSessions.setParameter("fromSessionId", fromUserSessionId);
+        queryClientSessions.setParameter("toSessionId", toUserSessionId);
+
+        processClientSessions(sessionsById, removedClientUUIDs, queryClientSessions);
+
+        removedClientUUIDs.forEach(this::onClientRemoved);
+
+        logger.tracef("Loaded %d user sessions (offline=%s, sessionIds=%s)", userSessionAdapters.size(), offlineStr, sessionsById.keySet());
+
+        return userSessionAdapters.stream().map(UserSessionModel.class::cast);
     }
 
     private void processClientSessions(Map<String, OfflineUserSessionModel> sessionsById, Set<String> removedClientUUIDs, TypedQuery<PersistentClientSessionEntity> queryClientSessions) {
@@ -536,7 +495,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         });
     }
 
-    private boolean addClientSessionToAuthenticatedClientSessionsIfPresent(OfflineUserSessionModel userSession, PersistentClientSessionEntity clientSessionEntity) {
+    private boolean addClientSessionToAuthenticatedClientSessionsIfPresent(UserSessionModel userSession, PersistentClientSessionEntity clientSessionEntity) {
 
         AuthenticatedClientSessionModel clientSessAdapter = toAdapter(userSession.getRealm(), null, userSession, clientSessionEntity);
 
@@ -547,16 +506,11 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
         logger.tracef("Adding client session %s / %s", userSession, clientSessAdapter);
 
-        String clientId = clientSessionEntity.getClientId();
-        if (isExternalClient(clientSessionEntity)) {
-            clientId = getExternalClientId(clientSessionEntity);
-        }
-
-        userSession.getAuthenticatedClientSessions().put(clientId, clientSessAdapter);
+        userSession.getAuthenticatedClientSessions().put(getClientId(clientSessionEntity), clientSessAdapter);
         return true;
     }
 
-    private OfflineUserSessionModel toAdapter(PersistentUserSessionEntity entity) {
+    private PersistentUserSessionAdapter toAdapter(PersistentUserSessionEntity entity) {
         RealmModel realm = session.realms().getRealm(entity.getRealmId());
         if (realm == null) {    // Realm has been deleted concurrently, ignore the entity
             return null;
@@ -564,7 +518,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         return toAdapter(realm, entity);
     }
 
-    private OfflineUserSessionModel toAdapter(RealmModel realm, PersistentUserSessionEntity entity) {
+    private PersistentUserSessionAdapter toAdapter(RealmModel realm, PersistentUserSessionEntity entity) {
         PersistentUserSessionModel model = new PersistentUserSessionModel() {
             @Override
             public String getUserSessionId() {
@@ -636,14 +590,10 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         return new PersistentUserSessionAdapter(session, model, realm, entity.getUserId(), clientSessions);
     }
 
-    private AuthenticatedClientSessionModel toAdapter(RealmModel realm, ClientModel client, UserSessionModel userSession, PersistentClientSessionEntity entity) {
+    private PersistentAuthenticatedClientSessionAdapter toAdapter(RealmModel realm, ClientModel client, UserSessionModel userSession, PersistentClientSessionEntity entity) {
         if (client == null) {
-            String clientId = entity.getClientId();
-            if (isExternalClient(entity)) {
-                clientId = getExternalClientId(entity);
-            }
             // can be null if client is not found anymore
-            client = realm.getClientById(clientId);
+            client = realm.getClientById(getClientId(entity));
             if (client == null) {
                 logger.debugf("Client not found for clientId %s clientStorageProvider %s externalClientId %s",
                         entity.getClientId(), entity.getClientStorageProvider(), entity.getExternalClientId());
@@ -663,11 +613,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
             @Override
             public String getClientId() {
-                String clientId = entity.getClientId();
-                if (isExternalClient(entity)) {
-                    clientId = getExternalClientId(entity);
-                }
-                return clientId;
+                return JpaUserSessionPersisterProvider.getClientId(entity);
             }
 
             @Override
@@ -757,19 +703,38 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         // NOOP
     }
 
-    private String offlineToString(boolean offline) {
+    private static String offlineToString(boolean offline) {
         return offline ? "1" : "0";
     }
 
-    private boolean offlineFromString(String offlineStr) {
+    private static boolean offlineFromString(String offlineStr) {
         return "1".equals(offlineStr);
     }
 
-    private boolean isExternalClient(PersistentClientSessionEntity entity) {
+    private static boolean isExternalClient(PersistentClientSessionEntity entity) {
         return !entity.getExternalClientId().equals(PersistentClientSessionEntity.LOCAL);
     }
 
-    private String getExternalClientId(PersistentClientSessionEntity entity) {
+    private static String getExternalClientId(PersistentClientSessionEntity entity) {
         return new StorageId(entity.getClientStorageProvider(), entity.getExternalClientId()).getId();
+    }
+
+    private static String getClientId(PersistentClientSessionEntity entity) {
+        return isExternalClient(entity) ? getExternalClientId(entity) : entity.getClientId();
+    }
+
+    private Stream<PersistentAuthenticatedClientSessionAdapter> fetchClientSessions(PersistentUserSessionAdapter userSession, String offlineStr) {
+        TypedQuery<PersistentClientSessionEntity> clientSessionQuery = em.createNamedQuery("findClientSessionsByUserSession", PersistentClientSessionEntity.class);
+        clientSessionQuery.setParameter("userSessionId", userSession.getId());
+        clientSessionQuery.setParameter("offline", offlineStr);
+
+        return closing(clientSessionQuery.getResultStream()
+                .map(entity -> toAdapter(userSession.getRealm(), null, userSession, entity))
+                .filter(JpaUserSessionPersisterProvider::hasClient)
+        );
+    }
+
+    private static boolean hasClient(PersistentAuthenticatedClientSessionAdapter clientSession) {
+        return clientSession.getClient() != null;
     }
 }


### PR DESCRIPTION
Closes #42628

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

I split the method `loadUserSessionsWithClientSessions(TypedQuery<PersistentUserSessionEntity> query, String offlineStr, boolean useExact)` as it has no common code between `useExact=true` and `useExact=false`. 
