### PR TITLE
Update OID4VCI documentation with new .well-known URL format

### DIFF
--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -457,7 +457,7 @@ Validate the setup by accessing the **issuer metadata endpoint**:
 +
 [source,bash]
 ----
-https://localhost:8443/realms/oid4vc-vci/.well-known/openid-credential-issuer
+https://localhost:8443/.well-known/openid-credential-issuer/realms/oid4vc-vci
 ----
 
 A successful response returns a JSON object containing details such as:


### PR DESCRIPTION
The OID4VCI documentation currently references the old .well-known URL format:

`https://localhost:8443/realms/oid4vc-vci/.well-known/openid-credential-issuer`

Recently, the URL format has been updated to:

`https://localhost:8443/.well-known/openid-credential-issuer/realms/oid4vc-vci`

The documentation should be revised to reflect this change to ensure consistency and avoid confusion for users.

Closes: #42927

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
