### PR TITLE
DPoP-binding only for refresh token

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -1167,7 +1167,7 @@ public class TokenManager {
 
         private void generateRefreshToken(boolean offlineTokenRequested) {
             AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
-            final AccessToken.Confirmation confirmation = getConfirmation(clientSession, accessToken);
+            AccessToken.Confirmation confirmation = getConfirmation(clientSession, accessToken);
             refreshToken = new RefreshToken(accessToken, confirmation);
             refreshToken.id(SecretGenerator.getInstance().generateSecureID());
             refreshToken.issuedNow();
@@ -1188,6 +1188,15 @@ public class TokenManager {
                 refreshToken.getOtherClaims().put(Constants.REQUESTED_AUDIENCE, Arrays.stream(resquestedAudienceClients)
                         .map(ClientModel::getClientId)
                         .collect(Collectors.toSet()));
+            }
+            Boolean bindOnlyRefreshToken = session.getAttributeOrDefault(DPoPUtil.DPOP_BINDING_ONLY_REFRESH_TOKEN_SESSION_ATTRIBUTE, false);
+            if (bindOnlyRefreshToken) {
+                DPoP dPoP = session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE, DPoP.class);
+                if (dPoP != null) {
+                    confirmation = new AccessToken.Confirmation();
+                    confirmation.setKeyThumbprint(dPoP.getThumbprint());
+                    refreshToken.setConfirmation(confirmation);
+                }
             }
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -186,7 +186,7 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
         DPoPUtil.validateDPoPJkt(codeData.getDpopJkt(), session, event, cors);
 
         try {
-            session.clientPolicy().triggerOnEvent(new TokenRequestContext(formParams, parseResult));
+            session.clientPolicy().triggerOnEvent(new TokenRequestContext(formParams, parseResult, client));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
@@ -59,7 +59,7 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
         String scopeParameter = getRequestedScopes();
 
         try {
-            session.clientPolicy().triggerOnEvent(new TokenRefreshContext(formParams));
+            session.clientPolicy().triggerOnEvent(new TokenRefreshContext(formParams, client));
             refreshToken = formParams.getFirst(OAuth2Constants.REFRESH_TOKEN);
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRefreshContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRefreshContext.java
@@ -19,6 +19,7 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
@@ -28,9 +29,11 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 public class TokenRefreshContext implements ClientPolicyContext {
 
     private final MultivaluedMap<String, String> params;
+    private final ClientModel client;
 
-    public TokenRefreshContext(MultivaluedMap<String, String> params) {
+    public TokenRefreshContext(MultivaluedMap<String, String> params, ClientModel client) {
         this.params = params;
+        this.client = client;
     }
 
     @Override
@@ -42,4 +45,7 @@ public class TokenRefreshContext implements ClientPolicyContext {
         return params;
     }
 
+    public ClientModel getClient() {
+        return client;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRequestContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRequestContext.java
@@ -19,6 +19,7 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
@@ -30,11 +31,12 @@ public class TokenRequestContext implements ClientPolicyContext {
 
     private final MultivaluedMap<String, String> params;
     private final OAuth2CodeParser.ParseResult parseResult;
+    private final ClientModel client;
 
-    public TokenRequestContext(MultivaluedMap<String, String> params,
-            OAuth2CodeParser.ParseResult parseResult) {
+    public TokenRequestContext(MultivaluedMap<String, String> params, OAuth2CodeParser.ParseResult parseResult, ClientModel client) {
         this.params = params;
         this.parseResult = parseResult;
+        this.client = client;
     }
 
     @Override
@@ -50,4 +52,7 @@ public class TokenRequestContext implements ClientPolicyContext {
         return parseResult;
     }
 
+    public ClientModel getClient() {
+        return client;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/DPoPBindEnforcerExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/DPoPBindEnforcerExecutorFactory.java
@@ -32,11 +32,18 @@ public class DPoPBindEnforcerExecutorFactory  implements ClientPolicyExecutorPro
 
     public static final String ENFORCE_AUTHORIZATION_CODE_BINDING_TO_DPOP = "enforce-authorization-code-binding-to-dpop";
 
+    public static final String ALLOW_ONLY_REFRESH_BINDING = "allow-only-refresh-token-binding";
+
     private static final ProviderConfigProperty AUTO_CONFIGURE_PROPERTY = new ProviderConfigProperty(
             AUTO_CONFIGURE, "Auto-configure", "If On, then the during client creation or update, the configuration of the client will be auto-configured to use DPoP bind token", ProviderConfigProperty.BOOLEAN_TYPE, false);
 
     private static final ProviderConfigProperty ENFORCE_AUTHORIZATION_CODE_BINDING_TO_DPOP_KEY = new ProviderConfigProperty(
             ENFORCE_AUTHORIZATION_CODE_BINDING_TO_DPOP, "Enforce Authorization Code binding to DPoP key", "If On, then there is enforced authorization code binding to DPoP key. This means that parameter 'dpop_jkt' will be required in the OIDC/OAuth2 authentication requests and will be verified during token request if it matches DPoP proof. When this is false, it is still possible to use 'dpop_jkt' parameter, but it will not be required", ProviderConfigProperty.BOOLEAN_TYPE, false);
+
+    private static final ProviderConfigProperty ALLOW_ONLY_REFRESH_BINDING_PROPERTY = new ProviderConfigProperty(
+            ALLOW_ONLY_REFRESH_BINDING, "Bind only refresh token for public client", "If On and the client is public the DPoP binding is enforced only for refresh token, this option is ignored if the DPoP is enforced in client settings or if the client is not public",
+            ProviderConfigProperty.BOOLEAN_TYPE, false);
+
 
     @Override
     public ClientPolicyExecutorProvider create(KeycloakSession session) {
@@ -67,6 +74,6 @@ public class DPoPBindEnforcerExecutorFactory  implements ClientPolicyExecutorPro
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return List.of(AUTO_CONFIGURE_PROPERTY, ENFORCE_AUTHORIZATION_CODE_BINDING_TO_DPOP_KEY);
+        return List.of(AUTO_CONFIGURE_PROPERTY, ENFORCE_AUTHORIZATION_CODE_BINDING_TO_DPOP_KEY, ALLOW_ONLY_REFRESH_BINDING_PROPERTY);
     }
 }

--- a/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
@@ -93,6 +93,7 @@ public class DPoPUtil {
     public static final String DPOP_TOKEN_TYPE = "DPoP";
     public static final String DPOP_SCHEME = "DPoP";
     public final static String DPOP_SESSION_ATTRIBUTE = "dpop";
+    public final static String DPOP_BINDING_ONLY_REFRESH_TOKEN_SESSION_ATTRIBUTE = "dpop-binding-only-refresh-token";
 
     public enum Mode {
         ENABLED,
@@ -593,6 +594,11 @@ public class DPoPUtil {
 
             DPoP dPoP = session.getAttribute(DPOP_SESSION_ATTRIBUTE, DPoP.class);
             if (dPoP == null) {
+                return super.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
+            }
+
+            Boolean bindOnlyRefreshToken = session.getAttributeOrDefault(DPOP_BINDING_ONLY_REFRESH_TOKEN_SESSION_ATTRIBUTE, false);
+            if (bindOnlyRefreshToken) {
                 return super.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
             }
             AccessToken.Confirmation confirmation = (AccessToken.Confirmation) token.getOtherClaims()

--- a/services/src/main/resources/keycloak-default-client-profiles.json
+++ b/services/src/main/resources/keycloak-default-client-profiles.json
@@ -369,7 +369,8 @@
           "executor": "dpop-bind-enforcer",
           "configuration": {
             "auto-configure": "true",
-            "enforce-authorization-code-binding-to-dpop": "false"
+            "enforce-authorization-code-binding-to-dpop": "false",
+            "allow-only-refresh-token-binding": "false"
           }
         },
         {
@@ -456,7 +457,8 @@
           "executor": "dpop-bind-enforcer",
           "configuration": {
             "auto-configure": "true",
-            "enforce-authorization-code-binding-to-dpop": "false"
+            "enforce-authorization-code-binding-to-dpop": "false",
+            "allow-only-refresh-token-binding": "false"
           }
         }
       ]
@@ -535,7 +537,8 @@
           "executor": "dpop-bind-enforcer",
           "configuration": {
             "auto-configure": "true",
-            "enforce-authorization-code-binding-to-dpop": "false"
+            "enforce-authorization-code-binding-to-dpop": "false",
+            "allow-only-refresh-token-binding": "false"
           }
         },
         {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -267,10 +267,11 @@ public final class ClientPoliciesUtil {
         return config;
     }
 
-    public static DPoPBindEnforcerExecutor.Configuration createDPoPBindEnforcerExecutorConfig(Boolean autoConfigure, Boolean enforceAuthorizationCodeBindingToDpop) {
+    public static DPoPBindEnforcerExecutor.Configuration createDPoPBindEnforcerExecutorConfig(Boolean autoConfigure, Boolean enforceAuthorizationCodeBindingToDpop, Boolean bindRefreshToken) {
         DPoPBindEnforcerExecutor.Configuration config = new DPoPBindEnforcerExecutor.Configuration();
         config.setAutoConfigure(autoConfigure);
         config.setEnforceAuthorizationCodeBindingToDpop(enforceAuthorizationCodeBindingToDpop);
+        config.setAllowOnlyRefreshTokenBinding(bindRefreshToken);
         return config;
     }
 


### PR DESCRIPTION
Closes #26277 

Added the switch "Bind only refresh token for public client" to the "dpop-bind-enforcer" executor to enforce DPoP binding only for refresh tokens when the client is public.

If the client is confidential, if the client has the switch to enforce DPoP binding in client settings enabled, or if the **"Bind only refresh token for public client"** switch is disabled, the enforcement is ignored.
