### PR TITLE
Ignore external links to https://www.npmjs.com/package

### DIFF
--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -36,6 +36,7 @@ https://account.live.com/developers/applications/create
 https://developer.twitter.com/apps/
 https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update
 https://stackapps.com/apps/oauth/register
+https://www.npmjs.com/package/*
 # Failing because of broken certificate, can likely be restored later.
 https://docs.kantarainitiative.org*
 https://saml.xml.org*


### PR DESCRIPTION
Closes #42856

Just ignoring the links to https://www.npmjs.com/package/*. The explanation of this change is https://github.com/orgs/community/discussions/174098.
