### PR TITLE
[26.3] Upgrade to Quarkus 3.20.3 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,14 +606,6 @@
                 <version>${nashorn.version}</version>
             </dependency>
 
-            <!-- BEGIN Remove once org.mariadb.jdbc:mariadb-java-client:3.5.3 is part of Quarkus distribution. See https://github.com/keycloak/keycloak/issues/41371 -->
-            <dependency>
-                <groupId>org.mariadb.jdbc</groupId>
-                <artifactId>mariadb-java-client</artifactId>
-                <version>${mariadb-jdbc.version}</version>
-            </dependency>
-            <!-- END -->
-
             <!-- Twitter -->
             <dependency>
                 <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.20.2.2</quarkus.version>
-        <quarkus.build.version>3.20.2.2</quarkus.build.version>
+        <quarkus.version>3.20.3</quarkus.version>
+        <quarkus.build.version>3.20.3</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>
@@ -161,7 +161,7 @@
         <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.5</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/41371
- Closes https://github.com/keycloak/keycloak/issues/42491
- Closes https://github.com/keycloak/keycloak/issues/42492
- Closes https://github.com/keycloak/keycloak/issues/41373

Required version of MariaDB: 3.5.5
<img width="796" height="51" alt="Screenshot From 2025-09-24 10-13-35" src="https://github.com/user-attachments/assets/a86d3a30-9104-4ce5-85c6-0439131f9aed" />

Required versions of Netty: >= 4.1.125.Final
<img width="727" height="383" alt="image" src="https://github.com/user-attachments/assets/12fa3131-813d-4587-87d1-35326b3e1dfa" />

