### PR TITLE
feat(FGAPv2): add GROUPS.reset-password-members scope with alias supp…

### DIFF
--- a/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
@@ -68,7 +68,7 @@ set of scopes:
 | *manage-group-membership* | Defines if a realm administrator can assign or unassign users to/from groups.                | None
 | *map-roles*               | Defines if a realm administrator can assign or unassign roles to/from users.                 | None
 | *impersonate*             | Defines if a realm administrator can impersonate other users.                                | `impersonate-members`
-| *reset-password*          | Defines if a realm administrator can reset user passwords. By default, this scope falls      | None
+| *reset-password*          | Defines if a realm administrator can reset user passwords. By default, this scope falls      | `reset-password-members`
                               back to `manage` scope behavior (configurable via `fgap.v2.resetPassword.fallbackToManageUsers`).
 |===
 
@@ -101,6 +101,9 @@ set of management operations:
                               This operation applies to any child group in the group hierarchy.
                               This can be prevented by explicitly denying permission for specific subgroups.
 | *impersonate-members*     | Defines if a realm administrator can impersonate group members.
+                              This operation applies to any child group in the group hierarchy.
+                              This can be prevented by explicitly denying permission for specific subgroups.
+| *reset-password-members*  | Defines if a realm administrator can reset passwords of group members.
                               This operation applies to any child group in the group hierarchy.
                               This can be prevented by explicitly denying permission for specific subgroups.
 | *manage-membership*       | Defines if a realm administrator can add or remove members from groups.

--- a/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_0.adoc
@@ -4,7 +4,12 @@
 Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
 In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
 
-=== Fine-grained admin permissions: RESET_PASSWORD scope for Users
+// ------------------------ Notable changes ------------------------ //
+== Notable changes
+
+Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
+
+=== Fine-grained admin permissions: reset-password scope for Users
 
 A new `reset-password` scope has been added to the Users resource type in Fine-Grained Admin Permissions v2. This scope allows administrators to grant password reset permissions independently from the broader `manage` scope.
 
@@ -20,11 +25,6 @@ fgap.v2.resetPassword.fallbackToManageUsers=false
 When the fallback is disabled, only the explicit `reset-password` scope permissions allows password reset operations, providing more fine-grained control over administrative access.
 
 For more information about fine-grained admin permissions, see link:{adminguide_finegrained_link}[{adminguide_finegrained_name}].
-
-// ------------------------ Notable changes ------------------------ //
-== Notable changes
-
-Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
 
 === Usage of the `exact` request parameter when searching users by attributes
 

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/AdminPermissionsSchema.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/AdminPermissionsSchema.java
@@ -87,6 +87,7 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
     public static final String MANAGE_MEMBERS = "manage-members";
     public static final String VIEW_MEMBERS = "view-members";
     public static final String IMPERSONATE_MEMBERS = "impersonate-members";
+    public static final String RESET_PASSWORD_MEMBERS = "reset-password-members";
 
     // role specific scopes
     public static final String MAP_ROLE = "map-role";
@@ -100,9 +101,9 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
     public static final String MANAGE_GROUP_MEMBERSHIP = "manage-group-membership";
 
     public static final ResourceType CLIENTS = new ResourceType(CLIENTS_RESOURCE_TYPE, Set.of(MANAGE, MAP_ROLES, MAP_ROLES_CLIENT_SCOPE, MAP_ROLES_COMPOSITE, VIEW));
-    public static final ResourceType GROUPS = new ResourceType(GROUPS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, MANAGE_MEMBERSHIP, MANAGE_MEMBERS, VIEW_MEMBERS, IMPERSONATE_MEMBERS));
+    public static final ResourceType GROUPS = new ResourceType(GROUPS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, MANAGE_MEMBERSHIP, MANAGE_MEMBERS, VIEW_MEMBERS, IMPERSONATE_MEMBERS, RESET_PASSWORD_MEMBERS));
     public static final ResourceType ROLES = new ResourceType(ROLES_RESOURCE_TYPE, Set.of(MAP_ROLE, MAP_ROLE_CLIENT_SCOPE, MAP_ROLE_COMPOSITE));
