### PR TITLE
[OID4VCI] Fix authorization_details generation and credential identifier mapping for conformance tests

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
@@ -46,4 +46,15 @@ public interface AuthorizationDetailsProcessor extends Provider {
     List<AuthorizationDetailsResponse> process(UserSessionModel userSession,
                                                ClientSessionContext clientSessionCtx,
                                                String authorizationDetailsParameter);
+
+    /**
+     * Method is invoked in cases when authorization_details parameter is missing in the request. It allows processor to
+     * generate authorization details response in such a case
+     *
+     * @param userSession      the user session
+     * @param clientSessionCtx the client session context
+     * @return authorization details response if this processor can handle current request in case that authorization_details parameter was not provided
+     */
+    List<AuthorizationDetailsResponse> handleMissingAuthorizationDetails(UserSessionModel userSession,
+                                                                         ClientSessionContext clientSessionCtx);
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -254,7 +254,7 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
      * @param clientSession the client session that contains the credential offer information
      * @return the authorization details response if generation was successful, null otherwise
      */
-    public List<AuthorizationDetailsResponse> generateAuthorizationDetailsFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
+    private List<AuthorizationDetailsResponse> generateAuthorizationDetailsFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
         logger.info("Processing authorization_details from credential offer");
 
         // Get supported credentials

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -15,247 +15,328 @@
  * limitations under the License.
  */
 
-package org.keycloak.protocol.oid4vc.issuance;
+ package org.keycloak.protocol.oid4vc.issuance;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import org.jboss.logging.Logger;
-import org.keycloak.models.ClientSessionContext;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
-import org.keycloak.protocol.oid4vc.model.ClaimsDescription;
-import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
-import org.keycloak.protocol.oid4vc.model.Claim;
-import org.keycloak.util.JsonSerialization;
-import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
-import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
-
-import static org.keycloak.models.Constants.AUTHORIZATION_DETAILS_RESPONSE;
-
-public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetailsProcessor {
-    private static final Logger logger = Logger.getLogger(OID4VCAuthorizationDetailsProcessor.class);
-    private final KeycloakSession session;
-
-    public static final String OPENID_CREDENTIAL_TYPE = "openid_credential";
-
-    public OID4VCAuthorizationDetailsProcessor(KeycloakSession session) {
-        this.session = session;
-    }
-
-    @Override
-    public List<AuthorizationDetailsResponse> process(UserSessionModel userSession, ClientSessionContext clientSessionCtx, String authorizationDetailsParameter) {
-        if (authorizationDetailsParameter == null) {
-            return null; // authorization_details is optional
-        }
-
-        List<AuthorizationDetail> authDetails = parseAuthorizationDetails(authorizationDetailsParameter);
-        Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
-        List<AuthorizationDetailsResponse> authDetailsResponse = new ArrayList<>();
-
-        // Retrieve authorization servers and issuer identifier for locations check
-        List<String> authorizationServers = OID4VCIssuerWellKnownProvider.getAuthorizationServers(session);
-        String issuerIdentifier = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
-
-        for (AuthorizationDetail detail : authDetails) {
-            validateAuthorizationDetail(detail, supportedCredentials, authorizationServers, issuerIdentifier);
-            AuthorizationDetailsResponse responseDetail = buildAuthorizationDetailResponse(detail, userSession, supportedCredentials, clientSessionCtx);
-            authDetailsResponse.add(responseDetail);
-        }
-
-        if (authDetailsResponse.isEmpty()) {
-            throw getInvalidRequestException("Invalid authorization_details: no valid authorization details found");
-        }
-
-        return authDetailsResponse;
-    }
-
-    private List<AuthorizationDetail> parseAuthorizationDetails(String authorizationDetailsParam) {
-        try {
-            return JsonSerialization.readValue(authorizationDetailsParam, new TypeReference<List<AuthorizationDetail>>() {
-            });
-        } catch (Exception e) {
-            logger.warnf(e, "Invalid authorization_details format: %s", authorizationDetailsParam);
-            throw getInvalidRequestException("Invalid authorization_details format: " + authorizationDetailsParam);
-        }
-    }
-
-    private RuntimeException getInvalidRequestException(String errorDescription) {
-        return new RuntimeException("Invalid authorization_details: " + errorDescription);
-    }
-
-    /**
-     * Validates an authorization detail against supported credentials and other constraints.
-     *
-     * @param detail               the authorization detail to validate
-     * @param supportedCredentials map of supported credential configurations
-     * @param authorizationServers list of authorization servers
-     * @param issuerIdentifier     the issuer identifier
-     */
-    private void validateAuthorizationDetail(AuthorizationDetail detail, Map<String, SupportedCredentialConfiguration> supportedCredentials, List<String> authorizationServers, String issuerIdentifier) {
-
-        String type = detail.getType();
-        String credentialConfigurationId = detail.getCredentialConfigurationId();
-        List<ClaimsDescription> claims = detail.getClaims();
-
-        // If authorization_servers is present, locations must be set to issuer identifier
-        if (authorizationServers != null && !authorizationServers.isEmpty() && OPENID_CREDENTIAL_TYPE.equals(type)) {
-            List<String> locations = detail.getLocations();
-            if (locations == null || locations.size() != 1 || !issuerIdentifier.equals(locations.get(0))) {
-                logger.warnf("Invalid locations field in authorization_details: %s, expected: %s", locations, issuerIdentifier);
-                throw getInvalidRequestException("Invalid authorization_details: locations=" + locations + ", expected=" + issuerIdentifier);
-            }
-        }
-
-        // Validate type
-        if (!OPENID_CREDENTIAL_TYPE.equals(type)) {
-            logger.warnf("Invalid authorization_details type: %s", type);
-            throw getInvalidRequestException("Invalid authorization_details type: " + type + ", expected=" + OPENID_CREDENTIAL_TYPE);
-        }
-
-        // credential_configuration_id is REQUIRED
-        if (credentialConfigurationId == null) {
-            logger.warnf("Missing credential_configuration_id in authorization_details");
-            throw getInvalidRequestException("Invalid authorization_details: credential_configuration_id is required");
-        }
-
-        // Validate credential_configuration_id
-        SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
-        if (config == null) {
-            logger.warnf("Unsupported credential_configuration_id: %s", credentialConfigurationId);
-            throw getInvalidRequestException("Invalid credential configuration: unsupported credential_configuration_id=" + credentialConfigurationId);
-        }
-
-
-        // Validate claims if present
-        if (claims != null && !claims.isEmpty()) {
-            validateClaims(claims, supportedCredentials, credentialConfigurationId);
-        }
-    }
-
-    /**
-     * Validates that the requested claims are supported by the credential configuration.
-     * This performs semantic validation by checking if Keycloak supports the requested claims.
-     *
-     * @param claims                    the list of claims to validate
-     * @param supportedCredentials      map of supported credential configurations
-     * @param credentialConfigurationId the ID of the credential configuration
-     */
-    private void validateClaims(List<ClaimsDescription> claims, Map<String, SupportedCredentialConfiguration> supportedCredentials, String credentialConfigurationId) {
-        SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
-
-        // Get the exposed claims from credential metadata
-        List<Claim> exposedClaims = null;
-        if (config.getCredentialMetadata() != null && config.getCredentialMetadata().getClaims() != null && !config.getCredentialMetadata().getClaims().isEmpty()) {
-            exposedClaims = config.getCredentialMetadata().getClaims();
-        }
-
-        if (exposedClaims == null || exposedClaims.isEmpty()) {
-            throw getInvalidRequestException("Credential configuration does not expose any claims metadata");
-        }
-
-        // Convert exposed claims to a set of paths for easy comparison
-        Set<String> exposedClaimPaths = exposedClaims.stream()
-                .filter(claim -> claim.getPath() != null && !claim.getPath().isEmpty())
-                .map(claim -> claim.getPath().toString())
-                .collect(Collectors.toSet());
-
-        // Validate each requested claim against exposed metadata
-        for (ClaimsDescription requestedClaim : claims) {
-            if (requestedClaim.getPath() == null || requestedClaim.getPath().isEmpty()) {
-                throw getInvalidRequestException("Invalid claims description: path is required");
-            }
-
-            // Validate the claims path pointer format according to OID4VCI specification
-            if (!ClaimsPathPointer.isValidPath(requestedClaim.getPath())) {
-                throw getInvalidRequestException("Invalid claims path pointer: " + requestedClaim.getPath() +
-                        ". Path must contain only strings, non-negative integers, and null values.");
-            }
-
-            String requestedPath = requestedClaim.getPath().toString();
-
-            // Check if the requested claim path exists in the exposed metadata
-            if (!exposedClaimPaths.contains(requestedPath)) {
-                throw getInvalidRequestException("Unsupported claim: " + requestedPath +
-                        ". This claim is not supported by the credential configuration.");
-            }
-        }
-
-        // Check for conflicts using ClaimsPathPointer utility
-        if (!ClaimsPathPointer.validateClaimsDescriptions(claims)) {
-            throw getInvalidRequestException("Invalid claims descriptions: conflicting or contradictory claims found");
-        }
-    }
-
-    private AuthorizationDetailsResponse buildAuthorizationDetailResponse(AuthorizationDetail detail, UserSessionModel userSession, Map<String, SupportedCredentialConfiguration> supportedCredentials, ClientSessionContext clientSessionCtx) {
-        String credentialConfigurationId = detail.getCredentialConfigurationId();
-
-        // Try to reuse identifier from authorizationDetailsResponse in client session context
-        List<AuthorizationDetailsResponse> previousResponses = clientSessionCtx.getAttribute(AUTHORIZATION_DETAILS_RESPONSE, List.class);
-        List<String> credentialIdentifiers = null;
-        if (previousResponses != null) {
-            for (AuthorizationDetailsResponse prev : previousResponses) {
-                if (prev instanceof OID4VCAuthorizationDetailsResponse) {
-                    OID4VCAuthorizationDetailsResponse oid4vcResponse = (OID4VCAuthorizationDetailsResponse) prev;
-                    credentialIdentifiers = oid4vcResponse.getCredentialIdentifiers();
-                    break;
-                }
-            }
-        }
-
-        if (credentialIdentifiers == null) {
-            credentialIdentifiers = new ArrayList<>();
-            credentialIdentifiers.add(UUID.randomUUID().toString());
-        }
-
-        OID4VCAuthorizationDetailsResponse responseDetail = new OID4VCAuthorizationDetailsResponse();
-        responseDetail.setType(OPENID_CREDENTIAL_TYPE);
-        responseDetail.setCredentialConfigurationId(credentialConfigurationId);
-        responseDetail.setCredentialIdentifiers(credentialIdentifiers);
-
-        // Store claims and credential context in user session notes for later use during credential issuance
-        if (detail.getClaims() != null) {
-            // Store claims with a unique key based on credential configuration ID
-            String claimsKey = "AUTHORIZATION_DETAILS_CLAIMS_" + credentialConfigurationId;
-            try {
-                userSession.setNote(claimsKey, JsonSerialization.writeValueAsString(detail.getClaims()));
-            } catch (Exception e) {
-                logger.warnf(e, "Failed to store claims in user session for credential configuration %s", credentialConfigurationId);
-            }
-
-            // Store credential context mapping using credential identifier as key
-            for (String credentialIdentifier : credentialIdentifiers) {
-                String contextKey = "CREDENTIAL_CONTEXT_" + credentialIdentifier;
-                try {
-                    // Store the complete credential context for later retrieval
-                    Map<String, Object> credentialContext = Map.of(
-                            "credentialConfigurationId", credentialConfigurationId,
-                            "claims", detail.getClaims(),
-                            "type", OPENID_CREDENTIAL_TYPE
-                    );
-                    userSession.setNote(contextKey, JsonSerialization.writeValueAsString(credentialContext));
-                } catch (Exception e) {
-                    logger.warnf(e, "Failed to store credential context for identifier %s", credentialIdentifier);
-                }
-            }
-
-            // Include claims in response
-            responseDetail.setClaims(detail.getClaims());
-        }
-
-        return responseDetail;
-    }
-
-    @Override
-    public void close() {
-        // No cleanup needed
-    }
-}
+ import com.fasterxml.jackson.core.type.TypeReference;
+ import org.jboss.logging.Logger;
+ import org.keycloak.models.ClientSessionContext;
+ import org.keycloak.models.KeycloakSession;
+ import org.keycloak.models.UserSessionModel;
+ import org.keycloak.models.AuthenticatedClientSessionModel;
+ import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
+ import org.keycloak.protocol.oid4vc.model.ClaimsDescription;
+ import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+ import org.keycloak.protocol.oid4vc.model.Claim;
+ import org.keycloak.util.JsonSerialization;
+ import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
+ import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
+ 
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.Set;
+ import java.util.UUID;
+ import java.util.stream.Collectors;
+ 
+ import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
+ 
+ import static org.keycloak.models.Constants.AUTHORIZATION_DETAILS_RESPONSE;
+ 
+ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetailsProcessor {
+     private static final Logger logger = Logger.getLogger(OID4VCAuthorizationDetailsProcessor.class);
+     private final KeycloakSession session;
+ 
+     public static final String OPENID_CREDENTIAL_TYPE = "openid_credential";
+ 
+     public OID4VCAuthorizationDetailsProcessor(KeycloakSession session) {
+         this.session = session;
+     }
+ 
+     @Override
+     public List<AuthorizationDetailsResponse> process(UserSessionModel userSession, ClientSessionContext clientSessionCtx, String authorizationDetailsParameter) {
+         if (authorizationDetailsParameter == null) {
+             return null; // authorization_details is optional
+         }
+ 
+         List<AuthorizationDetail> authDetails = parseAuthorizationDetails(authorizationDetailsParameter);
+         Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
+         List<AuthorizationDetailsResponse> authDetailsResponse = new ArrayList<>();
+ 
+         // Retrieve authorization servers and issuer identifier for locations check
+         List<String> authorizationServers = OID4VCIssuerWellKnownProvider.getAuthorizationServers(session);
+         String issuerIdentifier = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
+ 
+         for (AuthorizationDetail detail : authDetails) {
+             validateAuthorizationDetail(detail, supportedCredentials, authorizationServers, issuerIdentifier);
+             AuthorizationDetailsResponse responseDetail = buildAuthorizationDetailResponse(detail, userSession, supportedCredentials, clientSessionCtx);
+             authDetailsResponse.add(responseDetail);
+         }
+ 
+         if (authDetailsResponse.isEmpty()) {
+             throw getInvalidRequestException("Invalid authorization_details: no valid authorization details found");
+         }
+ 
+         return authDetailsResponse;
+     }
+ 
+     private List<AuthorizationDetail> parseAuthorizationDetails(String authorizationDetailsParam) {
+         try {
+             return JsonSerialization.readValue(authorizationDetailsParam, new TypeReference<List<AuthorizationDetail>>() {
+             });
+         } catch (Exception e) {
+             logger.warnf(e, "Invalid authorization_details format: %s", authorizationDetailsParam);
+             throw getInvalidRequestException("Invalid authorization_details format: " + authorizationDetailsParam);
+         }
+     }
+ 
+     private RuntimeException getInvalidRequestException(String errorDescription) {
+         return new RuntimeException("Invalid authorization_details: " + errorDescription);
+     }
+ 
+     /**
+      * Validates an authorization detail against supported credentials and other constraints.
+      *
+      * @param detail               the authorization detail to validate
+      * @param supportedCredentials map of supported credential configurations
+      * @param authorizationServers list of authorization servers
+      * @param issuerIdentifier     the issuer identifier
+      */
+     private void validateAuthorizationDetail(AuthorizationDetail detail, Map<String, SupportedCredentialConfiguration> supportedCredentials, List<String> authorizationServers, String issuerIdentifier) {
+ 
+         String type = detail.getType();
+         String credentialConfigurationId = detail.getCredentialConfigurationId();
+         List<ClaimsDescription> claims = detail.getClaims();
+ 
+         // If authorization_servers is present, locations must be set to issuer identifier
+         if (authorizationServers != null && !authorizationServers.isEmpty() && OPENID_CREDENTIAL_TYPE.equals(type)) {
+             List<String> locations = detail.getLocations();
+             if (locations == null || locations.size() != 1 || !issuerIdentifier.equals(locations.get(0))) {
+                 logger.warnf("Invalid locations field in authorization_details: %s, expected: %s", locations, issuerIdentifier);
+                 throw getInvalidRequestException("Invalid authorization_details: locations=" + locations + ", expected=" + issuerIdentifier);
+             }
+         }
+ 
+         // Validate type
+         if (!OPENID_CREDENTIAL_TYPE.equals(type)) {
+             logger.warnf("Invalid authorization_details type: %s", type);
+             throw getInvalidRequestException("Invalid authorization_details type: " + type + ", expected=" + OPENID_CREDENTIAL_TYPE);
+         }
+ 
+         // credential_configuration_id is REQUIRED
+         if (credentialConfigurationId == null) {
+             logger.warnf("Missing credential_configuration_id in authorization_details");
+             throw getInvalidRequestException("Invalid authorization_details: credential_configuration_id is required");
+         }
+ 
+         // Validate credential_configuration_id
+         SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
+         if (config == null) {
+             logger.warnf("Unsupported credential_configuration_id: %s", credentialConfigurationId);
+             throw getInvalidRequestException("Invalid credential configuration: unsupported credential_configuration_id=" + credentialConfigurationId);
+         }
+ 
+ 
+         // Validate claims if present
+         if (claims != null && !claims.isEmpty()) {
+             validateClaims(claims, supportedCredentials, credentialConfigurationId);
+         }
+     }
+ 
+     /**
+      * Validates that the requested claims are supported by the credential configuration.
+      * This performs semantic validation by checking if Keycloak supports the requested claims.
+      *
+      * @param claims                    the list of claims to validate
+      * @param supportedCredentials      map of supported credential configurations
+      * @param credentialConfigurationId the ID of the credential configuration
+      */
+     private void validateClaims(List<ClaimsDescription> claims, Map<String, SupportedCredentialConfiguration> supportedCredentials, String credentialConfigurationId) {
+         SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
+ 
+         // Get the exposed claims from credential metadata
+         List<Claim> exposedClaims = null;
+         if (config.getCredentialMetadata() != null && config.getCredentialMetadata().getClaims() != null && !config.getCredentialMetadata().getClaims().isEmpty()) {
+             exposedClaims = config.getCredentialMetadata().getClaims();
+         }
+ 
+         if (exposedClaims == null || exposedClaims.isEmpty()) {
+             throw getInvalidRequestException("Credential configuration does not expose any claims metadata");
+         }
+ 
+         // Convert exposed claims to a set of paths for easy comparison
+         Set<String> exposedClaimPaths = exposedClaims.stream()
+                 .filter(claim -> claim.getPath() != null && !claim.getPath().isEmpty())
+                 .map(claim -> claim.getPath().toString())
+                 .collect(Collectors.toSet());
+ 
+         // Validate each requested claim against exposed metadata
+         for (ClaimsDescription requestedClaim : claims) {
+             if (requestedClaim.getPath() == null || requestedClaim.getPath().isEmpty()) {
+                 throw getInvalidRequestException("Invalid claims description: path is required");
+             }
+ 
+             // Validate the claims path pointer format according to OID4VCI specification
+             if (!ClaimsPathPointer.isValidPath(requestedClaim.getPath())) {
+                 throw getInvalidRequestException("Invalid claims path pointer: " + requestedClaim.getPath() +
+                         ". Path must contain only strings, non-negative integers, and null values.");
+             }
+ 
+             String requestedPath = requestedClaim.getPath().toString();
+ 
+             // Check if the requested claim path exists in the exposed metadata
+             if (!exposedClaimPaths.contains(requestedPath)) {
+                 throw getInvalidRequestException("Unsupported claim: " + requestedPath +
+                         ". This claim is not supported by the credential configuration.");
+             }
+         }
+ 
+         // Check for conflicts using ClaimsPathPointer utility
+         if (!ClaimsPathPointer.validateClaimsDescriptions(claims)) {
+             throw getInvalidRequestException("Invalid claims descriptions: conflicting or contradictory claims found");
+         }
+     }
+ 
+     private AuthorizationDetailsResponse buildAuthorizationDetailResponse(AuthorizationDetail detail, UserSessionModel userSession, Map<String, SupportedCredentialConfiguration> supportedCredentials, ClientSessionContext clientSessionCtx) {
+         String credentialConfigurationId = detail.getCredentialConfigurationId();
+ 
+         // Try to reuse identifier from authorizationDetailsResponse in client session context
+         List<AuthorizationDetailsResponse> previousResponses = clientSessionCtx.getAttribute(AUTHORIZATION_DETAILS_RESPONSE, List.class);
+         List<String> credentialIdentifiers = null;
+         if (previousResponses != null) {
+             for (AuthorizationDetailsResponse prev : previousResponses) {
+                 if (prev instanceof OID4VCAuthorizationDetailsResponse) {
+                     OID4VCAuthorizationDetailsResponse oid4vcResponse = (OID4VCAuthorizationDetailsResponse) prev;
+                     credentialIdentifiers = oid4vcResponse.getCredentialIdentifiers();
+                     break;
+                 }
+             }
+         }
+ 
+         if (credentialIdentifiers == null) {
+             credentialIdentifiers = new ArrayList<>();
+             credentialIdentifiers.add(UUID.randomUUID().toString());
+         }
+ 
+         OID4VCAuthorizationDetailsResponse responseDetail = new OID4VCAuthorizationDetailsResponse();
+         responseDetail.setType(OPENID_CREDENTIAL_TYPE);
+         responseDetail.setCredentialConfigurationId(credentialConfigurationId);
+         responseDetail.setCredentialIdentifiers(credentialIdentifiers);
+ 
+         // Store credential identifier mapping in client session for later use during credential issuance
+         AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
+         for (String credentialIdentifier : credentialIdentifiers) {
+             // Store the mapping between credential identifier and configuration ID in client session
+             String mappingKey = "credential_identifier_" + credentialIdentifier;
+             clientSession.setNote(mappingKey, credentialConfigurationId);
+             logger.debugf("Stored credential identifier mapping: %s -> %s", credentialIdentifier, credentialConfigurationId);
+         }
+ 
+         // Store claims in user session for later use during credential issuance
+         if (detail.getClaims() != null) {
+             // Store claims with a unique key based on credential configuration ID
+             String claimsKey = "AUTHORIZATION_DETAILS_CLAIMS_" + credentialConfigurationId;
+             try {
+                 userSession.setNote(claimsKey, JsonSerialization.writeValueAsString(detail.getClaims()));
+             } catch (Exception e) {
+                 logger.warnf(e, "Failed to store claims in user session for credential configuration %s", credentialConfigurationId);
+             }
+ 
+             // Include claims in response
+             responseDetail.setClaims(detail.getClaims());
+         }
+ 
+         return responseDetail;
+     }
+ 
+ 
+     /**
+      * Process authorization_details from the credential offer when authorization_details parameter is not present in the token request.
+      * This method generates authorization_details based on the credential_configuration_ids from the credential offer.
+      *
+      * @param userSession      the user session
+      * @param clientSessionCtx the client session context
+      * @param clientSession    the client session that contains the credential offer information
+      * @return the authorization details response if processing was successful, null otherwise
+      */
+     public List<AuthorizationDetailsResponse> processFromCredentialOffer(UserSessionModel userSession, ClientSessionContext clientSessionCtx, AuthenticatedClientSessionModel clientSession) {
+         logger.info("Processing authorization_details from credential offer");
+ 
+         // Get supported credentials
+         Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
+         if (supportedCredentials == null || supportedCredentials.isEmpty()) {
+             logger.info("No supported credentials found, cannot generate authorization_details from credential offer");
+             return null;
+         }
+ 
+         // Extract credential_configuration_ids from the credential offer
+         List<String> credentialConfigurationIds = extractCredentialConfigurationIds(clientSession);
+ 
+         if (credentialConfigurationIds == null || credentialConfigurationIds.isEmpty()) {
+             logger.info("No credential_configuration_ids found in credential offer, cannot generate authorization_details");
+             return null;
+         }
+ 
+         // Generate authorization_details for each credential configuration
+         List<AuthorizationDetailsResponse> authorizationDetailsList = new ArrayList<>();
+ 
+         for (String credentialConfigurationId : credentialConfigurationIds) {
+             SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
+             if (config == null) {
+                 logger.warnf("Credential configuration '%s' not found in supported credentials, skipping", credentialConfigurationId);
+                 continue;
+             }
+ 
+             String credentialIdentifier = UUID.randomUUID().toString();
+ 
+             // Store the mapping between credential identifier and configuration ID in client session
+             // This will be used later when processing credential requests
+             String mappingKey = "credential_identifier_" + credentialIdentifier;
+             clientSession.setNote(mappingKey, credentialConfigurationId);
+ 
+             logger.debugf("Generated credential identifier '%s' for configuration '%s'",
+                     credentialIdentifier, credentialConfigurationId);
+ 
+             OID4VCAuthorizationDetailsResponse authDetail = new OID4VCAuthorizationDetailsResponse();
+             authDetail.setType(OPENID_CREDENTIAL_TYPE);
+             authDetail.setCredentialConfigurationId(credentialConfigurationId);
+             authDetail.setCredentialIdentifiers(List.of(credentialIdentifier));
+ 
+             authorizationDetailsList.add(authDetail);
+         }
+ 
+         if (authorizationDetailsList.isEmpty()) {
+             logger.debug("No valid credential configurations found, cannot generate authorization_details");
+             return null;
+         }
+ 
+         return authorizationDetailsList;
+     }
+ 
+     /**
+      * Extract credential_configuration_ids from the credential offer stored in client session
+      */
+     private List<String> extractCredentialConfigurationIds(AuthenticatedClientSessionModel clientSession) {
+         // Get credential configuration IDs from the predictable location
+         // This is stored when the credential offer is created in getCredentialOfferURI
+         String credentialConfigIdsJson = clientSession.getNote("CREDENTIAL_CONFIGURATION_IDS");
+         if (credentialConfigIdsJson != null) {
+             logger.debugf("Found credential configuration IDs in predictable location");
+             try {
+                 List<String> configIds = JsonSerialization.readValue(credentialConfigIdsJson, List.class);
+                 logger.debugf("Successfully parsed credential configuration IDs: %s", configIds);
+                 return configIds;
+             } catch (Exception e) {
+                 logger.warnf("Failed to parse credential configuration IDs from predictable location: %s", e.getMessage());
+             }
+         }
+ 
+         logger.debugf("No credential_configuration_ids found in predictable location");
+         return null;
+     }
+ 
+     @Override
+     public void close() {
+         // No cleanup needed
+     }
+ }
+ 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -15,328 +15,323 @@
  * limitations under the License.
  */
 
- package org.keycloak.protocol.oid4vc.issuance;
+package org.keycloak.protocol.oid4vc.issuance;
 
- import com.fasterxml.jackson.core.type.TypeReference;
- import org.jboss.logging.Logger;
- import org.keycloak.models.ClientSessionContext;
- import org.keycloak.models.KeycloakSession;
- import org.keycloak.models.UserSessionModel;
- import org.keycloak.models.AuthenticatedClientSessionModel;
- import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
- import org.keycloak.protocol.oid4vc.model.ClaimsDescription;
- import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
- import org.keycloak.protocol.oid4vc.model.Claim;
- import org.keycloak.util.JsonSerialization;
- import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
- import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
- 
- import java.util.ArrayList;
- import java.util.List;
- import java.util.Map;
- import java.util.Set;
- import java.util.UUID;
- import java.util.stream.Collectors;
- 
- import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
- 
- import static org.keycloak.models.Constants.AUTHORIZATION_DETAILS_RESPONSE;
- 
- public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetailsProcessor {
-     private static final Logger logger = Logger.getLogger(OID4VCAuthorizationDetailsProcessor.class);
-     private final KeycloakSession session;
- 
-     public static final String OPENID_CREDENTIAL_TYPE = "openid_credential";
- 
-     public OID4VCAuthorizationDetailsProcessor(KeycloakSession session) {
-         this.session = session;
-     }
- 
-     @Override
-     public List<AuthorizationDetailsResponse> process(UserSessionModel userSession, ClientSessionContext clientSessionCtx, String authorizationDetailsParameter) {
-         if (authorizationDetailsParameter == null) {
-             return null; // authorization_details is optional
-         }
- 
-         List<AuthorizationDetail> authDetails = parseAuthorizationDetails(authorizationDetailsParameter);
-         Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
-         List<AuthorizationDetailsResponse> authDetailsResponse = new ArrayList<>();
- 
-         // Retrieve authorization servers and issuer identifier for locations check
-         List<String> authorizationServers = OID4VCIssuerWellKnownProvider.getAuthorizationServers(session);
-         String issuerIdentifier = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
- 
-         for (AuthorizationDetail detail : authDetails) {
-             validateAuthorizationDetail(detail, supportedCredentials, authorizationServers, issuerIdentifier);
-             AuthorizationDetailsResponse responseDetail = buildAuthorizationDetailResponse(detail, userSession, supportedCredentials, clientSessionCtx);
-             authDetailsResponse.add(responseDetail);
-         }
- 
-         if (authDetailsResponse.isEmpty()) {
-             throw getInvalidRequestException("Invalid authorization_details: no valid authorization details found");
-         }
- 
-         return authDetailsResponse;
-     }
- 
-     private List<AuthorizationDetail> parseAuthorizationDetails(String authorizationDetailsParam) {
-         try {
-             return JsonSerialization.readValue(authorizationDetailsParam, new TypeReference<List<AuthorizationDetail>>() {
-             });
-         } catch (Exception e) {
-             logger.warnf(e, "Invalid authorization_details format: %s", authorizationDetailsParam);
-             throw getInvalidRequestException("Invalid authorization_details format: " + authorizationDetailsParam);
-         }
-     }
- 
-     private RuntimeException getInvalidRequestException(String errorDescription) {
-         return new RuntimeException("Invalid authorization_details: " + errorDescription);
-     }
- 
-     /**
-      * Validates an authorization detail against supported credentials and other constraints.
-      *
-      * @param detail               the authorization detail to validate
-      * @param supportedCredentials map of supported credential configurations
-      * @param authorizationServers list of authorization servers
-      * @param issuerIdentifier     the issuer identifier
-      */
-     private void validateAuthorizationDetail(AuthorizationDetail detail, Map<String, SupportedCredentialConfiguration> supportedCredentials, List<String> authorizationServers, String issuerIdentifier) {
- 
-         String type = detail.getType();
-         String credentialConfigurationId = detail.getCredentialConfigurationId();
-         List<ClaimsDescription> claims = detail.getClaims();
- 
-         // If authorization_servers is present, locations must be set to issuer identifier
-         if (authorizationServers != null && !authorizationServers.isEmpty() && OPENID_CREDENTIAL_TYPE.equals(type)) {
-             List<String> locations = detail.getLocations();
-             if (locations == null || locations.size() != 1 || !issuerIdentifier.equals(locations.get(0))) {
-                 logger.warnf("Invalid locations field in authorization_details: %s, expected: %s", locations, issuerIdentifier);
-                 throw getInvalidRequestException("Invalid authorization_details: locations=" + locations + ", expected=" + issuerIdentifier);
-             }
-         }
- 
-         // Validate type
-         if (!OPENID_CREDENTIAL_TYPE.equals(type)) {
-             logger.warnf("Invalid authorization_details type: %s", type);
-             throw getInvalidRequestException("Invalid authorization_details type: " + type + ", expected=" + OPENID_CREDENTIAL_TYPE);
-         }
- 
-         // credential_configuration_id is REQUIRED
-         if (credentialConfigurationId == null) {
-             logger.warnf("Missing credential_configuration_id in authorization_details");
-             throw getInvalidRequestException("Invalid authorization_details: credential_configuration_id is required");
-         }
- 
-         // Validate credential_configuration_id
-         SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
-         if (config == null) {
-             logger.warnf("Unsupported credential_configuration_id: %s", credentialConfigurationId);
-             throw getInvalidRequestException("Invalid credential configuration: unsupported credential_configuration_id=" + credentialConfigurationId);
-         }
- 
- 
-         // Validate claims if present
-         if (claims != null && !claims.isEmpty()) {
-             validateClaims(claims, supportedCredentials, credentialConfigurationId);
-         }
-     }
- 
-     /**
-      * Validates that the requested claims are supported by the credential configuration.
-      * This performs semantic validation by checking if Keycloak supports the requested claims.
-      *
-      * @param claims                    the list of claims to validate
-      * @param supportedCredentials      map of supported credential configurations
-      * @param credentialConfigurationId the ID of the credential configuration
-      */
-     private void validateClaims(List<ClaimsDescription> claims, Map<String, SupportedCredentialConfiguration> supportedCredentials, String credentialConfigurationId) {
-         SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
- 
-         // Get the exposed claims from credential metadata
-         List<Claim> exposedClaims = null;
-         if (config.getCredentialMetadata() != null && config.getCredentialMetadata().getClaims() != null && !config.getCredentialMetadata().getClaims().isEmpty()) {
-             exposedClaims = config.getCredentialMetadata().getClaims();
-         }
- 
-         if (exposedClaims == null || exposedClaims.isEmpty()) {
-             throw getInvalidRequestException("Credential configuration does not expose any claims metadata");
-         }
- 
-         // Convert exposed claims to a set of paths for easy comparison
-         Set<String> exposedClaimPaths = exposedClaims.stream()
-                 .filter(claim -> claim.getPath() != null && !claim.getPath().isEmpty())
-                 .map(claim -> claim.getPath().toString())
-                 .collect(Collectors.toSet());
- 
-         // Validate each requested claim against exposed metadata
-         for (ClaimsDescription requestedClaim : claims) {
-             if (requestedClaim.getPath() == null || requestedClaim.getPath().isEmpty()) {
-                 throw getInvalidRequestException("Invalid claims description: path is required");
-             }
- 
-             // Validate the claims path pointer format according to OID4VCI specification
-             if (!ClaimsPathPointer.isValidPath(requestedClaim.getPath())) {
-                 throw getInvalidRequestException("Invalid claims path pointer: " + requestedClaim.getPath() +
-                         ". Path must contain only strings, non-negative integers, and null values.");
-             }
- 
-             String requestedPath = requestedClaim.getPath().toString();
- 
-             // Check if the requested claim path exists in the exposed metadata
-             if (!exposedClaimPaths.contains(requestedPath)) {
-                 throw getInvalidRequestException("Unsupported claim: " + requestedPath +
-                         ". This claim is not supported by the credential configuration.");
-             }
-         }
- 
-         // Check for conflicts using ClaimsPathPointer utility
-         if (!ClaimsPathPointer.validateClaimsDescriptions(claims)) {
-             throw getInvalidRequestException("Invalid claims descriptions: conflicting or contradictory claims found");
-         }
-     }
- 
-     private AuthorizationDetailsResponse buildAuthorizationDetailResponse(AuthorizationDetail detail, UserSessionModel userSession, Map<String, SupportedCredentialConfiguration> supportedCredentials, ClientSessionContext clientSessionCtx) {
-         String credentialConfigurationId = detail.getCredentialConfigurationId();
- 
-         // Try to reuse identifier from authorizationDetailsResponse in client session context
-         List<AuthorizationDetailsResponse> previousResponses = clientSessionCtx.getAttribute(AUTHORIZATION_DETAILS_RESPONSE, List.class);
-         List<String> credentialIdentifiers = null;
-         if (previousResponses != null) {
-             for (AuthorizationDetailsResponse prev : previousResponses) {
-                 if (prev instanceof OID4VCAuthorizationDetailsResponse) {
-                     OID4VCAuthorizationDetailsResponse oid4vcResponse = (OID4VCAuthorizationDetailsResponse) prev;
-                     credentialIdentifiers = oid4vcResponse.getCredentialIdentifiers();
-                     break;
-                 }
-             }
-         }
- 
-         if (credentialIdentifiers == null) {
-             credentialIdentifiers = new ArrayList<>();
-             credentialIdentifiers.add(UUID.randomUUID().toString());
-         }
- 
-         OID4VCAuthorizationDetailsResponse responseDetail = new OID4VCAuthorizationDetailsResponse();
-         responseDetail.setType(OPENID_CREDENTIAL_TYPE);
-         responseDetail.setCredentialConfigurationId(credentialConfigurationId);
-         responseDetail.setCredentialIdentifiers(credentialIdentifiers);
- 
-         // Store credential identifier mapping in client session for later use during credential issuance
-         AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
-         for (String credentialIdentifier : credentialIdentifiers) {
-             // Store the mapping between credential identifier and configuration ID in client session
-             String mappingKey = "credential_identifier_" + credentialIdentifier;
-             clientSession.setNote(mappingKey, credentialConfigurationId);
-             logger.debugf("Stored credential identifier mapping: %s -> %s", credentialIdentifier, credentialConfigurationId);
-         }
- 
-         // Store claims in user session for later use during credential issuance
-         if (detail.getClaims() != null) {
-             // Store claims with a unique key based on credential configuration ID
-             String claimsKey = "AUTHORIZATION_DETAILS_CLAIMS_" + credentialConfigurationId;
-             try {
-                 userSession.setNote(claimsKey, JsonSerialization.writeValueAsString(detail.getClaims()));
-             } catch (Exception e) {
-                 logger.warnf(e, "Failed to store claims in user session for credential configuration %s", credentialConfigurationId);
-             }
- 
-             // Include claims in response
-             responseDetail.setClaims(detail.getClaims());
-         }
- 
-         return responseDetail;
-     }
- 
- 
-     /**
-      * Process authorization_details from the credential offer when authorization_details parameter is not present in the token request.
-      * This method generates authorization_details based on the credential_configuration_ids from the credential offer.
-      *
-      * @param userSession      the user session
-      * @param clientSessionCtx the client session context
-      * @param clientSession    the client session that contains the credential offer information
-      * @return the authorization details response if processing was successful, null otherwise
-      */
-     public List<AuthorizationDetailsResponse> processFromCredentialOffer(UserSessionModel userSession, ClientSessionContext clientSessionCtx, AuthenticatedClientSessionModel clientSession) {
-         logger.info("Processing authorization_details from credential offer");
- 
-         // Get supported credentials
-         Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
-         if (supportedCredentials == null || supportedCredentials.isEmpty()) {
-             logger.info("No supported credentials found, cannot generate authorization_details from credential offer");
-             return null;
-         }
- 
-         // Extract credential_configuration_ids from the credential offer
-         List<String> credentialConfigurationIds = extractCredentialConfigurationIds(clientSession);
- 
-         if (credentialConfigurationIds == null || credentialConfigurationIds.isEmpty()) {
-             logger.info("No credential_configuration_ids found in credential offer, cannot generate authorization_details");
-             return null;
-         }
- 
-         // Generate authorization_details for each credential configuration
-         List<AuthorizationDetailsResponse> authorizationDetailsList = new ArrayList<>();
- 
-         for (String credentialConfigurationId : credentialConfigurationIds) {
-             SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
-             if (config == null) {
-                 logger.warnf("Credential configuration '%s' not found in supported credentials, skipping", credentialConfigurationId);
-                 continue;
-             }
- 
-             String credentialIdentifier = UUID.randomUUID().toString();
- 
-             // Store the mapping between credential identifier and configuration ID in client session
-             // This will be used later when processing credential requests
-             String mappingKey = "credential_identifier_" + credentialIdentifier;
-             clientSession.setNote(mappingKey, credentialConfigurationId);
- 
-             logger.debugf("Generated credential identifier '%s' for configuration '%s'",
-                     credentialIdentifier, credentialConfigurationId);
- 
-             OID4VCAuthorizationDetailsResponse authDetail = new OID4VCAuthorizationDetailsResponse();
-             authDetail.setType(OPENID_CREDENTIAL_TYPE);
-             authDetail.setCredentialConfigurationId(credentialConfigurationId);
-             authDetail.setCredentialIdentifiers(List.of(credentialIdentifier));
- 
-             authorizationDetailsList.add(authDetail);
-         }
- 
-         if (authorizationDetailsList.isEmpty()) {
-             logger.debug("No valid credential configurations found, cannot generate authorization_details");
-             return null;
-         }
- 
-         return authorizationDetailsList;
-     }
- 
-     /**
-      * Extract credential_configuration_ids from the credential offer stored in client session
-      */
-     private List<String> extractCredentialConfigurationIds(AuthenticatedClientSessionModel clientSession) {
-         // Get credential configuration IDs from the predictable location
-         // This is stored when the credential offer is created in getCredentialOfferURI
-         String credentialConfigIdsJson = clientSession.getNote("CREDENTIAL_CONFIGURATION_IDS");
-         if (credentialConfigIdsJson != null) {
-             logger.debugf("Found credential configuration IDs in predictable location");
-             try {
-                 List<String> configIds = JsonSerialization.readValue(credentialConfigIdsJson, List.class);
-                 logger.debugf("Successfully parsed credential configuration IDs: %s", configIds);
-                 return configIds;
-             } catch (Exception e) {
-                 logger.warnf("Failed to parse credential configuration IDs from predictable location: %s", e.getMessage());
-             }
-         }
- 
-         logger.debugf("No credential_configuration_ids found in predictable location");
-         return null;
-     }
- 
-     @Override
-     public void close() {
-         // No cleanup needed
-     }
- }
- 
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.jboss.logging.Logger;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.ClaimsDescription;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+import org.keycloak.protocol.oid4vc.model.Claim;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
+import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
+
+import static org.keycloak.models.Constants.AUTHORIZATION_DETAILS_RESPONSE;
+
+public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetailsProcessor {
+    private static final Logger logger = Logger.getLogger(OID4VCAuthorizationDetailsProcessor.class);
+    private final KeycloakSession session;
+
+    public static final String OPENID_CREDENTIAL_TYPE = "openid_credential";
+
+    public OID4VCAuthorizationDetailsProcessor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public List<AuthorizationDetailsResponse> process(UserSessionModel userSession, ClientSessionContext clientSessionCtx, String authorizationDetailsParameter) {
+        if (authorizationDetailsParameter == null) {
+            return null; // authorization_details is optional
+        }
+
+        List<AuthorizationDetail> authDetails = parseAuthorizationDetails(authorizationDetailsParameter);
+        Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
+        List<AuthorizationDetailsResponse> authDetailsResponse = new ArrayList<>();
+
+        // Retrieve authorization servers and issuer identifier for locations check
+        List<String> authorizationServers = OID4VCIssuerWellKnownProvider.getAuthorizationServers(session);
+        String issuerIdentifier = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
+
+        for (AuthorizationDetail detail : authDetails) {
+            validateAuthorizationDetail(detail, supportedCredentials, authorizationServers, issuerIdentifier);
+            AuthorizationDetailsResponse responseDetail = buildAuthorizationDetailResponse(detail, userSession, clientSessionCtx);
+            authDetailsResponse.add(responseDetail);
+        }
+
+        if (authDetailsResponse.isEmpty()) {
+            throw getInvalidRequestException("no valid authorization details found");
+        }
+
+        return authDetailsResponse;
+    }
+
+    private List<AuthorizationDetail> parseAuthorizationDetails(String authorizationDetailsParam) {
+        try {
+            return JsonSerialization.readValue(authorizationDetailsParam, new TypeReference<List<AuthorizationDetail>>() {
+            });
+        } catch (Exception e) {
+            logger.warnf(e, "Invalid authorization_details format: %s", authorizationDetailsParam);
+            throw getInvalidRequestException("format: " + authorizationDetailsParam);
+        }
+    }
+
+    private RuntimeException getInvalidRequestException(String errorDescription) {
+        return new RuntimeException("Invalid authorization_details: " + errorDescription);
+    }
+
+    /**
+     * Validates an authorization detail against supported credentials and other constraints.
+     *
+     * @param detail               the authorization detail to validate
+     * @param supportedCredentials map of supported credential configurations
+     * @param authorizationServers list of authorization servers
+     * @param issuerIdentifier     the issuer identifier
+     */
+    private void validateAuthorizationDetail(AuthorizationDetail detail, Map<String, SupportedCredentialConfiguration> supportedCredentials, List<String> authorizationServers, String issuerIdentifier) {
+
+        String type = detail.getType();
+        String credentialConfigurationId = detail.getCredentialConfigurationId();
+        List<ClaimsDescription> claims = detail.getClaims();
+
+        // Validate type first
+        if (!OPENID_CREDENTIAL_TYPE.equals(type)) {
+            logger.warnf("Invalid authorization_details type: %s", type);
+            throw getInvalidRequestException("type: " + type + ", expected=" + OPENID_CREDENTIAL_TYPE);
+        }
+
+        // If authorization_servers is present, locations must be set to issuer identifier
+        if (authorizationServers != null && !authorizationServers.isEmpty()) {
+            List<String> locations = detail.getLocations();
+            if (locations == null || locations.size() != 1 || !issuerIdentifier.equals(locations.get(0))) {
+                logger.warnf("Invalid locations field in authorization_details: %s, expected: %s", locations, issuerIdentifier);
+                throw getInvalidRequestException("locations=" + locations + ", expected=" + issuerIdentifier);
+            }
+        }
+
+        // credential_configuration_id is REQUIRED
+        if (credentialConfigurationId == null) {
+            logger.warnf("Missing credential_configuration_id in authorization_details");
+            throw getInvalidRequestException("credential_configuration_id is required");
+        }
+
+        // Validate credential_configuration_id
+        SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
+        if (config == null) {
+            logger.warnf("Unsupported credential_configuration_id: %s", credentialConfigurationId);
+            throw getInvalidRequestException("Invalid credential configuration: unsupported credential_configuration_id=" + credentialConfigurationId);
+        }
+
+
+        // Validate claims if present
+        if (claims != null && !claims.isEmpty()) {
+            validateClaims(claims, config);
+        }
+    }
+
+    /**
+     * Validates that the requested claims are supported by the credential configuration.
+     * This performs semantic validation by checking if Keycloak supports the requested claims.
+     *
+     * @param claims the list of claims to validate
+     * @param config the credential configuration to validate against
+     */
+    private void validateClaims(List<ClaimsDescription> claims, SupportedCredentialConfiguration config) {
+
+        // Get the exposed claims from credential metadata
+        List<Claim> exposedClaims = null;
+        if (config.getCredentialMetadata() != null && config.getCredentialMetadata().getClaims() != null && !config.getCredentialMetadata().getClaims().isEmpty()) {
+            exposedClaims = config.getCredentialMetadata().getClaims();
+        }
+
+        if (exposedClaims == null || exposedClaims.isEmpty()) {
+            throw getInvalidRequestException("Credential configuration does not expose any claims metadata");
+        }
+
+        // Convert exposed claims to a set of paths for easy comparison
+        Set<String> exposedClaimPaths = exposedClaims.stream()
+                .filter(claim -> claim.getPath() != null && !claim.getPath().isEmpty())
+                .map(claim -> claim.getPath().toString())
+                .collect(Collectors.toSet());
+
+        // Validate each requested claim against exposed metadata
+        for (ClaimsDescription requestedClaim : claims) {
+            if (requestedClaim.getPath() == null || requestedClaim.getPath().isEmpty()) {
+                throw getInvalidRequestException("Invalid claims description: path is required");
+            }
+
+            // Validate the claims path pointer format according to OID4VCI specification
+            if (!ClaimsPathPointer.isValidPath(requestedClaim.getPath())) {
+                throw getInvalidRequestException("Invalid claims path pointer: " + requestedClaim.getPath() +
+                        ". Path must contain only strings, non-negative integers, and null values.");
+            }
+
+            String requestedPath = requestedClaim.getPath().toString();
+
+            // Check if the requested claim path exists in the exposed metadata
+            if (!exposedClaimPaths.contains(requestedPath)) {
+                throw getInvalidRequestException("Unsupported claim: " + requestedPath +
+                        ". This claim is not supported by the credential configuration.");
+            }
+        }
+
+        // Check for conflicts using ClaimsPathPointer utility
+        if (!ClaimsPathPointer.validateClaimsDescriptions(claims)) {
+            throw getInvalidRequestException("Invalid claims descriptions: conflicting or contradictory claims found");
+        }
+    }
+
+    private AuthorizationDetailsResponse buildAuthorizationDetailResponse(AuthorizationDetail detail, UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        String credentialConfigurationId = detail.getCredentialConfigurationId();
+
+        // Try to reuse identifier from authorizationDetailsResponse in client session context
+        List<AuthorizationDetailsResponse> previousResponses = clientSessionCtx.getAttribute(AUTHORIZATION_DETAILS_RESPONSE, List.class);
+        List<String> credentialIdentifiers = null;
+        if (previousResponses != null) {
+            for (AuthorizationDetailsResponse prev : previousResponses) {
+                if (prev instanceof OID4VCAuthorizationDetailsResponse) {
+                    OID4VCAuthorizationDetailsResponse oid4vcResponse = (OID4VCAuthorizationDetailsResponse) prev;
+                    credentialIdentifiers = oid4vcResponse.getCredentialIdentifiers();
+                    break;
+                }
+            }
+        }
+
+        if (credentialIdentifiers == null) {
+            credentialIdentifiers = new ArrayList<>();
+            credentialIdentifiers.add(UUID.randomUUID().toString());
+        }
+
+        OID4VCAuthorizationDetailsResponse responseDetail = new OID4VCAuthorizationDetailsResponse();
+        responseDetail.setType(OPENID_CREDENTIAL_TYPE);
+        responseDetail.setCredentialConfigurationId(credentialConfigurationId);
+        responseDetail.setCredentialIdentifiers(credentialIdentifiers);
+
+        // Store credential identifier mapping in client session for later use during credential issuance
+        AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
+        for (String credentialIdentifier : credentialIdentifiers) {
+            // Store the mapping between credential identifier and configuration ID in client session
+            String mappingKey = OID4VCIssuerEndpoint.CREDENTIAL_IDENTIFIER_PREFIX + credentialIdentifier;
+            clientSession.setNote(mappingKey, credentialConfigurationId);
+            logger.debugf("Stored credential identifier mapping: %s -> %s", credentialIdentifier, credentialConfigurationId);
+        }
+
+        // Store claims in user session for later use during credential issuance
+        if (detail.getClaims() != null) {
+            // Store claims with a unique key based on credential configuration ID
+            String claimsKey = OID4VCIssuerEndpoint.AUTHORIZATION_DETAILS_CLAIMS_PREFIX + credentialConfigurationId;
+            try {
+                userSession.setNote(claimsKey, JsonSerialization.writeValueAsString(detail.getClaims()));
+            } catch (Exception e) {
+                logger.warnf(e, "Failed to store claims in user session for credential configuration %s", credentialConfigurationId);
+            }
+
+            // Include claims in response
+            responseDetail.setClaims(detail.getClaims());
+        }
+
+        return responseDetail;
+    }
+
+
+    /**
+     * Process authorization_details from the credential offer when authorization_details parameter is not present in the token request.
+     * This method generates authorization_details based on the credential_configuration_ids from the credential offer.
+     *
+     * @param clientSession the client session that contains the credential offer information
+     * @return the authorization details response if processing was successful, null otherwise
+     */
+    public List<AuthorizationDetailsResponse> processFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
+        logger.info("Processing authorization_details from credential offer");
+
+        // Get supported credentials
+        Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
+        if (supportedCredentials == null || supportedCredentials.isEmpty()) {
+            logger.info("No supported credentials found, cannot generate authorization_details from credential offer");
+            return null;
+        }
+
+        // Extract credential_configuration_ids from the credential offer
+        List<String> credentialConfigurationIds = extractCredentialConfigurationIds(clientSession);
+
+        if (credentialConfigurationIds == null || credentialConfigurationIds.isEmpty()) {
+            logger.info("No credential_configuration_ids found in credential offer, cannot generate authorization_details");
+            return null;
+        }
+
+        // Generate authorization_details for each credential configuration
+        List<AuthorizationDetailsResponse> authorizationDetailsList = new ArrayList<>();
+
+        for (String credentialConfigurationId : credentialConfigurationIds) {
+            SupportedCredentialConfiguration config = supportedCredentials.get(credentialConfigurationId);
+            if (config == null) {
+                logger.warnf("Credential configuration '%s' not found in supported credentials, skipping", credentialConfigurationId);
+                continue;
+            }
+
+            String credentialIdentifier = UUID.randomUUID().toString();
+
+            // Store the mapping between credential identifier and configuration ID in client session
+            // This will be used later when processing credential requests
+            String mappingKey = OID4VCIssuerEndpoint.CREDENTIAL_IDENTIFIER_PREFIX + credentialIdentifier;
+            clientSession.setNote(mappingKey, credentialConfigurationId);
+
+            logger.debugf("Generated credential identifier '%s' for configuration '%s'",
+                    credentialIdentifier, credentialConfigurationId);
+
+            OID4VCAuthorizationDetailsResponse authDetail = new OID4VCAuthorizationDetailsResponse();
+            authDetail.setType(OPENID_CREDENTIAL_TYPE);
+            authDetail.setCredentialConfigurationId(credentialConfigurationId);
+            authDetail.setCredentialIdentifiers(List.of(credentialIdentifier));
+
+            authorizationDetailsList.add(authDetail);
+        }
+
+        if (authorizationDetailsList.isEmpty()) {
+            logger.debug("No valid credential configurations found, cannot generate authorization_details");
+            return null;
+        }
+
+        return authorizationDetailsList;
+    }
+
+    /**
+     * Extract credential_configuration_ids from the credential offer stored in client session
+     */
+    private List<String> extractCredentialConfigurationIds(AuthenticatedClientSessionModel clientSession) {
+        // Get credential configuration IDs from the predictable location
+        // This is stored when the credential offer is created in getCredentialOfferURI
+        String credentialConfigIdsJson = clientSession.getNote(OID4VCIssuerEndpoint.CREDENTIAL_CONFIGURATION_IDS_NOTE);
+        if (credentialConfigIdsJson != null) {
+            logger.debugf("Found credential configuration IDs in predictable location");
+            try {
+                List<String> configIds = JsonSerialization.readValue(credentialConfigIdsJson, List.class);
+                logger.debugf("Successfully parsed credential configuration IDs: %s", configIds);
+                return configIds;
+            } catch (Exception e) {
+                logger.warnf("Failed to parse credential configuration IDs from predictable location: %s", e.getMessage());
+            }
+        }
+
+        logger.debugf("No credential_configuration_ids found in predictable location");
+        return null;
+    }
+
+    @Override
+    public void close() {
+        // No cleanup needed
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -248,13 +248,13 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
 
 
     /**
-     * Process authorization_details from the credential offer when authorization_details parameter is not present in the token request.
+     * Generate authorization_details from the credential offer when authorization_details parameter is not present in the token request.
      * This method generates authorization_details based on the credential_configuration_ids from the credential offer.
      *
      * @param clientSession the client session that contains the credential offer information
-     * @return the authorization details response if processing was successful, null otherwise
+     * @return the authorization details response if generation was successful, null otherwise
      */
-    public List<AuthorizationDetailsResponse> processFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
+    public List<AuthorizationDetailsResponse> generateAuthorizationDetailsFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
         logger.info("Processing authorization_details from credential offer");
 
         // Get supported credentials
@@ -328,6 +328,12 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
 
         logger.debugf("No credential_configuration_ids found in predictable location");
         return null;
+    }
+
+    @Override
+    public List<AuthorizationDetailsResponse> handleMissingAuthorizationDetails(UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
+        return generateAuthorizationDetailsFromCredentialOffer(clientSession);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -214,13 +214,22 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
         // Set nonce as an attribute in the ClientSessionContext. Will be used for the token generation
         clientSessionCtx.setAttribute(OIDCLoginProtocol.NONCE_PARAM, codeData.getNonce());
 
-        // Process authorization_details using provider discovery (only if present)
+        // Process authorization_details using provider discovery (if present in request)
+        List<AuthorizationDetailsResponse> authorizationDetailsResponse = null;
         if (formParams.getFirst(AUTHORIZATION_DETAILS_PARAM) != null) {
-            List<AuthorizationDetailsResponse> authorizationDetailsResponse = processAuthorizationDetails(userSession, clientSessionCtx);
+            authorizationDetailsResponse = processAuthorizationDetails(userSession, clientSessionCtx);
             if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
                 clientSessionCtx.setAttribute(AUTHORIZATION_DETAILS_RESPONSE, authorizationDetailsResponse);
             } else {
                 logger.debugf("No available AuthorizationDetailsProcessor being able to process authorization_details '%s'", formParams.getFirst(AUTHORIZATION_DETAILS_PARAM));
+            }
+        }
+
+        // If no authorization_details were processed from the request, try to generate them from credential offer
+        if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
+            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession.getUserSession(), clientSessionCtx, clientSession);
+            if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
+                clientSessionCtx.setAttribute(AUTHORIZATION_DETAILS_RESPONSE, authorizationDetailsResponse);
             }
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -227,7 +227,7 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
 
         // If no authorization_details were processed from the request, try to generate them from credential offer
         if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
