### PR TITLE
Expose system-info information in the serverinfo endpoint only for users in the admin realm (26.2)

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_2_10.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_2_10.adoc
@@ -1,0 +1,15 @@
+// ------------------------ Notable changes ------------------------ //
+== Notable changes
+
+Notable changes where an internal behavior changed to prevent common misconfigurations, fix bugs or simplify running {project_name}.
+
+=== The `serverinfo` endpoint only returns the system info for administrators in the administrator realm
+
+Starting with this version, the `serverinfo` endpoint, which is used by the admin console to obtain some general information of the {project_name} installation, will only return the system information for administrators in the administration (master) realm. This change was done for security reasons.
+
+If, for whatever reason, an administrator in a common realm needs to access the `systemInfo`, `cpuInfo` or `memoryInfo` fields of the `serverinfo` response, you need to create and assign a new *view-system* role to that admin user:
+
+. In the affected realm, select the management client *realm-management*, and, in the *Roles* tab, create a new role called *view-system*.
+. In *Users* select the administrator account, and, in the *Role mapping* tab, assign the just created *view-system* client role to the admin user.
+
+The previous workaround is marked as deprecated and it can be removed in a future version of {project_name}.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -1,6 +1,10 @@
 [[migration-changes]]
 == Migration Changes
 
+=== Migrating to 26.2.10
+
+include::changes-26_2_10.adoc[leveloffset=2]
+
 === Migrating to 26.2.9
 
 include::changes-26_2_9.adoc[leveloffset=2]

--- a/server-spi-private/src/main/java/org/keycloak/models/AdminRoles.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/AdminRoles.java
@@ -35,12 +35,14 @@ public class AdminRoles {
     public static String CREATE_REALM = "create-realm";
     public static String CREATE_CLIENT = "create-client";
 
-    public static String VIEW_REALM = "view-realm";
-    public static String VIEW_USERS = "view-users";
-    public static String VIEW_CLIENTS = "view-clients";
-    public static String VIEW_EVENTS = "view-events";
-    public static String VIEW_IDENTITY_PROVIDERS = "view-identity-providers";
-    public static String VIEW_AUTHORIZATION = "view-authorization";
+    public static final String VIEW_REALM = "view-realm";
+    public static final String VIEW_USERS = "view-users";
+    public static final String VIEW_CLIENTS = "view-clients";
+    public static final String VIEW_EVENTS = "view-events";
+    public static final String VIEW_IDENTITY_PROVIDERS = "view-identity-providers";
+    public static final String VIEW_AUTHORIZATION = "view-authorization";
+    @Deprecated(since = "26.2.9", forRemoval = true)
+    public static final String VIEW_SYSTEM = "view-system";
 
     public static String MANAGE_REALM = "manage-realm";
     public static String MANAGE_USERS = "manage-users";

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -291,7 +291,7 @@ public class AdminRoot {
 
         Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
 
-        return new ServerInfoAdminResource(session);
+        return new ServerInfoAdminResource(session, auth);
     }
 
     private HttpRequest getHttpRequest() {


### PR DESCRIPTION
Closes #42828

PR:             https://github.com/keycloak/keycloak/pull/42859
Commit:         https://github.com/keycloak/keycloak/commit/1d28c0cd35a186551cf4114cbd6cdf75b9e3fe58
PR branch:      backport-42859-26.2
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.2

Note moved to 26.2.10. I'm just sending to 26.2 because it's a low security issue.