### PR TITLE
[26.0] Upgrade to Quarkus 3.15.7 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>3.15.6.2</quarkus.version>
-        <quarkus.build.version>3.15.6.2</quarkus.build.version>
+        <quarkus.version>3.15.7</quarkus.version>
+        <quarkus.build.version>3.15.7</quarkus.build.version>
 
         <project.build-time>${timestamp}</project.build-time>
 


### PR DESCRIPTION
- Closes #42898
- Closes #42491
- Closes #42492

Required versions of Netty: >= 4.1.125.Final
<img width="727" height="383" alt="Screenshot From 2025-09-24 10-30-04" src="https://github.com/user-attachments/assets/86eb7af7-21af-4c71-b60b-ac8a0cac21a2" />