-            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession);
+            authorizationDetailsResponse = handleMissingAuthorizationDetails(clientSession.getUserSession(), clientSessionCtx);
             if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
                 clientSessionCtx.setAttribute(AUTHORIZATION_DETAILS_RESPONSE, authorizationDetailsResponse);
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -227,7 +227,7 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
 
         // If no authorization_details were processed from the request, try to generate them from credential offer
         if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
-            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession.getUserSession(), clientSessionCtx, clientSession);
+            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession);
             if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
                 clientSessionCtx.setAttribute(AUTHORIZATION_DETAILS_RESPONSE, authorizationDetailsResponse);
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -295,12 +295,10 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
      * Process authorization_details from credential offer when authorization_details parameter is not present in the token request.
      * This is used in Pre-Authorized Code Flow where the credential offer contains the authorized credential configuration IDs.
      *
-     * @param userSession      the user session
-     * @param clientSessionCtx the client session context
-     * @param clientSession    the client session that contains the credential offer information
+     * @param clientSession the client session that contains the credential offer information
      * @return the authorization details response if processing was successful, null otherwise
      */
-    protected List<AuthorizationDetailsResponse> processAuthorizationDetailsFromCredentialOffer(UserSessionModel userSession, ClientSessionContext clientSessionCtx, AuthenticatedClientSessionModel clientSession) {
+    protected List<AuthorizationDetailsResponse> processAuthorizationDetailsFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
         try {
             return session.getKeycloakSessionFactory()
                     .getProviderFactoriesStream(AuthorizationDetailsProcessor.class)
@@ -308,7 +306,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
                     .map(f -> session.getProvider(AuthorizationDetailsProcessor.class, f.getId()))
                     .filter(processor -> processor instanceof org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor)
                     .map(processor -> (org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor) processor)
-                    .map(processor -> processor.processFromCredentialOffer(userSession, clientSessionCtx, clientSession))
+                    .map(processor -> processor.processFromCredentialOffer(clientSession))
                     .filter(authzDetailsResponse -> authzDetailsResponse != null)
                     .findFirst()
                     .orElse(null);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -29,6 +29,8 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.protocol.oidc.TokenManager;
@@ -103,6 +105,12 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         // Process authorization_details using provider discovery
         List<AuthorizationDetailsResponse> authorizationDetailsResponse = processAuthorizationDetails(clientSession.getUserSession(), sessionContext);
+        LOGGER.infof("Initial authorization_details processing result: %s", authorizationDetailsResponse);
+
+        // If no authorization_details were processed from the request, try to generate them from credential offer
+        if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
+            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession.getUserSession(), sessionContext, clientSession);
+        }
 
         AccessTokenResponse tokenResponse;
         try {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -29,8 +29,6 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.protocol.oidc.TokenManager;
@@ -109,7 +107,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         // If no authorization_details were processed from the request, try to generate them from credential offer
         if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
-            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession);
+            authorizationDetailsResponse = handleMissingAuthorizationDetails(clientSession.getUserSession(), sessionContext);
         }
 
         AccessTokenResponse tokenResponse;

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -109,7 +109,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         // If no authorization_details were processed from the request, try to generate them from credential offer
         if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