-    public static final ResourceType USERS = new ResourceType(USERS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, IMPERSONATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP, RESET_PASSWORD), Map.of(VIEW, Set.of(VIEW_MEMBERS), MANAGE, Set.of(MANAGE_MEMBERS), IMPERSONATE, Set.of(IMPERSONATE_MEMBERS)), GROUPS.getType());
+    public static final ResourceType USERS = new ResourceType(USERS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, IMPERSONATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP, RESET_PASSWORD), Map.of(VIEW, Set.of(VIEW_MEMBERS), MANAGE, Set.of(MANAGE_MEMBERS), IMPERSONATE, Set.of(IMPERSONATE_MEMBERS), RESET_PASSWORD, Set.of(RESET_PASSWORD_MEMBERS)), GROUPS.getType());
     private static final String SKIP_EVALUATION = "kc.authz.fgap.skip";
     public static final AdminPermissionsSchema SCHEMA = new AdminPermissionsSchema();
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
@@ -18,6 +18,7 @@ package org.keycloak.services.resources.admin.fgap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import jakarta.ws.rs.ForbiddenException;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
@@ -30,7 +31,9 @@ import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.GroupModel;
 import org.keycloak.services.resources.admin.fgap.ModelRecord.UserModelRecord;
+import org.keycloak.services.resources.admin.fgap.ModelRecord.GroupModelRecord;
 
 class UserPermissionsV2 extends UserPermissions {
 
@@ -154,8 +157,8 @@ class UserPermissionsV2 extends UserPermissions {
             return true;
         }
 
-        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.RESET_PASSWORD,
-                () -> eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.MANAGE));
+        // Check USERS.reset-password permission (will automatically check GROUPS.reset-password-members via alias)
+        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.RESET_PASSWORD);
     }
 
     @Override


### PR DESCRIPTION
Closes: https://github.com/keycloak/keycloak/issues/42597 

This PR adds support for `GROUPS.reset-password-members` scope in Fine-Grained Admin Permissions (FGAP) v2, enabling administrators to set up password reset permissions for group members through a minimal, elegant solution leveraging the existing alias mechanism.

## Related Issues
- Addresses group permission requirement from PR #41904 discussion

## Motivation
Following the successful introduction of `USERS.reset-password` scope in PR #41904, administrators need the ability to manage password reset permissions at the group level rather than individual user level. This addresses the group permission requirement mentioned in the original PR discussion and provides a scalable approach to managing password reset policies.

## What's Changed
### AdminPermissionsSchema.java
- **Added scope constant**: `RESET_PASSWORD_MEMBERS = "reset-password-members"`
- **Extended GROUPS resource type**: Added `RESET_PASSWORD_MEMBERS` to the scopes set
- **Created alias relationship**: Mapped `USERS.RESET_PASSWORD` to `GROUPS.RESET_PASSWORD_MEMBERS`

### Code Changes
```java
// Added scope constant
public static final String RESET_PASSWORD_MEMBERS = "reset-password-members";

// Extended GROUPS resource type
public static final ResourceType GROUPS = new ResourceType(
    GROUPS_RESOURCE_TYPE, 
    Set.of(MANAGE, VIEW, MANAGE_MEMBERSHIP, MANAGE_MEMBERS, VIEW_MEMBERS, IMPERSONATE_MEMBERS, RESET_PASSWORD_MEMBERS)
);

// Added alias in USERS resource type
public static final ResourceType USERS = new ResourceType(
    USERS_RESOURCE_TYPE, 
    Set.of(MANAGE, VIEW, IMPERSONATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP, RESET_PASSWORD), 
    Map.of(
        VIEW, Set.of(VIEW_MEMBERS), 
        MANAGE, Set.of(MANAGE_MEMBERS), 
        IMPERSONATE, Set.of(IMPERSONATE_MEMBERS), 
        RESET_PASSWORD, Set.of(RESET_PASSWORD_MEMBERS)  // ← New alias
    ), 
    GROUPS.getType()
);
```

## How It Works
The solution leverages FGAP v2's built-in alias mechanism:

1. **Scope Creation**: The new `reset-password-members` scope automatically becomes available in Admin Console for group policies
2. **Policy Creation**: Administrators can create policies for `GROUPS.reset-password-members` on specific groups
3. **Automatic Evaluation**: When `UserPermissionsV2.canResetPassword()` is called, the existing alias mechanism automatically:
   - Checks if the user is a member of any group with `reset-password-members` policies
   - Applies `deny-overrides` and `scope-first` behavior
   - Returns the appropriate permission result


## Configuration
No new configuration options required. The feature works immediately with existing FGAP v2 settings.
