### PR TITLE
Optimize offline session table indexes for efficient deletion

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="26.5.0-offline-session-cleanup-indexes">
+        <!-- Index for OFFLINE_USER_SESSION deleteExpiredUserSessions query -->
+        <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_LAST_SESSION_REFRESH">
+            <column name="REALM_ID"/>
+            <column name="OFFLINE_FLAG"/>
+            <column name="LAST_SESSION_REFRESH"/>
+        </createIndex>
+        
+        <!-- Index for OFFLINE_CLIENT_SESSION deleteExpiredClientSessions query -->
+        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_PRELOAD">
+            <column name="OFFLINE_FLAG"/>
+            <column name="USER_SESSION_ID"/>
+        </createIndex>
+        
+        <!-- Additional index for USER_SESSION_ID lookups in OFFLINE_USER_SESSION -->
+        <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USER_SESSION_ID">
+            <column name="USER_SESSION_ID"/>
+            <column name="OFFLINE_FLAG"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -89,5 +89,6 @@
     <include file="META-INF/jpa-changelog-26.2.6.xml"/>
     <include file="META-INF/jpa-changelog-26.3.0.xml"/>
     <include file="META-INF/jpa-changelog-26.4.0.xml"/>
+    <include file="META-INF/jpa-changelog-26.5.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
# Add database indexes for offline session cleanup performance

## Problem

Keycloak's cleanup tasks for offline sessions cause production issues when dealing with large datasets (millions of offline tokens). DELETE operations overwhelm the database due to missing indexes on critical columns.

**Issue identified in Keycloak 26.0.0**

**Specific issue experienced:**
- 98 million expired offline tokens caused database collapse
- DELETE queries on `OFFLINE_CLIENT_SESSION` and `OFFLINE_USER_SESSION` tables performed full table scans
- Query: `DELETE FROM OFFLINE_CLIENT_SESSION WHERE OFFLINE_FLAG = ? AND USER_SESSION_ID IN (SELECT USER_SESSION_ID FROM OFFLINE_USER_SESSION WHERE REALM_ID = ? AND OFFLINE_FLAG = ? AND LAST_SESSION_REFRESH < ?)`

## Solution

**Added:** Database indexes to optimize offline session cleanup queries

**Indexes created in `jpa-changelog-26.5.0.xml`:**
- `IDX_OFFLINE_USS_BY_LAST_SESSION_REFRESH` on `OFFLINE_USER_SESSION` (REALM_ID, OFFLINE_FLAG, LAST_SESSION_REFRESH)
- `IDX_OFFLINE_CSS_PRELOAD` on `OFFLINE_CLIENT_SESSION` (OFFLINE_FLAG, USER_SESSION_ID)  
- `IDX_OFFLINE_USS_BY_USER_SESSION_ID` on `OFFLINE_USER_SESSION` (USER_SESSION_ID, OFFLINE_FLAG)

**Optimized queries:**
- `deleteExpiredUserSessions` - eliminates full table scan on OFFLINE_USER_SESSION
- `deleteExpiredClientSessions` - optimizes subquery join performance

## Benefits

- **Performance:** Prevents table scans on tables with millions of records
- **Production Stability:** Eliminates database overload during cleanup
- **Automatic:** Indexes applied via standard Liquibase migration

## Files Changed

- `model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml`
- `model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml`

Related discussion: https://github.com/keycloak/keycloak/discussions/39374

Closes #[issue-number]