-            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession.getUserSession(), sessionContext, clientSession);
+            authorizationDetailsResponse = processAuthorizationDetailsFromCredentialOffer(clientSession);
         }
 
         AccessTokenResponse tokenResponse;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
@@ -182,7 +182,6 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         CredentialRequest credentialRequest = new CredentialRequest();
-        credentialRequest.setFormat(getCredentialFormat());
         credentialRequest.setCredentialIdentifier(credentialIdentifier);
 
         String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
@@ -206,7 +205,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
             Object credentialObj = credentialWrapper.getCredential();
             assertNotNull("Credential object should not be null", credentialObj);
 
-            // Verify the credential structure based on format
+            // Verify the credential structure based on formatfix-authorization_details-processing
             verifyCredentialStructure(credentialObj);
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
@@ -50,7 +50,9 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -447,6 +449,193 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
     }
 
     @Test
+    public void testPreAuthorizedCodeWithCredentialOfferBasedAuthorizationDetails() throws Exception {
+        String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
+        Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
+
+        // Test Pre-Authorized Code Flow without authorization_details parameter
+        // The system should generate authorization_details based on credential_configuration_ids from the credential offer
+        String credentialConfigId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
+
+        HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
+        parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, ctx.credentialsOffer.getGrants().getPreAuthorizedCode().getPreAuthorizedCode()));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        postPreAuthorizedCode.setEntity(formEntity);
+
+        try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
+            assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
+            String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            System.out.println("Token Response Status: " + tokenResponse.getStatusLine().getStatusCode());
+            System.out.println("Token Response Body: " + responseBody);
+
+            List<OID4VCAuthorizationDetailsResponse> authDetailsResponse = parseAuthorizationDetails(responseBody);
+            assertNotNull("authorization_details should be present in the response", authDetailsResponse);
+            assertEquals("Should have authorization_details for each credential configuration in the offer",
+                    ctx.credentialsOffer.getCredentialConfigurationIds().size(), authDetailsResponse.size());
+
+            // Verify each credential configuration from the offer has corresponding authorization_details
+            for (int i = 0; i < ctx.credentialsOffer.getCredentialConfigurationIds().size(); i++) {
+                String expectedConfigId = ctx.credentialsOffer.getCredentialConfigurationIds().get(i);
+                OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(i);
+
+                assertEquals(OPENID_CREDENTIAL_TYPE, authDetailResponse.getType());
+                assertEquals("Credential configuration ID should match the one from the offer",
+                        expectedConfigId, authDetailResponse.getCredentialConfigurationId());
+                assertNotNull("Credential identifiers should be present", authDetailResponse.getCredentialIdentifiers());
+                assertEquals("Should have exactly one credential identifier", 1, authDetailResponse.getCredentialIdentifiers().size());
+
+                String credentialIdentifier = authDetailResponse.getCredentialIdentifiers().get(0);
+                assertNotNull("Identifier should not be null", credentialIdentifier);
+                assertFalse("Identifier should not be empty", credentialIdentifier.isEmpty());
+                try {
+                    UUID.fromString(credentialIdentifier);
+                } catch (IllegalArgumentException e) {
+                    fail("Identifier should be a valid UUID, but was: " + credentialIdentifier);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCompleteFlowWithCredentialOfferBasedAuthorizationDetails() throws Exception {
+        String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
+        Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
+
+        String credentialConfigId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
+
+        // Step 1: Request token without authorization_details parameter (no scope needed)
+        HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
+        parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, ctx.credentialsOffer.getGrants().getPreAuthorizedCode().getPreAuthorizedCode()));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        postPreAuthorizedCode.setEntity(formEntity);
+
+        String credentialIdentifier = null;
+        String usedCredentialConfigId = null;
+        try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
+            assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
+            String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            List<OID4VCAuthorizationDetailsResponse> authDetailsResponse = parseAuthorizationDetails(responseBody);
+            assertNotNull("authorization_details should be present in the response", authDetailsResponse);
+            assertEquals("Should have authorization_details for each credential configuration in the offer",
+                    ctx.credentialsOffer.getCredentialConfigurationIds().size(), authDetailsResponse.size());
+
+            // Use the first authorization detail for credential request
+            OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(0);
+            assertNotNull("Credential identifiers should be present", authDetailResponse.getCredentialIdentifiers());
+            assertEquals(1, authDetailResponse.getCredentialIdentifiers().size());
+
+            credentialIdentifier = authDetailResponse.getCredentialIdentifiers().get(0);
+            usedCredentialConfigId = authDetailResponse.getCredentialConfigurationId();
+            assertNotNull("Credential identifier should not be null", credentialIdentifier);
+        }
+
+        // Step 2: Request the actual credential using ONLY the identifier (no credential_configuration_id)
+        // This tests that the mapping from credential identifier to credential configuration ID works correctly
+        HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
+        postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        CredentialRequest credentialRequest = new CredentialRequest();
+        credentialRequest.setCredentialIdentifier(credentialIdentifier);
+
+        String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
+        postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));
+
+        try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
+            assertEquals(HttpStatus.SC_OK, credentialResponse.getStatusLine().getStatusCode());
+            String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            // Parse the credential response
+            CredentialResponse parsedResponse = JsonSerialization.readValue(responseBody, CredentialResponse.class);
+            assertNotNull("Credential response should not be null", parsedResponse);
+            assertNotNull("Credentials should be present", parsedResponse.getCredentials());
+            assertEquals("Should have exactly one credential", 1, parsedResponse.getCredentials().size());
+
+            // Step 3: Verify that the issued credential structure is valid
+            CredentialResponse.Credential credentialWrapper = parsedResponse.getCredentials().get(0);
+            assertNotNull("Credential wrapper should not be null", credentialWrapper);
+
+            // The credential is stored as Object, so we need to cast it
+            Object credentialObj = credentialWrapper.getCredential();
+            assertNotNull("Credential object should not be null", credentialObj);
+
+            // Verify the credential structure based on format
+            verifyCredentialStructure(credentialObj);
+        }
+    }
+
+    @Test
+    public void testMultipleCredentialConfigurationsFromOffer() throws Exception {
+        String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
+        Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
+
+        // Verify that the credential offer has multiple configurations (if supported by the test setup)
+        assertTrue("Credential offer should have at least one credential configuration",
+                ctx.credentialsOffer.getCredentialConfigurationIds() != null &&
+                        !ctx.credentialsOffer.getCredentialConfigurationIds().isEmpty());
+
+        // Step 1: Request token without authorization_details parameter
+        HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
+        parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, ctx.credentialsOffer.getGrants().getPreAuthorizedCode().getPreAuthorizedCode()));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        postPreAuthorizedCode.setEntity(formEntity);
+
+        try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
+            assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
+            String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            List<OID4VCAuthorizationDetailsResponse> authDetailsResponse = parseAuthorizationDetails(responseBody);
+            assertNotNull("authorization_details should be present in the response", authDetailsResponse);
+
+            // Verify that we have authorization_details for each credential configuration in the offer
+            assertEquals("Should have authorization_details for each credential configuration in the offer",
+                    ctx.credentialsOffer.getCredentialConfigurationIds().size(), authDetailsResponse.size());
+
+            // Verify each authorization detail
+            for (int i = 0; i < authDetailsResponse.size(); i++) {
+                OID4VCAuthorizationDetailsResponse authDetail = authDetailsResponse.get(i);
+                String expectedConfigId = ctx.credentialsOffer.getCredentialConfigurationIds().get(i);
+
+                // Verify structure
+                assertEquals("Type should be openid_credential", OPENID_CREDENTIAL_TYPE, authDetail.getType());
+                assertEquals("Credential configuration ID should match the one from the offer",
+                        expectedConfigId, authDetail.getCredentialConfigurationId());
+                assertNotNull("Credential identifiers should be present", authDetail.getCredentialIdentifiers());
+                assertEquals("Should have exactly one credential identifier per configuration",
+                        1, authDetail.getCredentialIdentifiers().size());
+
+                // Verify identifier format
+                String credentialIdentifier = authDetail.getCredentialIdentifiers().get(0);
+                assertNotNull("Credential identifier should not be null", credentialIdentifier);
+                assertFalse("Credential identifier should not be empty", credentialIdentifier.isEmpty());
+                try {
+                    UUID.fromString(credentialIdentifier);
+                } catch (IllegalArgumentException e) {
+                    fail("Credential identifier should be a valid UUID, but was: " + credentialIdentifier);
+                }
+            }
+
+            // Verify that all credential identifiers are unique
+            Set<String> allIdentifiers = authDetailsResponse.stream()
+                    .flatMap(auth -> auth.getCredentialIdentifiers().stream())
+                    .collect(Collectors.toSet());
+            assertEquals("All credential identifiers should be unique",
+                    authDetailsResponse.size(), allIdentifiers.size());
+        }
+    }
+
+    @Test
     public void testCompleteFlowWithClaimsValidation() throws Exception {
         String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
         Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
@@ -504,7 +693,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         CredentialRequest credentialRequest = new CredentialRequest();
-        credentialRequest.setFormat(getCredentialFormat());
         credentialRequest.setCredentialIdentifier(credentialIdentifier);
 
         String requestBody = JsonSerialization.writeValueAsString(credentialRequest);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
@@ -455,7 +455,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
 
         // Test Pre-Authorized Code Flow without authorization_details parameter
         // The system should generate authorization_details based on credential_configuration_ids from the credential offer
-        String credentialConfigId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
 
         HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
         List<NameValuePair> parameters = new LinkedList<>();
@@ -468,9 +467,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
             assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
             String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
-
-            System.out.println("Token Response Status: " + tokenResponse.getStatusLine().getStatusCode());
-            System.out.println("Token Response Body: " + responseBody);
 
             List<OID4VCAuthorizationDetailsResponse> authDetailsResponse = parseAuthorizationDetails(responseBody);
             assertNotNull("authorization_details should be present in the response", authDetailsResponse);
@@ -505,8 +501,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
         Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
 
-        String credentialConfigId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
-
         // Step 1: Request token without authorization_details parameter (no scope needed)
         HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
         List<NameValuePair> parameters = new LinkedList<>();
@@ -517,7 +511,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         postPreAuthorizedCode.setEntity(formEntity);
 
         String credentialIdentifier = null;
-        String usedCredentialConfigId = null;
         try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
             assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
             String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -533,7 +526,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
             assertEquals(1, authDetailResponse.getCredentialIdentifiers().size());
 
             credentialIdentifier = authDetailResponse.getCredentialIdentifiers().get(0);
-            usedCredentialConfigId = authDetailResponse.getCredentialConfigurationId();
             assertNotNull("Credential identifier should not be null", credentialIdentifier);
         }
 


### PR DESCRIPTION
## Summary
Fixes OID4VCI conformance test failures by implementing proper authorization_details generation from credential offers and fixing credential identifier mapping.

## Problem
- OID4VCI conformance tests were failing because `authorization_details` weren't being generated in token responses when not provided in token requests
- Credential requests using only `credential_identifier` were failing due to mapping lookup issues

## Solution
- **Authorization Details Generation**: Added fallback mechanism to generate `authorization_details` from credential offer's `credential_configuration_ids` when not provided in token request
- **Credential Identifier Mapping**: Fixed client session lookup to ensure credential identifier mappings are found during credential requests

## Testing
## OID4VCI Conformance Test --  Without Authorization Details

<img width="1904" height="760" alt="Image" src="https://github.com/user-attachments/assets/3a03a4eb-4603-4dce-89ca-6044c672a266" />

## OID4VCI Conformance Test --  With  Authorization Details

<img width="1903" height="765" alt="Image" src="https://github.com/user-attachments/assets/40b9879e-0b48-408a-b4d5-2e0ddaacbaab" />

## Closses

closes https://github.com/keycloak/keycloak/issues/42818