### PR TITLE
Avoid invalidating the realm when managing client initial access

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -1800,28 +1800,32 @@ public class RealmAdapter implements CachedRealmModel {
 
     @Override
     public ClientInitialAccessModel createClientInitialAccessModel(int expiration, int count) {
-        getDelegateForUpdate();
-        return updated.createClientInitialAccessModel(expiration, count);
+        // This does not call getDelegateForUpdate() this data is never cached, and calling it would invalidate all cached realm data
+        return modelSupplier.get().createClientInitialAccessModel(expiration, count);
     }
 
     @Override
     public ClientInitialAccessModel getClientInitialAccessModel(String id) {
-        return getDelegateForUpdate().getClientInitialAccessModel(id);
+        // This does not call getDelegateForUpdate() this data is never cached, and calling it would invalidate all cached realm data
+        return modelSupplier.get().getClientInitialAccessModel(id);
     }
 
     @Override
     public void removeClientInitialAccessModel(String id) {
-        getDelegateForUpdate().removeClientInitialAccessModel(id);
+        // This does not call getDelegateForUpdate() this data is never cached, and calling it would invalidate all cached realm data
+        modelSupplier.get().removeClientInitialAccessModel(id);
     }
 
     @Override
     public Stream<ClientInitialAccessModel> getClientInitialAccesses() {
-        return getDelegateForUpdate().getClientInitialAccesses();
+        // This does not call getDelegateForUpdate() this data is never cached, and calling it would invalidate all cached realm data
+        return modelSupplier.get().getClientInitialAccesses();
     }
 
     @Override
     public void decreaseRemainingCount(ClientInitialAccessModel clientInitialAccess) {
-        getDelegateForUpdate().decreaseRemainingCount(clientInitialAccess);
+        // This does not call getDelegateForUpdate() this data is never cached, and calling it would invalidate all cached realm data
+        modelSupplier.get().decreaseRemainingCount(clientInitialAccess);
     }
 
     @Override


### PR DESCRIPTION
Closes #42922

This can be manually validated in one of the two following ways - I actually don't know how I would automatically test this, please share ideas if you could think of some. 

* Go to the Admin UI clients menu, and then access "Initial access token". Even selecting an entry would invalidate the cache previously. Now it wouldn't do that any more. 

OR

* Perform a client registration via https://www.keycloak.org/securing-apps/client-registration

You then look that no Realm invalidations are created in the debugger at 

https://github.com/keycloak/keycloak/blob/18a6c790113998bf039f46d6c71ffb668e961036/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RealmUpdatedEvent.java#L39

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
